### PR TITLE
story(issue-52): mount envoy TLS private keys via WithMountedSecret

### DIFF
--- a/daggerverse/envoy/main.go
+++ b/daggerverse/envoy/main.go
@@ -103,7 +103,13 @@ type Cluster struct {
 	// +private
 	UpstreamLeafCertPem *dagger.File // PEM cert chain of Envoy's client leaf for the upstream (MTLS only)
 	// +private
-	UpstreamLeafKeyPem *dagger.File // PEM PKCS#1 ("RSA PRIVATE KEY") private key for the upstream client leaf (MTLS only)
+	// UpstreamLeafKeyPem is the PKCS#1 ("RSA PRIVATE KEY") PEM
+	// private key for the upstream client leaf (MTLS only). Held as
+	// a *dagger.Secret so Service() can mount it via
+	// WithMountedSecret with restricted Mode/Owner instead of
+	// snapshotting world-readable key material into the container
+	// filesystem via WithFile.
+	UpstreamLeafKeyPem *dagger.Secret
 }
 
 // Cluster builds a Cluster optionally configured with upstream
@@ -557,7 +563,13 @@ type Listener struct {
 	// +private
 	LeafCertPem *dagger.File // PEM cert chain of the per-listener server leaf (TLS + MTLS)
 	// +private
-	LeafKeyPem *dagger.File // PEM-encoded PKCS#1 ("RSA PRIVATE KEY") private key for the leaf (TLS + MTLS)
+	// LeafKeyPem is the PKCS#1 ("RSA PRIVATE KEY") PEM private key
+	// for the per-listener server leaf (TLS + MTLS). Held as a
+	// *dagger.Secret so Service() can mount it via WithMountedSecret
+	// with restricted Mode/Owner instead of snapshotting
+	// world-readable key material into the container filesystem via
+	// WithFile.
+	LeafKeyPem *dagger.Secret
 	// +private
 	ClientTrustPem *dagger.File // PEM of the clientTrustStore's CA cert(s) (MTLS only)
 }
@@ -740,7 +752,10 @@ func (p *Proxy) Service() (*dagger.Service, error) {
 		if l.SecurityMode == "TLS" || l.SecurityMode == "MTLS" {
 			ctr = ctr.
 				WithFile(listenerCertPath(l.Name), l.LeafCertPem, dagger.ContainerWithFileOpts{Permissions: 0o644}).
-				WithFile(listenerKeyPath(l.Name), l.LeafKeyPem, dagger.ContainerWithFileOpts{Permissions: 0o644})
+				WithMountedSecret(listenerKeyPath(l.Name), l.LeafKeyPem, dagger.ContainerWithMountedSecretOpts{
+					Mode:  0o400,
+					Owner: envoyOwner,
+				})
 		}
 		if l.SecurityMode == "MTLS" {
 			ctr = ctr.WithFile(listenerTrustPath(l.Name), l.ClientTrustPem, dagger.ContainerWithFileOpts{Permissions: 0o644})
@@ -753,7 +768,10 @@ func (p *Proxy) Service() (*dagger.Service, error) {
 		if c.UpstreamMode == "MTLS" {
 			ctr = ctr.
 				WithFile(upstreamCertPath(c.Name), c.UpstreamLeafCertPem, dagger.ContainerWithFileOpts{Permissions: 0o644}).
-				WithFile(upstreamKeyPath(c.Name), c.UpstreamLeafKeyPem, dagger.ContainerWithFileOpts{Permissions: 0o644})
+				WithMountedSecret(upstreamKeyPath(c.Name), c.UpstreamLeafKeyPem, dagger.ContainerWithMountedSecretOpts{
+					Mode:  0o400,
+					Owner: envoyOwner,
+				})
 		}
 	}
 	for i, host := range p.BindingHosts {

--- a/daggerverse/envoy/security.go
+++ b/daggerverse/envoy/security.go
@@ -152,12 +152,16 @@ func effectiveUpstreamMode(up *UpstreamSecurity) string {
 // mounted inside the running envoy container.
 const envoySecretsDir = "/etc/envoy/secrets"
 
-// envoyOwner is the uid:gid the envoyproxy/envoy image runs the
-// envoy process as (the upstream image's `envoy` user). Private-key
-// mounts must be Chown'd to this owner (with Mode 0o400) so envoy
-// can read them while every other process in the container cannot.
-// Default WithMountedSecret perms are root-owned 0o400, which the
-// non-root envoy process cannot read.
+// envoyOwner is the uid:gid the default `envoyproxy/envoy:v1.32.1`
+// image runs the envoy process as (the upstream image's `envoy`
+// user). Private-key mounts are Chown'd to this owner with Mode
+// 0o400 so the non-root envoy process can read them; without the
+// Chown, default WithMountedSecret perms are root-owned 0o400 and
+// envoy cannot open the key. This is empirically verified for the
+// default Proxy() image tag only — callers that override the image
+// to one whose envoy user has a different uid:gid will see TLS
+// startup fail with EACCES on the key, and will need this constant
+// (and the matching mount) updated to track the new image.
 const envoyOwner = "101:101"
 
 func listenerCertPath(name string) string {
@@ -258,10 +262,14 @@ func renderUpstreamTransportSocket(clusterName, mode string) map[string]any {
 }
 
 // mintListenerLeaf signs a per-listener server leaf certificate from
-// the caller-supplied CA, extracts the cert + chain as a single PEM
-// file and the private key as a plain PEM file (suitable for Envoy's
+// the caller-supplied CA, returning the cert + chain as a single
+// PEM *dagger.File and the PKCS#1 private key as a *dagger.Secret.
+// The cert PEM is mounted via WithFile and the key Secret via
+// WithMountedSecret, so both still feed Envoy's
 // `certificate_chain.filename` + `private_key.filename` data
-// sources). Returns (nil, nil, nil) for PLAINTEXT mode.
+// sources at the in-container paths returned by listenerCertPath /
+// listenerKeyPath — only the key avoids being snapshotted into the
+// container filesystem. Returns (nil, nil, nil) for PLAINTEXT mode.
 func mintListenerLeaf(ctx context.Context, listenerName string, sec *ServerSecurity) (*dagger.File, *dagger.Secret, error) {
 	if sec == nil || sec.Mode == "PLAINTEXT" {
 		return nil, nil, nil

--- a/daggerverse/envoy/security.go
+++ b/daggerverse/envoy/security.go
@@ -152,6 +152,14 @@ func effectiveUpstreamMode(up *UpstreamSecurity) string {
 // mounted inside the running envoy container.
 const envoySecretsDir = "/etc/envoy/secrets"
 
+// envoyOwner is the uid:gid the envoyproxy/envoy image runs the
+// envoy process as (the upstream image's `envoy` user). Private-key
+// mounts must be Chown'd to this owner (with Mode 0o400) so envoy
+// can read them while every other process in the container cannot.
+// Default WithMountedSecret perms are root-owned 0o400, which the
+// non-root envoy process cannot read.
+const envoyOwner = "101:101"
+
 func listenerCertPath(name string) string {
 	return filepath.Join(envoySecretsDir, "listener-"+name+".crt")
 }
@@ -254,7 +262,7 @@ func renderUpstreamTransportSocket(clusterName, mode string) map[string]any {
 // file and the private key as a plain PEM file (suitable for Envoy's
 // `certificate_chain.filename` + `private_key.filename` data
 // sources). Returns (nil, nil, nil) for PLAINTEXT mode.
-func mintListenerLeaf(ctx context.Context, listenerName string, sec *ServerSecurity) (*dagger.File, *dagger.File, error) {
+func mintListenerLeaf(ctx context.Context, listenerName string, sec *ServerSecurity) (*dagger.File, *dagger.Secret, error) {
 	if sec == nil || sec.Mode == "PLAINTEXT" {
 		return nil, nil, nil
 	}
@@ -296,18 +304,20 @@ func mintListenerLeaf(ctx context.Context, listenerName string, sec *ServerSecur
 	if err != nil {
 		return nil, nil, fmt.Errorf("listener %q: %w", listenerName, err)
 	}
-	keyPem, err := pkcs8SecretToPkcs1File(ctx, "listener-"+listenerName+"-key", issued.PrivateKeyPem())
+	keySecret, err := pkcs8SecretToPkcs1Secret(ctx, "listener-"+listenerName+"-key", issued.PrivateKeyPem())
 	if err != nil {
 		return nil, nil, fmt.Errorf("listener %q: %w", listenerName, err)
 	}
-	return certPem, keyPem, nil
+	return certPem, keySecret, nil
 }
 
-// pkcs8SecretToPkcs1File reads a PKCS#8 PEM private key out of a
+// pkcs8SecretToPkcs1Secret reads a PKCS#8 PEM private key out of a
 // Dagger Secret and rewrites it as a PKCS#1 ("RSA PRIVATE KEY") PEM
-// file. Envoy's BoringSSL build is finicky about PKCS#8 PEM
-// envelopes and reliably reads PKCS#1.
-func pkcs8SecretToPkcs1File(ctx context.Context, label string, sec *dagger.Secret) (*dagger.File, error) {
+// inside a new Dagger Secret. Envoy's BoringSSL build is finicky
+// about PKCS#8 PEM envelopes and reliably reads PKCS#1; staying in
+// secret form keeps the rewritten key off the container filesystem
+// snapshot — it lands at mount time via WithMountedSecret.
+func pkcs8SecretToPkcs1Secret(ctx context.Context, label string, sec *dagger.Secret) (*dagger.Secret, error) {
 	plaintext, err := sec.Plaintext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("read %s secret: %w", label, err)
@@ -325,7 +335,7 @@ func pkcs8SecretToPkcs1File(ctx context.Context, label string, sec *dagger.Secre
 		return nil, fmt.Errorf("%s: unexpected key type %T (expected *rsa.PrivateKey)", label, priv)
 	}
 	out := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(rsa)})
-	return writeBinaryWorkdirFile(label, "leaf.key", out)
+	return dag.SetSecret(label+"-"+randSuffix(), string(out)), nil
 }
 
 // buildCertChainPem concatenates the leaf cert and issuer cert PEM
@@ -345,11 +355,13 @@ func buildCertChainPem(ctx context.Context, label string, leaf, issuer *dagger.F
 }
 
 // extractUpstreamLeafPemFromPkcs12 unseals a caller-supplied PKCS#12
-// client keystore and emits a PEM cert chain (leaf + chain) and a
-// PKCS#1 ("RSA PRIVATE KEY") PEM private key for Envoy's upstream
-// tls_certificates data sources — BoringSSL reads PKCS#1 reliably
-// where PKCS#8 envelopes sometimes fail.
-func extractUpstreamLeafPemFromPkcs12(ctx context.Context, label string, p12 *dagger.File, password *dagger.Secret) (*dagger.File, *dagger.File, error) {
+// client keystore and emits a PEM cert chain (leaf + chain) as a
+// file plus a PKCS#1 ("RSA PRIVATE KEY") PEM private key wrapped in
+// a Dagger Secret. Envoy's BoringSSL build reads PKCS#1 reliably
+// where PKCS#8 envelopes sometimes fail; staging the key as a Secret
+// keeps it off the container filesystem snapshot — it lands at mount
+// time via WithMountedSecret.
+func extractUpstreamLeafPemFromPkcs12(ctx context.Context, label string, p12 *dagger.File, password *dagger.Secret) (*dagger.File, *dagger.Secret, error) {
 	data, err := dagFileBytes(ctx, p12)
 	if err != nil {
 		return nil, nil, fmt.Errorf("export %s pkcs12: %w", label, err)
@@ -376,11 +388,8 @@ func extractUpstreamLeafPemFromPkcs12(ctx context.Context, label string, p12 *da
 		return nil, nil, fmt.Errorf("%s: unexpected key type %T (expected *rsa.PrivateKey)", label, priv)
 	}
 	keyPem := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(rsaKey)})
-	keyFile, err := writeBinaryWorkdirFile(label+"-key", "leaf.key", keyPem)
-	if err != nil {
-		return nil, nil, fmt.Errorf("stage %s key pem: %w", label, err)
-	}
-	return certFile, keyFile, nil
+	keySecret := dag.SetSecret(label+"-key-"+randSuffix(), string(keyPem))
+	return certFile, keySecret, nil
 }
 
 // extractCaPemFromPkcs12 unseals the given PKCS#12 truststore and


### PR DESCRIPTION
## Summary
- Closes #52. Per-listener server leaf keys and per-cluster upstream client leaf keys now mount via `WithMountedSecret(Mode: 0o400, Owner: "101:101")` instead of `WithFile(Permissions: 0o644)`, so key material stays off the container filesystem snapshot and is readable only by the envoy process.
- `Listener.LeafKeyPem` and `Cluster.UpstreamLeafKeyPem` retyped from `*dagger.File` to `*dagger.Secret`; `pkcs8SecretToPkcs1File` → `pkcs8SecretToPkcs1Secret` and `extractUpstreamLeafPemFromPkcs12` updated accordingly. Cert chains and trust PEMs (public material) remain on `WithFile`.
- The owner is `101:101` (verified empirically against `envoyproxy/envoy:v1.32.1`), not the `1000:1000` example from the issue.

## Test plan
- [x] `dagger -m daggerverse/envoy/tests call l-7-https-round-trip`
- [x] `dagger -m daggerverse/envoy/tests call l-7-https-mtls-rejects-anonymous-client`
- [x] `dagger -m daggerverse/envoy/tests call l-7-https-mtls-accepts-authorized-client`
- [x] `dagger -m daggerverse/envoy/tests call upstream-tls-round-trip`
- [x] `dagger -m daggerverse/envoy/tests call upstream-mtls-round-trip` (both listener + cluster keys exercised)
- [x] `dagger -m daggerverse/envoy/tests call l-4-tcp-tls-round-trip`
- [x] `dagger -m daggerverse/envoy/tests call all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)