### PR TITLE
story(issue-98): add qemu service-bind networking tests

### DIFF
--- a/daggerverse/qemu/tests/artifacts.go
+++ b/daggerverse/qemu/tests/artifacts.go
@@ -104,14 +104,18 @@ func serviceInitramfs(port int) *dagger.File {
 		// boot, so two reads of the same running instance match.
 		"/bin/busybox head -c 16 /dev/urandom | /bin/busybox od -An -tx1 | /bin/busybox tr -d ' \\n' > /tmp/token",
 		fmt.Sprintf("/bin/busybox echo LISTENER_UP %d", port),
-		// Serve the token on every connection with a persistent listener
-		// (-lk keeps listening; -e cat writes the token then exits, so the socket
-		// closes cleanly and the client reads token+EOF). The outer loop is
-		// belt-and-suspenders in case nc ever returns. Note: a slirp hostfwd port
-		// accepts host-side even before the guest listens, so only an actual
-		// data read (the token) proves end-to-end reachability — a bare connect
-		// would be a false positive.
-		fmt.Sprintf("while true; do /bin/busybox nc -lk -p %d -e /bin/busybox cat /tmp/token; done", port),
+		// Serve the token with a one-shot listener restarted by the outer loop:
+		// `nc -l` copies stdin (/tmp/token) to the connected socket, then exits
+		// when the client disconnects, so the client reads token+EOF and the next
+		// loop iteration relistens for the next probe. busybox nc has no `-k`
+		// keep-listening, and its `-e` execs a single program *path* with no
+		// applet args (`-e /bin/busybox cat` would exec busybox with no applet
+		// selected and never serve the token), so feeding the file via stdin is
+		// the reliable way to serve it. Note: a slirp hostfwd port accepts
+		// host-side even before the guest listens, so only an actual data read
+		// (the token) proves end-to-end reachability — a bare connect would be a
+		// false positive.
+		fmt.Sprintf("while true; do /bin/busybox nc -l -p %d < /tmp/token; done", port),
 		"",
 	}, "\n")
 

--- a/daggerverse/qemu/tests/artifacts.go
+++ b/daggerverse/qemu/tests/artifacts.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"strings"
 
 	"dagger/tests/internal/dagger"
@@ -29,6 +30,104 @@ func curlFile(url, out string) *dagger.File {
 		WithExec([]string{"apk", "add", "--no-cache", "curl"}).
 		WithExec([]string{"curl", "-fsSL", "-o", "/" + out, url}).
 		File("/" + out)
+}
+
+// alpineArm64NetModules extracts the kernel modules the virtio networking
+// stack needs into a flat *dagger.Directory of plain (decompressed) .ko files.
+// Alpine's aarch64 `linux-virt` kernel builds virtio_net, the -M virt MMIO
+// transport, and virtio_net's failover deps as modules (=m), so the busybox
+// initramfs has to insmod them before any eth0 exists. modloop-virt is pulled
+// from the same netboot release as the kernel, so the module versions match
+// vmlinuz-virt exactly. Modules are found by name (not a hardcoded version
+// path) so a 3.21 point-release still resolves, and normalized to plain .ko so
+// the guest's busybox insmod can load them without compression support.
+func alpineArm64NetModules() *dagger.Directory {
+	return dag.Container().
+		From("alpine:"+alpineTestTag).
+		WithExec([]string{"apk", "add", "--no-cache", "curl", "squashfs-tools", "zstd"}).
+		WithExec([]string{"curl", "-fsSL", "-o", "/modloop", alpineNetboot + "/modloop-virt"}).
+		WithExec([]string{"sh", "-c", `set -eu
+unsquashfs -d /sqsh /modloop
+mkdir /mods
+for m in failover net_failover virtio_mmio virtio_net; do
+  f=$(find /sqsh \( -name "$m.ko" -o -name "$m.ko.gz" -o -name "$m.ko.zst" \) | head -n1)
+  if [ -z "$f" ]; then echo "module $m not found in modloop" >&2; exit 1; fi
+  case "$f" in
+    *.gz)  gunzip -c "$f" > /mods/$m.ko ;;
+    *.zst) unzstd -c "$f" > /mods/$m.ko ;;
+    *)     cp "$f" /mods/$m.ko ;;
+  esac
+done`}).
+		Directory("/mods")
+}
+
+// serviceInitramfs builds a gzip-compressed cpio initramfs whose /init brings
+// up guest networking and runs a persistent TCP listener on port — the
+// service-bind counterpart to firmwareInitramfs. It bundles the virtio net
+// modules at /lib/modules, insmods them in dependency order, assigns slirp's
+// default guest address (10.0.2.15, the hostfwd target), then loops a busybox
+// `nc -l` so the forwarded port survives repeated probes (busybox nc serves one
+// connection per invocation). The busybox is the aarch64 static build, matching
+// the aarch64 kernel.
+func serviceInitramfs(port int) *dagger.File {
+	busybox := dag.Container(dagger.ContainerOpts{Platform: dagger.Platform("linux/arm64")}).
+		From("alpine:"+alpineTestTag).
+		WithExec([]string{"apk", "add", "--no-cache", "busybox-static"}).
+		File("/bin/busybox.static")
+
+	init := strings.Join([]string{
+		"#!/bin/busybox sh",
+		"/bin/busybox mkdir -p /proc /sys /dev /tmp",
+		"/bin/busybox mount -t proc none /proc",
+		"/bin/busybox mount -t sysfs none /sys",
+		"/bin/busybox mount -t devtmpfs none /dev",
+		// linux-virt builds the virtio net stack as modules (=m); load in dep
+		// order: failover <- net_failover <- virtio_net, plus the -M virt MMIO
+		// transport. virtio core/PCI are built-in (=y).
+		"/bin/busybox insmod /lib/modules/failover.ko",
+		"/bin/busybox insmod /lib/modules/net_failover.ko",
+		"/bin/busybox insmod /lib/modules/virtio_mmio.ko",
+		"/bin/busybox insmod /lib/modules/virtio_net.ko",
+		// Wait for the NIC to probe before configuring it.
+		"i=0; while [ $i -lt 30 ]; do /bin/busybox ifconfig eth0 >/dev/null 2>&1 && break; /bin/busybox sleep 1; i=$((i+1)); done",
+		"/bin/busybox ifconfig lo 127.0.0.1 up",
+		"/bin/busybox ifconfig eth0 10.0.2.15 netmask 255.255.255.0 up",
+		"/bin/busybox route add default gw 10.0.2.2",
+		// Prime QEMU slirp: a listen-only guest never sends outbound traffic, so
+		// slirp never learns the guest and inbound hostfwd silently fails to
+		// deliver (connect is accepted host-side but no data reaches the guest).
+		// One outbound packet to the gateway registers the guest so hostfwd works.
+		"/bin/busybox ping -c 2 -W 2 10.0.2.2 >/dev/null 2>&1 || true",
+		// Mint a per-boot identity token so a consumer can tell one boot of this
+		// machine from another: a fresh boot (e.g. after Stop tears the VM down
+		// and a rebind restarts it) serves a different token. Stable within one
+		// boot, so two reads of the same running instance match.
+		"/bin/busybox head -c 16 /dev/urandom | /bin/busybox od -An -tx1 | /bin/busybox tr -d ' \\n' > /tmp/token",
+		fmt.Sprintf("/bin/busybox echo LISTENER_UP %d", port),
+		// Serve the token on every connection with a persistent listener
+		// (-lk keeps listening; -e cat writes the token then exits, so the socket
+		// closes cleanly and the client reads token+EOF). The outer loop is
+		// belt-and-suspenders in case nc ever returns. Note: a slirp hostfwd port
+		// accepts host-side even before the guest listens, so only an actual
+		// data read (the token) proves end-to-end reachability — a bare connect
+		// would be a false positive.
+		fmt.Sprintf("while true; do /bin/busybox nc -lk -p %d -e /bin/busybox cat /tmp/token; done", port),
+		"",
+	}, "\n")
+
+	return dag.Container().
+		From("alpine:"+alpineTestTag).
+		WithExec([]string{"apk", "add", "--no-cache", "cpio"}).
+		WithMountedFile("/src/busybox", busybox).
+		WithMountedDirectory("/src/mods", alpineArm64NetModules()).
+		WithNewFile("/src/init", init).
+		WithExec([]string{"sh", "-c",
+			"set -e; mkdir -p /root/bin /root/lib/modules; " +
+				"cp /src/busybox /root/bin/busybox; chmod +x /root/bin/busybox; " +
+				"cp /src/mods/*.ko /root/lib/modules/; " +
+				"cp /src/init /root/init; chmod +x /root/init; " +
+				"cd /root && find . | cpio -o -H newc | gzip -9 > /initramfs.gz"}).
+		File("/initramfs.gz")
 }
 
 // firmwareInitramfs builds a tiny gzip-compressed cpio initramfs whose /init

--- a/daggerverse/qemu/tests/dagger.gen.go
+++ b/daggerverse/qemu/tests/dagger.gen.go
@@ -273,6 +273,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).LinuxRejectsNilKernel(&parent, ctx)
+		case "Networking":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var parallel int
+			if inputArgs["parallel"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["parallel"]), &parallel)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg parallel", err))
+				}
+			}
+			return nil, (*Tests).Networking(&parent, ctx, parallel)
 		case "RunCapturesFirmwareSerial":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -294,6 +308,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).SerialLogMaterializesFile(&parent, ctx)
+		case "ServiceForwardedPortReachable":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ServiceForwardedPortReachable(&parent, ctx)
+		case "StopHaltsService":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).StopHaltsService(&parent, ctx)
 		case "Validation":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/qemu/tests/main.go
+++ b/daggerverse/qemu/tests/main.go
@@ -1,13 +1,14 @@
 // Tests for the qemu daggerverse module. Each test is exposed as a standalone
 // dagger function so it can be invoked individually during TDD; All wires them
-// up for parallel execution under `dagger call all`. The three sub-aggregators
-// (Validation, Firmware, Boot) each carry `+check` so CI schedules them onto
-// their own runners.
+// up for parallel execution under `dagger call all`. The four sub-aggregators
+// (Validation, Firmware, Boot, Networking) each carry `+check` so CI schedules
+// them onto their own runners.
 package main
 
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	par "github.com/dagger/dagger/util/parallel"
@@ -37,6 +38,7 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("Validation", func(ctx context.Context) error { return t.Validation(ctx, parallel) })
 	jobs = jobs.WithJob("Firmware", func(ctx context.Context) error { return t.Firmware(ctx, parallel) })
 	jobs = jobs.WithJob("Boot", func(ctx context.Context) error { return t.Boot(ctx, parallel) })
+	jobs = jobs.WithJob("Networking", func(ctx context.Context) error { return t.Networking(ctx, parallel) })
 	return jobs.Run(ctx)
 }
 
@@ -107,6 +109,28 @@ func (t *Tests) Boot(
 	return jobs.Run(ctx)
 }
 
+// Networking runs the service-bind end-to-end tests: boot a guest that brings up
+// networking and serves a forwarded port, then prove reachability and teardown
+// through WithServiceBinding. These are slow TCG boots plus real networking.
+//
+// +check
+// +cache="session"
+func (t *Tests) Networking(
+	ctx context.Context,
+	// +default=0
+	parallel int,
+) error {
+	jobs := par.New().
+		WithRollupLogs(true).
+		WithRollupSpans(true)
+	if parallel > 0 {
+		jobs = jobs.WithLimit(parallel)
+	}
+	jobs = jobs.WithJob("service-forwarded-port-reachable", t.ServiceForwardedPortReachable)
+	jobs = jobs.WithJob("stop-halts-service", t.StopHaltsService)
+	return jobs.Run(ctx)
+}
+
 // -----------------------------------------------------------------------------
 // Helpers
 // -----------------------------------------------------------------------------
@@ -126,6 +150,72 @@ func randName(ctx context.Context, prefix string) (string, error) {
 // tests that never actually boot the guest.
 func placeholderFile(name string) *dagger.File {
 	return dag.Directory().WithNewFile(name, "qemu-test-placeholder").File(name)
+}
+
+// randPort mints an unprivileged TCP port at runtime from random bytes (no
+// literals committed) so parallel service tests never collide on a forwarded
+// port. The value folds into the guest listener, the tcpPorts hostfwd, and the
+// consumer probe alike.
+func randPort(ctx context.Context) (int, error) {
+	h, err := dag.Random().Sha256(ctx, dagger.RandomSha256Opts{N: 8})
+	if err != nil {
+		return 0, err
+	}
+	v, err := strconv.ParseInt(h[:4], 16, 32)
+	if err != nil {
+		return 0, err
+	}
+	return 20000 + int(v)%40000, nil
+}
+
+// serviceMachine builds an aarch64 Machine that boots the real Alpine kernel
+// with the service initramfs: it brings up networking and listens on port. label
+// keeps parallel tests on independent session-cached machines.
+func serviceMachine(ctx context.Context, label string, port int) (*dagger.QemuMachine, error) {
+	tok, err := randName(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+	return dag.Qemu().Linux(alpineArm64Kernel(), dagger.QemuLinuxOpts{
+		Initrd:   serviceInitramfs(port),
+		Cmdline:  "console=ttyAMA0 rdinit=/init",
+		TCPPorts: []int{port},
+		Name:     "qemu-svc-" + label + "-" + tok,
+	}), nil
+}
+
+// reachToken binds the machine into a fresh consumer and reads the guest's
+// per-boot identity token off the forwarded port, retrying up to attempts
+// seconds. The returned token identifies which boot answered, so a caller can
+// tell a torn-down-and-restarted instance from one that stayed up. The nonce
+// env var keeps two reads against the same host:port from cache-colliding.
+func reachToken(ctx context.Context, m *dagger.QemuMachine, port, attempts int) (string, error) {
+	host, err := m.Host(ctx)
+	if err != nil {
+		return "", err
+	}
+	nonce, err := randName(ctx, "")
+	if err != nil {
+		return "", err
+	}
+	bound := m.Bind(dag.Container().
+		From("alpine:" + alpineTestTag).
+		WithExec([]string{"apk", "add", "--no-cache", "busybox-extras"}))
+	// Hold the client's stdin open with a sleep so busybox nc doesn't close the
+	// socket on stdin-EOF before it reads the token the guest sends; head -c
+	// returns as soon as the token arrives. Each attempt is ~3s, so no extra
+	// sleep between iterations.
+	out, err := bound.
+		WithEnvVariable("REACH_NONCE", nonce).
+		WithExec([]string{"sh", "-c", fmt.Sprintf(
+			"for i in $(seq 1 %d); do out=$( (sleep 3) | nc -w 3 %s %d 2>/dev/null | tr -dc 'a-f0-9' | head -c 64 ); "+
+				"if [ -n \"$out\" ]; then printf '%%s' \"$out\"; exit 0; fi; done; exit 1",
+			attempts, host, port)}).
+		Stdout(ctx)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
 }
 
 // -----------------------------------------------------------------------------
@@ -379,6 +469,90 @@ func (t *Tests) LinuxBootReachesUserspace(ctx context.Context) error {
 	}
 	if !strings.Contains(out, "USERSPACE_OK") || !strings.Contains(out, marker) {
 		return fmt.Errorf("expected userspace to run (USERSPACE_OK + marker %q), got:\n%s", marker, out)
+	}
+	return nil
+}
+
+// -----------------------------------------------------------------------------
+// Networking (service-bind end-to-end) tests
+// -----------------------------------------------------------------------------
+
+// ServiceForwardedPortReachable boots a guest that brings up networking and
+// listens on a runtime-minted port, forwards it over slirp hostfwd, binds the
+// machine into a fresh consumer container, and asserts the port is reachable —
+// proving hostfwd + slirp + WithServiceBinding wiring end-to-end.
+//
+// +cache="never"
+func (t *Tests) ServiceForwardedPortReachable(ctx context.Context) error {
+	port, err := randPort(ctx)
+	if err != nil {
+		return err
+	}
+	m, err := serviceMachine(ctx, "reach", port)
+	if err != nil {
+		return err
+	}
+	defer m.Stop(ctx)
+	// Read the guest's per-boot token (not a bare connect): a slirp hostfwd port
+	// accepts host-side even before the guest listens, so only an actual data
+	// exchange proves the listener is reachable end-to-end.
+	tok, err := reachToken(ctx, m, port, 60)
+	if err != nil {
+		return fmt.Errorf("forwarded port %d was not reachable through the bound machine: %w", port, err)
+	}
+	if tok == "" {
+		return fmt.Errorf("reached port %d but read an empty identity token", port)
+	}
+	return nil
+}
+
+// StopHaltsService proves Stop's +cache="never" teardown actually halts the
+// backing service (the postgres EndpointShouldNotBeCached lifecycle analog).
+// The guest serves a per-boot identity token. We pin the service up with an
+// explicit Start so it stays one instance across reads, read the token, Stop
+// the machine, then read again — the second read re-binds and, because Stop
+// killed the original VM, gets a *fresh* boot with a different token. A no-op
+// Stop would leave the pinned instance serving the same token, so an unchanged
+// token fails the test. This is robust to fast TCG boots (it relies on the
+// restart, not on out-racing it); the per-read nonce keeps the two reads from
+// cache-colliding.
+//
+// +cache="never"
+func (t *Tests) StopHaltsService(ctx context.Context) error {
+	port, err := randPort(ctx)
+	if err != nil {
+		return err
+	}
+	m, err := serviceMachine(ctx, "stop", port)
+	if err != nil {
+		return err
+	}
+	// Pin the backing service up so it stays a single instance across the first
+	// and second reads absent a teardown; defer cleanup.
+	if _, err := m.Service().Start(ctx); err != nil {
+		return fmt.Errorf("start service: %w", err)
+	}
+	defer m.Stop(ctx)
+
+	tok1, err := reachToken(ctx, m, port, 60)
+	if err != nil {
+		return fmt.Errorf("service never became reachable on port %d before Stop: %w", port, err)
+	}
+	if tok1 == "" {
+		return fmt.Errorf("first read returned an empty identity token")
+	}
+	if err := m.Stop(ctx); err != nil {
+		return fmt.Errorf("stop machine: %w", err)
+	}
+	tok2, err := reachToken(ctx, m, port, 60)
+	if err != nil {
+		return fmt.Errorf("service did not come back after Stop+rebind: %w", err)
+	}
+	if tok2 == "" {
+		return fmt.Errorf("second read returned an empty identity token")
+	}
+	if tok1 == tok2 {
+		return fmt.Errorf("expected Stop to tear down the VM (fresh boot => new token), but the identity token was unchanged: %q", tok1)
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #98. Builds on #97.

Adds the end-to-end service-topology tests that #97 deferred: boot a real guest that brings up networking and serves a forwarded TCP port, bind it into a consumer container, and prove reachability and teardown. **Tests only — no changes to the `qemu` module's public API.**

## What's added (`daggerverse/qemu/tests/`)
- **`ServiceForwardedPortReachable`** — boots an aarch64 guest that loads the virtio net modules, brings up `eth0`, and serves a per-boot identity token on a runtime-minted forwarded port; binds the machine into a fresh `alpine` consumer and reads the token end-to-end.
- **`StopHaltsService`** — the postgres `EndpointShouldNotBeCached` lifecycle analog: `Start` the service, read the token, `Stop`, read again; a *changed* token proves `Stop` tore the VM down and forced a fresh boot.
- **`Networking`** `+check` aggregator (auto-discovered via the `qemu-tests` toolchain), wired into `All`.

All ports and tokens are minted at runtime via `dag.Random().Sha256` / `/dev/urandom` — no literals.

## Two non-obvious guest requirements (why guest networking was deferred)
1. **Module loading.** Alpine's aarch64 `linux-virt` kernel builds `virtio_net`, `virtio_mmio` (the `-M virt` MMIO transport), `net_failover`, and `failover` as modules (`=m`). The busybox initramfs extracts the matching `.ko`s from `modloop-virt` (same netboot release as the kernel) and `insmod`s them before `eth0` exists.
2. **slirp priming.** A listen-only slirp guest never registers with QEMU, so inbound `hostfwd` silently delivers **zero bytes** — the host-side connect is accepted (so `nc -z` and Dagger's port health check both pass: a false positive), but no data reaches the guest. One outbound gateway packet (`ping 10.0.2.2`) registers the guest and unblocks delivery. The tests therefore read a real token rather than relying on `nc -z`.

## Verification
Each passes individually and under the aggregator (TCG boots):
- `dagger -m daggerverse/qemu/tests call service-forwarded-port-reachable` ✔
- `dagger -m daggerverse/qemu/tests call stop-halts-service` ✔
- `dagger -m daggerverse/qemu/tests call networking` ✔
- `dagger check -l` lists `qemu-tests:networking`

🤖 Generated with [Claude Code](https://claude.com/claude-code)