### PR TITLE
story(issue-82): add docs/dagger-internals engine internals reference

### DIFF
--- a/docs/dagger-internals/README.md
+++ b/docs/dagger-internals/README.md
@@ -55,5 +55,11 @@ made explicit rather than glossed over.
   — there is one flat network, scoped by DNS).
 - **[container-execution.md](./container-execution.md)** — what a
   container exec does inside the engine, how it maps onto BuildKit LLB,
-  what it costs in CPU/memory/disk, the caching and prune/GC model, and
-  what all of that means for this repo's CI.
+  what it costs in CPU/memory/disk, and what all of that means for this
+  repo's CI.
+- **[caching-and-evaluation.md](./caching-and-evaluation.md)** — when a
+  pipeline actually runs (terminal vs. non-terminal selections, parallel
+  branch resolution) and the two caches that decide whether work
+  repeats: the dagql per-session call cache and the BuildKit
+  content-addressed operation cache, plus cache mounts and the prune/GC
+  story for disk reclamation.

--- a/docs/dagger-internals/README.md
+++ b/docs/dagger-internals/README.md
@@ -1,0 +1,59 @@
+# Dagger engine internals
+
+[docs.dagger.io](https://docs.dagger.io/) documents Dagger's public API
+well, but it has no pages explaining the engine's *under-the-hood*
+behavior. As this repo's `daggerverse/` modules have grown —
+cross-module type passing, service networking, container-heavy CI test
+suites — we keep running into questions whose answers are not written
+down anywhere official, and re-deriving them the hard way.
+
+These pages capture that research as reviewable, in-repo reference
+documentation. They are written for a contributor who already knows how
+to *use* Dagger but needs to reason about how it actually works.
+
+## Engine version
+
+All research here is pinned to the Dagger engine version this repo
+currently uses — **`v0.20.8`** (see the `engineVersion` field in the
+root `dagger.json` and every per-module `dagger.json`).
+
+Source citations point at the `dagger/dagger` repository at the commit
+the `v0.20.8` tag resolves to:
+[`74bff7d10fd78dd6935c60c4514558598f216451`](https://github.com/dagger/dagger/tree/74bff7d10fd78dd6935c60c4514558598f216451).
+Engine internals drift between releases — treat these pages as accurate
+for `v0.20.8` and re-verify against source before assuming they hold on
+a newer engine.
+
+## How to read these docs — the sourcing rule
+
+Every non-trivial claim in these pages is **either**:
+
+- **(a) source-backed** — cited with a permalink to a specific
+  file/line in `dagger/dagger`, pinned to commit `74bff7d…` (a tag or
+  commit, never `main`); **or**
+- **(b) experiment-backed** — substantiated by a reproducible
+  experiment, with the exact `dagger` command **and** its observed
+  output included inline.
+
+Experiments are self-contained and re-runnable by a reader: they rely
+on no local-only state, and where an experiment needs a scratch
+module or container the page includes the minimal setup steps.
+
+Each page ends with an **"Open questions / unverified"** section listing
+anything that could not be confirmed by source or experiment — gaps are
+made explicit rather than glossed over.
+
+## Pages
+
+- **[module-importing.md](./module-importing.md)** — how a module
+  declares, loads, and consumes another module; why types can be shared
+  across SDKs through the GraphQL boundary but native language types
+  cannot cross a module boundary.
+- **[networking.md](./networking.md)** — the service/networking model;
+  whether services and ports are scoped or global (per session); and
+  whether containers can be placed into isolated networks (they cannot
+  — there is one flat network, scoped by DNS).
+- **[container-execution.md](./container-execution.md)** — what a
+  container exec does inside the engine, how it maps onto BuildKit LLB,
+  what it costs in CPU/memory/disk, the caching and prune/GC model, and
+  what all of that means for this repo's CI.

--- a/docs/dagger-internals/caching-and-evaluation.md
+++ b/docs/dagger-internals/caching-and-evaluation.md
@@ -1,0 +1,432 @@
+# Caching and lazy evaluation
+
+When a Dagger pipeline actually *runs* — and whether the engine runs it
+at all, or returns a cached result — is two questions answered by the
+same machinery. This page documents that machinery: the build graph,
+when terminal selections force resolution, and the two caches (dagql
+per-session and BuildKit content-addressed) that decide whether work
+repeats.
+
+> Engine version: `v0.20.8`. Source permalinks are pinned to
+> `dagger/dagger` commit
+> [`74bff7d`](https://github.com/dagger/dagger/tree/74bff7d10fd78dd6935c60c4514558598f216451).
+> See [README.md](./README.md) for the sourcing rule.
+
+## The build graph (dagql)
+
+Every call on a `Container`, `Directory`, `File`, `Service` — core *or*
+module-defined — is a node in the dagql call graph. The engine identifies
+each node by a `call.ID`: the receiver chain plus the field name and
+arguments. Two nodes with the same ID are, by construction, the same
+node. dagql digests the ID into a content-addressed key —
+[`dagql/session_cache.go` L120](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/dagql/session_cache.go#L120):
+
+```go
+callKey := key.ID.Digest().String()
+```
+
+The graph is **constructed lazily**. Calling `WithExec`, `From`,
+`WithFile`, … on the SDK client appends to the receiver's ID without
+contacting the engine; only when the consumer asks for a value the SDK
+cannot synthesize locally does a GraphQL query go to the engine. That is
+the distinction between non-terminal and terminal selections, below.
+
+### What forces evaluation: terminal selections
+
+A selection that returns a graph-node type (`Container!`, `Directory!`,
+`Service!`, …) is non-terminal — the engine only needs to confirm the
+node is well-typed and hand the consumer the chained ID. A selection
+that returns a scalar (`String`, `Int`, an ID), a host-side effect
+(`export`), or that asks explicitly for resolution (`sync`) is terminal:
+the engine has to actually run the chain to produce a value.
+
+The clearest example is `sync` itself. Its resolver is registered with
+the `Syncer` helper —
+[`core/schema/util.go` L9-L17](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/schema/util.go#L9-L17):
+
+```go
+func Syncer[T core.Evaluatable]() dagql.Field[T] {
+    return dagql.NodeFunc("sync", func(ctx context.Context, self dagql.ObjectResult[T], _ struct{}) (res dagql.Result[dagql.ID[T]], _ error) {
+        _, err := self.Self().Evaluate(ctx)
+        if err != nil {
+            return res, err
+        }
+        id := dagql.NewID[T](self.ID())
+        return dagql.NewResultForCurrentID(ctx, id)
+    })
+}
+```
+
+It calls `Evaluate(ctx)` on anything implementing `core.Evaluatable`,
+then returns the resolved ID. For `Container`, `Evaluate` marshals the
+accumulated LLB into a definition and asks BuildKit to solve it with
+`Evaluate: true` —
+[`core/container.go` L2359-L2391](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/container.go#L2359-L2391):
+
+```go
+return bk.Solve(ctx, bkgw.SolveRequest{
+    Evaluate:   true,
+    Definition: def.ToPB(),
+})
+```
+
+`stdout`, `stderr`, `exitCode`, and `export` are similarly terminal:
+each requires the exec to have run (they read from the meta mount or
+write to a host path).
+
+**Experiment — `id` does not run the exec, `stdout` does.** The same
+chain is queried two ways. With `id`, the request just returns the
+serialized call ID; with `stdout`, the engine has to evaluate the chain.
+A side-effecting exec makes the difference visible: it writes
+`SIDE-EFFECT` to stderr if and only if it actually runs.
+
+```
+$ echo '{ container { from(address:"alpine:3") {
+            withExec(args:["sh","-c","echo SIDE-EFFECT >&2; date"]) { id }
+          } } }' | dagger --progress=plain query
+12 : withExec sh -c 'echo SIDE-EFFECT >&2; date'
+12 : Container.withExec DONE [0.0s]
+{ "container": { "from": { "withExec": { "id": "ChV4eGgz…" } } } }
+
+$ echo '{ container { from(address:"alpine:3") {
+            withExec(args:["sh","-c","echo SIDE-EFFECT >&2; date"]) { stdout }
+          } } }' | dagger --progress=plain query
+12 : withExec sh -c 'echo SIDE-EFFECT >&2; date'
+12 : [0.1s] | SIDE-EFFECT
+12 : [0.1s] | Sat May 23 00:58:06 UTC 2026
+12 : Container.withExec DONE [0.3s]
+{ "container": { "from": { "withExec": { "stdout": "Sat May 23 00:58:06 UTC 2026\n" } } } }
+```
+
+With `id`: no `SIDE-EFFECT`, no date, `DONE [0.0s]` — the dagql node
+resolved (the chain is well-typed) but the exec did not run. With
+`stdout`: the exec ran, the side-effect printed, and the chain took
+0.3s. "`Container.withExec DONE`" in the progress stream is dagql
+saying *the field resolved*, not *the work happened*.
+
+### Parallel branches resolve concurrently
+
+Within a single query, independent selections at the same level resolve
+in parallel —
+[`dagql/server.go` `Resolve` L563-L596](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/dagql/server.go#L563-L596):
+
+```go
+// Resolve resolves the given selections on the given object.
+// Each selection is resolved in parallel ...
+...
+pool := pool.New().WithErrors()
+for _, sel := range sels {
+    pool.Go(func() error {
+        res, err := s.resolvePath(ctx, self, sel)
+        ...
+    })
+}
+```
+
+A single-selection fast path skips the goroutine setup; multi-selection
+queries fan out over a `conc/pool` worker pool. Concurrency below that
+is bounded by the BuildKit `parallelismSem`
+([container-execution.md → Concurrency](./container-execution.md#concurrency-and-this-repos-ci)).
+
+**Experiment — two independent branches run in parallel.** Two
+top-level aliases each sleep for 3s and exit. If they serialized, the
+query would take ~6s; if they run concurrently, ~3s.
+
+```
+$ time dagger --progress=plain query <<'EOF'
+{
+  slow1: container { from(address:"alpine:3") {
+           withExec(args:["sh","-c","sleep 3; echo branch-1-done"]) { stdout } } }
+  slow2: container { from(address:"alpine:3") {
+           withExec(args:["sh","-c","sleep 3; echo branch-2-done"]) { stdout } } }
+}
+EOF
+14 : Container.stdout DONE [3.4s]
+15 : Container.stdout DONE [3.4s]
+…
+real    0m4.242s
+```
+
+Wall time 4.2s with two 3.4s branches — they overlapped almost
+completely. Both branches' `stdout` selections triggered Solve at the
+same time; the BuildKit worker ran them as two `runc` children inside
+the engine container.
+
+## Cache 1 — the dagql session cache
+
+The first cache layer is in-memory and per-session. The `SessionCache`
+wraps the inner dagql `Cache` and tracks every result the session has
+acquired so they can be released at session end —
+[`dagql/session_cache.go` L9-L24](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/dagql/session_cache.go#L9-L24):
+
+```go
+type SessionCache struct {
+    cache Cache
+
+    results          []AnyResult
+    arbitraryResults []ArbitraryCachedResult
+    mu               sync.Mutex
+
+    // isClosed is set to true when ReleaseAndClose is called.
+    // Any in-progress results will be released and errors returned.
+    isClosed bool
+
+    seenKeys sync.Map
+    ...
+}
+```
+
+Lookup is keyed by the call ID's digest —
+[L93-L148](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/dagql/session_cache.go#L93-L148):
+
+```go
+callKey := key.ID.Digest().String()
+...
+res, err = c.cache.GetOrInitCall(ctx, key, fn)
+```
+
+The underlying `Cache` keeps two maps —
+[`dagql/cache.go` L247-L255](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/dagql/cache.go#L247-L255):
+
+```go
+// calls that are in progress, keyed by a combination of the call key and the concurrency key
+ongoingCalls map[callConcurrencyKeys]*sharedResult
+// calls that have completed successfully and are cached, keyed by the storage key
+completedCalls map[string]*resultList
+```
+
+`GetOrInitCall` consults both: a completed call returns its cached
+result, an in-progress call has the second caller wait on the first
+(`sharedResult`), and a miss runs `fn` and stores the result. The
+practical effect: **two requests with the same ID digest, within the
+same session, evaluate at most once.** When the session ends,
+`ReleaseAndClose`
+([L235-L257](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/dagql/session_cache.go#L235-L257))
+walks `results` and calls `Release` on each — nothing in this cache
+outlives the `dagger` invocation.
+
+**Experiment — same call selected twice in one query runs once.** Two
+top-level aliases name the same content-addressed exec (a `cat` of
+`/proc/sys/kernel/random/uuid`, which prints a fresh UUID per run):
+
+```
+$ dagger --progress=plain query <<'EOF'
+{
+  a: container { from(address:"alpine:3") {
+       withExec(args:["sh","-c","cat /proc/sys/kernel/random/uuid"]) { stdout } } }
+  b: container { from(address:"alpine:3") {
+       withExec(args:["sh","-c","cat /proc/sys/kernel/random/uuid"]) { stdout } } }
+}
+EOF
+12 : withExec sh -c 'cat /proc/sys/kernel/random/uuid'
+12 : [0.1s] | e9b29e9b-c989-4bd4-838f-7c1bdb1ece35
+12 : Container.withExec DONE [0.3s]
+{
+  "a": { "from": { "withExec": { "stdout": "e9b29e9b-c989-4bd4-838f-7c1bdb1ece35\n" } } },
+  "b": { "from": { "withExec": { "stdout": "e9b29e9b-c989-4bd4-838f-7c1bdb1ece35\n" } } }
+}
+```
+
+The exec line appears once in the progress stream; both `a` and `b`
+return the *same* UUID. Two top-level selections collapsed to one
+resolution — the second `GetOrInitCall` found the first call already
+in `completedCalls` and returned its result.
+
+This is the same mechanism behind service deduplication described in
+[networking.md → Service & port scoping](./networking.md#service--port-scoping)
+(`ServiceKey` carries the session ID; same digest in one session →
+same `RunningService`) and behind the kafka test suite's shared cluster
+pointer pattern ([container-execution.md → Concurrency](./container-execution.md#concurrency-and-this-repos-ci)).
+
+## Cache 2 — the BuildKit operation cache
+
+The second cache layer is on-disk and persistent across sessions. It is
+BuildKit's, not dagql's. The unit is the LLB op: each `WithExec`,
+`WithMountedFile`, image pull, etc. lowers to an LLB vertex, and before
+running a vertex the solver asks for its **cache map** — a
+content-addressed key over the op and its inputs.
+
+Dagger wraps every op's `CacheMap` to inject client metadata —
+[`engine/buildkit/op.go` `CacheMap` L95-L111](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/engine/buildkit/op.go#L95-L111):
+
+```go
+func (op *CustomOpWrapper) CacheMap(ctx context.Context, g bksession.Group, index int) (*solver.CacheMap, bool, error) {
+    cm, ok, err := op.original.CacheMap(ctx, g, index)
+    if cm == nil || !ok || err != nil {
+        return cm, ok, err
+    }
+    ...
+    cm, err = op.Backend.CacheMap(ctx, cm)
+    ...
+}
+```
+
+If a result already exists for that cache key, the op is skipped
+entirely — the solver returns the cached snapshot to the requester.
+Unlike the dagql session cache this lives in the engine's local cache
+on disk, so a re-run **in a separate `dagger` invocation** still hits
+it.
+
+**Experiment — an identical exec is cached across invocations.** Two
+separate `dagger` invocations run the same UUID-printing exec:
+
+```
+$ dagger --progress=plain -c 'container | from alpine:3 |
+        with-exec cat,/proc/sys/kernel/random/uuid | stdout'
+14 : [0.2s] | 4d2eb92b-a3e2-4624-825f-c191d13ad2c4
+…
+4d2eb92b-a3e2-4624-825f-c191d13ad2c4
+
+$ # second, completely separate invocation:
+$ dagger --progress=plain -c 'container | from alpine:3 |
+        with-exec cat,/proc/sys/kernel/random/uuid | stdout'
+14 : Container.withExec CACHED [0.0s]
+…
+4d2eb92b-a3e2-4624-825f-c191d13ad2c4
+```
+
+`CACHED` and the identical UUID prove the second invocation did not
+re-run the exec — the engine returned the snapshot from disk. Pulled
+base-image layers (`from`) are cached the same way and tend to dominate
+the cache when this happens at scale.
+
+### Cache mounts
+
+A cache mount (`withMountedCache`) is a *mutable* directory that is
+**deliberately excluded** from the content-addressed result — it
+persists across execs and across `dagger` invocations, scoped by a
+cache-volume key. It is the escape hatch for things you want to reuse
+but not bake into the immutable result (package caches, build caches).
+
+**Experiment — a cache mount survives across separate invocations.**
+
+```
+$ dagger -c 'container | from alpine:3 |
+             with-mounted-cache /data $(cache-volume devex-exec-demo) |
+             with-exec touch /data/written-by-run-1 |
+             with-exec ls /data | stdout'
+written-by-run-1
+
+$ # a separate dagger invocation, same cache-volume key, no touch:
+$ dagger -c 'container | from alpine:3 |
+             with-mounted-cache /data $(cache-volume devex-exec-demo) |
+             with-exec ls /data | stdout'
+written-by-run-1
+```
+
+The file written by the first invocation is still present in the
+second — the cache volume is shared engine state, not part of any
+container's snapshot.
+
+### Prune and GC — reclaiming disk
+
+Cached snapshots accumulate. The engine exposes its on-disk cache and a
+garbage-collection policy through `dagger core engine local-cache`.
+
+**Experiment — the GC policy.** Each policy field is a queryable value
+(bytes; the CLI prints them in scientific notation):
+
+```
+$ dagger core engine local-cache max-used-space    # max bytes kept before pruning
+6.98e+11                                           # ~698 GB
+
+$ dagger core engine local-cache reserved-space    # min bytes always retained
+1e+10                                              # ~10 GB
+
+$ dagger core engine local-cache min-free-space    # free-space target for GC
+1.86e+11                                           # ~186 GB
+
+$ dagger core engine local-cache target-space
+0
+```
+
+**Experiment — the live cache.** `entry-set` reports what is currently
+cached on disk:
+
+```
+$ dagger core engine local-cache entry-set entry-count
+180379
+$ dagger core engine local-cache entry-set disk-space-bytes
+3.3531539275e+10                                    # ~33.5 GB
+```
+
+**Experiment — the prune command.** `prune` runs the GC pass on demand
+and accepts overrides so a reader can prune harder or softer than the
+standing policy:
+
+```
+$ dagger core engine local-cache prune --help
+Prune the cache of releaseable entries
+
+USAGE
+  dagger core engine local-cache prune [arguments]
+
+ARGUMENTS
+      --max-used-space string   Override the maximum disk space to keep
+                                before pruning (e.g. "200GB" or "80%").
+      --min-free-space string   Override the minimum free disk space
+                                target during pruning (e.g. "20GB" or "20%").
+      --reserved-space string   Override the minimum disk space to retain
+                                during pruning (e.g. "500GB" or "10%").
+```
+
+`prune` only releases entries that are not pinned by something still in
+use — cache mounts and in-use snapshots survive. Run with no arguments
+it applies the standing policy (the `*-space` values above); the
+override flags let CI reclaim disk more aggressively on demand.
+
+## How the two caches stack
+
+A terminal selection on a chain hits both caches in order:
+
+1. **dagql session cache** (`SessionCache.GetOrInitCall`,
+   [L93](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/dagql/session_cache.go#L93)).
+   Keyed by `call.ID.Digest()`. Hit → return the cached `AnyResult`
+   without touching BuildKit at all. Miss → run the resolver `fn`.
+2. **BuildKit op cache** (`CacheMap` per LLB vertex,
+   [`engine/buildkit/op.go` L95](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/engine/buildkit/op.go#L95)).
+   Keyed by op + inputs. Hit → return the cached snapshot. Miss → run
+   the executor.
+
+The two layers answer two different questions. The dagql layer makes
+intra-session reuse free: a service started twice in one session, an
+ID materialized twice in one query, a `Sync()` called twice on the same
+container — none of these issue duplicate BuildKit solves. The BuildKit
+layer makes cross-session reuse possible: rerunning the same pipeline
+in a fresh CI job or after a `dagger` restart skips work that the engine
+already has snapshots for.
+
+`DoNotCache: true` on a `CacheKey`
+([L33-L43](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/dagql/cache.go#L33-L43))
+bypasses the dagql layer for a specific call; `dagger up` uses this so
+its blocking foreground process is never collapsed into a prior result.
+There is no equivalent generic switch for the BuildKit layer — cache
+busting is done by changing the content of an op (a `WithEnvVariable`
+of a unique value, a non-cacheable upstream input, …), since both
+layers are content-addressed.
+
+## Open questions / unverified
+
+- **Concurrency-key semantics.** `CacheKey.ConcurrencyKey`
+  ([L33-L43](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/dagql/cache.go#L33-L43))
+  controls in-progress dedup specifically; how this differs in practice
+  from result-key dedup, and which callers set it to a non-empty value,
+  was not traced.
+- **TTL semantics.** `CacheKey.TTL` exists on the cache key; whether
+  anything in the engine's standing schema actually sets a non-zero TTL
+  (or whether it is a hook for SDKs / modules) was not verified.
+- **dagql cache hit on a re-issued query in a new session.** The
+  session cache is released at session end (`ReleaseAndClose`); whether
+  any portion is also persisted to the sqlite DB referenced by
+  `NewCache(ctx, dbPath)` ([`dagql/cache.go` L91](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/dagql/cache.go#L91))
+  and survives, vs. the DB being used only for in-process bookkeeping,
+  was not investigated.
+- **`Resolve` parallelism cap.** The selection-resolver `pool.New()`
+  ([`dagql/server.go` L585](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/dagql/server.go#L585))
+  is unbounded at the dagql layer; BuildKit's `parallelismSem` is the
+  real cap. Whether a deeply branching query can starve the engine
+  before BuildKit's semaphore engages was not measured.
+- **Per-exec cache-mount serialization.** Whether two concurrent execs
+  sharing one cache volume serialize on it or race was not tested
+  (carried over from
+  [container-execution.md → Open questions](./container-execution.md#open-questions--unverified)).

--- a/docs/dagger-internals/container-execution.md
+++ b/docs/dagger-internals/container-execution.md
@@ -111,119 +111,17 @@ The practical consequences:
 
 ## The caching model
 
-### Operation cache
-
-The unit of caching is the LLB operation. Before executing a vertex the
-solver computes a **cache map** — a content-addressed key over the op
-and its inputs —
-[`engine/buildkit/op.go` `CacheMap` L103-L120](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/engine/buildkit/op.go#L103-L120).
-If a result already exists for that key, the op is skipped entirely.
-
-**Experiment — an exec is cached by its inputs, not re-run.** Running
-the *same* exec twice: `date` would print a different time if it
-actually ran, but the second run returns the first run's output:
-
-```
-$ dagger --progress=plain -c 'container | from alpine:3 | with-exec date | stdout'
-24 : withExec date
-24 : [0.1s] | Thu May 21 22:30:45 UTC 2026
-24 : Container.withExec DONE [0.2s]
-Thu May 21 22:30:45 UTC 2026
-
-$ # identical command again:
-24 : withExec date
-24 : Container.withExec CACHED [0.0s]
-Thu May 21 22:30:45 UTC 2026
-```
-
-`CACHED` and the *identical* timestamp prove the second exec did not
-run — the engine returned the cached snapshot. Pulled base-image layers
-(`from`) are cached the same way.
-
-### Cache mounts
-
-A cache mount (`withMountedCache`) is a *mutable* directory that is
-**deliberately excluded** from the content-addressed result — it
-persists across execs and across `dagger` invocations, scoped by a
-cache-volume key. It is the escape hatch for things you want to reuse
-but not bake into the immutable result (package caches, build caches).
-
-**Experiment — a cache mount survives across separate invocations.**
-
-```
-$ dagger -c 'container | from alpine:3 |
-             with-mounted-cache /data $(cache-volume devex-exec-demo) |
-             with-exec touch /data/written-by-run-1 |
-             with-exec ls /data | stdout'
-written-by-run-1
-
-$ # a separate dagger invocation, same cache-volume key, no touch:
-$ dagger -c 'container | from alpine:3 |
-             with-mounted-cache /data $(cache-volume devex-exec-demo) |
-             with-exec ls /data | stdout'
-written-by-run-1
-```
-
-The file written by the first invocation is still present in the
-second — the cache volume is shared engine state, not part of any
-container's snapshot.
-
-### Prune and GC — reclaiming disk
-
-Cached snapshots accumulate. The engine exposes its on-disk cache and a
-garbage-collection policy through `dagger core engine local-cache`.
-
-**Experiment — the GC policy.** Each policy field is a queryable value
-(bytes; the CLI prints them in scientific notation):
-
-```
-$ dagger core engine local-cache max-used-space    # max bytes kept before pruning
-6.98e+11                                           # ~698 GB
-
-$ dagger core engine local-cache reserved-space    # min bytes always retained
-1e+10                                              # ~10 GB
-
-$ dagger core engine local-cache min-free-space    # free-space target for GC
-1.86e+11                                           # ~186 GB
-
-$ dagger core engine local-cache target-space
-0
-```
-
-**Experiment — the live cache.** `entry-set` reports what is currently
-cached on disk:
-
-```
-$ dagger core engine local-cache entry-set entry-count
-180379
-$ dagger core engine local-cache entry-set disk-space-bytes
-3.3531539275e+10                                    # ~33.5 GB
-```
-
-**Experiment — the prune command.** `prune` runs the GC pass on demand
-and accepts overrides so a reader can prune harder or softer than the
-standing policy:
-
-```
-$ dagger core engine local-cache prune --help
-Prune the cache of releaseable entries
-
-USAGE
-  dagger core engine local-cache prune [arguments]
-
-ARGUMENTS
-      --max-used-space string   Override the maximum disk space to keep
-                                before pruning (e.g. "200GB" or "80%").
-      --min-free-space string   Override the minimum free disk space
-                                target during pruning (e.g. "20GB" or "20%").
-      --reserved-space string   Override the minimum disk space to retain
-                                during pruning (e.g. "500GB" or "10%").
-```
-
-`prune` only releases entries that are not pinned by something still in
-use — cache mounts and in-use snapshots survive. Run with no arguments
-it applies the standing policy (the `*-space` values above); the
-override flags let CI reclaim disk more aggressively on demand.
+The cache story has its own page —
+[caching-and-evaluation.md](./caching-and-evaluation.md) — covering both
+the dagql per-session call cache and the BuildKit operation cache that
+makes exec results survive across `dagger` invocations, along with cache
+mounts and the prune/GC story for disk reclamation. The short version
+for this page: an exec is cached by a content-addressed key over the op
+and its inputs
+([`engine/buildkit/op.go` `CacheMap` L95-L111](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/engine/buildkit/op.go#L95-L111)),
+the snapshot is retained in the engine's local cache after the exec
+finishes, and that snapshot — not a re-run — is what a later identical
+exec gets back.
 
 ## Concurrency and this repo's CI
 
@@ -285,16 +183,8 @@ Practical guidance that follows from the resource model:
 - **`parallelismSem` default.** The semaphore exists and is engine-wide;
   its default weight / how it is configured was not traced to a config
   value.
-- **GC policy origin.** The `max-used-space` / `reserved-space` /
-  `min-free-space` numbers above are this engine's live values; whether
-  they are hard defaults or derived from host disk size at engine
-  startup was not verified.
-- **`target-space` meaning.** `target-space` reported `0`; its exact
-  role relative to `max-used-space` was not determined from source.
-- **Prune reclaim figure.** A full `dagger core engine local-cache
-  prune` over this engine's live cache (~180k entries / ~33.5 GB) did
-  not complete within a bounded time on the test machine, so a concrete
-  before/after reclaimed-bytes number is not captured here — only the
-  pre-prune `entry-set` and the `prune` command surface are shown.
-- **Cache-mount concurrency.** Whether two concurrent execs sharing one
-  cache volume serialize or race on it was not tested.
+
+Cache- and GC-related open questions (`target-space` semantics, GC
+policy origin, prune reclaim figures, cache-mount concurrency) live with
+the cache documentation in
+[caching-and-evaluation.md → Open questions](./caching-and-evaluation.md#open-questions--unverified).

--- a/docs/dagger-internals/container-execution.md
+++ b/docs/dagger-internals/container-execution.md
@@ -1,0 +1,300 @@
+# Container execution
+
+What a container exec actually does inside the Dagger engine, what it
+costs, how caching changes that cost, and what it means for this repo's
+container-heavy CI.
+
+> Engine version: `v0.20.8`. Source permalinks are pinned to
+> `dagger/dagger` commit
+> [`74bff7d`](https://github.com/dagger/dagger/tree/74bff7d10fd78dd6935c60c4514558598f216451).
+> See [README.md](./README.md) for the sourcing rule.
+
+## What `WithExec` does
+
+`WithExec` does not run anything by itself — it appends a step to a
+build graph. The actual execution happens when the resulting container
+(or something derived from it, like `.stdout`) is evaluated.
+
+`Container.WithExec` —
+[`core/container_exec.go` L216-L582](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/container_exec.go#L216-L582)
+— assembles the pieces of one execution:
+
+1. **Process spec.** `metaSpec` builds an `executor.Meta` — args, env,
+   cwd, user, expected exit codes —
+   [L167-L201](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/container_exec.go#L167-L201).
+2. **Mounts.** `bkcontainer.PrepareMounts` turns the container rootfs,
+   bind mounts, cache mounts, tmpfs, and secret mounts into a BuildKit
+   mount set —
+   [L272-L279](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/container_exec.go#L272-L279).
+3. **Secrets / services.** Secret env vars are resolved
+   ([L459-L463](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/container_exec.go#L459-L463))
+   and any bound services are started first
+   ([L469](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/container_exec.go#L469)).
+4. **Run.** It gets the BuildKit worker's executor and runs the process
+   against the prepared rootfs and mounts —
+   [L475-L483](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/container_exec.go#L475-L483):
+   ```go
+   worker := opt.Worker.(*buildkit.Worker)
+   worker = worker.ExecWorker(opt.CauseCtx, *execMD)
+   exec := worker.Executor()
+   procInfo := executor.ProcessInfo{Meta: meta}
+   _, execErr := exec.Run(ctx, "", p.Root, p.Mounts, procInfo, nil)
+   ```
+5. **Commit outputs.** The mutable result refs are committed back into
+   the container's filesystem and mounts
+   ([L485-L572](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/container_exec.go#L485-L572)).
+
+### Mapping onto BuildKit LLB
+
+The chain `WithExec` builds is BuildKit **LLB** (low-level build
+definition). Each exec becomes an LLB `ExecOp` vertex in the solver
+graph. When the solver resolves a vertex, Dagger's custom worker
+recognizes the exec op and wires itself in as the executor —
+[`engine/buildkit/worker.go` `ResolveOp` L138-L175](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/engine/buildkit/worker.go#L138-L175):
+
+```go
+if execOp, ok := baseOp.Op.(*pb.Op_Exec); ok {
+    ...
+    return ops.NewExecOp(vtx, execOp, baseOp.Platform,
+        w.workerCache, w.parallelismSem, sm, w /* executor */, w)
+}
+```
+
+So a `WithExec` is: an LLB `ExecOp` → solved by the BuildKit solver →
+executed by Dagger's `Worker`, which is also the executor
+([`Worker.Executor()` L134-L136](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/engine/buildkit/worker.go#L134-L136)).
+
+### The meta mount
+
+Every exec gets an extra **meta mount** — output ref index 1 becomes
+`container.Meta`
+([L356-L359](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/container_exec.go#L356-L359)).
+It captures stdout, stderr, combined output, the exit code, and the
+client ID, each read back as a file —
+[L593-L621](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/container_exec.go#L593-L621).
+That is why `.stdout`, `.stderr`, and `.exitCode` are available after an
+exec without re-running it: they are files in the meta mount, not live
+process state.
+
+## Where the work runs, and what it costs
+
+**Exec work runs inside the engine container.** The Dagger CLI is a thin
+client; the engine is a long-lived container (here, the OCI image
+`registry.dagger.io/engine:v0.20.8`, run by `podman` on this host). The
+`Worker` holds a `runc` handle and a cgroup parent —
+[`engine/buildkit/worker.go` `Worker` struct L38-L70](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/engine/buildkit/worker.go#L38-L70).
+Each exec is run by the executor as a `runc` container *nested inside
+the engine container* —
+[`engine/buildkit/executor.go` `Worker.Run` L157-L192](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/engine/buildkit/executor.go#L157-L192)
+runs a setup pipeline (`setupNetwork`, `injectInit`,
+`generateBaseSpec`, `setupRootfs`, …, `runContainer`) culminating in a
+runc process.
+
+The practical consequences:
+
+- **CPU / memory.** An exec's CPU and memory come out of the engine
+  container's own budget. There is no separate VM or host process per
+  exec — `N` concurrent execs are `N` runc children of one engine
+  process tree, all sharing the engine container's CPU shares and
+  memory limit. If the engine container is memory-capped, a heavy exec
+  (or many of them) is OOM-killed within that cap, not by the host at
+  large.
+- **Disk.** Every exec's rootfs, mounts, and committed outputs are
+  snapshots in the engine's local cache (see below). Disk is consumed in
+  the engine's storage, and it is *retained* after the exec finishes —
+  that is the cache. `Worker.Run` returns a
+  `bkresourcestypes.Recorder`, i.e. the executor records per-exec
+  resource usage.
+- **The engine container itself** grows over a session: started
+  services stay resident until detached, and cache snapshots accumulate
+  until GC runs.
+
+## The caching model
+
+### Operation cache
+
+The unit of caching is the LLB operation. Before executing a vertex the
+solver computes a **cache map** — a content-addressed key over the op
+and its inputs —
+[`engine/buildkit/op.go` `CacheMap` L103-L120](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/engine/buildkit/op.go#L103-L120).
+If a result already exists for that key, the op is skipped entirely.
+
+**Experiment — an exec is cached by its inputs, not re-run.** Running
+the *same* exec twice: `date` would print a different time if it
+actually ran, but the second run returns the first run's output:
+
+```
+$ dagger --progress=plain -c 'container | from alpine:3 | with-exec date | stdout'
+24 : withExec date
+24 : [0.1s] | Thu May 21 22:30:45 UTC 2026
+24 : Container.withExec DONE [0.2s]
+Thu May 21 22:30:45 UTC 2026
+
+$ # identical command again:
+24 : withExec date
+24 : Container.withExec CACHED [0.0s]
+Thu May 21 22:30:45 UTC 2026
+```
+
+`CACHED` and the *identical* timestamp prove the second exec did not
+run — the engine returned the cached snapshot. Pulled base-image layers
+(`from`) are cached the same way.
+
+### Cache mounts
+
+A cache mount (`withMountedCache`) is a *mutable* directory that is
+**deliberately excluded** from the content-addressed result — it
+persists across execs and across `dagger` invocations, scoped by a
+cache-volume key. It is the escape hatch for things you want to reuse
+but not bake into the immutable result (package caches, build caches).
+
+**Experiment — a cache mount survives across separate invocations.**
+
+```
+$ dagger -c 'container | from alpine:3 |
+             with-mounted-cache /data $(cache-volume devex-exec-demo) |
+             with-exec touch /data/written-by-run-1 |
+             with-exec ls /data | stdout'
+written-by-run-1
+
+$ # a separate dagger invocation, same cache-volume key, no touch:
+$ dagger -c 'container | from alpine:3 |
+             with-mounted-cache /data $(cache-volume devex-exec-demo) |
+             with-exec ls /data | stdout'
+written-by-run-1
+```
+
+The file written by the first invocation is still present in the
+second — the cache volume is shared engine state, not part of any
+container's snapshot.
+
+### Prune and GC — reclaiming disk
+
+Cached snapshots accumulate. The engine exposes its on-disk cache and a
+garbage-collection policy through `dagger core engine local-cache`.
+
+**Experiment — the GC policy.** Each policy field is a queryable value
+(bytes; the CLI prints them in scientific notation):
+
+```
+$ dagger core engine local-cache max-used-space    # max bytes kept before pruning
+6.98e+11                                           # ~698 GB
+
+$ dagger core engine local-cache reserved-space    # min bytes always retained
+1e+10                                              # ~10 GB
+
+$ dagger core engine local-cache min-free-space    # free-space target for GC
+1.86e+11                                           # ~186 GB
+
+$ dagger core engine local-cache target-space
+0
+```
+
+**Experiment — the live cache.** `entry-set` reports what is currently
+cached on disk:
+
+```
+$ dagger core engine local-cache entry-set entry-count
+180379
+$ dagger core engine local-cache entry-set disk-space-bytes
+3.3531539275e+10                                    # ~33.5 GB
+```
+
+**Experiment — the prune command.** `prune` runs the GC pass on demand
+and accepts overrides so a reader can prune harder or softer than the
+standing policy:
+
+```
+$ dagger core engine local-cache prune --help
+Prune the cache of releaseable entries
+
+USAGE
+  dagger core engine local-cache prune [arguments]
+
+ARGUMENTS
+      --max-used-space string   Override the maximum disk space to keep
+                                before pruning (e.g. "200GB" or "80%").
+      --min-free-space string   Override the minimum free disk space
+                                target during pruning (e.g. "20GB" or "20%").
+      --reserved-space string   Override the minimum disk space to retain
+                                during pruning (e.g. "500GB" or "10%").
+```
+
+`prune` only releases entries that are not pinned by something still in
+use — cache mounts and in-use snapshots survive. Run with no arguments
+it applies the standing policy (the `*-space` values above); the
+override flags let CI reclaim disk more aggressively on demand.
+
+## Concurrency and this repo's CI
+
+Concurrency is bounded at two layers:
+
+- **Engine-wide.** The `Worker` carries a `parallelismSem`, a weighted
+  semaphore passed into every `ExecOp` —
+  [`engine/buildkit/worker.go` L62](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/engine/buildkit/worker.go#L62)
+  and
+  [`ResolveOp` L160-L169](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/engine/buildkit/worker.go#L160-L169).
+  It caps how many execs run at once across the *whole* engine,
+  regardless of how many `dagger call`s are in flight. Beyond that cap,
+  execs queue.
+- **Application-level.** A module can additionally limit its own fan-out
+  in code.
+
+Because every concurrent exec shares the single engine container's
+CPU/memory/disk, "more parallelism" is not free: past the
+`parallelismSem` cap it does not even increase true concurrency, and
+before that cap it raises peak memory and disk pressure inside the
+engine.
+
+This repo's CI is a single entrypoint — `.github/workflows/ci.yml` runs
+one `dagger call test` against the root `ci` module (engine pinned to
+`0.20.8`). The heavy load is the kafka suite, which boots real Kafka
+clusters in containers. `daggerverse/kafka/tests/main.go` is explicit
+about managing this:
+
+- It fans tests out with a `par` pool under an explicit **`parallel`
+  cap (default 4)**, applied at *two* levels (distro groups × tests
+  within a group), so peak concurrency is bounded rather than
+  unbounded.
+- Same-shape clusters **share one `*dagger.KafkaCluster` pointer** so
+  "the engine collapses their boots to a single service" — this is the
+  service deduplication described in
+  [networking.md](./networking.md#service--port-scoping): one
+  `ServiceKey` per content digest per session.
+
+Practical guidance that follows from the resource model:
+
+- The `parallel` knob is a memory/disk dial, not just a speed dial.
+  Raising it multiplies the number of simultaneously-resident Kafka
+  containers inside the one engine container; size it to the engine's
+  memory, not the host's core count.
+- Reusing cluster pointers (so identical services dedup) is strictly
+  better than booting fresh clusters — it cuts both wall-clock and peak
+  resident containers.
+- For long or repeated CI, budget disk for the cache and prune on a
+  schedule (`dagger core engine local-cache prune`) rather than letting
+  it ride the 698 GB default ceiling.
+
+## Open questions / unverified
+
+- **Per-exec resource limits.** `Worker.Run` returns a resource
+  `Recorder` and the worker has a `cgroupParent`, but whether an
+  individual `WithExec` can be given an explicit CPU/memory *limit*
+  (vs. only being recorded and bounded by the engine's cgroup) was not
+  confirmed.
+- **`parallelismSem` default.** The semaphore exists and is engine-wide;
+  its default weight / how it is configured was not traced to a config
+  value.
+- **GC policy origin.** The `max-used-space` / `reserved-space` /
+  `min-free-space` numbers above are this engine's live values; whether
+  they are hard defaults or derived from host disk size at engine
+  startup was not verified.
+- **`target-space` meaning.** `target-space` reported `0`; its exact
+  role relative to `max-used-space` was not determined from source.
+- **Prune reclaim figure.** A full `dagger core engine local-cache
+  prune` over this engine's live cache (~180k entries / ~33.5 GB) did
+  not complete within a bounded time on the test machine, so a concrete
+  before/after reclaimed-bytes number is not captured here — only the
+  pre-prune `entry-set` and the `prune` command surface are shown.
+- **Cache-mount concurrency.** Whether two concurrent execs sharing one
+  cache volume serialize or race on it was not tested.

--- a/docs/dagger-internals/module-importing.md
+++ b/docs/dagger-internals/module-importing.md
@@ -1,0 +1,330 @@
+# Module importing
+
+How a Dagger module declares, loads, and consumes another module — with
+a focus on why types can be shared across SDKs but native language types
+cannot cross a module boundary.
+
+> Engine version: `v0.20.8`. Source permalinks are pinned to
+> `dagger/dagger` commit
+> [`74bff7d`](https://github.com/dagger/dagger/tree/74bff7d10fd78dd6935c60c4514558598f216451).
+> See [README.md](./README.md) for the sourcing rule.
+
+## Overview
+
+Every `daggerverse/` module in this repo declares its dependencies in
+`dagger.json`. For example `daggerverse/kafka/dagger.json`:
+
+```json
+{
+  "name": "kafka",
+  "engineVersion": "v0.20.8",
+  "sdk": { "source": "go" },
+  "dependencies": [
+    { "name": "certificate-management", "source": "../certificate-management" },
+    { "name": "crypto",                  "source": "../crypto" },
+    { "name": "random",                  "source": "../random" }
+  ]
+}
+```
+
+That declaration is consumed at two distinct times, by two distinct
+mechanisms:
+
+- **Codegen time** (`dagger develop`) — the SDK generates client
+  bindings so the module's source code can *call* its dependencies.
+- **Call time** (`dagger call`) — the engine loads each dependency
+  module, runs its SDK runtime to register type definitions, and serves
+  them in one unified GraphQL schema.
+
+The two are independent: codegen produces source files on disk; call
+time spins up containers in the engine. Neither step ever links the
+dependency's compiled code into the consumer.
+
+## Declaring a dependency: codegen time vs. call time
+
+### Codegen time (`dagger develop`)
+
+`dagger develop` regenerates the module's client bindings. An SDK opts
+into this by implementing the `CodeGenerator` interface — the engine
+calls the SDK's `codegen` GraphQL function, passing the module source
+**and an introspection-JSON file of the schema visible to the module**:
+
+> `core/sdk.go`,
+> [`CodeGenerator` interface, L99-L130](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/sdk.go#L99-L130):
+> ```go
+> // SDK must implement the `Codegen` function with the following signature:
+> //   codegen(
+> //       modSource: ModuleSource!
+> //       introspectionJSON: File!
+> //   ): GeneratedCode!
+> ```
+
+The `introspectionJSON` argument is the whole story: codegen does not
+read the dependency's Go/Python/TypeScript source. It reads a GraphQL
+introspection schema. The engine builds that file from the module's
+dependency set —
+[`core/schema/module.go` `moduleIntrospectionSchemaJSON`, L1005-L1011](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/schema/module.go#L1005-L1011)
+calls `mod.Deps.SchemaIntrospectionJSONFileForModule(ctx)`.
+
+**Experiment — codegen produces one client file per dependency.** The
+generated client files are not committed (`daggerverse/kafka/.gitignore`
+ignores `/dagger.gen.go` and `/internal/dagger`); `dagger develop`
+recreates them:
+
+```
+$ cd daggerverse/kafka && dagger develop
+✔ develop 4.0s
+
+$ ls internal/dagger/
+certificate-management.gen.go
+crypto.gen.go
+dagger.gen.go
+random.gen.go
+```
+
+One `*.gen.go` per entry in the `dependencies` array
+(`certificate-management`, `crypto`, `random`), plus an `internal/dagger`
+`dagger.gen.go` for the core API and a `dagger.gen.go` at the module
+root for the module itself. The generated code carries source-map
+comments back to the dependency's own source:
+
+```
+$ grep -nE 'type (Random|Crypto) struct' internal/dagger/random.gen.go internal/dagger/crypto.gen.go
+internal/dagger/random.gen.go:72:type Random struct { // random (../../../../daggerverse/random/main.go:17:6)
+internal/dagger/crypto.gen.go:63:type Crypto struct { // crypto (../../../../daggerverse/crypto/main.go:37:6)
+```
+
+So at codegen time a dependency is just a set of generated client stubs
+(`Random`, `Crypto`, `CryptoRsaKey`, …) that issue GraphQL queries. No
+dependency code is imported; nothing executes yet.
+
+### Call time (`dagger call`)
+
+At call time the dependency is a *running module*, not a source file.
+The consumer's `dagger.json` dependency list is resolved into a
+dependency DAG (`mod.Deps`). Each dependency module is loaded and its
+type definitions installed into the served schema —
+[`core/module.go` `Install`, L565-L632](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/module.go#L565-L632)
+walks the module's `ObjectDefs` / `InterfaceDefs` / `EnumDefs` and
+installs each into the `dagql` server. The dependencies a module can see
+are exactly its **direct** dependencies — type resolution against deps
+goes through
+[`modTypeFromDeps`, L760-L771](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/module.go#L760-L771),
+which is gated on `checkDirectDeps` and never recurses into transitive
+deps.
+
+**Experiment — a module's surface at call time.** `dagger functions`
+introspects the live schema the engine assembled:
+
+```
+$ dagger -m daggerverse/random functions
+Name       Description
+serial     Serial generates a random n-byte X.509 serial number ...
+sha-256    Sha256 generates a random n-byte value and returns its SHA-256 hash ...
+sha-512    Sha512 generates a random n-byte value and returns its SHA-512 hash ...
+uuid-v-4   UuidV4 generates a random UUID version 4 and returns it as a string.
+uuid-v-7   UuidV7 generates a random UUID version 7 and returns it as a string.
+```
+
+## The GraphQL boundary
+
+A module never links against its dependency. The only contract between
+them is the **GraphQL schema**. The introspection JSON passed to
+`codegen` (above) is the language-neutral description of that schema;
+the dependency's SDK is irrelevant to the consumer.
+
+This is why a Go module can depend on a Python module (or vice versa)
+with no special handling: the consumer's SDK generates client bindings
+purely from the introspection JSON, and the dependency's SDK runtime
+answers GraphQL queries. Each SDK implements three engine-facing
+GraphQL functions, all of which take the same `introspectionJSON: File!`
+argument and are entirely SDK-internal —
+[`core/sdk.go` `SDK` interface, L387-L408](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/sdk.go#L387-L408):
+
+| SDK capability   | GraphQL function | Used by         |
+| ---------------- | ---------------- | --------------- |
+| `CodeGenerator`  | `codegen`        | `dagger develop`|
+| `Runtime`        | `moduleRuntime`  | `dagger call`   |
+| `ModuleTypes`    | `moduleTypes`    | self-calls      |
+
+Because both directions of the boundary — generating a client and
+answering a query — are defined only in terms of the GraphQL schema,
+the SDKs on either side are decoupled. The schema is the interface
+definition language; the introspection JSON is its serialization.
+
+## How values cross the boundary
+
+### Objects cross as IDs
+
+Every object type in the schema — core types *and* module-defined types
+— is addressable by an opaque **ID scalar**. When a value is passed
+between modules, the object itself stays in the engine; only its ID
+crosses the wire.
+
+**Experiment — IDs in the schema.** Introspecting the `random` module's
+schema shows both a core object (`File`) and a module object (`Random`)
+expose an `id` field, and each has a matching `*ID` scalar (output
+elided to the relevant fields with `…`):
+
+```
+$ echo '{ f: __type(name:"File") { kind fields { name type { ofType { kind name } } } }
+          r: __type(name:"Random") { kind name }
+          i: __type(name:"RandomID") { kind name description } }' | dagger -m daggerverse/random query
+
+{
+    "f": {
+        "fields": [
+            …
+            {
+                "name": "id",
+                "type": {
+                    "ofType": {
+                        "kind": "SCALAR",
+                        "name": "FileID"
+                    }
+                }
+            },
+            …
+        ],
+        "kind": "OBJECT"
+    },
+    "i": {
+        "description": "The `RandomID` scalar type represents an identifier for an object of type Random.",
+        "kind": "SCALAR",
+        "name": "RandomID"
+    },
+    "r": {
+        "kind": "OBJECT",
+        "name": "Random"
+    }
+}
+```
+
+An ID encodes the full call chain that produced the object, so the
+receiving side can reconstruct (or look up) the object without the
+producing module needing to be the same SDK — or even still running in
+the same form.
+
+### Core types vs. module-defined types
+
+A type def resolves to one of three origins —
+[`core/module.go` `ModTypeFor`, L709-L758](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/module.go#L709-L758):
+
+- **Primitives** (`String`, `Int`, `Float`, `Boolean`, `Void`) — always
+  pass.
+- **Core types** — objects owned by the built-in `daggercore` module
+  (`Container`, `Directory`, `File`, `Secret`, `Service`, …). The core
+  module name is the constant `ModuleName` —
+  [`core/moddeps.go` L19](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/moddeps.go#L19):
+  `ModuleName = "daggercore"`.
+- **Module-defined types** — objects/interfaces/enums declared by a
+  specific user module, namespaced to it.
+
+### Why arbitrary native types cannot cross modules
+
+A native language type (a Go `*rsa.PrivateKey`, a Python `dict`) is not
+in the schema at all, so it can never cross. But the boundary is
+stricter than that: **even a rich type defined by one user module
+cannot appear in another user module's public API.** This is enforced
+at module load time —
+[`core/module.go` `validateObjectTypeDef`, L847-L936](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/module.go#L847-L936).
+
+For an object's fields
+([L879-L887](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/module.go#L879-L887)):
+
+```go
+// fields can reference core types and local types, but not types from other modules
+if sourceMod != nil && sourceMod.Name() != ModuleName && sourceMod != mod {
+    return fmt.Errorf("object %q field %q cannot reference external type from dependency module %q",
+        obj.OriginalName, field.OriginalName, sourceMod.Name())
+}
+```
+
+The same rule is repeated for function **return types**
+([L902-L910](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/module.go#L902-L910):
+`cannot return external type from dependency module`) and function
+**arguments**
+([L915-L933](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/module.go#L915-L933):
+`cannot reference external type from dependency module`). The condition
+`sourceMod.Name() != ModuleName` is what whitelists core types: a
+function may freely accept or return `*dagger.File` or `*dagger.Secret`
+(owned by `daggercore`) but never a `*dagger.KeyStore` defined by the
+`certificate-management` module.
+
+**The practical pattern.** Because rich dependency types cannot cross,
+a module that needs material produced by another module accepts the
+underlying *core* primitives and re-hydrates internally. `kafka`'s
+internal CA does exactly this — `daggerverse/kafka/internal_ca.go` calls
+`dag.Crypto()`, `dag.Random()`, and `dag.CertificateManagement()`,
+moving only `*dagger.File` and `*dagger.Secret` (plus strings) across
+each boundary, and reconstitutes rich objects with the dependency's
+`Load*` helpers on its own side. A module that produces such material
+mirrors the shape: return `*dagger.File` + `*dagger.Secret`, not a
+local struct, and ship a `Load*FromPkcs12`-style constructor so
+downstream modules have a clean re-hydration path.
+
+## Client codegen vs. server runtime
+
+It is worth being precise about what lives where:
+
+- **Client-side (generated by codegen, compiled into the consumer).**
+  The `internal/dagger/*.gen.go` files. Calling `dag.Random().Sha256()`
+  from `kafka` runs *generated stub code* that builds a GraphQL query.
+  It contains no `random` module logic.
+
+- **Server-side (executes in the engine).** The actual `random` module
+  code runs in **its own runtime container**, separate from `kafka`'s.
+  Each module's runtime is built from its SDK —
+  [`core/module.go` `LoadRuntime`, L1147-L1166](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/module.go#L1147-L1166)
+  asks the SDK for a `Runtime`, and
+  [`core/schema/module.go` `moduleRuntime`, L888-L899](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/schema/module.go#L888-L899)
+  exposes it as a `Container`.
+
+For a container-based SDK the runtime is a `Container` with an
+entrypoint. A function call mounts a metadata directory and execs that
+entrypoint —
+[`core/sdk.go` `ContainerRuntime.Call`, L166-L257](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/sdk.go#L166-L257)
+does a `withExec` with `useEntrypoint: true` and reads the result back
+from a meta file. The entrypoint has two modes —
+[`core/sdk.go` `Runtime` interface doc, L304-L322](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/sdk.go#L304-L322):
+with no object selected it **registers type definitions**; with an
+object selected it **executes the requested function**.
+
+So when `kafka` calls `dag.Random().Sha256()`:
+
+1. `kafka`'s generated client emits a GraphQL query.
+2. The engine routes it to the `random` module.
+3. The engine starts `random`'s **own runtime container** (its own SDK,
+   its own image) and execs its entrypoint to run `Sha256`.
+4. The result returns to `kafka` as a plain GraphQL value.
+
+`kafka` and `random` never share a process, an address space, or a
+language runtime. Each module is an isolated container; the GraphQL
+schema is the only thing between them.
+
+The unified schema the consumer sees is filtered so that only
+module-sourced functions appear as top-level entrypoints — core `Query`
+functions are stripped when `hideCore` is set —
+[`core/schema/module.go` `stripCoreQueryFunctions`, L941-L965](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/schema/module.go#L941-L965).
+The list of a module's installed dependencies is itself queryable —
+[`moduleDependencies`, L1121-L1139](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/schema/module.go#L1121-L1139).
+
+## Open questions / unverified
+
+- **Transitive dependency visibility.** `modTypeFromDeps` only checks
+  *direct* deps (`checkDirectDeps`). The exact behavior when a
+  dependency itself re-exposes a transitive type (e.g. via an
+  interface) was read from source but not exercised with a live
+  multi-level experiment here.
+- **Cross-SDK demonstration.** The cross-SDK claim is argued from
+  source (the SDK-agnostic `introspectionJSON` boundary) only — every
+  module in this repo is Go, so no live "Python module consumed from
+  Go" experiment was run. The mechanism is source-backed; an end-to-end
+  cross-SDK call was not.
+- **ID portability across sessions.** Object IDs encode a call chain;
+  whether/how an ID minted in one engine session can be resolved in a
+  later session was not tested.
+- **Runtime container reuse.** Whether two modules using the same SDK
+  and version share a runtime base image layer in the engine cache was
+  not measured; only that each module loads its own `Runtime` was
+  confirmed from source.

--- a/docs/dagger-internals/module-importing.md
+++ b/docs/dagger-internals/module-importing.md
@@ -40,6 +40,29 @@ The two are independent: codegen produces source files on disk; call
 time spins up containers in the engine. Neither step ever links the
 dependency's compiled code into the consumer.
 
+## How a module gets run
+
+The engine is the only GraphQL server. An imported module is **not** a
+GraphQL service of its own — it is a container with an entrypoint that
+the engine execs in one of two modes
+([`core/sdk.go` `Runtime` interface doc, L304-L322](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/sdk.go#L304-L322)):
+
+- **No object selected** — the entrypoint walks the module's own type
+  information (Go reflection, Python introspection, …) and calls back
+  into the engine's GraphQL API to register the module's typedefs.
+  Done once per load.
+- **Object/function selected** — the entrypoint executes that function
+  and writes the result to a meta file the engine reads.
+
+When this page refers to the engine calling a "GraphQL function" on an
+SDK (e.g. `codegen` in the next section), that field lives in the
+*engine's* schema; the engine resolves it by exec'ing the SDK's own
+runtime container — the same exec-the-entrypoint mechanism, applied to
+a meta-module (the SDK) rather than a user module. The detailed walk
+through this — including the `withExec` + meta-file dance — is in
+[Client codegen vs. server runtime](#client-codegen-vs-server-runtime)
+below.
+
 ## Declaring a dependency: codegen time vs. call time
 
 ### Codegen time (`dagger develop`)

--- a/docs/dagger-internals/networking.md
+++ b/docs/dagger-internals/networking.md
@@ -1,0 +1,281 @@
+# Networking
+
+How Dagger services, hostnames, and DNS work — and the answers to two
+questions that are not written down officially: *are services scoped or
+global?* and *can a container be placed in a specific network?*
+
+> Engine version: `v0.20.8`. Source permalinks are pinned to
+> `dagger/dagger` commit
+> [`74bff7d`](https://github.com/dagger/dagger/tree/74bff7d10fd78dd6935c60c4514558598f216451).
+> See [README.md](./README.md) for the sourcing rule.
+
+## The service model
+
+A `Service` is "a content-addressed service providing TCP connectivity"
+—
+[`core/service.go` L51-L89](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/service.go#L51-L89).
+There are three kinds, dispatched by
+[`Service.Start`, L296-L311](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/service.go#L296-L311):
+
+| Kind            | Backed by                | Direction          |
+| --------------- | ------------------------ | ------------------ |
+| Container svc   | `Container` (`AsService`)| container↔container|
+| Tunnel svc      | `TunnelUpstream`         | host → container   |
+| Reverse tunnel  | `HostSockets`            | container → host   |
+
+The everyday building blocks:
+
+- **`WithExposedPort(port)`** — records a port on the container and adds
+  it to the OCI `ExposedPorts` config —
+  [`core/container.go` L2228-L2254](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/container.go#L2228-L2254).
+- **`AsService(args)`** — turns a container into a `Service`, resolving
+  the command from explicit args / entrypoint / `Cmd` —
+  [`core/container.go` L2329+](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/container.go#L2329-L2360).
+- **`WithServiceBinding(svc, alias)`** — binds a service into a
+  consumer container under an `alias`, after resolving the service's
+  hostname —
+  [`core/container.go` L2275-L2297](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/container.go#L2275-L2297).
+- **`Endpoint(port, scheme)`** — formats `host:port`, defaulting to the
+  first exposed port —
+  [`core/service.go` L169-L237](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/service.go#L169-L237).
+
+This repo uses all of these: `daggerverse/kafka/cluster_kafka.go` wires
+brokers together with `WithExposedPort` + `AsService` +
+`WithServiceBinding`, and `daggerverse/grafana-stack/main.go` exposes
+Loki/Tempo/Mimir each via a `Service()` / `Endpoint()` pair.
+
+### Hostnames are content-addressed
+
+A service's hostname is **not** random — it is derived from the digest
+of the call ID that produced the service —
+[`Service.Hostname`, L114-L142](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/service.go#L114-L142):
+
+```go
+case svc.Container != nil, // container=>container
+    len(svc.HostSockets) > 0: // container=>host
+    return network.HostHash(id.Digest()), nil
+```
+
+`network.HostHash` is an `xxh3` hash of the ID digest, base32-encoded —
+[`network/hosts.go` L15-L22](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/network/hosts.go#L15-L22).
+A custom hostname can be set with `withHostname`
+([`WithHostname`, L108-L112](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/service.go#L108-L112)).
+
+**Experiment — the hostname is deterministic.** The same pipeline run
+twice produces the same hostname:
+
+```
+$ dagger -c 'container | from python:3.13-alpine | with-exposed-port 8080 |
+             as-service --args="python3,-m,http.server,8080" | hostname'
+9961bfn7kemr6
+
+$ # ...run the identical command again:
+9961bfn7kemr6
+```
+
+Because the hostname is a pure function of the call graph, two callers
+that build the *same* service get the *same* hostname — which is also
+why the engine can deduplicate them (see scoping, below).
+
+### DNS resolution between containers
+
+`WithServiceBinding` makes the service resolvable inside the consumer
+container, both by its content-addressed hostname and by the `alias`.
+
+**Experiment — a bound service resolves by alias.**
+
+```
+$ dagger -c 'container | from alpine:3 |
+             with-service-binding web $(container | from python:3.13-alpine |
+               with-exposed-port 8080 |
+               as-service --args="python3,-m,http.server,8080") |
+             with-exec getent hosts web | stdout'
+
+10.87.190.29      web  web
+```
+
+The alias `web` resolves to `10.87.190.29` — an address inside the
+engine's `10.87.0.0/16` range (see next section).
+
+## Service & port scoping
+
+**Services and their ports are scoped per Dagger session, not shared
+globally.** The unit of identity is `ServiceKey` —
+[`core/services.go` L74-L79](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/services.go#L74-L79):
+
+```go
+type ServiceKey struct {
+    Digest    digest.Digest // the service's content-addressed ID digest
+    SessionID string        // always set
+    ClientID  string        // set only when clientSpecific
+}
+```
+
+Every lookup, start, and stop keys on this struct, and `SessionID` is
+*always* populated —
+[`Get`, L94-L127](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/services.go#L94-L127)
+and
+[`StartWithIO`, L145-L217](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/services.go#L145-L217).
+The consequences:
+
+- **Within one session**, two requests for a service with the *same*
+  digest collapse to one running instance. `StartWithIO` finds it
+  already running, increments a binding count, and returns the existing
+  `RunningService`
+  ([L176-L180](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/services.go#L176-L180)).
+  This is the mechanism behind the kafka test suite sharing one cluster
+  pointer across many tests.
+- **Across sessions**, nothing is shared — a different `SessionID`
+  yields a different `ServiceKey`. When a session ends,
+  [`StopSessionServices`, L305-L331](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/services.go#L305-L331)
+  force-stops every service whose `Key.SessionID` matches. Services do
+  not outlive the `dagger` invocation that created them.
+- **Per-client scoping** is opt-in: `ClientID` is only added to the key
+  when `clientSpecific` is true — used for host tunnels, so a tunnel is
+  private to the client that opened it
+  ([`StartAndTrack`, L239-L250](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/service.go#L239-L250)
+  passes `clientSpecific` for tunnel services).
+
+There is no global port registry. "Port collisions" between unrelated
+services cannot happen, because each service has its own hostname/IP and
+the engine never reuses a frontend port across services. The only
+"collision" case is *the same service started twice* — which, as above,
+is resolved by reuse rather than a second bind. Frontend ports for host
+tunnels default to OS-chosen (`frontend = 0`) when unspecified —
+[`startTunnel`, L827-L833](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/service.go#L827-L833).
+
+## One network, or many?
+
+**There is a single, flat network per engine — not per-container
+networks.** Containers are isolated by DNS domain, not by separate
+networks, and **there is no public API to place a container into a
+specific or isolated network.**
+
+The engine has one bridge network with a fixed address range —
+[`network/consts.go`](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/network/consts.go):
+
+```go
+const DomainSuffix = ".dagger.local"
+const DefaultName  = "dagger"        // the bridge interface name
+const DefaultCIDR  = "10.87.0.0/16"  // address range for all networked containers
+```
+
+The bridge takes the `.1` address of that CIDR —
+[`network/bridge.go` L5-L16](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/network/bridge.go#L5-L16).
+
+Isolation is achieved with **DNS search domains**, not network
+segmentation:
+
+- A **session domain** scopes every service in a session:
+  `SessionDomain(sid)` = `{hash(sessionID)}.dagger.local` —
+  [`network/hosts.go` L28-L31](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/network/hosts.go#L28-L31).
+- A **module domain** further scopes services started by a module:
+  `ModuleDomain(modID, sid)` =
+  `{hash(modID)}.{hash(sessionID)}.dagger.local` —
+  [`network/hosts.go` L33-L41](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/network/hosts.go#L33-L41).
+
+When a container service starts,
+[`startContainer` L377-L391](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/service.go#L377-L391)
+picks the module domain if the service has a custom hostname and was
+started by a module (and adds it to `ExtraSearchDomains` so the service
+can still reach peers in the starting module), otherwise the session
+domain. The fully-qualified name is `host + "." + domain`. So
+"isolation" is two services simply not sharing a search domain — they
+are still on the same `10.87.0.0/16` bridge.
+
+**Experiment — the flat network and the session search domain.**
+`/etc/resolv.conf` inside any container in a session shows both:
+
+```
+$ dagger -c 'container | from alpine:3 |
+             with-service-binding web $(container | from python:3.13-alpine |
+               with-exposed-port 8080 |
+               as-service --args="python3,-m,http.server,8080") |
+             with-exec cat /etc/resolv.conf | stdout'
+
+nameserver 10.87.0.1
+search gl4e8gk0lc05c.dagger.local
+```
+
+`nameserver 10.87.0.1` is the bridge (`.1` of `10.87.0.0/16`);
+`search …​.dagger.local` is the session domain. Every container in the
+session gets the same nameserver and the same flat network. A reader
+who wants per-network isolation will not find a knob for it — the only
+boundary available is the DNS domain, and it is chosen by the engine,
+not the caller.
+
+## Host ↔ container
+
+### Host → container tunnels (`dagger up`)
+
+`up` forwards a host port into a service. `Container.up` first converts
+the container to a service, then calls `Service.up` —
+[`core/schema/service.go` L401-L462](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/schema/service.go#L401-L462).
+Under the hood it builds a tunnel service and calls
+`bk.ListenHostToContainer` to bind `0.0.0.0:frontend` on the host,
+forwarding to `upstream.Host:backend` —
+[`startTunnel`, L788-L878](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/service.go#L788-L878).
+The running tunnel's host is `127.0.0.1`, so the service becomes
+reachable at `localhost:<frontend>` — `up` logs exactly that
+([`L444-L456`](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/schema/service.go#L444-L456)).
+A reader can reproduce this with:
+
+```
+dagger -c 'container | from python:3.13-alpine | with-exposed-port 8080 |
+           as-service --args="python3,-m,http.server,8080" | up --ports 8080:8080'
+# then, from the host:  curl localhost:8080
+```
+
+`up` is marked `DoNotCache` and blocks until its context is canceled
+(`<-ctx.Done()`), i.e. until you Ctrl-C it.
+
+### Container → host (reverse tunnels)
+
+The reverse direction exposes a host socket *into* the engine network.
+`startReverseTunnel` provisions a CNI network namespace
+(`bk.NewNetworkNamespace`) and runs a `c2hTunnel` —
+[`core/service.go` L880-L960](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/service.go#L880-L960).
+Its hostname lives in the session domain like any other service.
+
+### Service lifecycle
+
+- **Start.** A container service implicitly starts its dependency
+  bindings via `StartBindings` before its own exec —
+  [`startContainer` L371-L375](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/service.go#L371-L375).
+  `Service.start` can also start one explicitly and wait for health
+  checks
+  ([`core/schema/service.go` L341-L355](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/schema/service.go#L341-L355)).
+- **Reuse.** As above, an already-running service is shared and its
+  binding count incremented.
+- **Teardown.** `Detach` decrements the binding count; only when it
+  reaches zero does the service stop, and even then after a grace
+  period —
+  [`Detach`, L333-L367](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/services.go#L333-L367).
+  Two timers govern this —
+  [`core/services.go` L20-L29](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/services.go#L20-L29):
+  `DetachGracePeriod` (10s, "avoid repeated stopping and re-starting…​in
+  rapid succession") and `TerminateGracePeriod` (10s between SIGTERM and
+  SIGKILL, applied by `stopGraceful`). Session end force-kills
+  everything (`StopSessionServices`, `force: true`).
+
+## Open questions / unverified
+
+- **Engine-wide vs. container-wide bridge.** `DefaultCIDR` is a single
+  `/16` for the whole engine. Whether two *separate* sessions on the
+  same engine get disjoint IP sub-ranges, or simply disjoint DNS
+  domains over the same address space, was not confirmed — the source
+  shows one CIDR and per-session *domains*, but not per-session IP
+  allocation.
+- **Custom CIDR.** `DefaultCIDR` is a `const`; whether an engine
+  operator can override the `10.87.0.0/16` range via engine config was
+  not investigated.
+- **Tunnel/`up` live run.** The `up` host-tunnel flow is documented
+  from source and the schema; an end-to-end `dagger up` + host `curl`
+  was not captured here because it requires a foreground process.
+- **Health checks.** `Service.start` "waits for health checks to
+  succeed"; the exact probe (TCP connect vs. port-open poll) was seen
+  referenced (`newPortHealth`) but not traced in detail.
+- **Cross-session service reachability.** Nested (child) Dagger
+  sessions propagate parent search domains via `DomainSuffix`; the
+  precise rules for a nested session reaching a parent's services were
+  not exercised experimentally.

--- a/docs/dagger-internals/networking.md
+++ b/docs/dagger-internals/networking.md
@@ -144,6 +144,47 @@ is resolved by reuse rather than a second bind. Frontend ports for host
 tunnels default to OS-chosen (`frontend = 0`) when unspecified —
 [`startTunnel`, L827-L833](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/service.go#L827-L833).
 
+### Same port, many containers — worked example
+
+Multiple containers in a single function call can all `WithExposedPort`
+the *same* port number without serializing. The reason is that
+`WithExposedPort` writes OCI `ExposedPorts` metadata on **that specific
+container's** config —
+[`core/container.go` L2228-L2254](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/container.go#L2228-L2254)
+— and each `Service` gets its own content-addressed hostname via
+`network.HostHash(id.Digest())` —
+[`Service.Hostname`, L114-L142](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/service.go#L114-L142).
+A unique hostname means a unique IP on the `10.87.0.0/16` bridge, so
+`<broker-A>:9092` and `<broker-B>:9092` are different sockets — same
+port number, different addresses.
+
+Take the kafka module's brokers as a concrete case. Inside one cluster,
+`daggerverse/kafka/cluster_kafka.go` boots multiple brokers that all
+expose `9092`, `9093`, and `19092` — they do not fight for those ports
+because each broker has its own hostname (`broker-100-<suffix>`,
+`broker-101-<suffix>`, …) and therefore its own IP. The same logic
+extends across clusters: spinning up *two* Kafka clusters in one
+function gives you 2×N brokers, each a distinct `Service` (distinct
+`id.Digest()` because their cluster IDs / CAs / configs differ),
+each on its own IP, all listening on `:9092` simultaneously. Nothing
+runs serially; nothing waits its turn for a port.
+
+There are two situations where this picture changes:
+
+- **Identical content digests dedup.** If two clusters happen to
+  produce *exactly* the same content digest — same image, same args,
+  same env, same security material — the engine reuses one
+  `RunningService` for both and increments its binding count
+  ([`StartWithIO` L176-L180](https://github.com/dagger/dagger/blob/74bff7d10fd78dd6935c60c4514558598f216451/core/services.go#L176-L180)).
+  That is *deduplication*, not port sharing. The kafka module keeps
+  clusters distinct (per-cluster CA / random suffixes) when isolation
+  matters, and deliberately reuses the same cluster pointer when it
+  doesn't (see `daggerverse/kafka/tests/main.go`).
+- **Host tunnels can collide.** With `dagger up` you bind a port on
+  the *real* host (`0.0.0.0:<frontend>`), so two `up` calls trying to
+  take the same frontend port on the same host machine will collide.
+  Inside the engine network there is no such restriction.
+
 ## One network, or many?
 
 **There is a single, flat network per engine — not per-container


### PR DESCRIPTION
## Summary

Implements #82 — a new `docs/dagger-internals/` reference covering three
Dagger engine subsystems, pinned to engine `v0.20.8`.

- **`README.md`** — index; records the engine version and the sourcing rule.
- **`module-importing.md`** — dependency loading at codegen (`dagger develop`)
  vs. call time; the GraphQL introspection schema as the language-neutral SDK
  boundary; why arbitrary external module types cannot cross a boundary
  (source-enforced in `validateObjectTypeDef`), corroborating the
  `*dagger.File`/`*dagger.Secret` + `Load*` re-hydration pattern.
- **`networking.md`** — the service model; services/ports are scoped per
  session (`ServiceKey.SessionID`); one flat `10.87.0.0/16` network isolated
  only by DNS domain — there is no API to place a container in its own network.
- **`container-execution.md`** — `WithExec` → BuildKit LLB `ExecOp` → runc
  inside the engine container; CPU/memory/disk cost; the operation/cache-mount/
  prune-GC model; concurrency via `parallelismSem` and guidance for the kafka
  CI suite.

## Sourcing rule

Every non-trivial claim is either **(a)** a permalink to `dagger/dagger` at
commit `74bff7d10fd78dd6935c60c4514558598f216451` (the `v0.20.8` tag), or
**(b)** a reproducible `dagger` experiment with exact command + observed
output inline. 62 source permalinks total; experiments were run live against
`dagger v0.20.8`. Each topic page ends with an "Open questions / unverified"
section.

## Test plan

- [x] All permalinks pin to commit `74bff7d…` — no `main`/branch refs
- [x] 14 cited line ranges spot-checked against the pinned source
- [x] All inline experiment outputs captured from live `dagger v0.20.8` runs
- [x] Docs-only change — no code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)