### PR TITLE
story(issue-41): expose bundled schema registry on RedpandaCluster

### DIFF
--- a/daggerverse/kafka/README.md
+++ b/daggerverse/kafka/README.md
@@ -259,6 +259,38 @@ The `*KafkaClient` returned by `RedpandaCluster.Client()` is the same
 type the Apache constructors return — bring whichever
 `*ClientSecurity` you already use. PKCS#12 truststores work as-is.
 
+### Bundled Schema Registry
+
+`rpk redpanda start` already runs a Schema Registry inside the broker
+process on `:8081` — there is no separate container. `cluster.SchemaRegistry()`
+surfaces it as the **same** `*SchemaRegistry` type
+`Kafka.ConfluentSchemaRegistry` returns, so the bundled and
+separate-container registries are interchangeable from a caller's
+perspective:
+
+```go
+sr := cluster.SchemaRegistry()
+client := sr.Client()
+
+id, err := client.RegisterSchema(ctx, "my-subject-value", avroSchema,
+    dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{SchemaType: "AVRO"})
+schema, err := client.LookupSchemaByID(ctx, id)
+```
+
+Unlike `ConfluentSchemaRegistry` — which boots a separate
+`confluentinc/cp-schema-registry` service alongside the brokers —
+Redpanda's registry needs no extra image: the constructor exposes port
+8081 on the broker container and passes `--schema-registry-addr` (TLS
+mode renders the equivalent `schema_registry` directive in
+`redpanda.yaml`). It speaks the Confluent Schema Registry REST API, so
+the `*SchemaRegistryClient` from `Client()`, `Endpoint()` and `BindTo()`
+all behave identically to the `ConfluentSchemaRegistry` variant.
+
+The registry's REST endpoint is plain HTTP regardless of the cluster's
+Kafka-listener security mode, so `SchemaRegistry()` works on both
+PLAINTEXT and TLS Redpanda clusters. (Securing the SR endpoint itself
+with TLS is a follow-up, matching `ConfluentSchemaRegistry`.)
+
 ## Client
 
 `dag.Kafka().Client(bootstrapServers, security)` constructs a franz-go-backed

--- a/daggerverse/kafka/README.md
+++ b/daggerverse/kafka/README.md
@@ -227,6 +227,9 @@ started via `rpk redpanda start --mode dev-container` (which bundles
   (*KafkaClient, error)` — returns the same `*Client` the Apache
   constructors return. The Kafka wire protocol matches, so
   producer/consumer code is shared.
+- `RedpandaCluster.SchemaRegistry(ctx) *SchemaRegistry` — the bundled
+  in-broker Schema Registry as the shared `*SchemaRegistry` type — see
+  "Bundled Schema Registry" below.
 
 ### Security profile
 
@@ -249,9 +252,12 @@ points the rendered `redpanda.yaml` at those paths (the YAML never
 embeds PEM material itself). Callers don't have to convert between
 formats. The server private key crosses into the broker container as
 a `*dagger.Secret` (mounted via `WithMountedSecret`) so its plaintext
-never lands in the module workdir. mTLS (truststore + client-auth) is
-a follow-up; this story is server-side TLS only, so no CA cert is
-mounted into the broker.
+never lands in the module workdir. The CA cert *is* mounted, at
+`/etc/redpanda/certs/ca.crt` — it is the truststore for the bundled
+Schema Registry's internal broker client, which must dial the TLS-only
+Kafka listener to persist `_schemas` (see "Bundled Schema Registry"
+below). mTLS on the external listener (client-auth) is a follow-up;
+this story is server-side TLS only.
 
 ### Client
 
@@ -291,8 +297,10 @@ Redpanda's registry needs no extra image: the constructor exposes port
 8081 on the broker container and passes `--schema-registry-addr` (TLS
 mode renders the equivalent `schema_registry` directive in
 `redpanda.yaml`). It speaks the Confluent Schema Registry REST API, so
-the `*SchemaRegistryClient` from `Client()`, `Endpoint()` and `BindTo()`
-all behave identically to the `ConfluentSchemaRegistry` variant.
+the whole `*SchemaRegistry` surface behaves identically to the
+`ConfluentSchemaRegistry` variant: `Endpoint()` and `BindTo()` on the
+`*SchemaRegistry`, and the `*SchemaRegistryClient` returned by
+`Client()`.
 
 The registry's REST endpoint is plain HTTP regardless of the cluster's
 Kafka-listener security mode, so `SchemaRegistry()` works on both
@@ -360,8 +368,10 @@ Topic auto-creation is disabled on the broker — call `CreateTopic` before
 
 The module exposes four cluster constructors. The first three speak
 the same `KAFKA_*` env-var contract and return the same `*Cluster`;
-`RedpandaCluster` returns its own `*RedpandaCluster` type with the
-same trio of methods but a different config layer underneath:
+`RedpandaCluster` returns its own `*RedpandaCluster` type — with
+`BootstrapServers`, `BindBrokers`, and `Client` mirroring `*Cluster`,
+plus its own `SchemaRegistry` — but a different config layer
+underneath:
 
 - `ApacheNativeCluster` → `<registry>/apache/kafka-native:<tag>`
   (default `docker.io/apache/kafka-native:4.2.0`). GraalVM-compiled;

--- a/daggerverse/kafka/README.md
+++ b/daggerverse/kafka/README.md
@@ -274,8 +274,16 @@ client := sr.Client()
 
 id, err := client.RegisterSchema(ctx, "my-subject-value", avroSchema,
     dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{SchemaType: "AVRO"})
-schema, err := client.LookupSchemaByID(ctx, id)
+
+// LookupSchemaByID returns a lazy RegisteredSchema object; its fields
+// resolve with context.
+schema := client.LookupSchemaByID(id)
+subject, err := schema.Subject(ctx)
 ```
+
+`sr.Stop()` is a safe no-op on the bundled registry — its service is the
+broker itself, so `cluster.Stop()` owns teardown. Calling `Stop()` uniformly
+over the shared `*SchemaRegistry` type therefore never kills the cluster.
 
 Unlike `ConfluentSchemaRegistry` — which boots a separate
 `confluentinc/cp-schema-registry` service alongside the brokers —

--- a/daggerverse/kafka/cluster_redpanda.go
+++ b/daggerverse/kafka/cluster_redpanda.go
@@ -162,6 +162,7 @@ func buildRedpandaCluster(
 		ctr = ctr.
 			WithFile("/etc/redpanda/certs/server.crt", assets.ServerCert, dagger.ContainerWithFileOpts{Permissions: 0o644, Owner: "redpanda:redpanda"}).
 			WithMountedSecret("/etc/redpanda/certs/server.key", assets.ServerKey, dagger.ContainerWithMountedSecretOpts{Owner: "redpanda:redpanda", Mode: 0o400}).
+			WithFile("/etc/redpanda/certs/ca.crt", assets.CaCert, dagger.ContainerWithFileOpts{Permissions: 0o644, Owner: "redpanda:redpanda"}).
 			WithFile("/etc/redpanda/redpanda.yaml", assets.ConfigFile, dagger.ContainerWithFileOpts{Permissions: 0o644, Owner: "redpanda:redpanda"})
 	} else {
 		// PLAINTEXT: no YAML needed — pass listener flags directly.
@@ -200,6 +201,7 @@ func buildRedpandaCluster(
 type redpandaTlsAssets struct {
 	ServerCert *dagger.File   // PEM, mounted at /etc/redpanda/certs/server.crt
 	ServerKey  *dagger.Secret // PEM PKCS#8, mounted at /etc/redpanda/certs/server.key
+	CaCert     *dagger.File   // CA PEM, mounted at /etc/redpanda/certs/ca.crt — truststore for the bundled SR's broker client
 	ConfigFile *dagger.File   // rendered redpanda.yaml, mounted at /etc/redpanda/redpanda.yaml
 }
 
@@ -249,6 +251,17 @@ func mintRedpandaTlsAssets(
 	if err != nil {
 		return nil, fmt.Errorf("stage redpanda server cert: %w", err)
 	}
+	// The bundled Schema Registry talks to the broker over the Kafka wire
+	// protocol; with a TLS-only external listener it must dial over TLS and
+	// trust the cluster CA, so the CA cert is mounted as its truststore.
+	caCertBytes, err := dagFileBytes(ctx, ca.CertPemFile())
+	if err != nil {
+		return nil, fmt.Errorf("materialize redpanda ca cert: %w", err)
+	}
+	caCertFile, err := writeWorkdirBytes("redpanda-ca-cert-"+brokerHost, "ca.crt", caCertBytes)
+	if err != nil {
+		return nil, fmt.Errorf("stage redpanda ca cert: %w", err)
+	}
 	yamlBytes, err := renderRedpandaYaml(brokerHost, true)
 	if err != nil {
 		return nil, fmt.Errorf("render redpanda.yaml: %w", err)
@@ -261,6 +274,7 @@ func mintRedpandaTlsAssets(
 	return &redpandaTlsAssets{
 		ServerCert: certFile,
 		ServerKey:  issued.PrivateKeyPem(),
+		CaCert:     caCertFile,
 		ConfigFile: yamlFile,
 	}, nil
 }
@@ -281,6 +295,18 @@ func renderRedpandaYaml(brokerHost string, withTls bool) ([]byte, error) {
 		KeyFile           string `yaml:"key_file"`
 		TruststoreFile    string `yaml:"truststore_file,omitempty"`
 		RequireClientAuth bool   `yaml:"require_client_auth"`
+	}
+	// brokerTLS / kafkaClientCfg configure the internal Kafka clients the
+	// bundled Schema Registry and pandaproxy use to reach the broker. On a
+	// TLS cluster the only Kafka listener is TLS, so these clients must dial
+	// it over TLS and trust the cluster CA.
+	type brokerTLS struct {
+		Enabled        bool   `yaml:"enabled"`
+		TruststoreFile string `yaml:"truststore_file"`
+	}
+	type kafkaClientCfg struct {
+		Brokers   []addr    `yaml:"brokers"`
+		BrokerTLS brokerTLS `yaml:"broker_tls"`
 	}
 	rpCfg := map[string]any{
 		"data_directory":            "/var/lib/redpanda/data",
@@ -324,6 +350,17 @@ func renderRedpandaYaml(brokerHost string, withTls bool) ([]byte, error) {
 			"coredump_dir": "/var/lib/redpanda/coredump",
 		},
 	}
+	if withTls {
+		clientCfg := kafkaClientCfg{
+			Brokers: []addr{{Address: brokerHost, Port: 9092}},
+			BrokerTLS: brokerTLS{
+				Enabled:        true,
+				TruststoreFile: "/etc/redpanda/certs/ca.crt",
+			},
+		}
+		full["schema_registry_client"] = clientCfg
+		full["pandaproxy_client"] = clientCfg
+	}
 	return yaml.Marshal(full)
 }
 
@@ -346,12 +383,18 @@ func (r *RedpandaCluster) BootstrapServers() []string {
 // REST endpoint is plain HTTP regardless of the cluster's Kafka-listener
 // security mode, so this never fails.
 //
+// The returned registry is Bundled: its service is the broker itself, so
+// Stop is a no-op on it — call cluster.Stop to tear the registry down with
+// the cluster. A caller that uniformly `defer sr.Stop(ctx)` over the shared
+// *SchemaRegistry type therefore can't accidentally kill the cluster.
+//
 // +cache="never"
 func (r *RedpandaCluster) SchemaRegistry(ctx context.Context) *SchemaRegistry {
 	return &SchemaRegistry{
 		SchemaRegistrySvc: r.BrokerSvc,
 		AdvertisedHost:    r.BrokerHost,
 		AdvertisedPort:    schemaRegistryPort,
+		Bundled:           true,
 	}
 }
 

--- a/daggerverse/kafka/cluster_redpanda.go
+++ b/daggerverse/kafka/cluster_redpanda.go
@@ -171,6 +171,7 @@ func buildRedpandaCluster(
 			"--advertise-kafka-addr", "PLAINTEXT://"+brokerHost+":9092",
 			"--rpc-addr", "0.0.0.0:33145",
 			"--advertise-rpc-addr", brokerHost+":33145",
+			"--schema-registry-addr", fmt.Sprintf("0.0.0.0:%d", schemaRegistryPort),
 			"--set", "redpanda.empty_seed_starts_cluster=true",
 		)
 	}
@@ -178,6 +179,7 @@ func buildRedpandaCluster(
 	svc := ctr.
 		WithExposedPort(9092).
 		WithExposedPort(33145).
+		WithExposedPort(schemaRegistryPort).
 		AsService(dagger.ContainerAsServiceOpts{
 			Args:          args,
 			UseEntrypoint: true,
@@ -308,9 +310,16 @@ func renderRedpandaYaml(brokerHost string, withTls bool) ([]byte, error) {
 		}}
 	}
 	full := map[string]any{
-		"redpanda":        rpCfg,
-		"pandaproxy":      map[string]any{},
-		"schema_registry": map[string]any{},
+		"redpanda":   rpCfg,
+		"pandaproxy": map[string]any{},
+		// Bundle the Schema Registry on a plain-HTTP listener — parallels
+		// the PLAINTEXT path's --schema-registry-addr flag. The SR REST
+		// API stays HTTP regardless of the Kafka listener's TLS mode.
+		"schema_registry": map[string]any{
+			"schema_registry_api": []addr{
+				{Address: "0.0.0.0", Port: schemaRegistryPort},
+			},
+		},
 		"rpk": map[string]any{
 			"coredump_dir": "/var/lib/redpanda/coredump",
 		},
@@ -324,6 +333,26 @@ func renderRedpandaYaml(brokerHost string, withTls bool) ([]byte, error) {
 // +cache="never"
 func (r *RedpandaCluster) BootstrapServers() []string {
 	return []string{r.BrokerHost + ":9092"}
+}
+
+// SchemaRegistry exposes Redpanda's bundled Schema Registry as the same
+// *SchemaRegistry type Kafka.ConfluentSchemaRegistry returns, so callers can
+// treat the bundled and separate-container registries uniformly.
+//
+// `rpk redpanda start` runs a Schema Registry inside the broker process on
+// :8081 — no extra container — so the returned *SchemaRegistry points at the
+// broker service itself. Redpanda's SR speaks the Confluent Schema Registry
+// REST API, so the *SchemaRegistryClient from Client() works unchanged. The
+// REST endpoint is plain HTTP regardless of the cluster's Kafka-listener
+// security mode, so this never fails.
+//
+// +cache="never"
+func (r *RedpandaCluster) SchemaRegistry(ctx context.Context) *SchemaRegistry {
+	return &SchemaRegistry{
+		SchemaRegistrySvc: r.BrokerSvc,
+		AdvertisedHost:    r.BrokerHost,
+		AdvertisedPort:    schemaRegistryPort,
+	}
 }
 
 // BindBrokers binds the single Redpanda broker service into the given

--- a/daggerverse/kafka/schema_registry.go
+++ b/daggerverse/kafka/schema_registry.go
@@ -40,6 +40,13 @@ type SchemaRegistry struct {
 	AdvertisedHost string
 	// +private
 	AdvertisedPort int
+	// Bundled marks a registry whose service is shared with the owning
+	// cluster (e.g. Redpanda's in-broker Schema Registry). The cluster owns
+	// that service's lifecycle, so Stop is a no-op for a bundled registry —
+	// stopping it would otherwise tear the whole cluster down.
+	//
+	// +private
+	Bundled bool
 }
 
 // SchemaRegistryClient is a pure-Go net/http client for a Schema Registry's
@@ -186,9 +193,14 @@ func (s *SchemaRegistry) Client() *SchemaRegistryClient {
 // returns immediately rather than waiting on graceful shutdown, mirroring
 // Cluster.Stop — tests should call this in a defer.
 //
+// For a bundled registry (Bundled == true) the service is shared with the
+// owning cluster, so Stop is a no-op: the cluster owns that lifecycle and
+// stopping it here would tear the whole cluster down. Callers that uniformly
+// `defer sr.Stop(ctx)` stay safe regardless of which registry they hold.
+//
 // +cache="never"
 func (s *SchemaRegistry) Stop(ctx context.Context) error {
-	if s == nil || s.SchemaRegistrySvc == nil {
+	if s == nil || s.SchemaRegistrySvc == nil || s.Bundled {
 		return nil
 	}
 	if _, err := s.SchemaRegistrySvc.Stop(ctx, dagger.ServiceStopOpts{Kill: true}); err != nil {

--- a/daggerverse/kafka/schema_registry.go
+++ b/daggerverse/kafka/schema_registry.go
@@ -25,10 +25,16 @@ const schemaRegistryPort = 8081
 // expects on requests and returns on responses.
 const srContentType = "application/vnd.schemaregistry.v1+json"
 
-// SchemaRegistry is a running Confluent Schema Registry service bound to a
-// Kafka cluster's brokers. Schema Registry stores schemas in the cluster's
-// `_schemas` topic and exposes a REST API for registering and looking up
-// Avro / JSON Schema / Protobuf schemas by subject.
+// SchemaRegistry is the module's shared Schema Registry abstraction, bound
+// to a Kafka cluster's brokers. It stores schemas in the cluster's `_schemas`
+// topic and exposes a REST API for registering and looking up Avro / JSON
+// Schema / Protobuf schemas by subject.
+//
+// The same type is returned both by Kafka.ConfluentSchemaRegistry — a
+// separate `cp-schema-registry` container — and by
+// RedpandaCluster.SchemaRegistry, which surfaces the Schema Registry bundled
+// inside the Redpanda broker process. Callers treat the two uniformly; the
+// Bundled field records which kind this is so Stop behaves correctly.
 //
 // The constructor is session-cached so chained calls
 // (Client().RegisterSchema(...) → LookupSchemaByID(...)) all observe the

--- a/daggerverse/kafka/tests/main.go
+++ b/daggerverse/kafka/tests/main.go
@@ -21,8 +21,9 @@
 //                          helpers + the three cp-kafka round-trip tests.
 //   - tests_redpanda.go  — RedpandaCluster (redpandadata/redpanda) cluster
 //                          helpers + the two Redpanda Kafka-wire round-trip
-//                          tests and the PLAINTEXT + TLS bundled-Schema-
-//                          Registry round-trips.
+//                          tests, the PLAINTEXT + TLS bundled-Schema-
+//                          Registry round-trips, and the bundled-registry
+//                          Stop-is-a-no-op lifecycle test.
 //   - tests_schema_registry.go — ConfluentSchemaRegistry tests: the
 //                          register/lookup/delete round-trip and the
 //                          non-PLAINTEXT-cluster rejection.
@@ -297,8 +298,8 @@ func (t *Tests) confluentTests(ctx context.Context, confluentImageTag string, pa
 }
 
 // redpandaTests runs the redpandadata/redpanda round-trip tests — the two
-// Kafka-wire round-trips plus the PLAINTEXT and TLS bundled-Schema-Registry
-// round-trips.
+// Kafka-wire round-trips, the PLAINTEXT and TLS bundled-Schema-Registry
+// round-trips, and the bundled-registry Stop-is-a-no-op lifecycle test.
 // Redpanda boots and tears down far faster than the JVM-based distros,
 // so running it as its own group means its clusters never linger past
 // this function's return.
@@ -321,6 +322,9 @@ func (t *Tests) redpandaTests(ctx context.Context, redpandaImageTag string, para
 	})
 	jobs = jobs.WithJob("RedpandaSchemaRegistryTlsRegisterLookupRoundTrip", func(ctx context.Context) error {
 		return t.RedpandaSchemaRegistryTlsRegisterLookupRoundTrip(ctx, redpandaImageTag)
+	})
+	jobs = jobs.WithJob("RedpandaSchemaRegistryBundledStopIsNoOp", func(ctx context.Context) error {
+		return t.RedpandaSchemaRegistryBundledStopIsNoOp(ctx, redpandaImageTag)
 	})
 
 	return jobs.Run(ctx)

--- a/daggerverse/kafka/tests/main.go
+++ b/daggerverse/kafka/tests/main.go
@@ -20,7 +20,8 @@
 //   - tests_confluent.go — ConfluentCluster (confluentinc/cp-kafka) cluster
 //                          helpers + the three cp-kafka round-trip tests.
 //   - tests_redpanda.go  — RedpandaCluster (redpandadata/redpanda) cluster
-//                          helpers + the two Redpanda round-trip tests.
+//                          helpers + the two Redpanda Kafka-wire round-trip
+//                          tests and the bundled-Schema-Registry round-trip.
 //   - tests_schema_registry.go — ConfluentSchemaRegistry tests: the
 //                          register/lookup/delete round-trip and the
 //                          non-PLAINTEXT-cluster rejection.
@@ -294,7 +295,8 @@ func (t *Tests) confluentTests(ctx context.Context, confluentImageTag string, pa
 	return jobs.Run(ctx)
 }
 
-// redpandaTests runs the two redpandadata/redpanda round-trip tests.
+// redpandaTests runs the redpandadata/redpanda round-trip tests — the two
+// Kafka-wire round-trips plus the bundled-Schema-Registry round-trip.
 // Redpanda boots and tears down far faster than the JVM-based distros,
 // so running it as its own group means its clusters never linger past
 // this function's return.
@@ -311,6 +313,9 @@ func (t *Tests) redpandaTests(ctx context.Context, redpandaImageTag string, para
 	})
 	jobs = jobs.WithJob("RedpandaClusterTlsRoundTrip", func(ctx context.Context) error {
 		return t.RedpandaClusterTlsRoundTrip(ctx, redpandaImageTag)
+	})
+	jobs = jobs.WithJob("RedpandaSchemaRegistryRegisterLookupRoundTrip", func(ctx context.Context) error {
+		return t.RedpandaSchemaRegistryRegisterLookupRoundTrip(ctx, redpandaImageTag)
 	})
 
 	return jobs.Run(ctx)

--- a/daggerverse/kafka/tests/main.go
+++ b/daggerverse/kafka/tests/main.go
@@ -21,7 +21,8 @@
 //                          helpers + the three cp-kafka round-trip tests.
 //   - tests_redpanda.go  — RedpandaCluster (redpandadata/redpanda) cluster
 //                          helpers + the two Redpanda Kafka-wire round-trip
-//                          tests and the bundled-Schema-Registry round-trip.
+//                          tests and the PLAINTEXT + TLS bundled-Schema-
+//                          Registry round-trips.
 //   - tests_schema_registry.go — ConfluentSchemaRegistry tests: the
 //                          register/lookup/delete round-trip and the
 //                          non-PLAINTEXT-cluster rejection.
@@ -296,7 +297,8 @@ func (t *Tests) confluentTests(ctx context.Context, confluentImageTag string, pa
 }
 
 // redpandaTests runs the redpandadata/redpanda round-trip tests — the two
-// Kafka-wire round-trips plus the bundled-Schema-Registry round-trip.
+// Kafka-wire round-trips plus the PLAINTEXT and TLS bundled-Schema-Registry
+// round-trips.
 // Redpanda boots and tears down far faster than the JVM-based distros,
 // so running it as its own group means its clusters never linger past
 // this function's return.
@@ -316,6 +318,9 @@ func (t *Tests) redpandaTests(ctx context.Context, redpandaImageTag string, para
 	})
 	jobs = jobs.WithJob("RedpandaSchemaRegistryRegisterLookupRoundTrip", func(ctx context.Context) error {
 		return t.RedpandaSchemaRegistryRegisterLookupRoundTrip(ctx, redpandaImageTag)
+	})
+	jobs = jobs.WithJob("RedpandaSchemaRegistryTlsRegisterLookupRoundTrip", func(ctx context.Context) error {
+		return t.RedpandaSchemaRegistryTlsRegisterLookupRoundTrip(ctx, redpandaImageTag)
 	})
 
 	return jobs.Run(ctx)

--- a/daggerverse/kafka/tests/tests_redpanda.go
+++ b/daggerverse/kafka/tests/tests_redpanda.go
@@ -168,3 +168,64 @@ func redpandaClusterTlsRoundTripOn(
 	}
 	return nil
 }
+
+// RedpandaSchemaRegistryRegisterLookupRoundTrip is the PLAINTEXT happy-path
+// test for RedpandaCluster.SchemaRegistry: `rpk redpanda start` runs a Schema
+// Registry inside the broker process on :8081, so this registers a schema
+// against cluster.SchemaRegistry() and asserts the lookup-by-id round-trip —
+// proving the bundled SR is reachable and interchangeable with the
+// separate-container ConfluentSchemaRegistry. The SR service is the broker
+// itself, so cluster.Stop tears it down — there is no separate sr.Stop.
+func (t *Tests) RedpandaSchemaRegistryRegisterLookupRoundTrip(
+	ctx context.Context,
+	// +default="v26.1.7"
+	redpandaImageTag string,
+) error {
+	cluster, err := freshRedpandaCluster(ctx, redpandaImageTag)
+	if err != nil {
+		return fmt.Errorf("create redpanda cluster: %w", err)
+	}
+	defer cluster.Stop(ctx)
+
+	client := cluster.SchemaRegistry().Client()
+
+	subject, err := randomTopicName(ctx)
+	if err != nil {
+		return err
+	}
+	subject += "-value"
+
+	id, err := client.RegisterSchema(ctx, subject, avroTestSchema, dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{
+		SchemaType: "AVRO",
+	})
+	if err != nil {
+		return fmt.Errorf("register schema: %w", err)
+	}
+	if id <= 0 {
+		return fmt.Errorf("expected a positive schema id, got %d", id)
+	}
+
+	got := client.LookupSchemaByID(id)
+	gotSubject, err := got.Subject(ctx)
+	if err != nil {
+		return fmt.Errorf("lookup schema by id: %w", err)
+	}
+	if gotSubject != subject {
+		return fmt.Errorf("lookup-by-id subject mismatch: want %q, got %q", subject, gotSubject)
+	}
+	gotType, err := got.SchemaType(ctx)
+	if err != nil {
+		return fmt.Errorf("read schema type: %w", err)
+	}
+	if gotType != "AVRO" {
+		return fmt.Errorf("lookup-by-id schemaType mismatch: want AVRO, got %q", gotType)
+	}
+	gotID, err := got.SchemaID(ctx)
+	if err != nil {
+		return fmt.Errorf("read schema id: %w", err)
+	}
+	if gotID != id {
+		return fmt.Errorf("lookup-by-id schemaID mismatch: want %d, got %d", id, gotID)
+	}
+	return nil
+}

--- a/daggerverse/kafka/tests/tests_redpanda.go
+++ b/daggerverse/kafka/tests/tests_redpanda.go
@@ -175,7 +175,8 @@ func redpandaClusterTlsRoundTripOn(
 // against cluster.SchemaRegistry() and asserts the lookup-by-id round-trip —
 // proving the bundled SR is reachable and interchangeable with the
 // separate-container ConfluentSchemaRegistry. The SR service is the broker
-// itself, so cluster.Stop tears it down — there is no separate sr.Stop.
+// itself, so cluster.Stop tears it down — sr.Stop is a no-op for a bundled
+// registry.
 func (t *Tests) RedpandaSchemaRegistryRegisterLookupRoundTrip(
 	ctx context.Context,
 	// +default="v26.1.7"
@@ -219,6 +220,60 @@ func (t *Tests) RedpandaSchemaRegistryRegisterLookupRoundTrip(
 	}
 	if gotType != "AVRO" {
 		return fmt.Errorf("lookup-by-id schemaType mismatch: want AVRO, got %q", gotType)
+	}
+	gotID, err := got.SchemaID(ctx)
+	if err != nil {
+		return fmt.Errorf("read schema id: %w", err)
+	}
+	if gotID != id {
+		return fmt.Errorf("lookup-by-id schemaID mismatch: want %d, got %d", id, gotID)
+	}
+	return nil
+}
+
+// RedpandaSchemaRegistryTlsRegisterLookupRoundTrip is the TLS-cluster
+// counterpart of RedpandaSchemaRegistryRegisterLookupRoundTrip. A TLS
+// Redpanda cluster configures its bundled Schema Registry through a
+// separately-rendered redpanda.yaml (the schema_registry_api block) rather
+// than the PLAINTEXT path's --schema-registry-addr flag, so this exercises
+// that YAML path end-to-end. The SR REST endpoint is plain HTTP regardless
+// of the Kafka listener's TLS mode, so the truststore is unused here.
+func (t *Tests) RedpandaSchemaRegistryTlsRegisterLookupRoundTrip(
+	ctx context.Context,
+	// +default="v26.1.7"
+	redpandaImageTag string,
+) error {
+	cluster, _, _, err := freshTlsRedpandaCluster(ctx, redpandaImageTag)
+	if err != nil {
+		return fmt.Errorf("create redpanda tls cluster: %w", err)
+	}
+	defer cluster.Stop(ctx)
+
+	client := cluster.SchemaRegistry().Client()
+
+	subject, err := randomTopicName(ctx)
+	if err != nil {
+		return err
+	}
+	subject += "-value"
+
+	id, err := client.RegisterSchema(ctx, subject, avroTestSchema, dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{
+		SchemaType: "AVRO",
+	})
+	if err != nil {
+		return fmt.Errorf("register schema: %w", err)
+	}
+	if id <= 0 {
+		return fmt.Errorf("expected a positive schema id, got %d", id)
+	}
+
+	got := client.LookupSchemaByID(id)
+	gotSubject, err := got.Subject(ctx)
+	if err != nil {
+		return fmt.Errorf("lookup schema by id: %w", err)
+	}
+	if gotSubject != subject {
+		return fmt.Errorf("lookup-by-id subject mismatch: want %q, got %q", subject, gotSubject)
 	}
 	gotID, err := got.SchemaID(ctx)
 	if err != nil {

--- a/daggerverse/kafka/tests/tests_redpanda.go
+++ b/daggerverse/kafka/tests/tests_redpanda.go
@@ -169,26 +169,13 @@ func redpandaClusterTlsRoundTripOn(
 	return nil
 }
 
-// RedpandaSchemaRegistryRegisterLookupRoundTrip is the PLAINTEXT happy-path
-// test for RedpandaCluster.SchemaRegistry: `rpk redpanda start` runs a Schema
-// Registry inside the broker process on :8081, so this registers a schema
-// against cluster.SchemaRegistry() and asserts the lookup-by-id round-trip —
-// proving the bundled SR is reachable and interchangeable with the
-// separate-container ConfluentSchemaRegistry. The SR service is the broker
-// itself, so cluster.Stop tears it down — sr.Stop is a no-op for a bundled
-// registry.
-func (t *Tests) RedpandaSchemaRegistryRegisterLookupRoundTrip(
-	ctx context.Context,
-	// +default="v26.1.7"
-	redpandaImageTag string,
-) error {
-	cluster, err := freshRedpandaCluster(ctx, redpandaImageTag)
-	if err != nil {
-		return fmt.Errorf("create redpanda cluster: %w", err)
-	}
-	defer cluster.Stop(ctx)
-
-	client := cluster.SchemaRegistry().Client()
+// redpandaSchemaRegistryRegisterLookupRoundTripOn registers a fresh schema
+// against the given bundled Schema Registry and asserts the full
+// lookup-by-id contract — positive id, Subject, SchemaType, and SchemaID.
+// Shared by the PLAINTEXT and TLS Redpanda SR tests so both paths cover the
+// identical assertion set; mirrors the redpandaCluster...RoundTripOn split.
+func redpandaSchemaRegistryRegisterLookupRoundTripOn(ctx context.Context, sr *dagger.KafkaSchemaRegistry) error {
+	client := sr.Client()
 
 	subject, err := randomTopicName(ctx)
 	if err != nil {
@@ -231,6 +218,28 @@ func (t *Tests) RedpandaSchemaRegistryRegisterLookupRoundTrip(
 	return nil
 }
 
+// RedpandaSchemaRegistryRegisterLookupRoundTrip is the PLAINTEXT happy-path
+// test for RedpandaCluster.SchemaRegistry: `rpk redpanda start` runs a Schema
+// Registry inside the broker process on :8081, so this registers a schema
+// against cluster.SchemaRegistry() and asserts the lookup-by-id round-trip —
+// proving the bundled SR is reachable and interchangeable with the
+// separate-container ConfluentSchemaRegistry. The SR service is the broker
+// itself, so cluster.Stop tears it down — sr.Stop is a no-op for a bundled
+// registry.
+func (t *Tests) RedpandaSchemaRegistryRegisterLookupRoundTrip(
+	ctx context.Context,
+	// +default="v26.1.7"
+	redpandaImageTag string,
+) error {
+	cluster, err := freshRedpandaCluster(ctx, redpandaImageTag)
+	if err != nil {
+		return fmt.Errorf("create redpanda cluster: %w", err)
+	}
+	defer cluster.Stop(ctx)
+
+	return redpandaSchemaRegistryRegisterLookupRoundTripOn(ctx, cluster.SchemaRegistry())
+}
+
 // RedpandaSchemaRegistryTlsRegisterLookupRoundTrip is the TLS-cluster
 // counterpart of RedpandaSchemaRegistryRegisterLookupRoundTrip. A TLS
 // Redpanda cluster configures its bundled Schema Registry through a
@@ -249,38 +258,62 @@ func (t *Tests) RedpandaSchemaRegistryTlsRegisterLookupRoundTrip(
 	}
 	defer cluster.Stop(ctx)
 
-	client := cluster.SchemaRegistry().Client()
+	return redpandaSchemaRegistryRegisterLookupRoundTripOn(ctx, cluster.SchemaRegistry())
+}
 
+// RedpandaSchemaRegistryBundledStopIsNoOp pins the bundled-registry lifecycle
+// contract: a bundled *SchemaRegistry shares the broker service, so sr.Stop
+// must be a no-op — the cluster owns teardown via cluster.Stop. This runs a
+// register/lookup round-trip, calls sr.Stop, then exercises the registry
+// again through the same handle. If sr.Stop had torn down the shared broker
+// service, that follow-up call would fail.
+func (t *Tests) RedpandaSchemaRegistryBundledStopIsNoOp(
+	ctx context.Context,
+	// +default="v26.1.7"
+	redpandaImageTag string,
+) error {
+	cluster, err := freshRedpandaCluster(ctx, redpandaImageTag)
+	if err != nil {
+		return fmt.Errorf("create redpanda cluster: %w", err)
+	}
+	defer cluster.Stop(ctx)
+
+	sr := cluster.SchemaRegistry()
+	if err := redpandaSchemaRegistryRegisterLookupRoundTripOn(ctx, sr); err != nil {
+		return fmt.Errorf("round-trip before sr.Stop: %w", err)
+	}
+
+	if err := sr.Stop(ctx); err != nil {
+		return fmt.Errorf("bundled sr.Stop should be a no-op, got: %w", err)
+	}
+
+	// The registry must still be reachable after sr.Stop — register one more
+	// schema and confirm its subject lands in ListSubjects. Both calls
+	// round-trip to the broker, so a torn-down broker would fail here. (A
+	// fresh register/lookup-by-id round-trip would not prove this: the
+	// registry dedups by schema content, so re-registering avroTestSchema
+	// returns the first id, whose lookup resolves to the first subject.)
+	client := sr.Client()
 	subject, err := randomTopicName(ctx)
 	if err != nil {
 		return err
 	}
 	subject += "-value"
-
 	id, err := client.RegisterSchema(ctx, subject, avroTestSchema, dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{
 		SchemaType: "AVRO",
 	})
 	if err != nil {
-		return fmt.Errorf("register schema: %w", err)
+		return fmt.Errorf("register after sr.Stop (broker should still be alive): %w", err)
 	}
 	if id <= 0 {
-		return fmt.Errorf("expected a positive schema id, got %d", id)
+		return fmt.Errorf("register after sr.Stop: expected a positive schema id, got %d", id)
 	}
-
-	got := client.LookupSchemaByID(id)
-	gotSubject, err := got.Subject(ctx)
+	subjects, err := client.ListSubjects(ctx)
 	if err != nil {
-		return fmt.Errorf("lookup schema by id: %w", err)
+		return fmt.Errorf("list subjects after sr.Stop: %w", err)
 	}
-	if gotSubject != subject {
-		return fmt.Errorf("lookup-by-id subject mismatch: want %q, got %q", subject, gotSubject)
-	}
-	gotID, err := got.SchemaID(ctx)
-	if err != nil {
-		return fmt.Errorf("read schema id: %w", err)
-	}
-	if gotID != id {
-		return fmt.Errorf("lookup-by-id schemaID mismatch: want %d, got %d", id, gotID)
+	if !contains(subjects, subject) {
+		return fmt.Errorf("expected subject %q in ListSubjects output after sr.Stop, got %v", subject, subjects)
 	}
 	return nil
 }


### PR DESCRIPTION
## Description

Closes #41.

`rpk redpanda start` already runs a Schema Registry inside the broker process on `:8081` — no separate container needed. This wires it up to the shared `*SchemaRegistry` / `*SchemaRegistryClient` types from #37 so callers can treat the bundled and separate-container registries uniformly.

## Changes

- **`(*RedpandaCluster).SchemaRegistry(ctx) *SchemaRegistry`** — new method returning the same `*SchemaRegistry` type `Kafka.ConfluentSchemaRegistry` returns, pointing at the broker service's `:8081`. `Endpoint()`, `BindTo()`, and `Client()` work identically.
- **Constructor** — exposes port 8081 on the broker container in both modes; PLAINTEXT passes `--schema-registry-addr 0.0.0.0:8081`, TLS renders an explicit `schema_registry` listener in `redpanda.yaml`.
- **Test** — new `RedpandaSchemaRegistryRegisterLookupRoundTrip`: PLAINTEXT register → lookup-by-id round-trip against `freshRedpandaCluster().SchemaRegistry()`.
- **README** — new "Bundled Schema Registry" subsection contrasting it with the separate-container `ConfluentSchemaRegistry`.
- `dagger develop` re-run in `daggerverse/kafka/` and `daggerverse/kafka/tests/`.

## Verification

- New test passes; existing `RedpandaClusterProduceListTopicsRoundTrip` and `RedpandaClusterTlsRoundTrip` still pass (no regression).
- Full `dagger -m daggerverse/kafka/tests call all` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)