### PR TITLE
story(issue-95): add zig cc / c++ cross-compiler to zig module

### DIFF
--- a/daggerverse/zig/README.md
+++ b/daggerverse/zig/README.md
@@ -30,6 +30,8 @@ falling back to the same default. The selected version must exist in
 | `Container(source)` | Prepared base container — escape hatch when a Zig command isn't covered by the typed helpers. Returns `*Container` lazily; the underlying constructor takes ctx + returns error so version inference and the toolchain download can run. |
 | `Build(source, optimize, target, steps, args)` | `zig build [-Doptimize=..] [-Dtarget=..] steps... args...`; returns the `zig-out` install directory. `optimize` ∈ {Debug, ReleaseSafe, ReleaseFast, ReleaseSmall} when set. |
 | `BuildExe(source, root, optimize, target, name, args)` | `zig build-exe <root> [-O ..] [-target ..] --name <name> args...`; returns the produced executable as a `*File`. `root` is required. |
+| `Cc(source, files, target, outputName, args)` | `zig cc <files...> [-target ..] -o <outputName> args...`; returns the compiled artifact as a `*File`. `files` is required; `outputName` defaults to `a.out`. |
+| `Cxx(source, files, target, outputName, args)` | `zig c++ <files...> [-target ..] -o <outputName> args...`; the C++ counterpart of `Cc`. |
 | `Run(source, args)` | `zig build run [-- args...]`; returns stdout. |
 | `Test(source, root, args)` | `zig build test` (empty `root`) or `zig test <root>`; returns stdout. |
 | `Fmt(source)` | `zig fmt --check .`; returns a non-nil error listing the unformatted files (nil when clean) so CI fails fast. |
@@ -39,6 +41,13 @@ falling back to the same default. The selected version must exist in
 
 `Build` uses Zig's build-system options (`-Doptimize=`, `-Dtarget=`), while
 `BuildExe` uses the compiler flags (`-O`, `-target`).
+
+`Cc`/`Cxx` expose Zig as a drop-in C/C++ cross-compiler: `zig cc` and `zig c++`
+are clang frontends that bundle libc and headers for every supported target, so
+cross-compilation needs no sysroot setup — pass a clang `-target` triple (e.g.
+`x86_64-windows-gnu`) and Zig supplies the rest. `outputName` is named so to
+avoid colliding with the Dagger CLI's top-level `--output`/`-o` flag (same
+precedent as `go`'s `Ci.WithBuild`).
 
 ## CLI quick reference
 
@@ -53,6 +62,10 @@ dagger -m daggerverse/zig call container \
 
 # Cross-compile a project for aarch64-linux
 dagger -m daggerverse/zig call build --source=. --target=aarch64-linux
+
+# Cross-compile a C file to a Windows .exe with `zig cc`
+dagger -m daggerverse/zig call cc --source=. --files=hello.c \
+    --target=x86_64-windows-gnu --output-name=hello.exe
 ```
 
 ## Zig SDK quick reference
@@ -68,6 +81,12 @@ exe := z.BuildExe(src, "main.zig", dagger.ZigBuildExeOpts{Name: "app"})
 
 // Run returns the program's stdout.
 stdout, err := z.Run(ctx, src)
+
+// Cc / Cxx compile C / C++ source, returning the artifact as a *File.
+exe := z.Cc(src, []string{"hello.c"}, dagger.ZigCcOpts{
+	Target:     "x86_64-windows-gnu",
+	OutputName: "hello.exe",
+})
 ```
 
 See `tests/main.go` for one example per function.

--- a/daggerverse/zig/dagger.gen.go
+++ b/daggerverse/zig/dagger.gen.go
@@ -286,6 +286,48 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Zig).BuildExe(&parent, ctx, source, root, optimize, target, name, args)
+		case "Cc":
+			var parent Zig
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var source *dagger.Directory
+			if inputArgs["source"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["source"]), &source)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg source", err))
+				}
+			}
+			var files []string
+			if inputArgs["files"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["files"]), &files)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg files", err))
+				}
+			}
+			var target string
+			if inputArgs["target"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["target"]), &target)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg target", err))
+				}
+			}
+			var outputName string
+			if inputArgs["outputName"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["outputName"]), &outputName)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg outputName", err))
+				}
+			}
+			var args []string
+			if inputArgs["args"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["args"]), &args)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg args", err))
+				}
+			}
+			return (*Zig).Cc(&parent, ctx, source, files, target, outputName, args)
 		case "Container":
 			var parent Zig
 			err = json.Unmarshal(parentJSON, &parent)
@@ -300,6 +342,48 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Zig).Container(&parent, ctx, source)
+		case "Cxx":
+			var parent Zig
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var source *dagger.Directory
+			if inputArgs["source"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["source"]), &source)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg source", err))
+				}
+			}
+			var files []string
+			if inputArgs["files"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["files"]), &files)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg files", err))
+				}
+			}
+			var target string
+			if inputArgs["target"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["target"]), &target)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg target", err))
+				}
+			}
+			var outputName string
+			if inputArgs["outputName"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["outputName"]), &outputName)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg outputName", err))
+				}
+			}
+			var args []string
+			if inputArgs["args"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["args"]), &args)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg args", err))
+				}
+			}
+			return (*Zig).Cxx(&parent, ctx, source, files, target, outputName, args)
 		case "Env":
 			var parent Zig
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/zig/main.go
+++ b/daggerverse/zig/main.go
@@ -188,6 +188,80 @@ func (z *Zig) BuildExe(
 	return ctr.WithExec(cmd).File("/src/" + out), nil
 }
 
+// Cc cross-compiles C source with `zig cc`, a clang frontend that bundles libc
+// and headers for every supported target, so cross-compilation needs no sysroot
+// setup. files is required (the C source files, relative to source). target,
+// when non-empty, sets clang's -target triple (e.g. "x86_64-windows-gnu").
+// outputName names the produced artifact (default "a.out"); extra clang flags
+// pass through via args. Returns the artifact as a *dagger.File.
+//
+// outputName (CLI: --output-name) is named so to avoid colliding with the
+// Dagger CLI's top-level --output/-o flag — same precedent as go's Ci.WithBuild.
+//
+// +cache="session"
+func (z *Zig) Cc(
+	ctx context.Context,
+	source *dagger.Directory,
+	files []string,
+	// +optional
+	target string,
+	// +default="a.out"
+	outputName string,
+	// +optional
+	args []string,
+) (*dagger.File, error) {
+	return z.compileC(ctx, "cc", source, files, target, outputName, args)
+}
+
+// Cxx cross-compiles C++ source with `zig c++` (the C++ frontend; bundles
+// libc++). Same parameters and semantics as Cc.
+//
+// +cache="session"
+func (z *Zig) Cxx(
+	ctx context.Context,
+	source *dagger.Directory,
+	files []string,
+	// +optional
+	target string,
+	// +default="a.out"
+	outputName string,
+	// +optional
+	args []string,
+) (*dagger.File, error) {
+	return z.compileC(ctx, "c++", source, files, target, outputName, args)
+}
+
+// compileC runs `zig <tool> <files...> [-target <target>] -o <outputName>
+// [args...]` against source and returns the produced artifact. tool is "cc" or
+// "c++".
+func (z *Zig) compileC(
+	ctx context.Context,
+	tool string,
+	source *dagger.Directory,
+	files []string,
+	target, outputName string,
+	args []string,
+) (*dagger.File, error) {
+	if len(files) == 0 {
+		return nil, fmt.Errorf("zig %s: files is required (at least one source file)", tool)
+	}
+	if outputName == "" {
+		outputName = "a.out"
+	}
+	ctr, err := z.Container(ctx, source)
+	if err != nil {
+		return nil, err
+	}
+	cmd := []string{"zig", tool}
+	cmd = append(cmd, files...)
+	if target != "" {
+		cmd = append(cmd, "-target", target)
+	}
+	cmd = append(cmd, "-o", outputName)
+	cmd = append(cmd, args...)
+	return ctr.WithExec(cmd).File("/src/" + outputName), nil
+}
+
 // Run runs `zig build run [-- args...]` against the supplied source and
 // returns the program's stdout.
 //

--- a/daggerverse/zig/main.go
+++ b/daggerverse/zig/main.go
@@ -248,6 +248,13 @@ func (z *Zig) compileC(
 	if outputName == "" {
 		outputName = "a.out"
 	}
+	// outputName is a bare filename, not a path: the artifact is resolved at
+	// "/src/"+outputName below, so a path-like value (e.g. "/tmp/a.out" or
+	// "sub/a.out") would write outside /src yet resolve at the wrong location
+	// and fail with a confusing file-not-found error. Reject it up front.
+	if strings.ContainsRune(outputName, '/') {
+		return nil, fmt.Errorf("zig %s: outputName %q must be a bare filename, not a path", tool, outputName)
+	}
 	ctr, err := z.Container(ctx, source)
 	if err != nil {
 		return nil, err

--- a/daggerverse/zig/tests/dagger.gen.go
+++ b/daggerverse/zig/tests/dagger.gen.go
@@ -245,6 +245,27 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).BuildRejectsInvalidOptimize(&parent, ctx)
+		case "CcCompilesHelloC":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).CcCompilesHelloC(&parent, ctx)
+		case "CcCrossWindowsProducesExe":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).CcCrossWindowsProducesExe(&parent, ctx)
+		case "CcRejectsEmptyFiles":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).CcRejectsEmptyFiles(&parent, ctx)
 		case "ContainerHasZigToolchain":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -259,6 +280,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).ContainerInfersVersionFromZon(&parent, ctx)
+		case "CxxCompilesHelloCpp":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).CxxCompilesHelloCpp(&parent, ctx)
 		case "EnvContainsVersionKey":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/zig/tests/dagger.gen.go
+++ b/daggerverse/zig/tests/dagger.gen.go
@@ -266,6 +266,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).CcRejectsEmptyFiles(&parent, ctx)
+		case "CcRejectsPathOutputName":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).CcRejectsPathOutputName(&parent, ctx)
 		case "ContainerHasZigToolchain":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/zig/tests/fixtures/c/hello.c
+++ b/daggerverse/zig/tests/fixtures/c/hello.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main(void) {
+    printf("hello\n");
+    return 0;
+}

--- a/daggerverse/zig/tests/fixtures/cpp/hello.cpp
+++ b/daggerverse/zig/tests/fixtures/cpp/hello.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main() {
+    std::cout << "hello" << std::endl;
+    return 0;
+}

--- a/daggerverse/zig/tests/internal/dagger/zig.gen.go
+++ b/daggerverse/zig/tests/internal/dagger/zig.gen.go
@@ -204,6 +204,50 @@ func (r *Zig) BuildExe(source *Directory, root string, opts ...ZigBuildExeOpts) 
 	}
 }
 
+// ZigCcOpts contains options for Zig.Cc
+type ZigCcOpts struct {
+	Target string // zig (../../../../../daggerverse/zig/main.go:207:2)
+
+	// Default: "a.out"
+	OutputName string // zig (../../../../../daggerverse/zig/main.go:209:2)
+
+	Args []string // zig (../../../../../daggerverse/zig/main.go:211:2)
+}
+
+// Cc cross-compiles C source with `zig cc`, a clang frontend that bundles libc
+// and headers for every supported target, so cross-compilation needs no sysroot
+// setup. files is required (the C source files, relative to source). target,
+// when non-empty, sets clang's -target triple (e.g. "x86_64-windows-gnu").
+// outputName names the produced artifact (default "a.out"); extra clang flags
+// pass through via args. Returns the artifact as a *dagger.File.
+//
+// outputName (CLI: --output-name) is named so to avoid colliding with the
+// Dagger CLI's top-level --output/-o flag — same precedent as go's Ci.WithBuild.
+func (r *Zig) Cc(source *Directory, files []string, opts ...ZigCcOpts) *File { // zig (../../../../../daggerverse/zig/main.go:202:1)
+	assertNotNil("source", source)
+	q := r.query.Select("cc")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `target` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Target) {
+			q = q.Arg("target", opts[i].Target)
+		}
+		// `outputName` optional argument
+		if !querybuilder.IsZeroValue(opts[i].OutputName) {
+			q = q.Arg("outputName", opts[i].OutputName)
+		}
+		// `args` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Args) {
+			q = q.Arg("args", opts[i].Args)
+		}
+	}
+	q = q.Arg("source", source)
+	q = q.Arg("files", files)
+
+	return &File{
+		query: q,
+	}
+}
+
 // Container returns the prepared base container with the zig toolchain on
 // PATH, the shared zig-cache cache volume mounted, source mounted at /src, and
 // the working directory set to /src. Use this as an escape hatch when a Zig
@@ -224,9 +268,46 @@ func (r *Zig) Container(source *Directory) *Container { // zig (../../../../../d
 	}
 }
 
+// ZigCxxOpts contains options for Zig.Cxx
+type ZigCxxOpts struct {
+	Target string // zig (../../../../../daggerverse/zig/main.go:225:2)
+
+	// Default: "a.out"
+	OutputName string // zig (../../../../../daggerverse/zig/main.go:227:2)
+
+	Args []string // zig (../../../../../daggerverse/zig/main.go:229:2)
+}
+
+// Cxx cross-compiles C++ source with `zig c++` (the C++ frontend; bundles
+// libc++). Same parameters and semantics as Cc.
+func (r *Zig) Cxx(source *Directory, files []string, opts ...ZigCxxOpts) *File { // zig (../../../../../daggerverse/zig/main.go:220:1)
+	assertNotNil("source", source)
+	q := r.query.Select("cxx")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `target` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Target) {
+			q = q.Arg("target", opts[i].Target)
+		}
+		// `outputName` optional argument
+		if !querybuilder.IsZeroValue(opts[i].OutputName) {
+			q = q.Arg("outputName", opts[i].OutputName)
+		}
+		// `args` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Args) {
+			q = q.Arg("args", opts[i].Args)
+		}
+	}
+	q = q.Arg("source", source)
+	q = q.Arg("files", files)
+
+	return &File{
+		query: q,
+	}
+}
+
 // Env runs `zig env` in a source-less base container and returns its stdout
 // (JSON).
-func (r *Zig) Env(ctx context.Context) (string, error) { // zig (../../../../../daggerverse/zig/main.go:295:1)
+func (r *Zig) Env(ctx context.Context) (string, error) { // zig (../../../../../daggerverse/zig/main.go:369:1)
 	if r.env != nil {
 		return *r.env, nil
 	}
@@ -249,7 +330,7 @@ func (r *Zig) Env(ctx context.Context) (string, error) { // zig (../../../../../
 // boundary whenever it also returns a non-nil error: a (string, error)
 // signature would leave the file list unreachable on exactly the failure path
 // that needs it.
-func (r *Zig) Fmt(ctx context.Context, source *Directory) error { // zig (../../../../../daggerverse/zig/main.go:252:1)
+func (r *Zig) Fmt(ctx context.Context, source *Directory) error { // zig (../../../../../daggerverse/zig/main.go:326:1)
 	assertNotNil("source", source)
 	if r.fmt != nil {
 		return nil
@@ -311,12 +392,12 @@ func (r *Zig) UnmarshalJSON(bs []byte) error {
 
 // ZigRunOpts contains options for Zig.Run
 type ZigRunOpts struct {
-	Args []string // zig (../../../../../daggerverse/zig/main.go:199:2)
+	Args []string // zig (../../../../../daggerverse/zig/main.go:273:2)
 }
 
 // Run runs `zig build run [-- args...]` against the supplied source and
 // returns the program's stdout.
-func (r *Zig) Run(ctx context.Context, source *Directory, opts ...ZigRunOpts) (string, error) { // zig (../../../../../daggerverse/zig/main.go:195:1)
+func (r *Zig) Run(ctx context.Context, source *Directory, opts ...ZigRunOpts) (string, error) { // zig (../../../../../daggerverse/zig/main.go:269:1)
 	assertNotNil("source", source)
 	if r.run != nil {
 		return *r.run, nil
@@ -338,7 +419,7 @@ func (r *Zig) Run(ctx context.Context, source *Directory, opts ...ZigRunOpts) (s
 
 // Targets runs `zig targets` in a source-less base container and returns its
 // stdout (the supported architecture/OS/ABI matrix).
-func (r *Zig) Targets(ctx context.Context) (string, error) { // zig (../../../../../daggerverse/zig/main.go:307:1)
+func (r *Zig) Targets(ctx context.Context) (string, error) { // zig (../../../../../daggerverse/zig/main.go:381:1)
 	if r.targets != nil {
 		return *r.targets, nil
 	}
@@ -352,14 +433,14 @@ func (r *Zig) Targets(ctx context.Context) (string, error) { // zig (../../../..
 
 // ZigTestOpts contains options for Zig.Test
 type ZigTestOpts struct {
-	Root string // zig (../../../../../daggerverse/zig/main.go:221:2)
+	Root string // zig (../../../../../daggerverse/zig/main.go:295:2)
 
-	Args []string // zig (../../../../../daggerverse/zig/main.go:223:2)
+	Args []string // zig (../../../../../daggerverse/zig/main.go:297:2)
 }
 
 // Test runs `zig build test` when root is empty, else `zig test <root>`,
 // against the supplied source and returns the combined stdout.
-func (r *Zig) Test(ctx context.Context, source *Directory, opts ...ZigTestOpts) (string, error) { // zig (../../../../../daggerverse/zig/main.go:217:1)
+func (r *Zig) Test(ctx context.Context, source *Directory, opts ...ZigTestOpts) (string, error) { // zig (../../../../../daggerverse/zig/main.go:291:1)
 	assertNotNil("source", source)
 	if r.test != nil {
 		return *r.test, nil
@@ -385,7 +466,7 @@ func (r *Zig) Test(ctx context.Context, source *Directory, opts ...ZigTestOpts) 
 
 // ToolVersion runs `zig version` in a source-less base container and returns
 // the trimmed output (e.g. "0.14.1").
-func (r *Zig) ToolVersion(ctx context.Context) (string, error) { // zig (../../../../../daggerverse/zig/main.go:279:1)
+func (r *Zig) ToolVersion(ctx context.Context) (string, error) { // zig (../../../../../daggerverse/zig/main.go:353:1)
 	if r.toolVersion != nil {
 		return *r.toolVersion, nil
 	}

--- a/daggerverse/zig/tests/internal/dagger/zig.gen.go
+++ b/daggerverse/zig/tests/internal/dagger/zig.gen.go
@@ -307,7 +307,7 @@ func (r *Zig) Cxx(source *Directory, files []string, opts ...ZigCxxOpts) *File {
 
 // Env runs `zig env` in a source-less base container and returns its stdout
 // (JSON).
-func (r *Zig) Env(ctx context.Context) (string, error) { // zig (../../../../../daggerverse/zig/main.go:369:1)
+func (r *Zig) Env(ctx context.Context) (string, error) { // zig (../../../../../daggerverse/zig/main.go:376:1)
 	if r.env != nil {
 		return *r.env, nil
 	}
@@ -330,7 +330,7 @@ func (r *Zig) Env(ctx context.Context) (string, error) { // zig (../../../../../
 // boundary whenever it also returns a non-nil error: a (string, error)
 // signature would leave the file list unreachable on exactly the failure path
 // that needs it.
-func (r *Zig) Fmt(ctx context.Context, source *Directory) error { // zig (../../../../../daggerverse/zig/main.go:326:1)
+func (r *Zig) Fmt(ctx context.Context, source *Directory) error { // zig (../../../../../daggerverse/zig/main.go:333:1)
 	assertNotNil("source", source)
 	if r.fmt != nil {
 		return nil
@@ -392,12 +392,12 @@ func (r *Zig) UnmarshalJSON(bs []byte) error {
 
 // ZigRunOpts contains options for Zig.Run
 type ZigRunOpts struct {
-	Args []string // zig (../../../../../daggerverse/zig/main.go:273:2)
+	Args []string // zig (../../../../../daggerverse/zig/main.go:280:2)
 }
 
 // Run runs `zig build run [-- args...]` against the supplied source and
 // returns the program's stdout.
-func (r *Zig) Run(ctx context.Context, source *Directory, opts ...ZigRunOpts) (string, error) { // zig (../../../../../daggerverse/zig/main.go:269:1)
+func (r *Zig) Run(ctx context.Context, source *Directory, opts ...ZigRunOpts) (string, error) { // zig (../../../../../daggerverse/zig/main.go:276:1)
 	assertNotNil("source", source)
 	if r.run != nil {
 		return *r.run, nil
@@ -419,7 +419,7 @@ func (r *Zig) Run(ctx context.Context, source *Directory, opts ...ZigRunOpts) (s
 
 // Targets runs `zig targets` in a source-less base container and returns its
 // stdout (the supported architecture/OS/ABI matrix).
-func (r *Zig) Targets(ctx context.Context) (string, error) { // zig (../../../../../daggerverse/zig/main.go:381:1)
+func (r *Zig) Targets(ctx context.Context) (string, error) { // zig (../../../../../daggerverse/zig/main.go:388:1)
 	if r.targets != nil {
 		return *r.targets, nil
 	}
@@ -433,14 +433,14 @@ func (r *Zig) Targets(ctx context.Context) (string, error) { // zig (../../../..
 
 // ZigTestOpts contains options for Zig.Test
 type ZigTestOpts struct {
-	Root string // zig (../../../../../daggerverse/zig/main.go:295:2)
+	Root string // zig (../../../../../daggerverse/zig/main.go:302:2)
 
-	Args []string // zig (../../../../../daggerverse/zig/main.go:297:2)
+	Args []string // zig (../../../../../daggerverse/zig/main.go:304:2)
 }
 
 // Test runs `zig build test` when root is empty, else `zig test <root>`,
 // against the supplied source and returns the combined stdout.
-func (r *Zig) Test(ctx context.Context, source *Directory, opts ...ZigTestOpts) (string, error) { // zig (../../../../../daggerverse/zig/main.go:291:1)
+func (r *Zig) Test(ctx context.Context, source *Directory, opts ...ZigTestOpts) (string, error) { // zig (../../../../../daggerverse/zig/main.go:298:1)
 	assertNotNil("source", source)
 	if r.test != nil {
 		return *r.test, nil
@@ -466,7 +466,7 @@ func (r *Zig) Test(ctx context.Context, source *Directory, opts ...ZigTestOpts) 
 
 // ToolVersion runs `zig version` in a source-less base container and returns
 // the trimmed output (e.g. "0.14.1").
-func (r *Zig) ToolVersion(ctx context.Context) (string, error) { // zig (../../../../../daggerverse/zig/main.go:353:1)
+func (r *Zig) ToolVersion(ctx context.Context) (string, error) { // zig (../../../../../daggerverse/zig/main.go:360:1)
 	if r.toolVersion != nil {
 		return *r.toolVersion, nil
 	}

--- a/daggerverse/zig/tests/main.go
+++ b/daggerverse/zig/tests/main.go
@@ -62,6 +62,7 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("CcCompilesHelloC", t.CcCompilesHelloC)
 	jobs = jobs.WithJob("CcCrossWindowsProducesExe", t.CcCrossWindowsProducesExe)
 	jobs = jobs.WithJob("CcRejectsEmptyFiles", t.CcRejectsEmptyFiles)
+	jobs = jobs.WithJob("CcRejectsPathOutputName", t.CcRejectsPathOutputName)
 	jobs = jobs.WithJob("CxxCompilesHelloCpp", t.CxxCompilesHelloCpp)
 
 	return jobs.Run(ctx)
@@ -353,6 +354,28 @@ func (t *Tests) CcRejectsEmptyFiles(ctx context.Context) error {
 	_, err := dag.Zig().Cc(cDir(), []string{}).Sync(ctx)
 	if err == nil {
 		return fmt.Errorf("expected error for empty files, got nil")
+	}
+	// Assert it's the validation error, not an incidental exec failure, so a
+	// regression that drops the up-front check (and instead fails inside zig)
+	// doesn't slip through.
+	if !strings.Contains(err.Error(), "files is required") {
+		return fmt.Errorf("expected files-required validation error, got: %v", err)
+	}
+	return nil
+}
+
+// CcRejectsPathOutputName asserts Cc rejects a path-like outputName (the
+// parameter is a bare filename, not a path). The validation error surfaces on
+// resolve, before any zig exec runs.
+func (t *Tests) CcRejectsPathOutputName(ctx context.Context) error {
+	_, err := dag.Zig().Cc(cDir(), []string{"hello.c"}, dagger.ZigCcOpts{
+		OutputName: "/tmp/a.out",
+	}).Sync(ctx)
+	if err == nil {
+		return fmt.Errorf("expected error for path-like outputName, got nil")
+	}
+	if !strings.Contains(err.Error(), "must be a bare filename") {
+		return fmt.Errorf("expected bare-filename validation error, got: %v", err)
 	}
 	return nil
 }

--- a/daggerverse/zig/tests/main.go
+++ b/daggerverse/zig/tests/main.go
@@ -59,6 +59,10 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("RunHelloPrintsHello", t.RunHelloPrintsHello)
 	jobs = jobs.WithJob("FmtHelloIsClean", t.FmtHelloIsClean)
 	jobs = jobs.WithJob("FmtUnformattedReportsFile", t.FmtUnformattedReportsFile)
+	jobs = jobs.WithJob("CcCompilesHelloC", t.CcCompilesHelloC)
+	jobs = jobs.WithJob("CcCrossWindowsProducesExe", t.CcCrossWindowsProducesExe)
+	jobs = jobs.WithJob("CcRejectsEmptyFiles", t.CcRejectsEmptyFiles)
+	jobs = jobs.WithJob("CxxCompilesHelloCpp", t.CxxCompilesHelloCpp)
 
 	return jobs.Run(ctx)
 }
@@ -85,6 +89,16 @@ func singleDir() *dagger.Directory {
 // bad.zig that `zig fmt --check` must report.
 func unformattedDir() *dagger.Directory {
 	return dag.CurrentModule().Source().Directory("fixtures/unformatted")
+}
+
+// cDir returns the C fixture (hello.c) for the Cc tests.
+func cDir() *dagger.Directory {
+	return dag.CurrentModule().Source().Directory("fixtures/c")
+}
+
+// cppDir returns the C++ fixture (hello.cpp) for the Cxx tests.
+func cppDir() *dagger.Directory {
+	return dag.CurrentModule().Source().Directory("fixtures/cpp")
 }
 
 // ContainerHasZigToolchain proves the base container is reachable, the
@@ -297,6 +311,61 @@ func (t *Tests) FmtUnformattedReportsFile(ctx context.Context) error {
 	}
 	if !strings.Contains(err.Error(), "bad.zig") {
 		return fmt.Errorf("expected 'bad.zig' in fmt error, got %q", err.Error())
+	}
+	return nil
+}
+
+// CcCompilesHelloC compiles the C fixture for the host with `zig cc` and
+// asserts the produced artifact is non-empty.
+func (t *Tests) CcCompilesHelloC(ctx context.Context) error {
+	size, err := dag.Zig().Cc(cDir(), []string{"hello.c"}).Size(ctx)
+	if err != nil {
+		return fmt.Errorf("Cc hello.c: %w", err)
+	}
+	if size == 0 {
+		return fmt.Errorf("expected non-empty artifact, got size 0")
+	}
+	return nil
+}
+
+// CcCrossWindowsProducesExe cross-compiles the C fixture for
+// x86_64-windows-gnu and asserts the artifact carries the requested output
+// name. Resolving .Name runs the cross-compile, so a successful Name read also
+// proves the cross build succeeded.
+func (t *Tests) CcCrossWindowsProducesExe(ctx context.Context) error {
+	f := dag.Zig().Cc(cDir(), []string{"hello.c"}, dagger.ZigCcOpts{
+		Target:     "x86_64-windows-gnu",
+		OutputName: "hello.exe",
+	})
+	name, err := f.Name(ctx)
+	if err != nil {
+		return fmt.Errorf("cross exe Name: %w", err)
+	}
+	if name != "hello.exe" {
+		return fmt.Errorf("expected exe name %q, got %q", "hello.exe", name)
+	}
+	return nil
+}
+
+// CcRejectsEmptyFiles asserts Cc rejects an empty files slice. Cc returns a
+// lazy file, so the validation error surfaces on resolve.
+func (t *Tests) CcRejectsEmptyFiles(ctx context.Context) error {
+	_, err := dag.Zig().Cc(cDir(), []string{}).Sync(ctx)
+	if err == nil {
+		return fmt.Errorf("expected error for empty files, got nil")
+	}
+	return nil
+}
+
+// CxxCompilesHelloCpp compiles the C++ fixture for the host with `zig c++` and
+// asserts the produced artifact is non-empty.
+func (t *Tests) CxxCompilesHelloCpp(ctx context.Context) error {
+	size, err := dag.Zig().Cxx(cppDir(), []string{"hello.cpp"}).Size(ctx)
+	if err != nil {
+		return fmt.Errorf("Cxx hello.cpp: %w", err)
+	}
+	if size == 0 {
+		return fmt.Errorf("expected non-empty artifact, got size 0")
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Exposes Zig's clang-frontend C/C++ compiler as first-class Dagger functions on the `zig` module:

- **`Cc`** — `zig cc <files...> [-target ..] -o <outputName> [args...]`
- **`Cxx`** — `zig c++ ...` (C++ counterpart)

`zig cc`/`zig c++` bundle libc and headers for every supported target, so cross-compilation needs no sysroot setup — useful for compiling C/C++ directly and as `CC` for foreign toolchains (e.g. Go CGO cross-builds). Both reuse the existing checksum-verified base container.

### Details
- `files` is required; an empty slice is rejected with a clear error before any exec.
- `outputName` (CLI `--output-name`) is renamed from `output` to avoid colliding with the Dagger CLI's top-level `--output`/`-o`, per the `go` module's `Ci.WithBuild` precedent. Defaults to `a.out`.
- Both functions carry `+cache="session"` and share an unexported `compileC` helper.
- Adds `fixtures/c/hello.c` + `fixtures/cpp/hello.cpp` and 4 tests wired into `tests/All` under `+check`.

## Test plan
- [x] `Cc`/`Cxx` appear in `dagger functions`.
- [x] Each test passes individually: `cc-compiles-hello-c`, `cc-cross-windows-produces-exe`, `cc-rejects-empty-files`, `cxx-compiles-hello-cpp`.
- [x] `dagger -m daggerverse/zig/tests call all` green.
- [x] `gofmt` + `go vet ./...` clean in both modules.

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)