### PR TITLE
story(issue-42): add SR-aware Produce/Consume to kafka Client

### DIFF
--- a/daggerverse/kafka/README.md
+++ b/daggerverse/kafka/README.md
@@ -404,6 +404,25 @@ records, err := client.Consume(ctx, "my-topic", dagger.KafkaClientConsumeOpts{
     Group: "", // group-less direct consume; pass "my-group" to consume as a group member
 })
 
+// Schema-Registry-framed data: register a schema via the Confluent /
+// Apicurio / Karapace SR client to get an id, then produce / consume
+// with the Confluent wire format (0x00 || uint32be(id) || payload).
+id, err := srClient.RegisterSchema(ctx, "my-topic-value", schema, dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{
+    SchemaType: "AVRO",
+})
+err = client.Produce(ctx, "my-topic", "k", "v", dagger.KafkaClientProduceOpts{
+    KeyEncoding: "raw", ValueEncoding: "raw",
+    ValueSchemaID: id, // optional KeySchemaID does the same for the key
+})
+framed, err := client.Consume(ctx, "my-topic", dagger.KafkaClientConsumeOpts{
+    MaxMessages: 1, Timeout: "10s",
+    KeyEncoding: "raw", ValueEncoding: "raw",
+    SchemaRegistryAware: true,
+})
+// framed[0].ValueSchemaID == id; framed[0].Value is the original payload
+// with the 5-byte header stripped. Records without 0x00 framing surface
+// ValueSchemaID == 0 and pass through unchanged.
+
 // java client.properties (+ p12 sidecars in TLS / mTLS modes) for the
 // Apache Kafka CLI tools — export the parent directory so the relative
 // truststore.p12 / keystore.p12 references resolve.

--- a/daggerverse/kafka/README.md
+++ b/daggerverse/kafka/README.md
@@ -419,9 +419,10 @@ framed, err := client.Consume(ctx, "my-topic", dagger.KafkaClientConsumeOpts{
     KeyEncoding: "raw", ValueEncoding: "raw",
     SchemaRegistryAware: true,
 })
-// framed[0].ValueSchemaID == id; framed[0].Value is the original payload
-// with the 5-byte header stripped. Records without 0x00 framing surface
-// ValueSchemaID == 0 and pass through unchanged.
+gotID, err := framed[0].ValueSchemaID(ctx)   // == id (the registered schema id)
+payload, err := framed[0].Value(ctx)         // original bytes, 5-byte header stripped
+// Records without 0x00 framing surface ValueSchemaID(ctx) == 0 and
+// Value(ctx) passes through unchanged.
 
 // java client.properties (+ p12 sidecars in TLS / mTLS modes) for the
 // Apache Kafka CLI tools — export the parent directory so the relative

--- a/daggerverse/kafka/client.go
+++ b/daggerverse/kafka/client.go
@@ -365,12 +365,12 @@ func (c *Client) DeleteTopic(ctx context.Context, name string) error {
 // Produce synchronously writes one record to the topic. Key and value are
 // decoded from their named encodings into raw bytes before being sent.
 //
-// keySchemaId / valueSchemaId, when non-zero, prepend the Confluent
+// keySchemaID / valueSchemaID, when positive, prepend the Confluent
 // Schema Registry wire-format header to the corresponding field:
 // `0x00 || uint32be(schemaID) || payload`. The header is laid down via
 // franz-go's sr.ConfluentHeader so the byte layout matches what
 // Schema-Registry-aware consumers expect. Default 0 means no framing
-// (the field is sent verbatim).
+// (the field is sent verbatim). Negative IDs are rejected.
 //
 // +cache="never"
 func (c *Client) Produce(
@@ -383,10 +383,17 @@ func (c *Client) Produce(
 	// +default="raw"
 	valueEncoding string,
 	// +default=0
-	keySchemaId int,
+	keySchemaID int,
 	// +default=0
-	valueSchemaId int,
+	valueSchemaID int,
 ) error {
+	if keySchemaID < 0 {
+		return fmt.Errorf("keySchemaID must be >= 0, got %d", keySchemaID)
+	}
+	if valueSchemaID < 0 {
+		return fmt.Errorf("valueSchemaID must be >= 0, got %d", valueSchemaID)
+	}
+
 	keyBytes, err := decodeString(key, keyEncoding)
 	if err != nil {
 		return fmt.Errorf("decode key: %w", err)
@@ -397,12 +404,18 @@ func (c *Client) Produce(
 	}
 
 	var hdr sr.ConfluentHeader
-	if keySchemaId != 0 {
-		framed, _ := hdr.AppendEncode(nil, keySchemaId, nil)
+	if keySchemaID > 0 {
+		framed, err := hdr.AppendEncode(nil, keySchemaID, nil)
+		if err != nil {
+			return fmt.Errorf("frame key with schema id %d: %w", keySchemaID, err)
+		}
 		keyBytes = append(framed, keyBytes...)
 	}
-	if valueSchemaId != 0 {
-		framed, _ := hdr.AppendEncode(nil, valueSchemaId, nil)
+	if valueSchemaID > 0 {
+		framed, err := hdr.AppendEncode(nil, valueSchemaID, nil)
+		if err != nil {
+			return fmt.Errorf("frame value with schema id %d: %w", valueSchemaID, err)
+		}
 		valBytes = append(framed, valBytes...)
 	}
 
@@ -429,6 +442,15 @@ func (c *Client) Produce(
 // metadata to __consumer_offsets (offsets are not committed — the function
 // stays idempotent under +cache="never"). When group is empty (the
 // default), partitions are consumed directly with no group state.
+//
+// When schemaRegistryAware is true, each record's key and value are
+// inspected for the Confluent Schema Registry wire-format header
+// (`0x00 || uint32be(schemaID) || payload`). When present, the 5-byte
+// header is stripped before encoding the payload and the extracted
+// schema ID is surfaced on ConsumedRecord.KeySchemaID /
+// ConsumedRecord.ValueSchemaID. Unframed fields pass through with a
+// zero schema ID. When false (the default), bytes are returned verbatim
+// and the schema ID fields are always zero.
 //
 // +cache="never"
 func (c *Client) Consume(

--- a/daggerverse/kafka/client.go
+++ b/daggerverse/kafka/client.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/sr"
 	"software.sslmate.com/src/go-pkcs12"
 )
 
@@ -41,10 +42,16 @@ type Client struct {
 }
 
 // ConsumedRecord is a single record returned by Client.Consume, with key and
-// value already encoded into the requested string representation.
+// value already encoded into the requested string representation. KeySchemaID
+// and ValueSchemaID are populated when Consume runs with schemaRegistryAware
+// and the corresponding record bytes carry the Confluent wire-format header
+// (`0x00 || uint32be(schemaID) || payload`); otherwise they are 0 and the
+// key/value bytes pass through untouched.
 type ConsumedRecord struct {
-	Key   string
-	Value string
+	Key           string
+	Value         string
+	KeySchemaID   int
+	ValueSchemaID int
 }
 
 // Client constructs a franz-go-backed Kafka client that targets the given
@@ -358,6 +365,13 @@ func (c *Client) DeleteTopic(ctx context.Context, name string) error {
 // Produce synchronously writes one record to the topic. Key and value are
 // decoded from their named encodings into raw bytes before being sent.
 //
+// keySchemaId / valueSchemaId, when non-zero, prepend the Confluent
+// Schema Registry wire-format header to the corresponding field:
+// `0x00 || uint32be(schemaID) || payload`. The header is laid down via
+// franz-go's sr.ConfluentHeader so the byte layout matches what
+// Schema-Registry-aware consumers expect. Default 0 means no framing
+// (the field is sent verbatim).
+//
 // +cache="never"
 func (c *Client) Produce(
 	ctx context.Context,
@@ -368,6 +382,10 @@ func (c *Client) Produce(
 	keyEncoding string,
 	// +default="raw"
 	valueEncoding string,
+	// +default=0
+	keySchemaId int,
+	// +default=0
+	valueSchemaId int,
 ) error {
 	keyBytes, err := decodeString(key, keyEncoding)
 	if err != nil {
@@ -376,6 +394,16 @@ func (c *Client) Produce(
 	valBytes, err := decodeString(value, valueEncoding)
 	if err != nil {
 		return fmt.Errorf("decode value: %w", err)
+	}
+
+	var hdr sr.ConfluentHeader
+	if keySchemaId != 0 {
+		framed, _ := hdr.AppendEncode(nil, keySchemaId, nil)
+		keyBytes = append(framed, keyBytes...)
+	}
+	if valueSchemaId != 0 {
+		framed, _ := hdr.AppendEncode(nil, valueSchemaId, nil)
+		valBytes = append(framed, valBytes...)
 	}
 
 	cl, err := c.newKgoClient(ctx)
@@ -416,6 +444,8 @@ func (c *Client) Consume(
 	valueEncoding string,
 	// +default=""
 	group string,
+	// +default=false
+	schemaRegistryAware bool,
 ) ([]ConsumedRecord, error) {
 	if maxMessages <= 0 {
 		return nil, fmt.Errorf("maxMessages must be > 0, got %d", maxMessages)
@@ -465,15 +495,31 @@ func (c *Client) Consume(
 		iter := fetches.RecordIter()
 		for !iter.Done() && len(out) < maxMessages {
 			r := iter.Next()
-			keyStr, err := encodeBytes(r.Key, keyEncoding)
+			keyRaw, valRaw := r.Key, r.Value
+			var keyID, valID int
+			if schemaRegistryAware {
+				var hdr sr.ConfluentHeader
+				if id, payload, err := hdr.DecodeID(keyRaw); err == nil {
+					keyID, keyRaw = id, payload
+				}
+				if id, payload, err := hdr.DecodeID(valRaw); err == nil {
+					valID, valRaw = id, payload
+				}
+			}
+			keyStr, err := encodeBytes(keyRaw, keyEncoding)
 			if err != nil {
 				return nil, fmt.Errorf("encode key: %w", err)
 			}
-			valStr, err := encodeBytes(r.Value, valueEncoding)
+			valStr, err := encodeBytes(valRaw, valueEncoding)
 			if err != nil {
 				return nil, fmt.Errorf("encode value: %w", err)
 			}
-			out = append(out, ConsumedRecord{Key: keyStr, Value: valStr})
+			out = append(out, ConsumedRecord{
+				Key:           keyStr,
+				Value:         valStr,
+				KeySchemaID:   keyID,
+				ValueSchemaID: valID,
+			})
 		}
 	}
 	return out, nil

--- a/daggerverse/kafka/go.mod
+++ b/daggerverse/kafka/go.mod
@@ -3,35 +3,18 @@ module dagger/kafka
 go 1.26.2
 
 require (
-	dagger.io/dagger v0.20.6-0.20260415192040-7058e9313c72
-	github.com/Khan/genqlient v0.8.1
 	github.com/dagger/otel-go v1.43.0
 	github.com/twmb/franz-go v1.21.1
 	github.com/twmb/franz-go/pkg/kadm v1.18.0
-	github.com/vektah/gqlparser/v2 v2.5.33
-	go.opentelemetry.io/otel v1.43.0
-	go.opentelemetry.io/otel/trace v1.43.0
+	github.com/twmb/franz-go/pkg/sr v1.7.0
 	gopkg.in/yaml.v3 v3.0.1
 	software.sslmate.com/src/go-pkcs12 v0.7.1
 )
 
 require (
-	github.com/klauspost/compress v1.18.5 // indirect
-	github.com/pierrec/lz4/v4 v4.1.26 // indirect
-	github.com/twmb/franz-go/pkg/kmsg v1.13.1 // indirect
-	golang.org/x/crypto v0.50.0 // indirect
-)
-
-require (
-	github.com/99designs/gqlgen v0.17.90 // indirect
+	dagger.io/dagger v0.20.6-0.20260415192040-7058e9313c72
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
-	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
-	github.com/sosodev/duration v1.4.0 // indirect
-	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.17.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.17.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.41.0 // indirect
@@ -40,19 +23,37 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.41.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.41.0 // indirect
 	go.opentelemetry.io/otel/log v0.17.0 // indirect
-	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/log v0.17.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260226221140-a57be14db171 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260226221140-a57be14db171 // indirect
 	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
+)
+
+require (
+	github.com/99designs/gqlgen v0.17.90 // indirect
+	github.com/Khan/genqlient v0.8.1
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/go-logr/logr v1.4.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/google/uuid v1.6.0 // indirect
+	github.com/klauspost/compress v1.18.5 // indirect
+	github.com/pierrec/lz4/v4 v4.1.26 // indirect
+	github.com/sosodev/duration v1.4.0 // indirect
+	github.com/twmb/franz-go/pkg/kmsg v1.13.1 // indirect
+	github.com/vektah/gqlparser/v2 v2.5.33
+	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/otel v1.43.0
+	go.opentelemetry.io/otel/metric v1.43.0 // indirect
+	go.opentelemetry.io/otel/trace v1.43.0
+	golang.org/x/crypto v0.50.0 // indirect
+	golang.org/x/sync v0.20.0 // indirect
+	golang.org/x/sys v0.44.0 // indirect
 )
 
 replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.16.0

--- a/daggerverse/kafka/go.sum
+++ b/daggerverse/kafka/go.sum
@@ -53,6 +53,8 @@ github.com/twmb/franz-go/pkg/kadm v1.18.0 h1:WRf/LZmDdcDXwX7WMbtDU++v+b3NzYh2bCG
 github.com/twmb/franz-go/pkg/kadm v1.18.0/go.mod h1:XeLhGoLXLFzK8/ryv5FfpxPxGwj4oFEGpPJMB/x6KDE=
 github.com/twmb/franz-go/pkg/kmsg v1.13.1 h1:fG5kItwysTk5UXqVwb64EpQEy3TydF3vYYK21nUQ+bI=
 github.com/twmb/franz-go/pkg/kmsg v1.13.1/go.mod h1:+DPt4NC8RmI6hqb8G09+3giKObE6uD2Eya6CfqBpeJY=
+github.com/twmb/franz-go/pkg/sr v1.7.0 h1:wHStlO6aOPWWgZ68ZYcdtQe9tRbkcTc1gRLbgs+8QAA=
+github.com/twmb/franz-go/pkg/sr v1.7.0/go.mod h1:64CsHlsQnyFRq1sYPcCmlRrEG3PlLPb6cDddx2wGr28=
 github.com/vektah/gqlparser/v2 v2.5.33 h1:lRp8aIeNUNbimf/axZd7ETg24q06hBtPaas+TcvI/7E=
 github.com/vektah/gqlparser/v2 v2.5.33/go.mod h1:c1I28gSOVNzlfc4WuDlqU7voQnsqI6OG2amkBAFmgts=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/daggerverse/kafka/tests/main.go
+++ b/daggerverse/kafka/tests/main.go
@@ -149,6 +149,12 @@ func (t *Tests) schemaRegistryTests(ctx context.Context, kafkaImageTag string, p
 	jobs = jobs.WithJob("KarapaceSchemaRegistryRegisterLookupRoundTrip", func(ctx context.Context) error {
 		return t.KarapaceSchemaRegistryRegisterLookupRoundTrip(ctx, kafkaImageTag)
 	})
+	jobs = jobs.WithJob("SchemaRegistryFramedProduceConsumeRoundTrip", func(ctx context.Context) error {
+		return t.SchemaRegistryFramedProduceConsumeRoundTrip(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("SchemaRegistryPlaintextConsumeUnframed", func(ctx context.Context) error {
+		return t.SchemaRegistryPlaintextConsumeUnframed(ctx, kafkaImageTag)
+	})
 
 	return jobs.Run(ctx)
 }

--- a/daggerverse/kafka/tests/tests_schema_registry.go
+++ b/daggerverse/kafka/tests/tests_schema_registry.go
@@ -394,6 +394,175 @@ func (t *Tests) KarapaceSchemaRegistryRegisterLookupRoundTrip(
 	return nil
 }
 
+// SchemaRegistryFramedProduceConsumeRoundTrip exercises the data path of the
+// Client with Confluent wire-format framing: register a schema to get an ID,
+// produce a record whose value is framed with that ID, then consume with
+// schemaRegistryAware=true and assert the parsed ID matches and the value
+// bytes are stripped back to the original payload.
+func (t *Tests) SchemaRegistryFramedProduceConsumeRoundTrip(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, err := freshCluster(ctx, kafkaImageTag)
+	if err != nil {
+		return fmt.Errorf("create cluster: %w", err)
+	}
+	defer cluster.Stop(ctx)
+
+	sr := dag.Kafka().ConfluentSchemaRegistry(cluster)
+	defer sr.Stop(ctx)
+
+	subject, err := randomTopicName(ctx)
+	if err != nil {
+		return err
+	}
+	topic := subject
+	subject += "-value"
+
+	id, err := sr.Client().RegisterSchema(ctx, subject, avroTestSchema, dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{
+		SchemaType: "AVRO",
+	})
+	if err != nil {
+		return fmt.Errorf("register schema: %w", err)
+	}
+	if id <= 0 {
+		return fmt.Errorf("expected a positive schema id, got %d", id)
+	}
+
+	client := cluster.Client(dag.Kafka().PlaintextClientSecurity())
+	if err := client.CreateTopic(ctx, topic, dagger.KafkaClientCreateTopicOpts{
+		Partitions:        1,
+		ReplicationFactor: 1,
+	}); err != nil {
+		return fmt.Errorf("create topic %q: %w", topic, err)
+	}
+
+	const wantKey, wantVal = "k", "hello-world"
+	if err := client.Produce(ctx, topic, wantKey, wantVal, dagger.KafkaClientProduceOpts{
+		KeyEncoding:   "raw",
+		ValueEncoding: "raw",
+		ValueSchemaID: id,
+	}); err != nil {
+		return fmt.Errorf("produce: %w", err)
+	}
+
+	records, err := client.Consume(ctx, topic, dagger.KafkaClientConsumeOpts{
+		MaxMessages:         1,
+		Timeout:             "10s",
+		KeyEncoding:         "raw",
+		ValueEncoding:       "raw",
+		SchemaRegistryAware: true,
+	})
+	if err != nil {
+		return fmt.Errorf("consume: %w", err)
+	}
+	if len(records) != 1 {
+		return fmt.Errorf("expected 1 record, got %d", len(records))
+	}
+	gotKey, err := records[0].Key(ctx)
+	if err != nil {
+		return fmt.Errorf("read key: %w", err)
+	}
+	gotVal, err := records[0].Value(ctx)
+	if err != nil {
+		return fmt.Errorf("read value: %w", err)
+	}
+	gotValID, err := records[0].ValueSchemaID(ctx)
+	if err != nil {
+		return fmt.Errorf("read value schema id: %w", err)
+	}
+	gotKeyID, err := records[0].KeySchemaID(ctx)
+	if err != nil {
+		return fmt.Errorf("read key schema id: %w", err)
+	}
+	if gotKey != wantKey {
+		return fmt.Errorf("key mismatch: want %q, got %q", wantKey, gotKey)
+	}
+	if gotVal != wantVal {
+		return fmt.Errorf("value mismatch: want %q, got %q", wantVal, gotVal)
+	}
+	if gotValID != id {
+		return fmt.Errorf("value schema id mismatch: want %d, got %d", id, gotValID)
+	}
+	if gotKeyID != 0 {
+		return fmt.Errorf("expected key schema id 0 (unframed), got %d", gotKeyID)
+	}
+	return nil
+}
+
+// SchemaRegistryPlaintextConsumeUnframed verifies the negative path: a record
+// produced without framing, consumed with schemaRegistryAware=true, must
+// surface ValueSchemaID=0 and pass the value bytes through unchanged.
+func (t *Tests) SchemaRegistryPlaintextConsumeUnframed(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, err := freshCluster(ctx, kafkaImageTag)
+	if err != nil {
+		return fmt.Errorf("create cluster: %w", err)
+	}
+	defer cluster.Stop(ctx)
+
+	client := cluster.Client(dag.Kafka().PlaintextClientSecurity())
+
+	topic, err := randomTopicName(ctx)
+	if err != nil {
+		return err
+	}
+	if err := client.CreateTopic(ctx, topic, dagger.KafkaClientCreateTopicOpts{
+		Partitions:        1,
+		ReplicationFactor: 1,
+	}); err != nil {
+		return fmt.Errorf("create topic %q: %w", topic, err)
+	}
+
+	const wantKey, wantVal = "k", "plain"
+	if err := client.Produce(ctx, topic, wantKey, wantVal, dagger.KafkaClientProduceOpts{
+		KeyEncoding:   "raw",
+		ValueEncoding: "raw",
+	}); err != nil {
+		return fmt.Errorf("produce: %w", err)
+	}
+
+	records, err := client.Consume(ctx, topic, dagger.KafkaClientConsumeOpts{
+		MaxMessages:         1,
+		Timeout:             "10s",
+		KeyEncoding:         "raw",
+		ValueEncoding:       "raw",
+		SchemaRegistryAware: true,
+	})
+	if err != nil {
+		return fmt.Errorf("consume: %w", err)
+	}
+	if len(records) != 1 {
+		return fmt.Errorf("expected 1 record, got %d", len(records))
+	}
+	gotVal, err := records[0].Value(ctx)
+	if err != nil {
+		return fmt.Errorf("read value: %w", err)
+	}
+	gotValID, err := records[0].ValueSchemaID(ctx)
+	if err != nil {
+		return fmt.Errorf("read value schema id: %w", err)
+	}
+	gotKeyID, err := records[0].KeySchemaID(ctx)
+	if err != nil {
+		return fmt.Errorf("read key schema id: %w", err)
+	}
+	if gotVal != wantVal {
+		return fmt.Errorf("value mismatch: want %q, got %q", wantVal, gotVal)
+	}
+	if gotValID != 0 {
+		return fmt.Errorf("expected ValueSchemaID=0 for unframed record, got %d", gotValID)
+	}
+	if gotKeyID != 0 {
+		return fmt.Errorf("expected KeySchemaID=0 for unframed record, got %d", gotKeyID)
+	}
+	return nil
+}
+
 // SchemaRegistryRejectsNonPlaintextCluster pins the PLAINTEXT-only contract
 // of this story: ConfluentSchemaRegistry must reject a cluster whose client
 // listener runs TLS rather than silently producing a broken registry. The


### PR DESCRIPTION
## Summary

- Extend `*Client.Produce` with `keySchemaId` / `valueSchemaId` opts — when non-zero, the field is prefixed with the Confluent wire-format header (`0x00 || uint32be(schemaID) || payload`) via `sr.ConfluentHeader.AppendEncode`.
- Extend `*Client.Consume` with `schemaRegistryAware` opt — when true, each record's key/value is run through `sr.ConfluentHeader.DecodeID`; framed records surface their parsed IDs on the new `ConsumedRecord.KeySchemaID` / `ValueSchemaID` fields and have their framing bytes stripped before `encodeBytes`. Plaintext (and malformed-framing) records pass through with `*SchemaID = 0` and bytes untouched.
- Payload (de)serialization (Avro / Protobuf / JSON Schema) stays out of scope per the issue — follow-up stories will add native serde on top of this primitive.

Closes #42.

## Test plan

- [x] `dagger -m daggerverse/kafka/tests call schema-registry-framed-produce-consume-round-trip` — happy path: register schema → produce framed → consume → assert `ValueSchemaID` and payload match.
- [x] `dagger -m daggerverse/kafka/tests call schema-registry-plaintext-consume-unframed` — negative path: plaintext record consumed with `schemaRegistryAware=true` surfaces `ValueSchemaID=0` and unmodified value.
- [x] `dagger -m daggerverse/kafka/tests call schema-registry-register-lookup-round-trip` — existing SR admin round-trip unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)