### PR TITLE
story(issue-17): align kafka cluster defaults with apache/kafka isolated example

### DIFF
--- a/ci/main.go
+++ b/ci/main.go
@@ -21,7 +21,9 @@ func (c *Ci) Test(ctx context.Context) error {
 	jobs = jobs.WithJob("crypto", dag.CryptoTests().All)
 	jobs = jobs.WithJob("certificate-management", dag.CertificateManagementTests().All)
 	jobs = jobs.WithJob("grafana-stack", dag.GrafanaStackTests().All)
-	jobs = jobs.WithJob("kafka", dag.KafkaTests().All)
+	jobs = jobs.WithJob("kafka", func(ctx context.Context) error {
+		return dag.KafkaTests().All(ctx)
+	})
 
 	return jobs.Run(ctx)
 }

--- a/daggerverse/kafka/README.md
+++ b/daggerverse/kafka/README.md
@@ -74,6 +74,7 @@ err := client.Produce(ctx, "my-topic", "k", "v", dagger.KafkaClientProduceOpts{
 records, err := client.Consume(ctx, "my-topic", dagger.KafkaClientConsumeOpts{
     MaxMessages: 10, Timeout: "10s",
     KeyEncoding: "raw", ValueEncoding: "raw",
+    Group: "", // group-less direct consume; pass "my-group" to consume as a group member
 })
 
 // java client.properties for the apache kafka CLI tools
@@ -82,6 +83,9 @@ props := client.PropertiesFile() // *dagger.File
 
 `keyEncoding` / `valueEncoding` accept `"raw"` (literal UTF-8 bytes),
 `"hex"`, or `"base64"` (standard padding). Anything else is rejected.
+
+Topic auto-creation is disabled on the broker — call `CreateTopic` before
+`Produce` / `Consume`.
 
 ## Image source
 

--- a/daggerverse/kafka/main.go
+++ b/daggerverse/kafka/main.go
@@ -129,9 +129,9 @@ func (k *Kafka) Cluster(
 		WithEnvVariable("KAFKA_PROCESS_ROLES", "controller").
 		WithEnvVariable("KAFKA_LISTENERS", "CONTROLLER://0.0.0.0:9093").
 		WithEnvVariable("KAFKA_CONTROLLER_LISTENER_NAMES", "CONTROLLER").
-		WithEnvVariable("KAFKA_LISTENER_SECURITY_PROTOCOL_MAP", "CONTROLLER:PLAINTEXT,INTERNAL:PLAINTEXT").
+		WithEnvVariable("KAFKA_LISTENER_SECURITY_PROTOCOL_MAP", "CONTROLLER:PLAINTEXT").
 		WithEnvVariable("KAFKA_CONTROLLER_QUORUM_VOTERS", quorumVoters).
-		WithEnvVariable("KAFKA_CLUSTER_ID", clusterId).
+		WithEnvVariable("CLUSTER_ID", clusterId).
 		WithExposedPort(9093)
 	ctrlSvc := ctrlCtr.AsService(dagger.ContainerAsServiceOpts{UseEntrypoint: true})
 
@@ -144,16 +144,25 @@ func (k *Kafka) Cluster(
 			WithServiceBinding(controllerAlias, ctrlSvc).
 			WithEnvVariable("KAFKA_NODE_ID", fmt.Sprintf("%d", nodeID)).
 			WithEnvVariable("KAFKA_PROCESS_ROLES", "broker").
-			WithEnvVariable("KAFKA_LISTENERS", "INTERNAL://0.0.0.0:9092").
-			WithEnvVariable("KAFKA_INTER_BROKER_LISTENER_NAME", "INTERNAL").
+			WithEnvVariable("KAFKA_LISTENERS", "PLAINTEXT://0.0.0.0:19092,PLAINTEXT_HOST://0.0.0.0:9092").
+			WithEnvVariable("KAFKA_INTER_BROKER_LISTENER_NAME", "PLAINTEXT").
 			WithEnvVariable("KAFKA_CONTROLLER_LISTENER_NAMES", "CONTROLLER").
-			WithEnvVariable("KAFKA_LISTENER_SECURITY_PROTOCOL_MAP", "CONTROLLER:PLAINTEXT,INTERNAL:PLAINTEXT").
+			WithEnvVariable("KAFKA_LISTENER_SECURITY_PROTOCOL_MAP", "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT").
 			WithEnvVariable("KAFKA_CONTROLLER_QUORUM_VOTERS", quorumVoters).
-			WithEnvVariable("KAFKA_CLUSTER_ID", clusterId).
+			WithEnvVariable("CLUSTER_ID", clusterId).
+			WithEnvVariable("KAFKA_LOG_DIRS", "/tmp/kraft-combined-logs").
+			WithEnvVariable("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false").
+			WithEnvVariable("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", "1").
+			WithEnvVariable("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", "1").
+			WithEnvVariable("KAFKA_TRANSACTION_STATE_LOG_MIN_ISR", "1").
+			WithEnvVariable("KAFKA_SHARE_COORDINATOR_STATE_TOPIC_REPLICATION_FACTOR", "1").
+			WithEnvVariable("KAFKA_SHARE_COORDINATOR_STATE_TOPIC_MIN_ISR", "1").
+			WithEnvVariable("KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS", "0").
 			WithExposedPort(9092).
+			WithExposedPort(19092).
 			WithEntrypoint([]string{"sh", "-c"}).
 			WithDefaultArgs([]string{
-				`export KAFKA_ADVERTISED_LISTENERS="INTERNAL://$(hostname):9092" && exec /etc/kafka/docker/run`,
+				`export KAFKA_ADVERTISED_LISTENERS="PLAINTEXT://$(hostname):19092,PLAINTEXT_HOST://$(hostname):9092" && exec /etc/kafka/docker/run`,
 			})
 
 		svc := brkCtr.AsService(dagger.ContainerAsServiceOpts{UseEntrypoint: true})
@@ -436,6 +445,12 @@ func (c *Client) Produce(
 // the parsed timeout elapses. Each record's key and value are encoded into
 // the requested string forms before being returned.
 //
+// When group is non-empty, the consume runs as a member of that consumer
+// group: the broker assigns partitions and the join itself writes group
+// metadata to __consumer_offsets (offsets are not committed — the function
+// stays idempotent under +cache="never"). When group is empty (the
+// default), partitions are consumed directly with no group state.
+//
 // +cache="never"
 func (c *Client) Consume(
 	ctx context.Context,
@@ -448,6 +463,8 @@ func (c *Client) Consume(
 	keyEncoding string,
 	// +default="raw"
 	valueEncoding string,
+	// +default=""
+	group string,
 ) ([]ConsumedRecord, error) {
 	if maxMessages <= 0 {
 		return nil, fmt.Errorf("maxMessages must be > 0, got %d", maxMessages)
@@ -460,10 +477,20 @@ func (c *Client) Consume(
 		return nil, fmt.Errorf("timeout must be > 0, got %s", d)
 	}
 
-	cl, err := c.newKgoClient(
+	opts := []kgo.Opt{
 		kgo.ConsumeTopics(topic),
 		kgo.ConsumeResetOffset(kgo.NewOffset().AtStart()),
-	)
+	}
+	if group != "" {
+		// DisableAutoCommit keeps Consume idempotent under
+		// +cache="never": re-runs triggered by lazy record loading
+		// always re-read from the start instead of resuming past a
+		// committed offset. The group join itself still exercises
+		// __consumer_offsets, which is what proves the system-topic
+		// replication-factor defaults are correct.
+		opts = append(opts, kgo.ConsumerGroup(group), kgo.DisableAutoCommit())
+	}
+	cl, err := c.newKgoClient(opts...)
 	if err != nil {
 		return nil, fmt.Errorf("new kafka client: %w", err)
 	}

--- a/daggerverse/kafka/main.go
+++ b/daggerverse/kafka/main.go
@@ -91,6 +91,7 @@ func (k *Kafka) Cluster(
 	brokers int,
 	// +default="docker.io"
 	registry string,
+	// +default="4.2.0"
 	tag string,
 	clientListenerSecurity *ServerSecurity,
 ) (*Cluster, error) {

--- a/daggerverse/kafka/tests/main.go
+++ b/daggerverse/kafka/tests/main.go
@@ -75,10 +75,12 @@ func (t *Tests) All(ctx context.Context) error {
 	jobs = jobs.WithJob("ProduceConsumeRoundTripBase64", t.ProduceConsumeRoundTripBase64)
 	jobs = jobs.WithJob("ProduceRejectsUnknownEncoding", t.ProduceRejectsUnknownEncoding)
 	jobs = jobs.WithJob("PropertiesFileContainsBootstrapAndSecurityProtocol", t.PropertiesFileContainsBootstrapAndSecurityProtocol)
-	jobs = jobs.WithJob("BindBrokersExposesBrokersToCallerContainer", t.BindBrokersExposesBrokersToCallerContainer)
+	jobs = jobs.WithJob("BindBrokersExposesBothListeners", t.BindBrokersExposesBothListeners)
 	jobs = jobs.WithJob("DedicatedControllerAndBrokerProduceConsume", t.DedicatedControllerAndBrokerProduceConsume)
 	jobs = jobs.WithJob("OneControllerTwoBrokersReplicationFactorTwo", t.OneControllerTwoBrokersReplicationFactorTwo)
 	jobs = jobs.WithJob("MultiControllerIsRejected", t.MultiControllerIsRejected)
+	jobs = jobs.WithJob("AutoCreateTopicsDisabled", t.AutoCreateTopicsDisabled)
+	jobs = jobs.WithJob("ConsumerGroupOnSingleBrokerWorks", t.ConsumerGroupOnSingleBrokerWorks)
 
 	return jobs.Run(ctx)
 }
@@ -431,11 +433,12 @@ func (t *Tests) DedicatedControllerAndBrokerProduceConsume(ctx context.Context) 
 	return roundTripBinary(ctx, "raw", "k", "v")
 }
 
-// BindBrokersExposesBrokersToCallerContainer binds the cluster's brokers
-// into a vanilla alpine container and asserts that the broker hostname
-// resolves and its client-facing port is reachable from inside that
-// container — the integration the BindBrokers contract promises.
-func (t *Tests) BindBrokersExposesBrokersToCallerContainer(ctx context.Context) error {
+// BindBrokersExposesBothListeners binds the cluster's brokers into a
+// vanilla alpine container and asserts that both the host-facing client
+// port (9092) and the inter-broker port (19092) are reachable from inside
+// that container — together they cover the dual-listener contract
+// (PLAINTEXT_HOST:9092 for clients, PLAINTEXT:19092 for inter-broker).
+func (t *Tests) BindBrokersExposesBothListeners(ctx context.Context) error {
 	cluster, err := freshCluster(ctx)
 	if err != nil {
 		return fmt.Errorf("create cluster: %w", err)
@@ -454,6 +457,7 @@ func (t *Tests) BindBrokersExposesBrokersToCallerContainer(ctx context.Context) 
 
 	out, err := cluster.BindBrokers(dag.Container().From("alpine:3.22")).
 		WithExec([]string{"nc", "-z", "-w", "5", host, port}).
+		WithExec([]string{"nc", "-z", "-w", "5", host, "19092"}).
 		WithExec([]string{"echo", "OK"}).
 		Stdout(ctx)
 	if err != nil {
@@ -461,6 +465,99 @@ func (t *Tests) BindBrokersExposesBrokersToCallerContainer(ctx context.Context) 
 	}
 	if !strings.Contains(out, "OK") {
 		return fmt.Errorf("expected OK from nc, got: %q", out)
+	}
+	return nil
+}
+
+// AutoCreateTopicsDisabled produces to a topic that was never created and
+// asserts the call errors out. With KAFKA_AUTO_CREATE_TOPICS_ENABLE=false on
+// the broker, the produce path must surface a topic-not-found error rather
+// than silently auto-creating, so producer typos can't pass tests.
+func (t *Tests) AutoCreateTopicsDisabled(ctx context.Context) error {
+	cluster, err := freshCluster(ctx)
+	if err != nil {
+		return fmt.Errorf("create cluster: %w", err)
+	}
+	client := cluster.Client(dag.Kafka().PlaintextClientSecurity())
+
+	topic, err := randomTopicName(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = client.Produce(ctx, topic, "k", "v", dagger.KafkaClientProduceOpts{
+		KeyEncoding:   "raw",
+		ValueEncoding: "raw",
+	})
+	if err == nil {
+		return fmt.Errorf("expected Produce to non-existent topic %q to fail, got nil error", topic)
+	}
+	return nil
+}
+
+// ConsumerGroupOnSingleBrokerWorks produces one record then consumes it back
+// through a consumer group on a 1-broker cluster. A successful round-trip
+// proves __consumer_offsets was created at the broker's configured
+// replication factor (1, after the system-topic env vars take effect).
+// Without KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1 the broker would refuse
+// to create __consumer_offsets at the upstream default RF=3 and the group
+// join would hang or error.
+func (t *Tests) ConsumerGroupOnSingleBrokerWorks(ctx context.Context) error {
+	cluster, err := freshCluster(ctx)
+	if err != nil {
+		return fmt.Errorf("create cluster: %w", err)
+	}
+	client := cluster.Client(dag.Kafka().PlaintextClientSecurity())
+
+	topic, err := randomTopicName(ctx)
+	if err != nil {
+		return err
+	}
+	if err := client.CreateTopic(ctx, topic, dagger.KafkaClientCreateTopicOpts{
+		Partitions:        1,
+		ReplicationFactor: 1,
+	}); err != nil {
+		return fmt.Errorf("create topic %q: %w", topic, err)
+	}
+
+	const wantKey, wantVal = "k", "v"
+	if err := client.Produce(ctx, topic, wantKey, wantVal, dagger.KafkaClientProduceOpts{
+		KeyEncoding:   "raw",
+		ValueEncoding: "raw",
+	}); err != nil {
+		return fmt.Errorf("produce: %w", err)
+	}
+
+	group, err := randomTopicName(ctx)
+	if err != nil {
+		return err
+	}
+	records, err := client.Consume(ctx, topic, dagger.KafkaClientConsumeOpts{
+		MaxMessages:   1,
+		Timeout:       "20s",
+		KeyEncoding:   "raw",
+		ValueEncoding: "raw",
+		Group:         group,
+	})
+	if err != nil {
+		return fmt.Errorf("consume with group: %w", err)
+	}
+	if len(records) != 1 {
+		return fmt.Errorf("expected 1 record, got %d", len(records))
+	}
+	gotKey, err := records[0].Key(ctx)
+	if err != nil {
+		return fmt.Errorf("read key: %w", err)
+	}
+	gotVal, err := records[0].Value(ctx)
+	if err != nil {
+		return fmt.Errorf("read value: %w", err)
+	}
+	if gotKey != wantKey {
+		return fmt.Errorf("key mismatch: want %q, got %q", wantKey, gotKey)
+	}
+	if gotVal != wantVal {
+		return fmt.Errorf("value mismatch: want %q, got %q", wantVal, gotVal)
 	}
 	return nil
 }

--- a/daggerverse/kafka/tests/main.go
+++ b/daggerverse/kafka/tests/main.go
@@ -15,11 +15,6 @@ import (
 	"github.com/dagger/dagger/util/parallel"
 )
 
-// kafkaImageTag is the apache/kafka-native tag the test suite spins up. Pin it
-// here so increments don't drift; bump deliberately when adopting a newer
-// Kafka release.
-const kafkaImageTag = "4.2.0"
-
 // newClusterId mints a fresh KRaft-shaped cluster ID — 16 random bytes
 // rendered as 22 unpadded base64-url characters — by feeding random bytes
 // from the random module through the standard library.
@@ -43,13 +38,15 @@ func newClusterId(ctx context.Context) (string, error) {
 // container — for use by every cluster-touching test. The returned
 // KafkaCluster is a lazy chain; the server-side Cluster constructor runs
 // only when a leaf op (e.g. BootstrapServers) resolves.
-func freshCluster(ctx context.Context) (*dagger.KafkaCluster, error) {
+func freshCluster(ctx context.Context, kafkaImageTag string) (*dagger.KafkaCluster, error) {
 	clusterId, err := newClusterId(ctx)
 	if err != nil {
 		return nil, err
 	}
 	k := dag.Kafka()
-	return k.Cluster(clusterId, kafkaImageTag, k.PlaintextServerSecurity()), nil
+	return k.Cluster(clusterId, k.PlaintextServerSecurity(), dagger.KafkaClusterOpts{
+		Tag: kafkaImageTag,
+	}), nil
 }
 
 type Tests struct{}
@@ -58,29 +55,66 @@ type Tests struct{}
 // the engine doesn't have dozens of cluster containers (controller +
 // brokers per test) in flight at once on smaller CI runners.
 //
+// kafkaImageTag picks the apache/kafka-native tag every spawned cluster
+// runs against, so callers can verify the module against a newer Kafka
+// release without first changing main.go. The default matches the
+// Cluster constructor's own default.
+//
 // +check
 // +cache="session"
-func (t *Tests) All(ctx context.Context) error {
+func (t *Tests) All(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
 	jobs := parallel.New().
 		WithLimit(2).
 		WithRollupLogs(true).
 		WithRollupSpans(true)
 
 	jobs = jobs.WithJob("PlaintextSecurityProfilesAreNonNil", t.PlaintextSecurityProfilesAreNonNil)
-	jobs = jobs.WithJob("SingleNodeClusterStarts", t.SingleNodeClusterStarts)
-	jobs = jobs.WithJob("ClusterClientCanListTopicsOnFreshCluster", t.ClusterClientCanListTopicsOnFreshCluster)
-	jobs = jobs.WithJob("CreateAndDeleteTopicRoundTrip", t.CreateAndDeleteTopicRoundTrip)
-	jobs = jobs.WithJob("ProduceConsumeRoundTripRaw", t.ProduceConsumeRoundTripRaw)
-	jobs = jobs.WithJob("ProduceConsumeRoundTripHex", t.ProduceConsumeRoundTripHex)
-	jobs = jobs.WithJob("ProduceConsumeRoundTripBase64", t.ProduceConsumeRoundTripBase64)
-	jobs = jobs.WithJob("ProduceRejectsUnknownEncoding", t.ProduceRejectsUnknownEncoding)
-	jobs = jobs.WithJob("PropertiesFileContainsBootstrapAndSecurityProtocol", t.PropertiesFileContainsBootstrapAndSecurityProtocol)
-	jobs = jobs.WithJob("BindBrokersExposesBothListeners", t.BindBrokersExposesBothListeners)
-	jobs = jobs.WithJob("DedicatedControllerAndBrokerProduceConsume", t.DedicatedControllerAndBrokerProduceConsume)
-	jobs = jobs.WithJob("OneControllerTwoBrokersReplicationFactorTwo", t.OneControllerTwoBrokersReplicationFactorTwo)
-	jobs = jobs.WithJob("MultiControllerIsRejected", t.MultiControllerIsRejected)
-	jobs = jobs.WithJob("AutoCreateTopicsDisabled", t.AutoCreateTopicsDisabled)
-	jobs = jobs.WithJob("ConsumerGroupOnSingleBrokerWorks", t.ConsumerGroupOnSingleBrokerWorks)
+	jobs = jobs.WithJob("SingleNodeClusterStarts", func(ctx context.Context) error {
+		return t.SingleNodeClusterStarts(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("ClusterClientCanListTopicsOnFreshCluster", func(ctx context.Context) error {
+		return t.ClusterClientCanListTopicsOnFreshCluster(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("CreateAndDeleteTopicRoundTrip", func(ctx context.Context) error {
+		return t.CreateAndDeleteTopicRoundTrip(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("ProduceConsumeRoundTripRaw", func(ctx context.Context) error {
+		return t.ProduceConsumeRoundTripRaw(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("ProduceConsumeRoundTripHex", func(ctx context.Context) error {
+		return t.ProduceConsumeRoundTripHex(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("ProduceConsumeRoundTripBase64", func(ctx context.Context) error {
+		return t.ProduceConsumeRoundTripBase64(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("ProduceRejectsUnknownEncoding", func(ctx context.Context) error {
+		return t.ProduceRejectsUnknownEncoding(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("PropertiesFileContainsBootstrapAndSecurityProtocol", func(ctx context.Context) error {
+		return t.PropertiesFileContainsBootstrapAndSecurityProtocol(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("BindBrokersExposesBothListeners", func(ctx context.Context) error {
+		return t.BindBrokersExposesBothListeners(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("DedicatedControllerAndBrokerProduceConsume", func(ctx context.Context) error {
+		return t.DedicatedControllerAndBrokerProduceConsume(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("OneControllerTwoBrokersReplicationFactorTwo", func(ctx context.Context) error {
+		return t.OneControllerTwoBrokersReplicationFactorTwo(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("MultiControllerIsRejected", func(ctx context.Context) error {
+		return t.MultiControllerIsRejected(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("AutoCreateTopicsDisabled", func(ctx context.Context) error {
+		return t.AutoCreateTopicsDisabled(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("ConsumerGroupOnSingleBrokerWorks", func(ctx context.Context) error {
+		return t.ConsumerGroupOnSingleBrokerWorks(ctx, kafkaImageTag)
+	})
 
 	return jobs.Run(ctx)
 }
@@ -124,8 +158,12 @@ func (t *Tests) PlaintextSecurityProfilesAreNonNil(ctx context.Context) error {
 // to run by resolving BootstrapServers, asserting only that the broker
 // hostname is non-empty. End-to-end reachability is covered by sibling
 // tests that exercise ListTopics / produce / consume.
-func (t *Tests) SingleNodeClusterStarts(ctx context.Context) error {
-	cluster, err := freshCluster(ctx)
+func (t *Tests) SingleNodeClusterStarts(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, err := freshCluster(ctx, kafkaImageTag)
 	if err != nil {
 		return fmt.Errorf("create cluster: %w", err)
 	}
@@ -149,8 +187,12 @@ func (t *Tests) SingleNodeClusterStarts(ctx context.Context) error {
 // A fresh KRaft cluster has no user topics, so the result may be empty —
 // but the call itself must succeed, which proves module-runtime networking
 // can reach the started broker service.
-func (t *Tests) ClusterClientCanListTopicsOnFreshCluster(ctx context.Context) error {
-	cluster, err := freshCluster(ctx)
+func (t *Tests) ClusterClientCanListTopicsOnFreshCluster(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, err := freshCluster(ctx, kafkaImageTag)
 	if err != nil {
 		return fmt.Errorf("create cluster: %w", err)
 	}
@@ -168,8 +210,12 @@ func (t *Tests) ClusterClientCanListTopicsOnFreshCluster(ctx context.Context) er
 // CreateAndDeleteTopicRoundTrip exercises the create/list/delete cycle to
 // confirm kadm wiring. The topic name is randomized so the test is
 // repeatable against the same cluster and never collides with leftovers.
-func (t *Tests) CreateAndDeleteTopicRoundTrip(ctx context.Context) error {
-	cluster, err := freshCluster(ctx)
+func (t *Tests) CreateAndDeleteTopicRoundTrip(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, err := freshCluster(ctx, kafkaImageTag)
 	if err != nil {
 		return fmt.Errorf("create cluster: %w", err)
 	}
@@ -213,8 +259,12 @@ func (t *Tests) CreateAndDeleteTopicRoundTrip(ctx context.Context) error {
 // and value, then consumes it back and asserts byte equality. The raw
 // encoding round-trips Go strings verbatim, so the assertion is direct
 // string equality.
-func (t *Tests) ProduceConsumeRoundTripRaw(ctx context.Context) error {
-	cluster, err := freshCluster(ctx)
+func (t *Tests) ProduceConsumeRoundTripRaw(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, err := freshCluster(ctx, kafkaImageTag)
 	if err != nil {
 		return fmt.Errorf("create cluster: %w", err)
 	}
@@ -271,20 +321,32 @@ func (t *Tests) ProduceConsumeRoundTripRaw(ctx context.Context) error {
 // ProduceConsumeRoundTripHex round-trips a binary payload through hex
 // encoding. The non-UTF-8 bytes (including 0x00) verify that hex transports
 // arbitrary binary safely.
-func (t *Tests) ProduceConsumeRoundTripHex(ctx context.Context) error {
-	return roundTripBinary(ctx, "hex", "deadbeef", "00010203fffefdfc")
+func (t *Tests) ProduceConsumeRoundTripHex(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	return roundTripBinary(ctx, kafkaImageTag, "hex", "deadbeef", "00010203fffefdfc")
 }
 
 // ProduceConsumeRoundTripBase64 round-trips the same kind of binary payload
 // through standard base64 (with padding).
-func (t *Tests) ProduceConsumeRoundTripBase64(ctx context.Context) error {
-	return roundTripBinary(ctx, "base64", "3q2+7w==", "AAECA//+/fw=")
+func (t *Tests) ProduceConsumeRoundTripBase64(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	return roundTripBinary(ctx, kafkaImageTag, "base64", "3q2+7w==", "AAECA//+/fw=")
 }
 
 // ProduceRejectsUnknownEncoding verifies that a Produce call with a bogus
 // encoding name fails fast rather than silently misbehaving.
-func (t *Tests) ProduceRejectsUnknownEncoding(ctx context.Context) error {
-	cluster, err := freshCluster(ctx)
+func (t *Tests) ProduceRejectsUnknownEncoding(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, err := freshCluster(ctx, kafkaImageTag)
 	if err != nil {
 		return err
 	}
@@ -315,8 +377,12 @@ func (t *Tests) ProduceRejectsUnknownEncoding(ctx context.Context) error {
 // rendered Java client.properties file carries the bootstrap.servers list
 // and a plaintext security.protocol entry — enough for the Apache Kafka
 // CLI tools to pick up the connection settings.
-func (t *Tests) PropertiesFileContainsBootstrapAndSecurityProtocol(ctx context.Context) error {
-	cluster, err := freshCluster(ctx)
+func (t *Tests) PropertiesFileContainsBootstrapAndSecurityProtocol(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, err := freshCluster(ctx, kafkaImageTag)
 	if err != nil {
 		return fmt.Errorf("create cluster: %w", err)
 	}
@@ -345,13 +411,18 @@ func (t *Tests) PropertiesFileContainsBootstrapAndSecurityProtocol(ctx context.C
 // must reject any larger value with a clear error rather than silently
 // spinning up a broken topology. Multi-controller HA is gated behind a
 // follow-up story; see daggerverse/kafka/README.md.
-func (t *Tests) MultiControllerIsRejected(ctx context.Context) error {
+func (t *Tests) MultiControllerIsRejected(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
 	clusterId, err := newClusterId(ctx)
 	if err != nil {
 		return err
 	}
 	k := dag.Kafka()
-	cluster := k.Cluster(clusterId, kafkaImageTag, k.PlaintextServerSecurity(), dagger.KafkaClusterOpts{
+	cluster := k.Cluster(clusterId, k.PlaintextServerSecurity(), dagger.KafkaClusterOpts{
+		Tag:         kafkaImageTag,
 		Controllers: 3,
 		Brokers:     1,
 	})
@@ -365,13 +436,18 @@ func (t *Tests) MultiControllerIsRejected(ctx context.Context) error {
 // creates a replication-factor-2 topic so the produce path forces inter-
 // broker replication. A successful round-trip proves brokers can reach
 // each other over the engine network without explicit peer bindings.
-func (t *Tests) OneControllerTwoBrokersReplicationFactorTwo(ctx context.Context) error {
+func (t *Tests) OneControllerTwoBrokersReplicationFactorTwo(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
 	clusterId, err := newClusterId(ctx)
 	if err != nil {
 		return err
 	}
 	k := dag.Kafka()
-	cluster := k.Cluster(clusterId, kafkaImageTag, k.PlaintextServerSecurity(), dagger.KafkaClusterOpts{
+	cluster := k.Cluster(clusterId, k.PlaintextServerSecurity(), dagger.KafkaClusterOpts{
+		Tag:         kafkaImageTag,
 		Controllers: 1,
 		Brokers:     2,
 	})
@@ -429,8 +505,12 @@ func (t *Tests) OneControllerTwoBrokersReplicationFactorTwo(ctx context.Context)
 // controller+broker topology (introduced this increment) still supports a
 // full produce/consume round-trip — i.e. the broker correctly joined the
 // controller quorum over its WithServiceBinding alias.
-func (t *Tests) DedicatedControllerAndBrokerProduceConsume(ctx context.Context) error {
-	return roundTripBinary(ctx, "raw", "k", "v")
+func (t *Tests) DedicatedControllerAndBrokerProduceConsume(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	return roundTripBinary(ctx, kafkaImageTag, "raw", "k", "v")
 }
 
 // BindBrokersExposesBothListeners binds the cluster's brokers into a
@@ -438,8 +518,12 @@ func (t *Tests) DedicatedControllerAndBrokerProduceConsume(ctx context.Context) 
 // port (9092) and the inter-broker port (19092) are reachable from inside
 // that container — together they cover the dual-listener contract
 // (PLAINTEXT_HOST:9092 for clients, PLAINTEXT:19092 for inter-broker).
-func (t *Tests) BindBrokersExposesBothListeners(ctx context.Context) error {
-	cluster, err := freshCluster(ctx)
+func (t *Tests) BindBrokersExposesBothListeners(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, err := freshCluster(ctx, kafkaImageTag)
 	if err != nil {
 		return fmt.Errorf("create cluster: %w", err)
 	}
@@ -473,8 +557,12 @@ func (t *Tests) BindBrokersExposesBothListeners(ctx context.Context) error {
 // asserts the call errors out. With KAFKA_AUTO_CREATE_TOPICS_ENABLE=false on
 // the broker, the produce path must surface a topic-not-found error rather
 // than silently auto-creating, so producer typos can't pass tests.
-func (t *Tests) AutoCreateTopicsDisabled(ctx context.Context) error {
-	cluster, err := freshCluster(ctx)
+func (t *Tests) AutoCreateTopicsDisabled(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, err := freshCluster(ctx, kafkaImageTag)
 	if err != nil {
 		return fmt.Errorf("create cluster: %w", err)
 	}
@@ -502,8 +590,12 @@ func (t *Tests) AutoCreateTopicsDisabled(ctx context.Context) error {
 // Without KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1 the broker would refuse
 // to create __consumer_offsets at the upstream default RF=3 and the group
 // join would hang or error.
-func (t *Tests) ConsumerGroupOnSingleBrokerWorks(ctx context.Context) error {
-	cluster, err := freshCluster(ctx)
+func (t *Tests) ConsumerGroupOnSingleBrokerWorks(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, err := freshCluster(ctx, kafkaImageTag)
 	if err != nil {
 		return fmt.Errorf("create cluster: %w", err)
 	}
@@ -565,8 +657,8 @@ func (t *Tests) ConsumerGroupOnSingleBrokerWorks(ctx context.Context) error {
 // roundTripBinary is shared helper for hex/base64 tests: produce one record
 // with the given encoding and assert the consumed key/value strings are
 // identical to the produced ones.
-func roundTripBinary(ctx context.Context, encoding, key, value string) error {
-	cluster, err := freshCluster(ctx)
+func roundTripBinary(ctx context.Context, kafkaImageTag, encoding, key, value string) error {
+	cluster, err := freshCluster(ctx, kafkaImageTag)
 	if err != nil {
 		return fmt.Errorf("create cluster: %w", err)
 	}


### PR DESCRIPTION
## Summary

Closes #17. Brings the daggerverse `kafka` module's `Cluster` env-var set in
line with the upstream `apache/kafka` `isolated/plaintext` compose example so
consumer-group / transaction / share-group flows succeed on the default
`brokers=1` path.

- **System-topic RF=1 + 0ms rebalance delay** — `__consumer_offsets`,
  `__transaction_state`, `__share_group_state` now create at RF=1 instead of
  the upstream default RF=3 that the broker would refuse on a 1-broker
  cluster; first-join latency drops by ~3s.
- **Dual broker listener** — split into `PLAINTEXT://19092` (inter-broker) +
  `PLAINTEXT_HOST://9092` (host clients). `BootstrapServers` / `BindBrokers`
  still advertise `:9092`, so the public API is unchanged.
- **`CLUSTER_ID` env var** — switched from `KAFKA_CLUSTER_ID` to match the
  documented contract of the `apache/kafka-native` entrypoint.
- **Pinned `KAFKA_LOG_DIRS=/tmp/kraft-combined-logs`** against future
  image-default drift.
- **`KAFKA_AUTO_CREATE_TOPICS_ENABLE=false`** — `Client.CreateTopic` already
  implies explicit creation; this stops producer typos from silently passing.
- **`Client.Consume` optional `Group`** — additive defaulted parameter so the
  new system-topic test can drive a consumer group end-to-end. Auto-commit is
  disabled when a group is set to keep `Consume` idempotent under
  `+cache="never"`.

## Test plan

- [x] `dagger call single-node-cluster-starts` — confirms `CLUSTER_ID` rename + trimmed protocol map format KRaft storage successfully.
- [x] `dagger call bind-brokers-exposes-both-listeners` — probes both `:9092` and `:19092` to cover the dual-listener contract.
- [x] `dagger call one-controller-two-brokers-replication-factor-two` — exercises inter-broker traffic on the new `PLAINTEXT://19092` listener.
- [x] `dagger call auto-create-topics-disabled` — produce to non-existent topic errors out.
- [x] `dagger call consumer-group-on-single-broker-works` — group join on a 1-broker cluster succeeds, implicitly proving `__consumer_offsets` RF=1.
- [x] `dagger call all` — full 15-test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)