### PR TITLE
story(issue-70): add Check terminal to Go.Ci

### DIFF
--- a/daggerverse/go/ci.go
+++ b/daggerverse/go/ci.go
@@ -17,7 +17,8 @@ const (
 )
 
 // Ci is a chained builder for a standardized Go CI pipeline. Construct via
-// Go.Ci(source); enable stages via the With* methods; call Run to execute.
+// Go.Ci(source); enable stages via the With* methods; call Run to execute
+// checks-then-build, or Check to run only the parallel checks.
 //
 // Stage 1 runs the enabled static checks in parallel (Fmt, Vet, Lint, Test);
 // errors are aggregated. Stage 2 builds the source and Run returns the
@@ -112,14 +113,15 @@ func (c *Ci) WithBuild(
 	return c
 }
 
-// Run executes the pipeline: stage 1 (parallel checks) → stage 2 (build).
-// Returns the built binary as a *dagger.File. Stage-1 errors are aggregated
-// via github.com/dagger/dagger/util/parallel; on stage-1 failure Run returns
-// the aggregated error and a nil file (stage 2 is skipped).
+// Check runs the enabled check stages (Fmt, Vet, Lint, Test) in
+// parallel via github.com/dagger/dagger/util/parallel and returns the
+// aggregated error. Use when callers want to run the checks
+// independently of the build (for example multi-platform pipelines
+// that share one check run across N platform builds).
 //
 // +check
 // +cache="session"
-func (c *Ci) Run(ctx context.Context) (*dagger.File, error) {
+func (c *Ci) Check(ctx context.Context) error {
 	jobs := parallel.New().
 		WithRollupLogs(true).
 		WithRollupSpans(true)
@@ -135,7 +137,17 @@ func (c *Ci) Run(ctx context.Context) (*dagger.File, error) {
 	if c.LintEnabled {
 		jobs = jobs.WithJob("lint", c.runLint)
 	}
-	if err := jobs.Run(ctx); err != nil {
+	return jobs.Run(ctx)
+}
+
+// Run executes the pipeline: stage 1 (Check) → stage 2 (build). Returns
+// the built binary as a *dagger.File. On stage-1 failure, returns the
+// aggregated error from Check and a nil file (stage 2 is skipped).
+//
+// +check
+// +cache="session"
+func (c *Ci) Run(ctx context.Context) (*dagger.File, error) {
+	if err := c.Check(ctx); err != nil {
 		return nil, err
 	}
 	return c.runBuild(ctx)

--- a/daggerverse/go/tests/main.go
+++ b/daggerverse/go/tests/main.go
@@ -131,17 +131,19 @@ func (t *Tests) All(
 }
 
 // CiCheckRunsEnabledChecksAndSkipsBuild configures every With* stage
-// including WithBuild, then calls Check (not Run) and asserts no error.
-// Check returns no *dagger.File by signature, so the "build did not run"
-// property is enforced at the type level; this test verifies the happy
-// path of the check-only terminal against a clean source.
+// against the clean hello fixture and calls Check (not Run), asserting
+// no error. To actively prove Check does not invoke the build stage
+// internally, WithBuild is configured with a non-existent package path:
+// if Check were to call runBuild, `go build ./does-not-exist` would
+// fail and surface here as an error. A nil return therefore proves
+// both (a) the checks passed and (b) the build was skipped.
 func (t *Tests) CiCheckRunsEnabledChecksAndSkipsBuild(ctx context.Context, goImageTag string) error {
 	err := dag.Go(dagger.GoOpts{Version: goImageTag}).Ci(helloDir()).
 		WithFmt().
 		WithVet().
 		WithLint().
 		WithTest(dagger.GoCiWithTestOpts{Race: true}).
-		WithBuild().
+		WithBuild(dagger.GoCiWithBuildOpts{Pkg: "./does-not-exist"}).
 		Check(ctx)
 	if err != nil {
 		return fmt.Errorf("Ci.Check on clean hello: %w", err)

--- a/daggerverse/go/tests/main.go
+++ b/daggerverse/go/tests/main.go
@@ -123,8 +123,30 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("CiRunVetBadAggregates", func(ctx context.Context) error {
 		return t.CiRunVetBadAggregates(ctx, goImageTag)
 	})
+	jobs = jobs.WithJob("CiCheckRunsEnabledChecksAndSkipsBuild", func(ctx context.Context) error {
+		return t.CiCheckRunsEnabledChecksAndSkipsBuild(ctx, goImageTag)
+	})
 
 	return jobs.Run(ctx)
+}
+
+// CiCheckRunsEnabledChecksAndSkipsBuild configures every With* stage
+// including WithBuild, then calls Check (not Run) and asserts no error.
+// Check returns no *dagger.File by signature, so the "build did not run"
+// property is enforced at the type level; this test verifies the happy
+// path of the check-only terminal against a clean source.
+func (t *Tests) CiCheckRunsEnabledChecksAndSkipsBuild(ctx context.Context, goImageTag string) error {
+	err := dag.Go(dagger.GoOpts{Version: goImageTag}).Ci(helloDir()).
+		WithFmt().
+		WithVet().
+		WithLint().
+		WithTest(dagger.GoCiWithTestOpts{Race: true}).
+		WithBuild().
+		Check(ctx)
+	if err != nil {
+		return fmt.Errorf("Ci.Check on clean hello: %w", err)
+	}
+	return nil
 }
 
 // CiRunVetBadAggregates runs Ci against the vet-bad fixture with both Vet


### PR DESCRIPTION
## Summary

- Extract the stage-1 parallel checks (Fmt, Vet, Lint, Test) from `Ci.Run` into a new public terminal `Check(ctx) error` on `daggerverse/go/ci.go`.
- Refactor `Run` to delegate: `Check(ctx)` → `runBuild(ctx)`. No behavior change to existing callers.
- Add `CiCheckRunsEnabledChecksAndSkipsBuild` to `daggerverse/go/tests/main.go` and register it in `Tests.All`.

Motivation: the upcoming `z5labs` multi-arch GoApp pipeline needs to run the checks once and build per platform — exposing `Check` independently avoids re-running fmt/vet/lint/test N times.

Closes #70.

## Test plan

- [x] `dagger -m daggerverse/go call ci --help` lists `check` alongside `run`.
- [x] `dagger -m daggerverse/go/tests call ci-check-runs-enabled-checks-and-skips-build --go-image-tag=""` passes.
- [x] `dagger -m daggerverse/go/tests call ci-run-vet-bad-aggregates --go-image-tag=""` passes (error aggregation preserved through `Run` → `Check`).
- [x] `dagger -m daggerverse/go/tests call ci-run-hello-all-stages --go-image-tag=""` passes (build still runs from `Run`).
- [x] `dagger -m daggerverse/go/tests call all --go-image-tag="" --parallel=0` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)