### PR TITLE
story(issue-43): add TLS and mTLS support to kafka SchemaRegistry

### DIFF
--- a/ci/internal/dagger/kafka-tests.gen.go
+++ b/ci/internal/dagger/kafka-tests.gen.go
@@ -51,6 +51,7 @@ type KafkaTests struct { // kafka-tests (../../../daggerverse/kafka/tests/main.g
 	apacheClusterTlsRoundTrip                          *Void
 	apacheJvm                                          *Void
 	apicurioSchemaRegistryRegisterLookupRoundTrip      *Void
+	apicurioSchemaRegistryTlsRegisterLookupRoundTrip   *Void
 	autoCreateTopicsDisabled                           *Void
 	avroBytesFieldRoundTrip                            *Void
 	avroConsumeUnframedErrors                          *Void
@@ -62,12 +63,15 @@ type KafkaTests struct { // kafka-tests (../../../daggerverse/kafka/tests/main.g
 	confluentClusterMtlsRoundTrip                      *Void
 	confluentClusterProduceListTopicsRoundTrip         *Void
 	confluentClusterTlsRoundTrip                       *Void
+	confluentSchemaRegistryMtlsRegisterLookupRoundTrip *Void
+	confluentSchemaRegistryTlsRegisterLookupRoundTrip  *Void
 	consumerGroupOnSingleBrokerWorks                   *Void
 	createAndDeleteTopicRoundTrip                      *Void
 	dedicatedControllerAndBrokerProduceConsume         *Void
 	id                                                 *ID
 	internalListenersAreEncrypted                      *Void
 	karapaceSchemaRegistryRegisterLookupRoundTrip      *Void
+	karapaceSchemaRegistryTlsRegisterLookupRoundTrip   *Void
 	mtlsRequiresClientCert                             *Void
 	mtlsRoundTrip                                      *Void
 	multiControllerIsRejected                          *Void
@@ -93,7 +97,7 @@ type KafkaTests struct { // kafka-tests (../../../daggerverse/kafka/tests/main.g
 	schemaRegistryJsonserializeRejectsMalformedInput   *Void
 	schemaRegistryPlaintextConsumeUnframed             *Void
 	schemaRegistryRegisterLookupRoundTrip              *Void
-	schemaRegistryRejectsNonPlaintextCluster           *Void
+	schemaRegistryRejectsClusterModeMismatch           *Void
 	singleNodeClusterStarts                            *Void
 	tlsClientWithWrongCaFails                          *Void
 	tlsClusterStarts                                   *Void
@@ -250,15 +254,15 @@ func (r *KafkaTests) ApacheClusterTLSRoundTrip(ctx context.Context, opts ...Kafk
 type KafkaTestsApacheJvmOpts struct {
 
 	// Default: "4.2.0"
-	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/main.go:278:2)
+	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/main.go:290:2)
 
-	Parallel int // kafka-tests (../../../daggerverse/kafka/tests/main.go:280:2)
+	Parallel int // kafka-tests (../../../daggerverse/kafka/tests/main.go:292:2)
 }
 
 // ApacheJVM runs the three apache/kafka JVM-image round-trip tests.
 // Each test owns a fresh ApacheCluster, so the group holds no shared
 // clusters of its own.
-func (r *KafkaTests) ApacheJvm(ctx context.Context, opts ...KafkaTestsApacheJvmOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/main.go:275:1)
+func (r *KafkaTests) ApacheJvm(ctx context.Context, opts ...KafkaTestsApacheJvmOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/main.go:287:1)
 	if r.apacheJvm != nil {
 		return nil
 	}
@@ -306,6 +310,30 @@ func (r *KafkaTests) ApicurioSchemaRegistryRegisterLookupRoundTrip(ctx context.C
 	return q.Execute(ctx)
 }
 
+// KafkaTestsApicurioSchemaRegistryTLSRegisterLookupRoundTripOpts contains options for KafkaTests.ApicurioSchemaRegistryTLSRegisterLookupRoundTrip
+type KafkaTestsApicurioSchemaRegistryTLSRegisterLookupRoundTripOpts struct {
+
+	// Default: "4.2.0"
+	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:1169:2)
+}
+
+// ApicurioSchemaRegistryTlsRegisterLookupRoundTrip drives the Apicurio TLS
+// path (Quarkus HTTPS REST + kafkasql SSL storage) end-to-end.
+func (r *KafkaTests) ApicurioSchemaRegistryTLSRegisterLookupRoundTrip(ctx context.Context, opts ...KafkaTestsApicurioSchemaRegistryTLSRegisterLookupRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:1166:1)
+	if r.apicurioSchemaRegistryTlsRegisterLookupRoundTrip != nil {
+		return nil
+	}
+	q := r.query.Select("apicurioSchemaRegistryTlsRegisterLookupRoundTrip")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `kafkaImageTag` optional argument
+		if !querybuilder.IsZeroValue(opts[i].KafkaImageTag) {
+			q = q.Arg("kafkaImageTag", opts[i].KafkaImageTag)
+		}
+	}
+
+	return q.Execute(ctx)
+}
+
 // KafkaTestsAutoCreateTopicsDisabledOpts contains options for KafkaTests.AutoCreateTopicsDisabled
 type KafkaTestsAutoCreateTopicsDisabledOpts struct {
 
@@ -336,7 +364,7 @@ func (r *KafkaTests) AutoCreateTopicsDisabled(ctx context.Context, opts ...Kafka
 type KafkaTestsAvroBytesFieldRoundTripOpts struct {
 
 	// Default: "4.2.0"
-	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:919:2)
+	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:921:2)
 }
 
 // AvroBytesFieldRoundTrip pins the Avro-spec JSON encoding of a bytes field.
@@ -346,7 +374,7 @@ type KafkaTestsAvroBytesFieldRoundTripOpts struct {
 // (code point U+00FF), which is outside the base64 alphabet, so a round-trip
 // that preserves it byte-for-byte proves the one-char-per-byte mapping and
 // would be impossible under a base64 interpretation.
-func (r *KafkaTests) AvroBytesFieldRoundTrip(ctx context.Context, opts ...KafkaTestsAvroBytesFieldRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:916:1)
+func (r *KafkaTests) AvroBytesFieldRoundTrip(ctx context.Context, opts ...KafkaTestsAvroBytesFieldRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:918:1)
 	if r.avroBytesFieldRoundTrip != nil {
 		return nil
 	}
@@ -365,7 +393,7 @@ func (r *KafkaTests) AvroBytesFieldRoundTrip(ctx context.Context, opts ...KafkaT
 type KafkaTestsAvroConsumeUnframedErrorsOpts struct {
 
 	// Default: "4.2.0"
-	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:759:2)
+	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:761:2)
 }
 
 // AvroConsumeUnframedErrors pins the negative consume path: a record produced
@@ -373,7 +401,7 @@ type KafkaTestsAvroConsumeUnframedErrorsOpts struct {
 // schemaRegistryAware=true, must error out pointing at the missing header. The
 // header check fires before any schema lookup, so the registry service never
 // has to start.
-func (r *KafkaTests) AvroConsumeUnframedErrors(ctx context.Context, opts ...KafkaTestsAvroConsumeUnframedErrorsOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:756:1)
+func (r *KafkaTests) AvroConsumeUnframedErrors(ctx context.Context, opts ...KafkaTestsAvroConsumeUnframedErrorsOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:758:1)
 	if r.avroConsumeUnframedErrors != nil {
 		return nil
 	}
@@ -392,7 +420,7 @@ func (r *KafkaTests) AvroConsumeUnframedErrors(ctx context.Context, opts ...Kafk
 type KafkaTestsAvroFramedProduceConsumeRoundTripOpts struct {
 
 	// Default: "4.2.0"
-	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:818:2)
+	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:820:2)
 }
 
 // AvroFramedProduceConsumeRoundTrip is the happy-path data round-trip for AVRO
@@ -401,7 +429,7 @@ type KafkaTestsAvroFramedProduceConsumeRoundTripOpts struct {
 // schemaRegistryAware=true. The asserted invariant is byte-equality of the
 // consumed value to the canonical JSON form of the original input, proving the
 // JSON->Avro-binary->JSON pipeline preserves the datum.
-func (r *KafkaTests) AvroFramedProduceConsumeRoundTrip(ctx context.Context, opts ...KafkaTestsAvroFramedProduceConsumeRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:815:1)
+func (r *KafkaTests) AvroFramedProduceConsumeRoundTrip(ctx context.Context, opts ...KafkaTestsAvroFramedProduceConsumeRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:817:1)
 	if r.avroFramedProduceConsumeRoundTrip != nil {
 		return nil
 	}
@@ -421,7 +449,7 @@ func (r *KafkaTests) AvroFramedProduceConsumeRoundTrip(ctx context.Context, opts
 // broker or registry I/O. dag.Kafka().Client(...) builds without I/O, so no
 // cluster boots — the failure is purely the missing-id guard on the AVRO
 // serializer.
-func (r *KafkaTests) AvroSerializeRequiresSchemaID(ctx context.Context) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:729:1)
+func (r *KafkaTests) AvroSerializeRequiresSchemaID(ctx context.Context) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:731:1)
 	if r.avroSerializeRequiresSchemaId != nil {
 		return nil
 	}
@@ -488,14 +516,14 @@ func (r *KafkaTests) ClusterClientCanListTopicsOnFreshCluster(ctx context.Contex
 type KafkaTestsConfluentOpts struct {
 
 	// Default: "8.2.0"
-	ConfluentImageTag string // kafka-tests (../../../daggerverse/kafka/tests/main.go:310:2)
+	ConfluentImageTag string // kafka-tests (../../../daggerverse/kafka/tests/main.go:322:2)
 
-	Parallel int // kafka-tests (../../../daggerverse/kafka/tests/main.go:312:2)
+	Parallel int // kafka-tests (../../../daggerverse/kafka/tests/main.go:324:2)
 }
 
 // Confluent runs the three confluentinc/cp-kafka round-trip tests.
 // Each test owns a fresh ConfluentCluster.
-func (r *KafkaTests) Confluent(ctx context.Context, opts ...KafkaTestsConfluentOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/main.go:307:1)
+func (r *KafkaTests) Confluent(ctx context.Context, opts ...KafkaTestsConfluentOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/main.go:319:1)
 	if r.confluent != nil {
 		return nil
 	}
@@ -588,6 +616,59 @@ func (r *KafkaTests) ConfluentClusterTLSRoundTrip(ctx context.Context, opts ...K
 		// `confluentImageTag` optional argument
 		if !querybuilder.IsZeroValue(opts[i].ConfluentImageTag) {
 			q = q.Arg("confluentImageTag", opts[i].ConfluentImageTag)
+		}
+	}
+
+	return q.Execute(ctx)
+}
+
+// KafkaTestsConfluentSchemaRegistryMtlsRegisterLookupRoundTripOpts contains options for KafkaTests.ConfluentSchemaRegistryMtlsRegisterLookupRoundTrip
+type KafkaTestsConfluentSchemaRegistryMtlsRegisterLookupRoundTripOpts struct {
+
+	// Default: "4.2.0"
+	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:1150:2)
+}
+
+// ConfluentSchemaRegistryMtlsRegisterLookupRoundTrip is the mTLS counterpart:
+// the REST endpoint requires a client certificate and the registry presents
+// its own leaf to the mTLS broker for the kafkastore connection, all rooted at
+// one CA.
+func (r *KafkaTests) ConfluentSchemaRegistryMtlsRegisterLookupRoundTrip(ctx context.Context, opts ...KafkaTestsConfluentSchemaRegistryMtlsRegisterLookupRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:1147:1)
+	if r.confluentSchemaRegistryMtlsRegisterLookupRoundTrip != nil {
+		return nil
+	}
+	q := r.query.Select("confluentSchemaRegistryMtlsRegisterLookupRoundTrip")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `kafkaImageTag` optional argument
+		if !querybuilder.IsZeroValue(opts[i].KafkaImageTag) {
+			q = q.Arg("kafkaImageTag", opts[i].KafkaImageTag)
+		}
+	}
+
+	return q.Execute(ctx)
+}
+
+// KafkaTestsConfluentSchemaRegistryTLSRegisterLookupRoundTripOpts contains options for KafkaTests.ConfluentSchemaRegistryTLSRegisterLookupRoundTrip
+type KafkaTestsConfluentSchemaRegistryTLSRegisterLookupRoundTripOpts struct {
+
+	// Default: "4.2.0"
+	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:1129:2)
+}
+
+// ConfluentSchemaRegistryTlsRegisterLookupRoundTrip is the canonical TLS test:
+// a TLS cp-schema-registry terminates HTTPS on its REST endpoint and talks SSL
+// to a TLS cluster's brokers for the `_schemas` topic, and the round-trip
+// succeeds over an HTTPS client verifying the registry cert against the
+// shared CA.
+func (r *KafkaTests) ConfluentSchemaRegistryTLSRegisterLookupRoundTrip(ctx context.Context, opts ...KafkaTestsConfluentSchemaRegistryTLSRegisterLookupRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:1126:1)
+	if r.confluentSchemaRegistryTlsRegisterLookupRoundTrip != nil {
+		return nil
+	}
+	q := r.query.Select("confluentSchemaRegistryTlsRegisterLookupRoundTrip")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `kafkaImageTag` optional argument
+		if !querybuilder.IsZeroValue(opts[i].KafkaImageTag) {
+			q = q.Arg("kafkaImageTag", opts[i].KafkaImageTag)
 		}
 	}
 
@@ -780,6 +861,30 @@ func (r *KafkaTests) KarapaceSchemaRegistryRegisterLookupRoundTrip(ctx context.C
 	return q.Execute(ctx)
 }
 
+// KafkaTestsKarapaceSchemaRegistryTLSRegisterLookupRoundTripOpts contains options for KafkaTests.KarapaceSchemaRegistryTLSRegisterLookupRoundTrip
+type KafkaTestsKarapaceSchemaRegistryTLSRegisterLookupRoundTripOpts struct {
+
+	// Default: "4.2.0"
+	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:1188:2)
+}
+
+// KarapaceSchemaRegistryTlsRegisterLookupRoundTrip drives the Karapace TLS
+// path (PEM REST listener + aiokafka SSL storage) end-to-end.
+func (r *KafkaTests) KarapaceSchemaRegistryTLSRegisterLookupRoundTrip(ctx context.Context, opts ...KafkaTestsKarapaceSchemaRegistryTLSRegisterLookupRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:1185:1)
+	if r.karapaceSchemaRegistryTlsRegisterLookupRoundTrip != nil {
+		return nil
+	}
+	q := r.query.Select("karapaceSchemaRegistryTlsRegisterLookupRoundTrip")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `kafkaImageTag` optional argument
+		if !querybuilder.IsZeroValue(opts[i].KafkaImageTag) {
+			q = q.Arg("kafkaImageTag", opts[i].KafkaImageTag)
+		}
+	}
+
+	return q.Execute(ctx)
+}
+
 // KafkaTestsMtlsRequiresClientCertOpts contains options for KafkaTests.MtlsRequiresClientCert
 type KafkaTestsMtlsRequiresClientCertOpts struct {
 
@@ -862,16 +967,16 @@ func (r *KafkaTests) MultiControllerIsRejected(ctx context.Context, opts ...Kafk
 type KafkaTestsNativeOpts struct {
 
 	// Default: "4.2.0"
-	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/main.go:169:2)
+	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/main.go:181:2)
 
-	Parallel int // kafka-tests (../../../daggerverse/kafka/tests/main.go:171:2)
+	Parallel int // kafka-tests (../../../daggerverse/kafka/tests/main.go:183:2)
 }
 
 // Native runs every apache/kafka-native test as one group. It boots
 // the three shared ApacheNativeClusters up front, fans the shared-cluster
 // and fresh-cluster native tests across a par pool capped at parallel,
 // and tears the shared clusters down on return.
-func (r *KafkaTests) Native(ctx context.Context, opts ...KafkaTestsNativeOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/main.go:166:1)
+func (r *KafkaTests) Native(ctx context.Context, opts ...KafkaTestsNativeOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/main.go:178:1)
 	if r.native != nil {
 		return nil
 	}
@@ -1103,15 +1208,15 @@ func (r *KafkaTests) PropertiesFileContainsTLSSettings(ctx context.Context, opts
 type KafkaTestsRedpandaOpts struct {
 
 	// Default: "v26.1.7"
-	RedpandaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/main.go:343:2)
+	RedpandaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/main.go:355:2)
 
-	Parallel int // kafka-tests (../../../daggerverse/kafka/tests/main.go:345:2)
+	Parallel int // kafka-tests (../../../daggerverse/kafka/tests/main.go:357:2)
 }
 
 // Redpanda runs the redpandadata/redpanda round-trip tests — the two
 // Kafka-wire round-trips, the PLAINTEXT and TLS bundled-Schema-Registry
 // round-trips, and the bundled-registry Stop-is-a-no-op lifecycle test.
-func (r *KafkaTests) Redpanda(ctx context.Context, opts ...KafkaTestsRedpandaOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/main.go:340:1)
+func (r *KafkaTests) Redpanda(ctx context.Context, opts ...KafkaTestsRedpandaOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/main.go:352:1)
 	if r.redpanda != nil {
 		return nil
 	}
@@ -1134,7 +1239,7 @@ func (r *KafkaTests) Redpanda(ctx context.Context, opts ...KafkaTestsRedpandaOpt
 type KafkaTestsRedpandaClusterProduceListTopicsRoundTripOpts struct {
 
 	// Default: "v26.1.7"
-	RedpandaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:60:2)
+	RedpandaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:64:2)
 }
 
 // RedpandaClusterProduceListTopicsRoundTrip is the PLAINTEXT happy-path
@@ -1142,7 +1247,7 @@ type KafkaTestsRedpandaClusterProduceListTopicsRoundTripOpts struct {
 // create a topic, produce one record, then assert the freshly-created
 // topic shows up in ListTopics. Pins down "redpanda actually serves
 // Kafka-wire traffic on the external listener".
-func (r *KafkaTests) RedpandaClusterProduceListTopicsRoundTrip(ctx context.Context, opts ...KafkaTestsRedpandaClusterProduceListTopicsRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:57:1)
+func (r *KafkaTests) RedpandaClusterProduceListTopicsRoundTrip(ctx context.Context, opts ...KafkaTestsRedpandaClusterProduceListTopicsRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:61:1)
 	if r.redpandaClusterProduceListTopicsRoundTrip != nil {
 		return nil
 	}
@@ -1161,7 +1266,7 @@ func (r *KafkaTests) RedpandaClusterProduceListTopicsRoundTrip(ctx context.Conte
 type KafkaTestsRedpandaClusterTLSRoundTripOpts struct {
 
 	// Default: "v26.1.7"
-	RedpandaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:109:2)
+	RedpandaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:113:2)
 }
 
 // RedpandaClusterTlsRoundTrip is the TLS happy-path round-trip for
@@ -1169,7 +1274,7 @@ type KafkaTestsRedpandaClusterTLSRoundTripOpts struct {
 // using PEM cert/key/CA mounted into /etc/redpanda/certs, then produce
 // and consume one record over the TLS listener with the franz-go client
 // verifying the broker leaf against the matching truststore.
-func (r *KafkaTests) RedpandaClusterTLSRoundTrip(ctx context.Context, opts ...KafkaTestsRedpandaClusterTLSRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:106:1)
+func (r *KafkaTests) RedpandaClusterTLSRoundTrip(ctx context.Context, opts ...KafkaTestsRedpandaClusterTLSRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:110:1)
 	if r.redpandaClusterTlsRoundTrip != nil {
 		return nil
 	}
@@ -1188,7 +1293,7 @@ func (r *KafkaTests) RedpandaClusterTLSRoundTrip(ctx context.Context, opts ...Ka
 type KafkaTestsRedpandaSchemaRegistryBundledStopIsNoOpOpts struct {
 
 	// Default: "v26.1.7"
-	RedpandaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:273:2)
+	RedpandaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:285:2)
 }
 
 // RedpandaSchemaRegistryBundledStopIsNoOp pins the bundled-registry lifecycle
@@ -1197,7 +1302,7 @@ type KafkaTestsRedpandaSchemaRegistryBundledStopIsNoOpOpts struct {
 // register/lookup round-trip, calls sr.Stop, then exercises the registry
 // again through the same handle. If sr.Stop had torn down the shared broker
 // service, that follow-up call would fail.
-func (r *KafkaTests) RedpandaSchemaRegistryBundledStopIsNoOp(ctx context.Context, opts ...KafkaTestsRedpandaSchemaRegistryBundledStopIsNoOpOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:270:1)
+func (r *KafkaTests) RedpandaSchemaRegistryBundledStopIsNoOp(ctx context.Context, opts ...KafkaTestsRedpandaSchemaRegistryBundledStopIsNoOpOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:282:1)
 	if r.redpandaSchemaRegistryBundledStopIsNoOp != nil {
 		return nil
 	}
@@ -1216,7 +1321,7 @@ func (r *KafkaTests) RedpandaSchemaRegistryBundledStopIsNoOp(ctx context.Context
 type KafkaTestsRedpandaSchemaRegistryRegisterLookupRoundTripOpts struct {
 
 	// Default: "v26.1.7"
-	RedpandaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:232:2)
+	RedpandaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:236:2)
 }
 
 // RedpandaSchemaRegistryRegisterLookupRoundTrip is the PLAINTEXT happy-path
@@ -1227,7 +1332,7 @@ type KafkaTestsRedpandaSchemaRegistryRegisterLookupRoundTripOpts struct {
 // separate-container ConfluentSchemaRegistry. The SR service is the broker
 // itself, so cluster.Stop tears it down — sr.Stop is a no-op for a bundled
 // registry.
-func (r *KafkaTests) RedpandaSchemaRegistryRegisterLookupRoundTrip(ctx context.Context, opts ...KafkaTestsRedpandaSchemaRegistryRegisterLookupRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:229:1)
+func (r *KafkaTests) RedpandaSchemaRegistryRegisterLookupRoundTrip(ctx context.Context, opts ...KafkaTestsRedpandaSchemaRegistryRegisterLookupRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:233:1)
 	if r.redpandaSchemaRegistryRegisterLookupRoundTrip != nil {
 		return nil
 	}
@@ -1246,17 +1351,17 @@ func (r *KafkaTests) RedpandaSchemaRegistryRegisterLookupRoundTrip(ctx context.C
 type KafkaTestsRedpandaSchemaRegistryTLSRegisterLookupRoundTripOpts struct {
 
 	// Default: "v26.1.7"
-	RedpandaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:253:2)
+	RedpandaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:259:2)
 }
 
 // RedpandaSchemaRegistryTlsRegisterLookupRoundTrip is the TLS-cluster
 // counterpart of RedpandaSchemaRegistryRegisterLookupRoundTrip. A TLS
-// Redpanda cluster configures its bundled Schema Registry through a
-// separately-rendered redpanda.yaml (the schema_registry_api block) rather
-// than the PLAINTEXT path's --schema-registry-addr flag, so this exercises
-// that YAML path end-to-end. The SR REST endpoint is plain HTTP regardless
-// of the Kafka listener's TLS mode, so the truststore is unused here.
-func (r *KafkaTests) RedpandaSchemaRegistryTLSRegisterLookupRoundTrip(ctx context.Context, opts ...KafkaTestsRedpandaSchemaRegistryTLSRegisterLookupRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:250:1)
+// Redpanda cluster terminates HTTPS on its bundled Schema Registry REST
+// endpoint, reusing the broker's server leaf (configured through the
+// separately-rendered redpanda.yaml schema_registry_api_tls block), so this
+// exercises that YAML path end-to-end and drives register/lookup over HTTPS,
+// verifying the SR cert against the cluster CA truststore.
+func (r *KafkaTests) RedpandaSchemaRegistryTLSRegisterLookupRoundTrip(ctx context.Context, opts ...KafkaTestsRedpandaSchemaRegistryTLSRegisterLookupRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:256:1)
 	if r.redpandaSchemaRegistryTlsRegisterLookupRoundTrip != nil {
 		return nil
 	}
@@ -1335,7 +1440,7 @@ func (r *KafkaTests) SchemaRegistryFramedProduceConsumeRoundTrip(ctx context.Con
 type KafkaTestsSchemaRegistryJsonframedProduceConsumeRoundTripOpts struct {
 
 	// Default: "4.2.0"
-	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:633:2)
+	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:635:2)
 }
 
 // SchemaRegistryJSONFramedProduceConsumeRoundTrip composes the framing
@@ -1345,7 +1450,7 @@ type KafkaTestsSchemaRegistryJsonframedProduceConsumeRoundTripOpts struct {
 // asserted invariant is byte-equality of the consumed value to the canonical
 // JSON form of the original input — proving frame strip and JSON validation
 // compose without corrupting the payload.
-func (r *KafkaTests) SchemaRegistryJsonframedProduceConsumeRoundTrip(ctx context.Context, opts ...KafkaTestsSchemaRegistryJsonframedProduceConsumeRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:630:1)
+func (r *KafkaTests) SchemaRegistryJsonframedProduceConsumeRoundTrip(ctx context.Context, opts ...KafkaTestsSchemaRegistryJsonframedProduceConsumeRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:632:1)
 	if r.schemaRegistryJsonframedProduceConsumeRoundTrip != nil {
 		return nil
 	}
@@ -1365,7 +1470,7 @@ func (r *KafkaTests) SchemaRegistryJsonframedProduceConsumeRoundTrip(ctx context
 // malformed JSON payload before any broker I/O. dag.Kafka().Client(...)
 // builds without I/O, so no cluster boots — the failure is purely a
 // payload-validation failure on the canonicalising serializer.
-func (r *KafkaTests) SchemaRegistryJsonserializeRejectsMalformedInput(ctx context.Context) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:602:1)
+func (r *KafkaTests) SchemaRegistryJsonserializeRejectsMalformedInput(ctx context.Context) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:604:1)
 	if r.schemaRegistryJsonserializeRejectsMalformedInput != nil {
 		return nil
 	}
@@ -1426,23 +1531,24 @@ func (r *KafkaTests) SchemaRegistryRegisterLookupRoundTrip(ctx context.Context, 
 	return q.Execute(ctx)
 }
 
-// KafkaTestsSchemaRegistryRejectsNonPlaintextClusterOpts contains options for KafkaTests.SchemaRegistryRejectsNonPlaintextCluster
-type KafkaTestsSchemaRegistryRejectsNonPlaintextClusterOpts struct {
+// KafkaTestsSchemaRegistryRejectsClusterModeMismatchOpts contains options for KafkaTests.SchemaRegistryRejectsClusterModeMismatch
+type KafkaTestsSchemaRegistryRejectsClusterModeMismatchOpts struct {
 
 	// Default: "4.2.0"
-	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:579:2)
+	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:580:2)
 }
 
-// SchemaRegistryRejectsNonPlaintextCluster pins the PLAINTEXT-only contract
-// of this story: ConfluentSchemaRegistry must reject a cluster whose client
-// listener runs TLS rather than silently producing a broken registry. The
-// constructor errors before any service boots, so the TLS cluster never
-// has to start.
-func (r *KafkaTests) SchemaRegistryRejectsNonPlaintextCluster(ctx context.Context, opts ...KafkaTestsSchemaRegistryRejectsNonPlaintextClusterOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:576:1)
-	if r.schemaRegistryRejectsNonPlaintextCluster != nil {
+// SchemaRegistryRejectsClusterModeMismatch pins the mode-match contract: a
+// registry's security profile must match its backing cluster's client-listener
+// mode, so the registry's kafka-storage connection authenticates against the
+// broker. Here a PLAINTEXT registry security is paired with a TLS cluster and
+// must be rejected with an error naming both modes. The constructor errors
+// before any service boots, so the TLS cluster never has to start.
+func (r *KafkaTests) SchemaRegistryRejectsClusterModeMismatch(ctx context.Context, opts ...KafkaTestsSchemaRegistryRejectsClusterModeMismatchOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:577:1)
+	if r.schemaRegistryRejectsClusterModeMismatch != nil {
 		return nil
 	}
-	q := r.query.Select("schemaRegistryRejectsNonPlaintextCluster")
+	q := r.query.Select("schemaRegistryRejectsClusterModeMismatch")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `kafkaImageTag` optional argument
 		if !querybuilder.IsZeroValue(opts[i].KafkaImageTag) {

--- a/daggerverse/kafka/README.md
+++ b/daggerverse/kafka/README.md
@@ -139,12 +139,13 @@ cluster := dag.Kafka().ConfluentCluster(clusterId, dag.Kafka().PlaintextServerSe
 
 sr := dag.Kafka().ConfluentSchemaRegistry(
     cluster,
+    dag.Kafka().PlaintextSchemaRegistrySecurity(),
     dagger.KafkaConfluentSchemaRegistryOpts{
         Tag:      "8.2.0",
         Registry: "docker.io",
     },
 )
-client := sr.Client()
+client := sr.Client(dag.Kafka().PlaintextSchemaRegistryClientSecurity())
 ```
 
 The registry composes on top of **any** `*Cluster` — it talks the Kafka
@@ -157,16 +158,27 @@ observe the same underlying service. It binds every broker via
 `cluster.BindBrokers` and wires `SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS`
 from `cluster.BootstrapServers()`.
 
-**PLAINTEXT only** in this story — the constructor rejects a cluster whose
-client listener runs TLS or mTLS. TLS / mTLS Schema Registry is a follow-up.
+**TLS / mTLS** — the required `security *SchemaRegistrySecurity` argument (from
+`Kafka.{Plaintext,Tls,Mtls}SchemaRegistrySecurity`) must **match the cluster's
+mode**: a PLAINTEXT registry pairs with a PLAINTEXT cluster (today's behaviour),
+and a TLS/mTLS registry pairs with a same-mode cluster so its kafka-storage
+connection authenticates against the broker. A mismatch returns an error naming
+both modes. Under TLS/mTLS the constructor mints a per-registry REST server leaf
+(DNS SAN = the registry's service hostname) from the supplied CA and derives the
+broker-facing truststore from the same CA — so pass the **same CA** to the
+cluster, the registry, and the client (the single-CA convention, see the
+[TLS / mTLS notes](#tls--mtls-notes)). See `SchemaRegistryClient` for the
+matching client profile.
 
 - `SchemaRegistry.Endpoint(ctx) (string, error)` — the `host:port` other
   containers (and the module runtime) reach the REST API on.
 - `SchemaRegistry.BindTo(c *dagger.Container) *dagger.Container` —
   `WithServiceBinding` so a caller's container resolves the registry at the
   same hostname `Endpoint` reports.
-- `SchemaRegistry.Client() *SchemaRegistryClient` — a pure-Go `net/http`
-  admin client; no helper containers.
+- `SchemaRegistry.Client(security *SchemaRegistryClientSecurity) *SchemaRegistryClient`
+  — a pure-Go `net/http` admin client (no helper containers); the client
+  profile must match the registry's mode (HTTP vs HTTPS, plus a client cert for
+  mTLS).
 - `SchemaRegistry.Stop(ctx) error` — tears the registry service down.
 
 ### ApicurioSchemaRegistry
@@ -203,8 +215,12 @@ Confluent-compatible surface only speaks `AVRO`, `JSON`, and `PROTOBUF` (the
 `schemaType` values `SchemaRegistryClient` already accepts). Apicurio's other
 artifact types are not reachable through this constructor.
 
-**PLAINTEXT only** in this story, matching `ConfluentSchemaRegistry` — the
-constructor rejects a cluster whose client listener runs TLS or mTLS.
+**TLS / mTLS**, matching `ConfluentSchemaRegistry`: pass a
+`security *SchemaRegistrySecurity` that matches the cluster's mode. Apicurio is
+a Quarkus app, so TLS terminates on the Quarkus HTTP layer
+(`QUARKUS_HTTP_SSL_*`, PKCS#12 keystore) while its kafkasql storage connection
+uses the Kafka client SSL config (`KAFKA_SECURITY_PROTOCOL=SSL` + PKCS#12
+truststore, fed PKCS#12 to avoid a PEM-truststore-plus-password startup bug).
 
 ### KarapaceSchemaRegistry
 
@@ -212,21 +228,22 @@ constructor rejects a cluster whose client listener runs TLS or mTLS.
 `ghcr.io/aiven-open/karapace` image. Karapace is Aiven's drop-in Python
 reimplementation of the Confluent Schema Registry — identical wire surface,
 different runtime. It takes the **same parameters** as `ConfluentSchemaRegistry`
-(`cluster`, plus optional `registry` / `tag`) and returns the **same
-`*SchemaRegistry` type**, so `Client()`, `Endpoint()`, `BindTo()`, and `Stop()`
-are all shared code.
+(`cluster`, the required `security *SchemaRegistrySecurity`, plus optional
+`registry` / `tag`) and returns the **same `*SchemaRegistry` type**, so
+`Client()`, `Endpoint()`, `BindTo()`, and `Stop()` are all shared code.
 
 ```go
 cluster := dag.Kafka().ConfluentCluster(clusterId, dag.Kafka().PlaintextServerSecurity())
 
 sr := dag.Kafka().KarapaceSchemaRegistry(
     cluster,
+    dag.Kafka().PlaintextSchemaRegistrySecurity(),
     dagger.KafkaKarapaceSchemaRegistryOpts{
         Tag:      "6.1.4",
         Registry: "ghcr.io",
     },
 )
-client := sr.Client()
+client := sr.Client(dag.Kafka().PlaintextSchemaRegistryClientSecurity())
 ```
 
 Unlike `ConfluentSchemaRegistry` and `ApicurioSchemaRegistry`, `registry`
@@ -237,8 +254,13 @@ image licensing. Karapace stores schemas in the cluster's `_schemas` topic
 its Confluent-compatible REST API **at the root**, so the same
 `SchemaRegistryClient` drives it unchanged.
 
-**PLAINTEXT only** in this story, matching `ConfluentSchemaRegistry` — the
-constructor rejects a cluster whose client listener runs TLS or mTLS.
+**TLS / mTLS**, matching `ConfluentSchemaRegistry`: pass a matching-mode
+`security *SchemaRegistrySecurity`. Karapace is a Python service that consumes
+**PEM** (not PKCS#12) for both its REST listener (`KARAPACE_SERVER_TLS_*`) and
+its aiokafka storage connection (`KARAPACE_SECURITY_PROTOCOL=SSL` +
+`KARAPACE_SSL_CAFILE`); the module extracts PEM from the supplied CA
+internally, so callers still pass the same PKCS#12 profile shape as the other
+registries.
 
 ### SchemaRegistryClient
 
@@ -258,6 +280,14 @@ level, err := client.GetCompatibility(ctx, "my-subject-value")
 `schemaType` accepts `AVRO`, `JSON`, or `PROTOBUF`. Compatibility `level`
 accepts `NONE`, `BACKWARD`, `BACKWARD_TRANSITIVE`, `FORWARD`,
 `FORWARD_TRANSITIVE`, `FULL`, or `FULL_TRANSITIVE`.
+
+`sr.Client(security)` picks its URL scheme from the registry's mode: a TLS/mTLS
+registry serves HTTPS and needs a matching `SchemaRegistryClientSecurity` (a
+truststore for the registry's cert, plus a client keystore for mTLS); the
+underlying `*http.Client` materialises a `tls.Config` from those PKCS#12
+archives the same way the franz-go `Client` does. A scheme/mode mismatch
+(HTTPS registry with a PLAINTEXT client, or vice versa) fails with a clear
+error on the first request.
 
 `RegisteredSchema` carries `Subject`, `Version`, `SchemaID`, `Definition`
 (the schema text), and `SchemaType`. The `SchemaID` / `Definition` names
@@ -346,8 +376,8 @@ separate-container registries are interchangeable from a caller's
 perspective:
 
 ```go
-sr := cluster.SchemaRegistry()
-client := sr.Client()
+sr := cluster.SchemaRegistry(dag.Kafka().PlaintextSchemaRegistrySecurity())
+client := sr.Client(dag.Kafka().PlaintextSchemaRegistryClientSecurity())
 
 id, err := client.RegisterSchema(ctx, "my-subject-value", avroSchema,
     dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{SchemaType: "AVRO"})
@@ -373,10 +403,16 @@ the whole `*SchemaRegistry` surface behaves identically to the
 `*SchemaRegistry`, and the `*SchemaRegistryClient` returned by
 `Client()`.
 
-The registry's REST endpoint is plain HTTP regardless of the cluster's
-Kafka-listener security mode, so `SchemaRegistry()` works on both
-PLAINTEXT and TLS Redpanda clusters. (Securing the SR endpoint itself
-with TLS is a follow-up, matching `ConfluentSchemaRegistry`.)
+`SchemaRegistry(security)` takes a `security *SchemaRegistrySecurity` matching
+the cluster's mode (Redpanda supports PLAINTEXT or TLS — it has no cluster-level
+mTLS). On a TLS cluster the bundled SR REST endpoint terminates **HTTPS**,
+reusing the broker's own server leaf (whose DNS SAN is the broker/registry host)
+via the `schema_registry_api_tls` block rendered into `redpanda.yaml` at
+cluster-build time — so no per-registry leaf is minted and the profile's CA
+keystore is unused (required only for API uniformity). Pass a matching TLS
+`SchemaRegistryClientSecurity` (a truststore from the cluster CA) to `Client()`
+to drive the HTTPS endpoint. SR-REST mTLS is not reachable, as it would require
+a cluster-level mTLS mode Redpanda does not have.
 
 ## Client
 
@@ -519,6 +555,34 @@ Topic auto-creation is disabled on the broker — call `CreateTopic` before
   the returned `*dagger.File` (`.Contents(ctx)` / `.Export(ctx)`).
   Export the resulting directory with restrictive permissions if you
   persist it.
+
+### Schema Registry TLS / mTLS
+
+- A TLS/mTLS Schema Registry secures **two** surfaces: its REST endpoint
+  (registry as server) and its kafka-storage connection to the broker (registry
+  as client). The constructor mints a **per-registry REST server leaf** from the
+  supplied CA — DNS SAN = the registry's service hostname (`csr-`/`asr-`/`ksr-`
+  + a per-cluster suffix) — exactly as the brokers mint their external leaves
+  (`mintServiceLeaf`, shared with the broker path). Redpanda's bundled registry
+  is the exception: it reuses the broker's own leaf, so no per-registry leaf is
+  minted.
+- **Security-mode coupling.** The registry's `SchemaRegistrySecurity` mode must
+  match the backing cluster's client-listener mode; a mismatch is rejected with
+  an error naming both modes. This guarantees the registry's kafka-storage
+  connection uses the same protocol the broker's client listener speaks.
+- **Single-CA convention.** Because the cluster does not carry its CA across the
+  API, the registry derives its broker-facing truststore from the CA the caller
+  re-supplies. Pass the **same CA** to the cluster (`TlsServerSecurity`), the
+  registry (`TlsSchemaRegistrySecurity`), and the client
+  (`TlsSchemaRegistryClientSecurity`) so every handshake chains to one root. For
+  mTLS the registry also mints its own client leaf from that CA to present to
+  the broker.
+- **PKCS#12 vs PEM per image.** Confluent (`cp-schema-registry`, Java) and
+  Apicurio (Quarkus) consume **PKCS#12** keystores/truststores via env vars;
+  Karapace (Python) and Redpanda consume **PEM** — the module extracts PEM from
+  the supplied PKCS#12 CA internally, so callers always pass the same profile
+  shape. Feed Apicurio's kafkasql storage PKCS#12 (not PEM) to avoid a
+  PEM-truststore-plus-password startup bug.
 
 ## Image source
 

--- a/daggerverse/kafka/avro.go
+++ b/daggerverse/kafka/avro.go
@@ -70,7 +70,12 @@ func (a *avroSchemas) get(ctx context.Context, id int) (*avroSchema, error) {
 	if a.registry == nil {
 		return nil, fmt.Errorf("AVRO mode requires a schema registry to resolve schema id %d", id)
 	}
-	rs, err := a.registry.Client().LookupSchemaByID(ctx, id)
+	// The franz-go avro path resolves schemas over the registry's REST API.
+	// It currently assumes a plaintext registry; wiring a TLS/mTLS client
+	// profile through Produce/Consume is a follow-up (#141). A TLS registry
+	// here surfaces a clear "serves HTTPS but client is PLAINTEXT" error from
+	// do().
+	rs, err := a.registry.Client(nil).LookupSchemaByID(ctx, id)
 	if err != nil {
 		return nil, fmt.Errorf("resolve schema id %d: %w", id, err)
 	}

--- a/daggerverse/kafka/cluster_redpanda.go
+++ b/daggerverse/kafka/cluster_redpanda.go
@@ -335,17 +335,30 @@ func renderRedpandaYaml(brokerHost string, withTls bool) ([]byte, error) {
 			RequireClientAuth: false,
 		}}
 	}
-	full := map[string]any{
-		"redpanda":   rpCfg,
-		"pandaproxy": map[string]any{},
-		// Bundle the Schema Registry on a plain-HTTP listener — parallels
-		// the PLAINTEXT path's --schema-registry-addr flag. The SR REST
-		// API stays HTTP regardless of the Kafka listener's TLS mode.
-		"schema_registry": map[string]any{
-			"schema_registry_api": []addr{
-				{Address: "0.0.0.0", Port: schemaRegistryPort},
-			},
+	// Bundle the Schema Registry REST listener. On a TLS cluster it reuses
+	// the broker's own server leaf (already mounted at /etc/redpanda/certs)
+	// to terminate HTTPS — the leaf's DNS SAN is brokerHost, which is also
+	// the registry's advertised host — so a TLS Redpanda cluster serves its
+	// bundled Schema Registry over HTTPS. (SR-REST mTLS is not reachable:
+	// Redpanda has no cluster-level mTLS mode.)
+	srBlock := map[string]any{
+		"schema_registry_api": []addr{
+			{Address: "0.0.0.0", Port: schemaRegistryPort, Name: "external"},
 		},
+	}
+	if withTls {
+		srBlock["schema_registry_api_tls"] = []tlsEntry{{
+			Name:              "external",
+			Enabled:           true,
+			CertFile:          "/etc/redpanda/certs/server.crt",
+			KeyFile:           "/etc/redpanda/certs/server.key",
+			RequireClientAuth: false,
+		}}
+	}
+	full := map[string]any{
+		"redpanda":        rpCfg,
+		"pandaproxy":      map[string]any{},
+		"schema_registry": srBlock,
 		"rpk": map[string]any{
 			"coredump_dir": "/var/lib/redpanda/coredump",
 		},
@@ -379,9 +392,14 @@ func (r *RedpandaCluster) BootstrapServers() []string {
 // `rpk redpanda start` runs a Schema Registry inside the broker process on
 // :8081 — no extra container — so the returned *SchemaRegistry points at the
 // broker service itself. Redpanda's SR speaks the Confluent Schema Registry
-// REST API, so the *SchemaRegistryClient from Client() works unchanged. The
-// REST endpoint is plain HTTP regardless of the cluster's Kafka-listener
-// security mode, so this never fails.
+// REST API, so the *SchemaRegistryClient from Client() works unchanged.
+//
+// security must match the cluster's mode (PLAINTEXT or TLS — Redpanda has no
+// mTLS): on a TLS cluster the bundled SR REST endpoint terminates HTTPS
+// reusing the broker's server leaf (configured at cluster-build time in
+// renderRedpandaYaml), so the caller must pass a TLS profile to get an HTTPS
+// client. The profile's CA keystore is unused here (the leaf is already
+// minted); it is required only for API uniformity with the other registries.
 //
 // The returned registry is Bundled: its service is the broker itself, so
 // Stop is a no-op on it — call cluster.Stop to tear the registry down with
@@ -389,13 +407,20 @@ func (r *RedpandaCluster) BootstrapServers() []string {
 // *SchemaRegistry type therefore can't accidentally kill the cluster.
 //
 // +cache="never"
-func (r *RedpandaCluster) SchemaRegistry(ctx context.Context) *SchemaRegistry {
+func (r *RedpandaCluster) SchemaRegistry(ctx context.Context, security *SchemaRegistrySecurity) (*SchemaRegistry, error) {
+	if r == nil || r.BrokerSvc == nil {
+		return nil, fmt.Errorf("RedpandaCluster.SchemaRegistry: cluster has no broker service")
+	}
+	if err := validateRegistrySecurity("RedpandaCluster.SchemaRegistry", security, r.ClientSecurityMode); err != nil {
+		return nil, err
+	}
 	return &SchemaRegistry{
 		SchemaRegistrySvc: r.BrokerSvc,
 		AdvertisedHost:    r.BrokerHost,
 		AdvertisedPort:    schemaRegistryPort,
 		Bundled:           true,
-	}
+		SecurityMode:      security.Mode,
+	}, nil
 }
 
 // BindBrokers binds the single Redpanda broker service into the given

--- a/daggerverse/kafka/dagger.gen.go
+++ b/daggerverse/kafka/dagger.gen.go
@@ -152,12 +152,14 @@ func (r SchemaRegistry) MarshalJSON() ([]byte, error) {
 		AdvertisedPort    int
 		Bundled           bool
 		BasePath          string
+		SecurityMode      string
 	}
 	concrete.SchemaRegistrySvc = r.SchemaRegistrySvc
 	concrete.AdvertisedHost = r.AdvertisedHost
 	concrete.AdvertisedPort = r.AdvertisedPort
 	concrete.Bundled = r.Bundled
 	concrete.BasePath = r.BasePath
+	concrete.SecurityMode = r.SecurityMode
 	return json.Marshal(&concrete)
 }
 
@@ -168,6 +170,7 @@ func (r *SchemaRegistry) UnmarshalJSON(bs []byte) error {
 		AdvertisedPort    int
 		Bundled           bool
 		BasePath          string
+		SecurityMode      string
 	}
 	err := json.Unmarshal(bs, &concrete)
 	if err != nil {
@@ -178,6 +181,43 @@ func (r *SchemaRegistry) UnmarshalJSON(bs []byte) error {
 	r.AdvertisedPort = concrete.AdvertisedPort
 	r.Bundled = concrete.Bundled
 	r.BasePath = concrete.BasePath
+	r.SecurityMode = concrete.SecurityMode
+	return nil
+}
+
+func (r SchemaRegistrySecurity) MarshalJSON() ([]byte, error) {
+	var concrete struct {
+		Mode                     string
+		CaKeyStore               *dagger.File
+		CaKeyStorePassword       *dagger.Secret
+		ClientTrustStore         *dagger.File
+		ClientTrustStorePassword *dagger.Secret
+	}
+	concrete.Mode = r.Mode
+	concrete.CaKeyStore = r.CaKeyStore
+	concrete.CaKeyStorePassword = r.CaKeyStorePassword
+	concrete.ClientTrustStore = r.ClientTrustStore
+	concrete.ClientTrustStorePassword = r.ClientTrustStorePassword
+	return json.Marshal(&concrete)
+}
+
+func (r *SchemaRegistrySecurity) UnmarshalJSON(bs []byte) error {
+	var concrete struct {
+		Mode                     string
+		CaKeyStore               *dagger.File
+		CaKeyStorePassword       *dagger.Secret
+		ClientTrustStore         *dagger.File
+		ClientTrustStorePassword *dagger.Secret
+	}
+	err := json.Unmarshal(bs, &concrete)
+	if err != nil {
+		return err
+	}
+	r.Mode = concrete.Mode
+	r.CaKeyStore = concrete.CaKeyStore
+	r.CaKeyStorePassword = concrete.CaKeyStorePassword
+	r.ClientTrustStore = concrete.ClientTrustStore
+	r.ClientTrustStorePassword = concrete.ClientTrustStorePassword
 	return nil
 }
 
@@ -238,6 +278,42 @@ func (r ClientSecurity) MarshalJSON() ([]byte, error) {
 }
 
 func (r *ClientSecurity) UnmarshalJSON(bs []byte) error {
+	var concrete struct {
+		Mode               string
+		TrustStore         *dagger.File
+		TrustStorePassword *dagger.Secret
+		KeyStore           *dagger.File
+		KeyStorePassword   *dagger.Secret
+	}
+	err := json.Unmarshal(bs, &concrete)
+	if err != nil {
+		return err
+	}
+	r.Mode = concrete.Mode
+	r.TrustStore = concrete.TrustStore
+	r.TrustStorePassword = concrete.TrustStorePassword
+	r.KeyStore = concrete.KeyStore
+	r.KeyStorePassword = concrete.KeyStorePassword
+	return nil
+}
+
+func (r SchemaRegistryClientSecurity) MarshalJSON() ([]byte, error) {
+	var concrete struct {
+		Mode               string
+		TrustStore         *dagger.File
+		TrustStorePassword *dagger.Secret
+		KeyStore           *dagger.File
+		KeyStorePassword   *dagger.Secret
+	}
+	concrete.Mode = r.Mode
+	concrete.TrustStore = r.TrustStore
+	concrete.TrustStorePassword = r.TrustStorePassword
+	concrete.KeyStore = r.KeyStore
+	concrete.KeyStorePassword = r.KeyStorePassword
+	return json.Marshal(&concrete)
+}
+
+func (r *SchemaRegistryClientSecurity) UnmarshalJSON(bs []byte) error {
 	var concrete struct {
 		Mode               string
 		TrustStore         *dagger.File
@@ -319,18 +395,33 @@ func (r *RedpandaServerSecurity) UnmarshalJSON(bs []byte) error {
 
 func (r SchemaRegistryClient) MarshalJSON() ([]byte, error) {
 	var concrete struct {
-		Svc     *dagger.Service
-		BaseURL string
+		Svc                *dagger.Service
+		BaseURL            string
+		SecurityMode       string
+		TrustStore         *dagger.File
+		TrustStorePassword *dagger.Secret
+		KeyStore           *dagger.File
+		KeyStorePassword   *dagger.Secret
 	}
 	concrete.Svc = r.Svc
 	concrete.BaseURL = r.BaseURL
+	concrete.SecurityMode = r.SecurityMode
+	concrete.TrustStore = r.TrustStore
+	concrete.TrustStorePassword = r.TrustStorePassword
+	concrete.KeyStore = r.KeyStore
+	concrete.KeyStorePassword = r.KeyStorePassword
 	return json.Marshal(&concrete)
 }
 
 func (r *SchemaRegistryClient) UnmarshalJSON(bs []byte) error {
 	var concrete struct {
-		Svc     *dagger.Service
-		BaseURL string
+		Svc                *dagger.Service
+		BaseURL            string
+		SecurityMode       string
+		TrustStore         *dagger.File
+		TrustStorePassword *dagger.Secret
+		KeyStore           *dagger.File
+		KeyStorePassword   *dagger.Secret
 	}
 	err := json.Unmarshal(bs, &concrete)
 	if err != nil {
@@ -338,6 +429,11 @@ func (r *SchemaRegistryClient) UnmarshalJSON(bs []byte) error {
 	}
 	r.Svc = concrete.Svc
 	r.BaseURL = concrete.BaseURL
+	r.SecurityMode = concrete.SecurityMode
+	r.TrustStore = concrete.TrustStore
+	r.TrustStorePassword = concrete.TrustStorePassword
+	r.KeyStore = concrete.KeyStore
+	r.KeyStorePassword = concrete.KeyStorePassword
 	return nil
 }
 
@@ -883,7 +979,14 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg tag", err))
 				}
 			}
-			return (*Kafka).ApicurioSchemaRegistry(&parent, ctx, cluster, registry, tag)
+			var security *SchemaRegistrySecurity
+			if inputArgs["security"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["security"]), &security)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg security", err))
+				}
+			}
+			return (*Kafka).ApicurioSchemaRegistry(&parent, ctx, cluster, registry, tag, security)
 		case "Client":
 			var parent Kafka
 			err = json.Unmarshal(parentJSON, &parent)
@@ -981,7 +1084,14 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg tag", err))
 				}
 			}
-			return (*Kafka).ConfluentSchemaRegistry(&parent, ctx, cluster, registry, tag)
+			var security *SchemaRegistrySecurity
+			if inputArgs["security"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["security"]), &security)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg security", err))
+				}
+			}
+			return (*Kafka).ConfluentSchemaRegistry(&parent, ctx, cluster, registry, tag, security)
 		case "KarapaceSchemaRegistry":
 			var parent Kafka
 			err = json.Unmarshal(parentJSON, &parent)
@@ -1009,7 +1119,14 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg tag", err))
 				}
 			}
-			return (*Kafka).KarapaceSchemaRegistry(&parent, ctx, cluster, registry, tag)
+			var security *SchemaRegistrySecurity
+			if inputArgs["security"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["security"]), &security)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg security", err))
+				}
+			}
+			return (*Kafka).KarapaceSchemaRegistry(&parent, ctx, cluster, registry, tag, security)
 		case "MtlsClientSecurity":
 			var parent Kafka
 			err = json.Unmarshal(parentJSON, &parent)
@@ -1045,6 +1162,76 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Kafka).MtlsClientSecurity(&parent, keyStore, keyStorePassword, trustStore, trustStorePassword), nil
+		case "MtlsSchemaRegistryClientSecurity":
+			var parent Kafka
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var keyStore *dagger.File
+			if inputArgs["keyStore"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["keyStore"]), &keyStore)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg keyStore", err))
+				}
+			}
+			var keyStorePassword *dagger.Secret
+			if inputArgs["keyStorePassword"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["keyStorePassword"]), &keyStorePassword)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg keyStorePassword", err))
+				}
+			}
+			var trustStore *dagger.File
+			if inputArgs["trustStore"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["trustStore"]), &trustStore)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg trustStore", err))
+				}
+			}
+			var trustStorePassword *dagger.Secret
+			if inputArgs["trustStorePassword"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["trustStorePassword"]), &trustStorePassword)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg trustStorePassword", err))
+				}
+			}
+			return (*Kafka).MtlsSchemaRegistryClientSecurity(&parent, keyStore, keyStorePassword, trustStore, trustStorePassword), nil
+		case "MtlsSchemaRegistrySecurity":
+			var parent Kafka
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var caKeyStore *dagger.File
+			if inputArgs["caKeyStore"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["caKeyStore"]), &caKeyStore)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg caKeyStore", err))
+				}
+			}
+			var caKeyStorePassword *dagger.Secret
+			if inputArgs["caKeyStorePassword"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["caKeyStorePassword"]), &caKeyStorePassword)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg caKeyStorePassword", err))
+				}
+			}
+			var clientTrustStore *dagger.File
+			if inputArgs["clientTrustStore"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["clientTrustStore"]), &clientTrustStore)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg clientTrustStore", err))
+				}
+			}
+			var clientTrustStorePassword *dagger.Secret
+			if inputArgs["clientTrustStorePassword"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["clientTrustStorePassword"]), &clientTrustStorePassword)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg clientTrustStorePassword", err))
+				}
+			}
+			return (*Kafka).MtlsSchemaRegistrySecurity(&parent, caKeyStore, caKeyStorePassword, clientTrustStore, clientTrustStorePassword), nil
 		case "MtlsServerSecurity":
 			var parent Kafka
 			err = json.Unmarshal(parentJSON, &parent)
@@ -1087,6 +1274,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return (*Kafka).PlaintextClientSecurity(&parent), nil
+		case "PlaintextSchemaRegistryClientSecurity":
+			var parent Kafka
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Kafka).PlaintextSchemaRegistryClientSecurity(&parent), nil
+		case "PlaintextSchemaRegistrySecurity":
+			var parent Kafka
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Kafka).PlaintextSchemaRegistrySecurity(&parent), nil
 		case "PlaintextServerSecurity":
 			var parent Kafka
 			err = json.Unmarshal(parentJSON, &parent)
@@ -1192,6 +1393,48 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Kafka).TlsClientSecurity(&parent, trustStore, trustStorePassword), nil
+		case "TlsSchemaRegistryClientSecurity":
+			var parent Kafka
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var trustStore *dagger.File
+			if inputArgs["trustStore"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["trustStore"]), &trustStore)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg trustStore", err))
+				}
+			}
+			var trustStorePassword *dagger.Secret
+			if inputArgs["trustStorePassword"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["trustStorePassword"]), &trustStorePassword)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg trustStorePassword", err))
+				}
+			}
+			return (*Kafka).TlsSchemaRegistryClientSecurity(&parent, trustStore, trustStorePassword), nil
+		case "TlsSchemaRegistrySecurity":
+			var parent Kafka
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var caKeyStore *dagger.File
+			if inputArgs["caKeyStore"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["caKeyStore"]), &caKeyStore)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg caKeyStore", err))
+				}
+			}
+			var caKeyStorePassword *dagger.Secret
+			if inputArgs["caKeyStorePassword"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["caKeyStorePassword"]), &caKeyStorePassword)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg caKeyStorePassword", err))
+				}
+			}
+			return (*Kafka).TlsSchemaRegistrySecurity(&parent, caKeyStore, caKeyStorePassword), nil
 		case "TlsServerSecurity":
 			var parent Kafka
 			err = json.Unmarshal(parentJSON, &parent)
@@ -1259,7 +1502,14 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 			if err != nil {
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
-			return (*RedpandaCluster).SchemaRegistry(&parent, ctx), nil
+			var security *SchemaRegistrySecurity
+			if inputArgs["security"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["security"]), &security)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg security", err))
+				}
+			}
+			return (*RedpandaCluster).SchemaRegistry(&parent, ctx, security)
 		case "Stop":
 			var parent RedpandaCluster
 			err = json.Unmarshal(parentJSON, &parent)
@@ -1292,7 +1542,14 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 			if err != nil {
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
-			return (*SchemaRegistry).Client(&parent), nil
+			var security *SchemaRegistryClientSecurity
+			if inputArgs["security"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["security"]), &security)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg security", err))
+				}
+			}
+			return (*SchemaRegistry).Client(&parent, security), nil
 		case "Endpoint":
 			var parent SchemaRegistry
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/kafka/internal_ca.go
+++ b/daggerverse/kafka/internal_ca.go
@@ -1,11 +1,15 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/pem"
 	"fmt"
 	"time"
 
 	"dagger/kafka/internal/dagger"
+
+	"software.sslmate.com/src/go-pkcs12"
 )
 
 // nodePkis bundles a single node's mTLS material for the internal listeners.
@@ -29,6 +33,20 @@ type internalMaterial struct {
 type externalLeaf struct {
 	KeyStoreFile     *dagger.File
 	KeyStorePassword *dagger.Secret
+}
+
+// serviceLeaf bundles a single service leaf certificate (broker external
+// listener or Schema Registry REST endpoint) in both representations so
+// PKCS#12-consuming images (Confluent, Kafka brokers, Apicurio REST) and
+// PEM-consuming images (Karapace) can share one minting path. The PKCS#12
+// keystore is eagerly staged content-addressed; the PEM cert/key stay lazy
+// (resolved only when a PEM caller mounts them) so the broker path pays no
+// extra I/O.
+type serviceLeaf struct {
+	KeyStoreFile     *dagger.File   // PKCS#12 leaf keystore (cert + private key)
+	KeyStorePassword *dagger.Secret // password sealing the PKCS#12 keystore
+	CertPemFile      *dagger.File   // leaf cert PEM (lazy)
+	PrivateKeyPem    *dagger.Secret // leaf private key PEM (lazy)
 }
 
 const (
@@ -198,44 +216,151 @@ func mintExternalLeaves(
 	brokerHosts []string,
 ) ([]externalLeaf, error) {
 	ca := dag.CertificateManagement().LoadCertificateAuthority(sec.CaKeyStore, sec.CaKeyStorePassword)
-	nb := time.Now().UTC().Format(time.RFC3339)
 	leaves := make([]externalLeaf, len(brokerHosts))
 	for i, h := range brokerHosts {
-		leafKeyPem, err := dag.Crypto().GenerateRsaKey(dagger.CryptoGenerateRsaKeyOpts{Bits: 2048}).Pem().Contents(ctx)
+		leaf, err := mintServiceLeafFromCA(ctx, ca, h, "external")
 		if err != nil {
-			return nil, fmt.Errorf("generate %q external leaf key: %w", h, err)
-		}
-		leafKey := dag.SetSecret("kafka-external-leaf-key-"+randSuffix(), leafKeyPem)
-
-		leafPwdHex, err := dag.Random().Sha256(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("generate %q external leaf password: %w", h, err)
-		}
-		leafPwd := dag.SetSecret("kafka-external-leaf-pwd-"+randSuffix(), leafPwdHex)
-
-		leafSerial, err := dag.Random().Serial(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("generate %q external leaf serial: %w", h, err)
-		}
-
-		issued := ca.IssueServerCertificate(h, nb, leafSerial, leafPwd, leafKey,
-			dagger.CertificateManagementCertificateAuthorityIssueServerCertificateOpts{
-				DNSSans:      []string{h, "localhost"},
-				IPSans:       []string{"127.0.0.1"},
-				ValidityDays: 365,
-			})
-		ksBytes, err := dagFileBytes(ctx, issued.KeyStore().Pkcs12())
-		if err != nil {
-			return nil, fmt.Errorf("materialize %q external keystore: %w", h, err)
-		}
-		ksFile, err := writeWorkdirBytes("external-keystore-"+h, "external.p12", ksBytes)
-		if err != nil {
-			return nil, fmt.Errorf("stage %q external keystore: %w", h, err)
+			return nil, err
 		}
 		leaves[i] = externalLeaf{
-			KeyStoreFile:     ksFile,
-			KeyStorePassword: leafPwd,
+			KeyStoreFile:     leaf.KeyStoreFile,
+			KeyStorePassword: leaf.KeyStorePassword,
 		}
 	}
 	return leaves, nil
+}
+
+// leafInputs generates the fresh key / keystore-password / serial / notBefore
+// material for one leaf certificate. The private key crosses as a sealed
+// Dagger secret; the keystore password is a random SHA-256 hex.
+func leafInputs(ctx context.Context, host string) (key *dagger.Secret, pwd *dagger.Secret, serial string, nb string, err error) {
+	keyPem, err := dag.Crypto().GenerateRsaKey(dagger.CryptoGenerateRsaKeyOpts{Bits: 2048}).Pem().Contents(ctx)
+	if err != nil {
+		return nil, nil, "", "", fmt.Errorf("generate %q leaf key: %w", host, err)
+	}
+	key = dag.SetSecret("kafka-leaf-key-"+randSuffix(), keyPem)
+
+	pwdHex, err := dag.Random().Sha256(ctx)
+	if err != nil {
+		return nil, nil, "", "", fmt.Errorf("generate %q leaf password: %w", host, err)
+	}
+	pwd = dag.SetSecret("kafka-leaf-pwd-"+randSuffix(), pwdHex)
+
+	serial, err = dag.Random().Serial(ctx)
+	if err != nil {
+		return nil, nil, "", "", fmt.Errorf("generate %q leaf serial: %w", host, err)
+	}
+	nb = time.Now().UTC().Format(time.RFC3339)
+	return key, pwd, serial, nb, nil
+}
+
+// stageLeaf materializes the PKCS#12 keystore of an issued leaf content-addressed
+// (byte-stable across concurrent consumers) and returns it plus the lazy PEM
+// cert/key. label + host disambiguate the staged file's scratch subdir.
+func stageLeaf(ctx context.Context, issued *dagger.CertificateManagementIssuedCertificate, pwd *dagger.Secret, host, label string) (serviceLeaf, error) {
+	ksBytes, err := dagFileBytes(ctx, issued.KeyStore().Pkcs12())
+	if err != nil {
+		return serviceLeaf{}, fmt.Errorf("materialize %q keystore: %w", host, err)
+	}
+	ksFile, err := writeWorkdirBytes(label+"-keystore-"+host, "leaf.p12", ksBytes)
+	if err != nil {
+		return serviceLeaf{}, fmt.Errorf("stage %q keystore: %w", host, err)
+	}
+	return serviceLeaf{
+		KeyStoreFile:     ksFile,
+		KeyStorePassword: pwd,
+		CertPemFile:      issued.CertPemFile(),
+		PrivateKeyPem:    issued.PrivateKeyPem(),
+	}, nil
+}
+
+// mintServiceLeafFromCA signs one server leaf (serverAuth EKU) whose hostname
+// is bound as a DNS SAN — the shared core of broker external-listener and
+// Schema Registry REST-endpoint leaf minting.
+func mintServiceLeafFromCA(ctx context.Context, ca *dagger.CertificateManagementCertificateAuthority, host, label string) (serviceLeaf, error) {
+	key, pwd, serial, nb, err := leafInputs(ctx, host)
+	if err != nil {
+		return serviceLeaf{}, err
+	}
+	issued := ca.IssueServerCertificate(host, nb, serial, pwd, key,
+		dagger.CertificateManagementCertificateAuthorityIssueServerCertificateOpts{
+			DNSSans:      []string{host, "localhost"},
+			IPSans:       []string{"127.0.0.1"},
+			ValidityDays: 365,
+		})
+	return stageLeaf(ctx, issued, pwd, host, label)
+}
+
+// mintServiceLeaf loads a caller CA and signs one server leaf for host. Used
+// by the Schema Registry constructors for the per-registry REST server cert.
+func mintServiceLeaf(ctx context.Context, caKeyStore *dagger.File, caKeyStorePassword *dagger.Secret, host, label string) (serviceLeaf, error) {
+	ca := dag.CertificateManagement().LoadCertificateAuthority(caKeyStore, caKeyStorePassword)
+	return mintServiceLeafFromCA(ctx, ca, host, label)
+}
+
+// mintClientLeaf loads a caller CA and signs one client leaf (clientAuth EKU)
+// with commonName cn. Used for a Schema Registry's own mTLS client cert when
+// its kafka-storage connection authenticates to an mTLS broker.
+func mintClientLeaf(ctx context.Context, caKeyStore *dagger.File, caKeyStorePassword *dagger.Secret, cn, label string) (serviceLeaf, error) {
+	ca := dag.CertificateManagement().LoadCertificateAuthority(caKeyStore, caKeyStorePassword)
+	key, pwd, serial, nb, err := leafInputs(ctx, cn)
+	if err != nil {
+		return serviceLeaf{}, err
+	}
+	issued := ca.IssueClientCertificate(cn, nb, serial, pwd, key)
+	return stageLeaf(ctx, issued, pwd, cn, label)
+}
+
+// caTrustStorePkcs12 loads a caller CA and re-exports its trust store as a
+// content-addressed PKCS#12 archive plus the sealing password — the
+// broker-facing truststore a Schema Registry uses to verify the cluster's
+// TLS/mTLS broker over its kafka-storage connection.
+func caTrustStorePkcs12(ctx context.Context, caKeyStore *dagger.File, caKeyStorePassword *dagger.Secret) (*dagger.File, *dagger.Secret, error) {
+	ts := dag.CertificateManagement().LoadCertificateAuthority(caKeyStore, caKeyStorePassword).TrustStore()
+	tsBytes, err := dagFileBytes(ctx, ts.Pkcs12())
+	if err != nil {
+		return nil, nil, fmt.Errorf("materialize CA truststore: %w", err)
+	}
+	tsFile, err := writeWorkdirBytes("sr-kafkastore-truststore", "truststore.p12", tsBytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("stage CA truststore: %w", err)
+	}
+	return tsFile, ts.Password(), nil
+}
+
+// caCertPem loads a caller CA and returns its cert as a content-addressed PEM
+// file — the broker-facing truststore for PEM-consuming registries (Karapace).
+func caCertPem(ctx context.Context, caKeyStore *dagger.File, caKeyStorePassword *dagger.Secret) (*dagger.File, error) {
+	ca := dag.CertificateManagement().LoadCertificateAuthority(caKeyStore, caKeyStorePassword)
+	pemBytes, err := dagFileBytes(ctx, ca.CertPemFile())
+	if err != nil {
+		return nil, fmt.Errorf("materialize CA cert PEM: %w", err)
+	}
+	return writeWorkdirBytes("sr-ca-cert", "ca.crt", pemBytes)
+}
+
+// pkcs12TruststorePem decodes a PKCS#12 truststore (a caller-supplied client
+// trust store) and re-encodes its CA certificates as a single PEM bundle —
+// PEM-consuming registries (Karapace) need their REST client-auth trust anchor
+// in PEM even when the caller supplies PKCS#12.
+func pkcs12TruststorePem(ctx context.Context, trustStore *dagger.File, password *dagger.Secret) (*dagger.File, error) {
+	tsBytes, err := dagFileBytes(ctx, trustStore)
+	if err != nil {
+		return nil, fmt.Errorf("export client trust store: %w", err)
+	}
+	pwd, err := password.Plaintext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("read client trust store password: %w", err)
+	}
+	certs, err := pkcs12.DecodeTrustStore(tsBytes, pwd)
+	if err != nil {
+		return nil, fmt.Errorf("decode client trust store: %w", err)
+	}
+	var buf bytes.Buffer
+	for _, c := range certs {
+		if err := pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: c.Raw}); err != nil {
+			return nil, fmt.Errorf("encode client trust cert PEM: %w", err)
+		}
+	}
+	return writeWorkdirBytes("sr-rest-ca", "rest-ca.crt", buf.Bytes())
 }

--- a/daggerverse/kafka/schema_registry.go
+++ b/daggerverse/kafka/schema_registry.go
@@ -714,7 +714,11 @@ func (c *SchemaRegistryClient) do(ctx context.Context, method, path string, reqB
 	}
 	httpClient := http.DefaultClient
 	if cfg != nil {
-		httpClient = &http.Client{Transport: &http.Transport{TLSClientConfig: cfg}}
+		// Clone DefaultTransport so we keep its proxy handling, dial/keepalive
+		// timeouts, and HTTP/2 settings, overriding only the TLS config.
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.TLSClientConfig = cfg
+		httpClient = &http.Client{Transport: transport}
 	}
 
 	var body []byte

--- a/daggerverse/kafka/schema_registry.go
+++ b/daggerverse/kafka/schema_registry.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -15,15 +17,34 @@ import (
 	"time"
 
 	"dagger/kafka/internal/dagger"
+
+	"software.sslmate.com/src/go-pkcs12"
 )
 
-// schemaRegistryPort is the HTTP port the Confluent Schema Registry REST
-// API listens on, both inside the container and as advertised to callers.
+// schemaRegistryPort is the HTTP(S) port the Schema Registry REST API listens
+// on, both inside the container and as advertised to callers.
 const schemaRegistryPort = 8081
 
 // srContentType is the versioned media type the Schema Registry REST API
 // expects on requests and returns on responses.
 const srContentType = "application/vnd.schemaregistry.v1+json"
+
+// Schema Registry TLS material mount paths inside the registry containers.
+// PKCS#12 for the Java (Confluent) and Quarkus (Apicurio) images; PEM for the
+// Python (Karapace) image.
+const (
+	srServerKeystorePath       = "/etc/schema-registry/secrets/server-keystore.p12"
+	srRestTruststorePath       = "/etc/schema-registry/secrets/rest-truststore.p12"
+	srKafkastoreTruststorePath = "/etc/schema-registry/secrets/kafkastore-truststore.p12"
+	srKafkastoreKeystorePath   = "/etc/schema-registry/secrets/kafkastore-keystore.p12"
+
+	karapaceServerCertPath = "/etc/karapace/certs/server.crt"
+	karapaceServerKeyPath  = "/etc/karapace/certs/server.key"
+	karapaceStorageCaPath  = "/etc/karapace/certs/storage-ca.crt"
+	karapaceRestCaPath     = "/etc/karapace/certs/rest-ca.crt"
+	karapaceClientCertPath = "/etc/karapace/certs/client.crt"
+	karapaceClientKeyPath  = "/etc/karapace/certs/client.key"
+)
 
 // SchemaRegistry is the module's shared Schema Registry abstraction, bound
 // to a Kafka cluster's brokers. It stores schemas in the cluster's `_schemas`
@@ -62,6 +83,13 @@ type SchemaRegistry struct {
 	//
 	// +private
 	BasePath string
+	// SecurityMode records how the registry's REST endpoint is secured
+	// (PLAINTEXT | TLS | MTLS). Client() reads it to choose the URL scheme
+	// (http vs https) and to validate the caller's client-security profile
+	// matches the server side.
+	//
+	// +private
+	SecurityMode string
 }
 
 // SchemaRegistryClient is a pure-Go net/http client for a Schema Registry's
@@ -72,6 +100,16 @@ type SchemaRegistryClient struct {
 	Svc *dagger.Service
 	// +private
 	BaseURL string
+	// +private
+	SecurityMode string // PLAINTEXT | TLS | MTLS
+	// +private
+	TrustStore *dagger.File // PKCS#12 CA(s) verifying the registry REST cert (TLS+MTLS)
+	// +private
+	TrustStorePassword *dagger.Secret
+	// +private
+	KeyStore *dagger.File // PKCS#12 client leaf presented to the registry (MTLS)
+	// +private
+	KeyStorePassword *dagger.Secret
 }
 
 // RegisteredSchema is one schema version as the Confluent Schema Registry
@@ -87,6 +125,97 @@ type RegisteredSchema struct {
 	SchemaID   int    // globally-unique registry schema id
 	Definition string // the schema text itself (Avro / JSON Schema / Protobuf)
 	SchemaType string // AVRO | JSON | PROTOBUF
+}
+
+// validateRegistrySecurity checks a registry constructor's security profile is
+// present, has a known mode, carries the material that mode requires, and
+// matches the backing cluster's security mode. name is the constructor name for
+// error messages. A matching mode means a PLAINTEXT registry pairs with a
+// PLAINTEXT cluster (reproducing pre-TLS behaviour) and a TLS/mTLS registry
+// pairs with a same-mode cluster so its kafka-storage connection authenticates.
+func validateRegistrySecurity(name string, security *SchemaRegistrySecurity, clusterMode string) error {
+	if security == nil {
+		return fmt.Errorf("%s: security must not be nil (use Kafka.PlaintextSchemaRegistrySecurity() for an unencrypted registry)", name)
+	}
+	switch security.Mode {
+	case "PLAINTEXT", "TLS", "MTLS":
+	default:
+		return fmt.Errorf("%s: unknown security mode %q (want PLAINTEXT|TLS|MTLS)", name, security.Mode)
+	}
+	if security.Mode != clusterMode {
+		return fmt.Errorf(
+			"%s: registry security is %q but the cluster client listener is %q; they must match "+
+				"so the registry's kafka-storage connection authenticates against the broker",
+			name, security.Mode, clusterMode,
+		)
+	}
+	if (security.Mode == "TLS" || security.Mode == "MTLS") && (security.CaKeyStore == nil || security.CaKeyStorePassword == nil) {
+		return fmt.Errorf("%s: %s security requires a CA keystore and password", name, security.Mode)
+	}
+	if security.Mode == "MTLS" && (security.ClientTrustStore == nil || security.ClientTrustStorePassword == nil) {
+		return fmt.Errorf("%s: MTLS security requires a client trust store and password", name)
+	}
+	return nil
+}
+
+// applyConfluentSchemaRegistryTls mounts the registry's REST server leaf and
+// broker-facing truststore/keystore onto a cp-schema-registry container and
+// sets the SSL env vars for both surfaces: the Jetty REST endpoint
+// (SCHEMA_REGISTRY_SSL_*) and the kafkastore client connection
+// (SCHEMA_REGISTRY_KAFKASTORE_SSL_*). All material is PKCS#12. Assumes the
+// caller has already switched SCHEMA_REGISTRY_LISTENERS to https and the
+// kafkastore bootstrap scheme to SSL://.
+func applyConfluentSchemaRegistryTls(ctx context.Context, ctr *dagger.Container, security *SchemaRegistrySecurity, srHost string) (*dagger.Container, error) {
+	leaf, err := mintServiceLeaf(ctx, security.CaKeyStore, security.CaKeyStorePassword, srHost, "sr-confluent-rest")
+	if err != nil {
+		return nil, fmt.Errorf("mint schema registry REST leaf: %w", err)
+	}
+	tsFile, tsPwd, err := caTrustStorePkcs12(ctx, security.CaKeyStore, security.CaKeyStorePassword)
+	if err != nil {
+		return nil, fmt.Errorf("derive kafkastore truststore: %w", err)
+	}
+	ctr = ctr.
+		// REST endpoint TLS termination.
+		WithFile(srServerKeystorePath, leaf.KeyStoreFile, dagger.ContainerWithFileOpts{Permissions: 0o644}).
+		WithEnvVariable("SCHEMA_REGISTRY_SSL_KEYSTORE_LOCATION", srServerKeystorePath).
+		WithSecretVariable("SCHEMA_REGISTRY_SSL_KEYSTORE_PASSWORD", leaf.KeyStorePassword).
+		WithEnvVariable("SCHEMA_REGISTRY_SSL_KEYSTORE_TYPE", "PKCS12").
+		WithSecretVariable("SCHEMA_REGISTRY_SSL_KEY_PASSWORD", leaf.KeyStorePassword).
+		// The inter-instance listener (used for leader coordination) defaults
+		// to the http scheme; with an https-only listener it must be pointed
+		// at https or startup fails with "No listener configured with
+		// requested scheme http".
+		WithEnvVariable("SCHEMA_REGISTRY_INTER_INSTANCE_PROTOCOL", "https").
+		// kafkastore connection verifies the broker against the cluster CA.
+		WithEnvVariable("SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL", "SSL").
+		WithFile(srKafkastoreTruststorePath, tsFile, dagger.ContainerWithFileOpts{Permissions: 0o644}).
+		WithEnvVariable("SCHEMA_REGISTRY_KAFKASTORE_SSL_TRUSTSTORE_LOCATION", srKafkastoreTruststorePath).
+		WithSecretVariable("SCHEMA_REGISTRY_KAFKASTORE_SSL_TRUSTSTORE_PASSWORD", tsPwd).
+		WithEnvVariable("SCHEMA_REGISTRY_KAFKASTORE_SSL_TRUSTSTORE_TYPE", "PKCS12")
+
+	if security.Mode == "MTLS" {
+		// REST endpoint requires client certs, trusted via ClientTrustStore.
+		ctr = ctr.
+			WithEnvVariable("SCHEMA_REGISTRY_SSL_CLIENT_AUTHENTICATION", "REQUIRED").
+			WithFile(srRestTruststorePath, security.ClientTrustStore, dagger.ContainerWithFileOpts{Permissions: 0o644}).
+			WithEnvVariable("SCHEMA_REGISTRY_SSL_TRUSTSTORE_LOCATION", srRestTruststorePath).
+			WithSecretVariable("SCHEMA_REGISTRY_SSL_TRUSTSTORE_PASSWORD", security.ClientTrustStorePassword).
+			WithEnvVariable("SCHEMA_REGISTRY_SSL_TRUSTSTORE_TYPE", "PKCS12")
+
+		// kafkastore connection presents the registry's own client leaf to
+		// the mTLS broker (signed by the same CA the broker trusts).
+		clientLeaf, err := mintClientLeaf(ctx, security.CaKeyStore, security.CaKeyStorePassword, srHost, "sr-confluent-kafkastore")
+		if err != nil {
+			return nil, fmt.Errorf("mint schema registry kafkastore client leaf: %w", err)
+		}
+		ctr = ctr.
+			WithFile(srKafkastoreKeystorePath, clientLeaf.KeyStoreFile, dagger.ContainerWithFileOpts{Permissions: 0o644}).
+			WithEnvVariable("SCHEMA_REGISTRY_KAFKASTORE_SSL_KEYSTORE_LOCATION", srKafkastoreKeystorePath).
+			WithSecretVariable("SCHEMA_REGISTRY_KAFKASTORE_SSL_KEYSTORE_PASSWORD", clientLeaf.KeyStorePassword).
+			WithEnvVariable("SCHEMA_REGISTRY_KAFKASTORE_SSL_KEYSTORE_TYPE", "PKCS12").
+			WithSecretVariable("SCHEMA_REGISTRY_KAFKASTORE_SSL_KEY_PASSWORD", clientLeaf.KeyStorePassword)
+	}
+	return ctr, nil
 }
 
 // ConfluentSchemaRegistry spins up a Confluent Schema Registry service
@@ -111,6 +240,7 @@ func (k *Kafka) ConfluentSchemaRegistry(
 	registry string,
 	// +default="8.2.0"
 	tag string,
+	security *SchemaRegistrySecurity,
 ) (*SchemaRegistry, error) {
 	if cluster == nil {
 		return nil, fmt.Errorf("Kafka.ConfluentSchemaRegistry: cluster must not be nil")
@@ -118,15 +248,10 @@ func (k *Kafka) ConfluentSchemaRegistry(
 	if len(cluster.BrokerSvcs) == 0 {
 		return nil, fmt.Errorf("Kafka.ConfluentSchemaRegistry: cluster has no brokers")
 	}
-	if cluster.ClientSecurityMode != "PLAINTEXT" {
-		return nil, fmt.Errorf(
-			"Kafka.ConfluentSchemaRegistry: cluster client listener is %q; only PLAINTEXT "+
-				"is supported in this story. TLS / mTLS Schema Registry "+
-				"(SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL=SSL plus keystore mounts) "+
-				"is a follow-up story.",
-			cluster.ClientSecurityMode,
-		)
+	if err := validateRegistrySecurity("Kafka.ConfluentSchemaRegistry", security, cluster.ClientSecurityMode); err != nil {
+		return nil, err
 	}
+	tls := security.Mode != "PLAINTEXT"
 
 	image := fmt.Sprintf("%s/confluentinc/cp-schema-registry:%s", registry, tag)
 	// `csr-` (confluent schema registry) keeps the hostname short — a
@@ -136,11 +261,16 @@ func (k *Kafka) ConfluentSchemaRegistry(
 	srHost := "csr-" + clusterHostSuffix(cluster.ClusterID)
 
 	// cp-schema-registry wants its bootstrap servers scheme-prefixed;
-	// Cluster.BootstrapServers reports bare host:port.
+	// Cluster.BootstrapServers reports bare host:port. On a TLS/mTLS cluster
+	// the kafkastore connection dials the broker's SSL listener.
+	storeScheme := "PLAINTEXT"
+	if tls {
+		storeScheme = "SSL"
+	}
 	bootstrap := cluster.BootstrapServers()
 	kafkastore := make([]string, len(bootstrap))
 	for i, b := range bootstrap {
-		kafkastore[i] = "PLAINTEXT://" + b
+		kafkastore[i] = storeScheme + "://" + b
 	}
 
 	// The brokers run with KAFKA_AUTO_CREATE_TOPICS_ENABLE=false and
@@ -153,13 +283,24 @@ func (k *Kafka) ConfluentSchemaRegistry(
 		rf = 3
 	}
 
+	listenerScheme := "http"
+	if tls {
+		listenerScheme = "https"
+	}
 	ctr := dag.Container().
 		From(image).
 		WithEnvVariable("SCHEMA_REGISTRY_HOST_NAME", srHost).
-		WithEnvVariable("SCHEMA_REGISTRY_LISTENERS", fmt.Sprintf("http://0.0.0.0:%d", schemaRegistryPort)).
+		WithEnvVariable("SCHEMA_REGISTRY_LISTENERS", fmt.Sprintf("%s://0.0.0.0:%d", listenerScheme, schemaRegistryPort)).
 		WithEnvVariable("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", strings.Join(kafkastore, ",")).
 		WithEnvVariable("SCHEMA_REGISTRY_KAFKASTORE_TOPIC_REPLICATION_FACTOR", strconv.Itoa(rf)).
 		WithExposedPort(schemaRegistryPort)
+	if tls {
+		var err error
+		ctr, err = applyConfluentSchemaRegistryTls(ctx, ctr, security, srHost)
+		if err != nil {
+			return nil, err
+		}
+	}
 	ctr = cluster.BindBrokers(ctr)
 
 	srSvc := ctr.
@@ -170,7 +311,64 @@ func (k *Kafka) ConfluentSchemaRegistry(
 		SchemaRegistrySvc: srSvc,
 		AdvertisedHost:    srHost,
 		AdvertisedPort:    schemaRegistryPort,
+		SecurityMode:      security.Mode,
 	}, nil
+}
+
+// applyApicurioSchemaRegistryTls terminates TLS on Apicurio's Quarkus REST
+// endpoint (PKCS#12 keystore) and secures its kafkasql storage connection to
+// the broker.
+//
+// NOTE: the kafkasql storage SSL env-var surface is the least-certain knob in
+// this feature (Apicurio 2.6 has shifted it across `KAFKA_SSL_*`,
+// `REGISTRY_KAFKASQL_SECURITY_*`, and `apicurio.kafka.common.*` between minor
+// builds); it is validated by the Apicurio TLS round-trip test and iterated
+// under TDD. PKCS#12 (not PEM) is fed to the storage truststore to avoid
+// Apicurio's PEM-truststore-plus-password startup failure (Apicurio #4975).
+func applyApicurioSchemaRegistryTls(ctx context.Context, ctr *dagger.Container, security *SchemaRegistrySecurity, srHost string) (*dagger.Container, error) {
+	leaf, err := mintServiceLeaf(ctx, security.CaKeyStore, security.CaKeyStorePassword, srHost, "sr-apicurio-rest")
+	if err != nil {
+		return nil, fmt.Errorf("mint apicurio REST leaf: %w", err)
+	}
+	tsFile, tsPwd, err := caTrustStorePkcs12(ctx, security.CaKeyStore, security.CaKeyStorePassword)
+	if err != nil {
+		return nil, fmt.Errorf("derive kafkasql truststore: %w", err)
+	}
+	ctr = ctr.
+		// Quarkus REST TLS: serve HTTPS only on schemaRegistryPort.
+		WithFile(srServerKeystorePath, leaf.KeyStoreFile, dagger.ContainerWithFileOpts{Permissions: 0o644}).
+		WithEnvVariable("QUARKUS_HTTP_SSL_PORT", strconv.Itoa(schemaRegistryPort)).
+		WithEnvVariable("QUARKUS_HTTP_INSECURE_REQUESTS", "disabled").
+		WithEnvVariable("QUARKUS_HTTP_SSL_CERTIFICATE_KEY_STORE_FILE", srServerKeystorePath).
+		WithSecretVariable("QUARKUS_HTTP_SSL_CERTIFICATE_KEY_STORE_PASSWORD", leaf.KeyStorePassword).
+		WithEnvVariable("QUARKUS_HTTP_SSL_CERTIFICATE_KEY_STORE_FILE_TYPE", "PKCS12").
+		// kafkasql storage over SSL, PKCS#12 truststore.
+		WithFile(srKafkastoreTruststorePath, tsFile, dagger.ContainerWithFileOpts{Permissions: 0o644}).
+		WithEnvVariable("KAFKA_SECURITY_PROTOCOL", "SSL").
+		WithEnvVariable("KAFKA_SSL_TRUSTSTORE_LOCATION", srKafkastoreTruststorePath).
+		WithSecretVariable("KAFKA_SSL_TRUSTSTORE_PASSWORD", tsPwd).
+		WithEnvVariable("KAFKA_SSL_TRUSTSTORE_TYPE", "PKCS12")
+
+	if security.Mode == "MTLS" {
+		ctr = ctr.
+			WithEnvVariable("QUARKUS_HTTP_SSL_CLIENT_AUTH", "required").
+			WithFile(srRestTruststorePath, security.ClientTrustStore, dagger.ContainerWithFileOpts{Permissions: 0o644}).
+			WithEnvVariable("QUARKUS_HTTP_SSL_CERTIFICATE_TRUST_STORE_FILE", srRestTruststorePath).
+			WithSecretVariable("QUARKUS_HTTP_SSL_CERTIFICATE_TRUST_STORE_PASSWORD", security.ClientTrustStorePassword).
+			WithEnvVariable("QUARKUS_HTTP_SSL_CERTIFICATE_TRUST_STORE_FILE_TYPE", "PKCS12")
+
+		clientLeaf, err := mintClientLeaf(ctx, security.CaKeyStore, security.CaKeyStorePassword, srHost, "sr-apicurio-kafkasql")
+		if err != nil {
+			return nil, fmt.Errorf("mint apicurio kafkasql client leaf: %w", err)
+		}
+		ctr = ctr.
+			WithFile(srKafkastoreKeystorePath, clientLeaf.KeyStoreFile, dagger.ContainerWithFileOpts{Permissions: 0o644}).
+			WithEnvVariable("KAFKA_SSL_KEYSTORE_LOCATION", srKafkastoreKeystorePath).
+			WithSecretVariable("KAFKA_SSL_KEYSTORE_PASSWORD", clientLeaf.KeyStorePassword).
+			WithEnvVariable("KAFKA_SSL_KEYSTORE_TYPE", "PKCS12").
+			WithSecretVariable("KAFKA_SSL_KEY_PASSWORD", clientLeaf.KeyStorePassword)
+	}
+	return ctr, nil
 }
 
 // ApicurioSchemaRegistry spins up an Apicurio Registry service
@@ -185,8 +383,10 @@ func (k *Kafka) ConfluentSchemaRegistry(
 // Protobuf, OpenAPI, AsyncAPI, GraphQL, WSDL, XSD); over the CSR-compat
 // surface only the AVRO / JSON / PROTOBUF subset is reachable.
 //
-// Only PLAINTEXT clusters are supported in this story: the constructor
-// rejects TLS / mTLS clusters and points callers at the TLS follow-up.
+// security must match the backing cluster's mode: a PLAINTEXT profile keeps
+// the REST endpoint on HTTP and the kafkasql connection unencrypted; a TLS /
+// mTLS profile terminates HTTPS on the REST endpoint and secures the kafkasql
+// connection against a matching-mode cluster.
 //
 // Session-cached for the same reason ConfluentSchemaRegistry is — a
 // `+cache="never"` directive here would mint a brand-new registry service
@@ -200,6 +400,7 @@ func (k *Kafka) ApicurioSchemaRegistry(
 	registry string,
 	// +default="2.6.13.Final"
 	tag string,
+	security *SchemaRegistrySecurity,
 ) (*SchemaRegistry, error) {
 	if cluster == nil {
 		return nil, fmt.Errorf("Kafka.ApicurioSchemaRegistry: cluster must not be nil")
@@ -207,15 +408,10 @@ func (k *Kafka) ApicurioSchemaRegistry(
 	if len(cluster.BrokerSvcs) == 0 {
 		return nil, fmt.Errorf("Kafka.ApicurioSchemaRegistry: cluster has no brokers")
 	}
-	if cluster.ClientSecurityMode != "PLAINTEXT" {
-		return nil, fmt.Errorf(
-			"Kafka.ApicurioSchemaRegistry: cluster client listener is %q; only PLAINTEXT "+
-				"is supported in this story. TLS / mTLS Schema Registry "+
-				"(KAFKA_SSL_* / REGISTRY_KAFKASQL_SECURITY_PROTOCOL plus keystore mounts) "+
-				"is a follow-up story.",
-			cluster.ClientSecurityMode,
-		)
+	if err := validateRegistrySecurity("Kafka.ApicurioSchemaRegistry", security, cluster.ClientSecurityMode); err != nil {
+		return nil, err
 	}
+	tls := security.Mode != "PLAINTEXT"
 
 	image := fmt.Sprintf("%s/apicurio/apicurio-registry-kafkasql:%s", registry, tag)
 	// `asr-` (apicurio schema registry) keeps the hostname short — a longer
@@ -230,10 +426,21 @@ func (k *Kafka) ApicurioSchemaRegistry(
 	ctr := dag.Container().
 		From(image).
 		WithEnvVariable("KAFKA_BOOTSTRAP_SERVERS", strings.Join(cluster.BootstrapServers(), ",")).
-		// Apicurio is a Quarkus app listening on 8080 by default; pin it to
-		// schemaRegistryPort so the advertised port matches cp-schema-registry.
-		WithEnvVariable("QUARKUS_HTTP_PORT", strconv.Itoa(schemaRegistryPort)).
 		WithExposedPort(schemaRegistryPort)
+	// Apicurio is a Quarkus app listening on 8080 by default; pin it to
+	// schemaRegistryPort so the advertised port matches cp-schema-registry.
+	// Under TLS the port is the HTTPS SSL port (set in the tls helper) and the
+	// plaintext HTTP port is disabled, so only pin QUARKUS_HTTP_PORT here for
+	// the plaintext path.
+	if !tls {
+		ctr = ctr.WithEnvVariable("QUARKUS_HTTP_PORT", strconv.Itoa(schemaRegistryPort))
+	} else {
+		var err error
+		ctr, err = applyApicurioSchemaRegistryTls(ctx, ctr, security, srHost)
+		if err != nil {
+			return nil, err
+		}
+	}
 	ctr = cluster.BindBrokers(ctr)
 
 	srSvc := ctr.
@@ -246,8 +453,57 @@ func (k *Kafka) ApicurioSchemaRegistry(
 		AdvertisedPort:    schemaRegistryPort,
 		// Apicurio serves the Confluent-compatible REST API under this
 		// prefix rather than at the root.
-		BasePath: "/apis/ccompat/v7",
+		BasePath:     "/apis/ccompat/v7",
+		SecurityMode: security.Mode,
 	}, nil
+}
+
+// applyKarapaceSchemaRegistryTls terminates TLS on Karapace's REST endpoint
+// and secures its aiokafka storage connection to the broker. Karapace is a
+// Python service that consumes PEM material only (no PKCS#12), so the leaf's
+// PEM cert/key and the CA cert PEM are mounted rather than keystores; the
+// private keys cross as *dagger.Secret so their plaintext never lands on disk.
+func applyKarapaceSchemaRegistryTls(ctx context.Context, ctr *dagger.Container, security *SchemaRegistrySecurity, srHost string) (*dagger.Container, error) {
+	leaf, err := mintServiceLeaf(ctx, security.CaKeyStore, security.CaKeyStorePassword, srHost, "sr-karapace-rest")
+	if err != nil {
+		return nil, fmt.Errorf("mint karapace REST leaf: %w", err)
+	}
+	caPem, err := caCertPem(ctx, security.CaKeyStore, security.CaKeyStorePassword)
+	if err != nil {
+		return nil, fmt.Errorf("derive karapace storage CA: %w", err)
+	}
+	ctr = ctr.
+		// REST endpoint TLS termination (PEM).
+		WithFile(karapaceServerCertPath, leaf.CertPemFile, dagger.ContainerWithFileOpts{Permissions: 0o644}).
+		WithMountedSecret(karapaceServerKeyPath, leaf.PrivateKeyPem, dagger.ContainerWithMountedSecretOpts{Mode: 0o444}).
+		WithEnvVariable("KARAPACE_SERVER_TLS_CERTFILE", karapaceServerCertPath).
+		WithEnvVariable("KARAPACE_SERVER_TLS_KEYFILE", karapaceServerKeyPath).
+		// aiokafka storage connection verifies the broker against the cluster CA.
+		WithEnvVariable("KARAPACE_SECURITY_PROTOCOL", "SSL").
+		WithFile(karapaceStorageCaPath, caPem, dagger.ContainerWithFileOpts{Permissions: 0o644}).
+		WithEnvVariable("KARAPACE_SSL_CAFILE", karapaceStorageCaPath)
+
+	if security.Mode == "MTLS" {
+		// REST endpoint requires client certs; Karapace needs the trust anchor
+		// in PEM, so convert the caller's PKCS#12 client trust store.
+		restCa, err := pkcs12TruststorePem(ctx, security.ClientTrustStore, security.ClientTrustStorePassword)
+		if err != nil {
+			return nil, fmt.Errorf("derive karapace REST client-auth CA: %w", err)
+		}
+		clientLeaf, err := mintClientLeaf(ctx, security.CaKeyStore, security.CaKeyStorePassword, srHost, "sr-karapace-storage")
+		if err != nil {
+			return nil, fmt.Errorf("mint karapace storage client leaf: %w", err)
+		}
+		ctr = ctr.
+			WithFile(karapaceRestCaPath, restCa, dagger.ContainerWithFileOpts{Permissions: 0o644}).
+			WithEnvVariable("KARAPACE_SERVER_TLS_CAFILE", karapaceRestCaPath).
+			WithEnvVariable("KARAPACE_SERVER_TLS_CLIENT_AUTH", "required").
+			WithFile(karapaceClientCertPath, clientLeaf.CertPemFile, dagger.ContainerWithFileOpts{Permissions: 0o644}).
+			WithMountedSecret(karapaceClientKeyPath, clientLeaf.PrivateKeyPem, dagger.ContainerWithMountedSecretOpts{Mode: 0o444}).
+			WithEnvVariable("KARAPACE_SSL_CERTFILE", karapaceClientCertPath).
+			WithEnvVariable("KARAPACE_SSL_KEYFILE", karapaceClientKeyPath)
+	}
+	return ctr, nil
 }
 
 // KarapaceSchemaRegistry spins up a Karapace service
@@ -263,8 +519,10 @@ func (k *Kafka) ApicurioSchemaRegistry(
 // which also keeps CI clear of Docker Hub rate limits and Confluent's image
 // licensing.
 //
-// Only PLAINTEXT clusters are supported in this story: the constructor
-// rejects TLS / mTLS clusters and points callers at the TLS follow-up.
+// security must match the backing cluster's mode. Karapace consumes PEM (not
+// PKCS#12) for its own listener and aiokafka storage; the module extracts PEM
+// from the supplied CA internally, so callers pass the same PKCS#12 profile
+// shape as the other registries.
 //
 // Session-cached for the same reason ConfluentSchemaRegistry is — a
 // `+cache="never"` directive here would mint a brand-new registry service
@@ -278,6 +536,7 @@ func (k *Kafka) KarapaceSchemaRegistry(
 	registry string,
 	// +default="6.1.4"
 	tag string,
+	security *SchemaRegistrySecurity,
 ) (*SchemaRegistry, error) {
 	if cluster == nil {
 		return nil, fmt.Errorf("Kafka.KarapaceSchemaRegistry: cluster must not be nil")
@@ -285,15 +544,10 @@ func (k *Kafka) KarapaceSchemaRegistry(
 	if len(cluster.BrokerSvcs) == 0 {
 		return nil, fmt.Errorf("Kafka.KarapaceSchemaRegistry: cluster has no brokers")
 	}
-	if cluster.ClientSecurityMode != "PLAINTEXT" {
-		return nil, fmt.Errorf(
-			"Kafka.KarapaceSchemaRegistry: cluster client listener is %q; only PLAINTEXT "+
-				"is supported in this story. TLS / mTLS Schema Registry "+
-				"(KARAPACE_SECURITY_PROTOCOL=SSL plus keystore mounts) "+
-				"is a follow-up story.",
-			cluster.ClientSecurityMode,
-		)
+	if err := validateRegistrySecurity("Kafka.KarapaceSchemaRegistry", security, cluster.ClientSecurityMode); err != nil {
+		return nil, err
 	}
+	tls := security.Mode != "PLAINTEXT"
 
 	image := fmt.Sprintf("%s/aiven-open/karapace:%s", registry, tag)
 	// `ksr-` (karapace schema registry) keeps the hostname short — a longer
@@ -335,6 +589,13 @@ func (k *Kafka) KarapaceSchemaRegistry(
 		// instead.
 		WithoutDockerHealthcheck().
 		WithExposedPort(schemaRegistryPort)
+	if tls {
+		var err error
+		ctr, err = applyKarapaceSchemaRegistryTls(ctx, ctr, security, srHost)
+		if err != nil {
+			return nil, err
+		}
+	}
 	ctr = cluster.BindBrokers(ctr)
 
 	// Karapace's production image ships no ENTRYPOINT/CMD. The schema
@@ -350,6 +611,7 @@ func (k *Kafka) KarapaceSchemaRegistry(
 		SchemaRegistrySvc: srSvc,
 		AdvertisedHost:    srHost,
 		AdvertisedPort:    schemaRegistryPort,
+		SecurityMode:      security.Mode,
 	}, nil
 }
 
@@ -375,13 +637,29 @@ func (s *SchemaRegistry) BindTo(ctr *dagger.Container) *dagger.Container {
 	return ctr.WithServiceBinding(s.AdvertisedHost, s.SchemaRegistrySvc)
 }
 
-// Client returns a typed HTTP client targeting this registry's REST API.
-// No I/O happens at construction time.
-func (s *SchemaRegistry) Client() *SchemaRegistryClient {
-	return &SchemaRegistryClient{
-		Svc:     s.SchemaRegistrySvc,
-		BaseURL: fmt.Sprintf("http://%s:%d%s", s.AdvertisedHost, s.AdvertisedPort, s.BasePath),
+// Client returns a typed HTTP client targeting this registry's REST API. The
+// URL scheme (http vs https) follows the registry's own security mode; the
+// supplied security profile must match it (a TLS/mTLS registry needs a TLS/mTLS
+// client profile, verified when the first request runs). No I/O happens at
+// construction time.
+func (s *SchemaRegistry) Client(security *SchemaRegistryClientSecurity) *SchemaRegistryClient {
+	scheme := "http"
+	if s.SecurityMode == "TLS" || s.SecurityMode == "MTLS" {
+		scheme = "https"
 	}
+	c := &SchemaRegistryClient{
+		Svc:          s.SchemaRegistrySvc,
+		BaseURL:      fmt.Sprintf("%s://%s:%d%s", scheme, s.AdvertisedHost, s.AdvertisedPort, s.BasePath),
+		SecurityMode: "PLAINTEXT",
+	}
+	if security != nil {
+		c.SecurityMode = security.Mode
+		c.TrustStore = security.TrustStore
+		c.TrustStorePassword = security.TrustStorePassword
+		c.KeyStore = security.KeyStore
+		c.KeyStorePassword = security.KeyStorePassword
+	}
+	return c
 }
 
 // Stop tears down the Schema Registry service. Kill is set so the stop
@@ -420,8 +698,23 @@ func (c *SchemaRegistryClient) do(ctx context.Context, method, path string, reqB
 	if c.Svc == nil {
 		return nil, 0, fmt.Errorf("schema registry client has no service")
 	}
+	https := strings.HasPrefix(c.BaseURL, "https://")
+	if https && c.SecurityMode == "PLAINTEXT" {
+		return nil, 0, fmt.Errorf("schema registry serves HTTPS but the client security is PLAINTEXT; pass a TLS or mTLS SchemaRegistryClientSecurity")
+	}
+	if !https && c.SecurityMode != "PLAINTEXT" {
+		return nil, 0, fmt.Errorf("schema registry serves plain HTTP but the client security is %s; pass PlaintextSchemaRegistryClientSecurity", c.SecurityMode)
+	}
 	if _, err := c.Svc.Start(ctx); err != nil {
 		return nil, 0, fmt.Errorf("start schema registry service: %w", err)
+	}
+	cfg, err := c.tlsConfig(ctx)
+	if err != nil {
+		return nil, 0, fmt.Errorf("build tls config: %w", err)
+	}
+	httpClient := http.DefaultClient
+	if cfg != nil {
+		httpClient = &http.Client{Transport: &http.Transport{TLSClientConfig: cfg}}
 	}
 
 	var body []byte
@@ -460,7 +753,7 @@ func (c *SchemaRegistryClient) do(ctx context.Context, method, path string, reqB
 			req.Header.Set("Content-Type", srContentType)
 		}
 
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := httpClient.Do(req)
 		if err != nil {
 			// The registry container may still be starting its HTTP
 			// listener; connection-level failures are retryable.
@@ -486,6 +779,63 @@ func (c *SchemaRegistryClient) do(ctx context.Context, method, path string, reqB
 		return respBody, resp.StatusCode, nil
 	}
 	return nil, 0, fmt.Errorf("%s %s: schema registry not ready after %d attempts: %w", method, path, attempts, lastErr)
+}
+
+// tlsConfig materializes the client-side *tls.Config from the client's PKCS#12
+// truststore (and, for mTLS, keystore), mirroring Client.tlsConfig on the
+// franz-go path. Returns (nil, nil) for a plaintext registry client.
+func (c *SchemaRegistryClient) tlsConfig(ctx context.Context) (*tls.Config, error) {
+	if c.SecurityMode == "PLAINTEXT" {
+		return nil, nil
+	}
+	if c.TrustStore == nil || c.TrustStorePassword == nil {
+		return nil, fmt.Errorf("%s registry client requires a trust store and password", c.SecurityMode)
+	}
+	tsBytes, err := dagFileBytes(ctx, c.TrustStore)
+	if err != nil {
+		return nil, fmt.Errorf("export truststore: %w", err)
+	}
+	tsPwd, err := c.TrustStorePassword.Plaintext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("read truststore password: %w", err)
+	}
+	rootCerts, err := pkcs12.DecodeTrustStore(tsBytes, tsPwd)
+	if err != nil {
+		return nil, fmt.Errorf("decode truststore: %w", err)
+	}
+	pool := x509.NewCertPool()
+	for _, ca := range rootCerts {
+		pool.AddCert(ca)
+	}
+	cfg := &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12}
+
+	if c.SecurityMode == "MTLS" {
+		if c.KeyStore == nil || c.KeyStorePassword == nil {
+			return nil, fmt.Errorf("MTLS registry client requires a key store and password")
+		}
+		ksBytes, err := dagFileBytes(ctx, c.KeyStore)
+		if err != nil {
+			return nil, fmt.Errorf("export keystore: %w", err)
+		}
+		ksPwd, err := c.KeyStorePassword.Plaintext(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("read keystore password: %w", err)
+		}
+		priv, leaf, chain, err := pkcs12.DecodeChain(ksBytes, ksPwd)
+		if err != nil {
+			return nil, fmt.Errorf("decode keystore: %w", err)
+		}
+		certBytes := [][]byte{leaf.Raw}
+		for _, link := range chain {
+			certBytes = append(certBytes, link.Raw)
+		}
+		cfg.Certificates = []tls.Certificate{{
+			Certificate: certBytes,
+			PrivateKey:  priv,
+			Leaf:        leaf,
+		}}
+	}
+	return cfg, nil
 }
 
 // isConnRefused reports whether err is a connection-refused dial failure,

--- a/daggerverse/kafka/security_schema_registry.go
+++ b/daggerverse/kafka/security_schema_registry.go
@@ -1,0 +1,126 @@
+package main
+
+import "dagger/kafka/internal/dagger"
+
+// SchemaRegistrySecurity describes how a Schema Registry's REST endpoint
+// authenticates and encrypts traffic from clients, mirroring *ServerSecurity
+// on the broker side. The same profile also parameterises the registry's
+// kafka-storage connection to the backing cluster: the CA it carries doubles
+// as the trust anchor the registry uses to dial the cluster's TLS/mTLS client
+// listener (the single-CA convention — pass the same CA to the cluster and the
+// registry).
+type SchemaRegistrySecurity struct {
+	// +private
+	Mode string // PLAINTEXT | TLS | MTLS
+	// +private
+	CaKeyStore *dagger.File // PKCS#12 CA used to mint the registry's REST server leaf and derive the broker-facing truststore (TLS + MTLS)
+	// +private
+	CaKeyStorePassword *dagger.Secret
+	// +private
+	ClientTrustStore *dagger.File // PKCS#12 of CA(s) trusted to sign incoming REST client certs (MTLS only)
+	// +private
+	ClientTrustStorePassword *dagger.Secret
+}
+
+// SchemaRegistryClientSecurity describes how a SchemaRegistryClient's HTTP
+// client authenticates to a Schema Registry's REST endpoint, mirroring
+// *ClientSecurity on the broker side.
+type SchemaRegistryClientSecurity struct {
+	// +private
+	Mode string // PLAINTEXT | TLS | MTLS
+	// +private
+	TrustStore *dagger.File // PKCS#12 of the CA(s) the client trusts to identify the registry (TLS + MTLS)
+	// +private
+	TrustStorePassword *dagger.Secret
+	// +private
+	KeyStore *dagger.File // PKCS#12 of the client's own leaf cert + key (MTLS only)
+	// +private
+	KeyStorePassword *dagger.Secret
+}
+
+// PlaintextSchemaRegistrySecurity returns a SchemaRegistrySecurity profile
+// configured for unencrypted, unauthenticated traffic on the registry REST
+// endpoint. It pairs with a PLAINTEXT cluster.
+func (k *Kafka) PlaintextSchemaRegistrySecurity() *SchemaRegistrySecurity {
+	return &SchemaRegistrySecurity{Mode: "PLAINTEXT"}
+}
+
+// TlsSchemaRegistrySecurity returns a SchemaRegistrySecurity profile that
+// terminates TLS on the registry REST endpoint. caKeyStore is a PKCS#12
+// archive containing the CA cert + private key the registry uses to mint its
+// per-registry server leaf (bound to the registry's service hostname as a DNS
+// SAN) and to derive the truststore its kafka-storage connection uses to
+// verify the backing broker. Pair with a TLS cluster minted from the same CA.
+func (k *Kafka) TlsSchemaRegistrySecurity(
+	caKeyStore *dagger.File,
+	caKeyStorePassword *dagger.Secret,
+) *SchemaRegistrySecurity {
+	return &SchemaRegistrySecurity{
+		Mode:               "TLS",
+		CaKeyStore:         caKeyStore,
+		CaKeyStorePassword: caKeyStorePassword,
+	}
+}
+
+// MtlsSchemaRegistrySecurity returns a SchemaRegistrySecurity profile that
+// terminates mTLS on the registry REST endpoint. caKeyStore signs the
+// registry's server leaf (and the registry's own client leaf presented to the
+// broker over mTLS); clientTrustStore holds the CA(s) the registry accepts
+// incoming REST client certs from. Pair with an MTLS cluster minted from the
+// same CA.
+func (k *Kafka) MtlsSchemaRegistrySecurity(
+	caKeyStore *dagger.File,
+	caKeyStorePassword *dagger.Secret,
+	clientTrustStore *dagger.File,
+	clientTrustStorePassword *dagger.Secret,
+) *SchemaRegistrySecurity {
+	return &SchemaRegistrySecurity{
+		Mode:                     "MTLS",
+		CaKeyStore:               caKeyStore,
+		CaKeyStorePassword:       caKeyStorePassword,
+		ClientTrustStore:         clientTrustStore,
+		ClientTrustStorePassword: clientTrustStorePassword,
+	}
+}
+
+// PlaintextSchemaRegistryClientSecurity returns a SchemaRegistryClientSecurity
+// profile configured for unencrypted HTTP traffic.
+func (k *Kafka) PlaintextSchemaRegistryClientSecurity() *SchemaRegistryClientSecurity {
+	return &SchemaRegistryClientSecurity{Mode: "PLAINTEXT"}
+}
+
+// TlsSchemaRegistryClientSecurity returns a SchemaRegistryClientSecurity
+// profile that opens an HTTPS connection to the registry. trustStore is a
+// PKCS#12 archive of the CA(s) the client uses to verify the registry's REST
+// leaf certificate (typically the truststore that pairs with the CA passed to
+// TlsSchemaRegistrySecurity on the server side).
+func (k *Kafka) TlsSchemaRegistryClientSecurity(
+	trustStore *dagger.File,
+	trustStorePassword *dagger.Secret,
+) *SchemaRegistryClientSecurity {
+	return &SchemaRegistryClientSecurity{
+		Mode:               "TLS",
+		TrustStore:         trustStore,
+		TrustStorePassword: trustStorePassword,
+	}
+}
+
+// MtlsSchemaRegistryClientSecurity returns a SchemaRegistryClientSecurity
+// profile that opens an mTLS HTTPS connection: the registry presents its REST
+// server cert (verified against trustStore) and the client presents its own
+// leaf cert from keyStore (signed by a CA the registry trusts via its
+// clientTrustStore).
+func (k *Kafka) MtlsSchemaRegistryClientSecurity(
+	keyStore *dagger.File,
+	keyStorePassword *dagger.Secret,
+	trustStore *dagger.File,
+	trustStorePassword *dagger.Secret,
+) *SchemaRegistryClientSecurity {
+	return &SchemaRegistryClientSecurity{
+		Mode:               "MTLS",
+		TrustStore:         trustStore,
+		TrustStorePassword: trustStorePassword,
+		KeyStore:           keyStore,
+		KeyStorePassword:   keyStorePassword,
+	}
+}

--- a/daggerverse/kafka/tests/dagger.gen.go
+++ b/daggerverse/kafka/tests/dagger.gen.go
@@ -304,6 +304,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Tests).ApicurioSchemaRegistryRegisterLookupRoundTrip(&parent, ctx, kafkaImageTag)
+		case "ApicurioSchemaRegistryTlsRegisterLookupRoundTrip":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var kafkaImageTag string
+			if inputArgs["kafkaImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["kafkaImageTag"]), &kafkaImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg kafkaImageTag", err))
+				}
+			}
+			return nil, (*Tests).ApicurioSchemaRegistryTlsRegisterLookupRoundTrip(&parent, ctx, kafkaImageTag)
 		case "AutoCreateTopicsDisabled":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -458,6 +472,34 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Tests).ConfluentClusterTlsRoundTrip(&parent, ctx, confluentImageTag)
+		case "ConfluentSchemaRegistryMtlsRegisterLookupRoundTrip":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var kafkaImageTag string
+			if inputArgs["kafkaImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["kafkaImageTag"]), &kafkaImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg kafkaImageTag", err))
+				}
+			}
+			return nil, (*Tests).ConfluentSchemaRegistryMtlsRegisterLookupRoundTrip(&parent, ctx, kafkaImageTag)
+		case "ConfluentSchemaRegistryTlsRegisterLookupRoundTrip":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var kafkaImageTag string
+			if inputArgs["kafkaImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["kafkaImageTag"]), &kafkaImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg kafkaImageTag", err))
+				}
+			}
+			return nil, (*Tests).ConfluentSchemaRegistryTlsRegisterLookupRoundTrip(&parent, ctx, kafkaImageTag)
 		case "ConsumerGroupOnSingleBrokerWorks":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -528,6 +570,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Tests).KarapaceSchemaRegistryRegisterLookupRoundTrip(&parent, ctx, kafkaImageTag)
+		case "KarapaceSchemaRegistryTlsRegisterLookupRoundTrip":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var kafkaImageTag string
+			if inputArgs["kafkaImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["kafkaImageTag"]), &kafkaImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg kafkaImageTag", err))
+				}
+			}
+			return nil, (*Tests).KarapaceSchemaRegistryTlsRegisterLookupRoundTrip(&parent, ctx, kafkaImageTag)
 		case "MtlsRequiresClientCert":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -885,7 +941,7 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Tests).SchemaRegistryRegisterLookupRoundTrip(&parent, ctx, kafkaImageTag)
-		case "SchemaRegistryRejectsNonPlaintextCluster":
+		case "SchemaRegistryRejectsClusterModeMismatch":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
 			if err != nil {
@@ -898,7 +954,7 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg kafkaImageTag", err))
 				}
 			}
-			return nil, (*Tests).SchemaRegistryRejectsNonPlaintextCluster(&parent, ctx, kafkaImageTag)
+			return nil, (*Tests).SchemaRegistryRejectsClusterModeMismatch(&parent, ctx, kafkaImageTag)
 		case "SingleNodeClusterStarts":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/kafka/tests/helpers.go
+++ b/daggerverse/kafka/tests/helpers.go
@@ -131,3 +131,42 @@ func contains(haystack []string, needle string) bool {
 	}
 	return false
 }
+
+// plaintextSchemaRegistrySecurity / plaintextSchemaRegistryClientSecurity are
+// shorthand for the unencrypted registry profiles the PLAINTEXT round-trip
+// tests pass to the registry constructors and Client().
+func plaintextSchemaRegistrySecurity() *dagger.KafkaSchemaRegistrySecurity {
+	return dag.Kafka().PlaintextSchemaRegistrySecurity()
+}
+
+func plaintextSchemaRegistryClientSecurity() *dagger.KafkaSchemaRegistryClientSecurity {
+	return dag.Kafka().PlaintextSchemaRegistryClientSecurity()
+}
+
+// issueClientKeystore mints a client leaf (clientAuth EKU) signed by ca with
+// the given common name and returns its PKCS#12 keystore + password, mirroring
+// freshMtlsCluster's client-leaf minting. Used to build an mTLS REST client
+// profile for the Schema Registry mTLS tests.
+func issueClientKeystore(ctx context.Context, ca *dagger.CertificateManagementCertificateAuthority, cn string) (*dagger.File, *dagger.Secret, error) {
+	suffix, err := randHex(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	keyPem, err := dag.Crypto().GenerateRsaKey(dagger.CryptoGenerateRsaKeyOpts{Bits: 2048}).Pem().Contents(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate %s client leaf key: %w", cn, err)
+	}
+	key := dag.SetSecret("sr-client-leaf-key-"+suffix, keyPem)
+	pwdHex, err := dag.Random().Sha256(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate %s client leaf password: %w", cn, err)
+	}
+	pwd := dag.SetSecret("sr-client-leaf-pwd-"+suffix, pwdHex)
+	serial, err := dag.Random().Serial(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate %s client leaf serial: %w", cn, err)
+	}
+	nb := time.Now().UTC().Format(time.RFC3339)
+	ks := ca.IssueClientCertificate(cn, nb, serial, pwd, key).KeyStore()
+	return ks.Pkcs12(), ks.Password(), nil
+}

--- a/daggerverse/kafka/tests/internal/dagger/dagger.gen.go
+++ b/daggerverse/kafka/tests/internal/dagger/dagger.gen.go
@@ -314,7 +314,13 @@ type KafkaRegisteredSchemaID string
 type KafkaSchemaRegistryClientID string
 
 // A unique identifier for an object.
+type KafkaSchemaRegistryClientSecurityID string
+
+// A unique identifier for an object.
 type KafkaSchemaRegistryID string
+
+// A unique identifier for an object.
+type KafkaSchemaRegistrySecurityID string
 
 // A unique identifier for an object.
 type KafkaServerSecurityID string
@@ -13318,12 +13324,32 @@ func (r *Query) LoadKafkaSchemaRegistryClientFromID(id KafkaSchemaRegistryClient
 	}
 }
 
+// Load a KafkaSchemaRegistryClientSecurity from its ID.
+func (r *Query) LoadKafkaSchemaRegistryClientSecurityFromID(id KafkaSchemaRegistryClientSecurityID) *KafkaSchemaRegistryClientSecurity {
+	q := r.query.Select("loadKafkaSchemaRegistryClientSecurityFromID")
+	q = q.Arg("id", id)
+
+	return &KafkaSchemaRegistryClientSecurity{
+		query: q,
+	}
+}
+
 // Load a KafkaSchemaRegistry from its ID.
 func (r *Query) LoadKafkaSchemaRegistryFromID(id KafkaSchemaRegistryID) *KafkaSchemaRegistry {
 	q := r.query.Select("loadKafkaSchemaRegistryFromID")
 	q = q.Arg("id", id)
 
 	return &KafkaSchemaRegistry{
+		query: q,
+	}
+}
+
+// Load a KafkaSchemaRegistrySecurity from its ID.
+func (r *Query) LoadKafkaSchemaRegistrySecurityFromID(id KafkaSchemaRegistrySecurityID) *KafkaSchemaRegistrySecurity {
+	q := r.query.Select("loadKafkaSchemaRegistrySecurityFromID")
+	q = q.Arg("id", id)
+
+	return &KafkaSchemaRegistrySecurity{
 		query: q,
 	}
 }

--- a/daggerverse/kafka/tests/internal/dagger/kafka.gen.go
+++ b/daggerverse/kafka/tests/internal/dagger/kafka.gen.go
@@ -64,7 +64,7 @@ func (r *Binding) AsKafkaRedpandaServerSecurity() *KafkaRedpandaServerSecurity {
 }
 
 // Retrieve the binding value, as type KafkaRegisteredSchema
-func (r *Binding) AsKafkaRegisteredSchema() *KafkaRegisteredSchema { // kafka (../../../../../daggerverse/kafka/schema_registry.go:84:6)
+func (r *Binding) AsKafkaRegisteredSchema() *KafkaRegisteredSchema { // kafka (../../../../../daggerverse/kafka/schema_registry.go:122:6)
 	q := r.query.Select("asKafkaRegisteredSchema")
 
 	return &KafkaRegisteredSchema{
@@ -73,7 +73,7 @@ func (r *Binding) AsKafkaRegisteredSchema() *KafkaRegisteredSchema { // kafka (.
 }
 
 // Retrieve the binding value, as type KafkaSchemaRegistry
-func (r *Binding) AsKafkaSchemaRegistry() *KafkaSchemaRegistry { // kafka (../../../../../daggerverse/kafka/schema_registry.go:42:6)
+func (r *Binding) AsKafkaSchemaRegistry() *KafkaSchemaRegistry { // kafka (../../../../../daggerverse/kafka/schema_registry.go:63:6)
 	q := r.query.Select("asKafkaSchemaRegistry")
 
 	return &KafkaSchemaRegistry{
@@ -82,10 +82,28 @@ func (r *Binding) AsKafkaSchemaRegistry() *KafkaSchemaRegistry { // kafka (../..
 }
 
 // Retrieve the binding value, as type KafkaSchemaRegistryClient
-func (r *Binding) AsKafkaSchemaRegistryClient() *KafkaSchemaRegistryClient { // kafka (../../../../../daggerverse/kafka/schema_registry.go:70:6)
+func (r *Binding) AsKafkaSchemaRegistryClient() *KafkaSchemaRegistryClient { // kafka (../../../../../daggerverse/kafka/schema_registry.go:98:6)
 	q := r.query.Select("asKafkaSchemaRegistryClient")
 
 	return &KafkaSchemaRegistryClient{
+		query: q,
+	}
+}
+
+// Retrieve the binding value, as type KafkaSchemaRegistryClientSecurity
+func (r *Binding) AsKafkaSchemaRegistryClientSecurity() *KafkaSchemaRegistryClientSecurity { // kafka (../../../../../daggerverse/kafka/security_schema_registry.go:28:6)
+	q := r.query.Select("asKafkaSchemaRegistryClientSecurity")
+
+	return &KafkaSchemaRegistryClientSecurity{
+		query: q,
+	}
+}
+
+// Retrieve the binding value, as type KafkaSchemaRegistrySecurity
+func (r *Binding) AsKafkaSchemaRegistrySecurity() *KafkaSchemaRegistrySecurity { // kafka (../../../../../daggerverse/kafka/security_schema_registry.go:12:6)
+	q := r.query.Select("asKafkaSchemaRegistrySecurity")
+
+	return &KafkaSchemaRegistrySecurity{
 		query: q,
 	}
 }
@@ -244,7 +262,7 @@ func (r *Env) WithKafkaRedpandaServerSecurityOutput(name string, description str
 }
 
 // Create or update a binding of type KafkaRegisteredSchema in the environment
-func (r *Env) WithKafkaRegisteredSchemaInput(name string, value *KafkaRegisteredSchema, description string) *Env { // kafka (../../../../../daggerverse/kafka/schema_registry.go:84:6)
+func (r *Env) WithKafkaRegisteredSchemaInput(name string, value *KafkaRegisteredSchema, description string) *Env { // kafka (../../../../../daggerverse/kafka/schema_registry.go:122:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withKafkaRegisteredSchemaInput")
 	q = q.Arg("name", name)
@@ -257,7 +275,7 @@ func (r *Env) WithKafkaRegisteredSchemaInput(name string, value *KafkaRegistered
 }
 
 // Declare a desired KafkaRegisteredSchema output to be assigned in the environment
-func (r *Env) WithKafkaRegisteredSchemaOutput(name string, description string) *Env { // kafka (../../../../../daggerverse/kafka/schema_registry.go:84:6)
+func (r *Env) WithKafkaRegisteredSchemaOutput(name string, description string) *Env { // kafka (../../../../../daggerverse/kafka/schema_registry.go:122:6)
 	q := r.query.Select("withKafkaRegisteredSchemaOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -268,7 +286,7 @@ func (r *Env) WithKafkaRegisteredSchemaOutput(name string, description string) *
 }
 
 // Create or update a binding of type KafkaSchemaRegistryClient in the environment
-func (r *Env) WithKafkaSchemaRegistryClientInput(name string, value *KafkaSchemaRegistryClient, description string) *Env { // kafka (../../../../../daggerverse/kafka/schema_registry.go:70:6)
+func (r *Env) WithKafkaSchemaRegistryClientInput(name string, value *KafkaSchemaRegistryClient, description string) *Env { // kafka (../../../../../daggerverse/kafka/schema_registry.go:98:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withKafkaSchemaRegistryClientInput")
 	q = q.Arg("name", name)
@@ -281,7 +299,7 @@ func (r *Env) WithKafkaSchemaRegistryClientInput(name string, value *KafkaSchema
 }
 
 // Declare a desired KafkaSchemaRegistryClient output to be assigned in the environment
-func (r *Env) WithKafkaSchemaRegistryClientOutput(name string, description string) *Env { // kafka (../../../../../daggerverse/kafka/schema_registry.go:70:6)
+func (r *Env) WithKafkaSchemaRegistryClientOutput(name string, description string) *Env { // kafka (../../../../../daggerverse/kafka/schema_registry.go:98:6)
 	q := r.query.Select("withKafkaSchemaRegistryClientOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -291,8 +309,32 @@ func (r *Env) WithKafkaSchemaRegistryClientOutput(name string, description strin
 	}
 }
 
+// Create or update a binding of type KafkaSchemaRegistryClientSecurity in the environment
+func (r *Env) WithKafkaSchemaRegistryClientSecurityInput(name string, value *KafkaSchemaRegistryClientSecurity, description string) *Env { // kafka (../../../../../daggerverse/kafka/security_schema_registry.go:28:6)
+	assertNotNil("value", value)
+	q := r.query.Select("withKafkaSchemaRegistryClientSecurityInput")
+	q = q.Arg("name", name)
+	q = q.Arg("value", value)
+	q = q.Arg("description", description)
+
+	return &Env{
+		query: q,
+	}
+}
+
+// Declare a desired KafkaSchemaRegistryClientSecurity output to be assigned in the environment
+func (r *Env) WithKafkaSchemaRegistryClientSecurityOutput(name string, description string) *Env { // kafka (../../../../../daggerverse/kafka/security_schema_registry.go:28:6)
+	q := r.query.Select("withKafkaSchemaRegistryClientSecurityOutput")
+	q = q.Arg("name", name)
+	q = q.Arg("description", description)
+
+	return &Env{
+		query: q,
+	}
+}
+
 // Create or update a binding of type KafkaSchemaRegistry in the environment
-func (r *Env) WithKafkaSchemaRegistryInput(name string, value *KafkaSchemaRegistry, description string) *Env { // kafka (../../../../../daggerverse/kafka/schema_registry.go:42:6)
+func (r *Env) WithKafkaSchemaRegistryInput(name string, value *KafkaSchemaRegistry, description string) *Env { // kafka (../../../../../daggerverse/kafka/schema_registry.go:63:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withKafkaSchemaRegistryInput")
 	q = q.Arg("name", name)
@@ -305,8 +347,32 @@ func (r *Env) WithKafkaSchemaRegistryInput(name string, value *KafkaSchemaRegist
 }
 
 // Declare a desired KafkaSchemaRegistry output to be assigned in the environment
-func (r *Env) WithKafkaSchemaRegistryOutput(name string, description string) *Env { // kafka (../../../../../daggerverse/kafka/schema_registry.go:42:6)
+func (r *Env) WithKafkaSchemaRegistryOutput(name string, description string) *Env { // kafka (../../../../../daggerverse/kafka/schema_registry.go:63:6)
 	q := r.query.Select("withKafkaSchemaRegistryOutput")
+	q = q.Arg("name", name)
+	q = q.Arg("description", description)
+
+	return &Env{
+		query: q,
+	}
+}
+
+// Create or update a binding of type KafkaSchemaRegistrySecurity in the environment
+func (r *Env) WithKafkaSchemaRegistrySecurityInput(name string, value *KafkaSchemaRegistrySecurity, description string) *Env { // kafka (../../../../../daggerverse/kafka/security_schema_registry.go:12:6)
+	assertNotNil("value", value)
+	q := r.query.Select("withKafkaSchemaRegistrySecurityInput")
+	q = q.Arg("name", name)
+	q = q.Arg("value", value)
+	q = q.Arg("description", description)
+
+	return &Env{
+		query: q,
+	}
+}
+
+// Declare a desired KafkaSchemaRegistrySecurity output to be assigned in the environment
+func (r *Env) WithKafkaSchemaRegistrySecurityOutput(name string, description string) *Env { // kafka (../../../../../daggerverse/kafka/security_schema_registry.go:12:6)
+	q := r.query.Select("withKafkaSchemaRegistrySecurityOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
 
@@ -485,10 +551,10 @@ func (r *Kafka) ApacheNativeCluster(clusterId string, clientListenerSecurity *Ka
 type KafkaApicurioSchemaRegistryOpts struct {
 
 	// Default: "docker.io"
-	Registry string // kafka (../../../../../daggerverse/kafka/schema_registry.go:200:2)
+	Registry string // kafka (../../../../../daggerverse/kafka/schema_registry.go:400:2)
 
 	// Default: "2.6.13.Final"
-	Tag string // kafka (../../../../../daggerverse/kafka/schema_registry.go:202:2)
+	Tag string // kafka (../../../../../daggerverse/kafka/schema_registry.go:402:2)
 }
 
 // ApicurioSchemaRegistry spins up an Apicurio Registry service
@@ -503,13 +569,16 @@ type KafkaApicurioSchemaRegistryOpts struct {
 // Protobuf, OpenAPI, AsyncAPI, GraphQL, WSDL, XSD); over the CSR-compat
 // surface only the AVRO / JSON / PROTOBUF subset is reachable.
 //
-// Only PLAINTEXT clusters are supported in this story: the constructor
-// rejects TLS / mTLS clusters and points callers at the TLS follow-up.
+// security must match the backing cluster's mode: a PLAINTEXT profile keeps
+// the REST endpoint on HTTP and the kafkasql connection unencrypted; a TLS /
+// mTLS profile terminates HTTPS on the REST endpoint and secures the kafkasql
+// connection against a matching-mode cluster.
 //
 // Session-cached for the same reason ConfluentSchemaRegistry is — a
 // `for every chained client call.
-func (r *Kafka) ApicurioSchemaRegistry(cluster *KafkaCluster, opts ...KafkaApicurioSchemaRegistryOpts) *KafkaSchemaRegistry { // kafka (../../../../../daggerverse/kafka/schema_registry.go:196:1)
+func (r *Kafka) ApicurioSchemaRegistry(cluster *KafkaCluster, security *KafkaSchemaRegistrySecurity, opts ...KafkaApicurioSchemaRegistryOpts) *KafkaSchemaRegistry { // kafka (../../../../../daggerverse/kafka/schema_registry.go:396:1)
 	assertNotNil("cluster", cluster)
+	assertNotNil("security", security)
 	q := r.query.Select("apicurioSchemaRegistry")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `registry` optional argument
@@ -522,6 +591,7 @@ func (r *Kafka) ApicurioSchemaRegistry(cluster *KafkaCluster, opts ...KafkaApicu
 		}
 	}
 	q = q.Arg("cluster", cluster)
+	q = q.Arg("security", security)
 
 	return &KafkaSchemaRegistry{
 		query: q,
@@ -602,10 +672,10 @@ func (r *Kafka) ConfluentCluster(clusterId string, clientListenerSecurity *Kafka
 type KafkaConfluentSchemaRegistryOpts struct {
 
 	// Default: "docker.io"
-	Registry string // kafka (../../../../../daggerverse/kafka/schema_registry.go:111:2)
+	Registry string // kafka (../../../../../daggerverse/kafka/schema_registry.go:240:2)
 
 	// Default: "8.2.0"
-	Tag string // kafka (../../../../../daggerverse/kafka/schema_registry.go:113:2)
+	Tag string // kafka (../../../../../daggerverse/kafka/schema_registry.go:242:2)
 }
 
 // ConfluentSchemaRegistry spins up a Confluent Schema Registry service
@@ -620,8 +690,9 @@ type KafkaConfluentSchemaRegistryOpts struct {
 //
 // Session-cached for the same reason the cluster constructors are — a
 // `for every chained client call.
-func (r *Kafka) ConfluentSchemaRegistry(cluster *KafkaCluster, opts ...KafkaConfluentSchemaRegistryOpts) *KafkaSchemaRegistry { // kafka (../../../../../daggerverse/kafka/schema_registry.go:107:1)
+func (r *Kafka) ConfluentSchemaRegistry(cluster *KafkaCluster, security *KafkaSchemaRegistrySecurity, opts ...KafkaConfluentSchemaRegistryOpts) *KafkaSchemaRegistry { // kafka (../../../../../daggerverse/kafka/schema_registry.go:236:1)
 	assertNotNil("cluster", cluster)
+	assertNotNil("security", security)
 	q := r.query.Select("confluentSchemaRegistry")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `registry` optional argument
@@ -634,6 +705,7 @@ func (r *Kafka) ConfluentSchemaRegistry(cluster *KafkaCluster, opts ...KafkaConf
 		}
 	}
 	q = q.Arg("cluster", cluster)
+	q = q.Arg("security", security)
 
 	return &KafkaSchemaRegistry{
 		query: q,
@@ -693,10 +765,10 @@ func (r *Kafka) UnmarshalJSON(bs []byte) error {
 type KafkaKarapaceSchemaRegistryOpts struct {
 
 	// Default: "ghcr.io"
-	Registry string // kafka (../../../../../daggerverse/kafka/schema_registry.go:278:2)
+	Registry string // kafka (../../../../../daggerverse/kafka/schema_registry.go:536:2)
 
 	// Default: "6.1.4"
-	Tag string // kafka (../../../../../daggerverse/kafka/schema_registry.go:280:2)
+	Tag string // kafka (../../../../../daggerverse/kafka/schema_registry.go:538:2)
 }
 
 // KarapaceSchemaRegistry spins up a Karapace service
@@ -712,13 +784,16 @@ type KafkaKarapaceSchemaRegistryOpts struct {
 // which also keeps CI clear of Docker Hub rate limits and Confluent's image
 // licensing.
 //
-// Only PLAINTEXT clusters are supported in this story: the constructor
-// rejects TLS / mTLS clusters and points callers at the TLS follow-up.
+// security must match the backing cluster's mode. Karapace consumes PEM (not
+// PKCS#12) for its own listener and aiokafka storage; the module extracts PEM
+// from the supplied CA internally, so callers pass the same PKCS#12 profile
+// shape as the other registries.
 //
 // Session-cached for the same reason ConfluentSchemaRegistry is — a
 // `for every chained client call.
-func (r *Kafka) KarapaceSchemaRegistry(cluster *KafkaCluster, opts ...KafkaKarapaceSchemaRegistryOpts) *KafkaSchemaRegistry { // kafka (../../../../../daggerverse/kafka/schema_registry.go:274:1)
+func (r *Kafka) KarapaceSchemaRegistry(cluster *KafkaCluster, security *KafkaSchemaRegistrySecurity, opts ...KafkaKarapaceSchemaRegistryOpts) *KafkaSchemaRegistry { // kafka (../../../../../daggerverse/kafka/schema_registry.go:532:1)
 	assertNotNil("cluster", cluster)
+	assertNotNil("security", security)
 	q := r.query.Select("karapaceSchemaRegistry")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `registry` optional argument
@@ -731,6 +806,7 @@ func (r *Kafka) KarapaceSchemaRegistry(cluster *KafkaCluster, opts ...KafkaKarap
 		}
 	}
 	q = q.Arg("cluster", cluster)
+	q = q.Arg("security", security)
 
 	return &KafkaSchemaRegistry{
 		query: q,
@@ -753,6 +829,49 @@ func (r *Kafka) MtlsClientSecurity(keyStore *File, keyStorePassword *Secret, tru
 	q = q.Arg("trustStorePassword", trustStorePassword)
 
 	return &KafkaClientSecurity{
+		query: q,
+	}
+}
+
+// MtlsSchemaRegistryClientSecurity returns a SchemaRegistryClientSecurity
+// profile that opens an mTLS HTTPS connection: the registry presents its REST
+// server cert (verified against trustStore) and the client presents its own
+// leaf cert from keyStore (signed by a CA the registry trusts via its
+// clientTrustStore).
+func (r *Kafka) MtlsSchemaRegistryClientSecurity(keyStore *File, keyStorePassword *Secret, trustStore *File, trustStorePassword *Secret) *KafkaSchemaRegistryClientSecurity { // kafka (../../../../../daggerverse/kafka/security_schema_registry.go:113:1)
+	assertNotNil("keyStore", keyStore)
+	assertNotNil("keyStorePassword", keyStorePassword)
+	assertNotNil("trustStore", trustStore)
+	assertNotNil("trustStorePassword", trustStorePassword)
+	q := r.query.Select("mtlsSchemaRegistryClientSecurity")
+	q = q.Arg("keyStore", keyStore)
+	q = q.Arg("keyStorePassword", keyStorePassword)
+	q = q.Arg("trustStore", trustStore)
+	q = q.Arg("trustStorePassword", trustStorePassword)
+
+	return &KafkaSchemaRegistryClientSecurity{
+		query: q,
+	}
+}
+
+// MtlsSchemaRegistrySecurity returns a SchemaRegistrySecurity profile that
+// terminates mTLS on the registry REST endpoint. caKeyStore signs the
+// registry's server leaf (and the registry's own client leaf presented to the
+// broker over mTLS); clientTrustStore holds the CA(s) the registry accepts
+// incoming REST client certs from. Pair with an MTLS cluster minted from the
+// same CA.
+func (r *Kafka) MtlsSchemaRegistrySecurity(caKeyStore *File, caKeyStorePassword *Secret, clientTrustStore *File, clientTrustStorePassword *Secret) *KafkaSchemaRegistrySecurity { // kafka (../../../../../daggerverse/kafka/security_schema_registry.go:71:1)
+	assertNotNil("caKeyStore", caKeyStore)
+	assertNotNil("caKeyStorePassword", caKeyStorePassword)
+	assertNotNil("clientTrustStore", clientTrustStore)
+	assertNotNil("clientTrustStorePassword", clientTrustStorePassword)
+	q := r.query.Select("mtlsSchemaRegistrySecurity")
+	q = q.Arg("caKeyStore", caKeyStore)
+	q = q.Arg("caKeyStorePassword", caKeyStorePassword)
+	q = q.Arg("clientTrustStore", clientTrustStore)
+	q = q.Arg("clientTrustStorePassword", clientTrustStorePassword)
+
+	return &KafkaSchemaRegistrySecurity{
 		query: q,
 	}
 }
@@ -784,6 +903,27 @@ func (r *Kafka) PlaintextClientSecurity() *KafkaClientSecurity { // kafka (../..
 	q := r.query.Select("plaintextClientSecurity")
 
 	return &KafkaClientSecurity{
+		query: q,
+	}
+}
+
+// PlaintextSchemaRegistryClientSecurity returns a SchemaRegistryClientSecurity
+// profile configured for unencrypted HTTP traffic.
+func (r *Kafka) PlaintextSchemaRegistryClientSecurity() *KafkaSchemaRegistryClientSecurity { // kafka (../../../../../daggerverse/kafka/security_schema_registry.go:88:1)
+	q := r.query.Select("plaintextSchemaRegistryClientSecurity")
+
+	return &KafkaSchemaRegistryClientSecurity{
+		query: q,
+	}
+}
+
+// PlaintextSchemaRegistrySecurity returns a SchemaRegistrySecurity profile
+// configured for unencrypted, unauthenticated traffic on the registry REST
+// endpoint. It pairs with a PLAINTEXT cluster.
+func (r *Kafka) PlaintextSchemaRegistrySecurity() *KafkaSchemaRegistrySecurity { // kafka (../../../../../daggerverse/kafka/security_schema_registry.go:44:1)
+	q := r.query.Select("plaintextSchemaRegistrySecurity")
+
+	return &KafkaSchemaRegistrySecurity{
 		query: q,
 	}
 }
@@ -897,6 +1037,41 @@ func (r *Kafka) TLSClientSecurity(trustStore *File, trustStorePassword *Secret) 
 	q = q.Arg("trustStorePassword", trustStorePassword)
 
 	return &KafkaClientSecurity{
+		query: q,
+	}
+}
+
+// TlsSchemaRegistryClientSecurity returns a SchemaRegistryClientSecurity
+// profile that opens an HTTPS connection to the registry. trustStore is a
+// PKCS#12 archive of the CA(s) the client uses to verify the registry's REST
+// leaf certificate (typically the truststore that pairs with the CA passed to
+// TlsSchemaRegistrySecurity on the server side).
+func (r *Kafka) TLSSchemaRegistryClientSecurity(trustStore *File, trustStorePassword *Secret) *KafkaSchemaRegistryClientSecurity { // kafka (../../../../../daggerverse/kafka/security_schema_registry.go:97:1)
+	assertNotNil("trustStore", trustStore)
+	assertNotNil("trustStorePassword", trustStorePassword)
+	q := r.query.Select("tlsSchemaRegistryClientSecurity")
+	q = q.Arg("trustStore", trustStore)
+	q = q.Arg("trustStorePassword", trustStorePassword)
+
+	return &KafkaSchemaRegistryClientSecurity{
+		query: q,
+	}
+}
+
+// TlsSchemaRegistrySecurity returns a SchemaRegistrySecurity profile that
+// terminates TLS on the registry REST endpoint. caKeyStore is a PKCS#12
+// archive containing the CA cert + private key the registry uses to mint its
+// per-registry server leaf (bound to the registry's service hostname as a DNS
+// SAN) and to derive the truststore its kafka-storage connection uses to
+// verify the backing broker. Pair with a TLS cluster minted from the same CA.
+func (r *Kafka) TLSSchemaRegistrySecurity(caKeyStore *File, caKeyStorePassword *Secret) *KafkaSchemaRegistrySecurity { // kafka (../../../../../daggerverse/kafka/security_schema_registry.go:54:1)
+	assertNotNil("caKeyStore", caKeyStore)
+	assertNotNil("caKeyStorePassword", caKeyStorePassword)
+	q := r.query.Select("tlsSchemaRegistrySecurity")
+	q = q.Arg("caKeyStore", caKeyStore)
+	q = q.Arg("caKeyStorePassword", caKeyStorePassword)
+
+	return &KafkaSchemaRegistrySecurity{
 		query: q,
 	}
 }
@@ -1505,7 +1680,7 @@ func (r *KafkaRedpandaCluster) WithGraphQLQuery(q *querybuilder.Selection) *Kafk
 
 // BindBrokers binds the single Redpanda broker service into the given
 // container so the container can reach it by hostname.
-func (r *KafkaRedpandaCluster) BindBrokers(ctr *Container) *Container { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:405:1)
+func (r *KafkaRedpandaCluster) BindBrokers(ctr *Container) *Container { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:430:1)
 	assertNotNil("ctr", ctr)
 	q := r.query.Select("bindBrokers")
 	q = q.Arg("ctr", ctr)
@@ -1517,7 +1692,7 @@ func (r *KafkaRedpandaCluster) BindBrokers(ctr *Container) *Container { // kafka
 
 // BootstrapServers returns the bootstrap address (single broker:9092) for
 // this Redpanda cluster.
-func (r *KafkaRedpandaCluster) BootstrapServers(ctx context.Context) ([]string, error) { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:371:1)
+func (r *KafkaRedpandaCluster) BootstrapServers(ctx context.Context) ([]string, error) { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:384:1)
 	q := r.query.Select("bootstrapServers")
 
 	var response []string
@@ -1529,7 +1704,7 @@ func (r *KafkaRedpandaCluster) BootstrapServers(ctx context.Context) ([]string, 
 // Client starts the Redpanda broker service and returns a franz-go-backed
 // *Client targeting it. The Kafka wire protocol matches Apache Kafka, so
 // the existing *Client + *ClientSecurity (PKCS#12) are reused unchanged.
-func (r *KafkaRedpandaCluster) Client(security *KafkaClientSecurity) *KafkaClient { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:414:1)
+func (r *KafkaRedpandaCluster) Client(security *KafkaClientSecurity) *KafkaClient { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:439:1)
 	assertNotNil("security", security)
 	q := r.query.Select("client")
 	q = q.Arg("security", security)
@@ -1595,16 +1770,23 @@ func (r *KafkaRedpandaCluster) UnmarshalJSON(bs []byte) error {
 // `rpk redpanda start` runs a Schema Registry inside the broker process on
 // :8081 — no extra container — so the returned *SchemaRegistry points at the
 // broker service itself. Redpanda's SR speaks the Confluent Schema Registry
-// REST API, so the *SchemaRegistryClient from Client() works unchanged. The
-// REST endpoint is plain HTTP regardless of the cluster's Kafka-listener
-// security mode, so this never fails.
+// REST API, so the *SchemaRegistryClient from Client() works unchanged.
+//
+// security must match the cluster's mode (PLAINTEXT or TLS — Redpanda has no
+// mTLS): on a TLS cluster the bundled SR REST endpoint terminates HTTPS
+// reusing the broker's server leaf (configured at cluster-build time in
+// renderRedpandaYaml), so the caller must pass a TLS profile to get an HTTPS
+// client. The profile's CA keystore is unused here (the leaf is already
+// minted); it is required only for API uniformity with the other registries.
 //
 // The returned registry is Bundled: its service is the broker itself, so
 // Stop is a no-op on it — call cluster.Stop to tear the registry down with
 // the cluster. A caller that uniformly `defer sr.Stop(ctx)` over the shared
 // *SchemaRegistry type therefore can't accidentally kill the cluster.
-func (r *KafkaRedpandaCluster) SchemaRegistry() *KafkaSchemaRegistry { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:392:1)
+func (r *KafkaRedpandaCluster) SchemaRegistry(security *KafkaSchemaRegistrySecurity) *KafkaSchemaRegistry { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:410:1)
+	assertNotNil("security", security)
 	q := r.query.Select("schemaRegistry")
+	q = q.Arg("security", security)
 
 	return &KafkaSchemaRegistry{
 		query: q,
@@ -1615,7 +1797,7 @@ func (r *KafkaRedpandaCluster) SchemaRegistry() *KafkaSchemaRegistry { // kafka 
 // Tests should call this in a defer so the broker `Container.asService`
 // span closes when the test work is done. Kill is set so Service.Stop
 // skips graceful shutdown — see Cluster.Stop for the rationale.
-func (r *KafkaRedpandaCluster) Stop(ctx context.Context) error { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:430:1)
+func (r *KafkaRedpandaCluster) Stop(ctx context.Context) error { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:455:1)
 	if r.stop != nil {
 		return nil
 	}
@@ -1713,7 +1895,7 @@ func (r *KafkaRedpandaServerSecurity) AsNode() Node {
 // (`id`, `schema`): an exported `ID` field collides with the synthetic
 // Dagger object `id`, and `Schema` is a GraphQL keyword that breaks
 // consumer-module codegen — see daggerverse/CLAUDE.md.
-type KafkaRegisteredSchema struct { // kafka (../../../../../daggerverse/kafka/schema_registry.go:84:6)
+type KafkaRegisteredSchema struct { // kafka (../../../../../daggerverse/kafka/schema_registry.go:122:6)
 	query *querybuilder.Selection
 
 	definition *string
@@ -1731,7 +1913,7 @@ func (r *KafkaRegisteredSchema) WithGraphQLQuery(q *querybuilder.Selection) *Kaf
 }
 
 // the schema text itself (Avro / JSON Schema / Protobuf)
-func (r *KafkaRegisteredSchema) Definition(ctx context.Context) (string, error) { // kafka (../../../../../daggerverse/kafka/schema_registry.go:88:2)
+func (r *KafkaRegisteredSchema) Definition(ctx context.Context) (string, error) { // kafka (../../../../../daggerverse/kafka/schema_registry.go:126:2)
 	if r.definition != nil {
 		return *r.definition, nil
 	}
@@ -1793,7 +1975,7 @@ func (r *KafkaRegisteredSchema) UnmarshalJSON(bs []byte) error {
 }
 
 // globally-unique registry schema id
-func (r *KafkaRegisteredSchema) SchemaID(ctx context.Context) (int, error) { // kafka (../../../../../daggerverse/kafka/schema_registry.go:87:2)
+func (r *KafkaRegisteredSchema) SchemaID(ctx context.Context) (int, error) { // kafka (../../../../../daggerverse/kafka/schema_registry.go:125:2)
 	if r.schemaId != nil {
 		return *r.schemaId, nil
 	}
@@ -1806,7 +1988,7 @@ func (r *KafkaRegisteredSchema) SchemaID(ctx context.Context) (int, error) { // 
 }
 
 // AVRO | JSON | PROTOBUF
-func (r *KafkaRegisteredSchema) SchemaType(ctx context.Context) (string, error) { // kafka (../../../../../daggerverse/kafka/schema_registry.go:89:2)
+func (r *KafkaRegisteredSchema) SchemaType(ctx context.Context) (string, error) { // kafka (../../../../../daggerverse/kafka/schema_registry.go:127:2)
 	if r.schemaType != nil {
 		return *r.schemaType, nil
 	}
@@ -1819,7 +2001,7 @@ func (r *KafkaRegisteredSchema) SchemaType(ctx context.Context) (string, error) 
 }
 
 // registry subject the schema is registered under
-func (r *KafkaRegisteredSchema) Subject(ctx context.Context) (string, error) { // kafka (../../../../../daggerverse/kafka/schema_registry.go:85:2)
+func (r *KafkaRegisteredSchema) Subject(ctx context.Context) (string, error) { // kafka (../../../../../daggerverse/kafka/schema_registry.go:123:2)
 	if r.subject != nil {
 		return *r.subject, nil
 	}
@@ -1832,7 +2014,7 @@ func (r *KafkaRegisteredSchema) Subject(ctx context.Context) (string, error) { /
 }
 
 // monotonic version within the subject
-func (r *KafkaRegisteredSchema) Version(ctx context.Context) (int, error) { // kafka (../../../../../daggerverse/kafka/schema_registry.go:86:2)
+func (r *KafkaRegisteredSchema) Version(ctx context.Context) (int, error) { // kafka (../../../../../daggerverse/kafka/schema_registry.go:124:2)
 	if r.version != nil {
 		return *r.version, nil
 	}
@@ -1866,7 +2048,7 @@ func (r *KafkaRegisteredSchema) AsNode() Node {
 // The constructor is session-cached so chained calls
 // (Client().RegisterSchema(...) → LookupSchemaByID(...)) all observe the
 // same underlying service.
-type KafkaSchemaRegistry struct { // kafka (../../../../../daggerverse/kafka/schema_registry.go:42:6)
+type KafkaSchemaRegistry struct { // kafka (../../../../../daggerverse/kafka/schema_registry.go:63:6)
 	query *querybuilder.Selection
 
 	endpoint *string
@@ -1883,7 +2065,7 @@ func (r *KafkaSchemaRegistry) WithGraphQLQuery(q *querybuilder.Selection) *Kafka
 // BindTo attaches the Schema Registry service to the given container under
 // the same hostname Endpoint reports, so the container resolves the
 // registry at that address.
-func (r *KafkaSchemaRegistry) BindTo(ctr *Container) *Container { // kafka (../../../../../daggerverse/kafka/schema_registry.go:374:1)
+func (r *KafkaSchemaRegistry) BindTo(ctr *Container) *Container { // kafka (../../../../../daggerverse/kafka/schema_registry.go:636:1)
 	assertNotNil("ctr", ctr)
 	q := r.query.Select("bindTo")
 	q = q.Arg("ctr", ctr)
@@ -1893,10 +2075,15 @@ func (r *KafkaSchemaRegistry) BindTo(ctr *Container) *Container { // kafka (../.
 	}
 }
 
-// Client returns a typed HTTP client targeting this registry's REST API.
-// No I/O happens at construction time.
-func (r *KafkaSchemaRegistry) Client() *KafkaSchemaRegistryClient { // kafka (../../../../../daggerverse/kafka/schema_registry.go:380:1)
+// Client returns a typed HTTP client targeting this registry's REST API. The
+// URL scheme (http vs https) follows the registry's own security mode; the
+// supplied security profile must match it (a TLS/mTLS registry needs a TLS/mTLS
+// client profile, verified when the first request runs). No I/O happens at
+// construction time.
+func (r *KafkaSchemaRegistry) Client(security *KafkaSchemaRegistryClientSecurity) *KafkaSchemaRegistryClient { // kafka (../../../../../daggerverse/kafka/schema_registry.go:645:1)
+	assertNotNil("security", security)
 	q := r.query.Select("client")
+	q = q.Arg("security", security)
 
 	return &KafkaSchemaRegistryClient{
 		query: q,
@@ -1905,7 +2092,7 @@ func (r *KafkaSchemaRegistry) Client() *KafkaSchemaRegistryClient { // kafka (..
 
 // Endpoint returns the host:port other containers (and the module runtime)
 // can reach the Schema Registry REST API on.
-func (r *KafkaSchemaRegistry) Endpoint(ctx context.Context) (string, error) { // kafka (../../../../../daggerverse/kafka/schema_registry.go:360:1)
+func (r *KafkaSchemaRegistry) Endpoint(ctx context.Context) (string, error) { // kafka (../../../../../daggerverse/kafka/schema_registry.go:622:1)
 	if r.endpoint != nil {
 		return *r.endpoint, nil
 	}
@@ -1974,7 +2161,7 @@ func (r *KafkaSchemaRegistry) UnmarshalJSON(bs []byte) error {
 // owning cluster, so Stop is a no-op: the cluster owns that lifecycle and
 // stopping it here would tear the whole cluster down. Callers that uniformly
 // `defer sr.Stop(ctx)` stay safe regardless of which registry they hold.
-func (r *KafkaSchemaRegistry) Stop(ctx context.Context) error { // kafka (../../../../../daggerverse/kafka/schema_registry.go:397:1)
+func (r *KafkaSchemaRegistry) Stop(ctx context.Context) error { // kafka (../../../../../daggerverse/kafka/schema_registry.go:675:1)
 	if r.stop != nil {
 		return nil
 	}
@@ -1994,7 +2181,7 @@ func (r *KafkaSchemaRegistry) AsNode() Node {
 // SchemaRegistryClient is a pure-Go net/http client for a Schema Registry's
 // admin REST API. Each method opens a fresh request so the function call is
 // stateless from Dagger's perspective.
-type KafkaSchemaRegistryClient struct { // kafka (../../../../../daggerverse/kafka/schema_registry.go:70:6)
+type KafkaSchemaRegistryClient struct { // kafka (../../../../../daggerverse/kafka/schema_registry.go:98:6)
 	query *querybuilder.Selection
 
 	getCompatibility *string
@@ -2011,7 +2198,7 @@ func (r *KafkaSchemaRegistryClient) WithGraphQLQuery(q *querybuilder.Selection) 
 
 // DeleteSubject deletes every version of the given subject and returns the
 // version numbers that were deleted.
-func (r *KafkaSchemaRegistryClient) DeleteSubject(ctx context.Context, subject string) ([]int, error) { // kafka (../../../../../daggerverse/kafka/schema_registry.go:661:1)
+func (r *KafkaSchemaRegistryClient) DeleteSubject(ctx context.Context, subject string) ([]int, error) { // kafka (../../../../../daggerverse/kafka/schema_registry.go:1011:1)
 	q := r.query.Select("deleteSubject")
 	q = q.Arg("subject", subject)
 
@@ -2024,7 +2211,7 @@ func (r *KafkaSchemaRegistryClient) DeleteSubject(ctx context.Context, subject s
 // GetCompatibility returns the compatibility level configured for the given
 // subject, falling back to the registry-wide default when the subject has
 // no explicit configuration.
-func (r *KafkaSchemaRegistryClient) GetCompatibility(ctx context.Context, subject string) (string, error) { // kafka (../../../../../daggerverse/kafka/schema_registry.go:701:1)
+func (r *KafkaSchemaRegistryClient) GetCompatibility(ctx context.Context, subject string) (string, error) { // kafka (../../../../../daggerverse/kafka/schema_registry.go:1051:1)
 	if r.getCompatibility != nil {
 		return *r.getCompatibility, nil
 	}
@@ -2087,7 +2274,7 @@ func (r *KafkaSchemaRegistryClient) UnmarshalJSON(bs []byte) error {
 }
 
 // ListSubjects returns the names of every subject registered.
-func (r *KafkaSchemaRegistryClient) ListSubjects(ctx context.Context) ([]string, error) { // kafka (../../../../../daggerverse/kafka/schema_registry.go:645:1)
+func (r *KafkaSchemaRegistryClient) ListSubjects(ctx context.Context) ([]string, error) { // kafka (../../../../../daggerverse/kafka/schema_registry.go:995:1)
 	q := r.query.Select("listSubjects")
 
 	var response []string
@@ -2098,7 +2285,7 @@ func (r *KafkaSchemaRegistryClient) ListSubjects(ctx context.Context) ([]string,
 
 // LookupLatestBySubject returns the latest registered schema version for
 // the given subject.
-func (r *KafkaSchemaRegistryClient) LookupLatestBySubject(subject string) *KafkaRegisteredSchema { // kafka (../../../../../daggerverse/kafka/schema_registry.go:615:1)
+func (r *KafkaSchemaRegistryClient) LookupLatestBySubject(subject string) *KafkaRegisteredSchema { // kafka (../../../../../daggerverse/kafka/schema_registry.go:965:1)
 	q := r.query.Select("lookupLatestBySubject")
 	q = q.Arg("subject", subject)
 
@@ -2113,7 +2300,7 @@ func (r *KafkaSchemaRegistryClient) LookupLatestBySubject(subject string) *Kafka
 // text and type, so a second call to GET /schemas/ids/{id}/versions
 // resolves the subject and version. When an id maps to more than one
 // subject/version pair, the first association is returned.
-func (r *KafkaSchemaRegistryClient) LookupSchemaByID(id int) *KafkaRegisteredSchema { // kafka (../../../../../daggerverse/kafka/schema_registry.go:574:1)
+func (r *KafkaSchemaRegistryClient) LookupSchemaByID(id int) *KafkaRegisteredSchema { // kafka (../../../../../daggerverse/kafka/schema_registry.go:924:1)
 	q := r.query.Select("lookupSchemaById")
 	q = q.Arg("id", id)
 
@@ -2126,13 +2313,13 @@ func (r *KafkaSchemaRegistryClient) LookupSchemaByID(id int) *KafkaRegisteredSch
 type KafkaSchemaRegistryClientRegisterSchemaOpts struct {
 
 	// Default: "AVRO"
-	SchemaType string // kafka (../../../../../daggerverse/kafka/schema_registry.go:544:2)
+	SchemaType string // kafka (../../../../../daggerverse/kafka/schema_registry.go:894:2)
 }
 
 // RegisterSchema registers schema under subject and returns the globally
 // unique schema id the registry assigned. schemaType must be one of AVRO,
 // JSON, or PROTOBUF.
-func (r *KafkaSchemaRegistryClient) RegisterSchema(ctx context.Context, subject string, schema string, opts ...KafkaSchemaRegistryClientRegisterSchemaOpts) (int, error) { // kafka (../../../../../daggerverse/kafka/schema_registry.go:539:1)
+func (r *KafkaSchemaRegistryClient) RegisterSchema(ctx context.Context, subject string, schema string, opts ...KafkaSchemaRegistryClientRegisterSchemaOpts) (int, error) { // kafka (../../../../../daggerverse/kafka/schema_registry.go:889:1)
 	if r.registerSchema != nil {
 		return *r.registerSchema, nil
 	}
@@ -2155,7 +2342,7 @@ func (r *KafkaSchemaRegistryClient) RegisterSchema(ctx context.Context, subject 
 // SetCompatibility sets the compatibility level for the given subject.
 // level must be one of NONE, BACKWARD, BACKWARD_TRANSITIVE, FORWARD,
 // FORWARD_TRANSITIVE, FULL, or FULL_TRANSITIVE.
-func (r *KafkaSchemaRegistryClient) SetCompatibility(ctx context.Context, subject string, level string) error { // kafka (../../../../../daggerverse/kafka/schema_registry.go:681:1)
+func (r *KafkaSchemaRegistryClient) SetCompatibility(ctx context.Context, subject string, level string) error { // kafka (../../../../../daggerverse/kafka/schema_registry.go:1031:1)
 	if r.setCompatibility != nil {
 		return nil
 	}
@@ -2169,6 +2356,154 @@ func (r *KafkaSchemaRegistryClient) SetCompatibility(ctx context.Context, subjec
 // AsNode returns this KafkaSchemaRegistryClient as a Node.
 // This is a local type conversion — no GraphQL call.
 func (r *KafkaSchemaRegistryClient) AsNode() Node {
+	return &NodeClient{
+		query: r.query,
+	}
+}
+
+// SchemaRegistryClientSecurity describes how a SchemaRegistryClient's HTTP
+// client authenticates to a Schema Registry's REST endpoint, mirroring
+// *ClientSecurity on the broker side.
+type KafkaSchemaRegistryClientSecurity struct { // kafka (../../../../../daggerverse/kafka/security_schema_registry.go:28:6)
+	query *querybuilder.Selection
+
+	id *ID
+}
+
+func (r *KafkaSchemaRegistryClientSecurity) WithGraphQLQuery(q *querybuilder.Selection) *KafkaSchemaRegistryClientSecurity {
+	return &KafkaSchemaRegistryClientSecurity{
+		query: q,
+	}
+}
+
+// A unique identifier for this KafkaSchemaRegistryClientSecurity.
+func (r *KafkaSchemaRegistryClientSecurity) ID(ctx context.Context) (ID, error) {
+	if r.id != nil {
+		return *r.id, nil
+	}
+	q := r.query.Select("id")
+
+	var response ID
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// XXX_GraphQLType is an internal function. It returns the native GraphQL type name
+func (r *KafkaSchemaRegistryClientSecurity) XXX_GraphQLType() string {
+	return "KafkaSchemaRegistryClientSecurity"
+}
+
+// XXX_GraphQLIDType is an internal function. It returns the native GraphQL type name for the ID of this object
+func (r *KafkaSchemaRegistryClientSecurity) XXX_GraphQLIDType() string {
+	return "ID"
+}
+
+// XXX_GraphQLID is an internal function. It returns the underlying type ID
+func (r *KafkaSchemaRegistryClientSecurity) XXX_GraphQLID(ctx context.Context) (string, error) {
+	id, err := r.ID(ctx)
+	if err != nil {
+		return "", err
+	}
+	return string(id), nil
+}
+
+func (r *KafkaSchemaRegistryClientSecurity) MarshalJSON() ([]byte, error) {
+	id, err := r.ID(marshalCtx)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(id)
+}
+func (r *KafkaSchemaRegistryClientSecurity) UnmarshalJSON(bs []byte) error {
+	var id string
+	err := json.Unmarshal(bs, &id)
+	if err != nil {
+		return err
+	}
+	*r = KafkaSchemaRegistryClientSecurity{query: selectNode(dag.query, id, "KafkaSchemaRegistryClientSecurity")}
+	return nil
+}
+
+// AsNode returns this KafkaSchemaRegistryClientSecurity as a Node.
+// This is a local type conversion — no GraphQL call.
+func (r *KafkaSchemaRegistryClientSecurity) AsNode() Node {
+	return &NodeClient{
+		query: r.query,
+	}
+}
+
+// SchemaRegistrySecurity describes how a Schema Registry's REST endpoint
+// authenticates and encrypts traffic from clients, mirroring *ServerSecurity
+// on the broker side. The same profile also parameterises the registry's
+// kafka-storage connection to the backing cluster: the CA it carries doubles
+// as the trust anchor the registry uses to dial the cluster's TLS/mTLS client
+// listener (the single-CA convention — pass the same CA to the cluster and the
+// registry).
+type KafkaSchemaRegistrySecurity struct { // kafka (../../../../../daggerverse/kafka/security_schema_registry.go:12:6)
+	query *querybuilder.Selection
+
+	id *ID
+}
+
+func (r *KafkaSchemaRegistrySecurity) WithGraphQLQuery(q *querybuilder.Selection) *KafkaSchemaRegistrySecurity {
+	return &KafkaSchemaRegistrySecurity{
+		query: q,
+	}
+}
+
+// A unique identifier for this KafkaSchemaRegistrySecurity.
+func (r *KafkaSchemaRegistrySecurity) ID(ctx context.Context) (ID, error) {
+	if r.id != nil {
+		return *r.id, nil
+	}
+	q := r.query.Select("id")
+
+	var response ID
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// XXX_GraphQLType is an internal function. It returns the native GraphQL type name
+func (r *KafkaSchemaRegistrySecurity) XXX_GraphQLType() string {
+	return "KafkaSchemaRegistrySecurity"
+}
+
+// XXX_GraphQLIDType is an internal function. It returns the native GraphQL type name for the ID of this object
+func (r *KafkaSchemaRegistrySecurity) XXX_GraphQLIDType() string {
+	return "ID"
+}
+
+// XXX_GraphQLID is an internal function. It returns the underlying type ID
+func (r *KafkaSchemaRegistrySecurity) XXX_GraphQLID(ctx context.Context) (string, error) {
+	id, err := r.ID(ctx)
+	if err != nil {
+		return "", err
+	}
+	return string(id), nil
+}
+
+func (r *KafkaSchemaRegistrySecurity) MarshalJSON() ([]byte, error) {
+	id, err := r.ID(marshalCtx)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(id)
+}
+func (r *KafkaSchemaRegistrySecurity) UnmarshalJSON(bs []byte) error {
+	var id string
+	err := json.Unmarshal(bs, &id)
+	if err != nil {
+		return err
+	}
+	*r = KafkaSchemaRegistrySecurity{query: selectNode(dag.query, id, "KafkaSchemaRegistrySecurity")}
+	return nil
+}
+
+// AsNode returns this KafkaSchemaRegistrySecurity as a Node.
+// This is a local type conversion — no GraphQL call.
+func (r *KafkaSchemaRegistrySecurity) AsNode() Node {
 	return &NodeClient{
 		query: r.query,
 	}

--- a/daggerverse/kafka/tests/main.go
+++ b/daggerverse/kafka/tests/main.go
@@ -119,8 +119,20 @@ func (t *Tests) SchemaRegistry(
 	jobs = jobs.WithJob("SchemaRegistryRegisterLookupRoundTrip", func(ctx context.Context) error {
 		return t.SchemaRegistryRegisterLookupRoundTrip(ctx, kafkaImageTag)
 	})
-	jobs = jobs.WithJob("SchemaRegistryRejectsNonPlaintextCluster", func(ctx context.Context) error {
-		return t.SchemaRegistryRejectsNonPlaintextCluster(ctx, kafkaImageTag)
+	jobs = jobs.WithJob("SchemaRegistryRejectsClusterModeMismatch", func(ctx context.Context) error {
+		return t.SchemaRegistryRejectsClusterModeMismatch(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("ConfluentSchemaRegistryTlsRegisterLookupRoundTrip", func(ctx context.Context) error {
+		return t.ConfluentSchemaRegistryTlsRegisterLookupRoundTrip(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("ConfluentSchemaRegistryMtlsRegisterLookupRoundTrip", func(ctx context.Context) error {
+		return t.ConfluentSchemaRegistryMtlsRegisterLookupRoundTrip(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("ApicurioSchemaRegistryTlsRegisterLookupRoundTrip", func(ctx context.Context) error {
+		return t.ApicurioSchemaRegistryTlsRegisterLookupRoundTrip(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("KarapaceSchemaRegistryTlsRegisterLookupRoundTrip", func(ctx context.Context) error {
+		return t.KarapaceSchemaRegistryTlsRegisterLookupRoundTrip(ctx, kafkaImageTag)
 	})
 	jobs = jobs.WithJob("ApicurioSchemaRegistryRegisterLookupRoundTrip", func(ctx context.Context) error {
 		return t.ApicurioSchemaRegistryRegisterLookupRoundTrip(ctx, kafkaImageTag)

--- a/daggerverse/kafka/tests/tests_redpanda.go
+++ b/daggerverse/kafka/tests/tests_redpanda.go
@@ -12,13 +12,17 @@ import (
 // helper and hands its PKCS#12 archive to Kafka.RedpandaTlsServerSecurity;
 // the cluster constructor extracts PEM internally for redpanda.yaml. The
 // matching truststore is returned so the franz-go client can verify the
-// broker leaf.
+// broker leaf, plus the CA keystore so the bundled Schema Registry can be
+// handed a matching TLS SchemaRegistrySecurity.
 func freshTlsRedpandaCluster(ctx context.Context, redpandaImageTag string) (
-	*dagger.KafkaRedpandaCluster, *dagger.File, *dagger.Secret, error,
+	cluster *dagger.KafkaRedpandaCluster,
+	trustStore *dagger.File, trustStorePwd *dagger.Secret,
+	caKeyStore *dagger.File, caKeyStorePwd *dagger.Secret,
+	err error,
 ) {
 	ca, err := freshCa(ctx, "tls-redpanda")
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, nil, err
 	}
 	caKs := ca.KeyStore()
 	serverSec := dag.Kafka().RedpandaTLSServerSecurity(caKs.Pkcs12(), caKs.Password())
@@ -26,12 +30,12 @@ func freshTlsRedpandaCluster(ctx context.Context, redpandaImageTag string) (
 
 	clusterId, err := newClusterId(ctx)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, nil, err
 	}
-	cluster := dag.Kafka().RedpandaCluster(clusterId, serverSec, dagger.KafkaRedpandaClusterOpts{
+	cluster = dag.Kafka().RedpandaCluster(clusterId, serverSec, dagger.KafkaRedpandaClusterOpts{
 		Tag: redpandaImageTag,
 	})
-	return cluster, ts.Pkcs12(), ts.Password(), nil
+	return cluster, ts.Pkcs12(), ts.Password(), caKs.Pkcs12(), caKs.Password(), nil
 }
 
 // freshRedpandaCluster spins up a single-node Redpanda cluster on PLAINTEXT
@@ -108,7 +112,7 @@ func (t *Tests) RedpandaClusterTlsRoundTrip(
 	// +default="v26.1.7"
 	redpandaImageTag string,
 ) error {
-	cluster, ts, tsPwd, err := freshTlsRedpandaCluster(ctx, redpandaImageTag)
+	cluster, ts, tsPwd, _, _, err := freshTlsRedpandaCluster(ctx, redpandaImageTag)
 	if err != nil {
 		return fmt.Errorf("create redpanda tls cluster: %w", err)
 	}
@@ -174,8 +178,8 @@ func redpandaClusterTlsRoundTripOn(
 // lookup-by-id contract — positive id, Subject, SchemaType, and SchemaID.
 // Shared by the PLAINTEXT and TLS Redpanda SR tests so both paths cover the
 // identical assertion set; mirrors the redpandaCluster...RoundTripOn split.
-func redpandaSchemaRegistryRegisterLookupRoundTripOn(ctx context.Context, sr *dagger.KafkaSchemaRegistry) error {
-	client := sr.Client()
+func redpandaSchemaRegistryRegisterLookupRoundTripOn(ctx context.Context, sr *dagger.KafkaSchemaRegistry, clientSec *dagger.KafkaSchemaRegistryClientSecurity) error {
+	client := sr.Client(clientSec)
 
 	subject, err := randomTopicName(ctx)
 	if err != nil {
@@ -237,28 +241,36 @@ func (t *Tests) RedpandaSchemaRegistryRegisterLookupRoundTrip(
 	}
 	defer cluster.Stop(ctx)
 
-	return redpandaSchemaRegistryRegisterLookupRoundTripOn(ctx, cluster.SchemaRegistry())
+	return redpandaSchemaRegistryRegisterLookupRoundTripOn(ctx,
+		cluster.SchemaRegistry(plaintextSchemaRegistrySecurity()),
+		plaintextSchemaRegistryClientSecurity())
 }
 
 // RedpandaSchemaRegistryTlsRegisterLookupRoundTrip is the TLS-cluster
 // counterpart of RedpandaSchemaRegistryRegisterLookupRoundTrip. A TLS
-// Redpanda cluster configures its bundled Schema Registry through a
-// separately-rendered redpanda.yaml (the schema_registry_api block) rather
-// than the PLAINTEXT path's --schema-registry-addr flag, so this exercises
-// that YAML path end-to-end. The SR REST endpoint is plain HTTP regardless
-// of the Kafka listener's TLS mode, so the truststore is unused here.
+// Redpanda cluster terminates HTTPS on its bundled Schema Registry REST
+// endpoint, reusing the broker's server leaf (configured through the
+// separately-rendered redpanda.yaml schema_registry_api_tls block), so this
+// exercises that YAML path end-to-end and drives register/lookup over HTTPS,
+// verifying the SR cert against the cluster CA truststore.
 func (t *Tests) RedpandaSchemaRegistryTlsRegisterLookupRoundTrip(
 	ctx context.Context,
 	// +default="v26.1.7"
 	redpandaImageTag string,
 ) error {
-	cluster, _, _, err := freshTlsRedpandaCluster(ctx, redpandaImageTag)
+	cluster, ts, tsPwd, caKs, caKsPwd, err := freshTlsRedpandaCluster(ctx, redpandaImageTag)
 	if err != nil {
 		return fmt.Errorf("create redpanda tls cluster: %w", err)
 	}
 	defer cluster.Stop(ctx)
 
-	return redpandaSchemaRegistryRegisterLookupRoundTripOn(ctx, cluster.SchemaRegistry())
+	// The bundled SR reuses the broker leaf; the caller still passes a TLS
+	// SchemaRegistrySecurity (its CA keystore is unused here) so the mode
+	// matches the TLS cluster, and a TLS client profile built from the same
+	// cluster CA truststore verifies the HTTPS endpoint.
+	srSec := dag.Kafka().TLSSchemaRegistrySecurity(caKs, caKsPwd)
+	clientSec := dag.Kafka().TLSSchemaRegistryClientSecurity(ts, tsPwd)
+	return redpandaSchemaRegistryRegisterLookupRoundTripOn(ctx, cluster.SchemaRegistry(srSec), clientSec)
 }
 
 // RedpandaSchemaRegistryBundledStopIsNoOp pins the bundled-registry lifecycle
@@ -278,8 +290,8 @@ func (t *Tests) RedpandaSchemaRegistryBundledStopIsNoOp(
 	}
 	defer cluster.Stop(ctx)
 
-	sr := cluster.SchemaRegistry()
-	if err := redpandaSchemaRegistryRegisterLookupRoundTripOn(ctx, sr); err != nil {
+	sr := cluster.SchemaRegistry(plaintextSchemaRegistrySecurity())
+	if err := redpandaSchemaRegistryRegisterLookupRoundTripOn(ctx, sr, plaintextSchemaRegistryClientSecurity()); err != nil {
 		return fmt.Errorf("round-trip before sr.Stop: %w", err)
 	}
 
@@ -293,7 +305,7 @@ func (t *Tests) RedpandaSchemaRegistryBundledStopIsNoOp(
 	// fresh register/lookup-by-id round-trip would not prove this: the
 	// registry dedups by schema content, so re-registering avroTestSchema
 	// returns the first id, whose lookup resolves to the first subject.)
-	client := sr.Client()
+	client := sr.Client(plaintextSchemaRegistryClientSecurity())
 	subject, err := randomTopicName(ctx)
 	if err != nil {
 		return err

--- a/daggerverse/kafka/tests/tests_schema_registry.go
+++ b/daggerverse/kafka/tests/tests_schema_registry.go
@@ -425,7 +425,7 @@ func (t *Tests) SchemaRegistryFramedProduceConsumeRoundTrip(
 	topic := subject
 	subject += "-value"
 
-	id, err := sr.Client(plaintextSchemaRegistryClientSecurity()).RegisterSchema(ctx, subject,avroTestSchema, dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{
+	id, err := sr.Client(plaintextSchemaRegistryClientSecurity()).RegisterSchema(ctx, subject, avroTestSchema, dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{
 		SchemaType: "AVRO",
 	})
 	if err != nil {
@@ -651,7 +651,7 @@ func (t *Tests) SchemaRegistryJSONFramedProduceConsumeRoundTrip(
 	subject += "-value"
 
 	const jsonSchema = `{"type":"object","properties":{"x":{"type":"string"}},"required":["x"]}`
-	id, err := sr.Client(plaintextSchemaRegistryClientSecurity()).RegisterSchema(ctx, subject,jsonSchema, dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{
+	id, err := sr.Client(plaintextSchemaRegistryClientSecurity()).RegisterSchema(ctx, subject, jsonSchema, dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{
 		SchemaType: "JSON",
 	})
 	if err != nil {
@@ -835,7 +835,7 @@ func (t *Tests) AvroFramedProduceConsumeRoundTrip(
 	topic := subject
 	subject += "-value"
 
-	id, err := sr.Client(plaintextSchemaRegistryClientSecurity()).RegisterSchema(ctx, subject,avroTestSchema, dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{
+	id, err := sr.Client(plaintextSchemaRegistryClientSecurity()).RegisterSchema(ctx, subject, avroTestSchema, dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{
 		SchemaType: "AVRO",
 	})
 	if err != nil {
@@ -936,7 +936,7 @@ func (t *Tests) AvroBytesFieldRoundTrip(
 	topic := subject
 	subject += "-value"
 
-	id, err := sr.Client(plaintextSchemaRegistryClientSecurity()).RegisterSchema(ctx, subject,avroBytesSchema, dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{
+	id, err := sr.Client(plaintextSchemaRegistryClientSecurity()).RegisterSchema(ctx, subject, avroBytesSchema, dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{
 		SchemaType: "AVRO",
 	})
 	if err != nil {

--- a/daggerverse/kafka/tests/tests_schema_registry.go
+++ b/daggerverse/kafka/tests/tests_schema_registry.go
@@ -33,10 +33,10 @@ func (t *Tests) SchemaRegistryRegisterLookupRoundTrip(
 	}
 	defer cluster.Stop(ctx)
 
-	sr := dag.Kafka().ConfluentSchemaRegistry(cluster)
+	sr := dag.Kafka().ConfluentSchemaRegistry(cluster, plaintextSchemaRegistrySecurity())
 	defer sr.Stop(ctx)
 
-	client := sr.Client()
+	client := sr.Client(plaintextSchemaRegistryClientSecurity())
 
 	subject, err := randomTopicName(ctx)
 	if err != nil {
@@ -161,10 +161,10 @@ func (t *Tests) ApicurioSchemaRegistryRegisterLookupRoundTrip(
 	}
 	defer cluster.Stop(ctx)
 
-	sr := dag.Kafka().ApicurioSchemaRegistry(cluster)
+	sr := dag.Kafka().ApicurioSchemaRegistry(cluster, plaintextSchemaRegistrySecurity())
 	defer sr.Stop(ctx)
 
-	client := sr.Client()
+	client := sr.Client(plaintextSchemaRegistryClientSecurity())
 
 	subject, err := randomTopicName(ctx)
 	if err != nil {
@@ -289,10 +289,10 @@ func (t *Tests) KarapaceSchemaRegistryRegisterLookupRoundTrip(
 	}
 	defer cluster.Stop(ctx)
 
-	sr := dag.Kafka().KarapaceSchemaRegistry(cluster)
+	sr := dag.Kafka().KarapaceSchemaRegistry(cluster, plaintextSchemaRegistrySecurity())
 	defer sr.Stop(ctx)
 
-	client := sr.Client()
+	client := sr.Client(plaintextSchemaRegistryClientSecurity())
 
 	subject, err := randomTopicName(ctx)
 	if err != nil {
@@ -415,7 +415,7 @@ func (t *Tests) SchemaRegistryFramedProduceConsumeRoundTrip(
 	}
 	defer cluster.Stop(ctx)
 
-	sr := dag.Kafka().ConfluentSchemaRegistry(cluster)
+	sr := dag.Kafka().ConfluentSchemaRegistry(cluster, plaintextSchemaRegistrySecurity())
 	defer sr.Stop(ctx)
 
 	subject, err := randomTopicName(ctx)
@@ -425,7 +425,7 @@ func (t *Tests) SchemaRegistryFramedProduceConsumeRoundTrip(
 	topic := subject
 	subject += "-value"
 
-	id, err := sr.Client().RegisterSchema(ctx, subject, avroTestSchema, dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{
+	id, err := sr.Client(plaintextSchemaRegistryClientSecurity()).RegisterSchema(ctx, subject,avroTestSchema, dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{
 		SchemaType: "AVRO",
 	})
 	if err != nil {
@@ -568,12 +568,13 @@ func (t *Tests) SchemaRegistryPlaintextConsumeUnframed(
 	return nil
 }
 
-// SchemaRegistryRejectsNonPlaintextCluster pins the PLAINTEXT-only contract
-// of this story: ConfluentSchemaRegistry must reject a cluster whose client
-// listener runs TLS rather than silently producing a broken registry. The
-// constructor errors before any service boots, so the TLS cluster never
-// has to start.
-func (t *Tests) SchemaRegistryRejectsNonPlaintextCluster(
+// SchemaRegistryRejectsClusterModeMismatch pins the mode-match contract: a
+// registry's security profile must match its backing cluster's client-listener
+// mode, so the registry's kafka-storage connection authenticates against the
+// broker. Here a PLAINTEXT registry security is paired with a TLS cluster and
+// must be rejected with an error naming both modes. The constructor errors
+// before any service boots, so the TLS cluster never has to start.
+func (t *Tests) SchemaRegistryRejectsClusterModeMismatch(
 	ctx context.Context,
 	// +default="4.2.0"
 	kafkaImageTag string,
@@ -584,12 +585,13 @@ func (t *Tests) SchemaRegistryRejectsNonPlaintextCluster(
 	}
 	defer cluster.Stop(ctx)
 
-	_, err = dag.Kafka().ConfluentSchemaRegistry(cluster).Endpoint(ctx)
+	_, err = dag.Kafka().ConfluentSchemaRegistry(cluster, plaintextSchemaRegistrySecurity()).Endpoint(ctx)
 	if err == nil {
-		return fmt.Errorf("expected ConfluentSchemaRegistry to reject a non-PLAINTEXT cluster, got nil error")
+		return fmt.Errorf("expected ConfluentSchemaRegistry to reject a PLAINTEXT registry on a TLS cluster, got nil error")
 	}
-	if !strings.Contains(err.Error(), "PLAINTEXT") {
-		return fmt.Errorf("expected rejection error to mention PLAINTEXT, got: %v", err)
+	// The mismatch error names both modes; PLAINTEXT is the registry side.
+	if !strings.Contains(err.Error(), "PLAINTEXT") || !strings.Contains(err.Error(), "TLS") {
+		return fmt.Errorf("expected mode-mismatch error to name both PLAINTEXT and TLS, got: %v", err)
 	}
 	return nil
 }
@@ -638,7 +640,7 @@ func (t *Tests) SchemaRegistryJSONFramedProduceConsumeRoundTrip(
 	}
 	defer cluster.Stop(ctx)
 
-	sr := dag.Kafka().ConfluentSchemaRegistry(cluster)
+	sr := dag.Kafka().ConfluentSchemaRegistry(cluster, plaintextSchemaRegistrySecurity())
 	defer sr.Stop(ctx)
 
 	subject, err := randomTopicName(ctx)
@@ -649,7 +651,7 @@ func (t *Tests) SchemaRegistryJSONFramedProduceConsumeRoundTrip(
 	subject += "-value"
 
 	const jsonSchema = `{"type":"object","properties":{"x":{"type":"string"}},"required":["x"]}`
-	id, err := sr.Client().RegisterSchema(ctx, subject, jsonSchema, dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{
+	id, err := sr.Client(plaintextSchemaRegistryClientSecurity()).RegisterSchema(ctx, subject,jsonSchema, dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{
 		SchemaType: "JSON",
 	})
 	if err != nil {
@@ -764,7 +766,7 @@ func (t *Tests) AvroConsumeUnframedErrors(
 	}
 	defer cluster.Stop(ctx)
 
-	sr := dag.Kafka().ConfluentSchemaRegistry(cluster)
+	sr := dag.Kafka().ConfluentSchemaRegistry(cluster, plaintextSchemaRegistrySecurity())
 	defer sr.Stop(ctx)
 
 	client := cluster.Client(dag.Kafka().PlaintextClientSecurity())
@@ -823,7 +825,7 @@ func (t *Tests) AvroFramedProduceConsumeRoundTrip(
 	}
 	defer cluster.Stop(ctx)
 
-	sr := dag.Kafka().ConfluentSchemaRegistry(cluster)
+	sr := dag.Kafka().ConfluentSchemaRegistry(cluster, plaintextSchemaRegistrySecurity())
 	defer sr.Stop(ctx)
 
 	subject, err := randomTopicName(ctx)
@@ -833,7 +835,7 @@ func (t *Tests) AvroFramedProduceConsumeRoundTrip(
 	topic := subject
 	subject += "-value"
 
-	id, err := sr.Client().RegisterSchema(ctx, subject, avroTestSchema, dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{
+	id, err := sr.Client(plaintextSchemaRegistryClientSecurity()).RegisterSchema(ctx, subject,avroTestSchema, dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{
 		SchemaType: "AVRO",
 	})
 	if err != nil {
@@ -924,7 +926,7 @@ func (t *Tests) AvroBytesFieldRoundTrip(
 	}
 	defer cluster.Stop(ctx)
 
-	sr := dag.Kafka().ConfluentSchemaRegistry(cluster)
+	sr := dag.Kafka().ConfluentSchemaRegistry(cluster, plaintextSchemaRegistrySecurity())
 	defer sr.Stop(ctx)
 
 	subject, err := randomTopicName(ctx)
@@ -934,7 +936,7 @@ func (t *Tests) AvroBytesFieldRoundTrip(
 	topic := subject
 	subject += "-value"
 
-	id, err := sr.Client().RegisterSchema(ctx, subject, avroBytesSchema, dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{
+	id, err := sr.Client(plaintextSchemaRegistryClientSecurity()).RegisterSchema(ctx, subject,avroBytesSchema, dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{
 		SchemaType: "AVRO",
 	})
 	if err != nil {
@@ -993,4 +995,206 @@ func (t *Tests) AvroBytesFieldRoundTrip(
 		return fmt.Errorf("value mismatch: want canonical %q, got %q", wantCanonical, gotVal)
 	}
 	return nil
+}
+
+// freshTlsRegistryStack mints one CA, stands up a single-broker TLS Apache
+// cluster from it, and returns the cluster plus a TLS SchemaRegistrySecurity
+// (server) and a TLS SchemaRegistryClientSecurity (client) all rooted at that
+// CA. The single-CA convention means the cluster's broker leaves, the
+// registry's REST leaf + kafkastore truststore, and the REST client's trust
+// anchor all chain to the same root, so a TLS registry authenticates its
+// storage connection and the client verifies the HTTPS endpoint.
+func freshTlsRegistryStack(ctx context.Context, kafkaImageTag string) (
+	*dagger.KafkaCluster, *dagger.KafkaSchemaRegistrySecurity, *dagger.KafkaSchemaRegistryClientSecurity, error,
+) {
+	ca, err := freshCa(ctx, "tls-sr")
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	caKs := ca.KeyStore()
+	ts := ca.TrustStore()
+
+	clusterId, err := newClusterId(ctx)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	k := dag.Kafka()
+	cluster := k.ApacheNativeCluster(clusterId, k.TLSServerSecurity(caKs.Pkcs12(), caKs.Password()),
+		dagger.KafkaApacheNativeClusterOpts{Tag: kafkaImageTag, Brokers: 1})
+	srSec := k.TLSSchemaRegistrySecurity(caKs.Pkcs12(), caKs.Password())
+	clientSec := k.TLSSchemaRegistryClientSecurity(ts.Pkcs12(), ts.Password())
+	return cluster, srSec, clientSec, nil
+}
+
+// freshMtlsRegistryStack is the mTLS counterpart of freshTlsRegistryStack. A
+// single CA does quadruple duty: it signs the broker server leaves, is the
+// broker's client-trust anchor, signs the registry's REST + kafkastore leaves,
+// is the registry's REST client-trust anchor, and signs the REST client's own
+// leaf — so every mTLS handshake in the chain validates against one root.
+func freshMtlsRegistryStack(ctx context.Context, kafkaImageTag string) (
+	*dagger.KafkaCluster, *dagger.KafkaSchemaRegistrySecurity, *dagger.KafkaSchemaRegistryClientSecurity, error,
+) {
+	ca, err := freshCa(ctx, "mtls-sr")
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	caKs := ca.KeyStore()
+	ts := ca.TrustStore()
+
+	clusterId, err := newClusterId(ctx)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	k := dag.Kafka()
+	cluster := k.ApacheNativeCluster(clusterId,
+		k.MtlsServerSecurity(caKs.Pkcs12(), caKs.Password(), ts.Pkcs12(), ts.Password()),
+		dagger.KafkaApacheNativeClusterOpts{Tag: kafkaImageTag, Brokers: 1})
+	srSec := k.MtlsSchemaRegistrySecurity(caKs.Pkcs12(), caKs.Password(), ts.Pkcs12(), ts.Password())
+
+	clientKs, clientKsPwd, err := issueClientKeystore(ctx, ca, "sr-rest-client")
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	clientSec := k.MtlsSchemaRegistryClientSecurity(clientKs, clientKsPwd, ts.Pkcs12(), ts.Password())
+	return cluster, srSec, clientSec, nil
+}
+
+// schemaRegistryRoundTripOn exercises the core register → lookup-by-id →
+// lookup-latest → list-subjects contract against sr using clientSec, proving a
+// registration reaches the `_schemas` store and reads back over the (possibly
+// TLS/mTLS) REST endpoint. Shared by the Confluent/Apicurio/Karapace TLS and
+// mTLS round-trip tests so every backend covers the same assertion set.
+func schemaRegistryRoundTripOn(ctx context.Context, sr *dagger.KafkaSchemaRegistry, clientSec *dagger.KafkaSchemaRegistryClientSecurity) error {
+	client := sr.Client(clientSec)
+
+	subject, err := randomTopicName(ctx)
+	if err != nil {
+		return err
+	}
+	subject += "-value"
+
+	id, err := client.RegisterSchema(ctx, subject, avroTestSchema, dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{
+		SchemaType: "AVRO",
+	})
+	if err != nil {
+		return fmt.Errorf("register schema: %w", err)
+	}
+	if id <= 0 {
+		return fmt.Errorf("expected a positive schema id, got %d", id)
+	}
+
+	got := client.LookupSchemaByID(id)
+	gotSubject, err := got.Subject(ctx)
+	if err != nil {
+		return fmt.Errorf("lookup schema by id: %w", err)
+	}
+	if gotSubject != subject {
+		return fmt.Errorf("lookup-by-id subject mismatch: want %q, got %q", subject, gotSubject)
+	}
+
+	latest := client.LookupLatestBySubject(subject)
+	latestVersion, err := latest.Version(ctx)
+	if err != nil {
+		return fmt.Errorf("lookup latest by subject: %w", err)
+	}
+	if latestVersion != 1 {
+		return fmt.Errorf("lookup-latest version mismatch: want 1, got %d", latestVersion)
+	}
+	latestID, err := latest.SchemaID(ctx)
+	if err != nil {
+		return fmt.Errorf("read latest schema id: %w", err)
+	}
+	if latestID != id {
+		return fmt.Errorf("lookup-latest schemaID mismatch: want %d, got %d", id, latestID)
+	}
+
+	subjects, err := client.ListSubjects(ctx)
+	if err != nil {
+		return fmt.Errorf("list subjects: %w", err)
+	}
+	if !contains(subjects, subject) {
+		return fmt.Errorf("expected subject %q in %v after register", subject, subjects)
+	}
+	return nil
+}
+
+// ConfluentSchemaRegistryTlsRegisterLookupRoundTrip is the canonical TLS test:
+// a TLS cp-schema-registry terminates HTTPS on its REST endpoint and talks SSL
+// to a TLS cluster's brokers for the `_schemas` topic, and the round-trip
+// succeeds over an HTTPS client verifying the registry cert against the
+// shared CA.
+func (t *Tests) ConfluentSchemaRegistryTlsRegisterLookupRoundTrip(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, srSec, clientSec, err := freshTlsRegistryStack(ctx, kafkaImageTag)
+	if err != nil {
+		return fmt.Errorf("create tls registry stack: %w", err)
+	}
+	defer cluster.Stop(ctx)
+
+	sr := dag.Kafka().ConfluentSchemaRegistry(cluster, srSec)
+	defer sr.Stop(ctx)
+
+	return schemaRegistryRoundTripOn(ctx, sr, clientSec)
+}
+
+// ConfluentSchemaRegistryMtlsRegisterLookupRoundTrip is the mTLS counterpart:
+// the REST endpoint requires a client certificate and the registry presents
+// its own leaf to the mTLS broker for the kafkastore connection, all rooted at
+// one CA.
+func (t *Tests) ConfluentSchemaRegistryMtlsRegisterLookupRoundTrip(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, srSec, clientSec, err := freshMtlsRegistryStack(ctx, kafkaImageTag)
+	if err != nil {
+		return fmt.Errorf("create mtls registry stack: %w", err)
+	}
+	defer cluster.Stop(ctx)
+
+	sr := dag.Kafka().ConfluentSchemaRegistry(cluster, srSec)
+	defer sr.Stop(ctx)
+
+	return schemaRegistryRoundTripOn(ctx, sr, clientSec)
+}
+
+// ApicurioSchemaRegistryTlsRegisterLookupRoundTrip drives the Apicurio TLS
+// path (Quarkus HTTPS REST + kafkasql SSL storage) end-to-end.
+func (t *Tests) ApicurioSchemaRegistryTlsRegisterLookupRoundTrip(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, srSec, clientSec, err := freshTlsRegistryStack(ctx, kafkaImageTag)
+	if err != nil {
+		return fmt.Errorf("create tls registry stack: %w", err)
+	}
+	defer cluster.Stop(ctx)
+
+	sr := dag.Kafka().ApicurioSchemaRegistry(cluster, srSec)
+	defer sr.Stop(ctx)
+
+	return schemaRegistryRoundTripOn(ctx, sr, clientSec)
+}
+
+// KarapaceSchemaRegistryTlsRegisterLookupRoundTrip drives the Karapace TLS
+// path (PEM REST listener + aiokafka SSL storage) end-to-end.
+func (t *Tests) KarapaceSchemaRegistryTlsRegisterLookupRoundTrip(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, srSec, clientSec, err := freshTlsRegistryStack(ctx, kafkaImageTag)
+	if err != nil {
+		return fmt.Errorf("create tls registry stack: %w", err)
+	}
+	defer cluster.Stop(ctx)
+
+	sr := dag.Kafka().KarapaceSchemaRegistry(cluster, srSec)
+	defer sr.Stop(ctx)
+
+	return schemaRegistryRoundTripOn(ctx, sr, clientSec)
 }


### PR DESCRIPTION
Closes #43.

Adds TLS + mTLS to the kafka Schema Registry across **all four registries**,
mirroring the existing broker TLS pattern (#12).

## What changed

- **New profiles** (`security_schema_registry.go`): `SchemaRegistrySecurity` +
  `SchemaRegistryClientSecurity` with the six `Plaintext/Tls/Mtls` constructors.
- **Constructors** gained a required positional `security` parameter and a
  **mode-match rule** (registry mode must equal the cluster's client-listener
  mode; a mismatch errors naming both modes) in place of the old
  `!= "PLAINTEXT"` rejection.
- **Per-registry TLS wiring** for both surfaces (REST endpoint + kafka-storage
  connection): Confluent (PKCS#12 `SCHEMA_REGISTRY_SSL_*` / `_KAFKASTORE_SSL_*`,
  incl. `INTER_INSTANCE_PROTOCOL=https`), Apicurio (Quarkus HTTPS + kafkasql
  SSL), Karapace (PEM), and Redpanda (reuses the broker's server leaf via a new
  `schema_registry_api_tls` block in `redpanda.yaml`).
- **Shared leaf minting** refactored into `mintServiceLeaf` / `mintClientLeaf`
  + CA-truststore/PEM derivers (`internal_ca.go`), reused by the broker path.
- **TLS-aware client**: `Client(security)` selects http/https from the registry
  mode and materialises a `tls.Config` from PKCS#12 in `do()`, mirroring the
  franz-go `Client`.
- **README**: relaxed the four "PLAINTEXT only" caveats and added a
  Schema Registry TLS/mTLS notes subsection (per-registry leaf minting,
  mode coupling, single-CA convention, PKCS#12-vs-PEM per image).

## Tests (all green against the pinned v0.21.3 engine)

- `SchemaRegistryRejectsClusterModeMismatch`
- Confluent TLS + Confluent mTLS register/lookup round-trips
- Apicurio TLS, Karapace TLS, Redpanda TLS round-trips
- Existing plaintext Confluent + Redpanda round-trips (regression) updated for
  the new required params

## Notes

- The single TDD surprise was Confluent needing
  `SCHEMA_REGISTRY_INTER_INSTANCE_PROTOCOL=https`; Apicurio's kafkasql SSL
  (flagged as uncertain in planning) worked with `KAFKA_SECURITY_PROTOCOL=SSL` +
  a PKCS#12 truststore.
- Generated bindings were produced with the repo's pinned dagger `v0.21.3` so
  the CI `Generated` drift check passes.
- Follow-up #141 tracks threading a TLS client profile through the franz-go
  avro `Produce`/`Consume` path (out of scope here; a TLS registry on that path
  currently surfaces a clear PLAINTEXT-client error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)