### PR TITLE
story(issue-12): add TLS and mTLS support to kafka module

### DIFF
--- a/daggerverse/kafka/README.md
+++ b/daggerverse/kafka/README.md
@@ -59,8 +59,8 @@ runs at most once per (clusterId, args) within an engine session, so
 chained method calls (`cluster.Client().Produce(...) → Consume(...)`) all
 observe the same underlying broker services and the same internal CA.
 
-- `Cluster.BootstrapServers() []string` — broker `host:port` pairs the
-  client (and `BindBrokers` consumers) connect to. Returns
+- `Cluster.BootstrapServers(ctx) ([]string, error)` — broker `host:port`
+  pairs the client (and `BindBrokers` consumers) connect to. Returns
   `["broker-100:9092", "broker-101:9092", ...]`.
 - `Cluster.BindBrokers(c *dagger.Container) *dagger.Container` — chains
   `WithServiceBinding` for every broker so a caller's container resolves
@@ -118,7 +118,7 @@ records, err := client.Consume(ctx, "my-topic", dagger.KafkaClientConsumeOpts{
 // java client.properties (+ p12 sidecars in TLS / mTLS modes) for the
 // Apache Kafka CLI tools — export the parent directory so the relative
 // truststore.p12 / keystore.p12 references resolve.
-props := client.PropertiesFile(ctx) // *dagger.File
+props := client.PropertiesFile() // *dagger.File — resolve via .Contents(ctx) / .Export(ctx)
 ```
 
 `keyEncoding` / `valueEncoding` accept `"raw"` (literal UTF-8 bytes),
@@ -139,10 +139,12 @@ Topic auto-creation is disabled on the broker — call `CreateTopic` before
   sign broker server certs is independent from the CA used to validate
   incoming client certs. Pass the same CA to both args for symmetric
   setups, or split for asymmetric trust.
-- `PropertiesFile(ctx)` writes plaintext passwords into the rendered
+- `PropertiesFile()` writes plaintext passwords into the rendered
   Java `client.properties` — the Apache Kafka CLI tools require
-  plaintext password values. Export the resulting directory with
-  restrictive permissions if you persist it.
+  plaintext password values. The context is provided when you resolve
+  the returned `*dagger.File` (`.Contents(ctx)` / `.Export(ctx)`).
+  Export the resulting directory with restrictive permissions if you
+  persist it.
 
 ## Image source
 

--- a/daggerverse/kafka/README.md
+++ b/daggerverse/kafka/README.md
@@ -5,24 +5,48 @@ A Dagger module that spins up a KRaft Kafka cluster from
 either the local cluster or any reachable remote cluster (AWS MSK,
 Confluent Cloud, etc.).
 
-Plaintext is the only security mechanism supported in this story; TLS /
-mTLS lands in a follow-up.
+The module supports plaintext, TLS, and mTLS on the external client-facing
+listener. The internal listeners (inter-broker and controller-quorum) are
+**always mTLS**, secured by a per-cluster CA the module mints internally and
+never surfaces on the API.
 
 ## Security profiles
 
 ```go
+// External listener: PLAINTEXT
 serverSec := dag.Kafka().PlaintextServerSecurity()
 clientSec := dag.Kafka().PlaintextClientSecurity()
+
+// External listener: TLS
+serverSec := dag.Kafka().TLSServerSecurity(caKeystore, caKeystorePwd)
+clientSec := dag.Kafka().TLSClientSecurity(truststore, truststorePwd)
+
+// External listener: mTLS
+serverSec := dag.Kafka().MtlsServerSecurity(
+    caKeystore, caKeystorePwd,         // signs per-broker server leaves
+    clientTruststore, clientTruststorePwd, // CAs the broker accepts client certs from
+)
+clientSec := dag.Kafka().MtlsClientSecurity(
+    clientKeystore, clientKeystorePwd, // client's own leaf cert + key
+    truststore, truststorePwd,         // CA that signs the broker leaves
+)
 ```
+
+The CA `keystore`/`truststore` arguments are PKCS#12 archives produced by
+the [`certificate-management`](../certificate-management) module (or any
+PKCS#12 source). The cluster mints per-broker leaf certificates from the
+supplied CA at `Cluster()` time, with each broker's stable hostname
+(`broker-100`, `broker-101`, ...) bound as a DNS SAN. Clients dialing the
+bootstrap address verify the broker's cert against the matching truststore.
 
 ## Cluster
 
 ```go
 cluster := dag.Kafka().Cluster(
     clusterId,        // 22-char base64-url Kafka cluster ID
-    "4.2.0",          // apache/kafka-native tag
     serverSec,
     dagger.KafkaClusterOpts{
+        Tag:         "4.2.0",
         Controllers: 1,    // multi-controller is rejected; see below
         Brokers:     2,
         Registry:    "docker.io",
@@ -30,26 +54,40 @@ cluster := dag.Kafka().Cluster(
 )
 ```
 
-`Cluster` is a lazy chain — the server-side constructor only runs when a
-leaf op (e.g. `BootstrapServers`) resolves.
+`Cluster` is a session-cached lazy chain — the server-side constructor
+runs at most once per (clusterId, args) within an engine session, so
+chained method calls (`cluster.Client().Produce(...) → Consume(...)`) all
+observe the same underlying broker services and the same internal CA.
 
-- `Cluster.BootstrapServers(ctx) ([]string, error)` — the broker `host:port`
-  pairs the client (and `BindBrokers` consumers) connect to.
+- `Cluster.BootstrapServers() []string` — broker `host:port` pairs the
+  client (and `BindBrokers` consumers) connect to. Returns
+  `["broker-100:9092", "broker-101:9092", ...]`.
 - `Cluster.BindBrokers(c *dagger.Container) *dagger.Container` — chains
   `WithServiceBinding` for every broker so a caller's container resolves
   the same hostnames `BootstrapServers` reports.
-- `Cluster.Client(security *KafkaClientSecurity) *KafkaClient` — starts every
-  broker service and returns a franz-go-backed Client wired to dial them.
+- `Cluster.Client(security *KafkaClientSecurity) *KafkaClient` — starts
+  every broker service and returns a franz-go-backed Client wired to dial
+  them.
+
+### Listener layout
+
+| Listener   | Port  | Role          | Security                              |
+|------------|-------|---------------|---------------------------------------|
+| EXTERNAL   | 9092  | client-facing | PLAINTEXT, SSL (TLS), or SSL (mTLS)   |
+| INTERNAL   | 19092 | inter-broker  | always SSL with mTLS (internal CA)    |
+| CONTROLLER | 9093  | KRaft quorum  | always SSL with mTLS (internal CA)    |
+
+Stable hostnames (`controller-1-<suffix>`, `broker-100-<suffix>`, ...) are
+assigned via `Service.WithHostname` — the suffix is a short hash derived
+from `clusterId` so parallel cluster spawns within one engine session
+don't collide on alias names.
 
 ### Topology limit
 
-`controllers > 1` is **rejected** in this story: a true HA quorum needs every
+`controllers > 1` is **rejected**: a true HA quorum needs every
 controller to know every other controller at static config time, which
 Dagger's `WithServiceBinding` model can't express without an unresolvable
-cycle (controllers don't have a runtime `$(hostname)` escape hatch the way
-brokers do, because each controller's `KAFKA_CONTROLLER_QUORUM_VOTERS`
-must reference *every* peer up-front). Multi-controller HA lands in a
-follow-up alongside TLS / mTLS.
+cycle. Multi-controller HA lands in a follow-up.
 
 ## Client
 
@@ -77,8 +115,10 @@ records, err := client.Consume(ctx, "my-topic", dagger.KafkaClientConsumeOpts{
     Group: "", // group-less direct consume; pass "my-group" to consume as a group member
 })
 
-// java client.properties for the apache kafka CLI tools
-props := client.PropertiesFile() // *dagger.File
+// java client.properties (+ p12 sidecars in TLS / mTLS modes) for the
+// Apache Kafka CLI tools — export the parent directory so the relative
+// truststore.p12 / keystore.p12 references resolve.
+props := client.PropertiesFile(ctx) // *dagger.File
 ```
 
 `keyEncoding` / `valueEncoding` accept `"raw"` (literal UTF-8 bytes),
@@ -87,8 +127,25 @@ props := client.PropertiesFile() // *dagger.File
 Topic auto-creation is disabled on the broker — call `CreateTopic` before
 `Produce` / `Consume`.
 
+## TLS / mTLS notes
+
+- The internal CA is fresh per `Cluster()` invocation. Cert material
+  never crosses the module boundary.
+- Caller-supplied CAs are loaded via
+  `dag.CertificateManagement().LoadCertificateAuthority(file, secret)`
+  inside the kafka module — `*dagger.File` + `*dagger.Secret` are the
+  only types crossing the API boundary.
+- The mTLS API splits server-side trust deliberately: the CA used to
+  sign broker server certs is independent from the CA used to validate
+  incoming client certs. Pass the same CA to both args for symmetric
+  setups, or split for asymmetric trust.
+- `PropertiesFile(ctx)` writes plaintext passwords into the rendered
+  Java `client.properties` — the Apache Kafka CLI tools require
+  plaintext password values. Export the resulting directory with
+  restrictive permissions if you persist it.
+
 ## Image source
 
 Image is built as `<registry>/apache/kafka-native:<tag>`. The
 `apache/kafka-native` portion is fixed; only `registry` (default
-`docker.io`) and `tag` are caller-overridable.
+`docker.io`) and `tag` (default `4.2.0`) are caller-overridable.

--- a/daggerverse/kafka/README.md
+++ b/daggerverse/kafka/README.md
@@ -36,8 +36,9 @@ The CA `keystore`/`truststore` arguments are PKCS#12 archives produced by
 the [`certificate-management`](../certificate-management) module (or any
 PKCS#12 source). The cluster mints per-broker leaf certificates from the
 supplied CA at `Cluster()` time, with each broker's stable hostname
-(`broker-100`, `broker-101`, ...) bound as a DNS SAN. Clients dialing the
-bootstrap address verify the broker's cert against the matching truststore.
+(`broker-100-<suffix>`, `broker-101-<suffix>`, ...) bound as a DNS SAN.
+Clients dialing the bootstrap address verify the broker's cert against
+the matching truststore.
 
 ## Cluster
 
@@ -61,7 +62,9 @@ observe the same underlying broker services and the same internal CA.
 
 - `Cluster.BootstrapServers(ctx) ([]string, error)` — broker `host:port`
   pairs the client (and `BindBrokers` consumers) connect to. Returns
-  `["broker-100:9092", "broker-101:9092", ...]`.
+  `["broker-100-<suffix>:9092", "broker-101-<suffix>:9092", ...]` where
+  `<suffix>` is a short DNS-safe hash derived from `clusterId` (see
+  "Listener layout" below).
 - `Cluster.BindBrokers(c *dagger.Container) *dagger.Container` — chains
   `WithServiceBinding` for every broker so a caller's container resolves
   the same hostnames `BootstrapServers` reports.

--- a/daggerverse/kafka/dagger.json
+++ b/daggerverse/kafka/dagger.json
@@ -3,5 +3,19 @@
   "engineVersion": "v0.20.8",
   "sdk": {
     "source": "go"
-  }
+  },
+  "dependencies": [
+    {
+      "name": "certificate-management",
+      "source": "../certificate-management"
+    },
+    {
+      "name": "crypto",
+      "source": "../crypto"
+    },
+    {
+      "name": "random",
+      "source": "../random"
+    }
+  ]
 }

--- a/daggerverse/kafka/go.mod
+++ b/daggerverse/kafka/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/vektah/gqlparser/v2 v2.5.33
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
+	software.sslmate.com/src/go-pkcs12 v0.7.1
 )
 
 require (

--- a/daggerverse/kafka/go.sum
+++ b/daggerverse/kafka/go.sum
@@ -107,3 +107,5 @@ google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBN
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+software.sslmate.com/src/go-pkcs12 v0.7.1 h1:bxkUPRsvTPNRBZa4M/aSX4PyMOEbq3V8I6hbkG4F4Q8=
+software.sslmate.com/src/go-pkcs12 v0.7.1/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=

--- a/daggerverse/kafka/main.go
+++ b/daggerverse/kafka/main.go
@@ -494,7 +494,7 @@ func writeWorkdirBytes(label, name string, content []byte) (*dagger.File, error)
 		os.Remove(tmpPath)
 		return nil, fmt.Errorf("write %s: %w", tmpPath, err)
 	}
-	if err := tmp.Chmod(0o644); err != nil {
+	if err := tmp.Chmod(0o600); err != nil {
 		tmp.Close()
 		os.Remove(tmpPath)
 		return nil, fmt.Errorf("chmod %s: %w", tmpPath, err)
@@ -801,8 +801,13 @@ func (c *Client) PropertiesFile(ctx context.Context) (*dagger.File, error) {
 	}
 
 	content := []byte(sb.String())
-	sum := sha256.Sum256(content)
-	dir := "props-" + hex.EncodeToString(sum[:])
+	h := sha256.New()
+	h.Write(content)
+	for _, sc := range sidecars {
+		fmt.Fprintf(h, "\x00%s\x00%d\x00", sc.name, len(sc.data))
+		h.Write(sc.data)
+	}
+	dir := "props-" + hex.EncodeToString(h.Sum(nil))
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return nil, fmt.Errorf("mkdir %q: %w", dir, err)
 	}

--- a/daggerverse/kafka/main.go
+++ b/daggerverse/kafka/main.go
@@ -8,7 +8,10 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/hex"
 	"errors"
@@ -24,22 +27,40 @@ import (
 
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kgo"
+	"software.sslmate.com/src/go-pkcs12"
 )
 
 type Kafka struct{}
 
-// ServerSecurity describes how a Kafka cluster's listener authenticates and
-// encrypts traffic from clients. Only PLAINTEXT is supported in this story.
+// ServerSecurity describes how a Kafka cluster's external listener
+// authenticates and encrypts traffic from clients. Internal listeners
+// (inter-broker + controller-quorum) are always mTLS, regardless of mode.
 type ServerSecurity struct {
 	// +private
-	Mode string
+	Mode string // PLAINTEXT | TLS | MTLS
+	// +private
+	CaKeyStore *dagger.File // PKCS#12 CA used to mint per-broker external leaf certs (TLS + MTLS)
+	// +private
+	CaKeyStorePassword *dagger.Secret
+	// +private
+	ClientTrustStore *dagger.File // PKCS#12 of CA(s) trusted to sign incoming client certs (MTLS only)
+	// +private
+	ClientTrustStorePassword *dagger.Secret
 }
 
 // ClientSecurity describes how a franz-go client authenticates to a Kafka
-// broker. Only PLAINTEXT is supported in this story.
+// broker.
 type ClientSecurity struct {
 	// +private
-	Mode string
+	Mode string // PLAINTEXT | TLS | MTLS
+	// +private
+	TrustStore *dagger.File // PKCS#12 of the CA(s) the client trusts to identify the broker (TLS + MTLS)
+	// +private
+	TrustStorePassword *dagger.Secret
+	// +private
+	KeyStore *dagger.File // PKCS#12 of the client's own leaf cert + key (MTLS only)
+	// +private
+	KeyStorePassword *dagger.Secret
 }
 
 // Cluster represents a running KRaft Kafka cluster, holding references to
@@ -57,15 +78,88 @@ type Cluster struct {
 }
 
 // PlaintextServerSecurity returns a ServerSecurity profile configured for
-// unencrypted, unauthenticated traffic.
+// unencrypted, unauthenticated traffic on the external listener. Internal
+// listeners (inter-broker + controller-quorum) still use mTLS.
 func (k *Kafka) PlaintextServerSecurity() *ServerSecurity {
 	return &ServerSecurity{Mode: "PLAINTEXT"}
+}
+
+// TlsServerSecurity returns a ServerSecurity profile that terminates TLS on
+// the external listener. caKeyStore is a PKCS#12 archive containing the
+// CA cert + private key the cluster uses to mint per-broker leaf certs;
+// each broker leaf carries its stable hostname (e.g. "broker-100") as a
+// DNS SAN so franz-go clients dialing the bootstrap address can verify
+// the broker against the same CA's truststore.
+func (k *Kafka) TlsServerSecurity(
+	caKeyStore *dagger.File,
+	caKeyStorePassword *dagger.Secret,
+) *ServerSecurity {
+	return &ServerSecurity{
+		Mode:               "TLS",
+		CaKeyStore:         caKeyStore,
+		CaKeyStorePassword: caKeyStorePassword,
+	}
+}
+
+// MtlsServerSecurity returns a ServerSecurity profile that terminates mTLS
+// on the external listener. caKeyStore signs per-broker server leaves;
+// clientTrustStore holds the CA(s) the broker will accept incoming client
+// certs from (this can be the same CA as caKeyStore or an independent one
+// for asymmetric trust).
+func (k *Kafka) MtlsServerSecurity(
+	caKeyStore *dagger.File,
+	caKeyStorePassword *dagger.Secret,
+	clientTrustStore *dagger.File,
+	clientTrustStorePassword *dagger.Secret,
+) *ServerSecurity {
+	return &ServerSecurity{
+		Mode:                     "MTLS",
+		CaKeyStore:               caKeyStore,
+		CaKeyStorePassword:       caKeyStorePassword,
+		ClientTrustStore:         clientTrustStore,
+		ClientTrustStorePassword: clientTrustStorePassword,
+	}
 }
 
 // PlaintextClientSecurity returns a ClientSecurity profile configured for
 // unencrypted, unauthenticated traffic.
 func (k *Kafka) PlaintextClientSecurity() *ClientSecurity {
 	return &ClientSecurity{Mode: "PLAINTEXT"}
+}
+
+// TlsClientSecurity returns a ClientSecurity profile that opens a TLS
+// connection to the broker. trustStore is a PKCS#12 archive of the CA(s)
+// the client uses to verify the broker's leaf certificate (typically the
+// truststore that pairs with the CA passed to TlsServerSecurity on the
+// server side).
+func (k *Kafka) TlsClientSecurity(
+	trustStore *dagger.File,
+	trustStorePassword *dagger.Secret,
+) *ClientSecurity {
+	return &ClientSecurity{
+		Mode:               "TLS",
+		TrustStore:         trustStore,
+		TrustStorePassword: trustStorePassword,
+	}
+}
+
+// MtlsClientSecurity returns a ClientSecurity profile that opens an mTLS
+// connection: the broker presents its server cert (verified against
+// trustStore) and the client presents its own leaf cert from keyStore
+// (signed by a CA the broker trusts via its clientTrustStore).
+func (k *Kafka) MtlsClientSecurity(
+	keyStore *dagger.File,
+	keyStorePassword *dagger.Secret,
+	trustStore *dagger.File,
+	trustStorePassword *dagger.Secret,
+) *ClientSecurity {
+	return &ClientSecurity{
+		Mode:               "MTLS",
+		TrustStore:         trustStore,
+		TrustStorePassword: trustStorePassword,
+		KeyStore:           keyStore,
+		KeyStorePassword:   keyStorePassword,
+	}
 }
 
 // Cluster spins up a KRaft Kafka cluster of the requested size with
@@ -81,7 +175,15 @@ func (k *Kafka) PlaintextClientSecurity() *ClientSecurity {
 // unresolvable cycle. TLS / mTLS and multi-controller both land in a
 // follow-up.
 //
-// +cache="never"
+// Session-cached so that repeated chained method calls on the returned
+// cluster (Client.Produce → Consume → ListTopics) all observe the SAME
+// underlying broker services. The internal CA + per-node leaves are
+// minted with fresh random material that we can't make content-addressable,
+// so a `+cache="never"` directive here would spawn a brand-new cluster
+// (with a brand-new CA the previous invocation's franz-go client doesn't
+// trust) every time the test calls another method on the chain.
+//
+// +cache="session"
 func (k *Kafka) Cluster(
 	ctx context.Context,
 	clusterId string,
@@ -107,8 +209,20 @@ func (k *Kafka) Cluster(
 	if brokers < 1 {
 		return nil, fmt.Errorf("at least one broker is required, got %d", brokers)
 	}
-	if clientListenerSecurity == nil || clientListenerSecurity.Mode != "PLAINTEXT" {
-		return nil, fmt.Errorf("only PLAINTEXT clientListenerSecurity is supported")
+	if clientListenerSecurity == nil {
+		return nil, fmt.Errorf("clientListenerSecurity must not be nil")
+	}
+	mode := clientListenerSecurity.Mode
+	switch mode {
+	case "PLAINTEXT", "TLS", "MTLS":
+	default:
+		return nil, fmt.Errorf("unknown clientListenerSecurity mode %q (want PLAINTEXT|TLS|MTLS)", mode)
+	}
+	if (mode == "TLS" || mode == "MTLS") && (clientListenerSecurity.CaKeyStore == nil || clientListenerSecurity.CaKeyStorePassword == nil) {
+		return nil, fmt.Errorf("clientListenerSecurity mode %q requires a CA keystore and password", mode)
+	}
+	if mode == "MTLS" && (clientListenerSecurity.ClientTrustStore == nil || clientListenerSecurity.ClientTrustStorePassword == nil) {
+		return nil, fmt.Errorf("MTLS clientListenerSecurity requires a client trust store and password")
 	}
 	if raw, err := base64.RawURLEncoding.DecodeString(clusterId); err != nil || len(raw) != 16 {
 		return nil, fmt.Errorf(
@@ -119,10 +233,38 @@ func (k *Kafka) Cluster(
 
 	image := fmt.Sprintf("%s/apache/kafka-native:%s", registry, tag)
 
-	const (
-		controllerAlias = "controller-1"
-		quorumVoters    = "1@" + controllerAlias + ":9093"
-	)
+	// Stable hostnames are scoped per-cluster so parallel test invocations
+	// don't collide on `broker-100` / `controller-1`. The suffix is derived
+	// from the clusterId (already random + DNS-safe after lowercasing and
+	// substituting `_` → `-`) so two distinct clusters in the same engine
+	// session get distinct hostnames AND each cluster's cert SANs match its
+	// own services.
+	hostSuffix := clusterHostSuffix(clusterId)
+	controllerAlias := "controller-1-" + hostSuffix
+	quorumVoters := "1@" + controllerAlias + ":9093"
+
+	brokerHosts := make([]string, brokers)
+	for i := range brokerHosts {
+		brokerHosts[i] = fmt.Sprintf("broker-%d-%s", 100+i, hostSuffix)
+	}
+
+	internal, err := mintInternalCA(ctx, controllerAlias, brokerHosts)
+	if err != nil {
+		return nil, fmt.Errorf("mint internal CA: %w", err)
+	}
+
+	var externalLeaves []externalLeaf
+	if mode == "TLS" || mode == "MTLS" {
+		externalLeaves, err = mintExternalLeaves(ctx, clientListenerSecurity, brokerHosts)
+		if err != nil {
+			return nil, fmt.Errorf("mint external leaves: %w", err)
+		}
+	}
+
+	externalProto := "PLAINTEXT"
+	if mode == "TLS" || mode == "MTLS" {
+		externalProto = "SSL"
+	}
 
 	ctrlCtr := dag.Container().
 		From(image).
@@ -130,25 +272,30 @@ func (k *Kafka) Cluster(
 		WithEnvVariable("KAFKA_PROCESS_ROLES", "controller").
 		WithEnvVariable("KAFKA_LISTENERS", "CONTROLLER://0.0.0.0:9093").
 		WithEnvVariable("KAFKA_CONTROLLER_LISTENER_NAMES", "CONTROLLER").
-		WithEnvVariable("KAFKA_LISTENER_SECURITY_PROTOCOL_MAP", "CONTROLLER:PLAINTEXT").
+		WithEnvVariable("KAFKA_LISTENER_SECURITY_PROTOCOL_MAP", "CONTROLLER:SSL").
 		WithEnvVariable("KAFKA_CONTROLLER_QUORUM_VOTERS", quorumVoters).
 		WithEnvVariable("CLUSTER_ID", clusterId).
 		WithExposedPort(9093)
-	ctrlSvc := ctrlCtr.AsService(dagger.ContainerAsServiceOpts{UseEntrypoint: true})
+	ctrlCtr = applyInternalListenerSsl(ctrlCtr, "CONTROLLER", internal.Controller)
+	ctrlSvc := ctrlCtr.
+		AsService(dagger.ContainerAsServiceOpts{UseEntrypoint: true}).
+		WithHostname(controllerAlias)
 
 	brokerSvcs := make([]*dagger.Service, brokers)
-	brokerHosts := make([]string, brokers)
 	for i := 0; i < brokers; i++ {
 		nodeID := 100 + i
+		brokerHost := brokerHosts[i]
+		advertised := fmt.Sprintf("INTERNAL://%s:19092,EXTERNAL://%s:9092", brokerHost, brokerHost)
 		brkCtr := dag.Container().
 			From(image).
 			WithServiceBinding(controllerAlias, ctrlSvc).
 			WithEnvVariable("KAFKA_NODE_ID", fmt.Sprintf("%d", nodeID)).
 			WithEnvVariable("KAFKA_PROCESS_ROLES", "broker").
-			WithEnvVariable("KAFKA_LISTENERS", "PLAINTEXT://0.0.0.0:19092,PLAINTEXT_HOST://0.0.0.0:9092").
-			WithEnvVariable("KAFKA_INTER_BROKER_LISTENER_NAME", "PLAINTEXT").
+			WithEnvVariable("KAFKA_LISTENERS", "INTERNAL://0.0.0.0:19092,EXTERNAL://0.0.0.0:9092").
+			WithEnvVariable("KAFKA_ADVERTISED_LISTENERS", advertised).
+			WithEnvVariable("KAFKA_INTER_BROKER_LISTENER_NAME", "INTERNAL").
 			WithEnvVariable("KAFKA_CONTROLLER_LISTENER_NAMES", "CONTROLLER").
-			WithEnvVariable("KAFKA_LISTENER_SECURITY_PROTOCOL_MAP", "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT").
+			WithEnvVariable("KAFKA_LISTENER_SECURITY_PROTOCOL_MAP", "CONTROLLER:SSL,INTERNAL:SSL,EXTERNAL:"+externalProto).
 			WithEnvVariable("KAFKA_CONTROLLER_QUORUM_VOTERS", quorumVoters).
 			WithEnvVariable("CLUSTER_ID", clusterId).
 			WithEnvVariable("KAFKA_LOG_DIRS", "/tmp/kraft-combined-logs").
@@ -160,19 +307,17 @@ func (k *Kafka) Cluster(
 			WithEnvVariable("KAFKA_SHARE_COORDINATOR_STATE_TOPIC_MIN_ISR", "1").
 			WithEnvVariable("KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS", "0").
 			WithExposedPort(9092).
-			WithExposedPort(19092).
-			WithEntrypoint([]string{"sh", "-c"}).
-			WithDefaultArgs([]string{
-				`export KAFKA_ADVERTISED_LISTENERS="PLAINTEXT://$(hostname):19092,PLAINTEXT_HOST://$(hostname):9092" && exec /etc/kafka/docker/run`,
-			})
-
-		svc := brkCtr.AsService(dagger.ContainerAsServiceOpts{UseEntrypoint: true})
-		host, err := svc.Hostname(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("get broker %d hostname: %w", i, err)
+			WithExposedPort(19092)
+		brkCtr = applyInternalListenerSsl(brkCtr, "INTERNAL", internal.Brokers[i])
+		brkCtr = applyInternalListenerSsl(brkCtr, "CONTROLLER", internal.Brokers[i])
+		if externalLeaves != nil {
+			brkCtr = applyExternalListenerSsl(brkCtr, externalLeaves[i], clientListenerSecurity)
 		}
+
+		svc := brkCtr.
+			AsService(dagger.ContainerAsServiceOpts{UseEntrypoint: true}).
+			WithHostname(brokerHost)
 		brokerSvcs[i] = svc
-		brokerHosts[i] = host
 	}
 
 	return &Cluster{
@@ -183,17 +328,322 @@ func (k *Kafka) Cluster(
 	}, nil
 }
 
+// nodePkis bundles a single node's mTLS material for the internal listeners.
+type nodePkis struct {
+	KeyStoreFile       *dagger.File
+	KeyStorePassword   *dagger.Secret
+	TrustStoreFile     *dagger.File
+	TrustStorePassword *dagger.Secret
+}
+
+// internalMaterial holds per-cluster CA-derived mTLS material, one entry per
+// node (controller + every broker). Truststore is shared across nodes.
+type internalMaterial struct {
+	Controller nodePkis
+	Brokers    []nodePkis
+}
+
+const (
+	internalKeystorePath   = "/etc/kafka/secrets/internal-keystore.p12"
+	internalTruststorePath = "/etc/kafka/secrets/internal-truststore.p12"
+)
+
+// applyInternalListenerSsl mounts the internal mTLS keystore + truststore at
+// fixed paths and configures per-listener Kafka SSL env vars so the named
+// listener uses them with required client auth. Mounts are idempotent across
+// repeat calls with the same node material — Dagger collapses duplicate
+// WithFile invocations of identical content.
+func applyInternalListenerSsl(ctr *dagger.Container, listenerName string, m nodePkis) *dagger.Container {
+	prefix := "KAFKA_LISTENER_NAME_" + listenerName + "_SSL_"
+	return ctr.
+		WithFile(internalKeystorePath, m.KeyStoreFile, dagger.ContainerWithFileOpts{Permissions: 0o644}).
+		WithFile(internalTruststorePath, m.TrustStoreFile, dagger.ContainerWithFileOpts{Permissions: 0o644}).
+		WithEnvVariable(prefix+"KEYSTORE_LOCATION", internalKeystorePath).
+		WithSecretVariable(prefix+"KEYSTORE_PASSWORD", m.KeyStorePassword).
+		WithEnvVariable(prefix+"KEYSTORE_TYPE", "PKCS12").
+		WithEnvVariable(prefix+"TRUSTSTORE_LOCATION", internalTruststorePath).
+		WithSecretVariable(prefix+"TRUSTSTORE_PASSWORD", m.TrustStorePassword).
+		WithEnvVariable(prefix+"TRUSTSTORE_TYPE", "PKCS12").
+		WithEnvVariable(prefix+"CLIENT_AUTH", "required")
+}
+
+// mintInternalCA mints a fresh per-cluster CA and a leaf certificate for
+// every node. Each leaf carries both serverAuth and clientAuth EKUs so the
+// node can both accept peer connections and originate connections to peers
+// or to the controller, all under the same internal trust domain. The CA's
+// truststore is shared across nodes; it never crosses the module boundary.
+//
+// All PKCS#12 archives (truststore + per-node keystores) are eagerly
+// materialized to byte arrays via Export and then re-staged as fresh files
+// in the kafka module's workdir. This guarantees that two distinct
+// references that should hold the same CA bytes are byte-identical even
+// when consumed concurrently — there is no possibility of a downstream
+// container build pulling the lazy `ca` chain a second time and getting a
+// re-derived (different) CA.
+func mintInternalCA(
+	ctx context.Context,
+	controllerHost string,
+	brokerHosts []string,
+) (*internalMaterial, error) {
+	caKeyPem, err := dag.Crypto().GenerateRsaKey(dagger.CryptoGenerateRsaKeyOpts{Bits: 4096}).Pem().Contents(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("generate internal CA key: %w", err)
+	}
+	caKey := dag.SetSecret("kafka-internal-ca-key-"+randSuffix(), caKeyPem)
+
+	caPwdHex, err := dag.Random().Sha256(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("generate internal CA password: %w", err)
+	}
+	caPwd := dag.SetSecret("kafka-internal-ca-pwd-"+randSuffix(), caPwdHex)
+
+	caSerial, err := dag.Random().Serial(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("generate internal CA serial: %w", err)
+	}
+	nb := time.Now().UTC().Format(time.RFC3339)
+
+	ca := dag.CertificateManagement().CreateCertificateAuthority(nb, caSerial, caPwd, caKey,
+		dagger.CertificateManagementCreateCertificateAuthorityOpts{
+			CommonName:   "Kafka Internal CA",
+			ValidityDays: 3650,
+		})
+
+	tsBytes, err := dagFileBytes(ctx, ca.TrustStore().Pkcs12())
+	if err != nil {
+		return nil, fmt.Errorf("materialize internal CA truststore: %w", err)
+	}
+	tsFile, err := writeWorkdirBytes("internal-truststore", "ca-truststore.p12", tsBytes)
+	if err != nil {
+		return nil, fmt.Errorf("stage internal CA truststore: %w", err)
+	}
+	// caPwd doubles as the truststore password (both KeyStore + TrustStore in
+	// the certificate-management module are sealed with the CA's bound Pwd).
+	tsPwd := caPwd
+
+	mintNode := func(hostname string) (nodePkis, error) {
+		leafKeyPem, err := dag.Crypto().GenerateRsaKey(dagger.CryptoGenerateRsaKeyOpts{Bits: 2048}).Pem().Contents(ctx)
+		if err != nil {
+			return nodePkis{}, fmt.Errorf("generate %q leaf key: %w", hostname, err)
+		}
+		leafKey := dag.SetSecret("kafka-internal-leaf-key-"+randSuffix(), leafKeyPem)
+		leafPwdHex, err := dag.Random().Sha256(ctx)
+		if err != nil {
+			return nodePkis{}, fmt.Errorf("generate %q leaf password: %w", hostname, err)
+		}
+		leafPwdName := "kafka-internal-leaf-pwd-" + randSuffix()
+		leafPwd := dag.SetSecret(leafPwdName, leafPwdHex)
+		leafSerial, err := dag.Random().Serial(ctx)
+		if err != nil {
+			return nodePkis{}, fmt.Errorf("generate %q leaf serial: %w", hostname, err)
+		}
+		issued := ca.IssueMutualTLSCertificate(hostname, nb, leafSerial, leafPwd, leafKey,
+			dagger.CertificateManagementCertificateAuthorityIssueMutualTLSCertificateOpts{
+				DNSSans:      []string{hostname, "localhost"},
+				IPSans:       []string{"127.0.0.1"},
+				ValidityDays: 365,
+			})
+		ksBytes, err := dagFileBytes(ctx, issued.KeyStore().Pkcs12())
+		if err != nil {
+			return nodePkis{}, fmt.Errorf("materialize %q keystore: %w", hostname, err)
+		}
+		ksFile, err := writeWorkdirBytes("internal-keystore-"+hostname, "node-keystore.p12", ksBytes)
+		if err != nil {
+			return nodePkis{}, fmt.Errorf("stage %q keystore: %w", hostname, err)
+		}
+		return nodePkis{
+			KeyStoreFile:       ksFile,
+			KeyStorePassword:   leafPwd,
+			TrustStoreFile:     tsFile,
+			TrustStorePassword: tsPwd,
+		}, nil
+	}
+
+	ctrl, err := mintNode(controllerHost)
+	if err != nil {
+		return nil, err
+	}
+	brks := make([]nodePkis, len(brokerHosts))
+	for i, h := range brokerHosts {
+		brks[i], err = mintNode(h)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &internalMaterial{Controller: ctrl, Brokers: brks}, nil
+}
+
+// writeWorkdirBytes writes content into a content-addressed subdir of the
+// kafka module runtime's scratch workdir and returns it as a *dagger.File.
+// Distinct callers writing distinct content land at distinct paths;
+// identical content collapses to one file (idempotent across re-entry).
+func writeWorkdirBytes(label, name string, content []byte) (*dagger.File, error) {
+	sum := sha256.Sum256(content)
+	dir := "kafka-" + label + "-" + hex.EncodeToString(sum[:8])
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+	path := filepath.Join(dir, name)
+	tmp, err := os.CreateTemp(dir, "."+name+"-*")
+	if err != nil {
+		return nil, fmt.Errorf("create temp in %s: %w", dir, err)
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(content); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return nil, fmt.Errorf("write %s: %w", tmpPath, err)
+	}
+	if err := tmp.Chmod(0o644); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return nil, fmt.Errorf("chmod %s: %w", tmpPath, err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return nil, fmt.Errorf("close %s: %w", tmpPath, err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		return nil, fmt.Errorf("rename to %s: %w", path, err)
+	}
+	return dag.CurrentModule().WorkdirFile(path), nil
+}
+
+// externalLeaf bundles a per-broker external-listener leaf certificate
+// (signed by the caller-supplied CA) and the password sealing its PKCS#12
+// keystore.
+type externalLeaf struct {
+	KeyStoreFile     *dagger.File
+	KeyStorePassword *dagger.Secret
+}
+
+const (
+	externalKeystorePath   = "/etc/kafka/secrets/external-keystore.p12"
+	externalTruststorePath = "/etc/kafka/secrets/external-truststore.p12"
+)
+
+// applyExternalListenerSsl mounts the per-broker external-listener leaf
+// keystore (and, for mTLS, the caller-supplied client truststore) and
+// configures Kafka's per-listener SSL env vars for the EXTERNAL listener.
+// TLS-only mode sets client.auth=none; MTLS sets it to required and points
+// at the truststore.
+func applyExternalListenerSsl(ctr *dagger.Container, leaf externalLeaf, sec *ServerSecurity) *dagger.Container {
+	const prefix = "KAFKA_LISTENER_NAME_EXTERNAL_SSL_"
+	ctr = ctr.
+		WithFile(externalKeystorePath, leaf.KeyStoreFile, dagger.ContainerWithFileOpts{Permissions: 0o644}).
+		WithEnvVariable(prefix+"KEYSTORE_LOCATION", externalKeystorePath).
+		WithSecretVariable(prefix+"KEYSTORE_PASSWORD", leaf.KeyStorePassword).
+		WithEnvVariable(prefix+"KEYSTORE_TYPE", "PKCS12")
+	if sec.Mode == "MTLS" {
+		ctr = ctr.
+			WithFile(externalTruststorePath, sec.ClientTrustStore, dagger.ContainerWithFileOpts{Permissions: 0o644}).
+			WithEnvVariable(prefix+"TRUSTSTORE_LOCATION", externalTruststorePath).
+			WithSecretVariable(prefix+"TRUSTSTORE_PASSWORD", sec.ClientTrustStorePassword).
+			WithEnvVariable(prefix+"TRUSTSTORE_TYPE", "PKCS12").
+			WithEnvVariable(prefix+"CLIENT_AUTH", "required")
+	} else {
+		ctr = ctr.WithEnvVariable(prefix+"CLIENT_AUTH", "none")
+	}
+	return ctr
+}
+
+// mintExternalLeaves loads the caller-supplied CA and signs one leaf
+// certificate per broker. Each leaf carries the broker's stable hostname
+// (e.g. "broker-100") as a DNS SAN so franz-go clients dialing the
+// bootstrap address verify the SSL endpoint identity successfully.
+func mintExternalLeaves(
+	ctx context.Context,
+	sec *ServerSecurity,
+	brokerHosts []string,
+) ([]externalLeaf, error) {
+	ca := dag.CertificateManagement().LoadCertificateAuthority(sec.CaKeyStore, sec.CaKeyStorePassword)
+	nb := time.Now().UTC().Format(time.RFC3339)
+	leaves := make([]externalLeaf, len(brokerHosts))
+	for i, h := range brokerHosts {
+		leafKeyPem, err := dag.Crypto().GenerateRsaKey(dagger.CryptoGenerateRsaKeyOpts{Bits: 2048}).Pem().Contents(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("generate %q external leaf key: %w", h, err)
+		}
+		leafKey := dag.SetSecret("kafka-external-leaf-key-"+randSuffix(), leafKeyPem)
+
+		leafPwdHex, err := dag.Random().Sha256(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("generate %q external leaf password: %w", h, err)
+		}
+		leafPwd := dag.SetSecret("kafka-external-leaf-pwd-"+randSuffix(), leafPwdHex)
+
+		leafSerial, err := dag.Random().Serial(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("generate %q external leaf serial: %w", h, err)
+		}
+
+		issued := ca.IssueServerCertificate(h, nb, leafSerial, leafPwd, leafKey,
+			dagger.CertificateManagementCertificateAuthorityIssueServerCertificateOpts{
+				DNSSans:      []string{h, "localhost"},
+				IPSans:       []string{"127.0.0.1"},
+				ValidityDays: 365,
+			})
+		ksBytes, err := dagFileBytes(ctx, issued.KeyStore().Pkcs12())
+		if err != nil {
+			return nil, fmt.Errorf("materialize %q external keystore: %w", h, err)
+		}
+		ksFile, err := writeWorkdirBytes("external-keystore-"+h, "external.p12", ksBytes)
+		if err != nil {
+			return nil, fmt.Errorf("stage %q external keystore: %w", h, err)
+		}
+		leaves[i] = externalLeaf{
+			KeyStoreFile:     ksFile,
+			KeyStorePassword: leafPwd,
+		}
+	}
+	return leaves, nil
+}
+
+// clusterHostSuffix derives a short DNS-safe suffix from a clusterId so
+// per-cluster service hostnames don't collide across parallel runs in the
+// same engine session. SHA-256 hex first 10 chars: deterministic per
+// clusterId (so cache keys are stable) and trivially DNS-LDH compliant
+// (lowercase hex, never empty, no leading/trailing dashes).
+func clusterHostSuffix(clusterId string) string {
+	sum := sha256.Sum256([]byte(clusterId))
+	return hex.EncodeToString(sum[:5]) // 10 hex chars = 40 bits
+}
+
+// randSuffix returns a fresh hex suffix for naming Dagger secrets uniquely
+// across concurrent helper calls.
+func randSuffix() string {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// crypto/rand failure is fatal in module runtime context.
+		panic(fmt.Sprintf("randSuffix: %v", err))
+	}
+	return hex.EncodeToString(b[:])
+}
+
 // Client constructs a franz-go-backed Kafka client that targets the given
 // bootstrap servers. No I/O happens at construction time.
 func (k *Kafka) Client(bootstrapServers []string, security *ClientSecurity) *Client {
-	mode := "PLAINTEXT"
-	if security != nil {
-		mode = security.Mode
-	}
-	return &Client{
+	return clientFrom(bootstrapServers, security)
+}
+
+// clientFrom builds a Client struct from a *ClientSecurity, copying only the
+// fields the franz-go path needs. PLAINTEXT mode leaves the TLS-material
+// fields nil; TLS / MTLS modes copy them through verbatim.
+func clientFrom(bootstrapServers []string, security *ClientSecurity) *Client {
+	c := &Client{
 		Bootstrap:    bootstrapServers,
-		SecurityMode: mode,
+		SecurityMode: "PLAINTEXT",
 	}
+	if security == nil {
+		return c
+	}
+	c.SecurityMode = security.Mode
+	c.TrustStore = security.TrustStore
+	c.TrustStorePassword = security.TrustStorePassword
+	c.KeyStore = security.KeyStore
+	c.KeyStorePassword = security.KeyStorePassword
+	return c
 }
 
 // BootstrapServers returns the host:port pairs each broker advertises on its
@@ -231,14 +681,7 @@ func (c *Cluster) Client(ctx context.Context, security *ClientSecurity) (*Client
 			return nil, fmt.Errorf("start broker %d: %w", i, err)
 		}
 	}
-	mode := "PLAINTEXT"
-	if security != nil {
-		mode = security.Mode
-	}
-	return &Client{
-		Bootstrap:    c.BootstrapServers(),
-		SecurityMode: mode,
-	}, nil
+	return clientFrom(c.BootstrapServers(), security), nil
 }
 
 // Client is a franz-go-backed Kafka client. Each method opens a fresh
@@ -248,6 +691,14 @@ type Client struct {
 	Bootstrap []string
 	// +private
 	SecurityMode string
+	// +private
+	TrustStore *dagger.File
+	// +private
+	TrustStorePassword *dagger.Secret
+	// +private
+	KeyStore *dagger.File
+	// +private
+	KeyStorePassword *dagger.Secret
 }
 
 // ConsumedRecord is a single record returned by Client.Consume, with key and
@@ -294,25 +745,76 @@ func encodeBytes(b []byte, encoding string) (string, error) {
 }
 
 // PropertiesFile renders this client's connection settings as a Java
-// `client.properties` file (bootstrap.servers + security.protocol) so callers
-// can hand it to the Apache Kafka command-line tools or to other JVM-based
-// consumers.
+// `client.properties` file so callers can hand it to the Apache Kafka
+// command-line tools or to other JVM-based consumers.
+//
+// For TLS / mTLS modes the properties reference PKCS#12 truststore (and
+// keystore for mTLS) by basename — the matching p12 files are written
+// alongside `client.properties` in the same directory. Callers should
+// export the parent directory (`props.Directory()`) so the relative
+// references resolve. Passwords appear plaintext, which is a Kafka CLI
+// constraint.
 //
 // +cache="never"
-func (c *Client) PropertiesFile() (*dagger.File, error) {
-	content := []byte(fmt.Sprintf(
-		"bootstrap.servers=%s\nsecurity.protocol=%s\n",
-		strings.Join(c.Bootstrap, ","),
-		c.SecurityMode,
-	))
+func (c *Client) PropertiesFile(ctx context.Context) (*dagger.File, error) {
+	proto := "PLAINTEXT"
+	if c.SecurityMode != "PLAINTEXT" {
+		proto = "SSL"
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "bootstrap.servers=%s\n", strings.Join(c.Bootstrap, ","))
+	fmt.Fprintf(&sb, "security.protocol=%s\n", proto)
 
+	type sidecar struct {
+		name string
+		data []byte
+	}
+	var sidecars []sidecar
+
+	if c.SecurityMode == "TLS" || c.SecurityMode == "MTLS" {
+		tsBytes, err := dagFileBytes(ctx, c.TrustStore)
+		if err != nil {
+			return nil, fmt.Errorf("export truststore: %w", err)
+		}
+		tsPwd, err := c.TrustStorePassword.Plaintext(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("read truststore password: %w", err)
+		}
+		sidecars = append(sidecars, sidecar{name: "truststore.p12", data: tsBytes})
+		fmt.Fprintf(&sb, "ssl.truststore.location=truststore.p12\n")
+		fmt.Fprintf(&sb, "ssl.truststore.password=%s\n", tsPwd)
+		fmt.Fprintf(&sb, "ssl.truststore.type=PKCS12\n")
+	}
+	if c.SecurityMode == "MTLS" {
+		ksBytes, err := dagFileBytes(ctx, c.KeyStore)
+		if err != nil {
+			return nil, fmt.Errorf("export keystore: %w", err)
+		}
+		ksPwd, err := c.KeyStorePassword.Plaintext(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("read keystore password: %w", err)
+		}
+		sidecars = append(sidecars, sidecar{name: "keystore.p12", data: ksBytes})
+		fmt.Fprintf(&sb, "ssl.keystore.location=keystore.p12\n")
+		fmt.Fprintf(&sb, "ssl.keystore.password=%s\n", ksPwd)
+		fmt.Fprintf(&sb, "ssl.keystore.type=PKCS12\n")
+	}
+
+	content := []byte(sb.String())
 	sum := sha256.Sum256(content)
 	dir := "props-" + hex.EncodeToString(sum[:])
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return nil, fmt.Errorf("mkdir %q: %w", dir, err)
 	}
-	path := filepath.Join(dir, "client.properties")
 
+	for _, sc := range sidecars {
+		scPath := filepath.Join(dir, sc.name)
+		if err := os.WriteFile(scPath, sc.data, 0o600); err != nil {
+			return nil, fmt.Errorf("write %s: %w", scPath, err)
+		}
+	}
+
+	path := filepath.Join(dir, "client.properties")
 	tmp, err := os.CreateTemp(dir, ".client.properties-*")
 	if err != nil {
 		return nil, fmt.Errorf("create temp: %w", err)
@@ -340,11 +842,88 @@ func (c *Client) PropertiesFile() (*dagger.File, error) {
 }
 
 // newKgoClient opens a fresh franz-go client against the configured bootstrap
-// servers. Callers are responsible for Close.
-func (c *Client) newKgoClient(extra ...kgo.Opt) (*kgo.Client, error) {
+// servers, applying TLS / mTLS dial options when the client is configured
+// for them. Callers are responsible for Close.
+func (c *Client) newKgoClient(ctx context.Context, extra ...kgo.Opt) (*kgo.Client, error) {
 	opts := []kgo.Opt{kgo.SeedBrokers(c.Bootstrap...)}
+	cfg, err := c.tlsConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("build tls config: %w", err)
+	}
+	if cfg != nil {
+		opts = append(opts, kgo.DialTLSConfig(cfg))
+	}
 	opts = append(opts, extra...)
 	return kgo.NewClient(opts...)
+}
+
+// tlsConfig materializes the client-side *tls.Config from the Client's
+// PKCS#12 truststore (and, for mTLS, keystore). Returns (nil, nil) for
+// PLAINTEXT mode.
+func (c *Client) tlsConfig(ctx context.Context) (*tls.Config, error) {
+	if c.SecurityMode == "PLAINTEXT" {
+		return nil, nil
+	}
+	if c.TrustStore == nil || c.TrustStorePassword == nil {
+		return nil, fmt.Errorf("%s mode requires TrustStore + TrustStorePassword", c.SecurityMode)
+	}
+	tsBytes, err := dagFileBytes(ctx, c.TrustStore)
+	if err != nil {
+		return nil, fmt.Errorf("export truststore: %w", err)
+	}
+	tsPwd, err := c.TrustStorePassword.Plaintext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("read truststore password: %w", err)
+	}
+	rootCerts, err := pkcs12.DecodeTrustStore(tsBytes, tsPwd)
+	if err != nil {
+		return nil, fmt.Errorf("decode truststore: %w", err)
+	}
+	pool := x509.NewCertPool()
+	for _, ca := range rootCerts {
+		pool.AddCert(ca)
+	}
+	cfg := &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12}
+
+	if c.SecurityMode == "MTLS" {
+		if c.KeyStore == nil || c.KeyStorePassword == nil {
+			return nil, fmt.Errorf("MTLS mode requires KeyStore + KeyStorePassword")
+		}
+		ksBytes, err := dagFileBytes(ctx, c.KeyStore)
+		if err != nil {
+			return nil, fmt.Errorf("export keystore: %w", err)
+		}
+		ksPwd, err := c.KeyStorePassword.Plaintext(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("read keystore password: %w", err)
+		}
+		priv, leaf, chain, err := pkcs12.DecodeChain(ksBytes, ksPwd)
+		if err != nil {
+			return nil, fmt.Errorf("decode keystore: %w", err)
+		}
+		certBytes := [][]byte{leaf.Raw}
+		for _, link := range chain {
+			certBytes = append(certBytes, link.Raw)
+		}
+		cfg.Certificates = []tls.Certificate{{
+			Certificate: certBytes,
+			PrivateKey:  priv,
+			Leaf:        leaf,
+		}}
+	}
+	return cfg, nil
+}
+
+// dagFileBytes materializes a *dagger.File via Export then ReadFile. Used
+// for binary content (PKCS#12 archives) where File.Contents() would corrupt
+// non-UTF-8 bytes when round-tripped through the GraphQL String type.
+func dagFileBytes(ctx context.Context, f *dagger.File) ([]byte, error) {
+	local := "kafka-tls-in-" + randSuffix()
+	if _, err := f.Export(ctx, local); err != nil {
+		return nil, fmt.Errorf("export file: %w", err)
+	}
+	defer os.Remove(local)
+	return os.ReadFile(local)
 }
 
 // CreateTopic creates a new topic with the given partition count and
@@ -365,7 +944,7 @@ func (c *Client) CreateTopic(
 	if replicationFactor <= 0 {
 		return fmt.Errorf("replicationFactor must be > 0, got %d", replicationFactor)
 	}
-	cl, err := c.newKgoClient()
+	cl, err := c.newKgoClient(ctx)
 	if err != nil {
 		return fmt.Errorf("new kafka client: %w", err)
 	}
@@ -386,7 +965,7 @@ func (c *Client) CreateTopic(
 //
 // +cache="never"
 func (c *Client) DeleteTopic(ctx context.Context, name string) error {
-	cl, err := c.newKgoClient()
+	cl, err := c.newKgoClient(ctx)
 	if err != nil {
 		return fmt.Errorf("new kafka client: %w", err)
 	}
@@ -428,7 +1007,7 @@ func (c *Client) Produce(
 		return fmt.Errorf("decode value: %w", err)
 	}
 
-	cl, err := c.newKgoClient()
+	cl, err := c.newKgoClient(ctx)
 	if err != nil {
 		return fmt.Errorf("new kafka client: %w", err)
 	}
@@ -491,7 +1070,7 @@ func (c *Client) Consume(
 		// replication-factor defaults are correct.
 		opts = append(opts, kgo.ConsumerGroup(group), kgo.DisableAutoCommit())
 	}
-	cl, err := c.newKgoClient(opts...)
+	cl, err := c.newKgoClient(ctx, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("new kafka client: %w", err)
 	}
@@ -533,7 +1112,7 @@ func (c *Client) Consume(
 //
 // +cache="never"
 func (c *Client) ListTopics(ctx context.Context) ([]string, error) {
-	cl, err := c.newKgoClient()
+	cl, err := c.newKgoClient(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("new kafka client: %w", err)
 	}

--- a/daggerverse/kafka/main.go
+++ b/daggerverse/kafka/main.go
@@ -758,8 +758,22 @@ func encodeBytes(b []byte, encoding string) (string, error) {
 // +cache="never"
 func (c *Client) PropertiesFile(ctx context.Context) (*dagger.File, error) {
 	proto := "PLAINTEXT"
-	if c.SecurityMode != "PLAINTEXT" {
+	switch c.SecurityMode {
+	case "PLAINTEXT":
+	case "TLS", "MTLS":
 		proto = "SSL"
+	default:
+		return nil, fmt.Errorf("PropertiesFile: unsupported SecurityMode %q", c.SecurityMode)
+	}
+	if c.SecurityMode == "TLS" || c.SecurityMode == "MTLS" {
+		if c.TrustStore == nil || c.TrustStorePassword == nil {
+			return nil, fmt.Errorf("PropertiesFile: %s mode requires TrustStore + TrustStorePassword", c.SecurityMode)
+		}
+	}
+	if c.SecurityMode == "MTLS" {
+		if c.KeyStore == nil || c.KeyStorePassword == nil {
+			return nil, fmt.Errorf("PropertiesFile: MTLS mode requires KeyStore + KeyStorePassword")
+		}
 	}
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "bootstrap.servers=%s\n", strings.Join(c.Bootstrap, ","))

--- a/daggerverse/kafka/tests/dagger.json
+++ b/daggerverse/kafka/tests/dagger.json
@@ -12,6 +12,14 @@
     {
       "name": "random",
       "source": "../../random"
+    },
+    {
+      "name": "certificate-management",
+      "source": "../../certificate-management"
+    },
+    {
+      "name": "crypto",
+      "source": "../../crypto"
     }
   ]
 }

--- a/daggerverse/kafka/tests/main.go
+++ b/daggerverse/kafka/tests/main.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strings"
+	"time"
 
 	"dagger/tests/internal/dagger"
 
@@ -47,6 +48,144 @@ func freshCluster(ctx context.Context, kafkaImageTag string) (*dagger.KafkaClust
 	return k.Cluster(clusterId, k.PlaintextServerSecurity(), dagger.KafkaClusterOpts{
 		Tag: kafkaImageTag,
 	}), nil
+}
+
+// freshCa mints a fresh per-test root CA via the certificate-management
+// module. Each call uses fresh inputs (random key, random password,
+// random serial, time.Now() notBefore) so the resulting CA is unique per
+// test. Returns the CA itself (lazy chain) for further leaf signing.
+func freshCa(ctx context.Context, label string) (*dagger.CertificateManagementCertificateAuthority, error) {
+	keyPem, err := dag.Crypto().GenerateRsaKey(dagger.CryptoGenerateRsaKeyOpts{Bits: 2048}).Pem().Contents(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("generate %s ca key: %w", label, err)
+	}
+	suffix, err := randHex(ctx)
+	if err != nil {
+		return nil, err
+	}
+	key := dag.SetSecret(label+"-ca-key-"+suffix, keyPem)
+
+	pwdHex, err := dag.Random().Sha256(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("generate %s ca password: %w", label, err)
+	}
+	pwd := dag.SetSecret(label+"-ca-pwd-"+suffix, pwdHex)
+
+	serial, err := dag.Random().Serial(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("generate %s ca serial: %w", label, err)
+	}
+	nb := time.Now().UTC().Format(time.RFC3339)
+	return dag.CertificateManagement().CreateCertificateAuthority(nb, serial, pwd, key,
+		dagger.CertificateManagementCreateCertificateAuthorityOpts{
+			CommonName:   "Test CA " + label,
+			ValidityDays: 30,
+		}), nil
+}
+
+// freshTlsCluster mints a fresh CA, hands its keystore to TlsServerSecurity,
+// and returns the cluster + the CA's truststore (file + password) so the
+// caller can build a matching TlsClientSecurity. Single-broker by default;
+// callers needing more brokers can extend the opts before calling.
+func freshTlsCluster(ctx context.Context, kafkaImageTag string, brokers int) (
+	*dagger.KafkaCluster, *dagger.File, *dagger.Secret, error,
+) {
+	ca, err := freshCa(ctx, "tls-server")
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	caKs := ca.KeyStore()
+	serverSec := dag.Kafka().TLSServerSecurity(caKs.Pkcs12(), caKs.Password())
+	ts := ca.TrustStore()
+
+	clusterId, err := newClusterId(ctx)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	cluster := dag.Kafka().Cluster(clusterId, serverSec, dagger.KafkaClusterOpts{
+		Tag:     kafkaImageTag,
+		Brokers: brokers,
+	})
+	return cluster, ts.Pkcs12(), ts.Password(), nil
+}
+
+// freshMtlsCluster mints two fresh CAs (one for the server-side leaf
+// signing, one for the client trust path), wires them into MtlsServerSecurity,
+// and additionally issues a client leaf signed by the client-side CA so the
+// caller can build a working MtlsClientSecurity. Returns the cluster, the
+// server-CA truststore (file + password) for the client to trust the broker,
+// and the client leaf keystore (file + password) for the broker to trust the
+// client.
+func freshMtlsCluster(ctx context.Context, kafkaImageTag string, brokers int) (
+	cluster *dagger.KafkaCluster,
+	serverTs *dagger.File, serverTsPwd *dagger.Secret,
+	clientKs *dagger.File, clientKsPwd *dagger.Secret,
+	err error,
+) {
+	serverCa, err := freshCa(ctx, "mtls-server")
+	if err != nil {
+		return nil, nil, nil, nil, nil, err
+	}
+	clientCa, err := freshCa(ctx, "mtls-client")
+	if err != nil {
+		return nil, nil, nil, nil, nil, err
+	}
+
+	serverCaKs := serverCa.KeyStore()
+	clientCaTs := clientCa.TrustStore()
+	serverSec := dag.Kafka().MtlsServerSecurity(
+		serverCaKs.Pkcs12(), serverCaKs.Password(),
+		clientCaTs.Pkcs12(), clientCaTs.Password(),
+	)
+
+	suffix, err := randHex(ctx)
+	if err != nil {
+		return nil, nil, nil, nil, nil, err
+	}
+	leafKeyPem, err := dag.Crypto().GenerateRsaKey(dagger.CryptoGenerateRsaKeyOpts{Bits: 2048}).Pem().Contents(ctx)
+	if err != nil {
+		return nil, nil, nil, nil, nil, fmt.Errorf("generate client leaf key: %w", err)
+	}
+	leafKey := dag.SetSecret("mtls-client-leaf-key-"+suffix, leafKeyPem)
+
+	leafPwdHex, err := dag.Random().Sha256(ctx)
+	if err != nil {
+		return nil, nil, nil, nil, nil, fmt.Errorf("generate client leaf password: %w", err)
+	}
+	leafPwd := dag.SetSecret("mtls-client-leaf-pwd-"+suffix, leafPwdHex)
+
+	leafSerial, err := dag.Random().Serial(ctx)
+	if err != nil {
+		return nil, nil, nil, nil, nil, fmt.Errorf("generate client leaf serial: %w", err)
+	}
+	nb := time.Now().UTC().Format(time.RFC3339)
+	clientLeaf := clientCa.IssueClientCertificate("test-client", nb, leafSerial, leafPwd, leafKey)
+	leafKs := clientLeaf.KeyStore()
+
+	serverTrust := serverCa.TrustStore()
+
+	clusterId, err := newClusterId(ctx)
+	if err != nil {
+		return nil, nil, nil, nil, nil, err
+	}
+	cluster = dag.Kafka().Cluster(clusterId, serverSec, dagger.KafkaClusterOpts{
+		Tag:     kafkaImageTag,
+		Brokers: brokers,
+	})
+	return cluster, serverTrust.Pkcs12(), serverTrust.Password(), leafKs.Pkcs12(), leafKs.Password(), nil
+}
+
+// randHex returns a fresh hex suffix, used to disambiguate Dagger secret
+// names across concurrent test invocations within the same engine session.
+func randHex(ctx context.Context) (string, error) {
+	h, err := dag.Random().Sha256(ctx)
+	if err != nil {
+		return "", fmt.Errorf("randHex: %w", err)
+	}
+	if len(h) < 16 {
+		return "", fmt.Errorf("randHex too short: %d", len(h))
+	}
+	return h[:16], nil
 }
 
 type Tests struct{}
@@ -115,6 +254,30 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("ConsumerGroupOnSingleBrokerWorks", func(ctx context.Context) error {
 		return t.ConsumerGroupOnSingleBrokerWorks(ctx, kafkaImageTag)
 	})
+	jobs = jobs.WithJob("TlsClusterStarts", func(ctx context.Context) error {
+		return t.TlsClusterStarts(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("TlsRoundTrip", func(ctx context.Context) error {
+		return t.TlsRoundTrip(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("TlsClientWithWrongCaFails", func(ctx context.Context) error {
+		return t.TlsClientWithWrongCaFails(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("InternalListenersAreEncrypted", func(ctx context.Context) error {
+		return t.InternalListenersAreEncrypted(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("MtlsRoundTrip", func(ctx context.Context) error {
+		return t.MtlsRoundTrip(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("MtlsRequiresClientCert", func(ctx context.Context) error {
+		return t.MtlsRequiresClientCert(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("PropertiesFileContainsTlsSettings", func(ctx context.Context) error {
+		return t.PropertiesFileContainsTlsSettings(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("PropertiesFileContainsMtlsSettings", func(ctx context.Context) error {
+		return t.PropertiesFileContainsMtlsSettings(ctx, kafkaImageTag)
+	})
 
 	return jobs.Run(ctx)
 }
@@ -139,6 +302,325 @@ func contains(haystack []string, needle string) bool {
 		}
 	}
 	return false
+}
+
+// PropertiesFileContainsTlsSettings verifies the rendered Java
+// client.properties carries security.protocol=SSL plus an ssl.truststore.*
+// triple referencing a sidecar PKCS#12 file by basename.
+func (t *Tests) PropertiesFileContainsTlsSettings(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, ts, tsPwd, err := freshTlsCluster(ctx, kafkaImageTag, 1)
+	if err != nil {
+		return fmt.Errorf("create tls cluster: %w", err)
+	}
+	props, err := cluster.Client(dag.Kafka().TLSClientSecurity(ts, tsPwd)).
+		PropertiesFile().
+		Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("read PropertiesFile: %w", err)
+	}
+	for _, want := range []string{
+		"security.protocol=SSL",
+		"ssl.truststore.location=truststore.p12",
+		"ssl.truststore.type=PKCS12",
+	} {
+		if !strings.Contains(props, want) {
+			return fmt.Errorf("expected properties to contain %q, got:\n%s", want, props)
+		}
+	}
+	return nil
+}
+
+// PropertiesFileContainsMtlsSettings verifies that mTLS mode also renders
+// the ssl.keystore.* triple referencing a keystore.p12 sidecar.
+func (t *Tests) PropertiesFileContainsMtlsSettings(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, ts, tsPwd, ks, ksPwd, err := freshMtlsCluster(ctx, kafkaImageTag, 1)
+	if err != nil {
+		return fmt.Errorf("create mtls cluster: %w", err)
+	}
+	props, err := cluster.Client(dag.Kafka().MtlsClientSecurity(ks, ksPwd, ts, tsPwd)).
+		PropertiesFile().
+		Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("read PropertiesFile: %w", err)
+	}
+	for _, want := range []string{
+		"security.protocol=SSL",
+		"ssl.truststore.location=truststore.p12",
+		"ssl.truststore.type=PKCS12",
+		"ssl.keystore.location=keystore.p12",
+		"ssl.keystore.type=PKCS12",
+	} {
+		if !strings.Contains(props, want) {
+			return fmt.Errorf("expected properties to contain %q, got:\n%s", want, props)
+		}
+	}
+	return nil
+}
+
+// MtlsRequiresClientCert points a TLS-only client (no keystore) at an
+// MTLS broker and asserts the handshake fails. Confirms the broker's
+// client.auth=required setting is actually being honoured.
+func (t *Tests) MtlsRequiresClientCert(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, ts, tsPwd, _, _, err := freshMtlsCluster(ctx, kafkaImageTag, 1)
+	if err != nil {
+		return fmt.Errorf("create mtls cluster: %w", err)
+	}
+	client := cluster.Client(dag.Kafka().TLSClientSecurity(ts, tsPwd))
+	if _, err := client.ListTopics(ctx); err == nil {
+		return fmt.Errorf("expected ListTopics to fail without a client cert against MTLS broker, got nil error")
+	}
+	return nil
+}
+
+// MtlsRoundTrip produces and consumes a single record over a mutual-TLS
+// external listener. The broker presents its cert (signed by the server
+// CA) and demands a client cert in return; the test client presents one
+// signed by an independent client CA the broker is configured to trust.
+func (t *Tests) MtlsRoundTrip(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, ts, tsPwd, ks, ksPwd, err := freshMtlsCluster(ctx, kafkaImageTag, 1)
+	if err != nil {
+		return fmt.Errorf("create mtls cluster: %w", err)
+	}
+	client := cluster.Client(dag.Kafka().MtlsClientSecurity(ks, ksPwd, ts, tsPwd))
+
+	topic, err := randomTopicName(ctx)
+	if err != nil {
+		return err
+	}
+	if err := client.CreateTopic(ctx, topic, dagger.KafkaClientCreateTopicOpts{
+		Partitions:        1,
+		ReplicationFactor: 1,
+	}); err != nil {
+		return fmt.Errorf("create topic %q: %w", topic, err)
+	}
+
+	const wantKey, wantVal = "k", "v"
+	if err := client.Produce(ctx, topic, wantKey, wantVal, dagger.KafkaClientProduceOpts{
+		KeyEncoding:   "raw",
+		ValueEncoding: "raw",
+	}); err != nil {
+		return fmt.Errorf("produce: %w", err)
+	}
+
+	records, err := client.Consume(ctx, topic, dagger.KafkaClientConsumeOpts{
+		MaxMessages:   1,
+		Timeout:       "15s",
+		KeyEncoding:   "raw",
+		ValueEncoding: "raw",
+	})
+	if err != nil {
+		return fmt.Errorf("consume: %w", err)
+	}
+	if len(records) != 1 {
+		return fmt.Errorf("expected 1 record, got %d", len(records))
+	}
+	gotKey, err := records[0].Key(ctx)
+	if err != nil {
+		return fmt.Errorf("read key: %w", err)
+	}
+	gotVal, err := records[0].Value(ctx)
+	if err != nil {
+		return fmt.Errorf("read value: %w", err)
+	}
+	if gotKey != wantKey || gotVal != wantVal {
+		return fmt.Errorf("mtls round-trip mismatch: got (%q, %q), want (%q, %q)", gotKey, gotVal, wantKey, wantVal)
+	}
+	return nil
+}
+
+// TlsClientWithWrongCaFails verifies that pointing the client at a
+// truststore for an unrelated CA fails the handshake — i.e. the broker is
+// genuinely presenting a cert chained to its own CA, not skipping
+// verification.
+func (t *Tests) TlsClientWithWrongCaFails(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, _, _, err := freshTlsCluster(ctx, kafkaImageTag, 1)
+	if err != nil {
+		return fmt.Errorf("create tls cluster: %w", err)
+	}
+	wrongCa, err := freshCa(ctx, "wrong")
+	if err != nil {
+		return fmt.Errorf("create unrelated ca: %w", err)
+	}
+	wrongTs := wrongCa.TrustStore()
+	client := cluster.Client(dag.Kafka().TLSClientSecurity(wrongTs.Pkcs12(), wrongTs.Password()))
+	if _, err := client.ListTopics(ctx); err == nil {
+		return fmt.Errorf("expected ListTopics to fail with wrong-CA truststore, got nil error")
+	}
+	return nil
+}
+
+// InternalListenersAreEncrypted spins up a 1+2 cluster with TLS on the
+// external listener and creates an RF=2 topic. A successful produce →
+// consume round-trip proves replication traffic flowed over the (always
+// mTLS) INTERNAL inter-broker listener: without working internal mTLS,
+// the second broker would never become an in-sync replica and the produce
+// (with default acks=all-isr) would stall.
+func (t *Tests) InternalListenersAreEncrypted(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, ts, tsPwd, err := freshTlsCluster(ctx, kafkaImageTag, 2)
+	if err != nil {
+		return fmt.Errorf("create tls cluster: %w", err)
+	}
+	client := cluster.Client(dag.Kafka().TLSClientSecurity(ts, tsPwd))
+
+	topic, err := randomTopicName(ctx)
+	if err != nil {
+		return err
+	}
+	if err := client.CreateTopic(ctx, topic, dagger.KafkaClientCreateTopicOpts{
+		Partitions:        1,
+		ReplicationFactor: 2,
+	}); err != nil {
+		return fmt.Errorf("create topic %q: %w", topic, err)
+	}
+
+	const wantKey, wantVal = "k", "v"
+	if err := client.Produce(ctx, topic, wantKey, wantVal, dagger.KafkaClientProduceOpts{
+		KeyEncoding:   "raw",
+		ValueEncoding: "raw",
+	}); err != nil {
+		return fmt.Errorf("produce: %w", err)
+	}
+
+	records, err := client.Consume(ctx, topic, dagger.KafkaClientConsumeOpts{
+		MaxMessages:   1,
+		Timeout:       "20s",
+		KeyEncoding:   "raw",
+		ValueEncoding: "raw",
+	})
+	if err != nil {
+		return fmt.Errorf("consume: %w", err)
+	}
+	if len(records) != 1 {
+		return fmt.Errorf("expected 1 record, got %d", len(records))
+	}
+	gotKey, err := records[0].Key(ctx)
+	if err != nil {
+		return fmt.Errorf("read key: %w", err)
+	}
+	gotVal, err := records[0].Value(ctx)
+	if err != nil {
+		return fmt.Errorf("read value: %w", err)
+	}
+	if gotKey != wantKey || gotVal != wantVal {
+		return fmt.Errorf("rf=2 round-trip mismatch: got (%q, %q), want (%q, %q)", gotKey, gotVal, wantKey, wantVal)
+	}
+	return nil
+}
+
+// TlsRoundTrip produces and consumes a single record over a TLS-only
+// external listener with TlsClientSecurity holding the CA's truststore.
+// Exercises: SAN matching the bootstrap address, kgo dialer + TLS, broker
+// SSL listener, end-to-end encryption.
+func (t *Tests) TlsRoundTrip(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, ts, tsPwd, err := freshTlsCluster(ctx, kafkaImageTag, 1)
+	if err != nil {
+		return fmt.Errorf("create tls cluster: %w", err)
+	}
+	client := cluster.Client(dag.Kafka().TLSClientSecurity(ts, tsPwd))
+
+	topic, err := randomTopicName(ctx)
+	if err != nil {
+		return err
+	}
+	if err := client.CreateTopic(ctx, topic, dagger.KafkaClientCreateTopicOpts{
+		Partitions:        1,
+		ReplicationFactor: 1,
+	}); err != nil {
+		return fmt.Errorf("create topic %q: %w", topic, err)
+	}
+
+	const wantKey, wantVal = "k", "v"
+	if err := client.Produce(ctx, topic, wantKey, wantVal, dagger.KafkaClientProduceOpts{
+		KeyEncoding:   "raw",
+		ValueEncoding: "raw",
+	}); err != nil {
+		return fmt.Errorf("produce: %w", err)
+	}
+
+	records, err := client.Consume(ctx, topic, dagger.KafkaClientConsumeOpts{
+		MaxMessages:   1,
+		Timeout:       "15s",
+		KeyEncoding:   "raw",
+		ValueEncoding: "raw",
+	})
+	if err != nil {
+		return fmt.Errorf("consume: %w", err)
+	}
+	if len(records) != 1 {
+		return fmt.Errorf("expected 1 record, got %d", len(records))
+	}
+	gotKey, err := records[0].Key(ctx)
+	if err != nil {
+		return fmt.Errorf("read key: %w", err)
+	}
+	gotVal, err := records[0].Value(ctx)
+	if err != nil {
+		return fmt.Errorf("read value: %w", err)
+	}
+	if gotKey != wantKey {
+		return fmt.Errorf("key mismatch: want %q, got %q", wantKey, gotKey)
+	}
+	if gotVal != wantVal {
+		return fmt.Errorf("value mismatch: want %q, got %q", wantVal, gotVal)
+	}
+	return nil
+}
+
+// TlsClusterStarts forces the lazy Cluster construction to run under
+// TlsServerSecurity and confirms BootstrapServers reports a non-empty,
+// non-zero-port broker address. No client connection attempted — this
+// proves caller's CA loads, leaf signing succeeds, the keystore mounts,
+// and the broker doesn't crash on startup.
+func (t *Tests) TlsClusterStarts(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, _, _, err := freshTlsCluster(ctx, kafkaImageTag, 1)
+	if err != nil {
+		return fmt.Errorf("create tls cluster: %w", err)
+	}
+	bs, err := cluster.BootstrapServers(ctx)
+	if err != nil {
+		return fmt.Errorf("bootstrap servers: %w", err)
+	}
+	if len(bs) == 0 {
+		return fmt.Errorf("expected at least one bootstrap server, got none")
+	}
+	for _, b := range bs {
+		if b == "" || b == ":9092" {
+			return fmt.Errorf("expected non-empty bootstrap server, got %q", b)
+		}
+	}
+	return nil
 }
 
 func (t *Tests) PlaintextSecurityProfilesAreNonNil(ctx context.Context) error {


### PR DESCRIPTION
Closes #12.

## Summary

- Adds `Kafka.TLSServerSecurity`, `Kafka.MtlsServerSecurity`, `Kafka.TLSClientSecurity`, `Kafka.MtlsClientSecurity` per the issue spec. Caller-supplied PKCS#12 CA drives the external listener; the kafka module mints its own per-cluster CA for inter-broker + controller-quorum mTLS (never surfaced on the API).
- Listeners renamed `EXTERNAL` / `INTERNAL` / `CONTROLLER` (no underscores) so `KAFKA_LISTENER_NAME_<NAME>_SSL_*` env-var translation works cleanly. Brokers + controller use `Service.WithHostname` for stable per-cluster aliases (suffix derived from `clusterId`) so cert SANs are knowable up-front and parallel cluster spawns don't collide.
- franz-go TLS via `kgo.DialTLSConfig`; truststore + keystore decoded with `software.sslmate.com/src/go-pkcs12`. `PropertiesFile(ctx)` emits `truststore.p12` / `keystore.p12` sidecars next to `client.properties`.
- 9 new tests (`TlsClusterStarts`, `TlsRoundTrip`, `TlsClientWithWrongCaFails`, `InternalListenersAreEncrypted`, `MtlsRoundTrip`, `MtlsRequiresClientCert`, `PropertiesFileContainsTlsSettings`, `PropertiesFileContainsMtlsSettings`, plus the existing PLAINTEXT suite still green). Full suite (25 tests) passes in 3m32s under concurrency=2.

## Test plan

- [x] `dagger call all --kafka-image-tag=4.2.0` from `daggerverse/kafka/tests`
- [x] `dagger call tls-round-trip` (single-broker TLS produce/consume)
- [x] `dagger call mtls-round-trip` (mTLS with client cert)
- [x] `dagger call mtls-requires-client-cert` (TLS-only client against mTLS broker fails handshake)
- [x] `dagger call tls-client-with-wrong-ca-fails` (unrelated truststore fails verification)
- [x] `dagger call internal-listeners-are-encrypted` (RF=2 replication under TLS)
- [x] `dagger call properties-file-contains-tls-settings` / `properties-file-contains-mtls-settings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)