### PR TITLE
story(issue-116): cache Dagger engine image to stop CI cold-start hangs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: read
 
+env:
+  DAGGER_VERSION: "0.21.3"
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -16,16 +19,41 @@ jobs:
   list:
     name: List checks
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     outputs:
       jobs: ${{ steps.route.outputs.jobs }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Cache Dagger engine image
+        id: engine-cache
+        uses: actions/cache@v4
+        with:
+          path: engine.tar.gz
+          key: dagger-engine-v${{ env.DAGGER_VERSION }}
+
+      - name: Load or pull Dagger engine
+        env:
+          CACHE_HIT: ${{ steps.engine-cache.outputs.cache-hit }}
+        run: |
+          IMAGE="registry.dagger.io/engine:v${DAGGER_VERSION}"
+          if [ "$CACHE_HIT" = "true" ]; then
+            gunzip -c engine.tar.gz | docker load
+          else
+            for i in 1 2 3; do
+              timeout 300 docker pull "$IMAGE" && break
+              echo "engine pull attempt $i failed/timed out; retrying in 5s" >&2
+              sleep 5
+            done
+            docker image inspect "$IMAGE" >/dev/null   # fail the job if still missing
+            docker save "$IMAGE" | gzip > engine.tar.gz
+          fi
+
       - id: list
         uses: dagger/checks@64525befa1c36dd55577dae083df5c8968d9325a # v1.1.0
         with:
-          version: "0.21.3"
+          version: ${{ env.DAGGER_VERSION }}
           list: "true"
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
 
@@ -66,6 +94,7 @@ jobs:
     name: ${{ matrix.job.name }}
     needs: [list]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -74,9 +103,32 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Restore Dagger engine image
+        id: engine-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: engine.tar.gz
+          key: dagger-engine-v${{ env.DAGGER_VERSION }}
+
+      - name: Load or pull Dagger engine
+        env:
+          CACHE_HIT: ${{ steps.engine-cache.outputs.cache-hit }}
+        run: |
+          IMAGE="registry.dagger.io/engine:v${DAGGER_VERSION}"
+          if [ "$CACHE_HIT" = "true" ]; then
+            gunzip -c engine.tar.gz | docker load
+          else
+            for i in 1 2 3; do
+              timeout 300 docker pull "$IMAGE" && break
+              echo "engine pull attempt $i failed/timed out; retrying in 5s" >&2
+              sleep 5
+            done
+            docker image inspect "$IMAGE" >/dev/null
+          fi
+
       - uses: dagger/checks@64525befa1c36dd55577dae083df5c8968d9325a # v1.1.0
         with:
-          version: "0.21.3"
+          version: ${{ env.DAGGER_VERSION }}
           module: ${{ matrix.job.module }}
           filter: ${{ matrix.job.filter }}
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}


### PR DESCRIPTION
## Summary

CI `run` matrix jobs intermittently "hang" for minutes because each fresh runner cold-pulls `registry.dagger.io/engine:v0.21.3` (633 MB) when `dagger/checks` provisions the engine. With ~13 runners pulling the same image simultaneously, registry throttling / TCP stalls drag the usual ~1 min pull into multi-minute hangs (Dagger Cloud trace `02537dce57ab677b584e24e57cf218e7`: 7m4s pull vs 41s check). `dagger/checks` exposes no caching/pre-pull input, and the engine's `--restart always` only warms a single runner.

This warms the engine in the workflow itself, trading the flaky 633 MB registry pull for a fast GitHub-cache restore produced once by the `list` job and consumed by every `run` job.

## Changes (`.github/workflows/ci.yml`)

- **Pin the version once** — workflow-level `env: DAGGER_VERSION: "0.21.3"`, reused by the cache key and both `dagger/checks` `version:` inputs so they can't drift.
- **`list` job = cache producer** — `actions/cache@v4` keyed on the version; `docker load` on hit, else pre-pull (3× retry, 300s per-attempt `timeout`) and `docker save | gzip` so the post-job save persists the image **once per version**.
- **`run` jobs = cache consumers** — `actions/cache/restore@v4` (restore-only) + `docker load` before `dagger/checks`, so a warm job does **no** `registry.dagger.io` pull. Same retry/timeout pre-pull as the cache-miss fallback.
- **`timeout-minutes: 20`** guard on both jobs so a genuinely stuck pull fails fast instead of sitting near the 6h default.
- The `route` step's matrix-routing `jq` is unchanged.

## Save cadence

The image is saved **once per `DAGGER_VERSION`**, not every run: `actions/cache@v4` only saves on an exact-key miss, so steady-state `list` runs (cache hit) skip the save; `run` jobs use `actions/cache/restore@v4` and never write the cache.

## Verification

- [x] YAML validates.
- [ ] First push: `list` shows a cache miss + single pre-pull; `run` jobs restore + `docker load` a warm engine; matrix routing unchanged.
- [ ] Fresh Dagger Cloud trace confirms the `docker pull registry.dagger.io/engine` span is gone / near-zero.
- [ ] CI green across the matrix.

Closes #116. Follows #105 (Dagger v0.21.3 upgrade).

🤖 Generated with [Claude Code](https://claude.com/claude-code)