### PR TITLE
story(issue-74): add Avro serde to kafka Client Produce/Consume

### DIFF
--- a/daggerverse/kafka/README.md
+++ b/daggerverse/kafka/README.md
@@ -440,6 +440,28 @@ validated, err := client.Consume(ctx, "my-topic", dagger.KafkaClientConsumeOpts{
     ValueDeserializeAs:  "JSON", // "" pass-through; "JSON" rejects non-parseable payloads
 })
 
+// Avro wire format: the JSON input is Avro-binary-encoded against the
+// registered schema and framed on Produce, and framed Avro-binary bytes
+// are decoded back to JSON on Consume. Both sides take a SchemaRegistry so
+// the schema text is resolved by id; Produce requires a positive
+// ValueSchemaID (it both selects the schema and frames the record).
+id, err = srClient.RegisterSchema(ctx, "my-topic-value", avroSchema, dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{
+    SchemaType: "AVRO",
+})
+err = client.Produce(ctx, "my-topic", "k", `{"x":"hello"}`, dagger.KafkaClientProduceOpts{
+    KeyEncoding: "raw", ValueEncoding: "raw",
+    ValueSchemaID:    id,
+    ValueSerializeAs: "AVRO", // JSON -> Avro binary, then frame with id
+    Registry:         sr,     // *SchemaRegistry: resolves schema text by id
+})
+decoded, err := client.Consume(ctx, "my-topic", dagger.KafkaClientConsumeOpts{
+    MaxMessages: 1, Timeout: "10s",
+    KeyEncoding: "raw", ValueEncoding: "raw",
+    SchemaRegistryAware: true,        // required: supplies the wire id
+    ValueDeserializeAs:  "AVRO",      // Avro binary -> JSON
+    Registry:            sr,
+})
+
 // java client.properties (+ p12 sidecars in TLS / mTLS modes) for the
 // Apache Kafka CLI tools — export the parent directory so the relative
 // truststore.p12 / keystore.p12 references resolve.
@@ -450,15 +472,31 @@ props := client.PropertiesFile() // *dagger.File — resolve via .Contents(ctx) 
 `"hex"`, or `"base64"` (standard padding). Anything else is rejected.
 
 The serde opts (`keySerializeAs` / `valueSerializeAs` on `Produce`,
-`keyDeserializeAs` / `valueDeserializeAs` on `Consume`) are wire-format
-enforcement only — they do not fetch or apply the registered schema's
-content rules. Defaults are `""` (pass-through); `"JSON"` is the only
-non-empty value accepted today. The producer side canonicalises (parse
-+ re-marshal via `encoding/json`) so what hits the wire is independent
-of caller-side whitespace; the consumer side validates with
-`json.Valid` after any frame strip. Composition order is
-decode → serialize → frame on `Produce`, unframe → deserialize → encode
-on `Consume`.
+`keyDeserializeAs` / `valueDeserializeAs` on `Consume`) accept `""`
+(pass-through, the default), `"JSON"`, or `"AVRO"`.
+
+`"JSON"` is wire-format enforcement only — it does not fetch or apply a
+registered schema. The producer side canonicalises (parse + re-marshal
+via `encoding/json`) so what hits the wire is independent of caller-side
+whitespace; the consumer side validates with `json.Valid` after any frame
+strip.
+
+`"AVRO"` is schema-bound. The caller's string is treated as a JSON
+document and **Avro-binary-encoded** against the registered schema on
+`Produce`, then framed; on `Consume` the framed Avro-binary payload is
+decoded and re-serialised back to JSON. Both directions resolve the
+schema text by id through the supplied `Registry` (`*SchemaRegistry`),
+caching per id for the duration of the call. `Produce` requires a
+positive `…SchemaID` (it both names the schema and frames the record) and
+errors before any I/O on a zero id; `Consume` requires
+`schemaRegistryAware=true` and errors on an unframed record. The JSON
+shape follows the Avro spec's JSON encoding (unions as
+`{"<type>": value}`, bare `null` for the null branch, `bytes` as a
+one-char-per-byte string); logical types, `decimal`, and `fixed` are not
+yet supported.
+
+Composition order is decode → serialize → frame on `Produce`,
+unframe → deserialize → encode on `Consume`.
 
 Topic auto-creation is disabled on the broker — call `CreateTopic` before
 `Produce` / `Consume`.

--- a/daggerverse/kafka/avro.go
+++ b/daggerverse/kafka/avro.go
@@ -1,0 +1,638 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"slices"
+	"strings"
+
+	"github.com/z5labs/avro-go"
+	"github.com/z5labs/avro-go/generic"
+)
+
+// avro.go bridges the kafka module's JSON string boundary to the Avro binary
+// wire format carried by Schema-Registry-aware Kafka.
+//
+// The Confluent wire payload is Avro *binary* (the 5-byte header laid down by
+// the framing step wraps Avro binary, never Avro-JSON). github.com/z5labs/
+// avro-go/generic encodes/decodes that binary, but its only input/output type
+// is a closed generic.Value tree — it has no JSON or map[string]any bridge. So
+// this file walks JSON <-> generic.Value *against the schema*: a JSON number
+// becomes Int / Long / Float / Double depending on the schema node, a JSON
+// object becomes a Record or a Map, a union picks a branch index, etc.
+//
+// The JSON shape follows the Avro spec's JSON encoding: a union value is bare
+// `null` for the null branch or `{"<typename>": value}` for a non-null branch;
+// `bytes` is a string with one character per byte (code points 0-255).
+//
+// Logical types, decimal, and fixed are intentionally out of scope for this
+// first cut and surface a clear "unsupported in AVRO mode" error.
+//
+// IMPORTANT: a defect in avro-go itself (avro.ParseJSON, generic.NewEncoder /
+// NewDecoder, Encode / Decode, or binary/schema-compilation correctness) must
+// be filed upstream on z5labs/avro-go and work paused — it must NOT be worked
+// around here. Only the JSON <-> generic.Value mapping below is ours to fix.
+
+// avroSchemas resolves and memoizes Avro schemas (and their compiled codecs)
+// by Schema Registry id for the lifetime of a single Produce / Consume call.
+// The issue requires schema resolution be cached per (registry, schemaID)
+// within one Consume call to avoid an HTTP round-trip per record; the same
+// cache serves Produce's single record.
+type avroSchemas struct {
+	registry *SchemaRegistry
+	byID     map[int]*avroSchema
+}
+
+// avroSchema is one resolved schema plus its lazily-built name table and
+// codecs. The encoder/decoder are compiled on first use so a Produce-only or
+// Consume-only path pays for just the direction it needs.
+type avroSchema struct {
+	schema avro.Schema
+	names  *nameTable
+	enc    *generic.Encoder
+	dec    *generic.Decoder
+}
+
+func newAvroSchemas(registry *SchemaRegistry) *avroSchemas {
+	return &avroSchemas{registry: registry, byID: make(map[int]*avroSchema)}
+}
+
+// get returns the resolved schema for id, fetching its text from the registry
+// and parsing it on first request and serving the cached entry thereafter.
+func (a *avroSchemas) get(ctx context.Context, id int) (*avroSchema, error) {
+	if s, ok := a.byID[id]; ok {
+		return s, nil
+	}
+	if a.registry == nil {
+		return nil, fmt.Errorf("AVRO mode requires a schema registry to resolve schema id %d", id)
+	}
+	rs, err := a.registry.Client().LookupSchemaByID(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("resolve schema id %d: %w", id, err)
+	}
+	schema, err := avro.ParseJSON([]byte(rs.Definition))
+	if err != nil {
+		return nil, fmt.Errorf("parse schema id %d: %w", id, err)
+	}
+	s := &avroSchema{schema: schema, names: buildNameTable(schema)}
+	a.byID[id] = s
+	return s, nil
+}
+
+func (s *avroSchema) encoder() (*generic.Encoder, error) {
+	if s.enc == nil {
+		enc, err := generic.NewEncoder(s.schema)
+		if err != nil {
+			return nil, fmt.Errorf("compile avro encoder: %w", err)
+		}
+		s.enc = enc
+	}
+	return s.enc, nil
+}
+
+func (s *avroSchema) decoder() (*generic.Decoder, error) {
+	if s.dec == nil {
+		dec, err := generic.NewDecoder(s.schema)
+		if err != nil {
+			return nil, fmt.Errorf("compile avro decoder: %w", err)
+		}
+		s.dec = dec
+	}
+	return s.dec, nil
+}
+
+// encode interprets raw as a JSON document, maps it to a generic.Value against
+// the schema identified by id, and returns the Avro binary encoding.
+func (a *avroSchemas) encode(ctx context.Context, id int, raw []byte) ([]byte, error) {
+	s, err := a.get(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	enc, err := s.encoder()
+	if err != nil {
+		return nil, err
+	}
+	doc, err := unmarshalJSONValue(raw)
+	if err != nil {
+		return nil, err
+	}
+	val, err := valueFromJSON(doc, s.schema, s.names, "")
+	if err != nil {
+		return nil, fmt.Errorf("map json to avro: %w", err)
+	}
+	var buf bytes.Buffer
+	if err := enc.Encode(&buf, val); err != nil {
+		return nil, fmt.Errorf("avro-encode: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// decode reads Avro binary bin against the schema identified by id and returns
+// its compact JSON encoding.
+func (a *avroSchemas) decode(ctx context.Context, id int, bin []byte) ([]byte, error) {
+	s, err := a.get(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	dec, err := s.decoder()
+	if err != nil {
+		return nil, err
+	}
+	val, err := dec.Decode(bytes.NewReader(bin))
+	if err != nil {
+		return nil, fmt.Errorf("avro-decode: %w", err)
+	}
+	doc, err := jsonFromValue(val, s.schema, s.names, "")
+	if err != nil {
+		return nil, fmt.Errorf("map avro to json: %w", err)
+	}
+	out, err := json.Marshal(doc)
+	if err != nil {
+		return nil, fmt.Errorf("marshal decoded json: %w", err)
+	}
+	return out, nil
+}
+
+// unmarshalJSONValue decodes raw into a Go value using json.Number so that
+// integers above 2^53 and high-precision decimals are not silently coerced to
+// float64 before they reach the schema-driven mapping.
+func unmarshalJSONValue(raw []byte) (any, error) {
+	d := json.NewDecoder(bytes.NewReader(raw))
+	d.UseNumber()
+	var v any
+	if err := d.Decode(&v); err != nil {
+		return nil, fmt.Errorf("payload is not valid JSON: %w", err)
+	}
+	if d.More() {
+		return nil, fmt.Errorf("payload has trailing data after JSON value")
+	}
+	return v, nil
+}
+
+// nameTable maps an Avro named type's full name to its schema so that an
+// avro.Ref encountered while walking can be resolved back to its definition,
+// matching Avro's name-resolution rules (namespace inherited from the
+// enclosing named type).
+type nameTable struct {
+	m map[string]avro.Schema
+}
+
+func buildNameTable(s avro.Schema) *nameTable {
+	t := &nameTable{m: make(map[string]avro.Schema)}
+	t.collect(s, "")
+	return t
+}
+
+func (t *nameTable) collect(s avro.Schema, ns string) {
+	switch x := s.(type) {
+	case avro.Record:
+		rns := nsOr(x.Namespace, ns)
+		t.m[fullName(x.Name, rns)] = x
+		for _, f := range x.Fields {
+			if f != nil {
+				t.collect(f.Type, rns)
+			}
+		}
+	case avro.Enum:
+		t.m[fullName(x.Name, nsOr(x.Namespace, ns))] = x
+	case avro.Fixed:
+		t.m[fullName(x.Name, nsOr(x.Namespace, ns))] = x
+	case avro.Array:
+		t.collect(x.Items, ns)
+	case avro.Map:
+		t.collect(x.Values, ns)
+	case avro.Union:
+		for _, b := range x.Types {
+			t.collect(b, ns)
+		}
+	}
+}
+
+func (t *nameTable) resolve(ref avro.Ref, ns string) (avro.Schema, bool) {
+	if s, ok := t.m[fullName(ref.Name, nsOr(ref.Namespace, ns))]; ok {
+		return s, true
+	}
+	s, ok := t.m[ref.Name]
+	return s, ok
+}
+
+// fullName joins a namespace and a name the way Avro does: a name already
+// containing a dot is fully qualified, and an empty namespace yields the bare
+// name.
+func fullName(name, ns string) string {
+	if ns == "" || strings.Contains(name, ".") {
+		return name
+	}
+	return ns + "." + name
+}
+
+func nsOr(declared, inherited string) string {
+	if declared != "" {
+		return declared
+	}
+	return inherited
+}
+
+// valueFromJSON walks a JSON-decoded Go value alongside its Avro schema and
+// produces the matching generic.Value. ns is the Avro namespace inherited from
+// the enclosing named type, used to resolve Refs and union branch names.
+func valueFromJSON(v any, s avro.Schema, t *nameTable, ns string) (generic.Value, error) {
+	switch sc := s.(type) {
+	case avro.Null:
+		if v != nil {
+			return nil, fmt.Errorf("expected null, got %T", v)
+		}
+		return generic.Null{}, nil
+	case avro.Boolean:
+		b, ok := v.(bool)
+		if !ok {
+			return nil, typeErr("boolean", v)
+		}
+		return generic.Bool(b), nil
+	case avro.Int:
+		n, err := toInt64(v)
+		if err != nil {
+			return nil, err
+		}
+		if n < math.MinInt32 || n > math.MaxInt32 {
+			return nil, fmt.Errorf("value %d out of range for int", n)
+		}
+		return generic.Int(int32(n)), nil
+	case avro.Long:
+		n, err := toInt64(v)
+		if err != nil {
+			return nil, err
+		}
+		return generic.Long(n), nil
+	case avro.Float:
+		f, err := toFloat64(v)
+		if err != nil {
+			return nil, err
+		}
+		return generic.Float(float32(f)), nil
+	case avro.Double:
+		f, err := toFloat64(v)
+		if err != nil {
+			return nil, err
+		}
+		return generic.Double(f), nil
+	case avro.Bytes:
+		str, ok := v.(string)
+		if !ok {
+			return nil, typeErr("bytes (json string)", v)
+		}
+		b, err := bytesFromJSONString(str)
+		if err != nil {
+			return nil, err
+		}
+		return generic.Bytes(b), nil
+	case avro.String:
+		str, ok := v.(string)
+		if !ok {
+			return nil, typeErr("string", v)
+		}
+		return generic.String(str), nil
+	case avro.Ref:
+		resolved, ok := t.resolve(sc, ns)
+		if !ok {
+			return nil, fmt.Errorf("unresolved schema reference %q", sc.Name)
+		}
+		return valueFromJSON(v, resolved, t, ns)
+	case avro.Record:
+		return recordFromJSON(v, sc, t, ns)
+	case avro.Enum:
+		str, ok := v.(string)
+		if !ok {
+			return nil, typeErr(fmt.Sprintf("enum %q symbol", sc.Name), v)
+		}
+		if !slices.Contains(sc.Symbols, str) {
+			return nil, fmt.Errorf("enum %q has no symbol %q", sc.Name, str)
+		}
+		return generic.Enum{Symbol: str}, nil
+	case avro.Array:
+		arr, ok := v.([]any)
+		if !ok {
+			return nil, typeErr("array", v)
+		}
+		out := make(generic.Array, len(arr))
+		for i, item := range arr {
+			iv, err := valueFromJSON(item, sc.Items, t, ns)
+			if err != nil {
+				return nil, fmt.Errorf("array[%d]: %w", i, err)
+			}
+			out[i] = iv
+		}
+		return out, nil
+	case avro.Map:
+		obj, ok := v.(map[string]any)
+		if !ok {
+			return nil, typeErr("map object", v)
+		}
+		out := make(generic.Map, len(obj))
+		for k, mv := range obj {
+			vv, err := valueFromJSON(mv, sc.Values, t, ns)
+			if err != nil {
+				return nil, fmt.Errorf("map[%q]: %w", k, err)
+			}
+			out[k] = vv
+		}
+		return out, nil
+	case avro.Union:
+		return unionFromJSON(v, sc, t, ns)
+	default:
+		return nil, fmt.Errorf("Avro type %T is not supported in AVRO mode", s)
+	}
+}
+
+func recordFromJSON(v any, rec avro.Record, t *nameTable, ns string) (generic.Value, error) {
+	obj, ok := v.(map[string]any)
+	if !ok {
+		return nil, typeErr(fmt.Sprintf("record %q object", rec.Name), v)
+	}
+	rns := nsOr(rec.Namespace, ns)
+	fields := make([]generic.Field, len(rec.Fields))
+	for i, f := range rec.Fields {
+		if f == nil {
+			return nil, fmt.Errorf("record %q has a nil field at index %d", rec.Name, i)
+		}
+		fv, present := obj[f.Name]
+		if !present {
+			if !f.HasDefault {
+				return nil, fmt.Errorf("record %q is missing field %q", rec.Name, f.Name)
+			}
+			fv = f.Default
+		}
+		val, err := valueFromJSON(fv, f.Type, t, rns)
+		if err != nil {
+			return nil, fmt.Errorf("field %q: %w", f.Name, err)
+		}
+		fields[i] = generic.Field{Name: f.Name, Value: val}
+	}
+	return generic.Record{Fields: fields}, nil
+}
+
+// unionFromJSON applies the Avro JSON encoding for unions: a bare null selects
+// the null branch; any other value must be a single-key object
+// {"<typename>": value} naming the branch.
+func unionFromJSON(v any, u avro.Union, t *nameTable, ns string) (generic.Value, error) {
+	if v == nil {
+		for i, b := range u.Types {
+			if _, ok := b.(avro.Null); ok {
+				return generic.Union{Index: i, Value: generic.Null{}}, nil
+			}
+		}
+		return nil, fmt.Errorf("null value but union has no null branch")
+	}
+	obj, ok := v.(map[string]any)
+	if !ok || len(obj) != 1 {
+		return nil, fmt.Errorf(`union value must be a single-key {"<type>": value} object (Avro JSON encoding), got %T`, v)
+	}
+	var key string
+	var inner any
+	for k, vv := range obj {
+		key, inner = k, vv
+	}
+	for i, b := range u.Types {
+		if unionBranchName(b, ns) == key {
+			val, err := valueFromJSON(inner, b, t, ns)
+			if err != nil {
+				return nil, err
+			}
+			return generic.Union{Index: i, Value: val}, nil
+		}
+	}
+	return nil, fmt.Errorf("union branch %q is not present in the schema", key)
+}
+
+// jsonFromValue walks a decoded generic.Value alongside its schema and returns
+// a Go value ready for json.Marshal, emitting the same Avro JSON encoding that
+// valueFromJSON consumes.
+func jsonFromValue(v generic.Value, s avro.Schema, t *nameTable, ns string) (any, error) {
+	switch sc := s.(type) {
+	case avro.Null:
+		return nil, nil
+	case avro.Boolean:
+		b, ok := v.(generic.Bool)
+		if !ok {
+			return nil, decodeTypeErr("boolean", v)
+		}
+		return bool(b), nil
+	case avro.Int:
+		i, ok := v.(generic.Int)
+		if !ok {
+			return nil, decodeTypeErr("int", v)
+		}
+		return int32(i), nil
+	case avro.Long:
+		l, ok := v.(generic.Long)
+		if !ok {
+			return nil, decodeTypeErr("long", v)
+		}
+		return int64(l), nil
+	case avro.Float:
+		f, ok := v.(generic.Float)
+		if !ok {
+			return nil, decodeTypeErr("float", v)
+		}
+		return float32(f), nil
+	case avro.Double:
+		d, ok := v.(generic.Double)
+		if !ok {
+			return nil, decodeTypeErr("double", v)
+		}
+		return float64(d), nil
+	case avro.Bytes:
+		b, ok := v.(generic.Bytes)
+		if !ok {
+			return nil, decodeTypeErr("bytes", v)
+		}
+		return bytesToJSONString(b), nil
+	case avro.String:
+		str, ok := v.(generic.String)
+		if !ok {
+			return nil, decodeTypeErr("string", v)
+		}
+		return string(str), nil
+	case avro.Ref:
+		resolved, ok := t.resolve(sc, ns)
+		if !ok {
+			return nil, fmt.Errorf("unresolved schema reference %q", sc.Name)
+		}
+		return jsonFromValue(v, resolved, t, ns)
+	case avro.Record:
+		rec, ok := v.(generic.Record)
+		if !ok {
+			return nil, decodeTypeErr(fmt.Sprintf("record %q", sc.Name), v)
+		}
+		if len(rec.Fields) != len(sc.Fields) {
+			return nil, fmt.Errorf("record %q: decoded %d fields, schema has %d", sc.Name, len(rec.Fields), len(sc.Fields))
+		}
+		rns := nsOr(sc.Namespace, ns)
+		out := make(map[string]any, len(sc.Fields))
+		for i, f := range sc.Fields {
+			fv, err := jsonFromValue(rec.Fields[i].Value, f.Type, t, rns)
+			if err != nil {
+				return nil, fmt.Errorf("field %q: %w", f.Name, err)
+			}
+			out[f.Name] = fv
+		}
+		return out, nil
+	case avro.Enum:
+		en, ok := v.(generic.Enum)
+		if !ok {
+			return nil, decodeTypeErr(fmt.Sprintf("enum %q", sc.Name), v)
+		}
+		return en.Symbol, nil
+	case avro.Array:
+		arr, ok := v.(generic.Array)
+		if !ok {
+			return nil, decodeTypeErr("array", v)
+		}
+		out := make([]any, len(arr))
+		for i, item := range arr {
+			iv, err := jsonFromValue(item, sc.Items, t, ns)
+			if err != nil {
+				return nil, fmt.Errorf("array[%d]: %w", i, err)
+			}
+			out[i] = iv
+		}
+		return out, nil
+	case avro.Map:
+		mp, ok := v.(generic.Map)
+		if !ok {
+			return nil, decodeTypeErr("map", v)
+		}
+		out := make(map[string]any, len(mp))
+		for k, mv := range mp {
+			vv, err := jsonFromValue(mv, sc.Values, t, ns)
+			if err != nil {
+				return nil, fmt.Errorf("map[%q]: %w", k, err)
+			}
+			out[k] = vv
+		}
+		return out, nil
+	case avro.Union:
+		un, ok := v.(generic.Union)
+		if !ok {
+			return nil, decodeTypeErr("union", v)
+		}
+		if un.Index < 0 || un.Index >= len(sc.Types) {
+			return nil, fmt.Errorf("union branch index %d out of range", un.Index)
+		}
+		branch := sc.Types[un.Index]
+		if _, isNull := branch.(avro.Null); isNull {
+			return nil, nil
+		}
+		inner, err := jsonFromValue(un.Value, branch, t, ns)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]any{unionBranchName(branch, ns): inner}, nil
+	default:
+		return nil, fmt.Errorf("Avro type %T is not supported in AVRO mode", s)
+	}
+}
+
+// unionBranchName returns the type name used as the key in the Avro JSON
+// encoding of a non-null union branch.
+func unionBranchName(s avro.Schema, ns string) string {
+	switch x := s.(type) {
+	case avro.Null:
+		return "null"
+	case avro.Boolean:
+		return "boolean"
+	case avro.Int:
+		return "int"
+	case avro.Long:
+		return "long"
+	case avro.Float:
+		return "float"
+	case avro.Double:
+		return "double"
+	case avro.Bytes:
+		return "bytes"
+	case avro.String:
+		return "string"
+	case avro.Array:
+		return "array"
+	case avro.Map:
+		return "map"
+	case avro.Record:
+		return fullName(x.Name, nsOr(x.Namespace, ns))
+	case avro.Enum:
+		return fullName(x.Name, nsOr(x.Namespace, ns))
+	case avro.Fixed:
+		return fullName(x.Name, nsOr(x.Namespace, ns))
+	case avro.Ref:
+		return fullName(x.Name, nsOr(x.Namespace, ns))
+	default:
+		return fmt.Sprintf("%T", s)
+	}
+}
+
+// ---- small helpers ----
+
+func toInt64(v any) (int64, error) {
+	switch n := v.(type) {
+	case json.Number:
+		return n.Int64()
+	case float64:
+		if n != math.Trunc(n) {
+			return 0, fmt.Errorf("expected an integer, got %v", n)
+		}
+		return int64(n), nil
+	case int:
+		return int64(n), nil
+	case int64:
+		return n, nil
+	default:
+		return 0, fmt.Errorf("expected a JSON number, got %T", v)
+	}
+}
+
+func toFloat64(v any) (float64, error) {
+	switch n := v.(type) {
+	case json.Number:
+		return n.Float64()
+	case float64:
+		return n, nil
+	case int:
+		return float64(n), nil
+	case int64:
+		return float64(n), nil
+	default:
+		return 0, fmt.Errorf("expected a JSON number, got %T", v)
+	}
+}
+
+// bytesFromJSONString decodes the Avro JSON encoding of bytes: a string whose
+// characters are the byte values (code points 0-255).
+func bytesFromJSONString(s string) ([]byte, error) {
+	out := make([]byte, 0, len(s))
+	for _, r := range s {
+		if r > 0xFF {
+			return nil, fmt.Errorf("bytes JSON string contains code point %U > 0xFF", r)
+		}
+		out = append(out, byte(r))
+	}
+	return out, nil
+}
+
+func bytesToJSONString(b []byte) string {
+	rs := make([]rune, len(b))
+	for i, c := range b {
+		rs[i] = rune(c)
+	}
+	return string(rs)
+}
+
+func typeErr(want string, got any) error {
+	return fmt.Errorf("expected JSON %s, got %T", want, got)
+}
+
+func decodeTypeErr(want string, got generic.Value) error {
+	return fmt.Errorf("decoded value is %T, expected %s", got, want)
+}

--- a/daggerverse/kafka/avro.go
+++ b/daggerverse/kafka/avro.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math"
 	"slices"
 	"strings"
@@ -149,9 +150,29 @@ func (a *avroSchemas) decode(ctx context.Context, id int, bin []byte) ([]byte, e
 	if err != nil {
 		return nil, fmt.Errorf("map avro to json: %w", err)
 	}
-	out, err := json.Marshal(doc)
+	out, err := marshalNoEscape(doc)
 	if err != nil {
 		return nil, fmt.Errorf("marshal decoded json: %w", err)
+	}
+	return out, nil
+}
+
+// marshalNoEscape compact-marshals v with HTML escaping disabled, matching the
+// JSON-canonicalization path (see canonicalJSON in client.go): json.Marshal
+// would rewrite "<", ">", and "&" in string values as < / > / &,
+// mutating decoded payloads as they cross the module boundary.
+func marshalNoEscape(v any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	// json.Encoder appends a trailing newline; strip it so the output matches
+	// what json.Marshal would have produced.
+	out := buf.Bytes()
+	if n := len(out); n > 0 && out[n-1] == '\n' {
+		out = out[:n-1]
 	}
 	return out, nil
 }
@@ -166,7 +187,11 @@ func unmarshalJSONValue(raw []byte) (any, error) {
 	if err := d.Decode(&v); err != nil {
 		return nil, fmt.Errorf("payload is not valid JSON: %w", err)
 	}
-	if d.More() {
+	// Reject trailing tokens (e.g. `{} {}`) so the caller can't smuggle extra
+	// documents past the validator. Decoding a second time and requiring io.EOF
+	// is unambiguous, unlike Decoder.More() whose contract is about iterating
+	// the *current* array/object rather than the top-level stream.
+	if err := d.Decode(&struct{}{}); err != io.EOF {
 		return nil, fmt.Errorf("payload has trailing data after JSON value")
 	}
 	return v, nil

--- a/daggerverse/kafka/client.go
+++ b/daggerverse/kafka/client.go
@@ -175,6 +175,49 @@ func applySerializeAs(b []byte, mode, field string) ([]byte, error) {
 	}
 }
 
+// serializeField runs the producer-side serializer for one field. "" and
+// "JSON" delegate to the pure applySerializeAs; "AVRO" needs the schema-id,
+// registry, and codec cache that only the Produce call has, so it is handled
+// here: the schema id is required (a zero / negative id errors before any
+// broker or registry I/O), then the bytes are mapped from JSON and
+// Avro-binary-encoded.
+func serializeField(ctx context.Context, b []byte, mode, field string, schemaID int, codecs *avroSchemas) ([]byte, error) {
+	switch mode {
+	case "", "JSON":
+		return applySerializeAs(b, mode, field)
+	case "AVRO":
+		if schemaID <= 0 {
+			return nil, fmt.Errorf("%sSerializeAs=\"AVRO\" requires %sSchemaID > 0, got %d", field, field, schemaID)
+		}
+		return codecs.encode(ctx, schemaID, b)
+	default:
+		return nil, fmt.Errorf("unsupported %sSerializeAs %q (want \"\"|\"JSON\"|\"AVRO\")", field, mode)
+	}
+}
+
+// deserializeField runs the consumer-side deserializer for one field, after
+// any Confluent frame has been stripped. "" and "JSON" delegate to the pure
+// applyDeserializeAs; "AVRO" decodes the Avro binary payload against the
+// schema identified by the wire id and re-serialises it to JSON. schemaID is
+// the id extracted from the frame (0 when the record was unframed); a zero id
+// in AVRO mode means the record carried no wire header and cannot be decoded.
+func deserializeField(ctx context.Context, b []byte, mode, field string, schemaID int, schemaRegistryAware bool, codecs *avroSchemas) ([]byte, error) {
+	switch mode {
+	case "", "JSON":
+		return applyDeserializeAs(b, mode, field)
+	case "AVRO":
+		if !schemaRegistryAware {
+			return nil, fmt.Errorf("%sDeserializeAs=\"AVRO\" requires schemaRegistryAware=true", field)
+		}
+		if schemaID <= 0 {
+			return nil, fmt.Errorf("%s record is missing the Confluent wire header (no schema id); cannot AVRO-decode", field)
+		}
+		return codecs.decode(ctx, schemaID, b)
+	default:
+		return nil, fmt.Errorf("unsupported %sDeserializeAs %q (want \"\"|\"JSON\"|\"AVRO\")", field, mode)
+	}
+}
+
 // applyDeserializeAs runs the named consumer-side deserializer against
 // payload bytes that have already had any Confluent frame stripped. "" is
 // pass-through; "JSON" validates with json.Valid. The bytes are returned
@@ -457,7 +500,16 @@ func (c *Client) DeleteTopic(ctx context.Context, name string) error {
 // decode → serialize → frame, so a single call can both canonicalise a
 // JSON payload and prepend the Confluent header. Invalid JSON is
 // rejected before any broker I/O. Default "" is pass-through; "JSON"
-// is the only non-empty value accepted in this story.
+// canonicalises.
+//
+// keySerializeAs / valueSerializeAs set to "AVRO" interpret the decoded
+// bytes as a JSON document and Avro-binary-encode it (via
+// github.com/z5labs/avro-go/generic) against the schema identified by
+// keySchemaID / valueSchemaID before framing. The id is required in this
+// mode — a zero / negative id errors out before any broker or registry
+// I/O — and registry must be supplied so the schema text can be resolved
+// by id. The JSON shape follows the Avro spec's JSON encoding; logical
+// types, decimal, and fixed are not yet supported.
 //
 // +cache="never"
 func (c *Client) Produce(
@@ -477,6 +529,11 @@ func (c *Client) Produce(
 	keySerializeAs string,
 	// +default=""
 	valueSerializeAs string,
+	// registry resolves the Avro schema text by id when keySerializeAs /
+	// valueSerializeAs is "AVRO". Required in that mode; ignored otherwise.
+	//
+	// +optional
+	registry *SchemaRegistry,
 ) error {
 	if keySchemaID < 0 {
 		return fmt.Errorf("keySchemaID must be >= 0, got %d", keySchemaID)
@@ -494,11 +551,12 @@ func (c *Client) Produce(
 		return fmt.Errorf("decode value: %w", err)
 	}
 
-	keyBytes, err = applySerializeAs(keyBytes, keySerializeAs, "key")
+	codecs := newAvroSchemas(registry)
+	keyBytes, err = serializeField(ctx, keyBytes, keySerializeAs, "key", keySchemaID, codecs)
 	if err != nil {
 		return fmt.Errorf("serialize key: %w", err)
 	}
-	valBytes, err = applySerializeAs(valBytes, valueSerializeAs, "value")
+	valBytes, err = serializeField(ctx, valBytes, valueSerializeAs, "value", valueSchemaID, codecs)
 	if err != nil {
 		return fmt.Errorf("serialize value: %w", err)
 	}
@@ -561,8 +619,18 @@ func (c *Client) Produce(
 // compose: framed bytes are stripped first and validation runs on the
 // payload alone. Records whose payloads fail to parse cause Consume to
 // error out and abandon the remaining poll. Default "" is
-// pass-through; "JSON" is the only non-empty value accepted in this
-// story.
+// pass-through; "JSON" validates.
+//
+// keyDeserializeAs / valueDeserializeAs set to "AVRO" decode each
+// record's post-frame-strip Avro binary payload (via
+// github.com/z5labs/avro-go/generic) against the schema identified by the
+// wire id and re-serialise it to JSON. This mode requires
+// schemaRegistryAware=true (so the wire id is available) and a registry
+// (so the schema text can be resolved by id); an unframed record errors
+// out pointing at the missing wire header. Schema resolution is cached
+// per id for the duration of the call. The JSON shape follows the Avro
+// spec's JSON encoding; logical types, decimal, and fixed are not yet
+// supported.
 //
 // +cache="never"
 func (c *Client) Consume(
@@ -584,9 +652,22 @@ func (c *Client) Consume(
 	keyDeserializeAs string,
 	// +default=""
 	valueDeserializeAs string,
+	// registry resolves the Avro schema text by id when keyDeserializeAs /
+	// valueDeserializeAs is "AVRO". Required in that mode; ignored otherwise.
+	//
+	// +optional
+	registry *SchemaRegistry,
 ) (string, error) {
 	if maxMessages <= 0 {
 		return "", fmt.Errorf("maxMessages must be > 0, got %d", maxMessages)
+	}
+	if keyDeserializeAs == "AVRO" || valueDeserializeAs == "AVRO" {
+		if !schemaRegistryAware {
+			return "", fmt.Errorf(`AVRO deserialize requires schemaRegistryAware=true so the wire schema id is available`)
+		}
+		if registry == nil {
+			return "", fmt.Errorf("AVRO deserialize requires a schema registry to resolve schema text by id")
+		}
 	}
 	d, err := time.ParseDuration(timeout)
 	if err != nil {
@@ -618,6 +699,10 @@ func (c *Client) Consume(
 	deadlineCtx, cancel := context.WithTimeout(ctx, d)
 	defer cancel()
 
+	// One codec cache per call so schema resolution is cached per id across
+	// every record polled (issue: avoid one HTTP round-trip per record).
+	codecs := newAvroSchemas(registry)
+
 	out := make([]ConsumedRecord, 0, maxMessages)
 	for len(out) < maxMessages {
 		fetches := cl.PollFetches(deadlineCtx)
@@ -645,11 +730,11 @@ func (c *Client) Consume(
 				}
 			}
 			var err error
-			keyRaw, err = applyDeserializeAs(keyRaw, keyDeserializeAs, "key")
+			keyRaw, err = deserializeField(ctx, keyRaw, keyDeserializeAs, "key", keyID, schemaRegistryAware, codecs)
 			if err != nil {
 				return "", fmt.Errorf("deserialize key: %w", err)
 			}
-			valRaw, err = applyDeserializeAs(valRaw, valueDeserializeAs, "value")
+			valRaw, err = deserializeField(ctx, valRaw, valueDeserializeAs, "value", valID, schemaRegistryAware, codecs)
 			if err != nil {
 				return "", fmt.Errorf("deserialize value: %w", err)
 			}

--- a/daggerverse/kafka/client.go
+++ b/daggerverse/kafka/client.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -143,7 +144,10 @@ func canonicalJSON(b []byte, field string) ([]byte, error) {
 	}
 	// json.Decoder accepts a stream of values — reject trailing tokens
 	// so the caller can't smuggle extra documents through the validator.
-	if dec.More() {
+	// Decoding a second time and requiring io.EOF is unambiguous, unlike
+	// Decoder.More() whose contract is about iterating the current
+	// array/object rather than the top-level stream.
+	if err := dec.Decode(&struct{}{}); err != io.EOF {
 		return nil, fmt.Errorf("%s has trailing data after JSON value", field)
 	}
 	var buf bytes.Buffer
@@ -730,11 +734,11 @@ func (c *Client) Consume(
 				}
 			}
 			var err error
-			keyRaw, err = deserializeField(ctx, keyRaw, keyDeserializeAs, "key", keyID, schemaRegistryAware, codecs)
+			keyRaw, err = deserializeField(deadlineCtx, keyRaw, keyDeserializeAs, "key", keyID, schemaRegistryAware, codecs)
 			if err != nil {
 				return "", fmt.Errorf("deserialize key: %w", err)
 			}
-			valRaw, err = deserializeField(ctx, valRaw, valueDeserializeAs, "value", valID, schemaRegistryAware, codecs)
+			valRaw, err = deserializeField(deadlineCtx, valRaw, valueDeserializeAs, "value", valID, schemaRegistryAware, codecs)
 			if err != nil {
 				return "", fmt.Errorf("deserialize value: %w", err)
 			}

--- a/daggerverse/kafka/dagger.gen.go
+++ b/daggerverse/kafka/dagger.gen.go
@@ -565,7 +565,14 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg valueDeserializeAs", err))
 				}
 			}
-			return (*Client).Consume(&parent, ctx, topic, maxMessages, timeout, keyEncoding, valueEncoding, group, schemaRegistryAware, keyDeserializeAs, valueDeserializeAs)
+			var registry *SchemaRegistry
+			if inputArgs["registry"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["registry"]), &registry)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg registry", err))
+				}
+			}
+			return (*Client).Consume(&parent, ctx, topic, maxMessages, timeout, keyEncoding, valueEncoding, group, schemaRegistryAware, keyDeserializeAs, valueDeserializeAs, registry)
 		case "CreateTopic":
 			var parent Client
 			err = json.Unmarshal(parentJSON, &parent)
@@ -684,7 +691,14 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg valueSerializeAs", err))
 				}
 			}
-			return nil, (*Client).Produce(&parent, ctx, topic, key, value, keyEncoding, valueEncoding, keySchemaId, valueSchemaId, keySerializeAs, valueSerializeAs)
+			var registry *SchemaRegistry
+			if inputArgs["registry"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["registry"]), &registry)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg registry", err))
+				}
+			}
+			return nil, (*Client).Produce(&parent, ctx, topic, key, value, keyEncoding, valueEncoding, keySchemaId, valueSchemaId, keySerializeAs, valueSerializeAs, registry)
 		case "PropertiesFile":
 			var parent Client
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/kafka/go.mod
+++ b/daggerverse/kafka/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/twmb/franz-go v1.21.1
 	github.com/twmb/franz-go/pkg/kadm v1.18.0
 	github.com/twmb/franz-go/pkg/sr v1.7.0
+	github.com/z5labs/avro-go v0.5.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	gopkg.in/yaml.v3 v3.0.1
 	software.sslmate.com/src/go-pkcs12 v0.7.1

--- a/daggerverse/kafka/go.sum
+++ b/daggerverse/kafka/go.sum
@@ -57,6 +57,8 @@ github.com/twmb/franz-go/pkg/sr v1.7.0 h1:wHStlO6aOPWWgZ68ZYcdtQe9tRbkcTc1gRLbgs
 github.com/twmb/franz-go/pkg/sr v1.7.0/go.mod h1:64CsHlsQnyFRq1sYPcCmlRrEG3PlLPb6cDddx2wGr28=
 github.com/vektah/gqlparser/v2 v2.5.33 h1:lRp8aIeNUNbimf/axZd7ETg24q06hBtPaas+TcvI/7E=
 github.com/vektah/gqlparser/v2 v2.5.33/go.mod h1:c1I28gSOVNzlfc4WuDlqU7voQnsqI6OG2amkBAFmgts=
+github.com/z5labs/avro-go v0.5.0 h1:WBEAp23ClHu5Zg6y7owKyVoPIS887TOXMHSUWTR5qbU=
+github.com/z5labs/avro-go v0.5.0/go.mod h1:vMukPZwJkvVA/4h48m2poyE0d5B1ETgx/K5L2qQRYns=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.43.0 h1:mYIM03dnh5zfN7HautFE4ieIig9amkNANT+xcVxAj9I=

--- a/daggerverse/kafka/tests/dagger.gen.go
+++ b/daggerverse/kafka/tests/dagger.gen.go
@@ -318,6 +318,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Tests).AutoCreateTopicsDisabled(&parent, ctx, kafkaImageTag)
+		case "AvroBytesFieldRoundTrip":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var kafkaImageTag string
+			if inputArgs["kafkaImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["kafkaImageTag"]), &kafkaImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg kafkaImageTag", err))
+				}
+			}
+			return nil, (*Tests).AvroBytesFieldRoundTrip(&parent, ctx, kafkaImageTag)
 		case "AvroConsumeUnframedErrors":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/kafka/tests/dagger.gen.go
+++ b/daggerverse/kafka/tests/dagger.gen.go
@@ -318,6 +318,41 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Tests).AutoCreateTopicsDisabled(&parent, ctx, kafkaImageTag)
+		case "AvroConsumeUnframedErrors":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var kafkaImageTag string
+			if inputArgs["kafkaImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["kafkaImageTag"]), &kafkaImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg kafkaImageTag", err))
+				}
+			}
+			return nil, (*Tests).AvroConsumeUnframedErrors(&parent, ctx, kafkaImageTag)
+		case "AvroFramedProduceConsumeRoundTrip":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var kafkaImageTag string
+			if inputArgs["kafkaImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["kafkaImageTag"]), &kafkaImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg kafkaImageTag", err))
+				}
+			}
+			return nil, (*Tests).AvroFramedProduceConsumeRoundTrip(&parent, ctx, kafkaImageTag)
+		case "AvroSerializeRequiresSchemaID":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).AvroSerializeRequiresSchemaID(&parent, ctx)
 		case "BindBrokersExposesBothListeners":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/kafka/tests/internal/dagger/kafka.gen.go
+++ b/daggerverse/kafka/tests/internal/dagger/kafka.gen.go
@@ -19,7 +19,7 @@ func (r *Binding) AsKafka() *Kafka { // kafka (../../../../../daggerverse/kafka/
 }
 
 // Retrieve the binding value, as type KafkaClient
-func (r *Binding) AsKafkaClient() *KafkaClient { // kafka (../../../../../daggerverse/kafka/client.go:31:6)
+func (r *Binding) AsKafkaClient() *KafkaClient { // kafka (../../../../../daggerverse/kafka/client.go:32:6)
 	q := r.query.Select("asKafkaClient")
 
 	return &KafkaClient{
@@ -100,7 +100,7 @@ func (r *Binding) AsKafkaServerSecurity() *KafkaServerSecurity { // kafka (../..
 }
 
 // Create or update a binding of type KafkaClient in the environment
-func (r *Env) WithKafkaClientInput(name string, value *KafkaClient, description string) *Env { // kafka (../../../../../daggerverse/kafka/client.go:31:6)
+func (r *Env) WithKafkaClientInput(name string, value *KafkaClient, description string) *Env { // kafka (../../../../../daggerverse/kafka/client.go:32:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withKafkaClientInput")
 	q = q.Arg("name", name)
@@ -113,7 +113,7 @@ func (r *Env) WithKafkaClientInput(name string, value *KafkaClient, description 
 }
 
 // Declare a desired KafkaClient output to be assigned in the environment
-func (r *Env) WithKafkaClientOutput(name string, description string) *Env { // kafka (../../../../../daggerverse/kafka/client.go:31:6)
+func (r *Env) WithKafkaClientOutput(name string, description string) *Env { // kafka (../../../../../daggerverse/kafka/client.go:32:6)
 	q := r.query.Select("withKafkaClientOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -530,7 +530,7 @@ func (r *Kafka) ApicurioSchemaRegistry(cluster *KafkaCluster, opts ...KafkaApicu
 
 // Client constructs a franz-go-backed Kafka client that targets the given
 // bootstrap servers. No I/O happens at construction time.
-func (r *Kafka) Client(bootstrapServers []string, security *KafkaClientSecurity) *KafkaClient { // kafka (../../../../../daggerverse/kafka/client.go:66:1)
+func (r *Kafka) Client(bootstrapServers []string, security *KafkaClientSecurity) *KafkaClient { // kafka (../../../../../daggerverse/kafka/client.go:67:1)
 	assertNotNil("security", security)
 	q := r.query.Select("client")
 	q = q.Arg("bootstrapServers", bootstrapServers)
@@ -929,7 +929,7 @@ func (r *Kafka) AsNode() Node {
 
 // Client is a franz-go-backed Kafka client. Each method opens a fresh
 // connection so the function call is stateless from Dagger's perspective.
-type KafkaClient struct { // kafka (../../../../../daggerverse/kafka/client.go:31:6)
+type KafkaClient struct { // kafka (../../../../../daggerverse/kafka/client.go:32:6)
 	query *querybuilder.Selection
 
 	consume     *string
@@ -949,29 +949,29 @@ func (r *KafkaClient) WithGraphQLQuery(q *querybuilder.Selection) *KafkaClient {
 type KafkaClientConsumeOpts struct {
 
 	// Default: 1
-	MaxMessages int // kafka (../../../../../daggerverse/kafka/client.go:640:2)
+	MaxMessages int // kafka (../../../../../daggerverse/kafka/client.go:644:2)
 
 	// Default: "10s"
-	Timeout string // kafka (../../../../../daggerverse/kafka/client.go:642:2)
+	Timeout string // kafka (../../../../../daggerverse/kafka/client.go:646:2)
 
 	// Default: "raw"
-	KeyEncoding string // kafka (../../../../../daggerverse/kafka/client.go:644:2)
+	KeyEncoding string // kafka (../../../../../daggerverse/kafka/client.go:648:2)
 
 	// Default: "raw"
-	ValueEncoding string // kafka (../../../../../daggerverse/kafka/client.go:646:2)
+	ValueEncoding string // kafka (../../../../../daggerverse/kafka/client.go:650:2)
 
-	Group string // kafka (../../../../../daggerverse/kafka/client.go:648:2)
+	Group string // kafka (../../../../../daggerverse/kafka/client.go:652:2)
 
-	SchemaRegistryAware bool // kafka (../../../../../daggerverse/kafka/client.go:650:2)
+	SchemaRegistryAware bool // kafka (../../../../../daggerverse/kafka/client.go:654:2)
 
-	KeyDeserializeAs string // kafka (../../../../../daggerverse/kafka/client.go:652:2)
+	KeyDeserializeAs string // kafka (../../../../../daggerverse/kafka/client.go:656:2)
 
-	ValueDeserializeAs string // kafka (../../../../../daggerverse/kafka/client.go:654:2)
+	ValueDeserializeAs string // kafka (../../../../../daggerverse/kafka/client.go:658:2)
 	//
 	// registry resolves the Avro schema text by id when keyDeserializeAs /
 	// valueDeserializeAs is "AVRO". Required in that mode; ignored otherwise.
 	//
-	Registry *KafkaSchemaRegistry // kafka (../../../../../daggerverse/kafka/client.go:659:2)
+	Registry *KafkaSchemaRegistry // kafka (../../../../../daggerverse/kafka/client.go:663:2)
 }
 
 // Consume reads up to maxMessages records from the topic, starting at the
@@ -1014,7 +1014,7 @@ type KafkaClientConsumeOpts struct {
 // per id for the duration of the call. The JSON shape follows the Avro
 // spec's JSON encoding; logical types, decimal, and fixed are not yet
 // supported.
-func (r *KafkaClient) Consume(ctx context.Context, topic string, opts ...KafkaClientConsumeOpts) (string, error) { // kafka (../../../../../daggerverse/kafka/client.go:636:1)
+func (r *KafkaClient) Consume(ctx context.Context, topic string, opts ...KafkaClientConsumeOpts) (string, error) { // kafka (../../../../../daggerverse/kafka/client.go:640:1)
 	if r.consume != nil {
 		return *r.consume, nil
 	}
@@ -1069,15 +1069,15 @@ func (r *KafkaClient) Consume(ctx context.Context, topic string, opts ...KafkaCl
 type KafkaClientCreateTopicOpts struct {
 
 	// Default: 1
-	Partitions int // kafka (../../../../../daggerverse/kafka/client.go:437:2)
+	Partitions int // kafka (../../../../../daggerverse/kafka/client.go:441:2)
 
 	// Default: 1
-	ReplicationFactor int // kafka (../../../../../daggerverse/kafka/client.go:439:2)
+	ReplicationFactor int // kafka (../../../../../daggerverse/kafka/client.go:443:2)
 }
 
 // CreateTopic creates a new topic with the given partition count and
 // replication factor. Errors out if the topic already exists.
-func (r *KafkaClient) CreateTopic(ctx context.Context, name string, opts ...KafkaClientCreateTopicOpts) error { // kafka (../../../../../daggerverse/kafka/client.go:433:1)
+func (r *KafkaClient) CreateTopic(ctx context.Context, name string, opts ...KafkaClientCreateTopicOpts) error { // kafka (../../../../../daggerverse/kafka/client.go:437:1)
 	if r.createTopic != nil {
 		return nil
 	}
@@ -1098,7 +1098,7 @@ func (r *KafkaClient) CreateTopic(ctx context.Context, name string, opts ...Kafk
 }
 
 // DeleteTopic deletes the named topic.
-func (r *KafkaClient) DeleteTopic(ctx context.Context, name string) error { // kafka (../../../../../daggerverse/kafka/client.go:467:1)
+func (r *KafkaClient) DeleteTopic(ctx context.Context, name string) error { // kafka (../../../../../daggerverse/kafka/client.go:471:1)
 	if r.deleteTopic != nil {
 		return nil
 	}
@@ -1158,7 +1158,7 @@ func (r *KafkaClient) UnmarshalJSON(bs []byte) error {
 }
 
 // ListTopics returns the names of every topic the broker reports.
-func (r *KafkaClient) ListTopics(ctx context.Context) ([]string, error) { // kafka (../../../../../daggerverse/kafka/client.go:773:1)
+func (r *KafkaClient) ListTopics(ctx context.Context) ([]string, error) { // kafka (../../../../../daggerverse/kafka/client.go:777:1)
 	q := r.query.Select("listTopics")
 
 	var response []string
@@ -1171,23 +1171,23 @@ func (r *KafkaClient) ListTopics(ctx context.Context) ([]string, error) { // kaf
 type KafkaClientProduceOpts struct {
 
 	// Default: "raw"
-	KeyEncoding string // kafka (../../../../../daggerverse/kafka/client.go:521:2)
+	KeyEncoding string // kafka (../../../../../daggerverse/kafka/client.go:525:2)
 
 	// Default: "raw"
-	ValueEncoding string // kafka (../../../../../daggerverse/kafka/client.go:523:2)
+	ValueEncoding string // kafka (../../../../../daggerverse/kafka/client.go:527:2)
 
-	KeySchemaID int // kafka (../../../../../daggerverse/kafka/client.go:525:2)
+	KeySchemaID int // kafka (../../../../../daggerverse/kafka/client.go:529:2)
 
-	ValueSchemaID int // kafka (../../../../../daggerverse/kafka/client.go:527:2)
+	ValueSchemaID int // kafka (../../../../../daggerverse/kafka/client.go:531:2)
 
-	KeySerializeAs string // kafka (../../../../../daggerverse/kafka/client.go:529:2)
+	KeySerializeAs string // kafka (../../../../../daggerverse/kafka/client.go:533:2)
 
-	ValueSerializeAs string // kafka (../../../../../daggerverse/kafka/client.go:531:2)
+	ValueSerializeAs string // kafka (../../../../../daggerverse/kafka/client.go:535:2)
 	//
 	// registry resolves the Avro schema text by id when keySerializeAs /
 	// valueSerializeAs is "AVRO". Required in that mode; ignored otherwise.
 	//
-	Registry *KafkaSchemaRegistry // kafka (../../../../../daggerverse/kafka/client.go:536:2)
+	Registry *KafkaSchemaRegistry // kafka (../../../../../daggerverse/kafka/client.go:540:2)
 }
 
 // Produce synchronously writes one record to the topic. Key and value are
@@ -1216,7 +1216,7 @@ type KafkaClientProduceOpts struct {
 // I/O — and registry must be supplied so the schema text can be resolved
 // by id. The JSON shape follows the Avro spec's JSON encoding; logical
 // types, decimal, and fixed are not yet supported.
-func (r *KafkaClient) Produce(ctx context.Context, topic string, key string, value string, opts ...KafkaClientProduceOpts) error { // kafka (../../../../../daggerverse/kafka/client.go:515:1)
+func (r *KafkaClient) Produce(ctx context.Context, topic string, key string, value string, opts ...KafkaClientProduceOpts) error { // kafka (../../../../../daggerverse/kafka/client.go:519:1)
 	if r.produce != nil {
 		return nil
 	}
@@ -1268,7 +1268,7 @@ func (r *KafkaClient) Produce(ctx context.Context, topic string, key string, val
 // export the parent directory (`props.Directory()`) so the relative
 // references resolve. Passwords appear plaintext, which is a Kafka CLI
 // constraint.
-func (r *KafkaClient) PropertiesFile() *File { // kafka (../../../../../daggerverse/kafka/client.go:252:1)
+func (r *KafkaClient) PropertiesFile() *File { // kafka (../../../../../daggerverse/kafka/client.go:256:1)
 	q := r.query.Select("propertiesFile")
 
 	return &File{

--- a/daggerverse/kafka/tests/internal/dagger/kafka.gen.go
+++ b/daggerverse/kafka/tests/internal/dagger/kafka.gen.go
@@ -949,24 +949,29 @@ func (r *KafkaClient) WithGraphQLQuery(q *querybuilder.Selection) *KafkaClient {
 type KafkaClientConsumeOpts struct {
 
 	// Default: 1
-	MaxMessages int // kafka (../../../../../daggerverse/kafka/client.go:572:2)
+	MaxMessages int // kafka (../../../../../daggerverse/kafka/client.go:640:2)
 
 	// Default: "10s"
-	Timeout string // kafka (../../../../../daggerverse/kafka/client.go:574:2)
+	Timeout string // kafka (../../../../../daggerverse/kafka/client.go:642:2)
 
 	// Default: "raw"
-	KeyEncoding string // kafka (../../../../../daggerverse/kafka/client.go:576:2)
+	KeyEncoding string // kafka (../../../../../daggerverse/kafka/client.go:644:2)
 
 	// Default: "raw"
-	ValueEncoding string // kafka (../../../../../daggerverse/kafka/client.go:578:2)
+	ValueEncoding string // kafka (../../../../../daggerverse/kafka/client.go:646:2)
 
-	Group string // kafka (../../../../../daggerverse/kafka/client.go:580:2)
+	Group string // kafka (../../../../../daggerverse/kafka/client.go:648:2)
 
-	SchemaRegistryAware bool // kafka (../../../../../daggerverse/kafka/client.go:582:2)
+	SchemaRegistryAware bool // kafka (../../../../../daggerverse/kafka/client.go:650:2)
 
-	KeyDeserializeAs string // kafka (../../../../../daggerverse/kafka/client.go:584:2)
+	KeyDeserializeAs string // kafka (../../../../../daggerverse/kafka/client.go:652:2)
 
-	ValueDeserializeAs string // kafka (../../../../../daggerverse/kafka/client.go:586:2)
+	ValueDeserializeAs string // kafka (../../../../../daggerverse/kafka/client.go:654:2)
+	//
+	// registry resolves the Avro schema text by id when keyDeserializeAs /
+	// valueDeserializeAs is "AVRO". Required in that mode; ignored otherwise.
+	//
+	Registry *KafkaSchemaRegistry // kafka (../../../../../daggerverse/kafka/client.go:659:2)
 }
 
 // Consume reads up to maxMessages records from the topic, starting at the
@@ -997,9 +1002,19 @@ type KafkaClientConsumeOpts struct {
 // compose: framed bytes are stripped first and validation runs on the
 // payload alone. Records whose payloads fail to parse cause Consume to
 // error out and abandon the remaining poll. Default "" is
-// pass-through; "JSON" is the only non-empty value accepted in this
-// story.
-func (r *KafkaClient) Consume(ctx context.Context, topic string, opts ...KafkaClientConsumeOpts) (string, error) { // kafka (../../../../../daggerverse/kafka/client.go:568:1)
+// pass-through; "JSON" validates.
+//
+// keyDeserializeAs / valueDeserializeAs set to "AVRO" decode each
+// record's post-frame-strip Avro binary payload (via
+// github.com/z5labs/avro-go/generic) against the schema identified by the
+// wire id and re-serialise it to JSON. This mode requires
+// schemaRegistryAware=true (so the wire id is available) and a registry
+// (so the schema text can be resolved by id); an unframed record errors
+// out pointing at the missing wire header. Schema resolution is cached
+// per id for the duration of the call. The JSON shape follows the Avro
+// spec's JSON encoding; logical types, decimal, and fixed are not yet
+// supported.
+func (r *KafkaClient) Consume(ctx context.Context, topic string, opts ...KafkaClientConsumeOpts) (string, error) { // kafka (../../../../../daggerverse/kafka/client.go:636:1)
 	if r.consume != nil {
 		return *r.consume, nil
 	}
@@ -1037,6 +1052,10 @@ func (r *KafkaClient) Consume(ctx context.Context, topic string, opts ...KafkaCl
 		if !querybuilder.IsZeroValue(opts[i].ValueDeserializeAs) {
 			q = q.Arg("valueDeserializeAs", opts[i].ValueDeserializeAs)
 		}
+		// `registry` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Registry) {
+			q = q.Arg("registry", opts[i].Registry)
+		}
 	}
 	q = q.Arg("topic", topic)
 
@@ -1050,15 +1069,15 @@ func (r *KafkaClient) Consume(ctx context.Context, topic string, opts ...KafkaCl
 type KafkaClientCreateTopicOpts struct {
 
 	// Default: 1
-	Partitions int // kafka (../../../../../daggerverse/kafka/client.go:394:2)
+	Partitions int // kafka (../../../../../daggerverse/kafka/client.go:437:2)
 
 	// Default: 1
-	ReplicationFactor int // kafka (../../../../../daggerverse/kafka/client.go:396:2)
+	ReplicationFactor int // kafka (../../../../../daggerverse/kafka/client.go:439:2)
 }
 
 // CreateTopic creates a new topic with the given partition count and
 // replication factor. Errors out if the topic already exists.
-func (r *KafkaClient) CreateTopic(ctx context.Context, name string, opts ...KafkaClientCreateTopicOpts) error { // kafka (../../../../../daggerverse/kafka/client.go:390:1)
+func (r *KafkaClient) CreateTopic(ctx context.Context, name string, opts ...KafkaClientCreateTopicOpts) error { // kafka (../../../../../daggerverse/kafka/client.go:433:1)
 	if r.createTopic != nil {
 		return nil
 	}
@@ -1079,7 +1098,7 @@ func (r *KafkaClient) CreateTopic(ctx context.Context, name string, opts ...Kafk
 }
 
 // DeleteTopic deletes the named topic.
-func (r *KafkaClient) DeleteTopic(ctx context.Context, name string) error { // kafka (../../../../../daggerverse/kafka/client.go:424:1)
+func (r *KafkaClient) DeleteTopic(ctx context.Context, name string) error { // kafka (../../../../../daggerverse/kafka/client.go:467:1)
 	if r.deleteTopic != nil {
 		return nil
 	}
@@ -1139,7 +1158,7 @@ func (r *KafkaClient) UnmarshalJSON(bs []byte) error {
 }
 
 // ListTopics returns the names of every topic the broker reports.
-func (r *KafkaClient) ListTopics(ctx context.Context) ([]string, error) { // kafka (../../../../../daggerverse/kafka/client.go:688:1)
+func (r *KafkaClient) ListTopics(ctx context.Context) ([]string, error) { // kafka (../../../../../daggerverse/kafka/client.go:773:1)
 	q := r.query.Select("listTopics")
 
 	var response []string
@@ -1152,18 +1171,23 @@ func (r *KafkaClient) ListTopics(ctx context.Context) ([]string, error) { // kaf
 type KafkaClientProduceOpts struct {
 
 	// Default: "raw"
-	KeyEncoding string // kafka (../../../../../daggerverse/kafka/client.go:469:2)
+	KeyEncoding string // kafka (../../../../../daggerverse/kafka/client.go:521:2)
 
 	// Default: "raw"
-	ValueEncoding string // kafka (../../../../../daggerverse/kafka/client.go:471:2)
+	ValueEncoding string // kafka (../../../../../daggerverse/kafka/client.go:523:2)
 
-	KeySchemaID int // kafka (../../../../../daggerverse/kafka/client.go:473:2)
+	KeySchemaID int // kafka (../../../../../daggerverse/kafka/client.go:525:2)
 
-	ValueSchemaID int // kafka (../../../../../daggerverse/kafka/client.go:475:2)
+	ValueSchemaID int // kafka (../../../../../daggerverse/kafka/client.go:527:2)
 
-	KeySerializeAs string // kafka (../../../../../daggerverse/kafka/client.go:477:2)
+	KeySerializeAs string // kafka (../../../../../daggerverse/kafka/client.go:529:2)
 
-	ValueSerializeAs string // kafka (../../../../../daggerverse/kafka/client.go:479:2)
+	ValueSerializeAs string // kafka (../../../../../daggerverse/kafka/client.go:531:2)
+	//
+	// registry resolves the Avro schema text by id when keySerializeAs /
+	// valueSerializeAs is "AVRO". Required in that mode; ignored otherwise.
+	//
+	Registry *KafkaSchemaRegistry // kafka (../../../../../daggerverse/kafka/client.go:536:2)
 }
 
 // Produce synchronously writes one record to the topic. Key and value are
@@ -1182,8 +1206,17 @@ type KafkaClientProduceOpts struct {
 // decode → serialize → frame, so a single call can both canonicalise a
 // JSON payload and prepend the Confluent header. Invalid JSON is
 // rejected before any broker I/O. Default "" is pass-through; "JSON"
-// is the only non-empty value accepted in this story.
-func (r *KafkaClient) Produce(ctx context.Context, topic string, key string, value string, opts ...KafkaClientProduceOpts) error { // kafka (../../../../../daggerverse/kafka/client.go:463:1)
+// canonicalises.
+//
+// keySerializeAs / valueSerializeAs set to "AVRO" interpret the decoded
+// bytes as a JSON document and Avro-binary-encode it (via
+// github.com/z5labs/avro-go/generic) against the schema identified by
+// keySchemaID / valueSchemaID before framing. The id is required in this
+// mode — a zero / negative id errors out before any broker or registry
+// I/O — and registry must be supplied so the schema text can be resolved
+// by id. The JSON shape follows the Avro spec's JSON encoding; logical
+// types, decimal, and fixed are not yet supported.
+func (r *KafkaClient) Produce(ctx context.Context, topic string, key string, value string, opts ...KafkaClientProduceOpts) error { // kafka (../../../../../daggerverse/kafka/client.go:515:1)
 	if r.produce != nil {
 		return nil
 	}
@@ -1213,6 +1246,10 @@ func (r *KafkaClient) Produce(ctx context.Context, topic string, key string, val
 		if !querybuilder.IsZeroValue(opts[i].ValueSerializeAs) {
 			q = q.Arg("valueSerializeAs", opts[i].ValueSerializeAs)
 		}
+		// `registry` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Registry) {
+			q = q.Arg("registry", opts[i].Registry)
+		}
 	}
 	q = q.Arg("topic", topic)
 	q = q.Arg("key", key)
@@ -1231,7 +1268,7 @@ func (r *KafkaClient) Produce(ctx context.Context, topic string, key string, val
 // export the parent directory (`props.Directory()`) so the relative
 // references resolve. Passwords appear plaintext, which is a Kafka CLI
 // constraint.
-func (r *KafkaClient) PropertiesFile() *File { // kafka (../../../../../daggerverse/kafka/client.go:209:1)
+func (r *KafkaClient) PropertiesFile() *File { // kafka (../../../../../daggerverse/kafka/client.go:252:1)
 	q := r.query.Select("propertiesFile")
 
 	return &File{

--- a/daggerverse/kafka/tests/main.go
+++ b/daggerverse/kafka/tests/main.go
@@ -149,6 +149,9 @@ func (t *Tests) SchemaRegistry(
 	jobs = jobs.WithJob("AvroFramedProduceConsumeRoundTrip", func(ctx context.Context) error {
 		return t.AvroFramedProduceConsumeRoundTrip(ctx, kafkaImageTag)
 	})
+	jobs = jobs.WithJob("AvroBytesFieldRoundTrip", func(ctx context.Context) error {
+		return t.AvroBytesFieldRoundTrip(ctx, kafkaImageTag)
+	})
 
 	return jobs.Run(ctx)
 }

--- a/daggerverse/kafka/tests/main.go
+++ b/daggerverse/kafka/tests/main.go
@@ -140,6 +140,15 @@ func (t *Tests) SchemaRegistry(
 	jobs = jobs.WithJob("SchemaRegistryJSONFramedProduceConsumeRoundTrip", func(ctx context.Context) error {
 		return t.SchemaRegistryJSONFramedProduceConsumeRoundTrip(ctx, kafkaImageTag)
 	})
+	jobs = jobs.WithJob("AvroSerializeRequiresSchemaID", func(ctx context.Context) error {
+		return t.AvroSerializeRequiresSchemaID(ctx)
+	})
+	jobs = jobs.WithJob("AvroConsumeUnframedErrors", func(ctx context.Context) error {
+		return t.AvroConsumeUnframedErrors(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("AvroFramedProduceConsumeRoundTrip", func(ctx context.Context) error {
+		return t.AvroFramedProduceConsumeRoundTrip(ctx, kafkaImageTag)
+	})
 
 	return jobs.Run(ctx)
 }

--- a/daggerverse/kafka/tests/tests_schema_registry.go
+++ b/daggerverse/kafka/tests/tests_schema_registry.go
@@ -715,3 +715,188 @@ func (t *Tests) SchemaRegistryJSONFramedProduceConsumeRoundTrip(
 	}
 	return nil
 }
+
+// AvroSerializeRequiresSchemaID pins the up-front validation contract of
+// valueSerializeAs="AVRO": Produce must reject a zero schema id before any
+// broker or registry I/O. dag.Kafka().Client(...) builds without I/O, so no
+// cluster boots — the failure is purely the missing-id guard on the AVRO
+// serializer.
+func (t *Tests) AvroSerializeRequiresSchemaID(
+	ctx context.Context,
+) error {
+	client := dag.Kafka().Client(
+		[]string{"127.0.0.1:1"},
+		dag.Kafka().PlaintextClientSecurity(),
+	)
+	err := client.Produce(ctx, "any-topic", "k", `{"x":"hello"}`, dagger.KafkaClientProduceOpts{
+		KeyEncoding:      "raw",
+		ValueEncoding:    "raw",
+		ValueSerializeAs: "AVRO",
+		ValueSchemaID:    0,
+	})
+	if err == nil {
+		return fmt.Errorf("expected Produce to reject AVRO with a zero schema id, got nil error")
+	}
+	if !strings.Contains(err.Error(), "valueSchemaID") {
+		return fmt.Errorf("expected error to mention the required valueSchemaID, got: %v", err)
+	}
+	return nil
+}
+
+// AvroConsumeUnframedErrors pins the negative consume path: a record produced
+// without a Confluent wire header, consumed with valueDeserializeAs="AVRO" +
+// schemaRegistryAware=true, must error out pointing at the missing header. The
+// header check fires before any schema lookup, so the registry service never
+// has to start.
+func (t *Tests) AvroConsumeUnframedErrors(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, err := freshCluster(ctx, kafkaImageTag)
+	if err != nil {
+		return fmt.Errorf("create cluster: %w", err)
+	}
+	defer cluster.Stop(ctx)
+
+	sr := dag.Kafka().ConfluentSchemaRegistry(cluster)
+	defer sr.Stop(ctx)
+
+	client := cluster.Client(dag.Kafka().PlaintextClientSecurity())
+
+	topic, err := randomTopicName(ctx)
+	if err != nil {
+		return err
+	}
+	if err := client.CreateTopic(ctx, topic, dagger.KafkaClientCreateTopicOpts{
+		Partitions:        1,
+		ReplicationFactor: 1,
+	}); err != nil {
+		return fmt.Errorf("create topic %q: %w", topic, err)
+	}
+
+	if err := client.Produce(ctx, topic, "k", "plain", dagger.KafkaClientProduceOpts{
+		KeyEncoding:   "raw",
+		ValueEncoding: "raw",
+	}); err != nil {
+		return fmt.Errorf("produce: %w", err)
+	}
+
+	_, err = client.Consume(ctx, topic, dagger.KafkaClientConsumeOpts{
+		MaxMessages:         1,
+		Timeout:             "10s",
+		KeyEncoding:         "raw",
+		ValueEncoding:       "raw",
+		SchemaRegistryAware: true,
+		ValueDeserializeAs:  "AVRO",
+		Registry:            sr,
+	})
+	if err == nil {
+		return fmt.Errorf("expected Consume to reject an unframed record under AVRO, got nil error")
+	}
+	if !strings.Contains(err.Error(), "wire header") {
+		return fmt.Errorf("expected error to point at the missing wire header, got: %v", err)
+	}
+	return nil
+}
+
+// AvroFramedProduceConsumeRoundTrip is the happy-path data round-trip for AVRO
+// serde: register an Avro record schema to get an id, Produce a JSON document
+// with valueSerializeAs="AVRO" + valueSchemaID=id (so it is Avro-binary-encoded
+// then framed), and Consume it back with valueDeserializeAs="AVRO" +
+// schemaRegistryAware=true. The asserted invariant is byte-equality of the
+// consumed value to the canonical JSON form of the original input, proving the
+// JSON->Avro-binary->JSON pipeline preserves the datum.
+func (t *Tests) AvroFramedProduceConsumeRoundTrip(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, err := freshCluster(ctx, kafkaImageTag)
+	if err != nil {
+		return fmt.Errorf("create cluster: %w", err)
+	}
+	defer cluster.Stop(ctx)
+
+	sr := dag.Kafka().ConfluentSchemaRegistry(cluster)
+	defer sr.Stop(ctx)
+
+	subject, err := randomTopicName(ctx)
+	if err != nil {
+		return err
+	}
+	topic := subject
+	subject += "-value"
+
+	id, err := sr.Client().RegisterSchema(ctx, subject, avroTestSchema, dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{
+		SchemaType: "AVRO",
+	})
+	if err != nil {
+		return fmt.Errorf("register schema: %w", err)
+	}
+	if id <= 0 {
+		return fmt.Errorf("expected a positive schema id, got %d", id)
+	}
+
+	client := cluster.Client(dag.Kafka().PlaintextClientSecurity())
+	if err := client.CreateTopic(ctx, topic, dagger.KafkaClientCreateTopicOpts{
+		Partitions:        1,
+		ReplicationFactor: 1,
+	}); err != nil {
+		return fmt.Errorf("create topic %q: %w", topic, err)
+	}
+
+	// Whitespace differs from the canonical form so the round-trip proves the
+	// payload is genuinely re-encoded, not passed through.
+	const inputJSON = `{ "x" :  "hello-world" }`
+	const wantCanonical = `{"x":"hello-world"}`
+	const wantKey = "k"
+
+	if err := client.Produce(ctx, topic, wantKey, inputJSON, dagger.KafkaClientProduceOpts{
+		KeyEncoding:      "raw",
+		ValueEncoding:    "raw",
+		ValueSchemaID:    id,
+		ValueSerializeAs: "AVRO",
+		Registry:         sr,
+	}); err != nil {
+		return fmt.Errorf("produce: %w", err)
+	}
+
+	records, err := consume(ctx, client, topic, dagger.KafkaClientConsumeOpts{
+		MaxMessages:         1,
+		Timeout:             "10s",
+		KeyEncoding:         "raw",
+		ValueEncoding:       "raw",
+		SchemaRegistryAware: true,
+		ValueDeserializeAs:  "AVRO",
+		Registry:            sr,
+	})
+	if err != nil {
+		return fmt.Errorf("consume: %w", err)
+	}
+	if len(records) != 1 {
+		return fmt.Errorf("expected 1 record, got %d", len(records))
+	}
+	gotKey, err := records[0].Key(ctx)
+	if err != nil {
+		return fmt.Errorf("read key: %w", err)
+	}
+	gotVal, err := records[0].Value(ctx)
+	if err != nil {
+		return fmt.Errorf("read value: %w", err)
+	}
+	gotValID, err := records[0].ValueSchemaID(ctx)
+	if err != nil {
+		return fmt.Errorf("read value schema id: %w", err)
+	}
+	if gotKey != wantKey {
+		return fmt.Errorf("key mismatch: want %q, got %q", wantKey, gotKey)
+	}
+	if gotVal != wantCanonical {
+		return fmt.Errorf("value mismatch: want canonical %q, got %q", wantCanonical, gotVal)
+	}
+	if gotValID != id {
+		return fmt.Errorf("value schema id mismatch: want %d, got %d", id, gotValID)
+	}
+	return nil
+}

--- a/daggerverse/kafka/tests/tests_schema_registry.go
+++ b/daggerverse/kafka/tests/tests_schema_registry.go
@@ -12,6 +12,11 @@ import (
 // Registry round-trip test.
 const avroTestSchema = `{"type":"record","name":"R","fields":[{"name":"x","type":"string"}]}`
 
+// avroBytesSchema is a minimal Avro record schema with a single bytes field,
+// used to exercise the Avro-spec JSON encoding of bytes (a string of code
+// points 0-255, one character per byte) end-to-end.
+const avroBytesSchema = `{"type":"record","name":"B","fields":[{"name":"b","type":"bytes"}]}`
+
 // SchemaRegistryRegisterLookupRoundTrip is the PLAINTEXT happy-path test
 // for Kafka.ConfluentSchemaRegistry: stand a cp-schema-registry up next to
 // a fresh cluster, then exercise register → lookup-by-id →
@@ -897,6 +902,95 @@ func (t *Tests) AvroFramedProduceConsumeRoundTrip(
 	}
 	if gotValID != id {
 		return fmt.Errorf("value schema id mismatch: want %d, got %d", id, gotValID)
+	}
+	return nil
+}
+
+// AvroBytesFieldRoundTrip pins the Avro-spec JSON encoding of a bytes field.
+// Per the Avro specification, the JSON encoding of bytes (and fixed) is a
+// string whose characters are the byte values as Unicode code points 0-255 —
+// one character per byte, NOT base64. The input value here contains byte 0xFF
+// (code point U+00FF), which is outside the base64 alphabet, so a round-trip
+// that preserves it byte-for-byte proves the one-char-per-byte mapping and
+// would be impossible under a base64 interpretation.
+func (t *Tests) AvroBytesFieldRoundTrip(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, err := freshCluster(ctx, kafkaImageTag)
+	if err != nil {
+		return fmt.Errorf("create cluster: %w", err)
+	}
+	defer cluster.Stop(ctx)
+
+	sr := dag.Kafka().ConfluentSchemaRegistry(cluster)
+	defer sr.Stop(ctx)
+
+	subject, err := randomTopicName(ctx)
+	if err != nil {
+		return err
+	}
+	topic := subject
+	subject += "-value"
+
+	id, err := sr.Client().RegisterSchema(ctx, subject, avroBytesSchema, dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{
+		SchemaType: "AVRO",
+	})
+	if err != nil {
+		return fmt.Errorf("register schema: %w", err)
+	}
+	if id <= 0 {
+		return fmt.Errorf("expected a positive schema id, got %d", id)
+	}
+
+	client := cluster.Client(dag.Kafka().PlaintextClientSecurity())
+	if err := client.CreateTopic(ctx, topic, dagger.KafkaClientCreateTopicOpts{
+		Partitions:        1,
+		ReplicationFactor: 1,
+	}); err != nil {
+		return fmt.Errorf("create topic %q: %w", topic, err)
+	}
+
+	// The bytes value is [0x41, 0xFF, 0x5A] ("A", 0xFF, "Z"). 0xFF is U+00FF,
+	// outside the base64 alphabet, so this only round-trips under the
+	// Avro-spec one-char-per-byte encoding. Whitespace differs from the
+	// canonical form so the round-trip proves genuine re-encoding.
+	const inputJSON = "{ \"b\" :  \"AÿZ\" }"
+	const wantCanonical = "{\"b\":\"AÿZ\"}"
+	const wantKey = "k"
+
+	if err := client.Produce(ctx, topic, wantKey, inputJSON, dagger.KafkaClientProduceOpts{
+		KeyEncoding:      "raw",
+		ValueEncoding:    "raw",
+		ValueSchemaID:    id,
+		ValueSerializeAs: "AVRO",
+		Registry:         sr,
+	}); err != nil {
+		return fmt.Errorf("produce: %w", err)
+	}
+
+	records, err := consume(ctx, client, topic, dagger.KafkaClientConsumeOpts{
+		MaxMessages:         1,
+		Timeout:             "10s",
+		KeyEncoding:         "raw",
+		ValueEncoding:       "raw",
+		SchemaRegistryAware: true,
+		ValueDeserializeAs:  "AVRO",
+		Registry:            sr,
+	})
+	if err != nil {
+		return fmt.Errorf("consume: %w", err)
+	}
+	if len(records) != 1 {
+		return fmt.Errorf("expected 1 record, got %d", len(records))
+	}
+	gotVal, err := records[0].Value(ctx)
+	if err != nil {
+		return fmt.Errorf("read value: %w", err)
+	}
+	if gotVal != wantCanonical {
+		return fmt.Errorf("value mismatch: want canonical %q, got %q", wantCanonical, gotVal)
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #74.

## What

Adds a new `"AVRO"` mode to the kafka Client serde dispatch (alongside the existing `""`/`"JSON"` from #73):

- **Produce** interprets the caller's string as a JSON document, Avro-**binary**-encodes it against the registered schema (via `github.com/z5labs/avro-go/generic`), and frames it with the Confluent wire header (`0x00 || uint32be(id) || binary`). `valueSchemaID`/`keySchemaID` is required in this mode and a zero id errors before any broker or registry I/O.
- **Consume** decodes a framed Avro-binary payload back into JSON. Requires `schemaRegistryAware=true`; an unframed record errors pointing at the missing wire header.
- Both methods gain an optional `registry *SchemaRegistry` arg to resolve schema text by id, cached per id for the duration of the call.

## Why a JSON⇄Value bridge

The Kafka wire payload is Avro **binary**. `avro-go/generic` encodes/decodes exactly that, but only over its closed `generic.Value` tree — it has **no** JSON / `map[string]any` bridge. So `daggerverse/kafka/avro.go` owns the schema-driven JSON⇄`generic.Value` mapping (primitives + record/array/map/union/enum, using the Avro-spec JSON encoding). Logical types / decimal / fixed are deferred to a follow-up.

Per the story guardrail: defects inside `avro-go` itself (`ParseJSON`, `NewEncoder`/`NewDecoder`, `Encode`/`Decode`) are to be filed upstream with work paused — not worked around here. None surfaced during this work.

## Tests (all green, individually and in the `SchemaRegistry` `+check` group)

- `AvroSerializeRequiresSchemaID` — zero id rejected before I/O.
- `AvroConsumeUnframedErrors` — unframed record under AVRO errors on the missing header.
- `AvroFramedProduceConsumeRoundTrip` — JSON → Avro binary → JSON round-trips byte-for-byte against a registered Avro record schema.

Full `dagger -m daggerverse/kafka/tests call schema-registry` passes (11 tests, ~1m18s). `dagger develop` re-run in both `daggerverse/kafka/` and `daggerverse/kafka/tests/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)