### PR TITLE
story(issue-45): add TLS/mTLS support to envoy daggerverse module

### DIFF
--- a/daggerverse/envoy/dagger.json
+++ b/daggerverse/envoy/dagger.json
@@ -3,5 +3,19 @@
   "engineVersion": "v0.20.8",
   "sdk": {
     "source": "go"
-  }
+  },
+  "dependencies": [
+    {
+      "name": "certificate-management",
+      "source": "../certificate-management"
+    },
+    {
+      "name": "crypto",
+      "source": "../crypto"
+    },
+    {
+      "name": "random",
+      "source": "../random"
+    }
+  ]
 }

--- a/daggerverse/envoy/go.mod
+++ b/daggerverse/envoy/go.mod
@@ -11,7 +11,12 @@ require (
 	go.opentelemetry.io/otel/trace v1.43.0
 )
 
-require gopkg.in/yaml.v3 v3.0.1
+require (
+	gopkg.in/yaml.v3 v3.0.1
+	software.sslmate.com/src/go-pkcs12 v0.7.1
+)
+
+require golang.org/x/crypto v0.49.0 // indirect
 
 require (
 	github.com/99designs/gqlgen v0.17.90 // indirect

--- a/daggerverse/envoy/go.sum
+++ b/daggerverse/envoy/go.sum
@@ -81,6 +81,8 @@ go.opentelemetry.io/proto/otlp v1.9.0 h1:l706jCMITVouPOqEnii2fIAuO3IVGBRPV5ICjce
 go.opentelemetry.io/proto/otlp v1.9.0/go.mod h1:xE+Cx5E/eEHw+ISFkwPLwCZefwVjY+pqKg1qcK03+/4=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=
+golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=
 golang.org/x/net v0.52.0 h1:He/TN1l0e4mmR3QqHMT2Xab3Aj3L9qjbhRm78/6jrW0=
 golang.org/x/net v0.52.0/go.mod h1:R1MAz7uMZxVMualyPXb+VaqGSa3LIaUqk0eEt3w36Sw=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
@@ -104,3 +106,5 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+software.sslmate.com/src/go-pkcs12 v0.7.1 h1:bxkUPRsvTPNRBZa4M/aSX4PyMOEbq3V8I6hbkG4F4Q8=
+software.sslmate.com/src/go-pkcs12 v0.7.1/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=

--- a/daggerverse/envoy/main.go
+++ b/daggerverse/envoy/main.go
@@ -580,7 +580,7 @@ func bakeListenerSecurity(ctx context.Context, l *Listener, name string, sec *Se
 	l.LeafKeyPem = keyPem
 	if mode == "MTLS" {
 		if sec.ClientTrustStore == nil || sec.ClientTrustStorePassword == nil {
-			return fmt.Errorf("MTLS requires ClientTrustStore + ClientTrustStorePassword")
+			return fmt.Errorf("listener %q: MTLS requires ClientTrustStore + ClientTrustStorePassword", name)
 		}
 		trustPem, err := extractCaPemFromPkcs12(ctx, "listener-"+name+"-trust", sec.ClientTrustStore, sec.ClientTrustStorePassword)
 		if err != nil {

--- a/daggerverse/envoy/main.go
+++ b/daggerverse/envoy/main.go
@@ -2,11 +2,11 @@
 // (envoyproxy/envoy) as a service for local development and testing,
 // with a builder API for composing L7 (HTTP) and L4 (TCP) listeners
 // and their referenced clusters into a static-resources Envoy
-// bootstrap without writing the YAML by hand.
-//
-// Plaintext is the only supported transport on every listener and
-// upstream in this story. TLS / mTLS lands in a follow-up. Dynamic
-// configuration (xDS) lands in a separate follow-up.
+// bootstrap without writing the YAML by hand. TLS / mTLS terminates
+// on listeners (downstream) and authenticates clusters (upstream)
+// via per-listener / per-cluster *ServerSecurity / *UpstreamSecurity
+// profiles. Dynamic configuration (xDS) lands in a separate
+// follow-up.
 package main
 
 import (
@@ -89,19 +89,34 @@ func (e *Envoy) Endpoint(host string, port int) (*Endpoint, error) {
 	return &Endpoint{Host: host, Port: port}, nil
 }
 
-// Cluster is a named upstream cluster of Endpoints.
+// Cluster is a named upstream cluster of Endpoints, optionally
+// configured with TLS / mTLS to the upstream side.
 type Cluster struct {
 	Name      string
 	Kind      string
 	Endpoints []*Endpoint
+
+	// +private
+	UpstreamMode string // "" | "TLS" | "MTLS" — drives transport_socket rendering and Service() mounts
+	// +private
+	UpstreamTrustPem *dagger.File // PEM of the upstream TrustStore's CA cert(s) (TLS + MTLS)
+	// +private
+	UpstreamLeafCertPem *dagger.File // PEM cert chain of Envoy's client leaf for the upstream (MTLS only)
+	// +private
+	UpstreamLeafKeyPem *dagger.File // PEM PKCS#8 private key for the upstream client leaf (MTLS only)
 }
 
-// Cluster builds an empty Cluster. clusterType defaults to
-// "STRICT_DNS"; unknown values return a non-nil error.
+// Cluster builds a Cluster optionally configured with upstream
+// TLS / mTLS via an UpstreamSecurity profile. clusterType defaults
+// to "STRICT_DNS"; unknown values return a non-nil error. A nil or
+// plaintext upstream produces the same plaintext cluster as before.
 func (e *Envoy) Cluster(
+	ctx context.Context,
 	name string,
 	// +default="STRICT_DNS"
 	clusterType string,
+	// +optional
+	upstream *UpstreamSecurity,
 ) (*Cluster, error) {
 	if err := validateName("name", name); err != nil {
 		return nil, err
@@ -109,7 +124,31 @@ func (e *Envoy) Cluster(
 	if err := validateClusterType(clusterType); err != nil {
 		return nil, err
 	}
-	return &Cluster{Name: name, Kind: clusterType}, nil
+	c := &Cluster{Name: name, Kind: clusterType}
+	mode := effectiveUpstreamMode(upstream)
+	if mode == "TLS" || mode == "MTLS" {
+		if upstream.TrustStore == nil || upstream.TrustStorePassword == nil {
+			return nil, fmt.Errorf("cluster %q: %s upstream requires TrustStore + TrustStorePassword", name, mode)
+		}
+		trustPem, err := extractCaPemFromPkcs12(ctx, "upstream-"+name+"-trust", upstream.TrustStore, upstream.TrustStorePassword)
+		if err != nil {
+			return nil, fmt.Errorf("cluster %q: %w", name, err)
+		}
+		c.UpstreamMode = mode
+		c.UpstreamTrustPem = trustPem
+	}
+	if mode == "MTLS" {
+		if upstream.KeyStore == nil || upstream.KeyStorePassword == nil {
+			return nil, fmt.Errorf("cluster %q: MTLS upstream requires KeyStore + KeyStorePassword", name)
+		}
+		certPem, keyPem, err := extractUpstreamLeafPemFromPkcs12(ctx, "upstream-"+name+"-leaf", upstream.KeyStore, upstream.KeyStorePassword)
+		if err != nil {
+			return nil, fmt.Errorf("cluster %q: %w", name, err)
+		}
+		c.UpstreamLeafCertPem = certPem
+		c.UpstreamLeafKeyPem = keyPem
+	}
+	return c, nil
 }
 
 // WithEndpoint appends an Endpoint to the cluster and returns a new
@@ -260,13 +299,20 @@ func (h *HttpConnectionManager) WithHttpFilter(f *HttpFilter) *HttpConnectionMan
 }
 
 // HttpListener builds an L7 listener bound at address:port whose
-// filter chain delegates to hcm.
+// filter chain delegates to hcm. A nil or plaintext security profile
+// renders the existing plaintext listener; TLS / MTLS mints a
+// per-listener server leaf certificate from the supplied CA at
+// factory time and embeds the transport_socket block in the filter
+// chain.
 func (e *Envoy) HttpListener(
+	ctx context.Context,
 	name string,
 	// +default="0.0.0.0"
 	address string,
 	port int,
 	hcm *HttpConnectionManager,
+	// +optional
+	security *ServerSecurity,
 ) (*Listener, error) {
 	if err := validateName("name", name); err != nil {
 		return nil, err
@@ -284,6 +330,18 @@ func (e *Envoy) HttpListener(
 	if err != nil {
 		return nil, fmt.Errorf("http listener %q: %w", name, err)
 	}
+	mode := effectiveServerMode(security)
+	fc0 := map[string]any{
+		"filters": []any{
+			map[string]any{
+				"name":         hcmFilterName,
+				"typed_config": hcmTyped,
+			},
+		},
+	}
+	if ts := renderDownstreamTransportSocket(name, mode); ts != nil {
+		fc0["transport_socket"] = ts
+	}
 	body := map[string]any{
 		"address": map[string]any{
 			"socket_address": map[string]any{
@@ -291,26 +349,21 @@ func (e *Envoy) HttpListener(
 				"port_value": port,
 			},
 		},
-		"filter_chains": []any{
-			map[string]any{
-				"filters": []any{
-					map[string]any{
-						"name":         hcmFilterName,
-						"typed_config": hcmTyped,
-					},
-				},
-			},
-		},
+		"filter_chains": []any{fc0},
 	}
 	bodyYAML, err := yaml.Marshal(body)
 	if err != nil {
 		return nil, fmt.Errorf("http listener %q: marshal body: %w", name, err)
 	}
-	return &Listener{
+	l := &Listener{
 		Name:        name,
 		Body:        string(bodyYAML),
 		ClusterRefs: collectHcmClusterRefs(hcm),
-	}, nil
+	}
+	if err := bakeListenerSecurity(ctx, l, name, security); err != nil {
+		return nil, fmt.Errorf("http listener %q: %w", name, err)
+	}
+	return l, nil
 }
 
 func renderHttpConnectionManager(h *HttpConnectionManager) (map[string]any, error) {
@@ -416,13 +469,19 @@ func (e *Envoy) TcpProxy(statPrefix, cluster string) (*TcpProxy, error) {
 }
 
 // TcpListener builds an L4 listener bound at address:port whose
-// filter chain delegates to proxy.
+// filter chain delegates to proxy. Accepts the same *ServerSecurity
+// union as HttpListener — TLS / mTLS terminates on the listener and
+// the resulting transport_socket lives on the filter chain alongside
+// the tcp_proxy filter.
 func (e *Envoy) TcpListener(
+	ctx context.Context,
 	name string,
 	// +default="0.0.0.0"
 	address string,
 	port int,
 	proxy *TcpProxy,
+	// +optional
+	security *ServerSecurity,
 ) (*Listener, error) {
 	if err := validateName("name", name); err != nil {
 		return nil, err
@@ -436,6 +495,22 @@ func (e *Envoy) TcpListener(
 	if proxy == nil {
 		return nil, fmt.Errorf("proxy: must be non-nil")
 	}
+	mode := effectiveServerMode(security)
+	fc0 := map[string]any{
+		"filters": []any{
+			map[string]any{
+				"name": "envoy.filters.network.tcp_proxy",
+				"typed_config": map[string]any{
+					"@type":       "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+					"stat_prefix": proxy.StatPrefix,
+					"cluster":     proxy.Cluster,
+				},
+			},
+		},
+	}
+	if ts := renderDownstreamTransportSocket(name, mode); ts != nil {
+		fc0["transport_socket"] = ts
+	}
 	body := map[string]any{
 		"address": map[string]any{
 			"socket_address": map[string]any{
@@ -443,30 +518,21 @@ func (e *Envoy) TcpListener(
 				"port_value": port,
 			},
 		},
-		"filter_chains": []any{
-			map[string]any{
-				"filters": []any{
-					map[string]any{
-						"name": "envoy.filters.network.tcp_proxy",
-						"typed_config": map[string]any{
-							"@type":       "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-							"stat_prefix": proxy.StatPrefix,
-							"cluster":     proxy.Cluster,
-						},
-					},
-				},
-			},
-		},
+		"filter_chains": []any{fc0},
 	}
 	bodyYAML, err := yaml.Marshal(body)
 	if err != nil {
 		return nil, fmt.Errorf("tcp listener %q: marshal body: %w", name, err)
 	}
-	return &Listener{
+	l := &Listener{
 		Name:        name,
 		Body:        string(bodyYAML),
 		ClusterRefs: []string{proxy.Cluster},
-	}, nil
+	}
+	if err := bakeListenerSecurity(ctx, l, name, security); err != nil {
+		return nil, fmt.Errorf("tcp listener %q: %w", name, err)
+	}
+	return l, nil
 }
 
 // Listener is a single Envoy listener — either typed
@@ -481,6 +547,44 @@ type Listener struct {
 	Name        string
 	Body        string
 	ClusterRefs []string
+
+	// +private
+	SecurityMode string // "" | "TLS" | "MTLS" — drives Service() mount fan-out
+	// +private
+	LeafCertPem *dagger.File // PEM cert chain of the per-listener server leaf (TLS + MTLS)
+	// +private
+	LeafKeyPem *dagger.File // PEM-encoded PKCS#8 private key for the leaf (TLS + MTLS)
+	// +private
+	ClientTrustPem *dagger.File // PEM of the clientTrustStore's CA cert(s) (MTLS only)
+}
+
+// bakeListenerSecurity mints the per-listener server leaf certificate
+// (TLS + MTLS) and extracts the client trust PEM (MTLS only),
+// stashing them on the Listener for Service() to mount. No-op for
+// PLAINTEXT mode.
+func bakeListenerSecurity(ctx context.Context, l *Listener, name string, sec *ServerSecurity) error {
+	mode := effectiveServerMode(sec)
+	if mode == "PLAINTEXT" {
+		return nil
+	}
+	certPem, keyPem, err := mintListenerLeaf(ctx, name, sec)
+	if err != nil {
+		return err
+	}
+	l.SecurityMode = mode
+	l.LeafCertPem = certPem
+	l.LeafKeyPem = keyPem
+	if mode == "MTLS" {
+		if sec.ClientTrustStore == nil || sec.ClientTrustStorePassword == nil {
+			return fmt.Errorf("MTLS requires ClientTrustStore + ClientTrustStorePassword")
+		}
+		trustPem, err := extractCaPemFromPkcs12(ctx, "listener-"+name+"-trust", sec.ClientTrustStore, sec.ClientTrustStorePassword)
+		if err != nil {
+			return err
+		}
+		l.ClientTrustPem = trustPem
+	}
+	return nil
 }
 
 // CustomListener builds a Listener whose body is the caller-supplied
@@ -629,13 +733,31 @@ func (p *Proxy) Service() (*dagger.Service, error) {
 		if port, ok := extractListenerPort(l.Body); ok {
 			ctr = ctr.WithExposedPort(port)
 		}
+		if l.SecurityMode == "TLS" || l.SecurityMode == "MTLS" {
+			ctr = ctr.
+				WithFile(listenerCertPath(l.Name), l.LeafCertPem, dagger.ContainerWithFileOpts{Permissions: 0o644}).
+				WithFile(listenerKeyPath(l.Name), l.LeafKeyPem, dagger.ContainerWithFileOpts{Permissions: 0o644})
+		}
+		if l.SecurityMode == "MTLS" {
+			ctr = ctr.WithFile(listenerTrustPath(l.Name), l.ClientTrustPem, dagger.ContainerWithFileOpts{Permissions: 0o644})
+		}
+	}
+	for _, c := range p.Clusters {
+		if c.UpstreamMode == "TLS" || c.UpstreamMode == "MTLS" {
+			ctr = ctr.WithFile(upstreamTrustPath(c.Name), c.UpstreamTrustPem, dagger.ContainerWithFileOpts{Permissions: 0o644})
+		}
+		if c.UpstreamMode == "MTLS" {
+			ctr = ctr.
+				WithFile(upstreamCertPath(c.Name), c.UpstreamLeafCertPem, dagger.ContainerWithFileOpts{Permissions: 0o644}).
+				WithFile(upstreamKeyPath(c.Name), c.UpstreamLeafKeyPem, dagger.ContainerWithFileOpts{Permissions: 0o644})
+		}
 	}
 	for i, host := range p.BindingHosts {
 		ctr = ctr.WithServiceBinding(host, p.BindingSvcs[i])
 	}
 	var args []string
 	if cfg != nil {
-		ctr = ctr.WithMountedFile(configMountPath, cfg)
+		ctr = ctr.WithFile(configMountPath, cfg)
 		args = []string{"-c", configMountPath}
 	}
 	return ctr.AsService(dagger.ContainerAsServiceOpts{
@@ -815,6 +937,9 @@ func renderCluster(c *Cluster) map[string]any {
 	out := map[string]any{
 		"name": c.Name,
 		"type": c.Kind,
+	}
+	if ts := renderUpstreamTransportSocket(c.Name, c.UpstreamMode); ts != nil {
+		out["transport_socket"] = ts
 	}
 	if len(c.Endpoints) > 0 {
 		lbEndpoints := make([]any, 0, len(c.Endpoints))

--- a/daggerverse/envoy/main.go
+++ b/daggerverse/envoy/main.go
@@ -103,7 +103,7 @@ type Cluster struct {
 	// +private
 	UpstreamLeafCertPem *dagger.File // PEM cert chain of Envoy's client leaf for the upstream (MTLS only)
 	// +private
-	UpstreamLeafKeyPem *dagger.File // PEM PKCS#8 private key for the upstream client leaf (MTLS only)
+	UpstreamLeafKeyPem *dagger.File // PEM PKCS#1 ("RSA PRIVATE KEY") private key for the upstream client leaf (MTLS only)
 }
 
 // Cluster builds a Cluster optionally configured with upstream
@@ -304,6 +304,8 @@ func (h *HttpConnectionManager) WithHttpFilter(f *HttpFilter) *HttpConnectionMan
 // per-listener server leaf certificate from the supplied CA at
 // factory time and embeds the transport_socket block in the filter
 // chain.
+//
+// +cache="session"
 func (e *Envoy) HttpListener(
 	ctx context.Context,
 	name string,
@@ -473,6 +475,8 @@ func (e *Envoy) TcpProxy(statPrefix, cluster string) (*TcpProxy, error) {
 // union as HttpListener — TLS / mTLS terminates on the listener and
 // the resulting transport_socket lives on the filter chain alongside
 // the tcp_proxy filter.
+//
+// +cache="session"
 func (e *Envoy) TcpListener(
 	ctx context.Context,
 	name string,
@@ -553,7 +557,7 @@ type Listener struct {
 	// +private
 	LeafCertPem *dagger.File // PEM cert chain of the per-listener server leaf (TLS + MTLS)
 	// +private
-	LeafKeyPem *dagger.File // PEM-encoded PKCS#8 private key for the leaf (TLS + MTLS)
+	LeafKeyPem *dagger.File // PEM-encoded PKCS#1 ("RSA PRIVATE KEY") private key for the leaf (TLS + MTLS)
 	// +private
 	ClientTrustPem *dagger.File // PEM of the clientTrustStore's CA cert(s) (MTLS only)
 }

--- a/daggerverse/envoy/security.go
+++ b/daggerverse/envoy/security.go
@@ -344,19 +344,6 @@ func buildCertChainPem(ctx context.Context, label string, leaf, issuer *dagger.F
 	return writeBinaryWorkdirFile(label+"-cert", "leaf.crt", combined)
 }
 
-// secretToFile materializes a Dagger Secret's plaintext into a file
-// in the envoy module workdir. Used for private keys: cert-mgmt
-// returns them as *dagger.Secret, but Envoy's `private_key.filename`
-// data source needs a real file.
-func secretToFile(ctx context.Context, label, name string, sec *dagger.Secret) (*dagger.File, error) {
-	plaintext, err := sec.Plaintext(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("read %s secret: %w", label, err)
-	}
-	return writeBinaryWorkdirFile(label, name, []byte(plaintext))
-}
-
-
 // extractUpstreamLeafPemFromPkcs12 unseals a caller-supplied PKCS#12
 // client keystore and emits a PEM cert chain (leaf + chain) and a
 // PKCS#1 ("RSA PRIVATE KEY") PEM private key for Envoy's upstream

--- a/daggerverse/envoy/security.go
+++ b/daggerverse/envoy/security.go
@@ -359,8 +359,9 @@ func secretToFile(ctx context.Context, label, name string, sec *dagger.Secret) (
 
 // extractUpstreamLeafPemFromPkcs12 unseals a caller-supplied PKCS#12
 // client keystore and emits a PEM cert chain (leaf + chain) and a
-// PKCS#8 PEM private key for Envoy's upstream tls_certificates data
-// sources.
+// PKCS#1 ("RSA PRIVATE KEY") PEM private key for Envoy's upstream
+// tls_certificates data sources — BoringSSL reads PKCS#1 reliably
+// where PKCS#8 envelopes sometimes fail.
 func extractUpstreamLeafPemFromPkcs12(ctx context.Context, label string, p12 *dagger.File, password *dagger.Secret) (*dagger.File, *dagger.File, error) {
 	data, err := dagFileBytes(ctx, p12)
 	if err != nil {

--- a/daggerverse/envoy/security.go
+++ b/daggerverse/envoy/security.go
@@ -1,0 +1,483 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	rsaPkg "crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"dagger/envoy/internal/dagger"
+
+	"software.sslmate.com/src/go-pkcs12"
+)
+
+// ServerSecurity describes how an Envoy listener authenticates and
+// encrypts traffic from downstream clients. Plaintext is the default;
+// TLS and mTLS modes carry the PKI material needed to terminate TLS
+// on the listener and (for mTLS) verify client certificates.
+type ServerSecurity struct {
+	// +private
+	Mode string // PLAINTEXT | TLS | MTLS
+	// +private
+	CaKeyStore *dagger.File // PKCS#12 of the CA used to mint per-listener server leaves (TLS + MTLS)
+	// +private
+	CaKeyStorePassword *dagger.Secret
+	// +private
+	ClientTrustStore *dagger.File // PKCS#12 of CA(s) trusted to sign incoming client certs (MTLS only)
+	// +private
+	ClientTrustStorePassword *dagger.Secret
+}
+
+// UpstreamSecurity describes how an Envoy cluster authenticates and
+// encrypts traffic to upstream endpoints. Plaintext is the default;
+// TLS validates the upstream's server cert; mTLS additionally
+// presents a client leaf to the upstream.
+type UpstreamSecurity struct {
+	// +private
+	Mode string // PLAINTEXT | TLS | MTLS
+	// +private
+	TrustStore *dagger.File // PKCS#12 of CA(s) the cluster trusts on the upstream side (TLS + MTLS)
+	// +private
+	TrustStorePassword *dagger.Secret
+	// +private
+	KeyStore *dagger.File // PKCS#12 of Envoy's own client leaf for the upstream (MTLS only)
+	// +private
+	KeyStorePassword *dagger.Secret
+}
+
+// PlaintextServerSecurity returns a ServerSecurity profile configured
+// for unencrypted, unauthenticated traffic.
+func (e *Envoy) PlaintextServerSecurity() *ServerSecurity {
+	return &ServerSecurity{Mode: "PLAINTEXT"}
+}
+
+// TlsServerSecurity returns a ServerSecurity profile that terminates
+// TLS on the listener. caKeyStore is a PKCS#12 archive containing the
+// CA cert + private key used to mint a per-listener leaf certificate.
+func (e *Envoy) TlsServerSecurity(
+	caKeyStore *dagger.File,
+	caKeyStorePassword *dagger.Secret,
+) *ServerSecurity {
+	return &ServerSecurity{
+		Mode:               "TLS",
+		CaKeyStore:         caKeyStore,
+		CaKeyStorePassword: caKeyStorePassword,
+	}
+}
+
+// MtlsServerSecurity returns a ServerSecurity profile that terminates
+// mTLS on the listener. caKeyStore signs the per-listener server
+// leaf; clientTrustStore holds the CA(s) the listener will accept
+// incoming client certs from (asymmetric trust is allowed).
+func (e *Envoy) MtlsServerSecurity(
+	caKeyStore *dagger.File,
+	caKeyStorePassword *dagger.Secret,
+	clientTrustStore *dagger.File,
+	clientTrustStorePassword *dagger.Secret,
+) *ServerSecurity {
+	return &ServerSecurity{
+		Mode:                     "MTLS",
+		CaKeyStore:               caKeyStore,
+		CaKeyStorePassword:       caKeyStorePassword,
+		ClientTrustStore:         clientTrustStore,
+		ClientTrustStorePassword: clientTrustStorePassword,
+	}
+}
+
+// PlaintextUpstreamSecurity returns an UpstreamSecurity profile
+// configured for unencrypted, unauthenticated cluster traffic.
+func (e *Envoy) PlaintextUpstreamSecurity() *UpstreamSecurity {
+	return &UpstreamSecurity{Mode: "PLAINTEXT"}
+}
+
+// TlsUpstreamSecurity returns an UpstreamSecurity profile that opens
+// a TLS connection to upstreams. trustStore is a PKCS#12 archive of
+// the CA(s) used to verify the upstream's server cert.
+func (e *Envoy) TlsUpstreamSecurity(
+	trustStore *dagger.File,
+	trustStorePassword *dagger.Secret,
+) *UpstreamSecurity {
+	return &UpstreamSecurity{
+		Mode:               "TLS",
+		TrustStore:         trustStore,
+		TrustStorePassword: trustStorePassword,
+	}
+}
+
+// MtlsUpstreamSecurity returns an UpstreamSecurity profile that opens
+// an mTLS connection to upstreams: the upstream's server cert is
+// validated against trustStore, and Envoy presents its own client
+// leaf from keyStore.
+func (e *Envoy) MtlsUpstreamSecurity(
+	keyStore *dagger.File,
+	keyStorePassword *dagger.Secret,
+	trustStore *dagger.File,
+	trustStorePassword *dagger.Secret,
+) *UpstreamSecurity {
+	return &UpstreamSecurity{
+		Mode:               "MTLS",
+		TrustStore:         trustStore,
+		TrustStorePassword: trustStorePassword,
+		KeyStore:           keyStore,
+		KeyStorePassword:   keyStorePassword,
+	}
+}
+
+// effectiveServerMode normalizes a possibly-nil ServerSecurity into a
+// concrete mode string. nil and PLAINTEXT both render as "PLAINTEXT".
+func effectiveServerMode(sec *ServerSecurity) string {
+	if sec == nil {
+		return "PLAINTEXT"
+	}
+	return sec.Mode
+}
+
+// effectiveUpstreamMode normalizes a possibly-nil UpstreamSecurity
+// into a concrete mode string.
+func effectiveUpstreamMode(up *UpstreamSecurity) string {
+	if up == nil {
+		return "PLAINTEXT"
+	}
+	return up.Mode
+}
+
+// envoySecretsDir is where every PKCS#12 keystore and trust PEM gets
+// mounted inside the running envoy container.
+const envoySecretsDir = "/etc/envoy/secrets"
+
+func listenerCertPath(name string) string {
+	return filepath.Join(envoySecretsDir, "listener-"+name+".crt")
+}
+
+func listenerKeyPath(name string) string {
+	return filepath.Join(envoySecretsDir, "listener-"+name+".key")
+}
+
+func listenerTrustPath(name string) string {
+	return filepath.Join(envoySecretsDir, "listener-"+name+"-trust.pem")
+}
+
+func upstreamCertPath(name string) string {
+	return filepath.Join(envoySecretsDir, "upstream-"+name+".crt")
+}
+
+func upstreamKeyPath(name string) string {
+	return filepath.Join(envoySecretsDir, "upstream-"+name+".key")
+}
+
+func upstreamTrustPath(name string) string {
+	return filepath.Join(envoySecretsDir, "upstream-"+name+"-trust.pem")
+}
+
+// renderDownstreamTransportSocket returns the transport_socket block
+// to embed under a listener's filter_chain for the given security
+// mode. Returns nil for PLAINTEXT.
+func renderDownstreamTransportSocket(listenerName, mode string) map[string]any {
+	if mode != "TLS" && mode != "MTLS" {
+		return nil
+	}
+	common := map[string]any{
+		"tls_certificates": []any{
+			map[string]any{
+				"certificate_chain": map[string]any{
+					"filename": listenerCertPath(listenerName),
+				},
+				"private_key": map[string]any{
+					"filename": listenerKeyPath(listenerName),
+				},
+			},
+		},
+	}
+	typed := map[string]any{
+		"@type":              "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+		"common_tls_context": common,
+	}
+	if mode == "MTLS" {
+		common["validation_context"] = map[string]any{
+			"trusted_ca": map[string]any{
+				"filename": listenerTrustPath(listenerName),
+			},
+		}
+		typed["require_client_certificate"] = true
+	}
+	return map[string]any{
+		"name":         "envoy.transport_sockets.tls",
+		"typed_config": typed,
+	}
+}
+
+// renderUpstreamTransportSocket returns the transport_socket block to
+// embed under a cluster for the given upstream security mode. Returns
+// nil for PLAINTEXT.
+func renderUpstreamTransportSocket(clusterName, mode string) map[string]any {
+	if mode != "TLS" && mode != "MTLS" {
+		return nil
+	}
+	common := map[string]any{
+		"validation_context": map[string]any{
+			"trusted_ca": map[string]any{
+				"filename": upstreamTrustPath(clusterName),
+			},
+		},
+	}
+	if mode == "MTLS" {
+		common["tls_certificates"] = []any{
+			map[string]any{
+				"certificate_chain": map[string]any{
+					"filename": upstreamCertPath(clusterName),
+				},
+				"private_key": map[string]any{
+					"filename": upstreamKeyPath(clusterName),
+				},
+			},
+		}
+	}
+	typed := map[string]any{
+		"@type":              "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+		"common_tls_context": common,
+	}
+	return map[string]any{
+		"name":         "envoy.transport_sockets.tls",
+		"typed_config": typed,
+	}
+}
+
+// mintListenerLeaf signs a per-listener server leaf certificate from
+// the caller-supplied CA, extracts the cert + chain as a single PEM
+// file and the private key as a plain PEM file (suitable for Envoy's
+// `certificate_chain.filename` + `private_key.filename` data
+// sources). Returns (nil, nil, nil) for PLAINTEXT mode.
+func mintListenerLeaf(ctx context.Context, listenerName string, sec *ServerSecurity) (*dagger.File, *dagger.File, error) {
+	if sec == nil || sec.Mode == "PLAINTEXT" {
+		return nil, nil, nil
+	}
+	if sec.CaKeyStore == nil || sec.CaKeyStorePassword == nil {
+		return nil, nil, fmt.Errorf("listener %q: %s mode requires CaKeyStore + CaKeyStorePassword", listenerName, sec.Mode)
+	}
+
+	leafKeyPem, err := dag.Crypto().GenerateRsaKey(dagger.CryptoGenerateRsaKeyOpts{Bits: 2048}).Pem().Contents(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("listener %q: generate leaf key: %w", listenerName, err)
+	}
+	leafKey := dag.SetSecret("envoy-listener-leaf-key-"+randSuffix(), leafKeyPem)
+
+	leafPwdHex, err := dag.Random().Sha256(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("listener %q: generate leaf password: %w", listenerName, err)
+	}
+	leafPwd := dag.SetSecret("envoy-listener-leaf-pwd-"+randSuffix(), leafPwdHex)
+
+	leafSerial, err := dag.Random().Serial(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("listener %q: generate leaf serial: %w", listenerName, err)
+	}
+	nb := time.Now().UTC().Format(time.RFC3339)
+
+	ca := dag.CertificateManagement().LoadCertificateAuthority(sec.CaKeyStore, sec.CaKeyStorePassword)
+	issued := ca.IssueServerCertificate(listenerName, nb, leafSerial, leafPwd, leafKey,
+		dagger.CertificateManagementCertificateAuthorityIssueServerCertificateOpts{
+			DNSSans:      []string{listenerName, "localhost", "envoy"},
+			IPSans:       []string{"127.0.0.1"},
+			ValidityDays: 365,
+		})
+
+	// Use cert-mgmt's PEM accessors directly: CertPemFile() returns
+	// the leaf cert; PrivateKeyPem() returns the leaf's private key
+	// secret (same one we just minted). Concatenate the issuer cert
+	// from IssuerCertFile() for the chain.
+	certPem, err := buildCertChainPem(ctx, "listener-"+listenerName, issued.CertPemFile(), issued.IssuerCertFile())
+	if err != nil {
+		return nil, nil, fmt.Errorf("listener %q: %w", listenerName, err)
+	}
+	keyPem, err := pkcs8SecretToPkcs1File(ctx, "listener-"+listenerName+"-key", issued.PrivateKeyPem())
+	if err != nil {
+		return nil, nil, fmt.Errorf("listener %q: %w", listenerName, err)
+	}
+	return certPem, keyPem, nil
+}
+
+// pkcs8SecretToPkcs1File reads a PKCS#8 PEM private key out of a
+// Dagger Secret and rewrites it as a PKCS#1 ("RSA PRIVATE KEY") PEM
+// file. Envoy's BoringSSL build is finicky about PKCS#8 PEM
+// envelopes and reliably reads PKCS#1.
+func pkcs8SecretToPkcs1File(ctx context.Context, label string, sec *dagger.Secret) (*dagger.File, error) {
+	plaintext, err := sec.Plaintext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("read %s secret: %w", label, err)
+	}
+	block, _ := pem.Decode([]byte(plaintext))
+	if block == nil {
+		return nil, fmt.Errorf("%s: no PEM block in private key secret", label)
+	}
+	priv, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("%s: parse pkcs8: %w", label, err)
+	}
+	rsa, ok := priv.(*rsaPkg.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("%s: unexpected key type %T (expected *rsa.PrivateKey)", label, priv)
+	}
+	out := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(rsa)})
+	return writeBinaryWorkdirFile(label, "leaf.key", out)
+}
+
+// buildCertChainPem concatenates the leaf cert and issuer cert PEM
+// files into a single chain file suitable for Envoy's
+// `certificate_chain.filename` data source.
+func buildCertChainPem(ctx context.Context, label string, leaf, issuer *dagger.File) (*dagger.File, error) {
+	leafBytes, err := dagFileBytes(ctx, leaf)
+	if err != nil {
+		return nil, fmt.Errorf("export %s leaf cert: %w", label, err)
+	}
+	issuerBytes, err := dagFileBytes(ctx, issuer)
+	if err != nil {
+		return nil, fmt.Errorf("export %s issuer cert: %w", label, err)
+	}
+	combined := append(append([]byte{}, leafBytes...), issuerBytes...)
+	return writeBinaryWorkdirFile(label+"-cert", "leaf.crt", combined)
+}
+
+// secretToFile materializes a Dagger Secret's plaintext into a file
+// in the envoy module workdir. Used for private keys: cert-mgmt
+// returns them as *dagger.Secret, but Envoy's `private_key.filename`
+// data source needs a real file.
+func secretToFile(ctx context.Context, label, name string, sec *dagger.Secret) (*dagger.File, error) {
+	plaintext, err := sec.Plaintext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("read %s secret: %w", label, err)
+	}
+	return writeBinaryWorkdirFile(label, name, []byte(plaintext))
+}
+
+
+// extractUpstreamLeafPemFromPkcs12 unseals a caller-supplied PKCS#12
+// client keystore and emits a PEM cert chain (leaf + chain) and a
+// PKCS#8 PEM private key for Envoy's upstream tls_certificates data
+// sources.
+func extractUpstreamLeafPemFromPkcs12(ctx context.Context, label string, p12 *dagger.File, password *dagger.Secret) (*dagger.File, *dagger.File, error) {
+	data, err := dagFileBytes(ctx, p12)
+	if err != nil {
+		return nil, nil, fmt.Errorf("export %s pkcs12: %w", label, err)
+	}
+	pwd, err := password.Plaintext(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read %s pkcs12 password: %w", label, err)
+	}
+	priv, leaf, chain, err := pkcs12.DecodeChain(data, pwd)
+	if err != nil {
+		return nil, nil, fmt.Errorf("decode %s pkcs12: %w", label, err)
+	}
+	var certPemBuf []byte
+	certPemBuf = append(certPemBuf, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leaf.Raw})...)
+	for _, c := range chain {
+		certPemBuf = append(certPemBuf, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: c.Raw})...)
+	}
+	certFile, err := writeBinaryWorkdirFile(label+"-cert", "leaf.crt", certPemBuf)
+	if err != nil {
+		return nil, nil, fmt.Errorf("stage %s cert pem: %w", label, err)
+	}
+	rsaKey, ok := priv.(*rsaPkg.PrivateKey)
+	if !ok {
+		return nil, nil, fmt.Errorf("%s: unexpected key type %T (expected *rsa.PrivateKey)", label, priv)
+	}
+	keyPem := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(rsaKey)})
+	keyFile, err := writeBinaryWorkdirFile(label+"-key", "leaf.key", keyPem)
+	if err != nil {
+		return nil, nil, fmt.Errorf("stage %s key pem: %w", label, err)
+	}
+	return certFile, keyFile, nil
+}
+
+// extractCaPemFromPkcs12 unseals the given PKCS#12 truststore and
+// re-encodes its CA certificate(s) as a single PEM file, returned as
+// a *dagger.File suitable for mounting at a fixed in-container path.
+func extractCaPemFromPkcs12(ctx context.Context, label string, p12 *dagger.File, password *dagger.Secret) (*dagger.File, error) {
+	data, err := dagFileBytes(ctx, p12)
+	if err != nil {
+		return nil, fmt.Errorf("export %s pkcs12: %w", label, err)
+	}
+	pwd, err := password.Plaintext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("read %s pkcs12 password: %w", label, err)
+	}
+	rootCerts, err := pkcs12.DecodeTrustStore(data, pwd)
+	if err != nil {
+		return nil, fmt.Errorf("decode %s truststore: %w", label, err)
+	}
+	if len(rootCerts) == 0 {
+		return nil, fmt.Errorf("decode %s truststore: archive contained no certificates", label)
+	}
+	var buf []byte
+	for _, c := range rootCerts {
+		buf = append(buf, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: c.Raw})...)
+	}
+	return writeBinaryWorkdirFile(label, "trust.pem", buf)
+}
+
+// dagFileBytes materializes a *dagger.File via Export + ReadFile.
+// Used for binary content (PKCS#12 archives) where File.Contents()
+// would corrupt non-UTF-8 bytes when round-tripped through GraphQL's
+// String type.
+func dagFileBytes(ctx context.Context, f *dagger.File) ([]byte, error) {
+	local := "envoy-tls-in-" + randSuffix()
+	if _, err := f.Export(ctx, local); err != nil {
+		return nil, fmt.Errorf("export file: %w", err)
+	}
+	defer os.Remove(local)
+	return os.ReadFile(local)
+}
+
+// writeBinaryWorkdirFile writes content into a content-addressed
+// subdir of the envoy module's scratch workdir and returns it as a
+// *dagger.File. Identical content collapses to the same path so
+// re-entry is idempotent.
+func writeBinaryWorkdirFile(label, name string, content []byte) (*dagger.File, error) {
+	sum := sha256.Sum256(content)
+	dir := "envoy-" + label + "-" + hex.EncodeToString(sum[:8])
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+	path := filepath.Join(dir, name)
+	tmp, err := os.CreateTemp(dir, "."+name+"-*")
+	if err != nil {
+		return nil, fmt.Errorf("create temp: %w", err)
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(content); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return nil, fmt.Errorf("write %s: %w", tmpPath, err)
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return nil, fmt.Errorf("chmod %s: %w", tmpPath, err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return nil, fmt.Errorf("close %s: %w", tmpPath, err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		return nil, fmt.Errorf("rename to %s: %w", path, err)
+	}
+	return dag.CurrentModule().WorkdirFile(path), nil
+}
+
+// randSuffix returns a fresh hex suffix for naming Dagger secrets
+// uniquely across concurrent helper calls.
+func randSuffix() string {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		panic(fmt.Sprintf("randSuffix: %v", err))
+	}
+	return hex.EncodeToString(b[:])
+}
+

--- a/daggerverse/envoy/tests/dagger.json
+++ b/daggerverse/envoy/tests/dagger.json
@@ -10,6 +10,14 @@
       "source": ".."
     },
     {
+      "name": "certificate-management",
+      "source": "../../certificate-management"
+    },
+    {
+      "name": "crypto",
+      "source": "../../crypto"
+    },
+    {
       "name": "random",
       "source": "../../random"
     }

--- a/daggerverse/envoy/tests/main.go
+++ b/daggerverse/envoy/tests/main.go
@@ -46,6 +46,30 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("L4TcpRoundTrip", func(ctx context.Context) error {
 		return t.L4TcpRoundTrip(ctx, envoyTag)
 	})
+	jobs = jobs.WithJob("TlsServerSecurityRendersDownstreamTlsContext", t.TlsServerSecurityRendersDownstreamTlsContext)
+	jobs = jobs.WithJob("MtlsServerSecurityRequiresClientCert", t.MtlsServerSecurityRequiresClientCert)
+	jobs = jobs.WithJob("PlaintextServerSecurityRendersNoTransportSocket", t.PlaintextServerSecurityRendersNoTransportSocket)
+	jobs = jobs.WithJob("TlsUpstreamSecurityRendersUpstreamTlsContext", t.TlsUpstreamSecurityRendersUpstreamTlsContext)
+	jobs = jobs.WithJob("MtlsUpstreamSecurityIncludesClientLeaf", t.MtlsUpstreamSecurityIncludesClientLeaf)
+	jobs = jobs.WithJob("PlaintextUpstreamSecurityRendersNoTransportSocket", t.PlaintextUpstreamSecurityRendersNoTransportSocket)
+	jobs = jobs.WithJob("L7HttpsRoundTrip", func(ctx context.Context) error {
+		return t.L7HttpsRoundTrip(ctx, envoyTag)
+	})
+	jobs = jobs.WithJob("L7HttpsMtlsRejectsAnonymousClient", func(ctx context.Context) error {
+		return t.L7HttpsMtlsRejectsAnonymousClient(ctx, envoyTag)
+	})
+	jobs = jobs.WithJob("L7HttpsMtlsAcceptsAuthorizedClient", func(ctx context.Context) error {
+		return t.L7HttpsMtlsAcceptsAuthorizedClient(ctx, envoyTag)
+	})
+	jobs = jobs.WithJob("UpstreamTlsRoundTrip", func(ctx context.Context) error {
+		return t.UpstreamTlsRoundTrip(ctx, envoyTag)
+	})
+	jobs = jobs.WithJob("UpstreamMtlsRoundTrip", func(ctx context.Context) error {
+		return t.UpstreamMtlsRoundTrip(ctx, envoyTag)
+	})
+	jobs = jobs.WithJob("L4TcpTlsRoundTrip", func(ctx context.Context) error {
+		return t.L4TcpTlsRoundTrip(ctx, envoyTag)
+	})
 	return jobs.Run(ctx)
 }
 

--- a/daggerverse/envoy/tests/roundtrips.go
+++ b/daggerverse/envoy/tests/roundtrips.go
@@ -1,0 +1,445 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"dagger/tests/internal/dagger"
+)
+
+// pythonHttpsUpstream stands up a python:3-alpine HTTPS server on
+// the given port, presenting a server leaf signed by ca and valid
+// for the given hostname (DNS SAN). Every GET returns 200 with
+// marker as the body.
+func pythonHttpsUpstream(ctx context.Context, ca *dagger.CertificateManagementCertificateAuthority, marker string, port int, hostname string, mtlsClientTrust *dagger.File) (*dagger.Service, error) {
+	keyPem, err := dag.Crypto().GenerateRsaKey(dagger.CryptoGenerateRsaKeyOpts{Bits: 2048}).Pem().Contents(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("upstream key: %w", err)
+	}
+	leafKey := dag.SetSecret("upstream-server-key-"+hostname, keyPem)
+	pwdHex, err := dag.Random().Sha256(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("upstream pwd: %w", err)
+	}
+	leafPwd := dag.SetSecret("upstream-server-pwd-"+hostname, pwdHex)
+	serial, err := dag.Random().Serial(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("upstream serial: %w", err)
+	}
+	nb := time.Now().UTC().Format(time.RFC3339)
+	issued := ca.IssueServerCertificate(hostname, nb, serial, leafPwd, leafKey,
+		dagger.CertificateManagementCertificateAuthorityIssueServerCertificateOpts{
+			DNSSans:      []string{hostname, "localhost"},
+			IPSans:       []string{"127.0.0.1"},
+			ValidityDays: 365,
+		})
+
+	reqClient := "False"
+	if mtlsClientTrust != nil {
+		reqClient = "True"
+	}
+	script := fmt.Sprintf(`import http.server, ssl, socketserver
+MARKER = %q
+class H(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        body = MARKER.encode()
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self.wfile.write(body)
+    def log_message(self, *a, **k): pass
+ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+ctx.load_cert_chain("/certs/server.crt", "/certs/server.key")
+if %s:
+    ctx.load_verify_locations("/certs/client-ca.pem")
+    ctx.verify_mode = ssl.CERT_REQUIRED
+socketserver.TCPServer.allow_reuse_address = True
+with socketserver.TCPServer(("", %d), H) as srv:
+    srv.socket = ctx.wrap_socket(srv.socket, server_side=True)
+    srv.serve_forever()
+`, marker, reqClient, port)
+
+	ctr := dag.Container().From("python:3-alpine").
+		WithExposedPort(port).
+		WithFile("/certs/server.crt", issued.CertPemFile()).
+		WithMountedSecret("/certs/server.key", issued.PrivateKeyPem())
+	if mtlsClientTrust != nil {
+		ctr = ctr.WithFile("/certs/client-ca.pem", mtlsClientTrust)
+	}
+	return ctr.AsService(dagger.ContainerAsServiceOpts{
+		Args: []string{"python", "-u", "-c", script},
+	}), nil
+}
+
+// L7HttpsRoundTrip stands up a plaintext HTTP upstream behind an
+// Envoy TLS-terminated HttpListener and asserts a client trusting
+// the CA can complete an HTTPS round-trip.
+func (t *Tests) L7HttpsRoundTrip(
+	ctx context.Context,
+	// +default="v1.32.1"
+	envoyTag string,
+) error {
+	mark, err := marker(ctx)
+	if err != nil {
+		return err
+	}
+	upstream := pythonHttpUpstream(mark, 5678)
+
+	ca, caPwd, err := testCa(ctx, "l7https")
+	if err != nil {
+		return err
+	}
+	e := dag.Envoy()
+	sec := e.TLSServerSecurity(ca.KeyStore().Pkcs12(), caPwd)
+	rc := e.RouteConfig("rc").WithVirtualHost(
+		e.VirtualHost("vh", []string{"*"}).WithRoute(e.RoutePrefix("/", "upstream")),
+	)
+	hcm := e.HTTPConnectionManager("ingress", rc).WithHTTPFilter(e.RouterHTTPFilter())
+	listener := e.HTTPListener("http", 18443, hcm, dagger.EnvoyHTTPListenerOpts{Security: sec})
+	cluster := e.Cluster("upstream").WithEndpoint(e.Endpoint("upstream", 5678))
+	svc := e.Proxy(proxyOpts(envoyTag)).
+		WithServiceBinding("upstream", upstream).
+		WithListener(listener).
+		WithCluster(cluster).
+		Service()
+
+	_, err = dag.Container().From(curlImage).
+		WithServiceBinding("envoy", svc).
+		WithFile("/certs/ca.pem", ca.CertPemFile(), dagger.ContainerWithFileOpts{Permissions: 0o644}).
+		WithEnvVariable("MARKER", mark).
+		WithExec([]string{"sh", "-c", `
+set -eu
+for i in $(seq 1 60); do
+  BODY=$(curl -sS --cacert /certs/ca.pem https://envoy:18443/ || true)
+  case "${BODY}" in *"${MARKER}"*) echo "marker observed after ${i}s"; exit 0 ;; esac
+  sleep 1
+done
+echo "marker ${MARKER} never appeared via TLS; last body: ${BODY}" >&2
+exit 1
+`}).Sync(ctx)
+	if err != nil {
+		return fmt.Errorf("L7Https round-trip: %w", err)
+	}
+	return nil
+}
+
+// L7HttpsMtlsRejectsAnonymousClient asserts that an mTLS-terminated
+// HttpListener refuses clients that don't present a cert signed by
+// the configured clientTrustStore CA — curl exits non-zero.
+func (t *Tests) L7HttpsMtlsRejectsAnonymousClient(
+	ctx context.Context,
+	// +default="v1.32.1"
+	envoyTag string,
+) error {
+	mark, err := marker(ctx)
+	if err != nil {
+		return err
+	}
+	upstream := pythonHttpUpstream(mark, 5678)
+
+	serverCa, serverCaPwd, err := testCa(ctx, "mtls-reject-server-ca")
+	if err != nil {
+		return err
+	}
+	clientCa, clientCaPwd, err := testCa(ctx, "mtls-reject-client-ca")
+	if err != nil {
+		return err
+	}
+	e := dag.Envoy()
+	sec := e.MtlsServerSecurity(serverCa.KeyStore().Pkcs12(), serverCaPwd, clientCa.TrustStore().Pkcs12(), clientCaPwd)
+	rc := e.RouteConfig("rc").WithVirtualHost(
+		e.VirtualHost("vh", []string{"*"}).WithRoute(e.RoutePrefix("/", "upstream")),
+	)
+	hcm := e.HTTPConnectionManager("ingress", rc).WithHTTPFilter(e.RouterHTTPFilter())
+	listener := e.HTTPListener("http", 18443, hcm, dagger.EnvoyHTTPListenerOpts{Security: sec})
+	cluster := e.Cluster("upstream").WithEndpoint(e.Endpoint("upstream", 5678))
+	svc := e.Proxy(proxyOpts(envoyTag)).
+		WithServiceBinding("upstream", upstream).
+		WithListener(listener).
+		WithCluster(cluster).
+		Service()
+
+	// Wait for envoy to come up (admin /ready 200), THEN probe without
+	// a client cert and assert curl fails.
+	_, err = dag.Container().From(curlImage).
+		WithServiceBinding("envoy", svc).
+		WithFile("/certs/ca.pem", serverCa.CertPemFile(), dagger.ContainerWithFileOpts{Permissions: 0o644}).
+		WithExec([]string{"sh", "-c", `
+set -eu
+for i in $(seq 1 60); do
+  CODE=$(curl -sS -o /dev/null -w '%{http_code}' http://envoy:9901/ready || echo 000)
+  if [ "$CODE" = "200" ]; then
+    break
+  fi
+  sleep 1
+done
+if [ "$CODE" != "200" ]; then
+  echo "envoy admin never ready" >&2
+  exit 2
+fi
+# No client cert — handshake must fail.
+if curl -sS --max-time 10 --cacert /certs/ca.pem https://envoy:18443/ >/tmp/out 2>/tmp/err; then
+  echo "expected curl to fail without client cert; stdout:" >&2
+  cat /tmp/out >&2
+  exit 1
+fi
+echo "curl rejected without client cert (expected)"
+`}).Sync(ctx)
+	if err != nil {
+		return fmt.Errorf("L7HttpsMtls reject: %w", err)
+	}
+	return nil
+}
+
+// L7HttpsMtlsAcceptsAuthorizedClient asserts that an mTLS-terminated
+// listener accepts curl clients that present a leaf signed by the
+// configured clientTrustStore CA.
+func (t *Tests) L7HttpsMtlsAcceptsAuthorizedClient(
+	ctx context.Context,
+	// +default="v1.32.1"
+	envoyTag string,
+) error {
+	mark, err := marker(ctx)
+	if err != nil {
+		return err
+	}
+	upstream := pythonHttpUpstream(mark, 5678)
+
+	serverCa, serverCaPwd, err := testCa(ctx, "mtls-accept-server-ca")
+	if err != nil {
+		return err
+	}
+	clientCa, clientCaPwd, err := testCa(ctx, "mtls-accept-client-ca")
+	if err != nil {
+		return err
+	}
+	clientCert, clientKey, err := issueClientLeaf(ctx, clientCa, "mtls-accept", "test-client")
+	if err != nil {
+		return err
+	}
+
+	e := dag.Envoy()
+	sec := e.MtlsServerSecurity(serverCa.KeyStore().Pkcs12(), serverCaPwd, clientCa.TrustStore().Pkcs12(), clientCaPwd)
+	rc := e.RouteConfig("rc").WithVirtualHost(
+		e.VirtualHost("vh", []string{"*"}).WithRoute(e.RoutePrefix("/", "upstream")),
+	)
+	hcm := e.HTTPConnectionManager("ingress", rc).WithHTTPFilter(e.RouterHTTPFilter())
+	listener := e.HTTPListener("http", 18443, hcm, dagger.EnvoyHTTPListenerOpts{Security: sec})
+	cluster := e.Cluster("upstream").WithEndpoint(e.Endpoint("upstream", 5678))
+	svc := e.Proxy(proxyOpts(envoyTag)).
+		WithServiceBinding("upstream", upstream).
+		WithListener(listener).
+		WithCluster(cluster).
+		Service()
+
+	_, err = dag.Container().From(curlImage).
+		WithServiceBinding("envoy", svc).
+		WithFile("/certs/ca.pem", serverCa.CertPemFile(), dagger.ContainerWithFileOpts{Permissions: 0o644}).
+		WithFile("/certs/client.crt", clientCert, dagger.ContainerWithFileOpts{Permissions: 0o644}).
+		WithMountedSecret("/certs/client.key", clientKey, dagger.ContainerWithMountedSecretOpts{Mode: 0o644}).
+		WithEnvVariable("MARKER", mark).
+		WithExec([]string{"sh", "-c", `
+set -eu
+for i in $(seq 1 60); do
+  BODY=$(curl -sS --cacert /certs/ca.pem --cert /certs/client.crt --key /certs/client.key https://envoy:18443/ || true)
+  case "${BODY}" in *"${MARKER}"*) echo "marker observed after ${i}s"; exit 0 ;; esac
+  sleep 1
+done
+echo "marker ${MARKER} never appeared; last body: ${BODY}" >&2
+exit 1
+`}).Sync(ctx)
+	if err != nil {
+		return fmt.Errorf("L7HttpsMtls accept: %w", err)
+	}
+	return nil
+}
+
+// UpstreamTlsRoundTrip stands up a python HTTPS upstream and asserts
+// Envoy connects to it over TLS when the cluster's
+// UpstreamSecurity truststore matches the upstream's server cert CA.
+func (t *Tests) UpstreamTlsRoundTrip(
+	ctx context.Context,
+	// +default="v1.32.1"
+	envoyTag string,
+) error {
+	mark, err := marker(ctx)
+	if err != nil {
+		return err
+	}
+	ca, caPwd, err := testCa(ctx, "upstream-tls")
+	if err != nil {
+		return err
+	}
+	upstream, err := pythonHttpsUpstream(ctx, ca, mark, 5679, "tls-upstream", nil)
+	if err != nil {
+		return err
+	}
+
+	e := dag.Envoy()
+	upSec := e.TLSUpstreamSecurity(ca.TrustStore().Pkcs12(), caPwd)
+	rc := e.RouteConfig("rc").WithVirtualHost(
+		e.VirtualHost("vh", []string{"*"}).WithRoute(e.RoutePrefix("/", "secured")),
+	)
+	hcm := e.HTTPConnectionManager("ingress", rc).WithHTTPFilter(e.RouterHTTPFilter())
+	listener := e.HTTPListener("http", 18080, hcm)
+	cluster := e.Cluster("secured", dagger.EnvoyClusterOpts{Upstream: upSec}).
+		WithEndpoint(e.Endpoint("tls-upstream", 5679))
+	svc := e.Proxy(proxyOpts(envoyTag)).
+		WithServiceBinding("tls-upstream", upstream).
+		WithListener(listener).
+		WithCluster(cluster).
+		Service()
+
+	_, err = dag.Container().From(curlImage).
+		WithServiceBinding("envoy", svc).
+		WithEnvVariable("MARKER", mark).
+		WithExec([]string{"sh", "-c", `
+set -eu
+for i in $(seq 1 60); do
+  BODY=$(curl -sS http://envoy:18080/ || true)
+  case "${BODY}" in *"${MARKER}"*) echo "marker observed after ${i}s"; exit 0 ;; esac
+  sleep 1
+done
+echo "marker ${MARKER} never appeared via upstream TLS; last body: ${BODY}" >&2
+exit 1
+`}).Sync(ctx)
+	if err != nil {
+		return fmt.Errorf("UpstreamTls round-trip: %w", err)
+	}
+	return nil
+}
+
+// UpstreamMtlsRoundTrip asserts Envoy presents a client leaf to a
+// mTLS upstream that verifies it against its own clientTrust CA.
+func (t *Tests) UpstreamMtlsRoundTrip(
+	ctx context.Context,
+	// +default="v1.32.1"
+	envoyTag string,
+) error {
+	mark, err := marker(ctx)
+	if err != nil {
+		return err
+	}
+	serverCa, serverCaPwd, err := testCa(ctx, "upstream-mtls-server")
+	if err != nil {
+		return err
+	}
+	clientCa, _, err := testCa(ctx, "upstream-mtls-client")
+	if err != nil {
+		return err
+	}
+	upstream, err := pythonHttpsUpstream(ctx, serverCa, mark, 5680, "mtls-upstream", clientCa.CertPemFile())
+	if err != nil {
+		return err
+	}
+
+	// Mint a client leaf signed by clientCa, packaged as PKCS#12 for
+	// Envoy's MtlsUpstreamSecurity keyStore.
+	leafKeyPem, err := dag.Crypto().GenerateRsaKey(dagger.CryptoGenerateRsaKeyOpts{Bits: 2048}).Pem().Contents(ctx)
+	if err != nil {
+		return err
+	}
+	leafKey := dag.SetSecret("upstream-mtls-envoy-leaf-key", leafKeyPem)
+	leafPwdHex, err := dag.Random().Sha256(ctx)
+	if err != nil {
+		return err
+	}
+	leafPwd := dag.SetSecret("upstream-mtls-envoy-leaf-pwd", leafPwdHex)
+	serial, err := dag.Random().Serial(ctx)
+	if err != nil {
+		return err
+	}
+	nb := time.Now().UTC().Format(time.RFC3339)
+	envoyClient := clientCa.IssueClientCertificate("envoy-upstream-client", nb, serial, leafPwd, leafKey,
+		dagger.CertificateManagementCertificateAuthorityIssueClientCertificateOpts{ValidityDays: 365})
+
+	e := dag.Envoy()
+	upSec := e.MtlsUpstreamSecurity(envoyClient.KeyStore().Pkcs12(), leafPwd, serverCa.TrustStore().Pkcs12(), serverCaPwd)
+	rc := e.RouteConfig("rc").WithVirtualHost(
+		e.VirtualHost("vh", []string{"*"}).WithRoute(e.RoutePrefix("/", "secured")),
+	)
+	hcm := e.HTTPConnectionManager("ingress", rc).WithHTTPFilter(e.RouterHTTPFilter())
+	listener := e.HTTPListener("http", 18080, hcm)
+	cluster := e.Cluster("secured", dagger.EnvoyClusterOpts{Upstream: upSec}).
+		WithEndpoint(e.Endpoint("mtls-upstream", 5680))
+	svc := e.Proxy(proxyOpts(envoyTag)).
+		WithServiceBinding("mtls-upstream", upstream).
+		WithListener(listener).
+		WithCluster(cluster).
+		Service()
+
+	_, err = dag.Container().From(curlImage).
+		WithServiceBinding("envoy", svc).
+		WithEnvVariable("MARKER", mark).
+		WithExec([]string{"sh", "-c", `
+set -eu
+for i in $(seq 1 60); do
+  BODY=$(curl -sS http://envoy:18080/ || true)
+  case "${BODY}" in *"${MARKER}"*) echo "marker observed after ${i}s"; exit 0 ;; esac
+  sleep 1
+done
+echo "marker ${MARKER} never appeared via upstream MTLS; last body: ${BODY}" >&2
+exit 1
+`}).Sync(ctx)
+	if err != nil {
+		return fmt.Errorf("UpstreamMtls round-trip: %w", err)
+	}
+	return nil
+}
+
+// L4TcpTlsRoundTrip stands up an nc echo upstream behind an Envoy
+// TLS-terminated TcpListener and asserts an openssl s_client probe
+// can complete a TLS round-trip with marker bytes echoed back.
+func (t *Tests) L4TcpTlsRoundTrip(
+	ctx context.Context,
+	// +default="v1.32.1"
+	envoyTag string,
+) error {
+	mark, err := marker(ctx)
+	if err != nil {
+		return err
+	}
+	upstream := dag.Container().From(probeImage).
+		WithExec([]string{"apk", "add", "--no-cache", "busybox-extras"}).
+		WithExposedPort(5000).
+		AsService(dagger.ContainerAsServiceOpts{
+			Args: []string{"sh", "-c", "while true; do nc -l -p 5000 -e /bin/cat; done"},
+		})
+
+	ca, caPwd, err := testCa(ctx, "l4tcp-tls")
+	if err != nil {
+		return err
+	}
+	e := dag.Envoy()
+	sec := e.TLSServerSecurity(ca.KeyStore().Pkcs12(), caPwd)
+	tcp := e.TCPProxy("tcp", "upstream")
+	listener := e.TCPListener("ingress", 14443, tcp, dagger.EnvoyTCPListenerOpts{Security: sec})
+	cluster := e.Cluster("upstream").WithEndpoint(e.Endpoint("upstream", 5000))
+	svc := e.Proxy(proxyOpts(envoyTag)).
+		WithServiceBinding("upstream", upstream).
+		WithListener(listener).
+		WithCluster(cluster).
+		Service()
+
+	_, err = dag.Container().From(probeImage).
+		WithExec([]string{"apk", "add", "--no-cache", "busybox-extras", "openssl"}).
+		WithServiceBinding("envoy", svc).
+		WithFile("/certs/ca.pem", ca.CertPemFile(), dagger.ContainerWithFileOpts{Permissions: 0o644}).
+		WithEnvVariable("MARKER", mark).
+		WithExec([]string{"sh", "-c", `
+set -eu
+for i in $(seq 1 60); do
+  OUT=$(printf "%s" "${MARKER}" | timeout 5 openssl s_client -quiet -connect envoy:14443 -CAfile /certs/ca.pem -verify_return_error 2>/dev/null || true)
+  case "${OUT}" in *"${MARKER}"*) echo "marker echoed via TLS after ${i}s"; exit 0 ;; esac
+  sleep 1
+done
+echo "marker ${MARKER} never echoed back through TLS; last out: ${OUT}" >&2
+exit 1
+`}).Sync(ctx)
+	if err != nil {
+		return fmt.Errorf("L4TcpTls round-trip: %w", err)
+	}
+	return nil
+}

--- a/daggerverse/envoy/tests/security.go
+++ b/daggerverse/envoy/tests/security.go
@@ -1,0 +1,364 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"dagger/tests/internal/dagger"
+
+	"gopkg.in/yaml.v3"
+)
+
+// testCa mints a fresh CA via certificate-management for tests that
+// need TLS material. The returned secret is the CA's bound password,
+// shared by ca.KeyStore() and ca.TrustStore().
+func testCa(ctx context.Context, label string) (*dagger.CertificateManagementCertificateAuthority, *dagger.Secret, error) {
+	keyPem, err := dag.Crypto().GenerateRsaKey(dagger.CryptoGenerateRsaKeyOpts{Bits: 2048}).Pem().Contents(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate CA key: %w", err)
+	}
+	caKey := dag.SetSecret(label+"-ca-key", keyPem)
+
+	pwdHex, err := dag.Random().Sha256(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate CA pwd: %w", err)
+	}
+	caPwd := dag.SetSecret(label+"-ca-pwd", pwdHex)
+
+	serial, err := dag.Random().Serial(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate CA serial: %w", err)
+	}
+	nb := time.Now().UTC().Format(time.RFC3339)
+
+	ca := dag.CertificateManagement().CreateCertificateAuthority(nb, serial, caPwd, caKey,
+		dagger.CertificateManagementCreateCertificateAuthorityOpts{
+			CommonName:   label + " Test CA",
+			ValidityDays: 365,
+		})
+	return ca, caPwd, nil
+}
+
+// issueClientLeaf mints a fresh client leaf signed by ca, returning
+// the leaf as a cert PEM file + private key secret suitable for curl
+// `--cert` / `--key`.
+func issueClientLeaf(ctx context.Context, ca *dagger.CertificateManagementCertificateAuthority, label, cn string) (*dagger.File, *dagger.Secret, error) {
+	keyPem, err := dag.Crypto().GenerateRsaKey(dagger.CryptoGenerateRsaKeyOpts{Bits: 2048}).Pem().Contents(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate leaf key: %w", err)
+	}
+	leafKey := dag.SetSecret(label+"-leaf-key", keyPem)
+
+	pwdHex, err := dag.Random().Sha256(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate leaf pwd: %w", err)
+	}
+	leafPwd := dag.SetSecret(label+"-leaf-pwd", pwdHex)
+
+	serial, err := dag.Random().Serial(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate leaf serial: %w", err)
+	}
+	nb := time.Now().UTC().Format(time.RFC3339)
+
+	issued := ca.IssueClientCertificate(cn, nb, serial, leafPwd, leafKey,
+		dagger.CertificateManagementCertificateAuthorityIssueClientCertificateOpts{
+			ValidityDays: 365,
+		})
+	return issued.CertPemFile(), issued.PrivateKeyPem(), nil
+}
+
+// listenerOf parses the rendered bootstrap and returns the first
+// listener's map for inspection.
+func listenerOf(contents string) (map[string]any, error) {
+	var cfg struct {
+		StaticResources struct {
+			Listeners []map[string]any `yaml:"listeners"`
+		} `yaml:"static_resources"`
+	}
+	if err := yaml.Unmarshal([]byte(contents), &cfg); err != nil {
+		return nil, fmt.Errorf("parse yaml: %w\n---\n%s", err, contents)
+	}
+	if len(cfg.StaticResources.Listeners) != 1 {
+		return nil, fmt.Errorf("expected 1 listener, got %d", len(cfg.StaticResources.Listeners))
+	}
+	return cfg.StaticResources.Listeners[0], nil
+}
+
+// clusterOf parses the rendered bootstrap and returns the first
+// cluster's map for inspection.
+func clusterOf(contents string) (map[string]any, error) {
+	var cfg struct {
+		StaticResources struct {
+			Clusters []map[string]any `yaml:"clusters"`
+		} `yaml:"static_resources"`
+	}
+	if err := yaml.Unmarshal([]byte(contents), &cfg); err != nil {
+		return nil, fmt.Errorf("parse yaml: %w\n---\n%s", err, contents)
+	}
+	if len(cfg.StaticResources.Clusters) != 1 {
+		return nil, fmt.Errorf("expected 1 cluster, got %d", len(cfg.StaticResources.Clusters))
+	}
+	return cfg.StaticResources.Clusters[0], nil
+}
+
+// minimalHttpListener builds a bare HCM + listener wired through the
+// "upstream" cluster name, used by the listener-side rendering
+// tests. Returns the listener, an HCM cluster name to register on
+// the proxy, and any error.
+func minimalHttpListener(name string, port int, security *dagger.EnvoyServerSecurity) *dagger.EnvoyListener {
+	e := dag.Envoy()
+	rc := e.RouteConfig("rc").WithVirtualHost(
+		e.VirtualHost("vh", []string{"*"}).WithRoute(e.RoutePrefix("/", "upstream")),
+	)
+	hcm := e.HTTPConnectionManager("ingress", rc).WithHTTPFilter(e.RouterHTTPFilter())
+	return e.HTTPListener(name, port, hcm, dagger.EnvoyHTTPListenerOpts{Security: security})
+}
+
+// TlsServerSecurityRendersDownstreamTlsContext asserts that an
+// HttpListener built with TlsServerSecurity renders a downstream TLS
+// transport_socket on its filter chain referencing the listener's
+// PKCS#12 mount path and a password env var, with no
+// require_client_certificate.
+func (t *Tests) TlsServerSecurityRendersDownstreamTlsContext(ctx context.Context) error {
+	e := dag.Envoy()
+	ca, caPwd, err := testCa(ctx, "tls-server")
+	if err != nil {
+		return err
+	}
+	sec := e.TLSServerSecurity(ca.KeyStore().Pkcs12(), caPwd)
+	listener := minimalHttpListener("http", 18443, sec)
+	contents, err := e.Proxy().
+		WithListener(listener).
+		WithCluster(e.Cluster("upstream")).
+		ConfigFile().
+		Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("ConfigFile().Contents: %w", err)
+	}
+	l, err := listenerOf(contents)
+	if err != nil {
+		return err
+	}
+	fcs, _ := l["filter_chains"].([]any)
+	if len(fcs) != 1 {
+		return fmt.Errorf("expected 1 filter chain, got %d", len(fcs))
+	}
+	fc, _ := fcs[0].(map[string]any)
+	ts, ok := fc["transport_socket"].(map[string]any)
+	if !ok {
+		return fmt.Errorf("expected transport_socket on filter_chains[0], got: %v", fc)
+	}
+	if got := ts["name"]; got != "envoy.transport_sockets.tls" {
+		return fmt.Errorf("transport_socket.name = %v, want envoy.transport_sockets.tls", got)
+	}
+	typed, _ := ts["typed_config"].(map[string]any)
+	if got := typed["@type"]; got != "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext" {
+		return fmt.Errorf("typed_config.@type = %v, want DownstreamTlsContext", got)
+	}
+	if _, present := typed["require_client_certificate"]; present {
+		return fmt.Errorf("TLS-only listener should not set require_client_certificate, got typed_config: %v", typed)
+	}
+	common, _ := typed["common_tls_context"].(map[string]any)
+	certs, _ := common["tls_certificates"].([]any)
+	if len(certs) != 1 {
+		return fmt.Errorf("expected 1 tls_certificate, got %d", len(certs))
+	}
+	cert, _ := certs[0].(map[string]any)
+	chain, _ := cert["certificate_chain"].(map[string]any)
+	if got := chain["filename"]; got != "/etc/envoy/secrets/listener-http.crt" {
+		return fmt.Errorf("tls_certificates[0].certificate_chain.filename = %v, want listener cert path", got)
+	}
+	key, _ := cert["private_key"].(map[string]any)
+	if got := key["filename"]; got != "/etc/envoy/secrets/listener-http.key" {
+		return fmt.Errorf("tls_certificates[0].private_key.filename = %v, want listener key path", got)
+	}
+	return nil
+}
+
+// MtlsServerSecurityRequiresClientCert asserts that mTLS adds
+// require_client_certificate + a validation_context.trusted_ca
+// pointing at the listener's trust PEM mount path.
+func (t *Tests) MtlsServerSecurityRequiresClientCert(ctx context.Context) error {
+	e := dag.Envoy()
+	serverCa, serverCaPwd, err := testCa(ctx, "mtls-server-ca")
+	if err != nil {
+		return err
+	}
+	clientCa, clientCaPwd, err := testCa(ctx, "mtls-server-client-ca")
+	if err != nil {
+		return err
+	}
+	sec := e.MtlsServerSecurity(serverCa.KeyStore().Pkcs12(), serverCaPwd, clientCa.TrustStore().Pkcs12(), clientCaPwd)
+	listener := minimalHttpListener("http", 18443, sec)
+	contents, err := e.Proxy().
+		WithListener(listener).
+		WithCluster(e.Cluster("upstream")).
+		ConfigFile().
+		Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("ConfigFile().Contents: %w", err)
+	}
+	l, err := listenerOf(contents)
+	if err != nil {
+		return err
+	}
+	fcs, _ := l["filter_chains"].([]any)
+	fc, _ := fcs[0].(map[string]any)
+	ts, _ := fc["transport_socket"].(map[string]any)
+	typed, _ := ts["typed_config"].(map[string]any)
+	if got, _ := typed["require_client_certificate"].(bool); !got {
+		return fmt.Errorf("MTLS listener must set require_client_certificate=true, got typed_config: %v", typed)
+	}
+	common, _ := typed["common_tls_context"].(map[string]any)
+	vc, _ := common["validation_context"].(map[string]any)
+	tca, _ := vc["trusted_ca"].(map[string]any)
+	if got := tca["filename"]; got != "/etc/envoy/secrets/listener-http-trust.pem" {
+		return fmt.Errorf("validation_context.trusted_ca.filename = %v, want listener trust pem path", got)
+	}
+	return nil
+}
+
+// PlaintextServerSecurityRendersNoTransportSocket asserts that a
+// listener built with PlaintextServerSecurity is byte-identical to
+// one built with nil security (no transport_socket in either).
+func (t *Tests) PlaintextServerSecurityRendersNoTransportSocket(ctx context.Context) error {
+	e := dag.Envoy()
+	nilContents, err := e.Proxy().
+		WithListener(minimalHttpListener("http", 18080, nil)).
+		WithCluster(e.Cluster("upstream")).
+		ConfigFile().Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("nil-security ConfigFile: %w", err)
+	}
+	plainContents, err := e.Proxy().
+		WithListener(minimalHttpListener("http", 18080, e.PlaintextServerSecurity())).
+		WithCluster(e.Cluster("upstream")).
+		ConfigFile().Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("plaintext-security ConfigFile: %w", err)
+	}
+	if nilContents != plainContents {
+		return fmt.Errorf("nil and PLAINTEXT renders differ:\n--- nil ---\n%s\n--- plaintext ---\n%s", nilContents, plainContents)
+	}
+	l, err := listenerOf(plainContents)
+	if err != nil {
+		return err
+	}
+	fcs, _ := l["filter_chains"].([]any)
+	fc, _ := fcs[0].(map[string]any)
+	if _, present := fc["transport_socket"]; present {
+		return fmt.Errorf("PLAINTEXT listener must not render transport_socket, got: %v", fc)
+	}
+	return nil
+}
+
+// TlsUpstreamSecurityRendersUpstreamTlsContext asserts that a
+// Cluster built with TlsUpstreamSecurity renders an
+// UpstreamTlsContext transport_socket on the cluster with a
+// validation_context pointing at the upstream trust PEM path.
+func (t *Tests) TlsUpstreamSecurityRendersUpstreamTlsContext(ctx context.Context) error {
+	e := dag.Envoy()
+	ca, caPwd, err := testCa(ctx, "tls-upstream")
+	if err != nil {
+		return err
+	}
+	sec := e.TLSUpstreamSecurity(ca.TrustStore().Pkcs12(), caPwd)
+	cluster := e.Cluster("upstream", dagger.EnvoyClusterOpts{Upstream: sec})
+	contents, err := e.Proxy().WithCluster(cluster).ConfigFile().Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("ConfigFile: %w", err)
+	}
+	c, err := clusterOf(contents)
+	if err != nil {
+		return err
+	}
+	ts, ok := c["transport_socket"].(map[string]any)
+	if !ok {
+		return fmt.Errorf("expected cluster.transport_socket, got: %v", c)
+	}
+	typed, _ := ts["typed_config"].(map[string]any)
+	if got := typed["@type"]; got != "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext" {
+		return fmt.Errorf("typed_config.@type = %v, want UpstreamTlsContext", got)
+	}
+	common, _ := typed["common_tls_context"].(map[string]any)
+	if _, present := common["tls_certificates"]; present {
+		return fmt.Errorf("TLS-only upstream should not set tls_certificates, got: %v", common)
+	}
+	vc, _ := common["validation_context"].(map[string]any)
+	tca, _ := vc["trusted_ca"].(map[string]any)
+	if got := tca["filename"]; got != "/etc/envoy/secrets/upstream-upstream-trust.pem" {
+		return fmt.Errorf("trusted_ca.filename = %v, want upstream trust pem path", got)
+	}
+	return nil
+}
+
+// MtlsUpstreamSecurityIncludesClientLeaf asserts that mTLS upstream
+// renders both validation_context AND tls_certificates referencing
+// the cluster keystore PKCS#12 path + env-var password.
+func (t *Tests) MtlsUpstreamSecurityIncludesClientLeaf(ctx context.Context) error {
+	e := dag.Envoy()
+	ksCa, ksPwd, err := testCa(ctx, "mtls-up-ks")
+	if err != nil {
+		return err
+	}
+	tsCa, tsPwd, err := testCa(ctx, "mtls-up-ts")
+	if err != nil {
+		return err
+	}
+	sec := e.MtlsUpstreamSecurity(ksCa.KeyStore().Pkcs12(), ksPwd, tsCa.TrustStore().Pkcs12(), tsPwd)
+	cluster := e.Cluster("backend", dagger.EnvoyClusterOpts{Upstream: sec})
+	contents, err := e.Proxy().WithCluster(cluster).ConfigFile().Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("ConfigFile: %w", err)
+	}
+	c, err := clusterOf(contents)
+	if err != nil {
+		return err
+	}
+	ts, _ := c["transport_socket"].(map[string]any)
+	typed, _ := ts["typed_config"].(map[string]any)
+	common, _ := typed["common_tls_context"].(map[string]any)
+	certs, ok := common["tls_certificates"].([]any)
+	if !ok || len(certs) != 1 {
+		return fmt.Errorf("expected 1 tls_certificate on MTLS upstream, got: %v", common)
+	}
+	cert, _ := certs[0].(map[string]any)
+	chain, _ := cert["certificate_chain"].(map[string]any)
+	if got := chain["filename"]; got != "/etc/envoy/secrets/upstream-backend.crt" {
+		return fmt.Errorf("upstream certificate_chain.filename = %v, want upstream cert path", got)
+	}
+	key, _ := cert["private_key"].(map[string]any)
+	if got := key["filename"]; got != "/etc/envoy/secrets/upstream-backend.key" {
+		return fmt.Errorf("upstream private_key.filename = %v, want upstream key path", got)
+	}
+	return nil
+}
+
+// PlaintextUpstreamSecurityRendersNoTransportSocket asserts that
+// PlaintextUpstreamSecurity renders the same cluster as nil upstream.
+func (t *Tests) PlaintextUpstreamSecurityRendersNoTransportSocket(ctx context.Context) error {
+	e := dag.Envoy()
+	nilContents, err := e.Proxy().WithCluster(e.Cluster("upstream")).ConfigFile().Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("nil-upstream ConfigFile: %w", err)
+	}
+	plainContents, err := e.Proxy().WithCluster(
+		e.Cluster("upstream", dagger.EnvoyClusterOpts{Upstream: e.PlaintextUpstreamSecurity()}),
+	).ConfigFile().Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("plaintext-upstream ConfigFile: %w", err)
+	}
+	if nilContents != plainContents {
+		return fmt.Errorf("nil and PLAINTEXT upstream renders differ:\n--- nil ---\n%s\n--- plaintext ---\n%s", nilContents, plainContents)
+	}
+	c, err := clusterOf(plainContents)
+	if err != nil {
+		return err
+	}
+	if _, present := c["transport_socket"]; present {
+		return fmt.Errorf("PLAINTEXT upstream must not render transport_socket, got: %v", c)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- Add `*ServerSecurity` and `*UpstreamSecurity` profile types with six factories (plaintext/TLS/mTLS for downstream listeners and upstream clusters), mirroring the kafka module's security-profile pattern and crossing the module boundary as `*dagger.File` + `*dagger.Secret`.
- Thread an `+optional` security parameter through `HttpListener`, `TcpListener`, and `Cluster`; mint per-listener server leaves at factory time via `certificate-management.IssueServerCertificate` and emit PKCS#1 PEM so BoringSSL accepts the key.
- Render `DownstreamTlsContext` / `UpstreamTlsContext` (with `require_client_certificate` + `validation_context` for mTLS) and fan out cert/key/trust mounts inside `Service()` with `Permissions: 0o644` so the non-root envoy user can read them.

## Test plan
- [x] `dagger -m daggerverse/envoy/tests call all` — green (38.6s)
- [x] Each of the 12 new tests passes individually (6 render-only + L7 HTTPS plain/mTLS reject/mTLS accept + upstream TLS/mTLS + L4 TCP TLS)
- [x] `go vet ./...` clean for both `daggerverse/envoy` and `daggerverse/envoy/tests`

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)