### PR TITLE
story(issue-124): add daggerverse plugin housing the renamed plan-dagger-module skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,5 +6,11 @@
   "metadata": {
     "description": "z5labs developer-experience plugins for Claude Code"
   },
-  "plugins": []
+  "plugins": [
+    {
+      "name": "daggerverse",
+      "source": "./plugins/daggerverse",
+      "description": "Claude Code tooling for designing and building daggerverse modules"
+    }
+  ]
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,5 +6,8 @@
         "repo": "z5labs/devex"
       }
     }
+  },
+  "enabledPlugins": {
+    "daggerverse@z5labs-devex": true
   }
 }

--- a/README.md
+++ b/README.md
@@ -47,15 +47,17 @@ marketplace](https://code.claude.com/docs/en/plugin-marketplaces) named
 /plugin marketplace add z5labs/devex
 ```
 
-Then install individual plugins as they become available:
+Then install a plugin:
 
 ```
-/plugin install <plugin>@z5labs-devex
+/plugin install daggerverse@z5labs-devex
 ```
 
-The first plugin (the `new-dagger-module` design workflow) lands in
-[#124](https://github.com/z5labs/devex/issues/124); see
-[`plugins/README.md`](plugins/README.md) for the plugin layout. To develop
+| Plugin | Provides |
+| ------ | -------- |
+| [`daggerverse`](plugins/daggerverse) | `/plan-dagger-module` — paces a design conversation and drafts story issues for a new daggerverse module. |
+
+See [`plugins/README.md`](plugins/README.md) for the plugin layout. To develop
 against an unmerged local checkout, run `/plugin marketplace add .` from the
 repo root instead.
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -5,9 +5,9 @@ published by the [`z5labs-devex` marketplace](../.claude-plugin/marketplace.json
 Keeping them here keeps the plugin catalog cleanly separate from the Dagger
 tooling (`daggerverse/`, `ci/`) and the docs (`docs/`).
 
-> No plugins live here yet. The first one — the `new-dagger-module` skill,
-> migrated in as `plan-dagger-module` — lands in
-> [#124](https://github.com/z5labs/devex/issues/124).
+> The first plugin, **[`daggerverse`](daggerverse/)**, houses the
+> `plan-dagger-module` skill — a paced design workflow that drafts story
+> issues for a new daggerverse module.
 
 ## Convention
 

--- a/plugins/daggerverse/.claude-plugin/plugin.json
+++ b/plugins/daggerverse/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "daggerverse",
+  "description": "Claude Code tooling for designing and building daggerverse modules",
+  "version": "0.1.0",
+  "author": { "name": "z5labs" }
+}

--- a/plugins/daggerverse/skills/plan-dagger-module/SKILL.md
+++ b/plugins/daggerverse/skills/plan-dagger-module/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: new-dagger-module
-description: Standardized 9-step workflow for designing a new daggerverse module from scratch — picking a name, researching prior art, proposing types/funcs and tests, drafting story issues against `.github/ISSUE_TEMPLATE/story.yaml`, and creating them with `gh issue create`. Use this whenever the user wants to start a new daggerverse module, kicks off a new module design under `daggerverse/`, or asks to "scope out", "plan", "design", or "propose issues for" a new module (Redis, Vault, MongoDB, NATS, anything). Use it even when the user types `/new-dagger-module` without naming a module — drive the workflow and ask. Skip only when the user is *implementing* an already-scoped module (issue already exists) or making changes to an existing module's API.
+name: plan-dagger-module
+description: Standardized 9-step workflow for designing a new daggerverse module from scratch — picking a name, researching prior art, proposing types/funcs and tests, drafting story issues against `.github/ISSUE_TEMPLATE/story.yaml`, and creating them with `gh issue create`. Use this whenever the user wants to start a new daggerverse module, kicks off a new module design under `daggerverse/`, or asks to "scope out", "plan", "design", or "propose issues for" a new module (Redis, Vault, MongoDB, NATS, anything). Use it even when the user types `/plan-dagger-module` without naming a module — drive the workflow and ask. Skip only when the user is *implementing* an already-scoped module (issue already exists) or making changes to an existing module's API.
 ---
 
-# new-dagger-module
+# plan-dagger-module
 
 A new daggerverse module starts as a design conversation, not a code patch. This skill paces that conversation: name → research → API → tests → issues → `gh issue create`. The point is to *converge with the user* before any module code is written, so the eventual implementation PR has a real spec to land against.
 


### PR DESCRIPTION
## Summary

Publishes the `z5labs-devex` marketplace's **first plugin**. Moves the `new-dagger-module` skill out of `.claude/skills/` into a broad **`daggerverse`** plugin under `plugins/`, renamed to **`plan-dagger-module`** — "plan" describes what it does (it paces a design conversation and drafts story issues; it never writes module code). Once installed via `/plugin install daggerverse@z5labs-devex`, the skill is invocable as `/plan-dagger-module` in any project, not just a clone of this repo.

## Changes

- **New manifest** `plugins/daggerverse/.claude-plugin/plugin.json` (`name: daggerverse`).
- **Moved + renamed skill** `.claude/skills/new-dagger-module/SKILL.md` → `plugins/daggerverse/skills/plan-dagger-module/SKILL.md` (via `git mv`, history preserved). Only the `name:` frontmatter, the `/`-invocation reference, and the H1 changed — the 9-step workflow, Constraints, and Shape references are byte-identical.
- **Registered** the plugin in `.claude-plugin/marketplace.json` (`./plugins/daggerverse`).
- **Enabled** `daggerverse@z5labs-devex` in `.claude/settings.json` so in-repo contributors keep auto-access after the skill leaves `.claude/skills/`.
- **Refreshed** `README.md` (real install example + plugin table) and `plugins/README.md`.
- **Removed** the now-empty `.claude/skills/`.

## Verification

- All three JSON files parse.
- No `new-dagger-module` string remains in the skill frontmatter, H1, body, or `/`-invocation references.
- Skill diff is confined to the 3 rename lines.
- Manual (slash-plugin commands aren't runnable from CI): `/plugin marketplace add .` → `/plugin install daggerverse@z5labs-devex` → confirm `/plan-dagger-module` triggers on "scope out / plan / design / propose issues for a new module" phrasings.

> Note: the `enabledPlugins` entry resolves against the published github marketplace, so it takes effect for fresh clones once this lands on `main`. For local dev on an unmerged branch, use `/plugin marketplace add .`.

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)