### PR TITLE
story(issue-137): re-run failed CI legs by job ID to avoid dynamic-matrix ghost jobs

### DIFF
--- a/.github/workflows/ci-auto-rerun.yml
+++ b/.github/workflows/ci-auto-rerun.yml
@@ -37,6 +37,45 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           RUN_ID: ${{ github.event.workflow_run.id }}
-        # --failed re-runs only the failed legs (on fresh runners), reusing the
-        # successful `list` job's outputs; passing legs are left untouched.
-        run: gh run rerun "$RUN_ID" --failed
+        # Re-run each failed leg by its explicit job databaseId, NOT
+        # `gh run rerun --failed`. On our dynamic, object-valued matrix
+        # (matrix.job: ${{ fromJSON(needs.list.outputs.jobs) }}, each entry a
+        # {name, module, filter} object) GitHub's rerun-failed-jobs API
+        # intermittently mis-resolves which leg failed: it re-runs a *passing*
+        # module-sibling (same module, differing name/filter) and stamps out
+        # orphaned job records stuck at status=queued/conclusion=null that never
+        # resolve, making a healthy run look broken (observed: run 26862681576).
+        # Re-running by job ID mirrors the per-job "Re-run this job" button and
+        # removes GitHub's need to guess which leg of a re-expanded dynamic
+        # matrix failed. It includes dependencies, so the passing `list` job's
+        # output is reused (no full-matrix re-run, avoiding the #125 throttling).
+        #
+        # ?filter=latest scopes to the most recent attempt's jobs; we use .id
+        # (databaseId) — NOT the job number from the browser URL, which 404s
+        # against `--job`.
+        #
+        # Multi-failure self-heal: GitHub has no "re-run this subset in one
+        # attempt" API (rerun-failed-jobs, removed here, was the only one), and
+        # per-job rerun creates a new attempt per call. So when >1 leg fails,
+        # re-running the first failed job creates attempt N+1 that carries the
+        # other failed leg(s) forward as failed; that attempt completes failure
+        # -> workflow_run fires again -> we re-run the next failed leg (with its
+        # fresh job ID). The run_attempt < 3 cap bounds this to ~2 cleared legs
+        # before the safety valve stops it — acceptable, since the telemetry-
+        # drain hang has only ever failed a single leg per run. A stale job ID
+        # from a superseded attempt is tolerated (|| logged warning) so it can't
+        # fail the whole step.
+        run: |
+          set -euo pipefail
+          ids=$(gh api --paginate \
+            "repos/$GH_REPO/actions/runs/$RUN_ID/jobs?filter=latest" \
+            --jq '.jobs[] | select(.conclusion=="failure") | .id')
+          if [ -z "$ids" ]; then
+            echo "No failed jobs on the latest attempt of run $RUN_ID; nothing to re-run."
+            exit 0
+          fi
+          for id in $ids; do
+            echo "Re-running failed job $id"
+            gh run rerun --job "$id" \
+              || echo "::warning::Failed to re-run job $id (likely superseded by a newer attempt); continuing."
+          done


### PR DESCRIPTION
## Summary

Reworks `ci-auto-rerun.yml` to re-run failed CI legs by explicit job `databaseId` instead of `gh run rerun --failed`, fixing the dynamic-matrix ghost-job problem in #137.

On our dynamic, object-valued matrix (`matrix.job: ${{ fromJSON(needs.list.outputs.jobs) }}`, each entry a `{name, module, filter}` object), GitHub's `rerun-failed-jobs` API intermittently mis-resolves which leg failed — re-running a *passing* module-sibling and stamping orphaned `queued`/`null` ghost job records that never resolve (observed: run 26862681576). This is GitHub-side leg-identity resolution, **not** our matrix-routing jq.

## Changes

The single `gh run rerun "$RUN_ID" --failed` step is replaced with a script that:

1. Lists failed jobs of the run's **latest attempt** — `gh api --paginate ".../actions/runs/$RUN_ID/jobs?filter=latest" --jq '.jobs[] | select(.conclusion=="failure") | .id'` (uses `.id`/databaseId, not the URL number which 404s against `--job`).
2. Re-runs each via `gh run rerun --job "$id"`, which includes dependencies (the passing `list` job's output is reused — no full-matrix re-run, avoiding the #125 burst-throttling).
3. Tolerates a stale job ID from a superseded attempt (`|| ::warning::`) so multi-failure self-heal across attempts can't fail the whole step. Empty-list case exits 0 cleanly.

The misleading "passing legs are left untouched" comment is replaced with the ghost-avoidance rationale, and the multi-failure self-heal behavior (bounded by `run_attempt < 3`) is documented.

## Acceptance criteria

- [x] Re-runs by `databaseId` via `--job`, not `--failed`
- [x] Reads from latest attempt (`?filter=latest`, `conclusion=="failure"`, `.id`)
- [x] Guards retained: `conclusion == 'failure'`, `run_attempt < 3`, `permissions: actions: write`, `timeout-minutes: 5`
- [x] Multi-failure self-heal documented; stale-ID rerun doesn't fail the step
- [x] Misleading comment corrected
- [x] No passing sibling re-run for a single-leg failure
- [ ] **Live verification deferred:** `workflow_run` always uses the workflow file from the default branch, so this only takes effect after merge to `main`. Verifying that a real failed-leg re-run produces no ghost records must happen on a post-merge failed run.

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)