### PR TITLE
story(issue-125): cap run-matrix concurrency to curb burst-throttling 504s

### DIFF
--- a/.github/workflows/ci-auto-rerun.yml
+++ b/.github/workflows/ci-auto-rerun.yml
@@ -1,0 +1,42 @@
+name: CI auto-rerun
+
+# Auto-rerun failed CI legs on a fresh runner. The Dagger Cloud telemetry-drain
+# hang (upstream dagger/dagger#7048, #12178) intermittently fails a leg even
+# though its check passed: the CLI blocks on flushing telemetry to
+# api.dagger.cloud and, when that ingest stalls, can't exit. Re-running the
+# failed leg on a fresh runner + fresh engine reliably clears it — the manual
+# re-run we'd otherwise do by hand. An in-process retry can't: it reuses the
+# same stuck engine and re-hits the still-ongoing Cloud stall.
+#
+# NOTE: workflow_run always uses the workflow file from the default branch, so
+# this only takes effect once merged to main (it won't rerun this PR's own runs).
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+# Only what `gh run rerun` needs; nothing else.
+permissions:
+  actions: write
+
+jobs:
+  rerun:
+    # Only act on genuine failures — a 'cancelled' run (e.g. PR concurrency
+    # cancel-in-progress) is skipped — and cap total attempts so a deterministic
+    # failure can't loop forever. run_attempt is 1 on the first run, so this
+    # allows reruns after attempts 1 and 2, for at most 3 attempts overall.
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.run_attempt < 3
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Re-run failed jobs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        # --failed re-runs only the failed legs (on fresh runners), reusing the
+        # successful `list` job's outputs; passing legs are left untouched.
+        run: gh run rerun "$RUN_ID" --failed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,10 @@ jobs:
     name: ${{ matrix.job.name }}
     needs: [list]
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # Worst case is all 3 bounded attempts timing out (3 x 8m) plus
+    # checkout/install, so the job cap must clear ~24m + buffer. The normal path
+    # is a single ~1-4m attempt; only a telemetry-drain hang reaches the retries.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       # Burst-throttling mitigation (#125): the matrix fans out one leg per
@@ -136,9 +139,47 @@ jobs:
             docker image inspect "$IMAGE" >/dev/null
           fi
 
-      - uses: dagger/checks@64525befa1c36dd55577dae083df5c8968d9325a # v1.1.0
-        with:
-          version: ${{ env.DAGGER_VERSION }}
-          module: ${{ matrix.job.module }}
-          filter: ${{ matrix.job.filter }}
-          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+      # Run dagger checks ourselves (instead of the dagger/checks action) so we
+      # can wrap the invocation in a wall-clock bound and retry. The action only
+      # runs `dagger checks <filter>`; replicating it costs one install step.
+      - name: Install Dagger
+        run: |
+          mkdir -p "$RUNNER_TEMP/bin"
+          curl -fsSL https://dl.dagger.io/dagger/install.sh \
+            | BIN_DIR="$RUNNER_TEMP/bin" DAGGER_VERSION="$DAGGER_VERSION" sh
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+
+      - name: Run checks (bounded drain, retry only on telemetry-drain hang)
+        env:
+          DAGGER_MODULE: ${{ matrix.job.module }}
+          DAGGER_PROGRESS: dots
+          DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+          FILTER: ${{ matrix.job.filter }}
+        run: |
+          # Dagger's CLI blocks on draining telemetry to Dagger Cloud when a run
+          # ends; when api.dagger.cloud's /v1/metrics ingest stalls, the process
+          # can't exit and hangs the leg until it's killed (upstream
+          # dagger/dagger#7048 and #12178). max-parallel (#125) cut the Docker
+          # Hub burst but can't stop a single stuck flush. So bound each attempt
+          # with a hard wall-clock `timeout` and auto-retry ONLY when an attempt
+          # times out (exit 124) — i.e. the drain hang. A real test failure exits
+          # fast with its own non-zero code and is NOT retried, so genuine
+          # breakage still fails immediately. A transient Cloud stall clears on
+          # the next attempt (the manual re-run we'd otherwise do by hand).
+          # Telemetry stays on (DAGGER_CLOUD_TOKEN is set) — we only bound how
+          # long a stuck drain may hang, we don't drop traces.
+          attempts=3
+          for i in $(seq 1 "$attempts"); do
+            code=0
+            timeout -k 30s 8m dagger checks "$FILTER" || code=$?
+            if [ "$code" -eq 0 ]; then
+              exit 0
+            fi
+            if [ "$code" -ne 124 ]; then
+              echo "::error::dagger checks exited $code (not a telemetry-drain timeout); failing without retry" >&2
+              exit "$code"
+            fi
+            echo "::warning::attempt $i/$attempts hit the 8m wall-clock bound (Dagger Cloud telemetry-drain hang); retrying" >&2
+          done
+          echo "::error::dagger checks still hanging on telemetry drain after $attempts attempts" >&2
+          exit 124

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,16 @@ jobs:
     timeout-minutes: 20
     strategy:
       fail-fast: false
+      # Burst-throttling mitigation (#125): the matrix fans out one leg per
+      # check (finer-grained than the toolchain modules), so an uncapped fan-out
+      # boots several dozen ephemeral engines at once that all simultaneously
+      # pull Docker Hub base images (anonymous, per-IP limited via GitHub's
+      # shared egress NAT) and flush OTLP telemetry to Dagger Cloud. Both
+      # upstreams answer the resulting thundering herd with 504s. Cap concurrent
+      # legs to spread the same load over time — remaining legs queue and start
+      # as slots free. Same shape as #116's cold engine-image pull. Do NOT raise
+      # this to "speed up CI" without re-checking the 504 rate.
+      max-parallel: 6
       matrix:
         job: ${{ fromJSON(needs.list.outputs.jobs) }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,10 +94,10 @@ jobs:
     name: ${{ matrix.job.name }}
     needs: [list]
     runs-on: ubuntu-latest
-    # Worst case is all 3 bounded attempts timing out (3 x 8m) plus
-    # checkout/install, so the job cap must clear ~24m + buffer. The normal path
-    # is a single ~1-4m attempt; only a telemetry-drain hang reaches the retries.
-    timeout-minutes: 30
+    # Per matrix leg. Observed real legs finish in <4m; this is only a backstop
+    # above the 6m dagger/checks step bound + setup, so the step's timeout is
+    # what fails a telemetry-drain hang fast, not this job cap.
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       # Burst-throttling mitigation (#125): the matrix fans out one leg per
@@ -139,47 +139,19 @@ jobs:
             docker image inspect "$IMAGE" >/dev/null
           fi
 
-      # Run dagger checks ourselves (instead of the dagger/checks action) so we
-      # can wrap the invocation in a wall-clock bound and retry. The action only
-      # runs `dagger checks <filter>`; replicating it costs one install step.
-      - name: Install Dagger
-        run: |
-          mkdir -p "$RUNNER_TEMP/bin"
-          curl -fsSL https://dl.dagger.io/dagger/install.sh \
-            | BIN_DIR="$RUNNER_TEMP/bin" DAGGER_VERSION="$DAGGER_VERSION" sh
-          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
-
-      - name: Run checks (bounded drain, retry only on telemetry-drain hang)
-        env:
-          DAGGER_MODULE: ${{ matrix.job.module }}
-          DAGGER_PROGRESS: dots
-          DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
-          FILTER: ${{ matrix.job.filter }}
-        run: |
-          # Dagger's CLI blocks on draining telemetry to Dagger Cloud when a run
-          # ends; when api.dagger.cloud's /v1/metrics ingest stalls, the process
-          # can't exit and hangs the leg until it's killed (upstream
-          # dagger/dagger#7048 and #12178). max-parallel (#125) cut the Docker
-          # Hub burst but can't stop a single stuck flush. So bound each attempt
-          # with a hard wall-clock `timeout` and auto-retry ONLY when an attempt
-          # times out (exit 124) — i.e. the drain hang. A real test failure exits
-          # fast with its own non-zero code and is NOT retried, so genuine
-          # breakage still fails immediately. A transient Cloud stall clears on
-          # the next attempt (the manual re-run we'd otherwise do by hand).
-          # Telemetry stays on (DAGGER_CLOUD_TOKEN is set) — we only bound how
-          # long a stuck drain may hang, we don't drop traces.
-          attempts=3
-          for i in $(seq 1 "$attempts"); do
-            code=0
-            timeout -k 30s 8m dagger checks "$FILTER" || code=$?
-            if [ "$code" -eq 0 ]; then
-              exit 0
-            fi
-            if [ "$code" -ne 124 ]; then
-              echo "::error::dagger checks exited $code (not a telemetry-drain timeout); failing without retry" >&2
-              exit "$code"
-            fi
-            echo "::warning::attempt $i/$attempts hit the 8m wall-clock bound (Dagger Cloud telemetry-drain hang); retrying" >&2
-          done
-          echo "::error::dagger checks still hanging on telemetry drain after $attempts attempts" >&2
-          exit 124
+      # Fail fast on the Dagger Cloud telemetry-drain hang. The check itself runs
+      # in ~1-4m; a leg still going at 6m is almost certainly stuck draining
+      # telemetry to api.dagger.cloud (upstream dagger/dagger#7048, #12178),
+      # which otherwise hangs the leg until the job timeout. Bounding the step
+      # makes the job fail quickly so ci-auto-rerun.yml re-runs the failed leg on
+      # a fresh runner + fresh engine — the manual re-run that reliably clears a
+      # transient/sustained Cloud stall (an in-process retry can't: it reuses the
+      # same stuck engine and re-hits the ongoing stall). Telemetry stays on
+      # (cloud-token set); we only bound how long a stuck drain may hang.
+      - uses: dagger/checks@64525befa1c36dd55577dae083df5c8968d9325a # v1.1.0
+        timeout-minutes: 6
+        with:
+          version: ${{ env.DAGGER_VERSION }}
+          module: ${{ matrix.job.module }}
+          filter: ${{ matrix.job.filter }}
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
       # legs to spread the same load over time — remaining legs queue and start
       # as slots free. Same shape as #116's cold engine-image pull. Do NOT raise
       # this to "speed up CI" without re-checking the 504 rate.
-      max-parallel: 6
+      max-parallel: 10
       matrix:
         job: ${{ fromJSON(needs.list.outputs.jobs) }}
     steps:


### PR DESCRIPTION
Closes #125

Mitigations for the CI thundering-herd / hang failures the issue describes.

## 1. `max-parallel: 10` on the `run` matrix (the #125 ask)

The `run` matrix fans out **one leg per check**. With `fail-fast: false` and no cap, every leg started at once — several dozen fresh runners each booting an ephemeral engine that simultaneously pulled Docker Hub base images (anonymous, per-IP limited via GitHub's shared egress NAT) and flushed OTLP telemetry to Dagger Cloud, and both upstreams answered the thundering herd with `504`s. Capping concurrent legs spreads the same load over time.

**Result:** on this PR's runs, the Docker Hub pull burst is tamed — the legs that pulled cleanly went green in 1–4 min.

## 2. The Dagger Cloud telemetry-drain hang

`max-parallel` can't stop the *other* failure #125 flagged: Dagger's CLI **blocks on draining telemetry to Dagger Cloud** at the end of a run, and when `api.dagger.cloud`'s `/v1/metrics` ingest stalls the process can't exit and **hangs the leg** (upstream dagger/dagger [#7048](https://github.com/dagger/dagger/issues/7048), [#12178](https://github.com/dagger/dagger/discussions/12178)). The *check passes*; only the drain hangs.

A real run proved an in-process retry can't fix this: the stall was **sustained (~24 min, `/v1/metrics` timing out the whole window across 3 legs at once)**, and a same-job retry **reconnects to the same stuck engine**, so every attempt re-hit the ongoing stall. A manual re-run works only because it runs *later* (stall cleared) on a *fresh* runner + engine. So we automate exactly that:

- **Fail fast:** the `dagger/checks` step gets a **6-minute `timeout-minutes`**. Real legs finish in <4 min, so a leg still running at 6 min is the drain hang — the step fails quickly instead of hanging the job. (`run` job cap dropped to a 10-min backstop above that.)
- **Auto-rerun:** new `ci-auto-rerun.yml` triggers on CI completion and `gh run rerun --failed` — re-running **only the failed legs on fresh runners**, skipping `cancelled` runs (e.g. PR concurrency cancels) and capped at **3 attempts** via `run_attempt`. This is the manual re-run, automated.

> **Note:** `workflow_run` always uses the workflow file from the **default branch**, so the auto-rerun only takes effect **once this is merged to main** — it won't rerun this PR's own runs. The 6-min fail-fast bound *is* active on the PR.

## Scope / non-goals

- **Telemetry stays on** — `DAGGER_CLOUD_TOKEN` unchanged for both `push` and `pull_request`. We only bound how long a *stuck* drain may hang; we don't drop traces (the issue's explicit non-goal).
- `fail-fast: false` retained; `max-parallel: 10` carries a comment marking it a burst-throttling mitigation.
- `list` job, the `route` step's matrix-routing jq, and the #116 engine-cache steps are untouched.

## Acceptance criteria

- [x] `run` job declares `max-parallel` on its `strategy`, `fail-fast: false` retained
- [x] Value carries a comment explaining it's a burst-throttling mitigation
- [x] Dagger Cloud telemetry still exported on both `push` and `pull_request` (`DAGGER_CLOUD_TOKEN` unchanged)
- [x] Checks, matrix routing jq, and #116 engine-cache steps unchanged
- [ ] CI stays green (fail-fast bound active on this PR; auto-rerun activates after merge to main)
- [ ] Peak concurrent `run` legs capped at 10, and telemetry-export / Docker Hub 504s drop vs. a prior full-fan-out run

## Follow-up

- File upstream: Dagger CLI should bound/decouple the Cloud telemetry drain so a Cloud ingest stall can't hang a run whose checks passed (relates to #7048 / #12178).

🤖 Generated with [Claude Code](https://claude.com/claude-code)