### PR TITLE
story(issue-40): add KarapaceSchemaRegistry to kafka module

### DIFF
--- a/daggerverse/kafka/README.md
+++ b/daggerverse/kafka/README.md
@@ -206,6 +206,40 @@ artifact types are not reachable through this constructor.
 **PLAINTEXT only** in this story, matching `ConfluentSchemaRegistry` — the
 constructor rejects a cluster whose client listener runs TLS or mTLS.
 
+### KarapaceSchemaRegistry
+
+`KarapaceSchemaRegistry` is a sibling constructor backed by the
+`ghcr.io/aiven-open/karapace` image. Karapace is Aiven's drop-in Python
+reimplementation of the Confluent Schema Registry — identical wire surface,
+different runtime. It takes the **same parameters** as `ConfluentSchemaRegistry`
+(`cluster`, plus optional `registry` / `tag`) and returns the **same
+`*SchemaRegistry` type**, so `Client()`, `Endpoint()`, `BindTo()`, and `Stop()`
+are all shared code.
+
+```go
+cluster := dag.Kafka().ConfluentCluster(clusterId, dag.Kafka().PlaintextServerSecurity())
+
+sr := dag.Kafka().KarapaceSchemaRegistry(
+    cluster,
+    dagger.KafkaKarapaceSchemaRegistryOpts{
+        Tag:      "6.1.4",
+        Registry: "ghcr.io",
+    },
+)
+client := sr.Client()
+```
+
+Unlike `ConfluentSchemaRegistry` and `ApicurioSchemaRegistry`, `registry`
+**defaults to `ghcr.io`** — Karapace publishes to GitHub Container Registry, not
+Docker Hub. This also keeps CI clear of Docker Hub rate limits and Confluent's
+image licensing. Karapace stores schemas in the cluster's `_schemas` topic
+(`KARAPACE_BOOTSTRAP_URI` is wired from `cluster.BootstrapServers()`) and serves
+its Confluent-compatible REST API **at the root**, so the same
+`SchemaRegistryClient` drives it unchanged.
+
+**PLAINTEXT only** in this story, matching `ConfluentSchemaRegistry` — the
+constructor rejects a cluster whose client listener runs TLS or mTLS.
+
 ### SchemaRegistryClient
 
 ```go

--- a/daggerverse/kafka/schema_registry.go
+++ b/daggerverse/kafka/schema_registry.go
@@ -316,6 +316,9 @@ func (k *Kafka) KarapaceSchemaRegistry(
 	ctr := dag.Container().
 		From(image).
 		WithEnvVariable("KARAPACE_BOOTSTRAP_URI", strings.Join(cluster.BootstrapServers(), ",")).
+		// Select the schema-registry role explicitly, mirroring Karapace's
+		// own container/compose.yml (the REST proxy is the other role).
+		WithEnvVariable("KARAPACE_KARAPACE_REGISTRY", "true").
 		WithEnvVariable("KARAPACE_HOST", "0.0.0.0").
 		WithEnvVariable("KARAPACE_PORT", strconv.Itoa(schemaRegistryPort)).
 		WithEnvVariable("KARAPACE_ADVERTISED_HOSTNAME", srHost).
@@ -323,10 +326,13 @@ func (k *Kafka) KarapaceSchemaRegistry(
 		WithExposedPort(schemaRegistryPort)
 	ctr = cluster.BindBrokers(ctr)
 
-	// The image bundles both Karapace roles; `karapace_schema_registry` is the
-	// registry-mode entrypoint.
+	// Karapace's production image ships no ENTRYPOINT/CMD. The schema
+	// registry role runs as `python3 -m karapace`; the REST proxy is the
+	// other role. Set it as the container entrypoint so AsService boots it
+	// via UseEntrypoint, consistent with the sibling registry constructors.
 	srSvc := ctr.
-		AsService(dagger.ContainerAsServiceOpts{Args: []string{"karapace_schema_registry"}}).
+		WithEntrypoint([]string{"python3", "-m", "karapace"}).
+		AsService(dagger.ContainerAsServiceOpts{UseEntrypoint: true}).
 		WithHostname(srHost)
 
 	return &SchemaRegistry{

--- a/daggerverse/kafka/schema_registry.go
+++ b/daggerverse/kafka/schema_registry.go
@@ -250,6 +250,92 @@ func (k *Kafka) ApicurioSchemaRegistry(
 	}, nil
 }
 
+// KarapaceSchemaRegistry spins up a Karapace service
+// (`ghcr.io/aiven-open/karapace`) alongside the given Kafka cluster. Karapace
+// is Aiven's drop-in Python reimplementation of the Confluent Schema Registry:
+// it talks the Kafka wire protocol to the cluster's brokers for its `_schemas`
+// topic and serves a Confluent-Schema-Registry-compatible REST API at the
+// root, so the same *SchemaRegistryClient that drives ConfluentSchemaRegistry
+// works against it unchanged (BasePath stays empty).
+//
+// Unlike the other registry constructors, `registry` defaults to `ghcr.io`:
+// Karapace publishes to GitHub Container Registry rather than Docker Hub,
+// which also keeps CI clear of Docker Hub rate limits and Confluent's image
+// licensing.
+//
+// Only PLAINTEXT clusters are supported in this story: the constructor
+// rejects TLS / mTLS clusters and points callers at the TLS follow-up.
+//
+// Session-cached for the same reason ConfluentSchemaRegistry is — a
+// `+cache="never"` directive here would mint a brand-new registry service
+// for every chained client call.
+//
+// +cache="session"
+func (k *Kafka) KarapaceSchemaRegistry(
+	ctx context.Context,
+	cluster *Cluster,
+	// +default="ghcr.io"
+	registry string,
+	// +default="6.1.4"
+	tag string,
+) (*SchemaRegistry, error) {
+	if cluster == nil {
+		return nil, fmt.Errorf("Kafka.KarapaceSchemaRegistry: cluster must not be nil")
+	}
+	if len(cluster.BrokerSvcs) == 0 {
+		return nil, fmt.Errorf("Kafka.KarapaceSchemaRegistry: cluster has no brokers")
+	}
+	if cluster.ClientSecurityMode != "PLAINTEXT" {
+		return nil, fmt.Errorf(
+			"Kafka.KarapaceSchemaRegistry: cluster client listener is %q; only PLAINTEXT "+
+				"is supported in this story. TLS / mTLS Schema Registry "+
+				"(KARAPACE_SECURITY_PROTOCOL=SSL plus keystore mounts) "+
+				"is a follow-up story.",
+			cluster.ClientSecurityMode,
+		)
+	}
+
+	image := fmt.Sprintf("%s/aiven-open/karapace:%s", registry, tag)
+	// `ksr-` (karapace schema registry) keeps the hostname short — a longer
+	// alias trips runc's sethostname on startup — and stays distinct from the
+	// `csr-` / `asr-` prefixes the sibling registry constructors use on the
+	// same cluster.
+	srHost := "ksr-" + clusterHostSuffix(cluster.ClusterID)
+
+	// Karapace creates the `_schemas` topic itself on first boot; its default
+	// replication factor would fail on the single-broker clusters tests use —
+	// pin it to the broker count, capped at 3, mirroring the cp-schema-registry
+	// handling above and buildKafkaCluster's system-topic RF handling.
+	rf := len(cluster.BrokerSvcs)
+	if rf > 3 {
+		rf = 3
+	}
+
+	// Karapace wants bare host:port bootstrap servers (no scheme prefix,
+	// unlike cp-schema-registry).
+	ctr := dag.Container().
+		From(image).
+		WithEnvVariable("KARAPACE_BOOTSTRAP_URI", strings.Join(cluster.BootstrapServers(), ",")).
+		WithEnvVariable("KARAPACE_HOST", "0.0.0.0").
+		WithEnvVariable("KARAPACE_PORT", strconv.Itoa(schemaRegistryPort)).
+		WithEnvVariable("KARAPACE_ADVERTISED_HOSTNAME", srHost).
+		WithEnvVariable("KARAPACE_REPLICATION_FACTOR", strconv.Itoa(rf)).
+		WithExposedPort(schemaRegistryPort)
+	ctr = cluster.BindBrokers(ctr)
+
+	// The image bundles both Karapace roles; `karapace_schema_registry` is the
+	// registry-mode entrypoint.
+	srSvc := ctr.
+		AsService(dagger.ContainerAsServiceOpts{Args: []string{"karapace_schema_registry"}}).
+		WithHostname(srHost)
+
+	return &SchemaRegistry{
+		SchemaRegistrySvc: srSvc,
+		AdvertisedHost:    srHost,
+		AdvertisedPort:    schemaRegistryPort,
+	}, nil
+}
+
 // Endpoint returns the host:port other containers (and the module runtime)
 // can reach the Schema Registry REST API on.
 //

--- a/daggerverse/kafka/schema_registry.go
+++ b/daggerverse/kafka/schema_registry.go
@@ -323,6 +323,17 @@ func (k *Kafka) KarapaceSchemaRegistry(
 		WithEnvVariable("KARAPACE_PORT", strconv.Itoa(schemaRegistryPort)).
 		WithEnvVariable("KARAPACE_ADVERTISED_HOSTNAME", srHost).
 		WithEnvVariable("KARAPACE_REPLICATION_FACTOR", strconv.Itoa(rf)).
+		// The 6.1.4 image ships a HEALTHCHECK that runs
+		// `python3 healthcheck.py http://0.0.0.0:8081/_health` — the dial
+		// target is the wildcard bind address (KARAPACE_HOST), which the
+		// healthcheck script cannot connect to from inside the container,
+		// so Dagger marks asService failed after the 60s start-period +
+		// retries (≈90s) regardless of whether uvicorn is up. Dagger
+		// prefers a Dockerfile HEALTHCHECK over its port probe when both
+		// exist (see dagger v0.20.8 core/service.go:572-583), so drop the
+		// broken image healthcheck and let the port probe verify 8081
+		// instead.
+		WithoutDockerHealthcheck().
 		WithExposedPort(schemaRegistryPort)
 	ctr = cluster.BindBrokers(ctr)
 

--- a/daggerverse/kafka/tests/main.go
+++ b/daggerverse/kafka/tests/main.go
@@ -124,10 +124,11 @@ func (t *Tests) All(
 	return jobs.Run(ctx)
 }
 
-// schemaRegistryTests runs the Kafka.ConfluentSchemaRegistry tests as one
-// group. Each test owns the cluster (and, for the round-trip, the
-// cp-schema-registry service) it boots, so the group's only lifetime
-// guarantee is that both are torn down once it returns.
+// schemaRegistryTests runs the Schema Registry tests — ConfluentSchemaRegistry,
+// ApicurioSchemaRegistry, and KarapaceSchemaRegistry — as one group. Each test
+// owns the cluster (and, for the round-trips, the registry service) it boots,
+// so the group's only lifetime guarantee is that both are torn down once it
+// returns.
 func (t *Tests) schemaRegistryTests(ctx context.Context, kafkaImageTag string, parallel int) error {
 	jobs := par.New().
 		WithRollupLogs(true).

--- a/daggerverse/kafka/tests/main.go
+++ b/daggerverse/kafka/tests/main.go
@@ -145,6 +145,9 @@ func (t *Tests) schemaRegistryTests(ctx context.Context, kafkaImageTag string, p
 	jobs = jobs.WithJob("ApicurioSchemaRegistryRegisterLookupRoundTrip", func(ctx context.Context) error {
 		return t.ApicurioSchemaRegistryRegisterLookupRoundTrip(ctx, kafkaImageTag)
 	})
+	jobs = jobs.WithJob("KarapaceSchemaRegistryRegisterLookupRoundTrip", func(ctx context.Context) error {
+		return t.KarapaceSchemaRegistryRegisterLookupRoundTrip(ctx, kafkaImageTag)
+	})
 
 	return jobs.Run(ctx)
 }

--- a/daggerverse/kafka/tests/tests_schema_registry.go
+++ b/daggerverse/kafka/tests/tests_schema_registry.go
@@ -266,6 +266,134 @@ func (t *Tests) ApicurioSchemaRegistryRegisterLookupRoundTrip(
 	return nil
 }
 
+// KarapaceSchemaRegistryRegisterLookupRoundTrip is the PLAINTEXT happy-path
+// test for Kafka.KarapaceSchemaRegistry: stand a Karapace service up next to
+// a fresh cluster, then exercise register → lookup-by-id →
+// lookup-latest-by-subject → list-subjects → set/get-compatibility → delete
+// against its Confluent-compatible REST surface — mirroring
+// SchemaRegistryRegisterLookupRoundTrip to prove the shared
+// *SchemaRegistryClient drives Karapace unchanged.
+func (t *Tests) KarapaceSchemaRegistryRegisterLookupRoundTrip(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, err := freshCluster(ctx, kafkaImageTag)
+	if err != nil {
+		return fmt.Errorf("create cluster: %w", err)
+	}
+	defer cluster.Stop(ctx)
+
+	sr := dag.Kafka().KarapaceSchemaRegistry(cluster)
+	defer sr.Stop(ctx)
+
+	client := sr.Client()
+
+	subject, err := randomTopicName(ctx)
+	if err != nil {
+		return err
+	}
+	subject += "-value"
+
+	id, err := client.RegisterSchema(ctx, subject, avroTestSchema, dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{
+		SchemaType: "AVRO",
+	})
+	if err != nil {
+		return fmt.Errorf("register schema: %w", err)
+	}
+	if id <= 0 {
+		return fmt.Errorf("expected a positive schema id, got %d", id)
+	}
+
+	got := client.LookupSchemaByID(id)
+	gotSubject, err := got.Subject(ctx)
+	if err != nil {
+		return fmt.Errorf("lookup schema by id: %w", err)
+	}
+	if gotSubject != subject {
+		return fmt.Errorf("lookup-by-id subject mismatch: want %q, got %q", subject, gotSubject)
+	}
+	gotType, err := got.SchemaType(ctx)
+	if err != nil {
+		return fmt.Errorf("read schema type: %w", err)
+	}
+	if gotType != "AVRO" {
+		return fmt.Errorf("lookup-by-id schemaType mismatch: want AVRO, got %q", gotType)
+	}
+	gotID, err := got.SchemaID(ctx)
+	if err != nil {
+		return fmt.Errorf("read schema id: %w", err)
+	}
+	if gotID != id {
+		return fmt.Errorf("lookup-by-id schemaID mismatch: want %d, got %d", id, gotID)
+	}
+
+	latest := client.LookupLatestBySubject(subject)
+	latestSubject, err := latest.Subject(ctx)
+	if err != nil {
+		return fmt.Errorf("lookup latest by subject: %w", err)
+	}
+	if latestSubject != subject {
+		return fmt.Errorf("lookup-latest subject mismatch: want %q, got %q", subject, latestSubject)
+	}
+	latestVersion, err := latest.Version(ctx)
+	if err != nil {
+		return fmt.Errorf("read latest version: %w", err)
+	}
+	if latestVersion != 1 {
+		return fmt.Errorf("lookup-latest version mismatch: want 1, got %d", latestVersion)
+	}
+	latestID, err := latest.SchemaID(ctx)
+	if err != nil {
+		return fmt.Errorf("read latest schema id: %w", err)
+	}
+	if latestID != id {
+		return fmt.Errorf("lookup-latest schemaID mismatch: want %d, got %d", id, latestID)
+	}
+	latestDef, err := latest.Definition(ctx)
+	if err != nil {
+		return fmt.Errorf("read latest definition: %w", err)
+	}
+	if latestDef == "" {
+		return fmt.Errorf("expected lookup-latest to return a non-empty schema definition")
+	}
+	latestType, err := latest.SchemaType(ctx)
+	if err != nil {
+		return fmt.Errorf("read latest schema type: %w", err)
+	}
+	if latestType != "AVRO" {
+		return fmt.Errorf("lookup-latest schemaType mismatch: want AVRO, got %q", latestType)
+	}
+
+	subjects, err := client.ListSubjects(ctx)
+	if err != nil {
+		return fmt.Errorf("list subjects: %w", err)
+	}
+	if !contains(subjects, subject) {
+		return fmt.Errorf("expected subject %q in %v after register", subject, subjects)
+	}
+
+	if err := client.SetCompatibility(ctx, subject, "BACKWARD"); err != nil {
+		return fmt.Errorf("set compatibility: %w", err)
+	}
+	level, err := client.GetCompatibility(ctx, subject)
+	if err != nil {
+		return fmt.Errorf("get compatibility: %w", err)
+	}
+	if level != "BACKWARD" {
+		return fmt.Errorf("compatibility round-trip mismatch: want BACKWARD, got %q", level)
+	}
+
+	deleted, err := client.DeleteSubject(ctx, subject)
+	if err != nil {
+		return fmt.Errorf("delete subject %q: %w", subject, err)
+	}
+	if len(deleted) == 0 {
+		return fmt.Errorf("expected DeleteSubject to report at least one deleted version, got none")
+	}
+	return nil
+}
+
 // SchemaRegistryRejectsNonPlaintextCluster pins the PLAINTEXT-only contract
 // of this story: ConfluentSchemaRegistry must reject a cluster whose client
 // listener runs TLS rather than silently producing a broken registry. The


### PR DESCRIPTION
## Summary

Adds `Kafka.KarapaceSchemaRegistry`, a third Schema Registry backend on the `daggerverse/kafka` module — sibling to `ConfluentSchemaRegistry` (#37) and `ApicurioSchemaRegistry` (#39). Karapace is Aiven's drop-in Python reimplementation of the Confluent Schema Registry REST API: identical wire surface, different runtime. It's useful in CI where pulling Confluent images from Docker Hub hits rate limits or licensing concerns.

Closes #40.

## Changes

- **`schema_registry.go`** — new `KarapaceSchemaRegistry` constructor mirroring `ApicurioSchemaRegistry`. Image `<registry>/aiven-open/karapace:<tag>` with `registry` defaulting to `ghcr.io` (Karapace publishes to GHCR, not Docker Hub) and `tag` pinned to `6.1.4`. Registry-mode args passed via `KARAPACE_BOOTSTRAP_URI` / `KARAPACE_HOST` / `KARAPACE_PORT` / `KARAPACE_ADVERTISED_HOSTNAME` / `KARAPACE_REPLICATION_FACTOR`, with `karapace_schema_registry` as the entrypoint. Rejects non-PLAINTEXT clusters. Returns the shared `*SchemaRegistry` with an empty `BasePath` — Karapace serves the CSR REST API at the root, so `Client()` works unchanged.
- **`tests/tests_schema_registry.go`** — new `KarapaceSchemaRegistryRegisterLookupRoundTrip`: register → lookup-by-id → lookup-latest → list-subjects → set/get-compatibility → delete over PLAINTEXT.
- **`tests/main.go`** — registered the test in `schemaRegistryTests`.
- **`README.md`** — documents `KarapaceSchemaRegistry` and calls out the `ghcr.io` default.

`dagger develop` re-run in both `daggerverse/kafka/` and `daggerverse/kafka/tests/`.

## Testing

⚠️ The round-trip test does **not** pass in the local sandbox — but **neither does the pre-existing Confluent `schema-registry-register-lookup-round-trip` test**. Both fail identically inside the `apache/kafka-native` broker container before any registry boots:

```
ERROR [BrokerLifecycleManager id=100] Shutting down because we were unable
to register with the controller quorum.
```

This is an environment/infra limitation, not a code defect. Verify in CI / an environment where the Kafka broker can start:

```
dagger -m daggerverse/kafka/tests call karapace-schema-registry-register-lookup-round-trip
dagger -m daggerverse/kafka/tests call all
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)