### PR TITLE
story(issue-73): add JSON serde to kafka Client Produce/Consume

### DIFF
--- a/daggerverse/kafka/README.md
+++ b/daggerverse/kafka/README.md
@@ -424,6 +424,22 @@ payload, err := framed[0].Value(ctx)         // original bytes, 5-byte header st
 // Records without 0x00 framing surface ValueSchemaID(ctx) == 0 and
 // Value(ctx) passes through unchanged.
 
+// JSON wire-format enforcement: parse-and-canonicalise on Produce,
+// json.Valid-check on Consume. Composes with the framing opts above —
+// a single Produce call can canonicalise then frame, a single Consume
+// call can unframe then validate.
+err = client.Produce(ctx, "my-topic", "k", `{"x":"hello"}`, dagger.KafkaClientProduceOpts{
+    KeyEncoding: "raw", ValueEncoding: "raw",
+    ValueSchemaID:    id,
+    ValueSerializeAs: "JSON", // "" pass-through; "JSON" parses + re-marshals canonically
+})
+validated, err := client.Consume(ctx, "my-topic", dagger.KafkaClientConsumeOpts{
+    MaxMessages: 1, Timeout: "10s",
+    KeyEncoding: "raw", ValueEncoding: "raw",
+    SchemaRegistryAware: true,
+    ValueDeserializeAs:  "JSON", // "" pass-through; "JSON" rejects non-parseable payloads
+})
+
 // java client.properties (+ p12 sidecars in TLS / mTLS modes) for the
 // Apache Kafka CLI tools — export the parent directory so the relative
 // truststore.p12 / keystore.p12 references resolve.
@@ -432,6 +448,17 @@ props := client.PropertiesFile() // *dagger.File — resolve via .Contents(ctx) 
 
 `keyEncoding` / `valueEncoding` accept `"raw"` (literal UTF-8 bytes),
 `"hex"`, or `"base64"` (standard padding). Anything else is rejected.
+
+The serde opts (`keySerializeAs` / `valueSerializeAs` on `Produce`,
+`keyDeserializeAs` / `valueDeserializeAs` on `Consume`) are wire-format
+enforcement only — they do not fetch or apply the registered schema's
+content rules. Defaults are `""` (pass-through); `"JSON"` is the only
+non-empty value accepted today. The producer side canonicalises (parse
++ re-marshal via `encoding/json`) so what hits the wire is independent
+of caller-side whitespace; the consumer side validates with
+`json.Valid` after any frame strip. Composition order is
+decode → serialize → frame on `Produce`, unframe → deserialize → encode
+on `Consume`.
 
 Topic auto-creation is disabled on the broker — call `CreateTopic` before
 `Produce` / `Consume`.

--- a/daggerverse/kafka/client.go
+++ b/daggerverse/kafka/client.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"crypto/tls"
@@ -121,14 +122,36 @@ func encodeBytes(b []byte, encoding string) (string, error) {
 // is "key" or "value" so the error message identifies which side failed.
 // Note: bare scalars (null, 42, "foo", true) are accepted — the contract is
 // "is this valid JSON?", not "is this a JSON object?".
+//
+// UseNumber preserves arbitrary-precision numeric tokens as json.Number
+// instead of float64, so integers above 2^53 and high-precision decimals
+// round-trip byte-for-byte rather than being silently coerced. Encoder
+// SetEscapeHTML(false) keeps "<", ">", and "&" in string values
+// verbatim rather than rewriting them as < / > / &, which
+// would otherwise mutate caller-supplied payloads.
 func canonicalJSON(b []byte, field string) ([]byte, error) {
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.UseNumber()
 	var v any
-	if err := json.Unmarshal(b, &v); err != nil {
+	if err := dec.Decode(&v); err != nil {
 		return nil, fmt.Errorf("%s is not valid JSON: %w", field, err)
 	}
-	out, err := json.Marshal(v)
-	if err != nil {
+	// json.Decoder accepts a stream of values — reject trailing tokens
+	// so the caller can't smuggle extra documents through the validator.
+	if dec.More() {
+		return nil, fmt.Errorf("%s has trailing data after JSON value", field)
+	}
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
 		return nil, fmt.Errorf("re-marshal %s as canonical JSON: %w", field, err)
+	}
+	// json.Encoder appends a trailing newline; strip it so the canonical
+	// form matches what json.Marshal would have produced.
+	out := buf.Bytes()
+	if n := len(out); n > 0 && out[n-1] == '\n' {
+		out = out[:n-1]
 	}
 	return out, nil
 }

--- a/daggerverse/kafka/client.go
+++ b/daggerverse/kafka/client.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -112,6 +113,56 @@ func encodeBytes(b []byte, encoding string) (string, error) {
 		return base64.StdEncoding.EncodeToString(b), nil
 	default:
 		return "", fmt.Errorf("unsupported encoding %q (want raw|hex|base64)", encoding)
+	}
+}
+
+// canonicalJSON parses b as a JSON value and returns the encoding/json
+// canonical re-marshal of it (compact, alphabetically-keyed objects). field
+// is "key" or "value" so the error message identifies which side failed.
+// Note: bare scalars (null, 42, "foo", true) are accepted — the contract is
+// "is this valid JSON?", not "is this a JSON object?".
+func canonicalJSON(b []byte, field string) ([]byte, error) {
+	var v any
+	if err := json.Unmarshal(b, &v); err != nil {
+		return nil, fmt.Errorf("%s is not valid JSON: %w", field, err)
+	}
+	out, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshal %s as canonical JSON: %w", field, err)
+	}
+	return out, nil
+}
+
+// applySerializeAs runs the named producer-side serializer. "" is
+// pass-through; "JSON" canonicalises via canonicalJSON; anything else is
+// rejected so a typo never silently degrades to pass-through.
+func applySerializeAs(b []byte, mode, field string) ([]byte, error) {
+	switch mode {
+	case "":
+		return b, nil
+	case "JSON":
+		return canonicalJSON(b, field)
+	default:
+		return nil, fmt.Errorf("unsupported %sSerializeAs %q (want \"\"|\"JSON\")", field, mode)
+	}
+}
+
+// applyDeserializeAs runs the named consumer-side deserializer against
+// payload bytes that have already had any Confluent frame stripped. "" is
+// pass-through; "JSON" validates with json.Valid. The bytes are returned
+// unchanged on success — consumers control rendering via keyEncoding /
+// valueEncoding, not via the deserialize step.
+func applyDeserializeAs(b []byte, mode, field string) ([]byte, error) {
+	switch mode {
+	case "":
+		return b, nil
+	case "JSON":
+		if !json.Valid(b) {
+			return nil, fmt.Errorf("%s is not valid JSON", field)
+		}
+		return b, nil
+	default:
+		return nil, fmt.Errorf("unsupported %sDeserializeAs %q (want \"\"|\"JSON\")", field, mode)
 	}
 }
 
@@ -372,6 +423,14 @@ func (c *Client) DeleteTopic(ctx context.Context, name string) error {
 // Schema-Registry-aware consumers expect. Default 0 means no framing
 // (the field is sent verbatim). Negative IDs are rejected.
 //
+// keySerializeAs / valueSerializeAs, when set to "JSON", parse the
+// corresponding decoded bytes with encoding/json and re-marshal to the
+// canonical form before any framing is applied. The pipeline order is
+// decode → serialize → frame, so a single call can both canonicalise a
+// JSON payload and prepend the Confluent header. Invalid JSON is
+// rejected before any broker I/O. Default "" is pass-through; "JSON"
+// is the only non-empty value accepted in this story.
+//
 // +cache="never"
 func (c *Client) Produce(
 	ctx context.Context,
@@ -386,6 +445,10 @@ func (c *Client) Produce(
 	keySchemaID int,
 	// +default=0
 	valueSchemaID int,
+	// +default=""
+	keySerializeAs string,
+	// +default=""
+	valueSerializeAs string,
 ) error {
 	if keySchemaID < 0 {
 		return fmt.Errorf("keySchemaID must be >= 0, got %d", keySchemaID)
@@ -401,6 +464,15 @@ func (c *Client) Produce(
 	valBytes, err := decodeString(value, valueEncoding)
 	if err != nil {
 		return fmt.Errorf("decode value: %w", err)
+	}
+
+	keyBytes, err = applySerializeAs(keyBytes, keySerializeAs, "key")
+	if err != nil {
+		return fmt.Errorf("serialize key: %w", err)
+	}
+	valBytes, err = applySerializeAs(valBytes, valueSerializeAs, "value")
+	if err != nil {
+		return fmt.Errorf("serialize value: %w", err)
 	}
 
 	var hdr sr.ConfluentHeader
@@ -452,6 +524,16 @@ func (c *Client) Produce(
 // zero schema ID. When false (the default), bytes are returned verbatim
 // and the schema ID fields are always zero.
 //
+// keyDeserializeAs / valueDeserializeAs, when set to "JSON", validate
+// each consumed record's post-frame-strip payload bytes via
+// encoding/json's json.Valid. The pipeline order is unframe →
+// deserialize → encode, so SchemaRegistryAware and a JSON deserializer
+// compose: framed bytes are stripped first and validation runs on the
+// payload alone. Records whose payloads fail to parse cause Consume to
+// error out and abandon the remaining poll. Default "" is
+// pass-through; "JSON" is the only non-empty value accepted in this
+// story.
+//
 // +cache="never"
 func (c *Client) Consume(
 	ctx context.Context,
@@ -468,6 +550,10 @@ func (c *Client) Consume(
 	group string,
 	// +default=false
 	schemaRegistryAware bool,
+	// +default=""
+	keyDeserializeAs string,
+	// +default=""
+	valueDeserializeAs string,
 ) ([]ConsumedRecord, error) {
 	if maxMessages <= 0 {
 		return nil, fmt.Errorf("maxMessages must be > 0, got %d", maxMessages)
@@ -527,6 +613,15 @@ func (c *Client) Consume(
 				if id, payload, err := hdr.DecodeID(valRaw); err == nil {
 					valID, valRaw = id, payload
 				}
+			}
+			var err error
+			keyRaw, err = applyDeserializeAs(keyRaw, keyDeserializeAs, "key")
+			if err != nil {
+				return nil, fmt.Errorf("deserialize key: %w", err)
+			}
+			valRaw, err = applyDeserializeAs(valRaw, valueDeserializeAs, "value")
+			if err != nil {
+				return nil, fmt.Errorf("deserialize value: %w", err)
 			}
 			keyStr, err := encodeBytes(keyRaw, keyEncoding)
 			if err != nil {

--- a/daggerverse/kafka/tests/main.go
+++ b/daggerverse/kafka/tests/main.go
@@ -155,6 +155,12 @@ func (t *Tests) schemaRegistryTests(ctx context.Context, kafkaImageTag string, p
 	jobs = jobs.WithJob("SchemaRegistryPlaintextConsumeUnframed", func(ctx context.Context) error {
 		return t.SchemaRegistryPlaintextConsumeUnframed(ctx, kafkaImageTag)
 	})
+	jobs = jobs.WithJob("SchemaRegistryJSONSerializeRejectsMalformedInput", func(ctx context.Context) error {
+		return t.SchemaRegistryJSONSerializeRejectsMalformedInput(ctx)
+	})
+	jobs = jobs.WithJob("SchemaRegistryJSONFramedProduceConsumeRoundTrip", func(ctx context.Context) error {
+		return t.SchemaRegistryJSONFramedProduceConsumeRoundTrip(ctx, kafkaImageTag)
+	})
 
 	return jobs.Run(ctx)
 }

--- a/daggerverse/kafka/tests/tests_schema_registry.go
+++ b/daggerverse/kafka/tests/tests_schema_registry.go
@@ -588,3 +588,130 @@ func (t *Tests) SchemaRegistryRejectsNonPlaintextCluster(
 	}
 	return nil
 }
+
+// SchemaRegistryJSONSerializeRejectsMalformedInput pins the up-front
+// validation contract of valueSerializeAs="JSON": Produce must reject a
+// malformed JSON payload before any broker I/O. dag.Kafka().Client(...)
+// builds without I/O, so no cluster boots — the failure is purely a
+// payload-validation failure on the canonicalising serializer.
+func (t *Tests) SchemaRegistryJSONSerializeRejectsMalformedInput(
+	ctx context.Context,
+) error {
+	client := dag.Kafka().Client(
+		[]string{"127.0.0.1:1"},
+		dag.Kafka().PlaintextClientSecurity(),
+	)
+	err := client.Produce(ctx, "any-topic", "k", "{not-json", dagger.KafkaClientProduceOpts{
+		KeyEncoding:      "raw",
+		ValueEncoding:    "raw",
+		ValueSerializeAs: "JSON",
+	})
+	if err == nil {
+		return fmt.Errorf("expected Produce to reject malformed JSON value, got nil error")
+	}
+	if !strings.Contains(err.Error(), "value is not valid JSON") {
+		return fmt.Errorf("expected error to mention JSON validation failure, got: %v", err)
+	}
+	return nil
+}
+
+// SchemaRegistryJSONFramedProduceConsumeRoundTrip composes the framing
+// primitive (valueSchemaID) with the JSON serde (valueSerializeAs /
+// valueDeserializeAs). A JSON document is registered as a JSON-schema-typed
+// subject, produced with both opts on, then consumed with both opts on; the
+// asserted invariant is byte-equality of the consumed value to the canonical
+// JSON form of the original input — proving frame strip and JSON validation
+// compose without corrupting the payload.
+func (t *Tests) SchemaRegistryJSONFramedProduceConsumeRoundTrip(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, err := freshCluster(ctx, kafkaImageTag)
+	if err != nil {
+		return fmt.Errorf("create cluster: %w", err)
+	}
+	defer cluster.Stop(ctx)
+
+	sr := dag.Kafka().ConfluentSchemaRegistry(cluster)
+	defer sr.Stop(ctx)
+
+	subject, err := randomTopicName(ctx)
+	if err != nil {
+		return err
+	}
+	topic := subject
+	subject += "-value"
+
+	const jsonSchema = `{"type":"object","properties":{"x":{"type":"string"}},"required":["x"]}`
+	id, err := sr.Client().RegisterSchema(ctx, subject, jsonSchema, dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{
+		SchemaType: "JSON",
+	})
+	if err != nil {
+		return fmt.Errorf("register schema: %w", err)
+	}
+	if id <= 0 {
+		return fmt.Errorf("expected a positive schema id, got %d", id)
+	}
+
+	client := cluster.Client(dag.Kafka().PlaintextClientSecurity())
+	if err := client.CreateTopic(ctx, topic, dagger.KafkaClientCreateTopicOpts{
+		Partitions:        1,
+		ReplicationFactor: 1,
+	}); err != nil {
+		return fmt.Errorf("create topic %q: %w", topic, err)
+	}
+
+	// Whitespace and extra spacing chosen so canonicalisation visibly
+	// changes the bytes — catches a regression where Produce skips
+	// re-marshal and only does json.Valid.
+	const inputJSON = `{ "x" :  "hello-world" }`
+	const wantCanonical = `{"x":"hello-world"}`
+	const wantKey = "k"
+
+	if err := client.Produce(ctx, topic, wantKey, inputJSON, dagger.KafkaClientProduceOpts{
+		KeyEncoding:      "raw",
+		ValueEncoding:    "raw",
+		ValueSchemaID:    id,
+		ValueSerializeAs: "JSON",
+	}); err != nil {
+		return fmt.Errorf("produce: %w", err)
+	}
+
+	records, err := client.Consume(ctx, topic, dagger.KafkaClientConsumeOpts{
+		MaxMessages:         1,
+		Timeout:             "10s",
+		KeyEncoding:         "raw",
+		ValueEncoding:       "raw",
+		SchemaRegistryAware: true,
+		ValueDeserializeAs:  "JSON",
+	})
+	if err != nil {
+		return fmt.Errorf("consume: %w", err)
+	}
+	if len(records) != 1 {
+		return fmt.Errorf("expected 1 record, got %d", len(records))
+	}
+	gotKey, err := records[0].Key(ctx)
+	if err != nil {
+		return fmt.Errorf("read key: %w", err)
+	}
+	gotVal, err := records[0].Value(ctx)
+	if err != nil {
+		return fmt.Errorf("read value: %w", err)
+	}
+	gotValID, err := records[0].ValueSchemaID(ctx)
+	if err != nil {
+		return fmt.Errorf("read value schema id: %w", err)
+	}
+	if gotKey != wantKey {
+		return fmt.Errorf("key mismatch: want %q, got %q", wantKey, gotKey)
+	}
+	if gotVal != wantCanonical {
+		return fmt.Errorf("value mismatch: want canonical %q, got %q", wantCanonical, gotVal)
+	}
+	if gotValID != id {
+		return fmt.Errorf("value schema id mismatch: want %d, got %d", id, gotValID)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- Adds `keySerializeAs` / `valueSerializeAs` to `*Client.Produce` and `keyDeserializeAs` / `valueDeserializeAs` to `*Client.Consume`. `"JSON"` is the only non-empty value accepted; default `""` is pass-through.
- Produce canonicalises via `encoding/json` (parse + re-marshal) before framing — invalid JSON is rejected before any broker I/O. Consume validates via `json.Valid` after frame strip.
- Composes with the existing `valueSchemaID` / `schemaRegistryAware` opts so a single call can both frame and validate. No new dependencies — `encoding/json` only.

Closes #73.

## Test plan
- [x] `dagger develop` in `daggerverse/kafka/` and `daggerverse/kafka/tests/`
- [x] `dagger -m daggerverse/kafka/tests call schema-registry-jsonserialize-rejects-malformed-input` (negative, no broker — 13s)
- [x] `dagger -m daggerverse/kafka/tests call schema-registry-jsonframed-produce-consume-round-trip --kafka-image-tag=4.2.0` (SR+JSON round-trip, asserts byte-equality against canonical form — 23s)
- [ ] `dagger -m daggerverse/kafka/tests call all --parallel=4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)