### PR TITLE
story(issue-14): add Grafana UI to grafana-stack module with datasource provisioning

### DIFF
--- a/ci/main.go
+++ b/ci/main.go
@@ -20,7 +20,9 @@ func (c *Ci) Test(ctx context.Context) error {
 	jobs = jobs.WithJob("random", dag.RandomTests().All)
 	jobs = jobs.WithJob("crypto", dag.CryptoTests().All)
 	jobs = jobs.WithJob("certificate-management", dag.CertificateManagementTests().All)
-	jobs = jobs.WithJob("grafana-stack", dag.GrafanaStackTests().All)
+	jobs = jobs.WithJob("grafana-stack", func(ctx context.Context) error {
+		return dag.GrafanaStackTests().All(ctx)
+	})
 	jobs = jobs.WithJob("kafka", func(ctx context.Context) error {
 		return dag.KafkaTests().All(ctx)
 	})

--- a/daggerverse/grafana-stack/README.md
+++ b/daggerverse/grafana-stack/README.md
@@ -196,9 +196,11 @@ dagger -m daggerverse/grafana-stack/tests call mimir-accepts-otlp-metrics
 dagger -m daggerverse/grafana-stack/tests call grafana-proxies-loki-query
 ```
 
-Each test takes a `--tag` flag (default matches the parent module's
-pinned defaults) so a fresh upstream release can be qualified
-end-to-end without editing any module:
+Each backend test exposes an image tag override (default matches the
+parent module's pinned defaults) so a fresh upstream release can be
+qualified end-to-end without editing any module. The single-backend
+tests take `--tag`; `grafana-proxies-loki-query` takes `--grafana-tag`
+and `--loki-tag`:
 
 ```sh
 dagger -m daggerverse/grafana-stack/tests call loki-accepts-otlp-logs --tag=3.5.0

--- a/daggerverse/grafana-stack/README.md
+++ b/daggerverse/grafana-stack/README.md
@@ -196,12 +196,22 @@ dagger -m daggerverse/grafana-stack/tests call mimir-accepts-otlp-metrics
 dagger -m daggerverse/grafana-stack/tests call grafana-proxies-loki-query
 ```
 
-Both `all` and `grafana-proxies-loki-query` accept a `--tag` argument
-(default `12.0.0`) so a fresh Grafana release can be qualified end-to-end
-without editing any module:
+Each test takes a `--tag` flag (default matches the parent module's
+pinned defaults) so a fresh upstream release can be qualified
+end-to-end without editing any module:
 
 ```sh
-dagger -m daggerverse/grafana-stack/tests call all --tag=12.1.0
+dagger -m daggerverse/grafana-stack/tests call loki-accepts-otlp-logs --tag=3.5.0
+dagger -m daggerverse/grafana-stack/tests call tempo-accepts-otlp-traces --tag=2.8.0
+dagger -m daggerverse/grafana-stack/tests call mimir-accepts-otlp-metrics --tag=2.16.0
+dagger -m daggerverse/grafana-stack/tests call grafana-proxies-loki-query --grafana-tag=12.1.0
+```
+
+`call all` exposes `--loki-tag`, `--tempo-tag`, `--mimir-tag`, and
+`--grafana-tag` (each with the same default as its single-test form):
+
+```sh
+dagger -m daggerverse/grafana-stack/tests call all --grafana-tag=12.1.0
 ```
 
 Note the kebab-case CLI form (`loki-accepts-otlp-logs`); the Go SDK

--- a/daggerverse/grafana-stack/README.md
+++ b/daggerverse/grafana-stack/README.md
@@ -1,12 +1,11 @@
 # grafana-stack
 
 A Dagger module that spins up Loki, Tempo, and Mimir as Dagger services
-for local development and testing. Each backend runs in single-binary /
-monolithic mode and exposes both its native ingest API and an OTLP/HTTP
-receiver. Plaintext is the only supported transport on every listener.
-
-The Grafana UI itself is intentionally out of scope for this module —
-that lands in a follow-up.
+for local development and testing, plus a Grafana UI wired up to all
+three with file-based datasource and dashboard provisioning. Each
+backend runs in single-binary / monolithic mode and exposes both its
+native ingest API and an OTLP/HTTP receiver. Plaintext is the only
+supported transport on every listener.
 
 ## Backends and ports
 
@@ -15,6 +14,7 @@ that lands in a follow-up.
 | Loki    | `:3100`     | `:3100/otlp/v1/logs`                 | —         |
 | Tempo   | `:3200`     | `:4318` (collector appends `/v1/...`)| `:4317`   |
 | Mimir   | `:9009`     | `:9009/otlp/v1/metrics`              | —         |
+| Grafana | `:3000`     | —                                    | —         |
 
 ## Quickstart
 
@@ -79,6 +79,52 @@ url, err = mimir.Endpoint(ctx)         // http://<host>:9009
 url, err = mimir.OtlpHttpEndpoint(ctx) // http://<host>:9009/otlp/v1/metrics
 ```
 
+## Grafana UI
+
+`Grafana(registry, tag, configFile, adminPassword, storage)` returns a
+`*Grafana` builder. `adminPassword` is required and is supplied as a
+`*dagger.Secret`; it is mounted into the container and read via
+`GF_SECURITY_ADMIN_PASSWORD__FILE` so plaintext never enters generated
+bindings. The default tag is `12.0.0`. `configFile` defaults to a
+minimal `grafana.ini` that disables analytics and lets every other
+setting fall through to the upstream image's default; supplying a
+config file fully replaces it (no merge).
+
+Datasources and dashboards are accumulated via builder methods that
+return a new `*Grafana`:
+
+```go
+g := dag.GrafanaStack().Grafana(adminPassword).
+    WithLokiDatasource("loki", dag.GrafanaStack().Loki()).
+    WithTempoDatasource("tempo", dag.GrafanaStack().Tempo()).
+    WithMimirDatasource("mimir", dag.GrafanaStack().Mimir()).
+    WithDashboard("api-overview", dashboardFile).
+    WithDashboards(dashboardDir)
+
+svc := g.Service()                    // listens on :3000
+url, _ := g.Endpoint(ctx)             // http://<host>:3000
+```
+
+The `name` argument to each `WithXDatasource` is used both as the
+in-network service hostname **and** the datasource name + UID. Setting
+`uid == name` lets callers address the datasource via Grafana's proxy
+API without an extra lookup:
+
+```
+http://<host>:3000/api/datasources/proxy/uid/<name>/<backend-path>
+```
+
+Mimir is registered as a `prometheus`-type datasource pointing at
+`http://<name>:9009/prometheus` (Mimir's Prometheus-compatible API
+prefix, matching the existing Mimir round-trip test).
+
+Dashboards land in a single flat folder at `/var/lib/grafana/dashboards`
+on the container (auto-generated provider config). `WithDashboard(name,
+file)` appends `.json` to the supplied name if missing;
+`WithDashboards(dir)` includes every `*.json` entry in the directory,
+preserving filenames. Callers wanting folder grouping should embed it
+in the dashboard JSON itself.
+
 ## Plaintext-only
 
 Every listener is plaintext HTTP/gRPC. The story explicitly defers TLS
@@ -128,13 +174,14 @@ multi-tenant production deployment.
 `tests/` contains a sibling Dagger module that exercises each backend
 end-to-end:
 
-| Test                       | What it does                                           |
-|----------------------------|--------------------------------------------------------|
-| `LokiAcceptsOtlpLogs`      | POST OTLP/HTTP log → poll LogQL until marker visible.  |
-| `TempoAcceptsOtlpTraces`   | POST OTLP/HTTP span → GET `/api/traces/<hex>` checks.  |
-| `MimirAcceptsOtlpMetrics`  | POST OTLP/HTTP gauge → poll Prometheus API for series. |
+| Test                       | What it does                                                       |
+|----------------------------|--------------------------------------------------------------------|
+| `LokiAcceptsOtlpLogs`      | POST OTLP/HTTP log → poll LogQL until marker visible.              |
+| `TempoAcceptsOtlpTraces`   | POST OTLP/HTTP span → GET `/api/traces/<hex>` checks.              |
+| `MimirAcceptsOtlpMetrics`  | POST OTLP/HTTP gauge → poll Prometheus API for series.             |
+| `GrafanaProxiesLokiQuery`  | POST OTLP/HTTP log → query through Grafana's datasource proxy API. |
 
-Run all three in parallel:
+Run all four in parallel:
 
 ```sh
 dagger -m daggerverse/grafana-stack/tests call all
@@ -146,6 +193,15 @@ Run a single one:
 dagger -m daggerverse/grafana-stack/tests call loki-accepts-otlp-logs
 dagger -m daggerverse/grafana-stack/tests call tempo-accepts-otlp-traces
 dagger -m daggerverse/grafana-stack/tests call mimir-accepts-otlp-metrics
+dagger -m daggerverse/grafana-stack/tests call grafana-proxies-loki-query
+```
+
+Both `all` and `grafana-proxies-loki-query` accept a `--tag` argument
+(default `12.0.0`) so a fresh Grafana release can be qualified end-to-end
+without editing any module:
+
+```sh
+dagger -m daggerverse/grafana-stack/tests call all --tag=12.1.0
 ```
 
 Note the kebab-case CLI form (`loki-accepts-otlp-logs`); the Go SDK

--- a/daggerverse/grafana-stack/configs/grafana.ini
+++ b/daggerverse/grafana-stack/configs/grafana.ini
@@ -1,0 +1,3 @@
+[analytics]
+reporting_enabled = false
+check_for_updates = false

--- a/daggerverse/grafana-stack/main.go
+++ b/daggerverse/grafana-stack/main.go
@@ -406,6 +406,10 @@ func (g *GrafanaStack) Grafana(
 // and accumulates a Loki datasource entry under the same name (which is
 // also used as the datasource uid, so callers can hit
 // /api/datasources/proxy/uid/<name>/...).
+//
+// `name` must be a valid DNS label: it is used as the in-network
+// hostname (enforced by Dagger's WithServiceBinding), as the Grafana
+// datasource uid, and is interpolated into provisioning YAML.
 func (g *Grafana) WithLokiDatasource(name string, loki *Loki) *Grafana {
 	out := *g
 	out.LokiNames = append(append([]string{}, g.LokiNames...), name)
@@ -415,6 +419,7 @@ func (g *Grafana) WithLokiDatasource(name string, loki *Loki) *Grafana {
 
 // WithTempoDatasource binds tempo into Grafana's network at hostname
 // `name` and accumulates a Tempo datasource entry under the same name.
+// See WithLokiDatasource for the constraints on `name`.
 func (g *Grafana) WithTempoDatasource(name string, tempo *Tempo) *Grafana {
 	out := *g
 	out.TempoNames = append(append([]string{}, g.TempoNames...), name)
@@ -424,7 +429,8 @@ func (g *Grafana) WithTempoDatasource(name string, tempo *Tempo) *Grafana {
 
 // WithMimirDatasource binds mimir into Grafana's network at hostname
 // `name` and accumulates a Prometheus-type datasource entry pointing at
-// Mimir's Prometheus-compatible API endpoint.
+// Mimir's Prometheus-compatible API endpoint. See WithLokiDatasource
+// for the constraints on `name`.
 func (g *Grafana) WithMimirDatasource(name string, mimir *Mimir) *Grafana {
 	out := *g
 	out.MimirNames = append(append([]string{}, g.MimirNames...), name)

--- a/daggerverse/grafana-stack/main.go
+++ b/daggerverse/grafana-stack/main.go
@@ -113,7 +113,7 @@ func (l *Loki) Service() *dagger.Service {
 	ctr := dag.Container().From(l.Image).
 		WithUser("0:0").
 		WithMountedFile(lokiConfigPath, l.ConfigFile).
-		WithExposedPort(3100)
+		WithExposedPort(lokiHTTPPort)
 	ctr = mountDataDir(ctr, lokiDataDir, l.Storage)
 	return ctr.AsService(dagger.ContainerAsServiceOpts{
 		UseEntrypoint: true,
@@ -126,7 +126,7 @@ func (l *Loki) Service() *dagger.Service {
 // +cache="never"
 func (l *Loki) Endpoint(ctx context.Context) (string, error) {
 	return l.Service().Endpoint(ctx, dagger.ServiceEndpointOpts{
-		Port:   3100,
+		Port:   lokiHTTPPort,
 		Scheme: "http",
 	})
 }
@@ -196,7 +196,7 @@ func (t *Tempo) Service() *dagger.Service {
 	ctr := dag.Container().From(t.Image).
 		WithUser("0:0").
 		WithMountedFile(tempoConfigPath, t.ConfigFile).
-		WithExposedPort(3200).
+		WithExposedPort(tempoHTTPPort).
 		WithExposedPort(4317).
 		WithExposedPort(4318)
 	ctr = mountDataDir(ctr, tempoDataDir, t.Storage)
@@ -212,7 +212,7 @@ func (t *Tempo) Service() *dagger.Service {
 // +cache="never"
 func (t *Tempo) HttpEndpoint(ctx context.Context) (string, error) {
 	return t.Service().Endpoint(ctx, dagger.ServiceEndpointOpts{
-		Port:   3200,
+		Port:   tempoHTTPPort,
 		Scheme: "http",
 	})
 }
@@ -296,7 +296,7 @@ func (m *Mimir) Service() *dagger.Service {
 	ctr := dag.Container().From(m.Image).
 		WithUser("0:0").
 		WithMountedFile(mimirConfigPath, m.ConfigFile).
-		WithExposedPort(9009)
+		WithExposedPort(mimirHTTPPort)
 	ctr = mountDataDir(ctr, mimirDataDir, m.Storage)
 	return ctr.AsService(dagger.ContainerAsServiceOpts{
 		UseEntrypoint: true,
@@ -311,7 +311,7 @@ func (m *Mimir) Service() *dagger.Service {
 // +cache="never"
 func (m *Mimir) Endpoint(ctx context.Context) (string, error) {
 	return m.Service().Endpoint(ctx, dagger.ServiceEndpointOpts{
-		Port:   9009,
+		Port:   mimirHTTPPort,
 		Scheme: "http",
 	})
 }

--- a/daggerverse/grafana-stack/main.go
+++ b/daggerverse/grafana-stack/main.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"dagger/grafana-stack/internal/dagger"
 )
@@ -30,14 +31,28 @@ var defaultTempoConfig []byte
 //go:embed configs/mimir.yaml
 var defaultMimirConfig []byte
 
+//go:embed configs/grafana.ini
+var defaultGrafanaConfig []byte
+
 const lokiDataDir = "/var/lib/loki"
 const lokiConfigPath = "/etc/loki/loki.yaml"
+const lokiHTTPPort = 3100
 
 const tempoDataDir = "/var/lib/tempo"
 const tempoConfigPath = "/etc/tempo/tempo.yaml"
+const tempoHTTPPort = 3200
 
 const mimirDataDir = "/var/lib/mimir"
 const mimirConfigPath = "/etc/mimir/mimir.yaml"
+const mimirHTTPPort = 9009
+
+const grafanaHTTPPort = 3000
+const grafanaDataDir = "/var/lib/grafana"
+const grafanaDashboardsDir = grafanaDataDir + "/dashboards"
+const grafanaConfigPath = "/etc/grafana/grafana.ini"
+const grafanaDsProvPath = "/etc/grafana/provisioning/datasources/datasources.yaml"
+const grafanaDbProvPath = "/etc/grafana/provisioning/dashboards/dashboards.yaml"
+const grafanaAdminPwdPath = "/run/secrets/grafana-admin-password"
 
 // Loki wraps a configured grafana/loki container. Use Service() to obtain
 // the *dagger.Service for binding into other containers, and Endpoint() /
@@ -312,6 +327,219 @@ func (m *Mimir) OtlpHttpEndpoint(ctx context.Context) (string, error) {
 		return "", err
 	}
 	return base + "/otlp/v1/metrics", nil
+}
+
+// Grafana wraps a configured grafana/grafana container with file-based
+// datasource and dashboard provisioning. Datasources and dashboards are
+// accumulated via the WithX builder methods and rendered into the
+// container's /etc/grafana/provisioning tree at Service() time.
+type Grafana struct {
+	// Image is the resolved <registry>/grafana/grafana:<tag> reference.
+	Image string
+	// ConfigFile is the grafana.ini config: caller-supplied override or
+	// the embedded default.
+	ConfigFile *dagger.File
+	// AdminPassword is mounted into the container as a file and pointed
+	// at via GF_SECURITY_ADMIN_PASSWORD__FILE so plaintext never enters
+	// generated bindings.
+	AdminPassword *dagger.Secret
+	// Storage is the optional persistence volume for /var/lib/grafana.
+	Storage *dagger.CacheVolume
+
+	// LokiNames[i] is the in-network hostname bound to LokiSvcs[i] and
+	// is also used as the Grafana datasource name + uid. Same shape for
+	// Tempo and Mimir.
+	LokiNames  []string
+	LokiSvcs   []*dagger.Service
+	TempoNames []string
+	TempoSvcs  []*dagger.Service
+	MimirNames []string
+	MimirSvcs  []*dagger.Service
+
+	// Dashboards is the accumulated set of dashboard JSON files, mounted
+	// at /var/lib/grafana/dashboards on the Grafana container at
+	// Service() time. Starts empty.
+	Dashboards *dagger.Directory
+}
+
+// Grafana configures a grafana/grafana service with file-based datasource
+// and dashboard provisioning. Listens on :3000 plaintext.
+//
+// registry defaults to docker.io. tag defaults to a known-good upstream
+// version. configFile fully replaces the embedded default when supplied.
+// adminPassword is required and is mounted into the container at a fixed
+// path; Grafana reads it via GF_SECURITY_ADMIN_PASSWORD__FILE so the
+// plaintext never enters generated bindings. storage, when non-nil, is
+// mounted at /var/lib/grafana for persistence; when nil, an ephemeral
+// empty Directory is mounted instead.
+func (g *GrafanaStack) Grafana(
+	// Container registry hosting the grafana/grafana image.
+	// +default="docker.io"
+	registry string,
+	// Image tag for grafana/grafana.
+	// +default="12.0.0"
+	tag string,
+	// grafana.ini config; replaces the embedded default when supplied.
+	// +optional
+	configFile *dagger.File,
+	// Admin password supplied to GF_SECURITY_ADMIN_PASSWORD__FILE.
+	adminPassword *dagger.Secret,
+	// Persistence volume mounted at /var/lib/grafana. When nil the data
+	// dir is ephemeral.
+	// +optional
+	storage *dagger.CacheVolume,
+) (*Grafana, error) {
+	cfg, err := resolveConfig(configFile, "grafana.ini", defaultGrafanaConfig)
+	if err != nil {
+		return nil, fmt.Errorf("resolve grafana config: %w", err)
+	}
+	return &Grafana{
+		Image:         fmt.Sprintf("%s/grafana/grafana:%s", registry, tag),
+		ConfigFile:    cfg,
+		AdminPassword: adminPassword,
+		Storage:       storage,
+		Dashboards:    dag.Directory(),
+	}, nil
+}
+
+// WithLokiDatasource binds loki into Grafana's network at hostname `name`
+// and accumulates a Loki datasource entry under the same name (which is
+// also used as the datasource uid, so callers can hit
+// /api/datasources/proxy/uid/<name>/...).
+func (g *Grafana) WithLokiDatasource(name string, loki *Loki) *Grafana {
+	out := *g
+	out.LokiNames = append(append([]string{}, g.LokiNames...), name)
+	out.LokiSvcs = append(append([]*dagger.Service{}, g.LokiSvcs...), loki.Service())
+	return &out
+}
+
+// WithTempoDatasource binds tempo into Grafana's network at hostname
+// `name` and accumulates a Tempo datasource entry under the same name.
+func (g *Grafana) WithTempoDatasource(name string, tempo *Tempo) *Grafana {
+	out := *g
+	out.TempoNames = append(append([]string{}, g.TempoNames...), name)
+	out.TempoSvcs = append(append([]*dagger.Service{}, g.TempoSvcs...), tempo.Service())
+	return &out
+}
+
+// WithMimirDatasource binds mimir into Grafana's network at hostname
+// `name` and accumulates a Prometheus-type datasource entry pointing at
+// Mimir's Prometheus-compatible API endpoint.
+func (g *Grafana) WithMimirDatasource(name string, mimir *Mimir) *Grafana {
+	out := *g
+	out.MimirNames = append(append([]string{}, g.MimirNames...), name)
+	out.MimirSvcs = append(append([]*dagger.Service{}, g.MimirSvcs...), mimir.Service())
+	return &out
+}
+
+// WithDashboard adds a single dashboard JSON file to the provisioned
+// dashboards directory under the supplied name. `.json` is appended if
+// the supplied name does not already end with it.
+func (g *Grafana) WithDashboard(name string, file *dagger.File) *Grafana {
+	if !strings.HasSuffix(name, ".json") {
+		name += ".json"
+	}
+	out := *g
+	out.Dashboards = g.Dashboards.WithFile(name, file)
+	return &out
+}
+
+// WithDashboards adds every *.json entry in dir to the provisioned
+// dashboards directory, preserving filenames.
+func (g *Grafana) WithDashboards(dir *dagger.Directory) *Grafana {
+	out := *g
+	out.Dashboards = g.Dashboards.WithDirectory(".", dir, dagger.DirectoryWithDirectoryOpts{
+		Include: []string{"*.json"},
+	})
+	return &out
+}
+
+// Service returns the Grafana Dagger service. The container is run as
+// root (see Loki.Service for the rationale). The accumulated datasource
+// and dashboard state is rendered into the container's provisioning
+// tree at this point — subsequent WithX calls on the same *Grafana
+// receiver are not visible to the returned service.
+func (g *Grafana) Service() *dagger.Service {
+	ctr := dag.Container().From(g.Image).
+		WithUser("0:0").
+		WithExposedPort(grafanaHTTPPort).
+		WithMountedFile(grafanaConfigPath, g.ConfigFile).
+		WithMountedSecret(grafanaAdminPwdPath, g.AdminPassword).
+		WithEnvVariable("GF_SECURITY_ADMIN_PASSWORD__FILE", grafanaAdminPwdPath)
+
+	ctr = mountDataDir(ctr, grafanaDataDir, g.Storage)
+
+	for i, n := range g.LokiNames {
+		ctr = ctr.WithServiceBinding(n, g.LokiSvcs[i])
+	}
+	for i, n := range g.TempoNames {
+		ctr = ctr.WithServiceBinding(n, g.TempoSvcs[i])
+	}
+	for i, n := range g.MimirNames {
+		ctr = ctr.WithServiceBinding(n, g.MimirSvcs[i])
+	}
+
+	dsYAML := renderDatasourcesYAML(g.LokiNames, g.TempoNames, g.MimirNames)
+	dsFile := dag.Directory().WithNewFile("datasources.yaml", dsYAML).File("datasources.yaml")
+	ctr = ctr.WithMountedFile(grafanaDsProvPath, dsFile)
+
+	dbFile := dag.Directory().WithNewFile("dashboards.yaml", dashboardsProviderYAML).File("dashboards.yaml")
+	ctr = ctr.
+		WithMountedFile(grafanaDbProvPath, dbFile).
+		WithMountedDirectory(grafanaDashboardsDir, g.Dashboards)
+
+	return ctr.AsService(dagger.ContainerAsServiceOpts{
+		UseEntrypoint: true,
+	})
+}
+
+// Endpoint returns the Grafana HTTP base URL, e.g. http://<host>:3000.
+//
+// +cache="never"
+func (g *Grafana) Endpoint(ctx context.Context) (string, error) {
+	return g.Service().Endpoint(ctx, dagger.ServiceEndpointOpts{
+		Port:   grafanaHTTPPort,
+		Scheme: "http",
+	})
+}
+
+// dashboardsProviderYAML is a fixed single-provider config pointing at
+// the on-disk dashboards directory inside the Grafana container. All
+// provisioned dashboards land in one flat folder at the Grafana UI;
+// callers wanting folder grouping should embed it in the dashboard JSON.
+const dashboardsProviderYAML = `apiVersion: 1
+providers:
+  - name: default
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: false
+    options:
+      path: ` + grafanaDashboardsDir + `
+`
+
+// renderDatasourcesYAML emits the file-based provisioning YAML for the
+// accumulated set of {Loki, Tempo, Mimir} datasources. Each entry sets
+// uid == name so callers can address datasources via the proxy API at
+// /api/datasources/proxy/uid/<name>/... without an extra lookup.
+func renderDatasourcesYAML(lokiNames, tempoNames, mimirNames []string) string {
+	var b strings.Builder
+	b.WriteString("apiVersion: 1\ndatasources:\n")
+	for _, n := range lokiNames {
+		fmt.Fprintf(&b, "  - name: %s\n    uid: %s\n    type: loki\n    access: proxy\n    url: http://%s:%d\n    isDefault: false\n",
+			n, n, n, lokiHTTPPort)
+	}
+	for _, n := range tempoNames {
+		fmt.Fprintf(&b, "  - name: %s\n    uid: %s\n    type: tempo\n    access: proxy\n    url: http://%s:%d\n    isDefault: false\n",
+			n, n, n, tempoHTTPPort)
+	}
+	for _, n := range mimirNames {
+		fmt.Fprintf(&b, "  - name: %s\n    uid: %s\n    type: prometheus\n    access: proxy\n    url: http://%s:%d/prometheus\n    isDefault: false\n",
+			n, n, n, mimirHTTPPort)
+	}
+	return b.String()
 }
 
 // resolveConfig returns the caller-supplied config file when non-nil,

--- a/daggerverse/grafana-stack/tests/main.go
+++ b/daggerverse/grafana-stack/tests/main.go
@@ -20,31 +20,48 @@ type Tests struct{}
 
 // All runs every grafana-stack round-trip test in parallel.
 //
-// tag is forwarded to GrafanaProxiesLokiQuery so callers can qualify a
-// new Grafana image at the CLI without editing any module:
+// Each tag flag is forwarded to the matching per-backend test so a fresh
+// upstream release can be qualified at the CLI without editing any
+// module:
 //
-//	dagger -m daggerverse/grafana-stack/tests call all --tag=12.1.0
+//	dagger -m daggerverse/grafana-stack/tests call all --grafana-tag=12.1.0
+//	dagger -m daggerverse/grafana-stack/tests call all --loki-tag=3.5.0
 //
-// The default matches the parent module's `Grafana(...)` default so the
-// bare `call all` keeps working.
+// Defaults match the parent module's pinned defaults so the bare
+// `call all` keeps working.
 //
 // +check
 // +cache="session"
 func (t *Tests) All(
 	ctx context.Context,
-	// Grafana image tag to test.
+	// grafana/loki image tag.
+	// +default="3.4.1"
+	lokiTag string,
+	// grafana/tempo image tag.
+	// +default="2.7.1"
+	tempoTag string,
+	// grafana/mimir image tag.
+	// +default="2.15.1"
+	mimirTag string,
+	// grafana/grafana image tag.
 	// +default="12.0.0"
-	tag string,
+	grafanaTag string,
 ) error {
 	jobs := parallel.New().
 		WithRollupLogs(true).
 		WithRollupSpans(true)
 
-	jobs = jobs.WithJob("LokiAcceptsOtlpLogs", t.LokiAcceptsOtlpLogs)
-	jobs = jobs.WithJob("TempoAcceptsOtlpTraces", t.TempoAcceptsOtlpTraces)
-	jobs = jobs.WithJob("MimirAcceptsOtlpMetrics", t.MimirAcceptsOtlpMetrics)
+	jobs = jobs.WithJob("LokiAcceptsOtlpLogs", func(ctx context.Context) error {
+		return t.LokiAcceptsOtlpLogs(ctx, lokiTag)
+	})
+	jobs = jobs.WithJob("TempoAcceptsOtlpTraces", func(ctx context.Context) error {
+		return t.TempoAcceptsOtlpTraces(ctx, tempoTag)
+	})
+	jobs = jobs.WithJob("MimirAcceptsOtlpMetrics", func(ctx context.Context) error {
+		return t.MimirAcceptsOtlpMetrics(ctx, mimirTag)
+	})
 	jobs = jobs.WithJob("GrafanaProxiesLokiQuery", func(ctx context.Context) error {
-		return t.GrafanaProxiesLokiQuery(ctx, tag)
+		return t.GrafanaProxiesLokiQuery(ctx, lokiTag, grafanaTag)
 	})
 
 	return jobs.Run(ctx)
@@ -77,13 +94,17 @@ func randomIDPair(n int) (hexEnc, b64Enc string, err error) {
 // the OTLP/HTTP receiver carrying a unique marker UUID, then queries Loki
 // LogQL until the marker reappears in the query response. Verifies the
 // default config wires up the OTLP HTTP ingester end-to-end.
-func (t *Tests) LokiAcceptsOtlpLogs(ctx context.Context) error {
+func (t *Tests) LokiAcceptsOtlpLogs(
+	ctx context.Context,
+	// +default="3.4.1"
+	tag string,
+) error {
 	marker, err := dag.Random().UUIDV4(ctx)
 	if err != nil {
 		return fmt.Errorf("generate marker: %w", err)
 	}
 
-	loki := dag.GrafanaStack().Loki()
+	loki := dag.GrafanaStack().Loki(dagger.GrafanaStackLokiOpts{Tag: tag})
 
 	script := `set -eu
 # Wait for Loki to become ready. /ready returns 503 during warmup
@@ -212,7 +233,11 @@ exit 1
 // /api/traces/<trace_id> until Tempo returns the trace. Verifies the
 // default config wires up the OTLP HTTP receiver and the local trace
 // store end-to-end.
-func (t *Tests) TempoAcceptsOtlpTraces(ctx context.Context) error {
+func (t *Tests) TempoAcceptsOtlpTraces(
+	ctx context.Context,
+	// +default="2.7.1"
+	tag string,
+) error {
 	traceIDHex, err := randomHex(16)
 	if err != nil {
 		return fmt.Errorf("generate trace id: %w", err)
@@ -222,7 +247,7 @@ func (t *Tests) TempoAcceptsOtlpTraces(ctx context.Context) error {
 		return fmt.Errorf("generate span id: %w", err)
 	}
 
-	tempo := dag.GrafanaStack().Tempo()
+	tempo := dag.GrafanaStack().Tempo(dagger.GrafanaStackTempoOpts{Tag: tag})
 
 	script := `set -eu
 # Wait for Tempo to become ready. Tempo takes a moment to bring up
@@ -345,7 +370,11 @@ exit 1
 // queries Mimir's Prometheus-compatible API until that metric appears.
 // Verifies the default config wires up the OTLP HTTP ingester and the
 // filesystem block store end-to-end.
-func (t *Tests) MimirAcceptsOtlpMetrics(ctx context.Context) error {
+func (t *Tests) MimirAcceptsOtlpMetrics(
+	ctx context.Context,
+	// +default="2.15.1"
+	tag string,
+) error {
 	suffix, err := randomHex(8)
 	if err != nil {
 		return fmt.Errorf("generate metric suffix: %w", err)
@@ -354,7 +383,7 @@ func (t *Tests) MimirAcceptsOtlpMetrics(ctx context.Context) error {
 	// suffix gives us a unique series per test run.
 	metricName := "grafana_stack_test_marker_" + suffix
 
-	mimir := dag.GrafanaStack().Mimir()
+	mimir := dag.GrafanaStack().Mimir(dagger.GrafanaStackMimirOpts{Tag: tag})
 
 	script := `set -eu
 READY_TIMEOUT=120
@@ -477,12 +506,14 @@ exit 1
 // mounting, datasources.yaml provisioning, the in-network service
 // binding hostname, and Grafana's proxy plumbing all work end-to-end.
 //
-// tag overrides the grafana/grafana image tag at the CLI; defaults to
-// the parent module's pinned default.
+// lokiTag and grafanaTag override their respective image tags at the
+// CLI; both default to the parent module's pinned defaults.
 func (t *Tests) GrafanaProxiesLokiQuery(
 	ctx context.Context,
+	// +default="3.4.1"
+	lokiTag string,
 	// +default="12.0.0"
-	tag string,
+	grafanaTag string,
 ) error {
 	pwd, err := randomHex(32)
 	if err != nil {
@@ -495,9 +526,9 @@ func (t *Tests) GrafanaProxiesLokiQuery(
 		return fmt.Errorf("generate marker: %w", err)
 	}
 
-	loki := dag.GrafanaStack().Loki()
+	loki := dag.GrafanaStack().Loki(dagger.GrafanaStackLokiOpts{Tag: lokiTag})
 	grafana := dag.GrafanaStack().
-		Grafana(adminPassword, dagger.GrafanaStackGrafanaOpts{Tag: tag}).
+		Grafana(adminPassword, dagger.GrafanaStackGrafanaOpts{Tag: grafanaTag}).
 		WithLokiDatasource("loki", loki)
 
 	script := `set -eu

--- a/daggerverse/grafana-stack/tests/main.go
+++ b/daggerverse/grafana-stack/tests/main.go
@@ -9,6 +9,8 @@ import (
 	"encoding/hex"
 	"fmt"
 
+	"dagger/tests/internal/dagger"
+
 	"github.com/dagger/dagger/util/parallel"
 )
 
@@ -18,9 +20,22 @@ type Tests struct{}
 
 // All runs every grafana-stack round-trip test in parallel.
 //
+// tag is forwarded to GrafanaProxiesLokiQuery so callers can qualify a
+// new Grafana image at the CLI without editing any module:
+//
+//	dagger -m daggerverse/grafana-stack/tests call all --tag=12.1.0
+//
+// The default matches the parent module's `Grafana(...)` default so the
+// bare `call all` keeps working.
+//
 // +check
 // +cache="session"
-func (t *Tests) All(ctx context.Context) error {
+func (t *Tests) All(
+	ctx context.Context,
+	// Grafana image tag to test.
+	// +default="12.0.0"
+	tag string,
+) error {
 	jobs := parallel.New().
 		WithRollupLogs(true).
 		WithRollupSpans(true)
@@ -28,6 +43,9 @@ func (t *Tests) All(ctx context.Context) error {
 	jobs = jobs.WithJob("LokiAcceptsOtlpLogs", t.LokiAcceptsOtlpLogs)
 	jobs = jobs.WithJob("TempoAcceptsOtlpTraces", t.TempoAcceptsOtlpTraces)
 	jobs = jobs.WithJob("MimirAcceptsOtlpMetrics", t.MimirAcceptsOtlpMetrics)
+	jobs = jobs.WithJob("GrafanaProxiesLokiQuery", func(ctx context.Context) error {
+		return t.GrafanaProxiesLokiQuery(ctx, tag)
+	})
 
 	return jobs.Run(ctx)
 }
@@ -445,6 +463,175 @@ exit 1
 		Stdout(ctx)
 	if err != nil {
 		return fmt.Errorf("mimir round-trip: %w", err)
+	}
+	_ = out
+	return nil
+}
+
+// GrafanaProxiesLokiQuery starts a Loki backend and a Grafana UI wired
+// to it via WithLokiDatasource, posts a single OTLP log carrying a
+// unique marker UUID directly to Loki, then issues an authenticated
+// LogQL query *through* Grafana's datasource proxy
+// (/api/datasources/proxy/uid/<name>/loki/api/v1/query_range) until the
+// marker reappears in the response. Verifies admin-password file
+// mounting, datasources.yaml provisioning, the in-network service
+// binding hostname, and Grafana's proxy plumbing all work end-to-end.
+//
+// tag overrides the grafana/grafana image tag at the CLI; defaults to
+// the parent module's pinned default.
+func (t *Tests) GrafanaProxiesLokiQuery(
+	ctx context.Context,
+	// +default="12.0.0"
+	tag string,
+) error {
+	pwd, err := randomHex(32)
+	if err != nil {
+		return fmt.Errorf("generate admin password: %w", err)
+	}
+	adminPassword := dag.SetSecret("grafana-admin-password", pwd)
+
+	marker, err := dag.Random().UUIDV4(ctx)
+	if err != nil {
+		return fmt.Errorf("generate marker: %w", err)
+	}
+
+	loki := dag.GrafanaStack().Loki()
+	grafana := dag.GrafanaStack().
+		Grafana(adminPassword, dagger.GrafanaStackGrafanaOpts{Tag: tag}).
+		WithLokiDatasource("loki", loki)
+
+	script := `set -eu
+# Wait for Loki and Grafana to become ready in turn. Loki readiness is
+# the same shape as in LokiAcceptsOtlpLogs; Grafana exposes /api/health
+# which returns {"database":"ok",...} once the DB is up.
+READY_TIMEOUT=120
+ATTEMPT=0
+while [ "${ATTEMPT}" -lt "${READY_TIMEOUT}" ]; do
+  if curl -fsS http://loki:3100/ready >/dev/null 2>&1; then
+    echo "loki ready after ${ATTEMPT}s"
+    break
+  fi
+  ATTEMPT=$((ATTEMPT + 1))
+  sleep 1
+done
+if [ "${ATTEMPT}" -ge "${READY_TIMEOUT}" ]; then
+  echo "loki not ready after ${READY_TIMEOUT}s" >&2
+  exit 1
+fi
+
+ATTEMPT=0
+while [ "${ATTEMPT}" -lt "${READY_TIMEOUT}" ]; do
+  HEALTH=$(curl -fsS http://grafana:3000/api/health || true)
+  case "${HEALTH}" in
+    *'"database": "ok"'*|*'"database":"ok"'*)
+      echo "grafana ready after ${ATTEMPT}s"
+      break
+      ;;
+  esac
+  ATTEMPT=$((ATTEMPT + 1))
+  sleep 1
+done
+if [ "${ATTEMPT}" -ge "${READY_TIMEOUT}" ]; then
+  echo "grafana not ready after ${READY_TIMEOUT}s" >&2
+  echo "last /api/health: ${HEALTH}" >&2
+  exit 1
+fi
+
+NS_NANOS="$(date +%s)000000000"
+PAYLOAD=$(cat <<EOF
+{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          {"key": "service.name", "value": {"stringValue": "grafana-stack-test"}}
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {"name": "grafana-stack-tests"},
+          "logRecords": [
+            {
+              "timeUnixNano": "${NS_NANOS}",
+              "severityNumber": 9,
+              "severityText": "INFO",
+              "body": {"stringValue": "${MARKER}"}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+EOF
+)
+
+ATTEMPT=0
+while [ "${ATTEMPT}" -lt 60 ]; do
+  HTTP_CODE=$(curl -sS -o /tmp/post.out -w '%{http_code}' \
+    -X POST -H 'content-type: application/json' \
+    --data "${PAYLOAD}" \
+    http://loki:3100/otlp/v1/logs || echo 000)
+  if [ "${HTTP_CODE}" = "200" ] || [ "${HTTP_CODE}" = "204" ]; then
+    echo "loki accepted OTLP push (HTTP ${HTTP_CODE}) after ${ATTEMPT}s"
+    break
+  fi
+  ATTEMPT=$((ATTEMPT + 1))
+  sleep 1
+done
+if [ "${ATTEMPT}" -ge 60 ]; then
+  echo "loki rejected OTLP push for 60s; last HTTP=${HTTP_CODE}" >&2
+  cat /tmp/post.out >&2 || true
+  exit 1
+fi
+
+# Allow the entry to land in the queriers before we ask Grafana to
+# proxy a LogQL request to Loki.
+sleep 2
+
+QUERY='{service_name="grafana-stack-test"}'
+NOW_SECONDS=$(date +%s)
+END_NANOS="${NOW_SECONDS}000000000"
+START_SECONDS=$((NOW_SECONDS - 600))
+START_NANOS="${START_SECONDS}000000000"
+
+ATTEMPT=0
+while [ "${ATTEMPT}" -lt 30 ]; do
+  HTTP_CODE=$(curl -sS -o /tmp/get.out -w '%{http_code}' --get \
+    -u "admin:${GRAFANA_PASSWORD}" \
+    --data-urlencode "query=${QUERY}" \
+    --data-urlencode "start=${START_NANOS}" \
+    --data-urlencode "end=${END_NANOS}" \
+    --data-urlencode 'limit=100' \
+    'http://grafana:3000/api/datasources/proxy/uid/loki/loki/api/v1/query_range' \
+    || echo 000)
+  if [ "${HTTP_CODE}" = "200" ]; then
+    case "$(cat /tmp/get.out)" in
+      *"${MARKER}"*)
+        echo "marker observed via grafana datasource proxy"
+        exit 0
+        ;;
+    esac
+  fi
+  ATTEMPT=$((ATTEMPT + 1))
+  sleep 1
+done
+
+echo "marker ${MARKER} never appeared via grafana proxy" >&2
+echo "last HTTP=${HTTP_CODE} body:" >&2
+cat /tmp/get.out >&2 || true
+exit 1
+`
+
+	out, err := dag.Container().From(curlImage).
+		WithServiceBinding("loki", loki.Service()).
+		WithServiceBinding("grafana", grafana.Service()).
+		WithEnvVariable("MARKER", marker).
+		WithEnvVariable("GRAFANA_PASSWORD", pwd).
+		WithExec([]string{"sh", "-c", script}).
+		Stdout(ctx)
+	if err != nil {
+		return fmt.Errorf("grafana proxy round-trip: %w", err)
 	}
 	_ = out
 	return nil


### PR DESCRIPTION
## Summary

- Adds a `Grafana` type to the `grafana-stack` daggerverse module with file-based datasource (`WithLokiDatasource`/`WithTempoDatasource`/`WithMimirDatasource`) and dashboard (`WithDashboard`/`WithDashboards`) provisioning. Each `WithX` returns a new `*Grafana`; the accumulated state is rendered into `/etc/grafana/provisioning/...` at `Service()` time.
- Admin password is taken as `*dagger.Secret`, mounted via `WithMountedSecret`, and read by Grafana through `GF_SECURITY_ADMIN_PASSWORD__FILE` so plaintext never enters generated bindings.
- New `GrafanaProxiesLokiQuery` round-trip test posts an OTLP log to Loki and then runs an authenticated LogQL query *through* Grafana's `/api/datasources/proxy/uid/loki/...`. Both `all` and `grafana-proxies-loki-query` accept a `--tag` flag (default `12.0.0`) so new Grafana releases can be qualified at the CLI without editing any module.

Closes #14.

## Test plan

- [x] `dagger -m daggerverse/grafana-stack functions` lists `grafana` alongside the existing backends
- [x] `dagger -m daggerverse/grafana-stack/tests functions` lists `grafana-proxies-loki-query`
- [x] `dagger -m daggerverse/grafana-stack/tests call grafana-proxies-loki-query` passes (~46s)
- [x] `dagger -m daggerverse/grafana-stack/tests call all` passes all four jobs in parallel (~22s)
- [ ] Reviewer: optionally re-run with `--tag=12.1.0` (or any newer Grafana release) to confirm the tag override works

🤖 Generated with [Claude Code](https://claude.com/claude-code)