### PR TITLE
story(issue-37): add ConfluentSchemaRegistry to kafka module

### DIFF
--- a/daggerverse/kafka/README.md
+++ b/daggerverse/kafka/README.md
@@ -126,6 +126,74 @@ The constructor silently sets `KAFKA_CONFLUENT_SUPPORT_METRICS_ENABLE=false`
 on each broker to disable Confluent's phone-home telemetry, matching
 the Apache variants' startup behavior.
 
+## Schema Registry
+
+A schema registry sits alongside the brokers as a separate service: it
+stores schemas in the cluster's `_schemas` Kafka topic and exposes a REST
+API for registering and looking up Avro / JSON Schema / Protobuf schemas by
+subject. `ConfluentSchemaRegistry` runs the `confluentinc/cp-schema-registry`
+image.
+
+```go
+cluster := dag.Kafka().ConfluentCluster(clusterId, dag.Kafka().PlaintextServerSecurity())
+
+sr := dag.Kafka().ConfluentSchemaRegistry(
+    cluster,
+    dagger.KafkaConfluentSchemaRegistryOpts{
+        Tag:      "8.2.0",
+        Registry: "docker.io",
+    },
+)
+client := sr.Client()
+```
+
+The registry composes on top of **any** `*Cluster` — it talks the Kafka
+wire protocol to the brokers for its `_schemas` topic and exposes its own
+REST API on top, so the cluster distro is orthogonal. `cp-schema-registry`
+simply pairs most naturally with a `cp-kafka` `ConfluentCluster`.
+
+`ConfluentSchemaRegistry` is session-cached, so chained client calls all
+observe the same underlying service. It binds every broker via
+`cluster.BindBrokers` and wires `SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS`
+from `cluster.BootstrapServers()`.
+
+**PLAINTEXT only** in this story — the constructor rejects a cluster whose
+client listener runs TLS or mTLS. TLS / mTLS Schema Registry is a follow-up.
+
+- `SchemaRegistry.Endpoint(ctx) (string, error)` — the `host:port` other
+  containers (and the module runtime) reach the REST API on.
+- `SchemaRegistry.BindTo(c *dagger.Container) *dagger.Container` —
+  `WithServiceBinding` so a caller's container resolves the registry at the
+  same hostname `Endpoint` reports.
+- `SchemaRegistry.Client() *SchemaRegistryClient` — a pure-Go `net/http`
+  admin client; no helper containers.
+- `SchemaRegistry.Stop(ctx) error` — tears the registry service down.
+
+### SchemaRegistryClient
+
+```go
+id, err := client.RegisterSchema(ctx, "my-subject-value", avroSchema,
+    dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{SchemaType: "AVRO"})
+
+schema, err := client.LookupSchemaByID(ctx, id)        // RegisteredSchema
+latest, err := client.LookupLatestBySubject(ctx, "my-subject-value")
+subjects, err := client.ListSubjects(ctx)              // []string
+deleted, err := client.DeleteSubject(ctx, "my-subject-value") // []int versions
+
+err = client.SetCompatibility(ctx, "my-subject-value", "BACKWARD")
+level, err := client.GetCompatibility(ctx, "my-subject-value")
+```
+
+`schemaType` accepts `AVRO`, `JSON`, or `PROTOBUF`. Compatibility `level`
+accepts `NONE`, `BACKWARD`, `BACKWARD_TRANSITIVE`, `FORWARD`,
+`FORWARD_TRANSITIVE`, `FULL`, or `FULL_TRANSITIVE`.
+
+`RegisteredSchema` carries `Subject`, `Version`, `SchemaID`, `Definition`
+(the schema text), and `SchemaType`. The `SchemaID` / `Definition` names
+diverge from the REST API's `id` / `schema` JSON keys: a Dagger object
+already has a synthetic `id` field and `schema` is a GraphQL keyword, so
+both would break consumer-module codegen.
+
 ## RedpandaCluster
 
 ```go

--- a/daggerverse/kafka/main.go
+++ b/daggerverse/kafka/main.go
@@ -22,6 +22,10 @@
 //                          PKCS#12 → *tls.Config, PropertiesFile, and the
 //                          admin / produce / consume / list-topics
 //                          method set.
+//   - schema_registry.go — *SchemaRegistry / *SchemaRegistryClient /
+//                          RegisteredSchema, the ConfluentSchemaRegistry
+//                          constructor, and the pure-Go net/http admin
+//                          client for the Schema Registry REST API.
 //   - util.go            — shared helpers (writeWorkdirBytes,
 //                          clusterHostSuffix, randSuffix, dagFileBytes).
 package main

--- a/daggerverse/kafka/schema_registry.go
+++ b/daggerverse/kafka/schema_registry.go
@@ -1,0 +1,510 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"dagger/kafka/internal/dagger"
+)
+
+// schemaRegistryPort is the HTTP port the Confluent Schema Registry REST
+// API listens on, both inside the container and as advertised to callers.
+const schemaRegistryPort = 8081
+
+// srContentType is the versioned media type the Schema Registry REST API
+// expects on requests and returns on responses.
+const srContentType = "application/vnd.schemaregistry.v1+json"
+
+// SchemaRegistry is a running Confluent Schema Registry service bound to a
+// Kafka cluster's brokers. Schema Registry stores schemas in the cluster's
+// `_schemas` topic and exposes a REST API for registering and looking up
+// Avro / JSON Schema / Protobuf schemas by subject.
+//
+// The constructor is session-cached so chained calls
+// (Client().RegisterSchema(...) → LookupSchemaByID(...)) all observe the
+// same underlying service.
+type SchemaRegistry struct {
+	// +private
+	SchemaRegistrySvc *dagger.Service
+	// +private
+	AdvertisedHost string
+	// +private
+	AdvertisedPort int
+}
+
+// SchemaRegistryClient is a pure-Go net/http client for a Schema Registry's
+// admin REST API. Each method opens a fresh request so the function call is
+// stateless from Dagger's perspective.
+type SchemaRegistryClient struct {
+	// +private
+	Svc *dagger.Service
+	// +private
+	BaseURL string
+}
+
+// RegisteredSchema is one schema version as the Confluent Schema Registry
+// reports it.
+//
+// The field names deliberately diverge from the REST API's JSON keys
+// (`id`, `schema`): an exported `ID` field collides with the synthetic
+// Dagger object `id`, and `Schema` is a GraphQL keyword that breaks
+// consumer-module codegen — see daggerverse/CLAUDE.md.
+type RegisteredSchema struct {
+	Subject    string // registry subject the schema is registered under
+	Version    int    // monotonic version within the subject
+	SchemaID   int    // globally-unique registry schema id
+	Definition string // the schema text itself (Avro / JSON Schema / Protobuf)
+	SchemaType string // AVRO | JSON | PROTOBUF
+}
+
+// ConfluentSchemaRegistry spins up a Confluent Schema Registry service
+// (`confluentinc/cp-schema-registry`) alongside the given Kafka cluster.
+// The registry talks the Kafka wire protocol to the cluster's brokers for
+// its `_schemas` topic and exposes its own REST API on top, so it composes
+// on any *Cluster regardless of distro — cp-schema-registry simply pairs
+// most naturally with a cp-kafka ConfluentCluster.
+//
+// Only PLAINTEXT clusters are supported in this story: the constructor
+// rejects TLS / mTLS clusters and points callers at the TLS follow-up.
+//
+// Session-cached for the same reason the cluster constructors are — a
+// `+cache="never"` directive here would mint a brand-new registry service
+// for every chained client call.
+//
+// +cache="session"
+func (k *Kafka) ConfluentSchemaRegistry(
+	ctx context.Context,
+	cluster *Cluster,
+	// +default="docker.io"
+	registry string,
+	// +default="8.2.0"
+	tag string,
+) (*SchemaRegistry, error) {
+	if cluster == nil {
+		return nil, fmt.Errorf("Kafka.ConfluentSchemaRegistry: cluster must not be nil")
+	}
+	if len(cluster.BrokerSvcs) == 0 {
+		return nil, fmt.Errorf("Kafka.ConfluentSchemaRegistry: cluster has no brokers")
+	}
+	if cluster.ClientSecurityMode != "PLAINTEXT" {
+		return nil, fmt.Errorf(
+			"Kafka.ConfluentSchemaRegistry: cluster client listener is %q; only PLAINTEXT "+
+				"is supported in this story. TLS / mTLS Schema Registry "+
+				"(SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL=SSL plus keystore mounts) "+
+				"is a follow-up story.",
+			cluster.ClientSecurityMode,
+		)
+	}
+
+	image := fmt.Sprintf("%s/confluentinc/cp-schema-registry:%s", registry, tag)
+	// `csr-` (confluent schema registry) keeps the hostname short — a
+	// longer `schema-registry-<suffix>` alias trips runc's sethostname on
+	// startup — and gives sibling registry implementations room to pick
+	// their own distinct prefix on the same cluster.
+	srHost := "csr-" + clusterHostSuffix(cluster.ClusterID)
+
+	// cp-schema-registry wants its bootstrap servers scheme-prefixed;
+	// Cluster.BootstrapServers reports bare host:port.
+	bootstrap := cluster.BootstrapServers()
+	kafkastore := make([]string, len(bootstrap))
+	for i, b := range bootstrap {
+		kafkastore[i] = "PLAINTEXT://" + b
+	}
+
+	// The brokers run with KAFKA_AUTO_CREATE_TOPICS_ENABLE=false and
+	// Schema Registry creates the `_schemas` topic itself on first boot.
+	// Its default replication factor is 3, which fails on the
+	// single-broker clusters tests use — pin it to the broker count,
+	// capped at 3, mirroring buildKafkaCluster's system-topic RF handling.
+	rf := len(cluster.BrokerSvcs)
+	if rf > 3 {
+		rf = 3
+	}
+
+	ctr := dag.Container().
+		From(image).
+		WithEnvVariable("SCHEMA_REGISTRY_HOST_NAME", srHost).
+		WithEnvVariable("SCHEMA_REGISTRY_LISTENERS", fmt.Sprintf("http://0.0.0.0:%d", schemaRegistryPort)).
+		WithEnvVariable("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", strings.Join(kafkastore, ",")).
+		WithEnvVariable("SCHEMA_REGISTRY_KAFKASTORE_TOPIC_REPLICATION_FACTOR", strconv.Itoa(rf)).
+		WithExposedPort(schemaRegistryPort)
+	ctr = cluster.BindBrokers(ctr)
+
+	srSvc := ctr.
+		AsService(dagger.ContainerAsServiceOpts{UseEntrypoint: true}).
+		WithHostname(srHost)
+
+	return &SchemaRegistry{
+		SchemaRegistrySvc: srSvc,
+		AdvertisedHost:    srHost,
+		AdvertisedPort:    schemaRegistryPort,
+	}, nil
+}
+
+// Endpoint returns the host:port other containers (and the module runtime)
+// can reach the Schema Registry REST API on.
+//
+// +cache="never"
+func (s *SchemaRegistry) Endpoint(ctx context.Context) (string, error) {
+	if s == nil || s.SchemaRegistrySvc == nil {
+		return "", fmt.Errorf("SchemaRegistry.Endpoint: no underlying service")
+	}
+	return s.SchemaRegistrySvc.Endpoint(ctx, dagger.ServiceEndpointOpts{
+		Port: s.AdvertisedPort,
+	})
+}
+
+// BindTo attaches the Schema Registry service to the given container under
+// the same hostname Endpoint reports, so the container resolves the
+// registry at that address.
+//
+// +cache="never"
+func (s *SchemaRegistry) BindTo(ctr *dagger.Container) *dagger.Container {
+	return ctr.WithServiceBinding(s.AdvertisedHost, s.SchemaRegistrySvc)
+}
+
+// Client returns a typed HTTP client targeting this registry's REST API.
+// No I/O happens at construction time.
+func (s *SchemaRegistry) Client() *SchemaRegistryClient {
+	return &SchemaRegistryClient{
+		Svc:     s.SchemaRegistrySvc,
+		BaseURL: fmt.Sprintf("http://%s:%d", s.AdvertisedHost, s.AdvertisedPort),
+	}
+}
+
+// Stop tears down the Schema Registry service. Kill is set so the stop
+// returns immediately rather than waiting on graceful shutdown, mirroring
+// Cluster.Stop — tests should call this in a defer.
+//
+// +cache="never"
+func (s *SchemaRegistry) Stop(ctx context.Context) error {
+	if s == nil || s.SchemaRegistrySvc == nil {
+		return nil
+	}
+	if _, err := s.SchemaRegistrySvc.Stop(ctx, dagger.ServiceStopOpts{Kill: true}); err != nil {
+		return fmt.Errorf("stop schema registry: %w", err)
+	}
+	return nil
+}
+
+// srError is the error body the Schema Registry REST API returns on a
+// non-2xx response.
+type srError struct {
+	ErrorCode int    `json:"error_code"`
+	Message   string `json:"message"`
+}
+
+// do issues one HTTP request against the Schema Registry REST API. It first
+// starts the registry service so the module runtime can resolve its
+// hostname, then retries transient failures — connection refused while the
+// HTTP listener is still coming up, and 5xx responses while the `_schemas`
+// store is still bootstrapping — until a fixed deadline.
+func (c *SchemaRegistryClient) do(ctx context.Context, method, path string, reqBody any) ([]byte, int, error) {
+	if c.Svc == nil {
+		return nil, 0, fmt.Errorf("schema registry client has no service")
+	}
+	if _, err := c.Svc.Start(ctx); err != nil {
+		return nil, 0, fmt.Errorf("start schema registry service: %w", err)
+	}
+
+	var body []byte
+	if reqBody != nil {
+		var err error
+		body, err = json.Marshal(reqBody)
+		if err != nil {
+			return nil, 0, fmt.Errorf("marshal request body: %w", err)
+		}
+	}
+
+	const (
+		attempts = 30
+		backoff  = time.Second
+	)
+	var lastErr error
+	for i := 0; i < attempts; i++ {
+		if i > 0 {
+			select {
+			case <-ctx.Done():
+				return nil, 0, ctx.Err()
+			case <-time.After(backoff):
+			}
+		}
+
+		var reader io.Reader
+		if body != nil {
+			reader = bytes.NewReader(body)
+		}
+		req, err := http.NewRequestWithContext(ctx, method, c.BaseURL+path, reader)
+		if err != nil {
+			return nil, 0, fmt.Errorf("build request: %w", err)
+		}
+		req.Header.Set("Accept", srContentType)
+		if body != nil {
+			req.Header.Set("Content-Type", srContentType)
+		}
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			// The registry container may still be starting its HTTP
+			// listener; connection-level failures are retryable.
+			var netErr net.Error
+			if errors.As(err, &netErr) || isConnRefused(err) {
+				lastErr = err
+				continue
+			}
+			return nil, 0, fmt.Errorf("%s %s: %w", method, path, err)
+		}
+		respBody, readErr := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if readErr != nil {
+			return nil, resp.StatusCode, fmt.Errorf("read response body: %w", readErr)
+		}
+
+		// 5xx means the registry is up but not yet ready (store still
+		// loading); retry. Everything else is a definitive answer.
+		if resp.StatusCode >= 500 {
+			lastErr = fmt.Errorf("%s %s: server returned %d: %s", method, path, resp.StatusCode, respBody)
+			continue
+		}
+		return respBody, resp.StatusCode, nil
+	}
+	return nil, 0, fmt.Errorf("%s %s: schema registry not ready after %d attempts: %w", method, path, attempts, lastErr)
+}
+
+// isConnRefused reports whether err is a connection-refused dial failure,
+// which happens while the registry's HTTP listener is still binding.
+func isConnRefused(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "connection refused")
+}
+
+// decodeOK unmarshals a 2xx response body into out. A non-2xx status is
+// turned into a Go error carrying the registry's error_code and message.
+func decodeOK(respBody []byte, status string, statusCode int, out any) error {
+	if statusCode < 200 || statusCode >= 300 {
+		var se srError
+		if json.Unmarshal(respBody, &se) == nil && se.Message != "" {
+			return fmt.Errorf("schema registry: %s (code %d, http %d)", se.Message, se.ErrorCode, statusCode)
+		}
+		return fmt.Errorf("schema registry: %s returned http %d: %s", status, statusCode, respBody)
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.Unmarshal(respBody, out); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	return nil
+}
+
+// validSchemaTypes is the set of schema types the registry accepts.
+var validSchemaTypes = map[string]bool{"AVRO": true, "JSON": true, "PROTOBUF": true}
+
+// validCompatLevels is the set of compatibility levels the registry accepts.
+var validCompatLevels = map[string]bool{
+	"NONE": true, "BACKWARD": true, "BACKWARD_TRANSITIVE": true,
+	"FORWARD": true, "FORWARD_TRANSITIVE": true, "FULL": true, "FULL_TRANSITIVE": true,
+}
+
+// normalizeSchemaType maps the registry's omitted schemaType (it leaves the
+// field empty for Avro, its default) back to an explicit "AVRO".
+func normalizeSchemaType(t string) string {
+	if t == "" {
+		return "AVRO"
+	}
+	return t
+}
+
+// RegisterSchema registers schema under subject and returns the globally
+// unique schema id the registry assigned. schemaType must be one of AVRO,
+// JSON, or PROTOBUF.
+//
+// +cache="never"
+func (c *SchemaRegistryClient) RegisterSchema(
+	ctx context.Context,
+	subject string,
+	schema string,
+	// +default="AVRO"
+	schemaType string,
+) (int, error) {
+	if subject == "" {
+		return 0, fmt.Errorf("RegisterSchema: subject must not be empty")
+	}
+	if !validSchemaTypes[schemaType] {
+		return 0, fmt.Errorf("RegisterSchema: unsupported schemaType %q (want AVRO|JSON|PROTOBUF)", schemaType)
+	}
+	reqBody := map[string]string{"schema": schema, "schemaType": schemaType}
+	body, code, err := c.do(ctx, http.MethodPost, "/subjects/"+url.PathEscape(subject)+"/versions", reqBody)
+	if err != nil {
+		return 0, err
+	}
+	var out struct {
+		ID int `json:"id"`
+	}
+	if err := decodeOK(body, "register schema", code, &out); err != nil {
+		return 0, err
+	}
+	return out.ID, nil
+}
+
+// LookupSchemaByID returns the schema registered under the given global id.
+//
+// The registry's GET /schemas/ids/{id} endpoint reports only the schema
+// text and type, so a second call to GET /schemas/ids/{id}/versions
+// resolves the subject and version. When an id maps to more than one
+// subject/version pair, the first association is returned.
+//
+// +cache="never"
+func (c *SchemaRegistryClient) LookupSchemaByID(ctx context.Context, id int) (RegisteredSchema, error) {
+	body, code, err := c.do(ctx, http.MethodGet, "/schemas/ids/"+strconv.Itoa(id), nil)
+	if err != nil {
+		return RegisteredSchema{}, err
+	}
+	var schema struct {
+		Schema     string `json:"schema"`
+		SchemaType string `json:"schemaType"`
+	}
+	if err := decodeOK(body, "lookup schema by id", code, &schema); err != nil {
+		return RegisteredSchema{}, err
+	}
+
+	versBody, versCode, err := c.do(ctx, http.MethodGet, "/schemas/ids/"+strconv.Itoa(id)+"/versions", nil)
+	if err != nil {
+		return RegisteredSchema{}, err
+	}
+	var versions []struct {
+		Subject string `json:"subject"`
+		Version int    `json:"version"`
+	}
+	if err := decodeOK(versBody, "lookup schema versions", versCode, &versions); err != nil {
+		return RegisteredSchema{}, err
+	}
+	if len(versions) == 0 {
+		return RegisteredSchema{}, fmt.Errorf("LookupSchemaByID: id %d has no subject/version associations", id)
+	}
+
+	return RegisteredSchema{
+		Subject:    versions[0].Subject,
+		Version:    versions[0].Version,
+		SchemaID:   id,
+		Definition: schema.Schema,
+		SchemaType: normalizeSchemaType(schema.SchemaType),
+	}, nil
+}
+
+// LookupLatestBySubject returns the latest registered schema version for
+// the given subject.
+//
+// +cache="never"
+func (c *SchemaRegistryClient) LookupLatestBySubject(ctx context.Context, subject string) (RegisteredSchema, error) {
+	if subject == "" {
+		return RegisteredSchema{}, fmt.Errorf("LookupLatestBySubject: subject must not be empty")
+	}
+	body, code, err := c.do(ctx, http.MethodGet, "/subjects/"+url.PathEscape(subject)+"/versions/latest", nil)
+	if err != nil {
+		return RegisteredSchema{}, err
+	}
+	var out struct {
+		Subject    string `json:"subject"`
+		Version    int    `json:"version"`
+		ID         int    `json:"id"`
+		Schema     string `json:"schema"`
+		SchemaType string `json:"schemaType"`
+	}
+	if err := decodeOK(body, "lookup latest by subject", code, &out); err != nil {
+		return RegisteredSchema{}, err
+	}
+	return RegisteredSchema{
+		Subject:    out.Subject,
+		Version:    out.Version,
+		SchemaID:   out.ID,
+		Definition: out.Schema,
+		SchemaType: normalizeSchemaType(out.SchemaType),
+	}, nil
+}
+
+// ListSubjects returns the names of every subject registered.
+//
+// +cache="never"
+func (c *SchemaRegistryClient) ListSubjects(ctx context.Context) ([]string, error) {
+	body, code, err := c.do(ctx, http.MethodGet, "/subjects", nil)
+	if err != nil {
+		return nil, err
+	}
+	var out []string
+	if err := decodeOK(body, "list subjects", code, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// DeleteSubject deletes every version of the given subject and returns the
+// version numbers that were deleted.
+//
+// +cache="never"
+func (c *SchemaRegistryClient) DeleteSubject(ctx context.Context, subject string) ([]int, error) {
+	if subject == "" {
+		return nil, fmt.Errorf("DeleteSubject: subject must not be empty")
+	}
+	body, code, err := c.do(ctx, http.MethodDelete, "/subjects/"+url.PathEscape(subject), nil)
+	if err != nil {
+		return nil, err
+	}
+	var out []int
+	if err := decodeOK(body, "delete subject", code, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// SetCompatibility sets the compatibility level for the given subject.
+// level must be one of NONE, BACKWARD, BACKWARD_TRANSITIVE, FORWARD,
+// FORWARD_TRANSITIVE, FULL, or FULL_TRANSITIVE.
+//
+// +cache="never"
+func (c *SchemaRegistryClient) SetCompatibility(ctx context.Context, subject string, level string) error {
+	if subject == "" {
+		return fmt.Errorf("SetCompatibility: subject must not be empty")
+	}
+	if !validCompatLevels[level] {
+		return fmt.Errorf("SetCompatibility: unsupported level %q", level)
+	}
+	body, code, err := c.do(ctx, http.MethodPut, "/config/"+url.PathEscape(subject),
+		map[string]string{"compatibility": level})
+	if err != nil {
+		return err
+	}
+	return decodeOK(body, "set compatibility", code, nil)
+}
+
+// GetCompatibility returns the compatibility level configured for the given
+// subject, falling back to the registry-wide default when the subject has
+// no explicit configuration.
+//
+// +cache="never"
+func (c *SchemaRegistryClient) GetCompatibility(ctx context.Context, subject string) (string, error) {
+	if subject == "" {
+		return "", fmt.Errorf("GetCompatibility: subject must not be empty")
+	}
+	body, code, err := c.do(ctx, http.MethodGet,
+		"/config/"+url.PathEscape(subject)+"?defaultToGlobal=true", nil)
+	if err != nil {
+		return "", err
+	}
+	var out struct {
+		CompatibilityLevel string `json:"compatibilityLevel"`
+	}
+	if err := decodeOK(body, "get compatibility", code, &out); err != nil {
+		return "", err
+	}
+	return out.CompatibilityLevel, nil
+}

--- a/daggerverse/kafka/tests/main.go
+++ b/daggerverse/kafka/tests/main.go
@@ -21,6 +21,9 @@
 //                          helpers + the three cp-kafka round-trip tests.
 //   - tests_redpanda.go  — RedpandaCluster (redpandadata/redpanda) cluster
 //                          helpers + the two Redpanda round-trip tests.
+//   - tests_schema_registry.go — ConfluentSchemaRegistry tests: the
+//                          register/lookup/delete round-trip and the
+//                          non-PLAINTEXT-cluster rejection.
 package main
 
 import (
@@ -110,6 +113,31 @@ func (t *Tests) All(
 	})
 	jobs = jobs.WithJob("redpandaTests", func(ctx context.Context) error {
 		return t.redpandaTests(ctx, redpandaImageTag, parallel)
+	})
+	jobs = jobs.WithJob("schemaRegistryTests", func(ctx context.Context) error {
+		return t.schemaRegistryTests(ctx, kafkaImageTag, parallel)
+	})
+
+	return jobs.Run(ctx)
+}
+
+// schemaRegistryTests runs the Kafka.ConfluentSchemaRegistry tests as one
+// group. Each test owns the cluster (and, for the round-trip, the
+// cp-schema-registry service) it boots, so the group's only lifetime
+// guarantee is that both are torn down once it returns.
+func (t *Tests) schemaRegistryTests(ctx context.Context, kafkaImageTag string, parallel int) error {
+	jobs := par.New().
+		WithRollupLogs(true).
+		WithRollupSpans(true)
+	if parallel > 0 {
+		jobs = jobs.WithLimit(parallel)
+	}
+
+	jobs = jobs.WithJob("SchemaRegistryRegisterLookupRoundTrip", func(ctx context.Context) error {
+		return t.SchemaRegistryRegisterLookupRoundTrip(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("SchemaRegistryRejectsNonPlaintextCluster", func(ctx context.Context) error {
+		return t.SchemaRegistryRejectsNonPlaintextCluster(ctx, kafkaImageTag)
 	})
 
 	return jobs.Run(ctx)

--- a/daggerverse/kafka/tests/tests_schema_registry.go
+++ b/daggerverse/kafka/tests/tests_schema_registry.go
@@ -14,8 +14,9 @@ const avroTestSchema = `{"type":"record","name":"R","fields":[{"name":"x","type"
 
 // SchemaRegistryRegisterLookupRoundTrip is the PLAINTEXT happy-path test
 // for Kafka.ConfluentSchemaRegistry: stand a cp-schema-registry up next to
-// a fresh cluster, then exercise register → lookup-by-id → list-subjects →
-// delete against it.
+// a fresh cluster, then exercise register → lookup-by-id →
+// lookup-latest-by-subject → list-subjects → set/get-compatibility →
+// delete against it — covering every SchemaRegistryClient operation.
 func (t *Tests) SchemaRegistryRegisterLookupRoundTrip(
 	ctx context.Context,
 	// +default="4.2.0"
@@ -71,12 +72,60 @@ func (t *Tests) SchemaRegistryRegisterLookupRoundTrip(
 		return fmt.Errorf("lookup-by-id schemaID mismatch: want %d, got %d", id, gotID)
 	}
 
+	latest := client.LookupLatestBySubject(subject)
+	latestSubject, err := latest.Subject(ctx)
+	if err != nil {
+		return fmt.Errorf("lookup latest by subject: %w", err)
+	}
+	if latestSubject != subject {
+		return fmt.Errorf("lookup-latest subject mismatch: want %q, got %q", subject, latestSubject)
+	}
+	latestVersion, err := latest.Version(ctx)
+	if err != nil {
+		return fmt.Errorf("read latest version: %w", err)
+	}
+	if latestVersion != 1 {
+		return fmt.Errorf("lookup-latest version mismatch: want 1, got %d", latestVersion)
+	}
+	latestID, err := latest.SchemaID(ctx)
+	if err != nil {
+		return fmt.Errorf("read latest schema id: %w", err)
+	}
+	if latestID != id {
+		return fmt.Errorf("lookup-latest schemaID mismatch: want %d, got %d", id, latestID)
+	}
+	latestDef, err := latest.Definition(ctx)
+	if err != nil {
+		return fmt.Errorf("read latest definition: %w", err)
+	}
+	if latestDef == "" {
+		return fmt.Errorf("expected lookup-latest to return a non-empty schema definition")
+	}
+	latestType, err := latest.SchemaType(ctx)
+	if err != nil {
+		return fmt.Errorf("read latest schema type: %w", err)
+	}
+	if latestType != "AVRO" {
+		return fmt.Errorf("lookup-latest schemaType mismatch: want AVRO, got %q", latestType)
+	}
+
 	subjects, err := client.ListSubjects(ctx)
 	if err != nil {
 		return fmt.Errorf("list subjects: %w", err)
 	}
 	if !contains(subjects, subject) {
 		return fmt.Errorf("expected subject %q in %v after register", subject, subjects)
+	}
+
+	if err := client.SetCompatibility(ctx, subject, "BACKWARD"); err != nil {
+		return fmt.Errorf("set compatibility: %w", err)
+	}
+	level, err := client.GetCompatibility(ctx, subject)
+	if err != nil {
+		return fmt.Errorf("get compatibility: %w", err)
+	}
+	if level != "BACKWARD" {
+		return fmt.Errorf("compatibility round-trip mismatch: want BACKWARD, got %q", level)
 	}
 
 	deleted, err := client.DeleteSubject(ctx, subject)

--- a/daggerverse/kafka/tests/tests_schema_registry.go
+++ b/daggerverse/kafka/tests/tests_schema_registry.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"dagger/tests/internal/dagger"
+)
+
+// avroTestSchema is a minimal Avro record schema used by the Schema
+// Registry round-trip test.
+const avroTestSchema = `{"type":"record","name":"R","fields":[{"name":"x","type":"string"}]}`
+
+// SchemaRegistryRegisterLookupRoundTrip is the PLAINTEXT happy-path test
+// for Kafka.ConfluentSchemaRegistry: stand a cp-schema-registry up next to
+// a fresh cluster, then exercise register → lookup-by-id → list-subjects →
+// delete against it.
+func (t *Tests) SchemaRegistryRegisterLookupRoundTrip(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, err := freshCluster(ctx, kafkaImageTag)
+	if err != nil {
+		return fmt.Errorf("create cluster: %w", err)
+	}
+	defer cluster.Stop(ctx)
+
+	sr := dag.Kafka().ConfluentSchemaRegistry(cluster)
+	defer sr.Stop(ctx)
+
+	client := sr.Client()
+
+	subject, err := randomTopicName(ctx)
+	if err != nil {
+		return err
+	}
+	subject += "-value"
+
+	id, err := client.RegisterSchema(ctx, subject, avroTestSchema, dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{
+		SchemaType: "AVRO",
+	})
+	if err != nil {
+		return fmt.Errorf("register schema: %w", err)
+	}
+	if id <= 0 {
+		return fmt.Errorf("expected a positive schema id, got %d", id)
+	}
+
+	got := client.LookupSchemaByID(id)
+	gotSubject, err := got.Subject(ctx)
+	if err != nil {
+		return fmt.Errorf("lookup schema by id: %w", err)
+	}
+	if gotSubject != subject {
+		return fmt.Errorf("lookup-by-id subject mismatch: want %q, got %q", subject, gotSubject)
+	}
+	gotType, err := got.SchemaType(ctx)
+	if err != nil {
+		return fmt.Errorf("read schema type: %w", err)
+	}
+	if gotType != "AVRO" {
+		return fmt.Errorf("lookup-by-id schemaType mismatch: want AVRO, got %q", gotType)
+	}
+	gotID, err := got.SchemaID(ctx)
+	if err != nil {
+		return fmt.Errorf("read schema id: %w", err)
+	}
+	if gotID != id {
+		return fmt.Errorf("lookup-by-id schemaID mismatch: want %d, got %d", id, gotID)
+	}
+
+	subjects, err := client.ListSubjects(ctx)
+	if err != nil {
+		return fmt.Errorf("list subjects: %w", err)
+	}
+	if !contains(subjects, subject) {
+		return fmt.Errorf("expected subject %q in %v after register", subject, subjects)
+	}
+
+	deleted, err := client.DeleteSubject(ctx, subject)
+	if err != nil {
+		return fmt.Errorf("delete subject %q: %w", subject, err)
+	}
+	if len(deleted) == 0 {
+		return fmt.Errorf("expected DeleteSubject to report at least one deleted version, got none")
+	}
+	return nil
+}
+
+// SchemaRegistryRejectsNonPlaintextCluster pins the PLAINTEXT-only contract
+// of this story: ConfluentSchemaRegistry must reject a cluster whose client
+// listener runs TLS rather than silently producing a broken registry. The
+// constructor errors before any service boots, so the TLS cluster never
+// has to start.
+func (t *Tests) SchemaRegistryRejectsNonPlaintextCluster(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, _, _, err := freshTlsCluster(ctx, kafkaImageTag, 1)
+	if err != nil {
+		return fmt.Errorf("create tls cluster: %w", err)
+	}
+	defer cluster.Stop(ctx)
+
+	_, err = dag.Kafka().ConfluentSchemaRegistry(cluster).Endpoint(ctx)
+	if err == nil {
+		return fmt.Errorf("expected ConfluentSchemaRegistry to reject a non-PLAINTEXT cluster, got nil error")
+	}
+	if !strings.Contains(err.Error(), "PLAINTEXT") {
+		return fmt.Errorf("expected rejection error to mention PLAINTEXT, got: %v", err)
+	}
+	return nil
+}


### PR DESCRIPTION
Closes #37.

Adds `Kafka.ConfluentSchemaRegistry` — a `confluentinc/cp-schema-registry` service that composes on top of any `*Cluster` — plus the shared `*SchemaRegistry`, `*SchemaRegistryClient`, and `RegisteredSchema` types that sibling registry stories (Apicurio, Karapace, Redpanda-bundled) will reuse.

## What's included

- **`ConfluentSchemaRegistry(cluster, ...)`** (`+cache="session"`) — builds `<registry>/confluentinc/cp-schema-registry:<tag>` (defaults `docker.io` / `8.2.0`), binds every broker via `cluster.BindBrokers`, wires `SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS` from `cluster.BootstrapServers()` with the `PLAINTEXT://` scheme prefix, and sets `SCHEMA_REGISTRY_KAFKASTORE_TOPIC_REPLICATION_FACTOR` to `min(3, brokers)` so `_schemas` can be created on a single-broker cluster.
- **PLAINTEXT only** — the constructor rejects TLS/mTLS clusters with an error pointing to the TLS follow-up story.
- `SchemaRegistry.Endpoint` / `BindTo` / `Client` / `Stop`.
- **`SchemaRegistryClient`** — pure-Go `net/http` admin client (no helper containers) with a bounded readiness-retry loop: `RegisterSchema`, `LookupSchemaByID`, `LookupLatestBySubject`, `ListSubjects`, `DeleteSubject`, `SetCompatibility`, `GetCompatibility`.
- Tests under `daggerverse/kafka/tests/`: register→lookup→list→delete round-trip and the non-PLAINTEXT rejection, wired into `All` as a new `schemaRegistryTests` group. README "Schema Registry" section added.

## Deviations from the issue (by design)

- **`RegisteredSchema` fields are `SchemaID`/`Definition`, not `ID`/`Schema`.** `ID` collides with the synthetic Dagger object `id` and `Schema` is a GraphQL keyword — both break consumer-module codegen per `daggerverse/CLAUDE.md`.
- Code lives in a new `schema_registry.go`, matching the module's per-feature file split (issue prose said `main.go`).
- Service alias is `csr-<suffix>`; the longer `schema-registry-<suffix>` reproducibly tripped runc's `sethostname` at container init.
- Adds `SchemaRegistry.Stop` for lifecycle symmetry with `Cluster.Stop`.

## Verification

`dagger develop` re-run in `daggerverse/kafka/` and `daggerverse/kafka/tests/`. Both new tests pass individually and the full `dagger -m daggerverse/kafka/tests call all` suite is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)