### PR TITLE
story(issue-31): add Kafka.ApacheCluster (JVM image) sibling

### DIFF
--- a/daggerverse/kafka/README.md
+++ b/daggerverse/kafka/README.md
@@ -151,6 +151,22 @@ Topic auto-creation is disabled on the broker — call `CreateTopic` before
 
 ## Image source
 
-Image is built as `<registry>/apache/kafka-native:<tag>`. The
-`apache/kafka-native` portion is fixed; only `registry` (default
-`docker.io`) and `tag` (default `4.2.0`) are caller-overridable.
+The module exposes two cluster constructors, one per upstream Apache
+image. Both speak the same `KAFKA_*` env-var contract and return the
+same `*Cluster`, so downstream code is identical regardless of which
+one you pick:
+
+- `ApacheNativeCluster` → `<registry>/apache/kafka-native:<tag>`
+  (default `docker.io/apache/kafka-native:4.2.0`). GraalVM-compiled;
+  fastest cold start.
+- `ApacheCluster` → `<registry>/apache/kafka:<tag>` (default
+  `docker.io/apache/kafka:4.2.0`). Stock JVM image; slower cold start
+  but does not share the native image's AOT-compiled `Pwd.getpwuid`
+  substitution (`SystemPropertiesSupport.userHomeValue`) that has been
+  observed to segfault during broker startup under Dagger Cloud trace
+  `377f2e176c4f0e9844cb7f958c1e911b`. Prefer this constructor when
+  startup robustness matters more than cold-start latency.
+
+`registry` (default `docker.io`) and `tag` (default `4.2.0`) are the
+only caller-overridable parts; the `apache/kafka{-native,}` portion is
+fixed per constructor.

--- a/daggerverse/kafka/main.go
+++ b/daggerverse/kafka/main.go
@@ -187,7 +187,7 @@ func (k *Kafka) MtlsClientSecurity(
 // The GraalVM-compiled image has been observed to flake during the broker
 // `setup` step under load — see Dagger Cloud trace
 // `377f2e176c4f0e9844cb7f958c1e911b`. If you need the JVM image instead,
-// use `ApacheCluster()` (forthcoming).
+// use `ApacheCluster()`.
 //
 // +cache="session"
 func (k *Kafka) ApacheNativeCluster(
@@ -201,6 +201,53 @@ func (k *Kafka) ApacheNativeCluster(
 	registry string,
 	// +default="4.2.0"
 	tag string,
+	clientListenerSecurity *ServerSecurity,
+) (*Cluster, error) {
+	image := fmt.Sprintf("%s/apache/kafka-native:%s", registry, tag)
+	return buildApacheCluster(ctx, clusterId, controllers, brokers, image, clientListenerSecurity)
+}
+
+// ApacheCluster spins up a KRaft Kafka cluster of the requested size with
+// dedicated controller and broker containers, using the `apache/kafka`
+// JVM image.
+//
+// Identical in topology, caching, and security semantics to
+// ApacheNativeCluster — only the image differs. The JVM image runs the
+// same Scala wrapper but on HotSpot, so it does not share
+// `apache/kafka-native`'s AOT-compiled `getpwuid` substitution
+// (`Pwd.getpwuid` from `SystemPropertiesSupport.userHomeValue`) that has
+// been observed to segfault during broker startup — see Dagger Cloud
+// trace `377f2e176c4f0e9844cb7f958c1e911b`. Prefer this constructor
+// whenever startup robustness matters more than cold-start latency.
+//
+// +cache="session"
+func (k *Kafka) ApacheCluster(
+	ctx context.Context,
+	clusterId string,
+	// +default=1
+	controllers int,
+	// +default=1
+	brokers int,
+	// +default="docker.io"
+	registry string,
+	// +default="4.2.0"
+	tag string,
+	clientListenerSecurity *ServerSecurity,
+) (*Cluster, error) {
+	image := fmt.Sprintf("%s/apache/kafka:%s", registry, tag)
+	return buildApacheCluster(ctx, clusterId, controllers, brokers, image, clientListenerSecurity)
+}
+
+// buildApacheCluster is the shared body behind ApacheNativeCluster and
+// ApacheCluster. Both Apache images share an identical Scala wrapper +
+// `KAFKA_*` env-var contract, so the only thing that varies between the
+// two callers is the image string.
+func buildApacheCluster(
+	ctx context.Context,
+	clusterId string,
+	controllers int,
+	brokers int,
+	image string,
 	clientListenerSecurity *ServerSecurity,
 ) (*Cluster, error) {
 	if controllers < 1 {
@@ -236,8 +283,6 @@ func (k *Kafka) ApacheNativeCluster(
 			clusterId,
 		)
 	}
-
-	image := fmt.Sprintf("%s/apache/kafka-native:%s", registry, tag)
 
 	// Stable hostnames are scoped per-cluster so parallel test invocations
 	// don't collide on `broker-100` / `controller-1`. The suffix is derived

--- a/daggerverse/kafka/tests/main.go
+++ b/daggerverse/kafka/tests/main.go
@@ -175,6 +175,104 @@ func freshMtlsCluster(ctx context.Context, kafkaImageTag string, brokers int) (
 	return cluster, serverTrust.Pkcs12(), serverTrust.Password(), leafKs.Pkcs12(), leafKs.Password(), nil
 }
 
+// freshClusterApache is the JVM-image (apache/kafka) sibling of freshCluster.
+// Same single-controller-single-broker plaintext topology — only the
+// underlying image differs — so it lets tests verify the JVM variant
+// without otherwise diverging from the freshCluster flow.
+func freshClusterApache(ctx context.Context, kafkaImageTag string) (*dagger.KafkaCluster, error) {
+	clusterId, err := newClusterId(ctx)
+	if err != nil {
+		return nil, err
+	}
+	k := dag.Kafka()
+	return k.ApacheCluster(clusterId, k.PlaintextServerSecurity(), dagger.KafkaApacheClusterOpts{
+		Tag: kafkaImageTag,
+	}), nil
+}
+
+// freshTlsClusterApache is the JVM-image sibling of freshTlsCluster.
+func freshTlsClusterApache(ctx context.Context, kafkaImageTag string, brokers int) (
+	*dagger.KafkaCluster, *dagger.File, *dagger.Secret, error,
+) {
+	ca, err := freshCa(ctx, "tls-server")
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	caKs := ca.KeyStore()
+	serverSec := dag.Kafka().TLSServerSecurity(caKs.Pkcs12(), caKs.Password())
+	ts := ca.TrustStore()
+
+	clusterId, err := newClusterId(ctx)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	cluster := dag.Kafka().ApacheCluster(clusterId, serverSec, dagger.KafkaApacheClusterOpts{
+		Tag:     kafkaImageTag,
+		Brokers: brokers,
+	})
+	return cluster, ts.Pkcs12(), ts.Password(), nil
+}
+
+// freshMtlsClusterApache is the JVM-image sibling of freshMtlsCluster.
+func freshMtlsClusterApache(ctx context.Context, kafkaImageTag string, brokers int) (
+	cluster *dagger.KafkaCluster,
+	serverTs *dagger.File, serverTsPwd *dagger.Secret,
+	clientKs *dagger.File, clientKsPwd *dagger.Secret,
+	err error,
+) {
+	serverCa, err := freshCa(ctx, "mtls-server")
+	if err != nil {
+		return nil, nil, nil, nil, nil, err
+	}
+	clientCa, err := freshCa(ctx, "mtls-client")
+	if err != nil {
+		return nil, nil, nil, nil, nil, err
+	}
+
+	serverCaKs := serverCa.KeyStore()
+	clientCaTs := clientCa.TrustStore()
+	serverSec := dag.Kafka().MtlsServerSecurity(
+		serverCaKs.Pkcs12(), serverCaKs.Password(),
+		clientCaTs.Pkcs12(), clientCaTs.Password(),
+	)
+
+	suffix, err := randHex(ctx)
+	if err != nil {
+		return nil, nil, nil, nil, nil, err
+	}
+	leafKeyPem, err := dag.Crypto().GenerateRsaKey(dagger.CryptoGenerateRsaKeyOpts{Bits: 2048}).Pem().Contents(ctx)
+	if err != nil {
+		return nil, nil, nil, nil, nil, fmt.Errorf("generate client leaf key: %w", err)
+	}
+	leafKey := dag.SetSecret("mtls-apache-client-leaf-key-"+suffix, leafKeyPem)
+
+	leafPwdHex, err := dag.Random().Sha256(ctx)
+	if err != nil {
+		return nil, nil, nil, nil, nil, fmt.Errorf("generate client leaf password: %w", err)
+	}
+	leafPwd := dag.SetSecret("mtls-apache-client-leaf-pwd-"+suffix, leafPwdHex)
+
+	leafSerial, err := dag.Random().Serial(ctx)
+	if err != nil {
+		return nil, nil, nil, nil, nil, fmt.Errorf("generate client leaf serial: %w", err)
+	}
+	nb := time.Now().UTC().Format(time.RFC3339)
+	clientLeaf := clientCa.IssueClientCertificate("test-client", nb, leafSerial, leafPwd, leafKey)
+	leafKs := clientLeaf.KeyStore()
+
+	serverTrust := serverCa.TrustStore()
+
+	clusterId, err := newClusterId(ctx)
+	if err != nil {
+		return nil, nil, nil, nil, nil, err
+	}
+	cluster = dag.Kafka().ApacheCluster(clusterId, serverSec, dagger.KafkaApacheClusterOpts{
+		Tag:     kafkaImageTag,
+		Brokers: brokers,
+	})
+	return cluster, serverTrust.Pkcs12(), serverTrust.Password(), leafKs.Pkcs12(), leafKs.Password(), nil
+}
+
 // randHex returns a fresh hex suffix, used to disambiguate Dagger secret
 // names across concurrent test invocations within the same engine session.
 func randHex(ctx context.Context) (string, error) {
@@ -277,6 +375,15 @@ func (t *Tests) All(
 	})
 	jobs = jobs.WithJob("PropertiesFileContainsMtlsSettings", func(ctx context.Context) error {
 		return t.PropertiesFileContainsMtlsSettings(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("ApacheClusterProduceListTopicsRoundTrip", func(ctx context.Context) error {
+		return t.ApacheClusterProduceListTopicsRoundTrip(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("ApacheClusterTlsRoundTrip", func(ctx context.Context) error {
+		return t.ApacheClusterTlsRoundTrip(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("ApacheClusterMtlsRoundTrip", func(ctx context.Context) error {
+		return t.ApacheClusterMtlsRoundTrip(ctx, kafkaImageTag)
 	})
 
 	return jobs.Run(ctx)
@@ -1187,6 +1294,172 @@ func roundTripBinary(ctx context.Context, kafkaImageTag, encoding, key, value st
 	}
 	if gotVal != value {
 		return fmt.Errorf("%s value mismatch: want %q, got %q", encoding, value, gotVal)
+	}
+	return nil
+}
+
+// ApacheClusterProduceListTopicsRoundTrip is the PLAINTEXT happy-path
+// smoke test for Kafka.ApacheCluster (the JVM image variant): produce a
+// single raw record, then call ListTopics and assert the freshly-created
+// topic shows up. Together these prove the JVM image's data plane and
+// control plane both work; the env-var contract matches
+// ApacheNativeCluster so this single test pins down "JVM image actually
+// serves traffic".
+func (t *Tests) ApacheClusterProduceListTopicsRoundTrip(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, err := freshClusterApache(ctx, kafkaImageTag)
+	if err != nil {
+		return fmt.Errorf("create apache cluster: %w", err)
+	}
+	client := cluster.Client(dag.Kafka().PlaintextClientSecurity())
+
+	topic, err := randomTopicName(ctx)
+	if err != nil {
+		return err
+	}
+	if err := client.CreateTopic(ctx, topic, dagger.KafkaClientCreateTopicOpts{
+		Partitions:        1,
+		ReplicationFactor: 1,
+	}); err != nil {
+		return fmt.Errorf("create topic %q: %w", topic, err)
+	}
+
+	if err := client.Produce(ctx, topic, "k", "v", dagger.KafkaClientProduceOpts{
+		KeyEncoding:   "raw",
+		ValueEncoding: "raw",
+	}); err != nil {
+		return fmt.Errorf("produce: %w", err)
+	}
+
+	topics, err := client.ListTopics(ctx)
+	if err != nil {
+		return fmt.Errorf("list topics: %w", err)
+	}
+	if !contains(topics, topic) {
+		return fmt.Errorf("expected topic %q in ListTopics output, got %v", topic, topics)
+	}
+	return nil
+}
+
+// ApacheClusterTlsRoundTrip is the TLS happy-path round-trip for
+// Kafka.ApacheCluster. Mirrors TlsRoundTrip but on the JVM image to
+// rule out image-specific differences in keystore mounts, hostname
+// verification, and SSL listener bring-up.
+func (t *Tests) ApacheClusterTlsRoundTrip(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, ts, tsPwd, err := freshTlsClusterApache(ctx, kafkaImageTag, 1)
+	if err != nil {
+		return fmt.Errorf("create apache tls cluster: %w", err)
+	}
+	client := cluster.Client(dag.Kafka().TLSClientSecurity(ts, tsPwd))
+
+	topic, err := randomTopicName(ctx)
+	if err != nil {
+		return err
+	}
+	if err := client.CreateTopic(ctx, topic, dagger.KafkaClientCreateTopicOpts{
+		Partitions:        1,
+		ReplicationFactor: 1,
+	}); err != nil {
+		return fmt.Errorf("create topic %q: %w", topic, err)
+	}
+
+	const wantKey, wantVal = "k", "v"
+	if err := client.Produce(ctx, topic, wantKey, wantVal, dagger.KafkaClientProduceOpts{
+		KeyEncoding:   "raw",
+		ValueEncoding: "raw",
+	}); err != nil {
+		return fmt.Errorf("produce: %w", err)
+	}
+
+	records, err := client.Consume(ctx, topic, dagger.KafkaClientConsumeOpts{
+		MaxMessages:   1,
+		Timeout:       "15s",
+		KeyEncoding:   "raw",
+		ValueEncoding: "raw",
+	})
+	if err != nil {
+		return fmt.Errorf("consume: %w", err)
+	}
+	if len(records) != 1 {
+		return fmt.Errorf("expected 1 record, got %d", len(records))
+	}
+	gotKey, err := records[0].Key(ctx)
+	if err != nil {
+		return fmt.Errorf("read key: %w", err)
+	}
+	gotVal, err := records[0].Value(ctx)
+	if err != nil {
+		return fmt.Errorf("read value: %w", err)
+	}
+	if gotKey != wantKey || gotVal != wantVal {
+		return fmt.Errorf("apache tls round-trip mismatch: got (%q, %q), want (%q, %q)", gotKey, gotVal, wantKey, wantVal)
+	}
+	return nil
+}
+
+// ApacheClusterMtlsRoundTrip is the MTLS happy-path round-trip for
+// Kafka.ApacheCluster. Mirrors MtlsRoundTrip but on the JVM image to
+// rule out image-specific differences in how client-cert challenge is
+// handled.
+func (t *Tests) ApacheClusterMtlsRoundTrip(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, ts, tsPwd, ks, ksPwd, err := freshMtlsClusterApache(ctx, kafkaImageTag, 1)
+	if err != nil {
+		return fmt.Errorf("create apache mtls cluster: %w", err)
+	}
+	client := cluster.Client(dag.Kafka().MtlsClientSecurity(ks, ksPwd, ts, tsPwd))
+
+	topic, err := randomTopicName(ctx)
+	if err != nil {
+		return err
+	}
+	if err := client.CreateTopic(ctx, topic, dagger.KafkaClientCreateTopicOpts{
+		Partitions:        1,
+		ReplicationFactor: 1,
+	}); err != nil {
+		return fmt.Errorf("create topic %q: %w", topic, err)
+	}
+
+	const wantKey, wantVal = "k", "v"
+	if err := client.Produce(ctx, topic, wantKey, wantVal, dagger.KafkaClientProduceOpts{
+		KeyEncoding:   "raw",
+		ValueEncoding: "raw",
+	}); err != nil {
+		return fmt.Errorf("produce: %w", err)
+	}
+
+	records, err := client.Consume(ctx, topic, dagger.KafkaClientConsumeOpts{
+		MaxMessages:   1,
+		Timeout:       "15s",
+		KeyEncoding:   "raw",
+		ValueEncoding: "raw",
+	})
+	if err != nil {
+		return fmt.Errorf("consume: %w", err)
+	}
+	if len(records) != 1 {
+		return fmt.Errorf("expected 1 record, got %d", len(records))
+	}
+	gotKey, err := records[0].Key(ctx)
+	if err != nil {
+		return fmt.Errorf("read key: %w", err)
+	}
+	gotVal, err := records[0].Value(ctx)
+	if err != nil {
+		return fmt.Errorf("read value: %w", err)
+	}
+	if gotKey != wantKey || gotVal != wantVal {
+		return fmt.Errorf("apache mtls round-trip mismatch: got (%q, %q), want (%q, %q)", gotKey, gotVal, wantKey, wantVal)
 	}
 	return nil
 }

--- a/daggerverse/kafka/tests/main.go
+++ b/daggerverse/kafka/tests/main.go
@@ -292,10 +292,11 @@ type Tests struct{}
 // the engine doesn't have dozens of cluster containers (controller +
 // brokers per test) in flight at once on smaller CI runners.
 //
-// kafkaImageTag picks the apache/kafka-native tag every spawned cluster
-// runs against, so callers can verify the module against a newer Kafka
-// release without first changing main.go. The default matches the
-// Cluster constructor's own default.
+// kafkaImageTag picks the tag every spawned cluster runs against — applied
+// to both the apache/kafka-native image (ApacheNativeCluster) and the
+// apache/kafka JVM image (ApacheCluster) — so callers can verify the module
+// against a newer Kafka release without first changing main.go. The default
+// matches the cluster constructors' own default.
 //
 // +check
 // +cache="session"


### PR DESCRIPTION
## Summary

- Adds `Kafka.ApacheCluster` that spins up a KRaft cluster from the JVM `apache/kafka` image, sidestepping `apache/kafka-native:4.2.0`'s segfault in the AOT-compiled `Pwd.getpwuid` path (trace `377f2e176c4f0e9844cb7f958c1e911b`).
- Refactors `ApacheNativeCluster`'s body into a private `buildApacheCluster` helper so the two constructors share everything but the image string. Same parameter shape, same `*Cluster` return, same `KAFKA_*` env-var contract.
- Adds three happy-path tests on the JVM image — PLAINTEXT (produce → `ListTopics`), TLS, and MTLS — wired into `(*Tests).All` so any image-specific networking quirks surface.
- README "Image source" now documents both constructors and cites the segfault as motivation for the JVM variant.

Closes #31.

## Test plan

- [ ] `cd daggerverse/kafka/tests && dagger call apache-cluster-produce-list-topics-round-trip`
- [ ] `cd daggerverse/kafka/tests && dagger call apache-cluster-tls-round-trip`
- [ ] `cd daggerverse/kafka/tests && dagger call apache-cluster-mtls-round-trip`
- [ ] Regression: `dagger call produce-consume-round-trip-raw`, `tls-round-trip`, `mtls-round-trip` against the native image still pass
- [ ] `cd daggerverse/kafka/tests && dagger call all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)