### PR TITLE
story(issue-108): add objcopy + size to zig module

### DIFF
--- a/daggerverse/zig/dagger.gen.go
+++ b/daggerverse/zig/dagger.gen.go
@@ -76,6 +76,42 @@ func (r *Zig) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
+func (r SectionSizes) MarshalJSON() ([]byte, error) {
+	var concrete struct {
+		Text  int
+		Data  int
+		Bss   int
+		Flash int
+		Ram   int
+	}
+	concrete.Text = r.Text
+	concrete.Data = r.Data
+	concrete.Bss = r.Bss
+	concrete.Flash = r.Flash
+	concrete.Ram = r.Ram
+	return json.Marshal(&concrete)
+}
+
+func (r *SectionSizes) UnmarshalJSON(bs []byte) error {
+	var concrete struct {
+		Text  int
+		Data  int
+		Bss   int
+		Flash int
+		Ram   int
+	}
+	err := json.Unmarshal(bs, &concrete)
+	if err != nil {
+		return err
+	}
+	r.Text = concrete.Text
+	r.Data = concrete.Data
+	r.Bss = concrete.Bss
+	r.Flash = concrete.Flash
+	r.Ram = concrete.Ram
+	return nil
+}
+
 func main() {
 	ctx := context.Background()
 
@@ -405,6 +441,41 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Zig).Fmt(&parent, ctx, source)
+		case "ObjCopy":
+			var parent Zig
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var input *dagger.File
+			if inputArgs["input"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["input"]), &input)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg input", err))
+				}
+			}
+			var format string
+			if inputArgs["format"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["format"]), &format)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg format", err))
+				}
+			}
+			var outputName string
+			if inputArgs["outputName"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["outputName"]), &outputName)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg outputName", err))
+				}
+			}
+			var args []string
+			if inputArgs["args"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["args"]), &args)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg args", err))
+				}
+			}
+			return (*Zig).ObjCopy(&parent, ctx, input, format, outputName, args)
 		case "Run":
 			var parent Zig
 			err = json.Unmarshal(parentJSON, &parent)
@@ -426,6 +497,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Zig).Run(&parent, ctx, source, args)
+		case "Size":
+			var parent Zig
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var input *dagger.File
+			if inputArgs["input"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["input"]), &input)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg input", err))
+				}
+			}
+			return (*Zig).Size(&parent, ctx, input)
 		case "Targets":
 			var parent Zig
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/zig/main.go
+++ b/daggerverse/zig/main.go
@@ -14,8 +14,11 @@ package main
 
 import (
 	"context"
+	"debug/elf"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -267,6 +270,122 @@ func (z *Zig) compileC(
 	cmd = append(cmd, "-o", outputName)
 	cmd = append(cmd, args...)
 	return ctr.WithExec(cmd).File("/src/" + outputName), nil
+}
+
+// ObjCopy runs `zig objcopy -O <format> <input> <output>` in the toolchain
+// container, converting an ELF (e.g. from BuildExe) into a flashable artifact,
+// and returns the result as a *dagger.File. This is the post-build step every
+// embedded flow needs before flashing.
+//
+// format selects the output target: "binary" (a raw .bin image) or "hex" (Intel
+// HEX). Any other value is rejected with a clear error — notably UF2 is out of
+// scope here, since `zig objcopy` can't emit it.
+//
+// outputName names the produced artifact and defaults to the input's basename
+// with its extension replaced by the format's (.bin or .hex). Extra flags (e.g.
+// --only-section, --pad-to) pass through via args.
+//
+// outputName (CLI: --output-name) is named so to avoid colliding with the Dagger
+// CLI's top-level --output/-o flag — same precedent as Cc/Cxx.
+//
+// +cache="session"
+func (z *Zig) ObjCopy(
+	ctx context.Context,
+	input *dagger.File,
+	// +default="binary"
+	format string,
+	// +default=""
+	outputName string,
+	// +optional
+	args []string,
+) (*dagger.File, error) {
+	ext, err := objCopyExt(format)
+	if err != nil {
+		return nil, err
+	}
+	if outputName == "" {
+		name, err := input.Name(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("ObjCopy: resolve input name: %w", err)
+		}
+		outputName = strings.TrimSuffix(name, filepath.Ext(name)) + ext
+	}
+	// outputName is a bare filename, not a path: the artifact is resolved at
+	// "/work/"+outputName below, so a path-like value would write outside /work
+	// yet resolve at the wrong location and fail confusingly. Reject it up front
+	// (same rule as compileC's outputName).
+	if strings.ContainsRune(outputName, '/') {
+		return nil, fmt.Errorf("ObjCopy: outputName %q must be a bare filename, not a path", outputName)
+	}
+	base, err := z.baseContainer(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	const inputPath = "/work/input"
+	cmd := []string{"zig", "objcopy", "-O", format, inputPath, outputName}
+	cmd = append(cmd, args...)
+	return base.
+		WithWorkdir("/work").
+		WithMountedFile(inputPath, input).
+		WithExec(cmd).
+		File("/work/" + outputName), nil
+}
+
+// SectionSizes is the per-section footprint of an ELF, in bytes. Flash and Ram
+// are the budget-relevant rollups: Flash is what the image occupies in flash,
+// Ram what it claims at runtime.
+type SectionSizes struct {
+	Text  int // SHF_ALLOC|SHF_EXECINSTR (code)
+	Data  int // SHF_ALLOC|SHF_WRITE, PROGBITS (initialized data)
+	Bss   int // SHF_ALLOC|SHF_WRITE, NOBITS (zero-init data)
+	Flash int // Text + Data (consumes flash)
+	Ram   int // Data + Bss (consumes RAM)
+}
+
+// Size reports the per-section byte totals of an ELF input (e.g. a freestanding
+// BuildExe output) so CI can gate Flash/Ram against a target's budget.
+//
+// Zig ships no `size` subcommand, so this is computed in pure Go via debug/elf:
+// the input is exported and its section headers are read directly — no helper
+// container (per the established runtime-I/O pattern). A non-ELF input returns a
+// clear error.
+//
+// +cache="session"
+func (z *Zig) Size(ctx context.Context, input *dagger.File) (*SectionSizes, error) {
+	dir, err := os.MkdirTemp(".", "elf-")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(dir)
+
+	path := filepath.Join(dir, "input")
+	if _, err := input.Export(ctx, path); err != nil {
+		return nil, fmt.Errorf("Size: export input: %w", err)
+	}
+
+	f, err := elf.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("Size: not a valid ELF file: %w", err)
+	}
+	defer f.Close()
+
+	var sizes SectionSizes
+	for _, sh := range f.Sections {
+		if sh.Flags&elf.SHF_ALLOC == 0 {
+			continue
+		}
+		switch {
+		case sh.Flags&elf.SHF_EXECINSTR != 0:
+			sizes.Text += int(sh.Size)
+		case sh.Flags&elf.SHF_WRITE != 0 && sh.Type == elf.SHT_PROGBITS:
+			sizes.Data += int(sh.Size)
+		case sh.Flags&elf.SHF_WRITE != 0 && sh.Type == elf.SHT_NOBITS:
+			sizes.Bss += int(sh.Size)
+		}
+	}
+	sizes.Flash = sizes.Text + sizes.Data
+	sizes.Ram = sizes.Data + sizes.Bss
+	return &sizes, nil
 }
 
 // Run runs `zig build run [-- args...]` against the supplied source and
@@ -571,6 +690,20 @@ func validateOptimize(optimize string) error {
 		return nil
 	default:
 		return fmt.Errorf("invalid optimize %q: must be one of Debug, ReleaseSafe, ReleaseFast, ReleaseSmall", optimize)
+	}
+}
+
+// objCopyExt validates an ObjCopy format and returns the output filename
+// extension for it: "binary" -> ".bin", "hex" -> ".hex". Any other value
+// (e.g. "uf2", which zig objcopy can't emit) is rejected with a clear error.
+func objCopyExt(format string) (string, error) {
+	switch format {
+	case "binary":
+		return ".bin", nil
+	case "hex":
+		return ".hex", nil
+	default:
+		return "", fmt.Errorf("invalid objcopy format %q: must be one of binary, hex", format)
 	}
 }
 

--- a/daggerverse/zig/main.go
+++ b/daggerverse/zig/main.go
@@ -322,8 +322,12 @@ func (z *Zig) ObjCopy(
 		return nil, err
 	}
 	const inputPath = "/work/input"
-	cmd := []string{"zig", "objcopy", "-O", format, inputPath, outputName}
+	// Options precede the positional <input> <output> operands: passing extra
+	// flags (e.g. --only-section, --pad-to) after the operands would make
+	// objcopy treat them as additional positional arguments.
+	cmd := []string{"zig", "objcopy", "-O", format}
 	cmd = append(cmd, args...)
+	cmd = append(cmd, inputPath, outputName)
 	return base.
 		WithWorkdir("/work").
 		WithMountedFile(inputPath, input).
@@ -335,7 +339,7 @@ func (z *Zig) ObjCopy(
 // are the budget-relevant rollups: Flash is what the image occupies in flash,
 // Ram what it claims at runtime.
 type SectionSizes struct {
-	Text  int // SHF_ALLOC|SHF_EXECINSTR (code)
+	Text  int // SHF_ALLOC, read-only: code (.text) + constants (.rodata)
 	Data  int // SHF_ALLOC|SHF_WRITE, PROGBITS (initialized data)
 	Bss   int // SHF_ALLOC|SHF_WRITE, NOBITS (zero-init data)
 	Flash int // Text + Data (consumes flash)
@@ -375,12 +379,17 @@ func (z *Zig) Size(ctx context.Context, input *dagger.File) (*SectionSizes, erro
 			continue
 		}
 		switch {
-		case sh.Flags&elf.SHF_EXECINSTR != 0:
+		case sh.Flags&elf.SHF_WRITE == 0:
+			// Read-only allocatable: executable code (.text) and constants
+			// (.rodata). Both occupy flash, so they roll up into Text (matching
+			// GNU/Berkeley `size`); omitting .rodata would under-report Flash.
 			sizes.Text += int(sh.Size)
-		case sh.Flags&elf.SHF_WRITE != 0 && sh.Type == elf.SHT_PROGBITS:
-			sizes.Data += int(sh.Size)
-		case sh.Flags&elf.SHF_WRITE != 0 && sh.Type == elf.SHT_NOBITS:
+		case sh.Type == elf.SHT_NOBITS:
+			// Writable, zero-initialized (.bss): claims RAM, no flash image.
 			sizes.Bss += int(sh.Size)
+		default:
+			// Writable, initialized (.data): claims RAM and a flash image.
+			sizes.Data += int(sh.Size)
 		}
 	}
 	sizes.Flash = sizes.Text + sizes.Data

--- a/daggerverse/zig/tests/dagger.gen.go
+++ b/daggerverse/zig/tests/dagger.gen.go
@@ -315,6 +315,27 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).FmtUnformattedReportsFile(&parent, ctx)
+		case "ObjCopyProducesBinary":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ObjCopyProducesBinary(&parent, ctx)
+		case "ObjCopyProducesIntelHex":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ObjCopyProducesIntelHex(&parent, ctx)
+		case "ObjCopyRejectsUnknownFormat":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ObjCopyRejectsUnknownFormat(&parent, ctx)
 		case "RunHelloPrintsHello":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -322,6 +343,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).RunHelloPrintsHello(&parent, ctx)
+		case "SizeRejectsNonElf":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).SizeRejectsNonElf(&parent, ctx)
+		case "SizeReportsSections":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).SizeReportsSections(&parent, ctx)
 		case "TargetsListsKnownArch":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/zig/tests/internal/dagger/zig.gen.go
+++ b/daggerverse/zig/tests/internal/dagger/zig.gen.go
@@ -13,7 +13,7 @@ import (
 type ZigID string // zig (../../../../../daggerverse/zig/main.go:50:6)
 
 // The `ZigSectionSizesID` scalar type represents an identifier for an object of type ZigSectionSizes.
-type ZigSectionSizesID string // zig (../../../../../daggerverse/zig/main.go:337:6)
+type ZigSectionSizesID string // zig (../../../../../daggerverse/zig/main.go:341:6)
 
 // Retrieve the binding value, as type Zig
 func (r *Binding) AsZig() *Zig { // zig (../../../../../daggerverse/zig/main.go:50:6)
@@ -25,7 +25,7 @@ func (r *Binding) AsZig() *Zig { // zig (../../../../../daggerverse/zig/main.go:
 }
 
 // Retrieve the binding value, as type ZigSectionSizes
-func (r *Binding) AsZigSectionSizes() *ZigSectionSizes { // zig (../../../../../daggerverse/zig/main.go:337:6)
+func (r *Binding) AsZigSectionSizes() *ZigSectionSizes { // zig (../../../../../daggerverse/zig/main.go:341:6)
 	q := r.query.Select("asZigSectionSizes")
 
 	return &ZigSectionSizes{
@@ -58,7 +58,7 @@ func (r *Env) WithZigOutput(name string, description string) *Env { // zig (../.
 }
 
 // Create or update a binding of type ZigSectionSizes in the environment
-func (r *Env) WithZigSectionSizesInput(name string, value *ZigSectionSizes, description string) *Env { // zig (../../../../../daggerverse/zig/main.go:337:6)
+func (r *Env) WithZigSectionSizesInput(name string, value *ZigSectionSizes, description string) *Env { // zig (../../../../../daggerverse/zig/main.go:341:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withZigSectionSizesInput")
 	q = q.Arg("name", name)
@@ -71,7 +71,7 @@ func (r *Env) WithZigSectionSizesInput(name string, value *ZigSectionSizes, desc
 }
 
 // Declare a desired ZigSectionSizes output to be assigned in the environment
-func (r *Env) WithZigSectionSizesOutput(name string, description string) *Env { // zig (../../../../../daggerverse/zig/main.go:337:6)
+func (r *Env) WithZigSectionSizesOutput(name string, description string) *Env { // zig (../../../../../daggerverse/zig/main.go:341:6)
 	q := r.query.Select("withZigSectionSizesOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -92,7 +92,7 @@ func (r *Query) LoadZigFromID(id ZigID) *Zig { // zig (../../../../../daggervers
 }
 
 // Load a ZigSectionSizes from its ID.
-func (r *Query) LoadZigSectionSizesFromID(id ZigSectionSizesID) *ZigSectionSizes { // zig (../../../../../daggerverse/zig/main.go:337:6)
+func (r *Query) LoadZigSectionSizesFromID(id ZigSectionSizesID) *ZigSectionSizes { // zig (../../../../../daggerverse/zig/main.go:341:6)
 	q := r.query.Select("loadZigSectionSizesFromID")
 	q = q.Arg("id", id)
 
@@ -353,7 +353,7 @@ func (r *Zig) Cxx(source *Directory, files []string, opts ...ZigCxxOpts) *File {
 
 // Env runs `zig env` in a source-less base container and returns its stdout
 // (JSON).
-func (r *Zig) Env(ctx context.Context) (string, error) { // zig (../../../../../daggerverse/zig/main.go:495:1)
+func (r *Zig) Env(ctx context.Context) (string, error) { // zig (../../../../../daggerverse/zig/main.go:504:1)
 	if r.env != nil {
 		return *r.env, nil
 	}
@@ -376,7 +376,7 @@ func (r *Zig) Env(ctx context.Context) (string, error) { // zig (../../../../../
 // boundary whenever it also returns a non-nil error: a (string, error)
 // signature would leave the file list unreachable on exactly the failure path
 // that needs it.
-func (r *Zig) Fmt(ctx context.Context, source *Directory) error { // zig (../../../../../daggerverse/zig/main.go:452:1)
+func (r *Zig) Fmt(ctx context.Context, source *Directory) error { // zig (../../../../../daggerverse/zig/main.go:461:1)
 	assertNotNil("source", source)
 	if r.fmt != nil {
 		return nil
@@ -488,12 +488,12 @@ func (r *Zig) ObjCopy(input *File, opts ...ZigObjCopyOpts) *File { // zig (../..
 
 // ZigRunOpts contains options for Zig.Run
 type ZigRunOpts struct {
-	Args []string // zig (../../../../../daggerverse/zig/main.go:399:2)
+	Args []string // zig (../../../../../daggerverse/zig/main.go:408:2)
 }
 
 // Run runs `zig build run [-- args...]` against the supplied source and
 // returns the program's stdout.
-func (r *Zig) Run(ctx context.Context, source *Directory, opts ...ZigRunOpts) (string, error) { // zig (../../../../../daggerverse/zig/main.go:395:1)
+func (r *Zig) Run(ctx context.Context, source *Directory, opts ...ZigRunOpts) (string, error) { // zig (../../../../../daggerverse/zig/main.go:404:1)
 	assertNotNil("source", source)
 	if r.run != nil {
 		return *r.run, nil
@@ -520,7 +520,7 @@ func (r *Zig) Run(ctx context.Context, source *Directory, opts ...ZigRunOpts) (s
 // the input is exported and its section headers are read directly — no helper
 // container (per the established runtime-I/O pattern). A non-ELF input returns a
 // clear error.
-func (r *Zig) Size(input *File) *ZigSectionSizes { // zig (../../../../../daggerverse/zig/main.go:354:1)
+func (r *Zig) Size(input *File) *ZigSectionSizes { // zig (../../../../../daggerverse/zig/main.go:358:1)
 	assertNotNil("input", input)
 	q := r.query.Select("size")
 	q = q.Arg("input", input)
@@ -532,7 +532,7 @@ func (r *Zig) Size(input *File) *ZigSectionSizes { // zig (../../../../../dagger
 
 // Targets runs `zig targets` in a source-less base container and returns its
 // stdout (the supported architecture/OS/ABI matrix).
-func (r *Zig) Targets(ctx context.Context) (string, error) { // zig (../../../../../daggerverse/zig/main.go:507:1)
+func (r *Zig) Targets(ctx context.Context) (string, error) { // zig (../../../../../daggerverse/zig/main.go:516:1)
 	if r.targets != nil {
 		return *r.targets, nil
 	}
@@ -546,14 +546,14 @@ func (r *Zig) Targets(ctx context.Context) (string, error) { // zig (../../../..
 
 // ZigTestOpts contains options for Zig.Test
 type ZigTestOpts struct {
-	Root string // zig (../../../../../daggerverse/zig/main.go:421:2)
+	Root string // zig (../../../../../daggerverse/zig/main.go:430:2)
 
-	Args []string // zig (../../../../../daggerverse/zig/main.go:423:2)
+	Args []string // zig (../../../../../daggerverse/zig/main.go:432:2)
 }
 
 // Test runs `zig build test` when root is empty, else `zig test <root>`,
 // against the supplied source and returns the combined stdout.
-func (r *Zig) Test(ctx context.Context, source *Directory, opts ...ZigTestOpts) (string, error) { // zig (../../../../../daggerverse/zig/main.go:417:1)
+func (r *Zig) Test(ctx context.Context, source *Directory, opts ...ZigTestOpts) (string, error) { // zig (../../../../../daggerverse/zig/main.go:426:1)
 	assertNotNil("source", source)
 	if r.test != nil {
 		return *r.test, nil
@@ -579,7 +579,7 @@ func (r *Zig) Test(ctx context.Context, source *Directory, opts ...ZigTestOpts) 
 
 // ToolVersion runs `zig version` in a source-less base container and returns
 // the trimmed output (e.g. "0.14.1").
-func (r *Zig) ToolVersion(ctx context.Context) (string, error) { // zig (../../../../../daggerverse/zig/main.go:479:1)
+func (r *Zig) ToolVersion(ctx context.Context) (string, error) { // zig (../../../../../daggerverse/zig/main.go:488:1)
 	if r.toolVersion != nil {
 		return *r.toolVersion, nil
 	}
@@ -609,7 +609,7 @@ func (r *Zig) Version(ctx context.Context) (string, error) { // zig (../../../..
 // SectionSizes is the per-section footprint of an ELF, in bytes. Flash and Ram
 // are the budget-relevant rollups: Flash is what the image occupies in flash,
 // Ram what it claims at runtime.
-type ZigSectionSizes struct { // zig (../../../../../daggerverse/zig/main.go:337:6)
+type ZigSectionSizes struct { // zig (../../../../../daggerverse/zig/main.go:341:6)
 	query *querybuilder.Selection
 
 	bss   *int
@@ -627,7 +627,7 @@ func (r *ZigSectionSizes) WithGraphQLQuery(q *querybuilder.Selection) *ZigSectio
 }
 
 // SHF_ALLOC|SHF_WRITE, NOBITS (zero-init data)
-func (r *ZigSectionSizes) Bss(ctx context.Context) (int, error) { // zig (../../../../../daggerverse/zig/main.go:340:2)
+func (r *ZigSectionSizes) Bss(ctx context.Context) (int, error) { // zig (../../../../../daggerverse/zig/main.go:344:2)
 	if r.bss != nil {
 		return *r.bss, nil
 	}
@@ -640,7 +640,7 @@ func (r *ZigSectionSizes) Bss(ctx context.Context) (int, error) { // zig (../../
 }
 
 // SHF_ALLOC|SHF_WRITE, PROGBITS (initialized data)
-func (r *ZigSectionSizes) Data(ctx context.Context) (int, error) { // zig (../../../../../daggerverse/zig/main.go:339:2)
+func (r *ZigSectionSizes) Data(ctx context.Context) (int, error) { // zig (../../../../../daggerverse/zig/main.go:343:2)
 	if r.data != nil {
 		return *r.data, nil
 	}
@@ -653,7 +653,7 @@ func (r *ZigSectionSizes) Data(ctx context.Context) (int, error) { // zig (../..
 }
 
 // Text + Data (consumes flash)
-func (r *ZigSectionSizes) Flash(ctx context.Context) (int, error) { // zig (../../../../../daggerverse/zig/main.go:341:2)
+func (r *ZigSectionSizes) Flash(ctx context.Context) (int, error) { // zig (../../../../../daggerverse/zig/main.go:345:2)
 	if r.flash != nil {
 		return *r.flash, nil
 	}
@@ -715,7 +715,7 @@ func (r *ZigSectionSizes) UnmarshalJSON(bs []byte) error {
 }
 
 // Data + Bss (consumes RAM)
-func (r *ZigSectionSizes) RAM(ctx context.Context) (int, error) { // zig (../../../../../daggerverse/zig/main.go:342:2)
+func (r *ZigSectionSizes) RAM(ctx context.Context) (int, error) { // zig (../../../../../daggerverse/zig/main.go:346:2)
 	if r.ram != nil {
 		return *r.ram, nil
 	}
@@ -727,8 +727,8 @@ func (r *ZigSectionSizes) RAM(ctx context.Context) (int, error) { // zig (../../
 	return response, q.Execute(ctx)
 }
 
-// SHF_ALLOC|SHF_EXECINSTR (code)
-func (r *ZigSectionSizes) Text(ctx context.Context) (int, error) { // zig (../../../../../daggerverse/zig/main.go:338:2)
+// SHF_ALLOC, read-only: code (.text) + constants (.rodata)
+func (r *ZigSectionSizes) Text(ctx context.Context) (int, error) { // zig (../../../../../daggerverse/zig/main.go:342:2)
 	if r.text != nil {
 		return *r.text, nil
 	}

--- a/daggerverse/zig/tests/internal/dagger/zig.gen.go
+++ b/daggerverse/zig/tests/internal/dagger/zig.gen.go
@@ -10,10 +10,13 @@ import (
 )
 
 // The `ZigID` scalar type represents an identifier for an object of type Zig.
-type ZigID string // zig (../../../../../daggerverse/zig/main.go:47:6)
+type ZigID string // zig (../../../../../daggerverse/zig/main.go:50:6)
+
+// The `ZigSectionSizesID` scalar type represents an identifier for an object of type ZigSectionSizes.
+type ZigSectionSizesID string // zig (../../../../../daggerverse/zig/main.go:337:6)
 
 // Retrieve the binding value, as type Zig
-func (r *Binding) AsZig() *Zig { // zig (../../../../../daggerverse/zig/main.go:47:6)
+func (r *Binding) AsZig() *Zig { // zig (../../../../../daggerverse/zig/main.go:50:6)
 	q := r.query.Select("asZig")
 
 	return &Zig{
@@ -21,8 +24,17 @@ func (r *Binding) AsZig() *Zig { // zig (../../../../../daggerverse/zig/main.go:
 	}
 }
 
+// Retrieve the binding value, as type ZigSectionSizes
+func (r *Binding) AsZigSectionSizes() *ZigSectionSizes { // zig (../../../../../daggerverse/zig/main.go:337:6)
+	q := r.query.Select("asZigSectionSizes")
+
+	return &ZigSectionSizes{
+		query: q,
+	}
+}
+
 // Create or update a binding of type Zig in the environment
-func (r *Env) WithZigInput(name string, value *Zig, description string) *Env { // zig (../../../../../daggerverse/zig/main.go:47:6)
+func (r *Env) WithZigInput(name string, value *Zig, description string) *Env { // zig (../../../../../daggerverse/zig/main.go:50:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withZigInput")
 	q = q.Arg("name", name)
@@ -35,7 +47,7 @@ func (r *Env) WithZigInput(name string, value *Zig, description string) *Env { /
 }
 
 // Declare a desired Zig output to be assigned in the environment
-func (r *Env) WithZigOutput(name string, description string) *Env { // zig (../../../../../daggerverse/zig/main.go:47:6)
+func (r *Env) WithZigOutput(name string, description string) *Env { // zig (../../../../../daggerverse/zig/main.go:50:6)
 	q := r.query.Select("withZigOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -45,8 +57,32 @@ func (r *Env) WithZigOutput(name string, description string) *Env { // zig (../.
 	}
 }
 
+// Create or update a binding of type ZigSectionSizes in the environment
+func (r *Env) WithZigSectionSizesInput(name string, value *ZigSectionSizes, description string) *Env { // zig (../../../../../daggerverse/zig/main.go:337:6)
+	assertNotNil("value", value)
+	q := r.query.Select("withZigSectionSizesInput")
+	q = q.Arg("name", name)
+	q = q.Arg("value", value)
+	q = q.Arg("description", description)
+
+	return &Env{
+		query: q,
+	}
+}
+
+// Declare a desired ZigSectionSizes output to be assigned in the environment
+func (r *Env) WithZigSectionSizesOutput(name string, description string) *Env { // zig (../../../../../daggerverse/zig/main.go:337:6)
+	q := r.query.Select("withZigSectionSizesOutput")
+	q = q.Arg("name", name)
+	q = q.Arg("description", description)
+
+	return &Env{
+		query: q,
+	}
+}
+
 // Load a Zig from its ID.
-func (r *Query) LoadZigFromID(id ZigID) *Zig { // zig (../../../../../daggerverse/zig/main.go:47:6)
+func (r *Query) LoadZigFromID(id ZigID) *Zig { // zig (../../../../../daggerverse/zig/main.go:50:6)
 	q := r.query.Select("loadZigFromID")
 	q = q.Arg("id", id)
 
@@ -55,16 +91,26 @@ func (r *Query) LoadZigFromID(id ZigID) *Zig { // zig (../../../../../daggervers
 	}
 }
 
+// Load a ZigSectionSizes from its ID.
+func (r *Query) LoadZigSectionSizesFromID(id ZigSectionSizesID) *ZigSectionSizes { // zig (../../../../../daggerverse/zig/main.go:337:6)
+	q := r.query.Select("loadZigSectionSizesFromID")
+	q = q.Arg("id", id)
+
+	return &ZigSectionSizes{
+		query: q,
+	}
+}
+
 // ZigOpts contains options for Query.Zig
 type ZigOpts struct {
-	Version string // zig (../../../../../daggerverse/zig/main.go:60:2)
+	Version string // zig (../../../../../daggerverse/zig/main.go:63:2)
 }
 
 // New returns a Zig module configured for the given toolchain version.
 // version is optional: empty means the version is inferred from the source's
 // build.zig.zon for source-bearing funcs, and the module-pinned default is
 // used for source-less funcs (ToolVersion, Env, Targets).
-func (r *Query) Zig(opts ...ZigOpts) *Zig { // zig (../../../../../daggerverse/zig/main.go:58:1)
+func (r *Query) Zig(opts ...ZigOpts) *Zig { // zig (../../../../../daggerverse/zig/main.go:61:1)
 	q := r.query.Select("zig")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `version` optional argument
@@ -82,7 +128,7 @@ func (r *Query) Zig(opts ...ZigOpts) *Zig { // zig (../../../../../daggerverse/z
 // Container() for the prepared base container, or use the per-CLI helpers
 // (Build, BuildExe, Run, Test, Fmt, ...) which reuse the same backing
 // container.
-type Zig struct { // zig (../../../../../daggerverse/zig/main.go:47:6)
+type Zig struct { // zig (../../../../../daggerverse/zig/main.go:50:6)
 	query *querybuilder.Selection
 
 	env         *string
@@ -103,13 +149,13 @@ func (r *Zig) WithGraphQLQuery(q *querybuilder.Selection) *Zig {
 
 // ZigBuildOpts contains options for Zig.Build
 type ZigBuildOpts struct {
-	Optimize string // zig (../../../../../daggerverse/zig/main.go:112:2)
+	Optimize string // zig (../../../../../daggerverse/zig/main.go:115:2)
 
-	Target string // zig (../../../../../daggerverse/zig/main.go:114:2)
+	Target string // zig (../../../../../daggerverse/zig/main.go:117:2)
 
-	Steps []string // zig (../../../../../daggerverse/zig/main.go:116:2)
+	Steps []string // zig (../../../../../daggerverse/zig/main.go:119:2)
 
-	Args []string // zig (../../../../../daggerverse/zig/main.go:118:2)
+	Args []string // zig (../../../../../daggerverse/zig/main.go:121:2)
 }
 
 // Build runs `zig build [-Doptimize=<optimize>] [-Dtarget=<target>] [steps...]
@@ -125,7 +171,7 @@ type ZigBuildOpts struct {
 // build-system arguments/options) — neither is forwarded to a built program. To
 // pass arguments to the program itself, use Run, which inserts the `--`
 // separator `zig build run` expects.
-func (r *Zig) Build(source *Directory, opts ...ZigBuildOpts) *Directory { // zig (../../../../../daggerverse/zig/main.go:108:1)
+func (r *Zig) Build(source *Directory, opts ...ZigBuildOpts) *Directory { // zig (../../../../../daggerverse/zig/main.go:111:1)
 	assertNotNil("source", source)
 	q := r.query.Select("build")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -155,13 +201,13 @@ func (r *Zig) Build(source *Directory, opts ...ZigBuildOpts) *Directory { // zig
 
 // ZigBuildExeOpts contains options for Zig.BuildExe
 type ZigBuildExeOpts struct {
-	Optimize string // zig (../../../../../daggerverse/zig/main.go:157:2)
+	Optimize string // zig (../../../../../daggerverse/zig/main.go:160:2)
 
-	Target string // zig (../../../../../daggerverse/zig/main.go:159:2)
+	Target string // zig (../../../../../daggerverse/zig/main.go:162:2)
 
-	Name string // zig (../../../../../daggerverse/zig/main.go:161:2)
+	Name string // zig (../../../../../daggerverse/zig/main.go:164:2)
 
-	Args []string // zig (../../../../../daggerverse/zig/main.go:163:2)
+	Args []string // zig (../../../../../daggerverse/zig/main.go:166:2)
 }
 
 // BuildExe runs `zig build-exe <root> [-O <optimize>] [-target <target>]
@@ -175,7 +221,7 @@ type ZigBuildExeOpts struct {
 // Note the flag spelling differs from Build: build-exe uses -O / -target /
 // --name (compiler flags), not the -Doptimize= / -Dtarget= build-system
 // options.
-func (r *Zig) BuildExe(source *Directory, root string, opts ...ZigBuildExeOpts) *File { // zig (../../../../../daggerverse/zig/main.go:152:1)
+func (r *Zig) BuildExe(source *Directory, root string, opts ...ZigBuildExeOpts) *File { // zig (../../../../../daggerverse/zig/main.go:155:1)
 	assertNotNil("source", source)
 	q := r.query.Select("buildExe")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -206,12 +252,12 @@ func (r *Zig) BuildExe(source *Directory, root string, opts ...ZigBuildExeOpts) 
 
 // ZigCcOpts contains options for Zig.Cc
 type ZigCcOpts struct {
-	Target string // zig (../../../../../daggerverse/zig/main.go:207:2)
+	Target string // zig (../../../../../daggerverse/zig/main.go:210:2)
 
 	// Default: "a.out"
-	OutputName string // zig (../../../../../daggerverse/zig/main.go:209:2)
+	OutputName string // zig (../../../../../daggerverse/zig/main.go:212:2)
 
-	Args []string // zig (../../../../../daggerverse/zig/main.go:211:2)
+	Args []string // zig (../../../../../daggerverse/zig/main.go:214:2)
 }
 
 // Cc cross-compiles C source with `zig cc`, a clang frontend that bundles libc
@@ -223,7 +269,7 @@ type ZigCcOpts struct {
 //
 // outputName (CLI: --output-name) is named so to avoid colliding with the
 // Dagger CLI's top-level --output/-o flag — same precedent as go's Ci.WithBuild.
-func (r *Zig) Cc(source *Directory, files []string, opts ...ZigCcOpts) *File { // zig (../../../../../daggerverse/zig/main.go:202:1)
+func (r *Zig) Cc(source *Directory, files []string, opts ...ZigCcOpts) *File { // zig (../../../../../daggerverse/zig/main.go:205:1)
 	assertNotNil("source", source)
 	q := r.query.Select("cc")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -258,7 +304,7 @@ func (r *Zig) Cc(source *Directory, files []string, opts ...ZigCcOpts) *File { /
 // (falling back to the module-pinned default). The signature takes ctx +
 // returns error because version inference and the tarball download require
 // async I/O.
-func (r *Zig) Container(source *Directory) *Container { // zig (../../../../../daggerverse/zig/main.go:77:1)
+func (r *Zig) Container(source *Directory) *Container { // zig (../../../../../daggerverse/zig/main.go:80:1)
 	assertNotNil("source", source)
 	q := r.query.Select("container")
 	q = q.Arg("source", source)
@@ -270,17 +316,17 @@ func (r *Zig) Container(source *Directory) *Container { // zig (../../../../../d
 
 // ZigCxxOpts contains options for Zig.Cxx
 type ZigCxxOpts struct {
-	Target string // zig (../../../../../daggerverse/zig/main.go:225:2)
+	Target string // zig (../../../../../daggerverse/zig/main.go:228:2)
 
 	// Default: "a.out"
-	OutputName string // zig (../../../../../daggerverse/zig/main.go:227:2)
+	OutputName string // zig (../../../../../daggerverse/zig/main.go:230:2)
 
-	Args []string // zig (../../../../../daggerverse/zig/main.go:229:2)
+	Args []string // zig (../../../../../daggerverse/zig/main.go:232:2)
 }
 
 // Cxx cross-compiles C++ source with `zig c++` (the C++ frontend; bundles
 // libc++). Same parameters and semantics as Cc.
-func (r *Zig) Cxx(source *Directory, files []string, opts ...ZigCxxOpts) *File { // zig (../../../../../daggerverse/zig/main.go:220:1)
+func (r *Zig) Cxx(source *Directory, files []string, opts ...ZigCxxOpts) *File { // zig (../../../../../daggerverse/zig/main.go:223:1)
 	assertNotNil("source", source)
 	q := r.query.Select("cxx")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -307,7 +353,7 @@ func (r *Zig) Cxx(source *Directory, files []string, opts ...ZigCxxOpts) *File {
 
 // Env runs `zig env` in a source-less base container and returns its stdout
 // (JSON).
-func (r *Zig) Env(ctx context.Context) (string, error) { // zig (../../../../../daggerverse/zig/main.go:376:1)
+func (r *Zig) Env(ctx context.Context) (string, error) { // zig (../../../../../daggerverse/zig/main.go:495:1)
 	if r.env != nil {
 		return *r.env, nil
 	}
@@ -330,7 +376,7 @@ func (r *Zig) Env(ctx context.Context) (string, error) { // zig (../../../../../
 // boundary whenever it also returns a non-nil error: a (string, error)
 // signature would leave the file list unreachable on exactly the failure path
 // that needs it.
-func (r *Zig) Fmt(ctx context.Context, source *Directory) error { // zig (../../../../../daggerverse/zig/main.go:333:1)
+func (r *Zig) Fmt(ctx context.Context, source *Directory) error { // zig (../../../../../daggerverse/zig/main.go:452:1)
 	assertNotNil("source", source)
 	if r.fmt != nil {
 		return nil
@@ -390,14 +436,64 @@ func (r *Zig) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
+// ZigObjCopyOpts contains options for Zig.ObjCopy
+type ZigObjCopyOpts struct {
+
+	// Default: "binary"
+	Format string // zig (../../../../../daggerverse/zig/main.go:296:2)
+
+	OutputName string // zig (../../../../../daggerverse/zig/main.go:298:2)
+
+	Args []string // zig (../../../../../daggerverse/zig/main.go:300:2)
+}
+
+// ObjCopy runs `zig objcopy -O <format> <input> <output>` in the toolchain
+// container, converting an ELF (e.g. from BuildExe) into a flashable artifact,
+// and returns the result as a *dagger.File. This is the post-build step every
+// embedded flow needs before flashing.
+//
+// format selects the output target: "binary" (a raw .bin image) or "hex" (Intel
+// HEX). Any other value is rejected with a clear error — notably UF2 is out of
+// scope here, since `zig objcopy` can't emit it.
+//
+// outputName names the produced artifact and defaults to the input's basename
+// with its extension replaced by the format's (.bin or .hex). Extra flags (e.g.
+// --only-section, --pad-to) pass through via args.
+//
+// outputName (CLI: --output-name) is named so to avoid colliding with the Dagger
+// CLI's top-level --output/-o flag — same precedent as Cc/Cxx.
+func (r *Zig) ObjCopy(input *File, opts ...ZigObjCopyOpts) *File { // zig (../../../../../daggerverse/zig/main.go:292:1)
+	assertNotNil("input", input)
+	q := r.query.Select("objCopy")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `format` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Format) {
+			q = q.Arg("format", opts[i].Format)
+		}
+		// `outputName` optional argument
+		if !querybuilder.IsZeroValue(opts[i].OutputName) {
+			q = q.Arg("outputName", opts[i].OutputName)
+		}
+		// `args` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Args) {
+			q = q.Arg("args", opts[i].Args)
+		}
+	}
+	q = q.Arg("input", input)
+
+	return &File{
+		query: q,
+	}
+}
+
 // ZigRunOpts contains options for Zig.Run
 type ZigRunOpts struct {
-	Args []string // zig (../../../../../daggerverse/zig/main.go:280:2)
+	Args []string // zig (../../../../../daggerverse/zig/main.go:399:2)
 }
 
 // Run runs `zig build run [-- args...]` against the supplied source and
 // returns the program's stdout.
-func (r *Zig) Run(ctx context.Context, source *Directory, opts ...ZigRunOpts) (string, error) { // zig (../../../../../daggerverse/zig/main.go:276:1)
+func (r *Zig) Run(ctx context.Context, source *Directory, opts ...ZigRunOpts) (string, error) { // zig (../../../../../daggerverse/zig/main.go:395:1)
 	assertNotNil("source", source)
 	if r.run != nil {
 		return *r.run, nil
@@ -417,9 +513,26 @@ func (r *Zig) Run(ctx context.Context, source *Directory, opts ...ZigRunOpts) (s
 	return response, q.Execute(ctx)
 }
 
+// Size reports the per-section byte totals of an ELF input (e.g. a freestanding
+// BuildExe output) so CI can gate Flash/Ram against a target's budget.
+//
+// Zig ships no `size` subcommand, so this is computed in pure Go via debug/elf:
+// the input is exported and its section headers are read directly — no helper
+// container (per the established runtime-I/O pattern). A non-ELF input returns a
+// clear error.
+func (r *Zig) Size(input *File) *ZigSectionSizes { // zig (../../../../../daggerverse/zig/main.go:354:1)
+	assertNotNil("input", input)
+	q := r.query.Select("size")
+	q = q.Arg("input", input)
+
+	return &ZigSectionSizes{
+		query: q,
+	}
+}
+
 // Targets runs `zig targets` in a source-less base container and returns its
 // stdout (the supported architecture/OS/ABI matrix).
-func (r *Zig) Targets(ctx context.Context) (string, error) { // zig (../../../../../daggerverse/zig/main.go:388:1)
+func (r *Zig) Targets(ctx context.Context) (string, error) { // zig (../../../../../daggerverse/zig/main.go:507:1)
 	if r.targets != nil {
 		return *r.targets, nil
 	}
@@ -433,14 +546,14 @@ func (r *Zig) Targets(ctx context.Context) (string, error) { // zig (../../../..
 
 // ZigTestOpts contains options for Zig.Test
 type ZigTestOpts struct {
-	Root string // zig (../../../../../daggerverse/zig/main.go:302:2)
+	Root string // zig (../../../../../daggerverse/zig/main.go:421:2)
 
-	Args []string // zig (../../../../../daggerverse/zig/main.go:304:2)
+	Args []string // zig (../../../../../daggerverse/zig/main.go:423:2)
 }
 
 // Test runs `zig build test` when root is empty, else `zig test <root>`,
 // against the supplied source and returns the combined stdout.
-func (r *Zig) Test(ctx context.Context, source *Directory, opts ...ZigTestOpts) (string, error) { // zig (../../../../../daggerverse/zig/main.go:298:1)
+func (r *Zig) Test(ctx context.Context, source *Directory, opts ...ZigTestOpts) (string, error) { // zig (../../../../../daggerverse/zig/main.go:417:1)
 	assertNotNil("source", source)
 	if r.test != nil {
 		return *r.test, nil
@@ -466,7 +579,7 @@ func (r *Zig) Test(ctx context.Context, source *Directory, opts ...ZigTestOpts) 
 
 // ToolVersion runs `zig version` in a source-less base container and returns
 // the trimmed output (e.g. "0.14.1").
-func (r *Zig) ToolVersion(ctx context.Context) (string, error) { // zig (../../../../../daggerverse/zig/main.go:360:1)
+func (r *Zig) ToolVersion(ctx context.Context) (string, error) { // zig (../../../../../daggerverse/zig/main.go:479:1)
 	if r.toolVersion != nil {
 		return *r.toolVersion, nil
 	}
@@ -481,13 +594,147 @@ func (r *Zig) ToolVersion(ctx context.Context) (string, error) { // zig (../../.
 // Version is the pinned Zig toolchain version (e.g. "0.14.1"). Empty
 // means infer from the supplied source's build.zig.zon
 // `minimum_zig_version`; falls back to a module-pinned default.
-func (r *Zig) Version(ctx context.Context) (string, error) { // zig (../../../../../daggerverse/zig/main.go:51:2)
+func (r *Zig) Version(ctx context.Context) (string, error) { // zig (../../../../../daggerverse/zig/main.go:54:2)
 	if r.version != nil {
 		return *r.version, nil
 	}
 	q := r.query.Select("version")
 
 	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// SectionSizes is the per-section footprint of an ELF, in bytes. Flash and Ram
+// are the budget-relevant rollups: Flash is what the image occupies in flash,
+// Ram what it claims at runtime.
+type ZigSectionSizes struct { // zig (../../../../../daggerverse/zig/main.go:337:6)
+	query *querybuilder.Selection
+
+	bss   *int
+	data  *int
+	flash *int
+	id    *ZigSectionSizesID
+	ram   *int
+	text  *int
+}
+
+func (r *ZigSectionSizes) WithGraphQLQuery(q *querybuilder.Selection) *ZigSectionSizes {
+	return &ZigSectionSizes{
+		query: q,
+	}
+}
+
+// SHF_ALLOC|SHF_WRITE, NOBITS (zero-init data)
+func (r *ZigSectionSizes) Bss(ctx context.Context) (int, error) { // zig (../../../../../daggerverse/zig/main.go:340:2)
+	if r.bss != nil {
+		return *r.bss, nil
+	}
+	q := r.query.Select("bss")
+
+	var response int
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// SHF_ALLOC|SHF_WRITE, PROGBITS (initialized data)
+func (r *ZigSectionSizes) Data(ctx context.Context) (int, error) { // zig (../../../../../daggerverse/zig/main.go:339:2)
+	if r.data != nil {
+		return *r.data, nil
+	}
+	q := r.query.Select("data")
+
+	var response int
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// Text + Data (consumes flash)
+func (r *ZigSectionSizes) Flash(ctx context.Context) (int, error) { // zig (../../../../../daggerverse/zig/main.go:341:2)
+	if r.flash != nil {
+		return *r.flash, nil
+	}
+	q := r.query.Select("flash")
+
+	var response int
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// A unique identifier for this ZigSectionSizes.
+func (r *ZigSectionSizes) ID(ctx context.Context) (ZigSectionSizesID, error) {
+	if r.id != nil {
+		return *r.id, nil
+	}
+	q := r.query.Select("id")
+
+	var response ZigSectionSizesID
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// XXX_GraphQLType is an internal function. It returns the native GraphQL type name
+func (r *ZigSectionSizes) XXX_GraphQLType() string {
+	return "ZigSectionSizes"
+}
+
+// XXX_GraphQLIDType is an internal function. It returns the native GraphQL type name for the ID of this object
+func (r *ZigSectionSizes) XXX_GraphQLIDType() string {
+	return "ZigSectionSizesID"
+}
+
+// XXX_GraphQLID is an internal function. It returns the underlying type ID
+func (r *ZigSectionSizes) XXX_GraphQLID(ctx context.Context) (string, error) {
+	id, err := r.ID(ctx)
+	if err != nil {
+		return "", err
+	}
+	return string(id), nil
+}
+
+func (r *ZigSectionSizes) MarshalJSON() ([]byte, error) {
+	id, err := r.ID(marshalCtx)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(id)
+}
+func (r *ZigSectionSizes) UnmarshalJSON(bs []byte) error {
+	var id string
+	err := json.Unmarshal(bs, &id)
+	if err != nil {
+		return err
+	}
+	*r = *dag.LoadZigSectionSizesFromID(ZigSectionSizesID(id))
+	return nil
+}
+
+// Data + Bss (consumes RAM)
+func (r *ZigSectionSizes) RAM(ctx context.Context) (int, error) { // zig (../../../../../daggerverse/zig/main.go:342:2)
+	if r.ram != nil {
+		return *r.ram, nil
+	}
+	q := r.query.Select("ram")
+
+	var response int
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// SHF_ALLOC|SHF_EXECINSTR (code)
+func (r *ZigSectionSizes) Text(ctx context.Context) (int, error) { // zig (../../../../../daggerverse/zig/main.go:338:2)
+	if r.text != nil {
+		return *r.text, nil
+	}
+	q := r.query.Select("text")
+
+	var response int
 
 	q = q.Bind(&response)
 	return response, q.Execute(ctx)

--- a/daggerverse/zig/tests/main.go
+++ b/daggerverse/zig/tests/main.go
@@ -64,6 +64,11 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("CcRejectsEmptyFiles", t.CcRejectsEmptyFiles)
 	jobs = jobs.WithJob("CcRejectsPathOutputName", t.CcRejectsPathOutputName)
 	jobs = jobs.WithJob("CxxCompilesHelloCpp", t.CxxCompilesHelloCpp)
+	jobs = jobs.WithJob("ObjCopyProducesBinary", t.ObjCopyProducesBinary)
+	jobs = jobs.WithJob("ObjCopyProducesIntelHex", t.ObjCopyProducesIntelHex)
+	jobs = jobs.WithJob("ObjCopyRejectsUnknownFormat", t.ObjCopyRejectsUnknownFormat)
+	jobs = jobs.WithJob("SizeReportsSections", t.SizeReportsSections)
+	jobs = jobs.WithJob("SizeRejectsNonElf", t.SizeRejectsNonElf)
 
 	return jobs.Run(ctx)
 }
@@ -325,6 +330,109 @@ func (t *Tests) CcCompilesHelloC(ctx context.Context) error {
 	}
 	if size == 0 {
 		return fmt.Errorf("expected non-empty artifact, got size 0")
+	}
+	return nil
+}
+
+// singleExe builds the single-file fixture into a host ELF executable, reused as
+// the input for the ObjCopy and Size tests.
+func singleExe() *dagger.File {
+	return dag.Zig().BuildExe(singleDir(), "main.zig")
+}
+
+// ObjCopyProducesBinary converts the BuildExe ELF to a raw .bin and asserts the
+// result is non-empty and no longer carries the ELF magic.
+func (t *Tests) ObjCopyProducesBinary(ctx context.Context) error {
+	out := dag.Zig().ObjCopy(singleExe(), dagger.ZigObjCopyOpts{Format: "binary"})
+	size, err := out.Size(ctx)
+	if err != nil {
+		return fmt.Errorf("ObjCopy binary: %w", err)
+	}
+	if size == 0 {
+		return fmt.Errorf("expected non-empty .bin, got size 0")
+	}
+	contents, err := out.Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("read .bin contents: %w", err)
+	}
+	if strings.HasPrefix(contents, "\x7fELF") {
+		return fmt.Errorf("expected raw binary without ELF magic, but found it")
+	}
+	return nil
+}
+
+// ObjCopyProducesIntelHex converts the BuildExe ELF to Intel HEX and asserts the
+// first record begins with ':' (the Intel HEX record start code).
+func (t *Tests) ObjCopyProducesIntelHex(ctx context.Context) error {
+	contents, err := dag.Zig().ObjCopy(singleExe(), dagger.ZigObjCopyOpts{Format: "hex"}).Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("ObjCopy hex: %w", err)
+	}
+	if !strings.HasPrefix(strings.TrimLeft(contents, "\r\n"), ":") {
+		return fmt.Errorf("expected Intel HEX output starting with ':', got %.20q", contents)
+	}
+	return nil
+}
+
+// ObjCopyRejectsUnknownFormat asserts ObjCopy rejects an unsupported format
+// (e.g. "uf2"). ObjCopy returns a lazy file, so the error surfaces on resolve.
+func (t *Tests) ObjCopyRejectsUnknownFormat(ctx context.Context) error {
+	_, err := dag.Zig().ObjCopy(singleExe(), dagger.ZigObjCopyOpts{Format: "uf2"}).Sync(ctx)
+	if err == nil {
+		return fmt.Errorf("expected error for unknown format, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid objcopy format") {
+		return fmt.Errorf("expected format-validation error, got: %v", err)
+	}
+	return nil
+}
+
+// SizeReportsSections asserts Size on the BuildExe host ELF returns Text > 0 and
+// internally consistent Flash/Ram rollups.
+func (t *Tests) SizeReportsSections(ctx context.Context) error {
+	s := dag.Zig().Size(singleExe())
+	text, err := s.Text(ctx)
+	if err != nil {
+		return fmt.Errorf("Size.Text: %w", err)
+	}
+	data, err := s.Data(ctx)
+	if err != nil {
+		return fmt.Errorf("Size.Data: %w", err)
+	}
+	bss, err := s.Bss(ctx)
+	if err != nil {
+		return fmt.Errorf("Size.Bss: %w", err)
+	}
+	flash, err := s.Flash(ctx)
+	if err != nil {
+		return fmt.Errorf("Size.Flash: %w", err)
+	}
+	ram, err := s.RAM(ctx)
+	if err != nil {
+		return fmt.Errorf("Size.Ram: %w", err)
+	}
+	if text <= 0 {
+		return fmt.Errorf("expected Text > 0, got %d", text)
+	}
+	if flash != text+data {
+		return fmt.Errorf("expected Flash == Text+Data (%d), got %d", text+data, flash)
+	}
+	if ram != data+bss {
+		return fmt.Errorf("expected Ram == Data+Bss (%d), got %d", data+bss, ram)
+	}
+	return nil
+}
+
+// SizeRejectsNonElf feeds a raw .bin (produced by ObjCopy) into Size and asserts
+// a clear non-ELF error.
+func (t *Tests) SizeRejectsNonElf(ctx context.Context) error {
+	bin := dag.Zig().ObjCopy(singleExe(), dagger.ZigObjCopyOpts{Format: "binary"})
+	_, err := dag.Zig().Size(bin).Text(ctx)
+	if err == nil {
+		return fmt.Errorf("expected error for non-ELF input, got nil")
+	}
+	if !strings.Contains(err.Error(), "not a valid ELF file") {
+		return fmt.Errorf("expected non-ELF error, got: %v", err)
 	}
 	return nil
 }

--- a/daggerverse/zig/tests/main.go
+++ b/daggerverse/zig/tests/main.go
@@ -4,8 +4,11 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"dagger/tests/internal/dagger"
@@ -351,11 +354,23 @@ func (t *Tests) ObjCopyProducesBinary(ctx context.Context) error {
 	if size == 0 {
 		return fmt.Errorf("expected non-empty .bin, got size 0")
 	}
-	contents, err := out.Contents(ctx)
+	// A raw .bin holds arbitrary, non-UTF-8 bytes, so File.Contents() (which
+	// resolves as a string) is the wrong tool — it can error or mangle the
+	// data. Export the file and inspect its magic bytes directly.
+	dir, err := os.MkdirTemp(".", "objcopy-")
 	if err != nil {
-		return fmt.Errorf("read .bin contents: %w", err)
+		return err
 	}
-	if strings.HasPrefix(contents, "\x7fELF") {
+	defer os.RemoveAll(dir)
+	path := filepath.Join(dir, "out.bin")
+	if _, err := out.Export(ctx, path); err != nil {
+		return fmt.Errorf("export .bin: %w", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read .bin: %w", err)
+	}
+	if bytes.HasPrefix(data, []byte("\x7fELF")) {
 		return fmt.Errorf("expected raw binary without ELF magic, but found it")
 	}
 	return nil


### PR DESCRIPTION
## Summary

Adds `ObjCopy` and `Size` to the `zig` module — the two artifact steps every embedded flow needs after a freestanding `BuildExe`. Builds on the checksum-verified base container from #94; `ObjCopy` is a prerequisite for the on-device flashing tier of the embedded roadmap (#106).

- **`ObjCopy`** runs `zig objcopy -O <format> <input> <output>` in the toolchain container, converting an ELF into a flashable `.bin` (raw) or `.hex` (Intel HEX). `format` is validated to `{binary, hex}`; unknown values (e.g. `uf2`, which `zig objcopy` can't emit) are rejected with a clear error. Extra flags pass through via `args`. `outputName` (CLI `--output-name`) follows the `Cc`/`Cxx` precedent so it doesn't collide with the Dagger CLI's top-level `--output`/`-o`.
- **`Size`** reports per-section byte totals — `Text`/`Data`/`Bss` plus the `Flash` (Text+Data) and `Ram` (Data+Bss) rollups — so CI can gate footprint against a target's budget. Zig ships no `size` subcommand, so it's computed in pure Go via `debug/elf` using the established `file.Export` runtime-I/O pattern (no helper container). A non-ELF input returns a clear error.
- Both carry `+cache="session"`.

## Tests

Adds `ObjCopyProducesBinary`, `ObjCopyProducesIntelHex`, `ObjCopyRejectsUnknownFormat`, `SizeReportsSections`, and `SizeRejectsNonElf`, each wired into `tests/All` under `+check`. Tests reuse the existing `fixtures/single` host ELF and the raw `.bin` from `ObjCopy` as the non-ELF input — no new fixtures. Each passes individually and `dagger call all` is green. `dagger develop` was run in both `daggerverse/zig` and `daggerverse/zig/tests`.

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)