### PR TITLE
story(issue-62): include otel tests in Ci.Test

### DIFF
--- a/ci/main.go
+++ b/ci/main.go
@@ -59,6 +59,9 @@ func (c *Ci) Test(
 	jobs = jobs.WithJob("envoy", func(ctx context.Context) error {
 		return dag.EnvoyTests().All(ctx)
 	})
+	jobs = jobs.WithJob("otel", func(ctx context.Context) error {
+		return dag.OtelTests().All(ctx)
+	})
 
 	return jobs.Run(ctx)
 }

--- a/dagger.json
+++ b/dagger.json
@@ -32,6 +32,10 @@
     {
       "name": "envoy-tests",
       "source": "daggerverse/envoy/tests"
+    },
+    {
+      "name": "otel-tests",
+      "source": "daggerverse/otel/tests"
     }
   ],
   "source": "ci"


### PR DESCRIPTION
## Description

Wires the `otel` module's `tests/All()` into `Ci.Test`, the repo's aggregate test entry point. Previously seven of eight daggerverse modules were covered; otel regressions slipped past `dagger call test`.

## Changes

- `dagger.json`: add `otel-tests` to `dependencies`, sourced from `daggerverse/otel/tests`
- `ci/main.go`: add an `otel` job calling `dag.OtelTests().All(ctx)`, alongside the other module jobs

## Testing

- `dagger develop` regenerated the client so `dag.OtelTests()` is available
- `dagger call test` from the repo root runs all eight modules (including otel) and passes (4m36s)

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)