### PR TITLE
story(issue-39): add ApicurioSchemaRegistry to kafka module

### DIFF
--- a/daggerverse/kafka/README.md
+++ b/daggerverse/kafka/README.md
@@ -169,6 +169,43 @@ client listener runs TLS or mTLS. TLS / mTLS Schema Registry is a follow-up.
   admin client; no helper containers.
 - `SchemaRegistry.Stop(ctx) error` — tears the registry service down.
 
+### ApicurioSchemaRegistry
+
+`ApicurioSchemaRegistry` is a sibling constructor backed by the
+`apicurio/apicurio-registry-kafkasql` image — Apicurio Registry's
+Kafka-storage build. It takes the **same parameters** as
+`ConfluentSchemaRegistry` (`cluster`, plus optional `registry` /  `tag`) and
+returns the **same `*SchemaRegistry` type**, so `Client()`, `Endpoint()`,
+`BindTo()`, and `Stop()` are all shared code.
+
+```go
+cluster := dag.Kafka().ConfluentCluster(clusterId, dag.Kafka().PlaintextServerSecurity())
+
+sr := dag.Kafka().ApicurioSchemaRegistry(
+    cluster,
+    dagger.KafkaApicurioSchemaRegistryOpts{
+        Tag:      "2.6.13.Final",
+        Registry: "docker.io",
+    },
+)
+client := sr.Client()
+```
+
+Apicurio is a more permissively licensed alternative to `cp-schema-registry`.
+It stores schemas in its own Kafka topic (`KAFKA_BOOTSTRAP_SERVERS` is wired
+from `cluster.BootstrapServers()`) and exposes a **Confluent-Schema-Registry-
+compatible** REST API under `/apis/ccompat/v7`, so the same
+`SchemaRegistryClient` drives it unchanged.
+
+**CSR-compat caveat.** Apicurio's native catalogue spans Avro, JSON Schema,
+Protobuf, OpenAPI, AsyncAPI, GraphQL, WSDL, and XSD, but the
+Confluent-compatible surface only speaks `AVRO`, `JSON`, and `PROTOBUF` (the
+`schemaType` values `SchemaRegistryClient` already accepts). Apicurio's other
+artifact types are not reachable through this constructor.
+
+**PLAINTEXT only** in this story, matching `ConfluentSchemaRegistry` — the
+constructor rejects a cluster whose client listener runs TLS or mTLS.
+
 ### SchemaRegistryClient
 
 ```go

--- a/daggerverse/kafka/main.go
+++ b/daggerverse/kafka/main.go
@@ -24,8 +24,9 @@
 //                          method set.
 //   - schema_registry.go — *SchemaRegistry / *SchemaRegistryClient /
 //                          RegisteredSchema, the ConfluentSchemaRegistry
-//                          constructor, and the pure-Go net/http admin
-//                          client for the Schema Registry REST API.
+//                          and ApicurioSchemaRegistry constructors, and the
+//                          pure-Go net/http admin client for the Schema
+//                          Registry REST API.
 //   - util.go            — shared helpers (writeWorkdirBytes,
 //                          clusterHostSuffix, randSuffix, dagFileBytes).
 package main

--- a/daggerverse/kafka/schema_registry.go
+++ b/daggerverse/kafka/schema_registry.go
@@ -53,6 +53,15 @@ type SchemaRegistry struct {
 	//
 	// +private
 	Bundled bool
+	// BasePath is the URL path the registry's Confluent-Schema-Registry REST
+	// surface is rooted at. Confluent (cp-schema-registry) and Redpanda serve
+	// it at the root, so they leave this empty; Apicurio exposes it under a
+	// CSR-compat prefix (`/apis/ccompat/v7`). Client() folds it into the
+	// client BaseURL so every SchemaRegistryClient method composes the same
+	// `/subjects/...` paths regardless of backend.
+	//
+	// +private
+	BasePath string
 }
 
 // SchemaRegistryClient is a pure-Go net/http client for a Schema Registry's
@@ -164,6 +173,83 @@ func (k *Kafka) ConfluentSchemaRegistry(
 	}, nil
 }
 
+// ApicurioSchemaRegistry spins up an Apicurio Registry service
+// (`apicurio/apicurio-registry-kafkasql`) alongside the given Kafka cluster.
+// Apicurio stores its data in a Kafka topic of its own and exposes a
+// Confluent-Schema-Registry-compatible REST API under `/apis/ccompat/v7`, so
+// the same *SchemaRegistryClient that drives ConfluentSchemaRegistry works
+// against it unchanged — the CSR-compat prefix is folded into BasePath.
+//
+// Apicurio is a more permissively licensed alternative to cp-schema-registry
+// with a broader native artifact-type catalogue (Avro, JSON Schema,
+// Protobuf, OpenAPI, AsyncAPI, GraphQL, WSDL, XSD); over the CSR-compat
+// surface only the AVRO / JSON / PROTOBUF subset is reachable.
+//
+// Only PLAINTEXT clusters are supported in this story: the constructor
+// rejects TLS / mTLS clusters and points callers at the TLS follow-up.
+//
+// Session-cached for the same reason ConfluentSchemaRegistry is — a
+// `+cache="never"` directive here would mint a brand-new registry service
+// for every chained client call.
+//
+// +cache="session"
+func (k *Kafka) ApicurioSchemaRegistry(
+	ctx context.Context,
+	cluster *Cluster,
+	// +default="docker.io"
+	registry string,
+	// +default="2.6.13.Final"
+	tag string,
+) (*SchemaRegistry, error) {
+	if cluster == nil {
+		return nil, fmt.Errorf("Kafka.ApicurioSchemaRegistry: cluster must not be nil")
+	}
+	if len(cluster.BrokerSvcs) == 0 {
+		return nil, fmt.Errorf("Kafka.ApicurioSchemaRegistry: cluster has no brokers")
+	}
+	if cluster.ClientSecurityMode != "PLAINTEXT" {
+		return nil, fmt.Errorf(
+			"Kafka.ApicurioSchemaRegistry: cluster client listener is %q; only PLAINTEXT "+
+				"is supported in this story. TLS / mTLS Schema Registry "+
+				"(KAFKA_SSL_* / REGISTRY_KAFKASQL_SECURITY_PROTOCOL plus keystore mounts) "+
+				"is a follow-up story.",
+			cluster.ClientSecurityMode,
+		)
+	}
+
+	image := fmt.Sprintf("%s/apicurio/apicurio-registry-kafkasql:%s", registry, tag)
+	// `asr-` (apicurio schema registry) keeps the hostname short — a longer
+	// alias trips runc's sethostname on startup — and stays distinct from
+	// the `csr-` prefix ConfluentSchemaRegistry uses on the same cluster.
+	srHost := "asr-" + clusterHostSuffix(cluster.ClusterID)
+
+	// Apicurio's kafkasql storage wants bare host:port bootstrap servers
+	// (no scheme prefix, unlike cp-schema-registry). It auto-creates its
+	// own journal topic at replication factor 1, so no broker-count RF
+	// capping is needed here.
+	ctr := dag.Container().
+		From(image).
+		WithEnvVariable("KAFKA_BOOTSTRAP_SERVERS", strings.Join(cluster.BootstrapServers(), ",")).
+		// Apicurio is a Quarkus app listening on 8080 by default; pin it to
+		// schemaRegistryPort so the advertised port matches cp-schema-registry.
+		WithEnvVariable("QUARKUS_HTTP_PORT", strconv.Itoa(schemaRegistryPort)).
+		WithExposedPort(schemaRegistryPort)
+	ctr = cluster.BindBrokers(ctr)
+
+	srSvc := ctr.
+		AsService(dagger.ContainerAsServiceOpts{UseEntrypoint: true}).
+		WithHostname(srHost)
+
+	return &SchemaRegistry{
+		SchemaRegistrySvc: srSvc,
+		AdvertisedHost:    srHost,
+		AdvertisedPort:    schemaRegistryPort,
+		// Apicurio serves the Confluent-compatible REST API under this
+		// prefix rather than at the root.
+		BasePath: "/apis/ccompat/v7",
+	}, nil
+}
+
 // Endpoint returns the host:port other containers (and the module runtime)
 // can reach the Schema Registry REST API on.
 //
@@ -191,7 +277,7 @@ func (s *SchemaRegistry) BindTo(ctr *dagger.Container) *dagger.Container {
 func (s *SchemaRegistry) Client() *SchemaRegistryClient {
 	return &SchemaRegistryClient{
 		Svc:     s.SchemaRegistrySvc,
-		BaseURL: fmt.Sprintf("http://%s:%d", s.AdvertisedHost, s.AdvertisedPort),
+		BaseURL: fmt.Sprintf("http://%s:%d%s", s.AdvertisedHost, s.AdvertisedPort, s.BasePath),
 	}
 }
 

--- a/daggerverse/kafka/tests/main.go
+++ b/daggerverse/kafka/tests/main.go
@@ -142,6 +142,9 @@ func (t *Tests) schemaRegistryTests(ctx context.Context, kafkaImageTag string, p
 	jobs = jobs.WithJob("SchemaRegistryRejectsNonPlaintextCluster", func(ctx context.Context) error {
 		return t.SchemaRegistryRejectsNonPlaintextCluster(ctx, kafkaImageTag)
 	})
+	jobs = jobs.WithJob("ApicurioSchemaRegistryRegisterLookupRoundTrip", func(ctx context.Context) error {
+		return t.ApicurioSchemaRegistryRegisterLookupRoundTrip(ctx, kafkaImageTag)
+	})
 
 	return jobs.Run(ctx)
 }

--- a/daggerverse/kafka/tests/tests_schema_registry.go
+++ b/daggerverse/kafka/tests/tests_schema_registry.go
@@ -138,6 +138,134 @@ func (t *Tests) SchemaRegistryRegisterLookupRoundTrip(
 	return nil
 }
 
+// ApicurioSchemaRegistryRegisterLookupRoundTrip is the PLAINTEXT happy-path
+// test for Kafka.ApicurioSchemaRegistry: stand an
+// apicurio-registry-kafkasql up next to a fresh cluster, then exercise
+// register → lookup-by-id → lookup-latest-by-subject → list-subjects →
+// set/get-compatibility → delete against its Confluent-compatible REST
+// surface — mirroring SchemaRegistryRegisterLookupRoundTrip to prove the
+// shared *SchemaRegistryClient drives Apicurio unchanged.
+func (t *Tests) ApicurioSchemaRegistryRegisterLookupRoundTrip(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, err := freshCluster(ctx, kafkaImageTag)
+	if err != nil {
+		return fmt.Errorf("create cluster: %w", err)
+	}
+	defer cluster.Stop(ctx)
+
+	sr := dag.Kafka().ApicurioSchemaRegistry(cluster)
+	defer sr.Stop(ctx)
+
+	client := sr.Client()
+
+	subject, err := randomTopicName(ctx)
+	if err != nil {
+		return err
+	}
+	subject += "-value"
+
+	id, err := client.RegisterSchema(ctx, subject, avroTestSchema, dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{
+		SchemaType: "AVRO",
+	})
+	if err != nil {
+		return fmt.Errorf("register schema: %w", err)
+	}
+	if id <= 0 {
+		return fmt.Errorf("expected a positive schema id, got %d", id)
+	}
+
+	got := client.LookupSchemaByID(id)
+	gotSubject, err := got.Subject(ctx)
+	if err != nil {
+		return fmt.Errorf("lookup schema by id: %w", err)
+	}
+	if gotSubject != subject {
+		return fmt.Errorf("lookup-by-id subject mismatch: want %q, got %q", subject, gotSubject)
+	}
+	gotType, err := got.SchemaType(ctx)
+	if err != nil {
+		return fmt.Errorf("read schema type: %w", err)
+	}
+	if gotType != "AVRO" {
+		return fmt.Errorf("lookup-by-id schemaType mismatch: want AVRO, got %q", gotType)
+	}
+	gotID, err := got.SchemaID(ctx)
+	if err != nil {
+		return fmt.Errorf("read schema id: %w", err)
+	}
+	if gotID != id {
+		return fmt.Errorf("lookup-by-id schemaID mismatch: want %d, got %d", id, gotID)
+	}
+
+	latest := client.LookupLatestBySubject(subject)
+	latestSubject, err := latest.Subject(ctx)
+	if err != nil {
+		return fmt.Errorf("lookup latest by subject: %w", err)
+	}
+	if latestSubject != subject {
+		return fmt.Errorf("lookup-latest subject mismatch: want %q, got %q", subject, latestSubject)
+	}
+	latestVersion, err := latest.Version(ctx)
+	if err != nil {
+		return fmt.Errorf("read latest version: %w", err)
+	}
+	if latestVersion != 1 {
+		return fmt.Errorf("lookup-latest version mismatch: want 1, got %d", latestVersion)
+	}
+	latestID, err := latest.SchemaID(ctx)
+	if err != nil {
+		return fmt.Errorf("read latest schema id: %w", err)
+	}
+	if latestID != id {
+		return fmt.Errorf("lookup-latest schemaID mismatch: want %d, got %d", id, latestID)
+	}
+	latestDef, err := latest.Definition(ctx)
+	if err != nil {
+		return fmt.Errorf("read latest definition: %w", err)
+	}
+	if latestDef == "" {
+		return fmt.Errorf("expected lookup-latest to return a non-empty schema definition")
+	}
+	latestType, err := latest.SchemaType(ctx)
+	if err != nil {
+		return fmt.Errorf("read latest schema type: %w", err)
+	}
+	if latestType != "AVRO" {
+		return fmt.Errorf("lookup-latest schemaType mismatch: want AVRO, got %q", latestType)
+	}
+
+	subjects, err := client.ListSubjects(ctx)
+	if err != nil {
+		return fmt.Errorf("list subjects: %w", err)
+	}
+	if !contains(subjects, subject) {
+		return fmt.Errorf("expected subject %q in %v after register", subject, subjects)
+	}
+
+	if err := client.SetCompatibility(ctx, subject, "BACKWARD"); err != nil {
+		return fmt.Errorf("set compatibility: %w", err)
+	}
+	level, err := client.GetCompatibility(ctx, subject)
+	if err != nil {
+		return fmt.Errorf("get compatibility: %w", err)
+	}
+	if level != "BACKWARD" {
+		return fmt.Errorf("compatibility round-trip mismatch: want BACKWARD, got %q", level)
+	}
+
+	deleted, err := client.DeleteSubject(ctx, subject)
+	if err != nil {
+		return fmt.Errorf("delete subject %q: %w", subject, err)
+	}
+	if len(deleted) == 0 {
+		return fmt.Errorf("expected DeleteSubject to report at least one deleted version, got none")
+	}
+	return nil
+}
+
 // SchemaRegistryRejectsNonPlaintextCluster pins the PLAINTEXT-only contract
 // of this story: ConfluentSchemaRegistry must reject a cluster whose client
 // listener runs TLS rather than silently producing a broken registry. The


### PR DESCRIPTION
Closes #39.

Adds `Kafka.ApicurioSchemaRegistry`, a sibling to `ConfluentSchemaRegistry` (#37) backed by `apicurio/apicurio-registry-kafkasql`. Apicurio is a more permissively licensed alternative that exposes a Confluent-Schema-Registry-compatible REST API, so the shared `*SchemaRegistryClient` works against it unchanged.

## Changes

- **`schema_registry.go`** — new `ApicurioSchemaRegistry(cluster, registry, tag)` constructor (same parameter shape as `ConfluentSchemaRegistry`, returns the same `*SchemaRegistry` type). Adds a private `BasePath` field threaded into `Client()`'s `BaseURL`: Confluent/Redpanda leave it empty, Apicurio sets `/apis/ccompat/v7`.
- **`tests/`** — new `ApicurioSchemaRegistryRegisterLookupRoundTrip` PLAINTEXT happy-path test, registered in the `schemaRegistryTests` group.
- **`README.md`** — documents `ApicurioSchemaRegistry` and the CSR-compat caveat.

## Implementation notes

The issue suggested an `APICURIO_CCOMPAT_ENABLED` env var, but research showed Apicurio always exposes the Confluent-compatible API at `/apis/ccompat/v7` — the real work is routing the client through that prefix. Apicurio takes bare `host:port` in `KAFKA_BOOTSTRAP_SERVERS` (no scheme prefix), listens on 8080 by default (pinned to 8081 via `QUARKUS_HTTP_PORT` so the advertised port matches cp-schema-registry), and auto-creates its journal topic at RF 1.

## Testing

`dagger develop` re-run in `daggerverse/kafka/` and `daggerverse/kafka/tests/`. All three Schema Registry tests pass:
- `apicurio-schema-registry-register-lookup-round-trip` (new) ✅
- `schema-registry-register-lookup-round-trip` (Confluent, no regression) ✅
- `schema-registry-rejects-non-plaintext-cluster` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)