### PR TITLE
story(issue-30): rename Kafka.Cluster to Kafka.ApacheNativeCluster

### DIFF
--- a/daggerverse/kafka/README.md
+++ b/daggerverse/kafka/README.md
@@ -35,18 +35,18 @@ clientSec := dag.Kafka().MtlsClientSecurity(
 The CA `keystore`/`truststore` arguments are PKCS#12 archives produced by
 the [`certificate-management`](../certificate-management) module (or any
 PKCS#12 source). The cluster mints per-broker leaf certificates from the
-supplied CA at `Cluster()` time, with each broker's stable hostname
+supplied CA at `ApacheNativeCluster()` time, with each broker's stable hostname
 (`broker-100-<suffix>`, `broker-101-<suffix>`, ...) bound as a DNS SAN.
 Clients dialing the bootstrap address verify the broker's cert against
 the matching truststore.
 
-## Cluster
+## ApacheNativeCluster
 
 ```go
-cluster := dag.Kafka().Cluster(
+cluster := dag.Kafka().ApacheNativeCluster(
     clusterId,        // 22-char base64-url Kafka cluster ID
     serverSec,
-    dagger.KafkaClusterOpts{
+    dagger.KafkaApacheNativeClusterOpts{
         Tag:         "4.2.0",
         Controllers: 1,    // multi-controller is rejected; see below
         Brokers:     2,
@@ -55,7 +55,7 @@ cluster := dag.Kafka().Cluster(
 )
 ```
 
-`Cluster` is a session-cached lazy chain — the server-side constructor
+`ApacheNativeCluster` is a session-cached lazy chain — the server-side constructor
 runs at most once per (clusterId, args) within an engine session, so
 chained method calls (`cluster.Client().Produce(...) → Consume(...)`) all
 observe the same underlying broker services and the same internal CA.
@@ -132,7 +132,7 @@ Topic auto-creation is disabled on the broker — call `CreateTopic` before
 
 ## TLS / mTLS notes
 
-- The internal CA is fresh per `Cluster()` invocation. Cert material
+- The internal CA is fresh per `ApacheNativeCluster()` invocation. Cert material
   never crosses the module boundary.
 - Caller-supplied CAs are loaded via
   `dag.CertificateManagement().LoadCertificateAuthority(file, secret)`

--- a/daggerverse/kafka/main.go
+++ b/daggerverse/kafka/main.go
@@ -162,8 +162,9 @@ func (k *Kafka) MtlsClientSecurity(
 	}
 }
 
-// Cluster spins up a KRaft Kafka cluster of the requested size with
-// dedicated controller and broker containers.
+// ApacheNativeCluster spins up a KRaft Kafka cluster of the requested
+// size with dedicated controller and broker containers, using the
+// `apache/kafka-native` GraalVM-compiled image.
 //
 // Topology: a single controller forms a one-node KRaft quorum; one or more
 // brokers connect to it and discover each other over the engine's
@@ -183,8 +184,13 @@ func (k *Kafka) MtlsClientSecurity(
 // (with a brand-new CA the previous invocation's franz-go client doesn't
 // trust) every time the test calls another method on the chain.
 //
+// The GraalVM-compiled image has been observed to flake during the broker
+// `setup` step under load — see Dagger Cloud trace
+// `377f2e176c4f0e9844cb7f958c1e911b`. If you need the JVM image instead,
+// use `ApacheCluster()` (forthcoming).
+//
 // +cache="session"
-func (k *Kafka) Cluster(
+func (k *Kafka) ApacheNativeCluster(
 	ctx context.Context,
 	clusterId string,
 	// +default=1

--- a/daggerverse/kafka/tests/main.go
+++ b/daggerverse/kafka/tests/main.go
@@ -45,7 +45,7 @@ func freshCluster(ctx context.Context, kafkaImageTag string) (*dagger.KafkaClust
 		return nil, err
 	}
 	k := dag.Kafka()
-	return k.Cluster(clusterId, k.PlaintextServerSecurity(), dagger.KafkaClusterOpts{
+	return k.ApacheNativeCluster(clusterId,k.PlaintextServerSecurity(), dagger.KafkaApacheNativeClusterOpts{
 		Tag: kafkaImageTag,
 	}), nil
 }
@@ -102,7 +102,7 @@ func freshTlsCluster(ctx context.Context, kafkaImageTag string, brokers int) (
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	cluster := dag.Kafka().Cluster(clusterId, serverSec, dagger.KafkaClusterOpts{
+	cluster := dag.Kafka().ApacheNativeCluster(clusterId,serverSec, dagger.KafkaApacheNativeClusterOpts{
 		Tag:     kafkaImageTag,
 		Brokers: brokers,
 	})
@@ -168,7 +168,7 @@ func freshMtlsCluster(ctx context.Context, kafkaImageTag string, brokers int) (
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
 	}
-	cluster = dag.Kafka().Cluster(clusterId, serverSec, dagger.KafkaClusterOpts{
+	cluster = dag.Kafka().ApacheNativeCluster(clusterId,serverSec, dagger.KafkaApacheNativeClusterOpts{
 		Tag:     kafkaImageTag,
 		Brokers: brokers,
 	})
@@ -903,7 +903,7 @@ func (t *Tests) MultiControllerIsRejected(
 		return err
 	}
 	k := dag.Kafka()
-	cluster := k.Cluster(clusterId, k.PlaintextServerSecurity(), dagger.KafkaClusterOpts{
+	cluster := k.ApacheNativeCluster(clusterId,k.PlaintextServerSecurity(), dagger.KafkaApacheNativeClusterOpts{
 		Tag:         kafkaImageTag,
 		Controllers: 3,
 		Brokers:     1,
@@ -928,7 +928,7 @@ func (t *Tests) OneControllerTwoBrokersReplicationFactorTwo(
 		return err
 	}
 	k := dag.Kafka()
-	cluster := k.Cluster(clusterId, k.PlaintextServerSecurity(), dagger.KafkaClusterOpts{
+	cluster := k.ApacheNativeCluster(clusterId,k.PlaintextServerSecurity(), dagger.KafkaApacheNativeClusterOpts{
 		Tag:         kafkaImageTag,
 		Controllers: 1,
 		Brokers:     2,


### PR DESCRIPTION
## Summary
- Renames `Kafka.Cluster()` → `Kafka.ApacheNativeCluster()` so the distro choice (the `apache/kafka-native` GraalVM image) is explicit in the function name, leaving room for sibling constructors (`ApacheCluster`, `ConfluentCluster`, `RedpandaCluster`) without one being the implicit default.
- Doc comment now calls out the GraalVM `setup` flake observed under Dagger Cloud trace `377f2e176c4f0e9844cb7f958c1e911b` and forward-references `ApacheCluster()` for callers who'd prefer the JVM image.
- Breaking change; pre-1.0 module, only in-tree caller is `daggerverse/kafka/tests/`. Return type `*Cluster` and `ServerSecurity` parameter shape unchanged.

Closes #30.

## Test plan
- [x] `dagger develop` re-run in `daggerverse/kafka/` and `daggerverse/kafka/tests/` so generated bindings match
- [x] `dagger call all` passes locally — full kafka test suite, 3m34s (trace `662c529c728e9d1c2379c35c654b3350`)
- [x] `dagger call multi-controller-is-rejected` passes (sanity check on the renamed constructor's validation path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)