### PR TITLE
story(issue-145): open Update Dagger PR via a GitHub App token

### DIFF
--- a/.github/workflows/update-dagger.yml
+++ b/.github/workflows/update-dagger.yml
@@ -109,10 +109,29 @@ jobs:
           grep -Eq "DAGGER_VERSION:[[:space:]]*\"${BARE//./\\.}\"" .github/workflows/ci.yml \
             || { echo "ci.yml DAGGER_VERSION pin was not updated to ${BARE}" >&2; exit 1; }
 
+      - name: Mint a GitHub App installation token
+        # GITHUB_TOKEN is itself a GitHub App installation token, and GitHub
+        # categorically forbids those from creating/updating files under
+        # .github/workflows/ -- so pushing this PR (which bumps the DAGGER_VERSION
+        # pin in ci.yml) fails with the `workflows` permission rejection (#145).
+        # Mint a short-lived token from our own App, which IS installed with
+        # Workflows: write. A non-GITHUB_TOKEN author also makes GitHub fire
+        # `on: pull_request`, so CI validates the regenerated tree automatically.
+        #
+        # One-time setup (see README "CI"): an App installed on this repo with
+        # Contents/Pull requests/Workflows: write, plus two repo secrets:
+        #   UPDATE_DAGGER_APP_ID  -- the App's numeric App ID
+        #   UPDATE_DAGGER_APP_KEY -- the App's PEM private key
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.UPDATE_DAGGER_APP_ID }}
+          private-key: ${{ secrets.UPDATE_DAGGER_APP_KEY }}
+
       - name: Open upgrade PR
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ github.token }}
+          token: ${{ steps.app-token.outputs.token }}
           branch: chore/update-dagger-${{ steps.resolve.outputs.bare }}
           delete-branch: true
           commit-message: "chore(ci): upgrade Dagger to ${{ steps.resolve.outputs.vtag }} across all modules"
@@ -124,10 +143,5 @@ jobs:
             regenerated `*.gen.go`, refreshed `go.mod`/`go.sum`, and bumped the
             `DAGGER_VERSION` pin in `ci.yml`.
 
-            > [!IMPORTANT]
-            > **CI will not run automatically on this PR.** It was opened with
-            > `GITHUB_TOKEN`, and GitHub does not fire `on: pull_request`
-            > workflows for token-authored PRs. Nudge it to validate the
-            > regenerated code: push an empty commit
-            > (`git commit --allow-empty -m ci && git push`) or close & reopen
-            > the PR.
+            CI runs automatically on this PR (opened via the update-dagger GitHub
+            App rather than `GITHUB_TOKEN`), validating the regenerated tree.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,21 @@ in [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Each module has a
 sibling `tests/` module exposed as a toolchain in
 [`dagger.json`](dagger.json).
 
+The manually-triggered
+[`update-dagger.yml`](.github/workflows/update-dagger.yml) workflow bumps the
+Dagger pin across every module and opens a PR. Its PR edits `ci.yml` (a workflow
+file), which the default `GITHUB_TOKEN` may not push, so it authenticates with a
+dedicated **update-dagger GitHub App** via two repository secrets:
+
+| Secret | Value |
+| ------ | ----- |
+| `UPDATE_DAGGER_APP_ID` | the App's numeric App ID |
+| `UPDATE_DAGGER_APP_KEY` | the App's PEM private key |
+
+Install the App on this repo with `Contents`, `Pull requests`, and `Workflows`
+all set to **Read and write** (`Workflows: write` is what `GITHUB_TOKEN` can't
+have). The short-lived token is minted per run, so nothing needs rotating.
+
 ## License
 
 [MIT](LICENSE) © Z5labs and Contributors


### PR DESCRIPTION
Fixes #145.

## Problem

The manually-triggered **Update Dagger** workflow does all its real work correctly (installs the target CLI, runs `dagger develop` across every module, regenerates the ~70-file tree, bumps the pin) but **fails deterministically on the final "Open upgrade PR" push**. Its PR edits `.github/workflows/ci.yml` (the `DAGGER_VERSION` pin), so the branch carries a **workflow-file change**, and GitHub categorically forbids the default `GITHUB_TOKEN` (itself a GitHub App installation token) from pushing anything under `.github/workflows/`. The `workflows` scope is not grantable to `GITHUB_TOKEN` at all, so the workflow has never successfully opened a PR.

## Fix (Option A — GitHub App token)

- Add a **Mint a GitHub App installation token** step (`actions/create-github-app-token@v3`) before "Open upgrade PR", and push the PR with `steps.app-token.outputs.token` instead of `github.token`. The App is installed with `Workflows: write`, so the push is allowed.
- Because a non-`GITHUB_TOKEN` identity opens the PR, GitHub fires `on: pull_request` and **CI validates the regenerated tree automatically** — so the PR body's manual empty-commit "nudge" note is removed.
- `ci.yml` is untouched: the pin stays as the single source of truth and is still bumped in-PR by the existing `sed` step (this is Option A, not the pin-relocation Option B).
- Document the two required secrets and the App permissions in the README CI section.

## ⚠️ Required one-time setup before this workflow can run

A dedicated **update-dagger GitHub App** must exist, and two repository secrets must be set:

| Secret | Value |
| ------ | ----- |
| `UPDATE_DAGGER_APP_ID` | the App's numeric App ID |
| `UPDATE_DAGGER_APP_KEY` | the App's PEM private key |

The App must be installed on this repo with `Contents`, `Pull requests`, and `Workflows` all set to **Read and write**. The token is minted per run, so nothing needs rotating.

## Verification

Owner-driven once the App/secrets exist and this is merged: `workflow_dispatch` **Update Dagger** with `version: 0.21.7` (or re-run the previously-failing v0.21.7 dispatch) and confirm the run opens a PR (no `workflows` permission rejection), the PR carries the full upgrade diff (bumped `engineVersion` in every `dagger.json`, regenerated `*.gen.go`, refreshed `go.mod`/`go.sum`, bumped `DAGGER_VERSION` in `ci.yml`), and CI runs automatically on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
