### PR TITLE
story(issue-32): add Kafka.ConfluentCluster (cp-kafka image) sibling

### DIFF
--- a/daggerverse/kafka/README.md
+++ b/daggerverse/kafka/README.md
@@ -1,9 +1,10 @@
 # kafka
 
-A Dagger module that spins up a KRaft Kafka cluster from
-`apache/kafka-native` and exposes a pure-Go franz-go client that targets
-either the local cluster or any reachable remote cluster (AWS MSK,
-Confluent Cloud, etc.).
+A Dagger module that spins up a KRaft Kafka cluster from one of three
+upstream images — `apache/kafka-native` (GraalVM), `apache/kafka` (JVM),
+or `confluentinc/cp-kafka` (Confluent Platform) — and exposes a pure-Go
+franz-go client that targets either the local cluster or any reachable
+remote cluster (AWS MSK, Confluent Cloud, etc.).
 
 The module supports plaintext, TLS, and mTLS on the external client-facing
 listener. The internal listeners (inter-broker and controller-quorum) are
@@ -92,6 +93,32 @@ controller to know every other controller at static config time, which
 Dagger's `WithServiceBinding` model can't express without an unresolvable
 cycle. Multi-controller HA lands in a follow-up.
 
+## ConfluentCluster
+
+```go
+cluster := dag.Kafka().ConfluentCluster(
+    clusterId,
+    serverSec,
+    dagger.KafkaConfluentClusterOpts{
+        Tag:         "8.2.0",
+        Controllers: 1,
+        Brokers:     2,
+        Registry:    "docker.io",
+    },
+)
+```
+
+`ConfluentCluster` uses the `confluentinc/cp-kafka` image and is
+otherwise API-identical to the Apache constructors — same topology,
+same `ServerSecurity` / `*Cluster` types, same listener layout. Confluent
+Platform 8.x bundles Apache Kafka 4.x with the same minor version (CP
+8.2.0 ships Kafka 4.2.0), so callers swap distros by changing the
+constructor name alone.
+
+The constructor silently sets `KAFKA_CONFLUENT_SUPPORT_METRICS_ENABLE=false`
+on each broker to disable Confluent's phone-home telemetry, matching
+the Apache variants' startup behavior.
+
 ## Client
 
 `dag.Kafka().Client(bootstrapServers, security)` constructs a franz-go-backed
@@ -151,10 +178,10 @@ Topic auto-creation is disabled on the broker — call `CreateTopic` before
 
 ## Image source
 
-The module exposes two cluster constructors, one per upstream Apache
-image. Both speak the same `KAFKA_*` env-var contract and return the
-same `*Cluster`, so downstream code is identical regardless of which
-one you pick:
+The module exposes three cluster constructors, one per upstream image.
+All three speak the same `KAFKA_*` env-var contract and return the same
+`*Cluster`, so downstream code is identical regardless of which one
+you pick:
 
 - `ApacheNativeCluster` → `<registry>/apache/kafka-native:<tag>`
   (default `docker.io/apache/kafka-native:4.2.0`). GraalVM-compiled;
@@ -166,7 +193,12 @@ one you pick:
   observed to segfault during broker startup under Dagger Cloud trace
   `377f2e176c4f0e9844cb7f958c1e911b`. Prefer this constructor when
   startup robustness matters more than cold-start latency.
+- `ConfluentCluster` → `<registry>/confluentinc/cp-kafka:<tag>` (default
+  `docker.io/confluentinc/cp-kafka:8.2.0`). Confluent Platform 8.x
+  bundles Apache Kafka 4.x at the same minor version, so CP 8.2.0
+  ships Kafka 4.2.0. The constructor silently disables Confluent's
+  phone-home telemetry (`KAFKA_CONFLUENT_SUPPORT_METRICS_ENABLE=false`).
 
-`registry` (default `docker.io`) and `tag` (default `4.2.0`) are the
-only caller-overridable parts; the `apache/kafka{-native,}` portion is
-fixed per constructor.
+`registry` (default `docker.io`) and `tag` are the only caller-
+overridable parts; the `apache/kafka{-native,}` or `confluentinc/cp-kafka`
+portion is fixed per constructor.

--- a/daggerverse/kafka/main.go
+++ b/daggerverse/kafka/main.go
@@ -204,7 +204,7 @@ func (k *Kafka) ApacheNativeCluster(
 	clientListenerSecurity *ServerSecurity,
 ) (*Cluster, error) {
 	image := fmt.Sprintf("%s/apache/kafka-native:%s", registry, tag)
-	return buildApacheCluster(ctx, clusterId, controllers, brokers, image, clientListenerSecurity)
+	return buildKafkaCluster(ctx, clusterId, controllers, brokers, image, nil, clientListenerSecurity)
 }
 
 // ApacheCluster spins up a KRaft Kafka cluster of the requested size with
@@ -235,19 +235,61 @@ func (k *Kafka) ApacheCluster(
 	clientListenerSecurity *ServerSecurity,
 ) (*Cluster, error) {
 	image := fmt.Sprintf("%s/apache/kafka:%s", registry, tag)
-	return buildApacheCluster(ctx, clusterId, controllers, brokers, image, clientListenerSecurity)
+	return buildKafkaCluster(ctx, clusterId, controllers, brokers, image, nil, clientListenerSecurity)
 }
 
-// buildApacheCluster is the shared body behind ApacheNativeCluster and
-// ApacheCluster. Both Apache images share an identical Scala wrapper +
-// `KAFKA_*` env-var contract, so the only thing that varies between the
-// two callers is the image string.
-func buildApacheCluster(
+// ConfluentCluster spins up a KRaft Kafka cluster of the requested size
+// using the `confluentinc/cp-kafka` image — the Confluent Platform
+// distribution. Confluent Platform 8.x bundles Apache Kafka 4.x (CP
+// 8.2.0 ships Kafka 4.2.0), and cp-kafka speaks the same Scala-wrapper
+// `KAFKA_*` env-var contract that ApacheCluster does, so the returned
+// `*Cluster` and `ServerSecurity` API are identical to the Apache
+// constructors — callers swap distros by changing the constructor
+// name alone.
+//
+// The constructor silently disables Confluent's phone-home telemetry
+// (`KAFKA_CONFLUENT_SUPPORT_METRICS_ENABLE=false`) on every broker so
+// the cluster behaves the same way the Apache variants do at startup.
+//
+// +cache="session"
+func (k *Kafka) ConfluentCluster(
+	ctx context.Context,
+	clusterId string,
+	// +default=1
+	controllers int,
+	// +default=1
+	brokers int,
+	// +default="docker.io"
+	registry string,
+	// +default="8.2.0"
+	tag string,
+	clientListenerSecurity *ServerSecurity,
+) (*Cluster, error) {
+	image := fmt.Sprintf("%s/confluentinc/cp-kafka:%s", registry, tag)
+	extraEnv := []envKV{
+		{K: "KAFKA_CONFLUENT_SUPPORT_METRICS_ENABLE", V: "false"},
+	}
+	return buildKafkaCluster(ctx, clusterId, controllers, brokers, image, extraEnv, clientListenerSecurity)
+}
+
+// envKV is a key/value pair for distro-specific broker env overrides
+// passed into buildKafkaCluster. A slice (not a map) so iteration order
+// is stable across invocations and doesn't perturb Dagger's per-arg
+// cache key.
+type envKV struct{ K, V string }
+
+// buildKafkaCluster is the shared body behind every Kafka.*Cluster
+// constructor. The Apache and Confluent images all speak the same
+// `KAFKA_*` Scala-wrapper env-var contract under KRaft, so the only
+// per-distro inputs are the image string and any extra broker-side
+// env overrides (e.g. Confluent's telemetry kill switch).
+func buildKafkaCluster(
 	ctx context.Context,
 	clusterId string,
 	controllers int,
 	brokers int,
 	image string,
+	extraBrokerEnv []envKV,
 	clientListenerSecurity *ServerSecurity,
 ) (*Cluster, error) {
 	if controllers < 1 {
@@ -319,6 +361,12 @@ func buildApacheCluster(
 
 	ctrlCtr := dag.Container().
 		From(image).
+		// confluentinc/cp-kafka pre-sets KAFKA_ADVERTISED_LISTENERS=""
+		// in the image; the Scala config validator rejects the empty
+		// value even on controller-only nodes that have no advertised
+		// listeners. Strip it so the controller boots regardless of
+		// distro (no-op for the Apache images, which don't pre-set it).
+		WithoutEnvVariable("KAFKA_ADVERTISED_LISTENERS").
 		WithEnvVariable("KAFKA_NODE_ID", "1").
 		WithEnvVariable("KAFKA_PROCESS_ROLES", "controller").
 		WithEnvVariable("KAFKA_LISTENERS", "CONTROLLER://0.0.0.0:9093").
@@ -359,6 +407,9 @@ func buildApacheCluster(
 			WithEnvVariable("KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS", "0").
 			WithExposedPort(9092).
 			WithExposedPort(19092)
+		for _, kv := range extraBrokerEnv {
+			brkCtr = brkCtr.WithEnvVariable(kv.K, kv.V)
+		}
 		brkCtr = applyInternalListenerSsl(brkCtr, "INTERNAL", internal.Brokers[i])
 		brkCtr = applyInternalListenerSsl(brkCtr, "CONTROLLER", internal.Brokers[i])
 		if externalLeaves != nil {

--- a/daggerverse/kafka/tests/main.go
+++ b/daggerverse/kafka/tests/main.go
@@ -273,6 +273,104 @@ func freshMtlsClusterApache(ctx context.Context, kafkaImageTag string, brokers i
 	return cluster, serverTrust.Pkcs12(), serverTrust.Password(), leafKs.Pkcs12(), leafKs.Password(), nil
 }
 
+// freshConfluentCluster is the Confluent Platform (cp-kafka) sibling of
+// freshCluster. Single-controller, single-broker, plaintext external
+// listener — only the underlying image differs — so tests can verify
+// the cp-kafka distro without diverging from the freshCluster flow.
+func freshConfluentCluster(ctx context.Context, confluentImageTag string) (*dagger.KafkaCluster, error) {
+	clusterId, err := newClusterId(ctx)
+	if err != nil {
+		return nil, err
+	}
+	k := dag.Kafka()
+	return k.ConfluentCluster(clusterId, k.PlaintextServerSecurity(), dagger.KafkaConfluentClusterOpts{
+		Tag: confluentImageTag,
+	}), nil
+}
+
+// freshTlsConfluentCluster is the cp-kafka sibling of freshTlsCluster.
+func freshTlsConfluentCluster(ctx context.Context, confluentImageTag string, brokers int) (
+	*dagger.KafkaCluster, *dagger.File, *dagger.Secret, error,
+) {
+	ca, err := freshCa(ctx, "tls-server")
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	caKs := ca.KeyStore()
+	serverSec := dag.Kafka().TLSServerSecurity(caKs.Pkcs12(), caKs.Password())
+	ts := ca.TrustStore()
+
+	clusterId, err := newClusterId(ctx)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	cluster := dag.Kafka().ConfluentCluster(clusterId, serverSec, dagger.KafkaConfluentClusterOpts{
+		Tag:     confluentImageTag,
+		Brokers: brokers,
+	})
+	return cluster, ts.Pkcs12(), ts.Password(), nil
+}
+
+// freshMtlsConfluentCluster is the cp-kafka sibling of freshMtlsCluster.
+func freshMtlsConfluentCluster(ctx context.Context, confluentImageTag string, brokers int) (
+	cluster *dagger.KafkaCluster,
+	serverTs *dagger.File, serverTsPwd *dagger.Secret,
+	clientKs *dagger.File, clientKsPwd *dagger.Secret,
+	err error,
+) {
+	serverCa, err := freshCa(ctx, "mtls-server")
+	if err != nil {
+		return nil, nil, nil, nil, nil, err
+	}
+	clientCa, err := freshCa(ctx, "mtls-client")
+	if err != nil {
+		return nil, nil, nil, nil, nil, err
+	}
+
+	serverCaKs := serverCa.KeyStore()
+	clientCaTs := clientCa.TrustStore()
+	serverSec := dag.Kafka().MtlsServerSecurity(
+		serverCaKs.Pkcs12(), serverCaKs.Password(),
+		clientCaTs.Pkcs12(), clientCaTs.Password(),
+	)
+
+	suffix, err := randHex(ctx)
+	if err != nil {
+		return nil, nil, nil, nil, nil, err
+	}
+	leafKeyPem, err := dag.Crypto().GenerateRsaKey(dagger.CryptoGenerateRsaKeyOpts{Bits: 2048}).Pem().Contents(ctx)
+	if err != nil {
+		return nil, nil, nil, nil, nil, fmt.Errorf("generate client leaf key: %w", err)
+	}
+	leafKey := dag.SetSecret("mtls-confluent-client-leaf-key-"+suffix, leafKeyPem)
+
+	leafPwdHex, err := dag.Random().Sha256(ctx)
+	if err != nil {
+		return nil, nil, nil, nil, nil, fmt.Errorf("generate client leaf password: %w", err)
+	}
+	leafPwd := dag.SetSecret("mtls-confluent-client-leaf-pwd-"+suffix, leafPwdHex)
+
+	leafSerial, err := dag.Random().Serial(ctx)
+	if err != nil {
+		return nil, nil, nil, nil, nil, fmt.Errorf("generate client leaf serial: %w", err)
+	}
+	nb := time.Now().UTC().Format(time.RFC3339)
+	clientLeaf := clientCa.IssueClientCertificate("test-client", nb, leafSerial, leafPwd, leafKey)
+	leafKs := clientLeaf.KeyStore()
+
+	serverTrust := serverCa.TrustStore()
+
+	clusterId, err := newClusterId(ctx)
+	if err != nil {
+		return nil, nil, nil, nil, nil, err
+	}
+	cluster = dag.Kafka().ConfluentCluster(clusterId, serverSec, dagger.KafkaConfluentClusterOpts{
+		Tag:     confluentImageTag,
+		Brokers: brokers,
+	})
+	return cluster, serverTrust.Pkcs12(), serverTrust.Password(), leafKs.Pkcs12(), leafKs.Password(), nil
+}
+
 // randHex returns a fresh hex suffix, used to disambiguate Dagger secret
 // names across concurrent test invocations within the same engine session.
 func randHex(ctx context.Context) (string, error) {
@@ -292,11 +390,16 @@ type Tests struct{}
 // the engine doesn't have dozens of cluster containers (controller +
 // brokers per test) in flight at once on smaller CI runners.
 //
-// kafkaImageTag picks the tag every spawned cluster runs against — applied
-// to both the apache/kafka-native image (ApacheNativeCluster) and the
-// apache/kafka JVM image (ApacheCluster) — so callers can verify the module
-// against a newer Kafka release without first changing main.go. The default
-// matches the cluster constructors' own default.
+// kafkaImageTag picks the tag every spawned Apache cluster runs against —
+// applied to both the apache/kafka-native image (ApacheNativeCluster) and
+// the apache/kafka JVM image (ApacheCluster) — so callers can verify the
+// module against a newer Kafka release without first changing main.go.
+// The default matches the Apache constructors' own default.
+//
+// confluentImageTag is the independent knob for the cp-kafka tests
+// (ConfluentCluster). Confluent Platform versioning is not aligned with
+// Apache's release numbering (CP 8.2.0 bundles Kafka 4.2.0), so this
+// gets its own argument and its own default.
 //
 // +check
 // +cache="session"
@@ -304,6 +407,8 @@ func (t *Tests) All(
 	ctx context.Context,
 	// +default="4.2.0"
 	kafkaImageTag string,
+	// +default="8.2.0"
+	confluentImageTag string,
 ) error {
 	jobs := parallel.New().
 		WithLimit(2).
@@ -385,6 +490,15 @@ func (t *Tests) All(
 	})
 	jobs = jobs.WithJob("ApacheClusterMtlsRoundTrip", func(ctx context.Context) error {
 		return t.ApacheClusterMtlsRoundTrip(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("ConfluentClusterProduceListTopicsRoundTrip", func(ctx context.Context) error {
+		return t.ConfluentClusterProduceListTopicsRoundTrip(ctx, confluentImageTag)
+	})
+	jobs = jobs.WithJob("ConfluentClusterTlsRoundTrip", func(ctx context.Context) error {
+		return t.ConfluentClusterTlsRoundTrip(ctx, confluentImageTag)
+	})
+	jobs = jobs.WithJob("ConfluentClusterMtlsRoundTrip", func(ctx context.Context) error {
+		return t.ConfluentClusterMtlsRoundTrip(ctx, confluentImageTag)
 	})
 
 	return jobs.Run(ctx)
@@ -1461,6 +1575,171 @@ func (t *Tests) ApacheClusterMtlsRoundTrip(
 	}
 	if gotKey != wantKey || gotVal != wantVal {
 		return fmt.Errorf("apache mtls round-trip mismatch: got (%q, %q), want (%q, %q)", gotKey, gotVal, wantKey, wantVal)
+	}
+	return nil
+}
+
+// ConfluentClusterProduceListTopicsRoundTrip is the PLAINTEXT happy-path
+// smoke test for Kafka.ConfluentCluster (the cp-kafka image variant):
+// produce a single raw record, then call ListTopics and assert the
+// freshly-created topic shows up. Confluent Platform's cp-kafka image
+// uses the same `KAFKA_*` Scala-wrapper contract as Apache, so this
+// single test pins down "cp-kafka actually serves traffic".
+func (t *Tests) ConfluentClusterProduceListTopicsRoundTrip(
+	ctx context.Context,
+	// +default="8.2.0"
+	confluentImageTag string,
+) error {
+	cluster, err := freshConfluentCluster(ctx, confluentImageTag)
+	if err != nil {
+		return fmt.Errorf("create confluent cluster: %w", err)
+	}
+	client := cluster.Client(dag.Kafka().PlaintextClientSecurity())
+
+	topic, err := randomTopicName(ctx)
+	if err != nil {
+		return err
+	}
+	if err := client.CreateTopic(ctx, topic, dagger.KafkaClientCreateTopicOpts{
+		Partitions:        1,
+		ReplicationFactor: 1,
+	}); err != nil {
+		return fmt.Errorf("create topic %q: %w", topic, err)
+	}
+
+	if err := client.Produce(ctx, topic, "k", "v", dagger.KafkaClientProduceOpts{
+		KeyEncoding:   "raw",
+		ValueEncoding: "raw",
+	}); err != nil {
+		return fmt.Errorf("produce: %w", err)
+	}
+
+	topics, err := client.ListTopics(ctx)
+	if err != nil {
+		return fmt.Errorf("list topics: %w", err)
+	}
+	if !contains(topics, topic) {
+		return fmt.Errorf("expected topic %q in ListTopics output, got %v", topic, topics)
+	}
+	return nil
+}
+
+// ConfluentClusterTlsRoundTrip is the TLS happy-path round-trip for
+// Kafka.ConfluentCluster. Mirrors TlsRoundTrip but on cp-kafka to rule
+// out distro-specific differences in keystore mounts, hostname
+// verification, and SSL listener bring-up.
+func (t *Tests) ConfluentClusterTlsRoundTrip(
+	ctx context.Context,
+	// +default="8.2.0"
+	confluentImageTag string,
+) error {
+	cluster, ts, tsPwd, err := freshTlsConfluentCluster(ctx, confluentImageTag, 1)
+	if err != nil {
+		return fmt.Errorf("create confluent tls cluster: %w", err)
+	}
+	client := cluster.Client(dag.Kafka().TLSClientSecurity(ts, tsPwd))
+
+	topic, err := randomTopicName(ctx)
+	if err != nil {
+		return err
+	}
+	if err := client.CreateTopic(ctx, topic, dagger.KafkaClientCreateTopicOpts{
+		Partitions:        1,
+		ReplicationFactor: 1,
+	}); err != nil {
+		return fmt.Errorf("create topic %q: %w", topic, err)
+	}
+
+	const wantKey, wantVal = "k", "v"
+	if err := client.Produce(ctx, topic, wantKey, wantVal, dagger.KafkaClientProduceOpts{
+		KeyEncoding:   "raw",
+		ValueEncoding: "raw",
+	}); err != nil {
+		return fmt.Errorf("produce: %w", err)
+	}
+
+	records, err := client.Consume(ctx, topic, dagger.KafkaClientConsumeOpts{
+		MaxMessages:   1,
+		Timeout:       "15s",
+		KeyEncoding:   "raw",
+		ValueEncoding: "raw",
+	})
+	if err != nil {
+		return fmt.Errorf("consume: %w", err)
+	}
+	if len(records) != 1 {
+		return fmt.Errorf("expected 1 record, got %d", len(records))
+	}
+	gotKey, err := records[0].Key(ctx)
+	if err != nil {
+		return fmt.Errorf("read key: %w", err)
+	}
+	gotVal, err := records[0].Value(ctx)
+	if err != nil {
+		return fmt.Errorf("read value: %w", err)
+	}
+	if gotKey != wantKey || gotVal != wantVal {
+		return fmt.Errorf("confluent tls round-trip mismatch: got (%q, %q), want (%q, %q)", gotKey, gotVal, wantKey, wantVal)
+	}
+	return nil
+}
+
+// ConfluentClusterMtlsRoundTrip is the MTLS happy-path round-trip for
+// Kafka.ConfluentCluster. Mirrors MtlsRoundTrip but on cp-kafka to rule
+// out distro-specific differences in how client-cert challenge is
+// handled.
+func (t *Tests) ConfluentClusterMtlsRoundTrip(
+	ctx context.Context,
+	// +default="8.2.0"
+	confluentImageTag string,
+) error {
+	cluster, ts, tsPwd, ks, ksPwd, err := freshMtlsConfluentCluster(ctx, confluentImageTag, 1)
+	if err != nil {
+		return fmt.Errorf("create confluent mtls cluster: %w", err)
+	}
+	client := cluster.Client(dag.Kafka().MtlsClientSecurity(ks, ksPwd, ts, tsPwd))
+
+	topic, err := randomTopicName(ctx)
+	if err != nil {
+		return err
+	}
+	if err := client.CreateTopic(ctx, topic, dagger.KafkaClientCreateTopicOpts{
+		Partitions:        1,
+		ReplicationFactor: 1,
+	}); err != nil {
+		return fmt.Errorf("create topic %q: %w", topic, err)
+	}
+
+	const wantKey, wantVal = "k", "v"
+	if err := client.Produce(ctx, topic, wantKey, wantVal, dagger.KafkaClientProduceOpts{
+		KeyEncoding:   "raw",
+		ValueEncoding: "raw",
+	}); err != nil {
+		return fmt.Errorf("produce: %w", err)
+	}
+
+	records, err := client.Consume(ctx, topic, dagger.KafkaClientConsumeOpts{
+		MaxMessages:   1,
+		Timeout:       "15s",
+		KeyEncoding:   "raw",
+		ValueEncoding: "raw",
+	})
+	if err != nil {
+		return fmt.Errorf("consume: %w", err)
+	}
+	if len(records) != 1 {
+		return fmt.Errorf("expected 1 record, got %d", len(records))
+	}
+	gotKey, err := records[0].Key(ctx)
+	if err != nil {
+		return fmt.Errorf("read key: %w", err)
+	}
+	gotVal, err := records[0].Value(ctx)
+	if err != nil {
+		return fmt.Errorf("read value: %w", err)
+	}
+	if gotKey != wantKey || gotVal != wantVal {
+		return fmt.Errorf("confluent mtls round-trip mismatch: got (%q, %q), want (%q, %q)", gotKey, gotVal, wantKey, wantVal)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- Adds `Kafka.ConfluentCluster` backed by `confluentinc/cp-kafka:8.2.0` (CP 8.x ships Kafka 4.x at the same minor version, so callers swap distros by changing the constructor name alone).
- Refactors `buildApacheCluster` → `buildKafkaCluster` with an `extraBrokerEnv []envKV` slice (stable-ordered for cache-key determinism), used to apply Confluent's `KAFKA_CONFLUENT_SUPPORT_METRICS_ENABLE=false` override on each broker.
- Strips the empty `KAFKA_ADVERTISED_LISTENERS` that cp-kafka pre-sets in the image — the Scala config validator rejects it on controller-only nodes (no-op for Apache).
- Adds three round-trip tests (`ConfluentClusterProduceListTopicsRoundTrip`, `ConfluentClusterTlsRoundTrip`, `ConfluentClusterMtlsRoundTrip`) and three `freshConfluentCluster*` helpers, mirroring the `ApacheCluster*` set. `All` gets a new `confluentImageTag` parameter (default `"8.2.0"`) independent of `kafkaImageTag`, since CP versioning is not aligned with Apache's release numbering.

Closes #32.

## Test plan

- [x] `dagger call confluent-cluster-produce-list-topics-round-trip` — green
- [x] `dagger call confluent-cluster-tls-round-trip` — green
- [x] `dagger call confluent-cluster-mtls-round-trip` — green
- [x] `dagger call apache-cluster-produce-list-topics-round-trip` (post-rename regression check) — green
- [x] `dagger call all` (all 28 jobs) — green
  - First run flaked on `MtlsRoundTrip` with the documented `apache/kafka-native` GraalVM `Pwd.getpwuid` segfault (trace 377f2e176c4f0e9844cb7f958c1e911b, called out in `ApacheNativeCluster`'s doc comment) — unrelated to Confluent additions. Retry passed cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)