### PR TITLE
story(issue-141): thread TLS/mTLS Schema Registry profile through kafka avro Produce/Consume

### DIFF
--- a/ci/internal/dagger/kafka-tests.gen.go
+++ b/ci/internal/dagger/kafka-tests.gen.go
@@ -56,7 +56,9 @@ type KafkaTests struct { // kafka-tests (../../../daggerverse/kafka/tests/main.g
 	avroBytesFieldRoundTrip                            *Void
 	avroConsumeUnframedErrors                          *Void
 	avroFramedProduceConsumeRoundTrip                  *Void
+	avroMtlsFramedProduceConsumeRoundTrip              *Void
 	avroSerializeRequiresSchemaId                      *Void
+	avroTlsFramedProduceConsumeRoundTrip               *Void
 	bindBrokersExposesBothListeners                    *Void
 	clusterClientCanListTopicsOnFreshCluster           *Void
 	confluent                                          *Void
@@ -254,15 +256,15 @@ func (r *KafkaTests) ApacheClusterTLSRoundTrip(ctx context.Context, opts ...Kafk
 type KafkaTestsApacheJvmOpts struct {
 
 	// Default: "4.2.0"
-	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/main.go:290:2)
+	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/main.go:296:2)
 
-	Parallel int // kafka-tests (../../../daggerverse/kafka/tests/main.go:292:2)
+	Parallel int // kafka-tests (../../../daggerverse/kafka/tests/main.go:298:2)
 }
 
 // ApacheJVM runs the three apache/kafka JVM-image round-trip tests.
 // Each test owns a fresh ApacheCluster, so the group holds no shared
 // clusters of its own.
-func (r *KafkaTests) ApacheJvm(ctx context.Context, opts ...KafkaTestsApacheJvmOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/main.go:287:1)
+func (r *KafkaTests) ApacheJvm(ctx context.Context, opts ...KafkaTestsApacheJvmOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/main.go:293:1)
 	if r.apacheJvm != nil {
 		return nil
 	}
@@ -314,12 +316,12 @@ func (r *KafkaTests) ApicurioSchemaRegistryRegisterLookupRoundTrip(ctx context.C
 type KafkaTestsApicurioSchemaRegistryTLSRegisterLookupRoundTripOpts struct {
 
 	// Default: "4.2.0"
-	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:1169:2)
+	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:1386:2)
 }
 
 // ApicurioSchemaRegistryTlsRegisterLookupRoundTrip drives the Apicurio TLS
 // path (Quarkus HTTPS REST + kafkasql SSL storage) end-to-end.
-func (r *KafkaTests) ApicurioSchemaRegistryTLSRegisterLookupRoundTrip(ctx context.Context, opts ...KafkaTestsApicurioSchemaRegistryTLSRegisterLookupRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:1166:1)
+func (r *KafkaTests) ApicurioSchemaRegistryTLSRegisterLookupRoundTrip(ctx context.Context, opts ...KafkaTestsApicurioSchemaRegistryTLSRegisterLookupRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:1383:1)
 	if r.apicurioSchemaRegistryTlsRegisterLookupRoundTrip != nil {
 		return nil
 	}
@@ -364,7 +366,7 @@ func (r *KafkaTests) AutoCreateTopicsDisabled(ctx context.Context, opts ...Kafka
 type KafkaTestsAvroBytesFieldRoundTripOpts struct {
 
 	// Default: "4.2.0"
-	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:921:2)
+	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:1067:2)
 }
 
 // AvroBytesFieldRoundTrip pins the Avro-spec JSON encoding of a bytes field.
@@ -374,7 +376,7 @@ type KafkaTestsAvroBytesFieldRoundTripOpts struct {
 // (code point U+00FF), which is outside the base64 alphabet, so a round-trip
 // that preserves it byte-for-byte proves the one-char-per-byte mapping and
 // would be impossible under a base64 interpretation.
-func (r *KafkaTests) AvroBytesFieldRoundTrip(ctx context.Context, opts ...KafkaTestsAvroBytesFieldRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:918:1)
+func (r *KafkaTests) AvroBytesFieldRoundTrip(ctx context.Context, opts ...KafkaTestsAvroBytesFieldRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:1064:1)
 	if r.avroBytesFieldRoundTrip != nil {
 		return nil
 	}
@@ -444,6 +446,33 @@ func (r *KafkaTests) AvroFramedProduceConsumeRoundTrip(ctx context.Context, opts
 	return q.Execute(ctx)
 }
 
+// KafkaTestsAvroMtlsFramedProduceConsumeRoundTripOpts contains options for KafkaTests.AvroMtlsFramedProduceConsumeRoundTrip
+type KafkaTestsAvroMtlsFramedProduceConsumeRoundTripOpts struct {
+
+	// Default: "4.2.0"
+	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:944:2)
+}
+
+// AvroMtlsFramedProduceConsumeRoundTrip is the mTLS counterpart: the same
+// round-trip where the kafka-wire client and the REST schema-resolution client
+// each present their own leaf (both signed by the single CA). It proves the
+// threaded RegistrySecurity profile also carries a client key store through to
+// the avro path, not just a trust store.
+func (r *KafkaTests) AvroMtlsFramedProduceConsumeRoundTrip(ctx context.Context, opts ...KafkaTestsAvroMtlsFramedProduceConsumeRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:941:1)
+	if r.avroMtlsFramedProduceConsumeRoundTrip != nil {
+		return nil
+	}
+	q := r.query.Select("avroMtlsFramedProduceConsumeRoundTrip")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `kafkaImageTag` optional argument
+		if !querybuilder.IsZeroValue(opts[i].KafkaImageTag) {
+			q = q.Arg("kafkaImageTag", opts[i].KafkaImageTag)
+		}
+	}
+
+	return q.Execute(ctx)
+}
+
 // AvroSerializeRequiresSchemaID pins the up-front validation contract of
 // valueSerializeAs="AVRO": Produce must reject a zero schema id before any
 // broker or registry I/O. dag.Kafka().Client(...) builds without I/O, so no
@@ -454,6 +483,36 @@ func (r *KafkaTests) AvroSerializeRequiresSchemaID(ctx context.Context) error { 
 		return nil
 	}
 	q := r.query.Select("avroSerializeRequiresSchemaId")
+
+	return q.Execute(ctx)
+}
+
+// KafkaTestsAvroTLSFramedProduceConsumeRoundTripOpts contains options for KafkaTests.AvroTLSFramedProduceConsumeRoundTrip
+type KafkaTestsAvroTLSFramedProduceConsumeRoundTripOpts struct {
+
+	// Default: "4.2.0"
+	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:922:2)
+}
+
+// AvroTlsFramedProduceConsumeRoundTrip is the TLS counterpart of
+// AvroFramedProduceConsumeRoundTrip: it stands up a TLS cluster and a TLS
+// cp-schema-registry rooted at one CA and drives the same JSON->Avro-binary->
+// JSON round-trip, but every hop is encrypted — the kafka-wire client speaks
+// TLS to the brokers and the Produce/Consume avro path resolves the schema
+// over HTTPS via the threaded RegistrySecurity profile (#141). Without that
+// profile the resolution would fail with "serves HTTPS but client is
+// PLAINTEXT", so a green round-trip proves the profile reaches Client(...).
+func (r *KafkaTests) AvroTLSFramedProduceConsumeRoundTrip(ctx context.Context, opts ...KafkaTestsAvroTLSFramedProduceConsumeRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:919:1)
+	if r.avroTlsFramedProduceConsumeRoundTrip != nil {
+		return nil
+	}
+	q := r.query.Select("avroTlsFramedProduceConsumeRoundTrip")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `kafkaImageTag` optional argument
+		if !querybuilder.IsZeroValue(opts[i].KafkaImageTag) {
+			q = q.Arg("kafkaImageTag", opts[i].KafkaImageTag)
+		}
+	}
 
 	return q.Execute(ctx)
 }
@@ -516,14 +575,14 @@ func (r *KafkaTests) ClusterClientCanListTopicsOnFreshCluster(ctx context.Contex
 type KafkaTestsConfluentOpts struct {
 
 	// Default: "8.2.0"
-	ConfluentImageTag string // kafka-tests (../../../daggerverse/kafka/tests/main.go:322:2)
+	ConfluentImageTag string // kafka-tests (../../../daggerverse/kafka/tests/main.go:328:2)
 
-	Parallel int // kafka-tests (../../../daggerverse/kafka/tests/main.go:324:2)
+	Parallel int // kafka-tests (../../../daggerverse/kafka/tests/main.go:330:2)
 }
 
 // Confluent runs the three confluentinc/cp-kafka round-trip tests.
 // Each test owns a fresh ConfluentCluster.
-func (r *KafkaTests) Confluent(ctx context.Context, opts ...KafkaTestsConfluentOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/main.go:319:1)
+func (r *KafkaTests) Confluent(ctx context.Context, opts ...KafkaTestsConfluentOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/main.go:325:1)
 	if r.confluent != nil {
 		return nil
 	}
@@ -626,14 +685,14 @@ func (r *KafkaTests) ConfluentClusterTLSRoundTrip(ctx context.Context, opts ...K
 type KafkaTestsConfluentSchemaRegistryMtlsRegisterLookupRoundTripOpts struct {
 
 	// Default: "4.2.0"
-	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:1150:2)
+	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:1367:2)
 }
 
 // ConfluentSchemaRegistryMtlsRegisterLookupRoundTrip is the mTLS counterpart:
 // the REST endpoint requires a client certificate and the registry presents
 // its own leaf to the mTLS broker for the kafkastore connection, all rooted at
 // one CA.
-func (r *KafkaTests) ConfluentSchemaRegistryMtlsRegisterLookupRoundTrip(ctx context.Context, opts ...KafkaTestsConfluentSchemaRegistryMtlsRegisterLookupRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:1147:1)
+func (r *KafkaTests) ConfluentSchemaRegistryMtlsRegisterLookupRoundTrip(ctx context.Context, opts ...KafkaTestsConfluentSchemaRegistryMtlsRegisterLookupRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:1364:1)
 	if r.confluentSchemaRegistryMtlsRegisterLookupRoundTrip != nil {
 		return nil
 	}
@@ -652,7 +711,7 @@ func (r *KafkaTests) ConfluentSchemaRegistryMtlsRegisterLookupRoundTrip(ctx cont
 type KafkaTestsConfluentSchemaRegistryTLSRegisterLookupRoundTripOpts struct {
 
 	// Default: "4.2.0"
-	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:1129:2)
+	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:1346:2)
 }
 
 // ConfluentSchemaRegistryTlsRegisterLookupRoundTrip is the canonical TLS test:
@@ -660,7 +719,7 @@ type KafkaTestsConfluentSchemaRegistryTLSRegisterLookupRoundTripOpts struct {
 // to a TLS cluster's brokers for the `_schemas` topic, and the round-trip
 // succeeds over an HTTPS client verifying the registry cert against the
 // shared CA.
-func (r *KafkaTests) ConfluentSchemaRegistryTLSRegisterLookupRoundTrip(ctx context.Context, opts ...KafkaTestsConfluentSchemaRegistryTLSRegisterLookupRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:1126:1)
+func (r *KafkaTests) ConfluentSchemaRegistryTLSRegisterLookupRoundTrip(ctx context.Context, opts ...KafkaTestsConfluentSchemaRegistryTLSRegisterLookupRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:1343:1)
 	if r.confluentSchemaRegistryTlsRegisterLookupRoundTrip != nil {
 		return nil
 	}
@@ -865,12 +924,12 @@ func (r *KafkaTests) KarapaceSchemaRegistryRegisterLookupRoundTrip(ctx context.C
 type KafkaTestsKarapaceSchemaRegistryTLSRegisterLookupRoundTripOpts struct {
 
 	// Default: "4.2.0"
-	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:1188:2)
+	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:1405:2)
 }
 
 // KarapaceSchemaRegistryTlsRegisterLookupRoundTrip drives the Karapace TLS
 // path (PEM REST listener + aiokafka SSL storage) end-to-end.
-func (r *KafkaTests) KarapaceSchemaRegistryTLSRegisterLookupRoundTrip(ctx context.Context, opts ...KafkaTestsKarapaceSchemaRegistryTLSRegisterLookupRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:1185:1)
+func (r *KafkaTests) KarapaceSchemaRegistryTLSRegisterLookupRoundTrip(ctx context.Context, opts ...KafkaTestsKarapaceSchemaRegistryTLSRegisterLookupRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_schema_registry.go:1402:1)
 	if r.karapaceSchemaRegistryTlsRegisterLookupRoundTrip != nil {
 		return nil
 	}
@@ -967,16 +1026,16 @@ func (r *KafkaTests) MultiControllerIsRejected(ctx context.Context, opts ...Kafk
 type KafkaTestsNativeOpts struct {
 
 	// Default: "4.2.0"
-	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/main.go:181:2)
+	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/main.go:187:2)
 
-	Parallel int // kafka-tests (../../../daggerverse/kafka/tests/main.go:183:2)
+	Parallel int // kafka-tests (../../../daggerverse/kafka/tests/main.go:189:2)
 }
 
 // Native runs every apache/kafka-native test as one group. It boots
 // the three shared ApacheNativeClusters up front, fans the shared-cluster
 // and fresh-cluster native tests across a par pool capped at parallel,
 // and tears the shared clusters down on return.
-func (r *KafkaTests) Native(ctx context.Context, opts ...KafkaTestsNativeOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/main.go:178:1)
+func (r *KafkaTests) Native(ctx context.Context, opts ...KafkaTestsNativeOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/main.go:184:1)
 	if r.native != nil {
 		return nil
 	}
@@ -1208,15 +1267,15 @@ func (r *KafkaTests) PropertiesFileContainsTLSSettings(ctx context.Context, opts
 type KafkaTestsRedpandaOpts struct {
 
 	// Default: "v26.1.7"
-	RedpandaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/main.go:355:2)
+	RedpandaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/main.go:361:2)
 
-	Parallel int // kafka-tests (../../../daggerverse/kafka/tests/main.go:357:2)
+	Parallel int // kafka-tests (../../../daggerverse/kafka/tests/main.go:363:2)
 }
 
 // Redpanda runs the redpandadata/redpanda round-trip tests — the two
 // Kafka-wire round-trips, the PLAINTEXT and TLS bundled-Schema-Registry
 // round-trips, and the bundled-registry Stop-is-a-no-op lifecycle test.
-func (r *KafkaTests) Redpanda(ctx context.Context, opts ...KafkaTestsRedpandaOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/main.go:352:1)
+func (r *KafkaTests) Redpanda(ctx context.Context, opts ...KafkaTestsRedpandaOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/main.go:358:1)
 	if r.redpanda != nil {
 		return nil
 	}

--- a/daggerverse/kafka/README.md
+++ b/daggerverse/kafka/README.md
@@ -489,6 +489,10 @@ err = client.Produce(ctx, "my-topic", "k", `{"x":"hello"}`, dagger.KafkaClientPr
     ValueSchemaID:    id,
     ValueSerializeAs: "AVRO", // JSON -> Avro binary, then frame with id
     Registry:         sr,     // *SchemaRegistry: resolves schema text by id
+    // RegistrySecurity: for a TLS/mTLS registry pass the matching client
+    // profile (Kafka.{Tls,Mtls}SchemaRegistryClientSecurity); omit / nil
+    // resolves over plaintext HTTP.
+    RegistrySecurity: srClientSec,
 })
 decoded, err := client.Consume(ctx, "my-topic", dagger.KafkaClientConsumeOpts{
     MaxMessages: 1, Timeout: "10s",
@@ -496,6 +500,7 @@ decoded, err := client.Consume(ctx, "my-topic", dagger.KafkaClientConsumeOpts{
     SchemaRegistryAware: true,        // required: supplies the wire id
     ValueDeserializeAs:  "AVRO",      // Avro binary -> JSON
     Registry:            sr,
+    RegistrySecurity:    srClientSec, // same client profile as Produce
 })
 
 // java client.properties (+ p12 sidecars in TLS / mTLS modes) for the
@@ -522,7 +527,12 @@ document and **Avro-binary-encoded** against the registered schema on
 `Produce`, then framed; on `Consume` the framed Avro-binary payload is
 decoded and re-serialised back to JSON. Both directions resolve the
 schema text by id through the supplied `Registry` (`*SchemaRegistry`),
-caching per id for the duration of the call. `Produce` requires a
+caching per id for the duration of the call. Against a **TLS / mTLS**
+registry, also pass the matching `RegistrySecurity`
+(`*SchemaRegistryClientSecurity` from
+`Kafka.{Tls,Mtls}SchemaRegistryClientSecurity`) so the resolution client
+speaks HTTPS (and, for mTLS, presents its client leaf); a nil / omitted
+profile resolves over plaintext HTTP. `Produce` requires a
 positive `…SchemaID` (it both names the schema and frames the record) and
 errors before any I/O on a zero id; `Consume` requires
 `schemaRegistryAware=true` and errors on an unframed record. The JSON

--- a/daggerverse/kafka/README.md
+++ b/daggerverse/kafka/README.md
@@ -159,7 +159,7 @@ observe the same underlying service. It binds every broker via
 from `cluster.BootstrapServers()`.
 
 **TLS / mTLS** — the required `security *SchemaRegistrySecurity` argument (from
-`Kafka.{Plaintext,Tls,Mtls}SchemaRegistrySecurity`) must **match the cluster's
+`Kafka.{Plaintext,TLS,Mtls}SchemaRegistrySecurity`) must **match the cluster's
 mode**: a PLAINTEXT registry pairs with a PLAINTEXT cluster (today's behaviour),
 and a TLS/mTLS registry pairs with a same-mode cluster so its kafka-storage
 connection authenticates against the broker. A mismatch returns an error naming
@@ -490,7 +490,7 @@ err = client.Produce(ctx, "my-topic", "k", `{"x":"hello"}`, dagger.KafkaClientPr
     ValueSerializeAs: "AVRO", // JSON -> Avro binary, then frame with id
     Registry:         sr,     // *SchemaRegistry: resolves schema text by id
     // RegistrySecurity: for a TLS/mTLS registry pass the matching client
-    // profile (Kafka.{Tls,Mtls}SchemaRegistryClientSecurity); omit / nil
+    // profile (Kafka.{TLS,Mtls}SchemaRegistryClientSecurity); omit / nil
     // resolves over plaintext HTTP.
     RegistrySecurity: srClientSec,
 })
@@ -530,7 +530,7 @@ schema text by id through the supplied `Registry` (`*SchemaRegistry`),
 caching per id for the duration of the call. Against a **TLS / mTLS**
 registry, also pass the matching `RegistrySecurity`
 (`*SchemaRegistryClientSecurity` from
-`Kafka.{Tls,Mtls}SchemaRegistryClientSecurity`) so the resolution client
+`Kafka.{TLS,Mtls}SchemaRegistryClientSecurity`) so the resolution client
 speaks HTTPS (and, for mTLS, presents its client leaf); a nil / omitted
 profile resolves over plaintext HTTP. `Produce` requires a
 positive `…SchemaID` (it both names the schema and frames the record) and
@@ -582,9 +582,9 @@ Topic auto-creation is disabled on the broker — call `CreateTopic` before
   connection uses the same protocol the broker's client listener speaks.
 - **Single-CA convention.** Because the cluster does not carry its CA across the
   API, the registry derives its broker-facing truststore from the CA the caller
-  re-supplies. Pass the **same CA** to the cluster (`TlsServerSecurity`), the
-  registry (`TlsSchemaRegistrySecurity`), and the client
-  (`TlsSchemaRegistryClientSecurity`) so every handshake chains to one root. For
+  re-supplies. Pass the **same CA** to the cluster (`TLSServerSecurity`), the
+  registry (`TLSSchemaRegistrySecurity`), and the client
+  (`TLSSchemaRegistryClientSecurity`) so every handshake chains to one root. For
   mTLS the registry also mints its own client leaf from that CA to present to
   the broker.
 - **PKCS#12 vs PEM per image.** Confluent (`cp-schema-registry`, Java) and

--- a/daggerverse/kafka/avro.go
+++ b/daggerverse/kafka/avro.go
@@ -43,8 +43,9 @@ import (
 // within one Consume call to avoid an HTTP round-trip per record; the same
 // cache serves Produce's single record.
 type avroSchemas struct {
-	registry *SchemaRegistry
-	byID     map[int]*avroSchema
+	registry         *SchemaRegistry
+	registrySecurity *SchemaRegistryClientSecurity
+	byID             map[int]*avroSchema
 }
 
 // avroSchema is one resolved schema plus its lazily-built name table and
@@ -57,8 +58,8 @@ type avroSchema struct {
 	dec    *generic.Decoder
 }
 
-func newAvroSchemas(registry *SchemaRegistry) *avroSchemas {
-	return &avroSchemas{registry: registry, byID: make(map[int]*avroSchema)}
+func newAvroSchemas(registry *SchemaRegistry, security *SchemaRegistryClientSecurity) *avroSchemas {
+	return &avroSchemas{registry: registry, registrySecurity: security, byID: make(map[int]*avroSchema)}
 }
 
 // get returns the resolved schema for id, fetching its text from the registry
@@ -71,11 +72,11 @@ func (a *avroSchemas) get(ctx context.Context, id int) (*avroSchema, error) {
 		return nil, fmt.Errorf("AVRO mode requires a schema registry to resolve schema id %d", id)
 	}
 	// The franz-go avro path resolves schemas over the registry's REST API.
-	// It currently assumes a plaintext registry; wiring a TLS/mTLS client
-	// profile through Produce/Consume is a follow-up (#141). A TLS registry
-	// here surfaces a clear "serves HTTPS but client is PLAINTEXT" error from
-	// do().
-	rs, err := a.registry.Client(nil).LookupSchemaByID(ctx, id)
+	// registrySecurity is the client profile threaded from Produce/Consume: a
+	// nil profile resolves over plaintext HTTP (today's behaviour), while a
+	// TLS/mTLS profile resolves the schema over HTTPS against a secured
+	// registry (#141).
+	rs, err := a.registry.Client(a.registrySecurity).LookupSchemaByID(ctx, id)
 	if err != nil {
 		return nil, fmt.Errorf("resolve schema id %d: %w", id, err)
 	}

--- a/daggerverse/kafka/client.go
+++ b/daggerverse/kafka/client.go
@@ -538,6 +538,12 @@ func (c *Client) Produce(
 	//
 	// +optional
 	registry *SchemaRegistry,
+	// registrySecurity is the TLS/mTLS client profile used to resolve Avro
+	// schema text against a secured registry. Nil (the default) resolves over
+	// plaintext HTTP, reproducing today's behaviour.
+	//
+	// +optional
+	registrySecurity *SchemaRegistryClientSecurity,
 ) error {
 	if keySchemaID < 0 {
 		return fmt.Errorf("keySchemaID must be >= 0, got %d", keySchemaID)
@@ -555,7 +561,7 @@ func (c *Client) Produce(
 		return fmt.Errorf("decode value: %w", err)
 	}
 
-	codecs := newAvroSchemas(registry)
+	codecs := newAvroSchemas(registry, registrySecurity)
 	keyBytes, err = serializeField(ctx, keyBytes, keySerializeAs, "key", keySchemaID, codecs)
 	if err != nil {
 		return fmt.Errorf("serialize key: %w", err)
@@ -661,6 +667,12 @@ func (c *Client) Consume(
 	//
 	// +optional
 	registry *SchemaRegistry,
+	// registrySecurity is the TLS/mTLS client profile used to resolve Avro
+	// schema text against a secured registry. Nil (the default) resolves over
+	// plaintext HTTP, reproducing today's behaviour.
+	//
+	// +optional
+	registrySecurity *SchemaRegistryClientSecurity,
 ) (string, error) {
 	if maxMessages <= 0 {
 		return "", fmt.Errorf("maxMessages must be > 0, got %d", maxMessages)
@@ -705,7 +717,7 @@ func (c *Client) Consume(
 
 	// One codec cache per call so schema resolution is cached per id across
 	// every record polled (issue: avoid one HTTP round-trip per record).
-	codecs := newAvroSchemas(registry)
+	codecs := newAvroSchemas(registry, registrySecurity)
 
 	out := make([]ConsumedRecord, 0, maxMessages)
 	for len(out) < maxMessages {

--- a/daggerverse/kafka/dagger.gen.go
+++ b/daggerverse/kafka/dagger.gen.go
@@ -668,7 +668,14 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg registry", err))
 				}
 			}
-			return (*Client).Consume(&parent, ctx, topic, maxMessages, timeout, keyEncoding, valueEncoding, group, schemaRegistryAware, keyDeserializeAs, valueDeserializeAs, registry)
+			var registrySecurity *SchemaRegistryClientSecurity
+			if inputArgs["registrySecurity"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["registrySecurity"]), &registrySecurity)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg registrySecurity", err))
+				}
+			}
+			return (*Client).Consume(&parent, ctx, topic, maxMessages, timeout, keyEncoding, valueEncoding, group, schemaRegistryAware, keyDeserializeAs, valueDeserializeAs, registry, registrySecurity)
 		case "CreateTopic":
 			var parent Client
 			err = json.Unmarshal(parentJSON, &parent)
@@ -794,7 +801,14 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg registry", err))
 				}
 			}
-			return nil, (*Client).Produce(&parent, ctx, topic, key, value, keyEncoding, valueEncoding, keySchemaId, valueSchemaId, keySerializeAs, valueSerializeAs, registry)
+			var registrySecurity *SchemaRegistryClientSecurity
+			if inputArgs["registrySecurity"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["registrySecurity"]), &registrySecurity)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg registrySecurity", err))
+				}
+			}
+			return nil, (*Client).Produce(&parent, ctx, topic, key, value, keyEncoding, valueEncoding, keySchemaId, valueSchemaId, keySerializeAs, valueSerializeAs, registry, registrySecurity)
 		case "PropertiesFile":
 			var parent Client
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/kafka/tests/dagger.gen.go
+++ b/daggerverse/kafka/tests/dagger.gen.go
@@ -374,6 +374,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Tests).AvroFramedProduceConsumeRoundTrip(&parent, ctx, kafkaImageTag)
+		case "AvroMtlsFramedProduceConsumeRoundTrip":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var kafkaImageTag string
+			if inputArgs["kafkaImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["kafkaImageTag"]), &kafkaImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg kafkaImageTag", err))
+				}
+			}
+			return nil, (*Tests).AvroMtlsFramedProduceConsumeRoundTrip(&parent, ctx, kafkaImageTag)
 		case "AvroSerializeRequiresSchemaID":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -381,6 +395,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).AvroSerializeRequiresSchemaID(&parent, ctx)
+		case "AvroTlsFramedProduceConsumeRoundTrip":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var kafkaImageTag string
+			if inputArgs["kafkaImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["kafkaImageTag"]), &kafkaImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg kafkaImageTag", err))
+				}
+			}
+			return nil, (*Tests).AvroTlsFramedProduceConsumeRoundTrip(&parent, ctx, kafkaImageTag)
 		case "BindBrokersExposesBothListeners":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/kafka/tests/internal/dagger/kafka.gen.go
+++ b/daggerverse/kafka/tests/internal/dagger/kafka.gen.go
@@ -1124,29 +1124,35 @@ func (r *KafkaClient) WithGraphQLQuery(q *querybuilder.Selection) *KafkaClient {
 type KafkaClientConsumeOpts struct {
 
 	// Default: 1
-	MaxMessages int // kafka (../../../../../daggerverse/kafka/client.go:644:2)
+	MaxMessages int // kafka (../../../../../daggerverse/kafka/client.go:650:2)
 
 	// Default: "10s"
-	Timeout string // kafka (../../../../../daggerverse/kafka/client.go:646:2)
+	Timeout string // kafka (../../../../../daggerverse/kafka/client.go:652:2)
 
 	// Default: "raw"
-	KeyEncoding string // kafka (../../../../../daggerverse/kafka/client.go:648:2)
+	KeyEncoding string // kafka (../../../../../daggerverse/kafka/client.go:654:2)
 
 	// Default: "raw"
-	ValueEncoding string // kafka (../../../../../daggerverse/kafka/client.go:650:2)
+	ValueEncoding string // kafka (../../../../../daggerverse/kafka/client.go:656:2)
 
-	Group string // kafka (../../../../../daggerverse/kafka/client.go:652:2)
+	Group string // kafka (../../../../../daggerverse/kafka/client.go:658:2)
 
-	SchemaRegistryAware bool // kafka (../../../../../daggerverse/kafka/client.go:654:2)
+	SchemaRegistryAware bool // kafka (../../../../../daggerverse/kafka/client.go:660:2)
 
-	KeyDeserializeAs string // kafka (../../../../../daggerverse/kafka/client.go:656:2)
+	KeyDeserializeAs string // kafka (../../../../../daggerverse/kafka/client.go:662:2)
 
-	ValueDeserializeAs string // kafka (../../../../../daggerverse/kafka/client.go:658:2)
+	ValueDeserializeAs string // kafka (../../../../../daggerverse/kafka/client.go:664:2)
 	//
 	// registry resolves the Avro schema text by id when keyDeserializeAs /
 	// valueDeserializeAs is "AVRO". Required in that mode; ignored otherwise.
 	//
-	Registry *KafkaSchemaRegistry // kafka (../../../../../daggerverse/kafka/client.go:663:2)
+	Registry *KafkaSchemaRegistry // kafka (../../../../../daggerverse/kafka/client.go:669:2)
+	//
+	// registrySecurity is the TLS/mTLS client profile used to resolve Avro
+	// schema text against a secured registry. Nil (the default) resolves over
+	// plaintext HTTP, reproducing today's behaviour.
+	//
+	RegistrySecurity *KafkaSchemaRegistryClientSecurity // kafka (../../../../../daggerverse/kafka/client.go:675:2)
 }
 
 // Consume reads up to maxMessages records from the topic, starting at the
@@ -1189,7 +1195,7 @@ type KafkaClientConsumeOpts struct {
 // per id for the duration of the call. The JSON shape follows the Avro
 // spec's JSON encoding; logical types, decimal, and fixed are not yet
 // supported.
-func (r *KafkaClient) Consume(ctx context.Context, topic string, opts ...KafkaClientConsumeOpts) (string, error) { // kafka (../../../../../daggerverse/kafka/client.go:640:1)
+func (r *KafkaClient) Consume(ctx context.Context, topic string, opts ...KafkaClientConsumeOpts) (string, error) { // kafka (../../../../../daggerverse/kafka/client.go:646:1)
 	if r.consume != nil {
 		return *r.consume, nil
 	}
@@ -1230,6 +1236,10 @@ func (r *KafkaClient) Consume(ctx context.Context, topic string, opts ...KafkaCl
 		// `registry` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Registry) {
 			q = q.Arg("registry", opts[i].Registry)
+		}
+		// `registrySecurity` optional argument
+		if !querybuilder.IsZeroValue(opts[i].RegistrySecurity) {
+			q = q.Arg("registrySecurity", opts[i].RegistrySecurity)
 		}
 	}
 	q = q.Arg("topic", topic)
@@ -1333,7 +1343,7 @@ func (r *KafkaClient) UnmarshalJSON(bs []byte) error {
 }
 
 // ListTopics returns the names of every topic the broker reports.
-func (r *KafkaClient) ListTopics(ctx context.Context) ([]string, error) { // kafka (../../../../../daggerverse/kafka/client.go:777:1)
+func (r *KafkaClient) ListTopics(ctx context.Context) ([]string, error) { // kafka (../../../../../daggerverse/kafka/client.go:789:1)
 	q := r.query.Select("listTopics")
 
 	var response []string
@@ -1363,6 +1373,12 @@ type KafkaClientProduceOpts struct {
 	// valueSerializeAs is "AVRO". Required in that mode; ignored otherwise.
 	//
 	Registry *KafkaSchemaRegistry // kafka (../../../../../daggerverse/kafka/client.go:540:2)
+	//
+	// registrySecurity is the TLS/mTLS client profile used to resolve Avro
+	// schema text against a secured registry. Nil (the default) resolves over
+	// plaintext HTTP, reproducing today's behaviour.
+	//
+	RegistrySecurity *KafkaSchemaRegistryClientSecurity // kafka (../../../../../daggerverse/kafka/client.go:546:2)
 }
 
 // Produce synchronously writes one record to the topic. Key and value are
@@ -1424,6 +1440,10 @@ func (r *KafkaClient) Produce(ctx context.Context, topic string, key string, val
 		// `registry` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Registry) {
 			q = q.Arg("registry", opts[i].Registry)
+		}
+		// `registrySecurity` optional argument
+		if !querybuilder.IsZeroValue(opts[i].RegistrySecurity) {
+			q = q.Arg("registrySecurity", opts[i].RegistrySecurity)
 		}
 	}
 	q = q.Arg("topic", topic)

--- a/daggerverse/kafka/tests/main.go
+++ b/daggerverse/kafka/tests/main.go
@@ -161,6 +161,12 @@ func (t *Tests) SchemaRegistry(
 	jobs = jobs.WithJob("AvroFramedProduceConsumeRoundTrip", func(ctx context.Context) error {
 		return t.AvroFramedProduceConsumeRoundTrip(ctx, kafkaImageTag)
 	})
+	jobs = jobs.WithJob("AvroTlsFramedProduceConsumeRoundTrip", func(ctx context.Context) error {
+		return t.AvroTlsFramedProduceConsumeRoundTrip(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("AvroMtlsFramedProduceConsumeRoundTrip", func(ctx context.Context) error {
+		return t.AvroMtlsFramedProduceConsumeRoundTrip(ctx, kafkaImageTag)
+	})
 	jobs = jobs.WithJob("AvroBytesFieldRoundTrip", func(ctx context.Context) error {
 		return t.AvroBytesFieldRoundTrip(ctx, kafkaImageTag)
 	})

--- a/daggerverse/kafka/tests/tests_schema_registry.go
+++ b/daggerverse/kafka/tests/tests_schema_registry.go
@@ -908,6 +908,152 @@ func (t *Tests) AvroFramedProduceConsumeRoundTrip(
 	return nil
 }
 
+// AvroTlsFramedProduceConsumeRoundTrip is the TLS counterpart of
+// AvroFramedProduceConsumeRoundTrip: it stands up a TLS cluster and a TLS
+// cp-schema-registry rooted at one CA and drives the same JSON->Avro-binary->
+// JSON round-trip, but every hop is encrypted — the kafka-wire client speaks
+// TLS to the brokers and the Produce/Consume avro path resolves the schema
+// over HTTPS via the threaded RegistrySecurity profile (#141). Without that
+// profile the resolution would fail with "serves HTTPS but client is
+// PLAINTEXT", so a green round-trip proves the profile reaches Client(...).
+func (t *Tests) AvroTlsFramedProduceConsumeRoundTrip(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, srSec, registryClientSec, wireClientSec, err := freshTlsAvroStack(ctx, kafkaImageTag)
+	if err != nil {
+		return fmt.Errorf("create tls avro stack: %w", err)
+	}
+	defer cluster.Stop(ctx)
+
+	sr := dag.Kafka().ConfluentSchemaRegistry(cluster, srSec)
+	defer sr.Stop(ctx)
+
+	return avroFramedRoundTripOn(ctx, cluster, sr, registryClientSec, wireClientSec)
+}
+
+// AvroMtlsFramedProduceConsumeRoundTrip is the mTLS counterpart: the same
+// round-trip where the kafka-wire client and the REST schema-resolution client
+// each present their own leaf (both signed by the single CA). It proves the
+// threaded RegistrySecurity profile also carries a client key store through to
+// the avro path, not just a trust store.
+func (t *Tests) AvroMtlsFramedProduceConsumeRoundTrip(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, srSec, registryClientSec, wireClientSec, err := freshMtlsAvroStack(ctx, kafkaImageTag)
+	if err != nil {
+		return fmt.Errorf("create mtls avro stack: %w", err)
+	}
+	defer cluster.Stop(ctx)
+
+	sr := dag.Kafka().ConfluentSchemaRegistry(cluster, srSec)
+	defer sr.Stop(ctx)
+
+	return avroFramedRoundTripOn(ctx, cluster, sr, registryClientSec, wireClientSec)
+}
+
+// avroFramedRoundTripOn is the shared body for the plaintext-agnostic avro
+// serde round-trip: register an Avro record schema over registryClientSec,
+// Produce a JSON document with valueSerializeAs="AVRO" (Avro-binary-encoded
+// then framed) over the kafka-wire wireClientSec, and Consume it back with
+// valueDeserializeAs="AVRO" + schemaRegistryAware=true. Both Produce and
+// Consume pass registryClientSec as RegistrySecurity so the schema text is
+// resolved against a (possibly TLS/mTLS) registry. Asserts byte-equality of
+// the consumed value to the canonical JSON form and that the wire schema id
+// survives. Mirrors AvroFramedProduceConsumeRoundTrip so the TLS and mTLS
+// tests differ only in how the stack is minted.
+func avroFramedRoundTripOn(
+	ctx context.Context,
+	cluster *dagger.KafkaCluster,
+	sr *dagger.KafkaSchemaRegistry,
+	registryClientSec *dagger.KafkaSchemaRegistryClientSecurity,
+	wireClientSec *dagger.KafkaClientSecurity,
+) error {
+	subject, err := randomTopicName(ctx)
+	if err != nil {
+		return err
+	}
+	topic := subject
+	subject += "-value"
+
+	id, err := sr.Client(registryClientSec).RegisterSchema(ctx, subject, avroTestSchema, dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{
+		SchemaType: "AVRO",
+	})
+	if err != nil {
+		return fmt.Errorf("register schema: %w", err)
+	}
+	if id <= 0 {
+		return fmt.Errorf("expected a positive schema id, got %d", id)
+	}
+
+	client := cluster.Client(wireClientSec)
+	if err := client.CreateTopic(ctx, topic, dagger.KafkaClientCreateTopicOpts{
+		Partitions:        1,
+		ReplicationFactor: 1,
+	}); err != nil {
+		return fmt.Errorf("create topic %q: %w", topic, err)
+	}
+
+	// Whitespace differs from the canonical form so the round-trip proves the
+	// payload is genuinely re-encoded, not passed through.
+	const inputJSON = `{ "x" :  "hello-world" }`
+	const wantCanonical = `{"x":"hello-world"}`
+	const wantKey = "k"
+
+	if err := client.Produce(ctx, topic, wantKey, inputJSON, dagger.KafkaClientProduceOpts{
+		KeyEncoding:      "raw",
+		ValueEncoding:    "raw",
+		ValueSchemaID:    id,
+		ValueSerializeAs: "AVRO",
+		Registry:         sr,
+		RegistrySecurity: registryClientSec,
+	}); err != nil {
+		return fmt.Errorf("produce: %w", err)
+	}
+
+	records, err := consume(ctx, client, topic, dagger.KafkaClientConsumeOpts{
+		MaxMessages:         1,
+		Timeout:             "10s",
+		KeyEncoding:         "raw",
+		ValueEncoding:       "raw",
+		SchemaRegistryAware: true,
+		ValueDeserializeAs:  "AVRO",
+		Registry:            sr,
+		RegistrySecurity:    registryClientSec,
+	})
+	if err != nil {
+		return fmt.Errorf("consume: %w", err)
+	}
+	if len(records) != 1 {
+		return fmt.Errorf("expected 1 record, got %d", len(records))
+	}
+	gotKey, err := records[0].Key(ctx)
+	if err != nil {
+		return fmt.Errorf("read key: %w", err)
+	}
+	gotVal, err := records[0].Value(ctx)
+	if err != nil {
+		return fmt.Errorf("read value: %w", err)
+	}
+	gotValID, err := records[0].ValueSchemaID(ctx)
+	if err != nil {
+		return fmt.Errorf("read value schema id: %w", err)
+	}
+	if gotKey != wantKey {
+		return fmt.Errorf("key mismatch: want %q, got %q", wantKey, gotKey)
+	}
+	if gotVal != wantCanonical {
+		return fmt.Errorf("value mismatch: want canonical %q, got %q", wantCanonical, gotVal)
+	}
+	if gotValID != id {
+		return fmt.Errorf("value schema id mismatch: want %d, got %d", id, gotValID)
+	}
+	return nil
+}
+
 // AvroBytesFieldRoundTrip pins the Avro-spec JSON encoding of a bytes field.
 // Per the Avro specification, the JSON encoding of bytes (and fixed) is a
 // string whose characters are the byte values as Unicode code points 0-255 —
@@ -1057,6 +1203,77 @@ func freshMtlsRegistryStack(ctx context.Context, kafkaImageTag string) (
 	}
 	clientSec := k.MtlsSchemaRegistryClientSecurity(clientKs, clientKsPwd, ts.Pkcs12(), ts.Password())
 	return cluster, srSec, clientSec, nil
+}
+
+// freshTlsAvroStack mints one CA and returns everything the avro
+// Produce/Consume TLS round-trip needs, all rooted at that CA: a TLS
+// single-broker cluster, a TLS SchemaRegistrySecurity (server), a TLS
+// SchemaRegistryClientSecurity (the REST profile threaded through the avro
+// path), and a TLS KafkaClientSecurity for the kafka-wire producer/consumer.
+// It differs from freshTlsRegistryStack only by also building the kafka-wire
+// client profile (freshTlsRegistryStack feeds register/lookup tests that never
+// produce or consume, so it does not need one).
+func freshTlsAvroStack(ctx context.Context, kafkaImageTag string) (
+	*dagger.KafkaCluster, *dagger.KafkaSchemaRegistrySecurity, *dagger.KafkaSchemaRegistryClientSecurity, *dagger.KafkaClientSecurity, error,
+) {
+	ca, err := freshCa(ctx, "tls-avro")
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	caKs := ca.KeyStore()
+	ts := ca.TrustStore()
+
+	clusterId, err := newClusterId(ctx)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	k := dag.Kafka()
+	cluster := k.ApacheNativeCluster(clusterId, k.TLSServerSecurity(caKs.Pkcs12(), caKs.Password()),
+		dagger.KafkaApacheNativeClusterOpts{Tag: kafkaImageTag, Brokers: 1})
+	srSec := k.TLSSchemaRegistrySecurity(caKs.Pkcs12(), caKs.Password())
+	registryClientSec := k.TLSSchemaRegistryClientSecurity(ts.Pkcs12(), ts.Password())
+	wireClientSec := k.TLSClientSecurity(ts.Pkcs12(), ts.Password())
+	return cluster, srSec, registryClientSec, wireClientSec, nil
+}
+
+// freshMtlsAvroStack is the mTLS counterpart of freshTlsAvroStack. The single
+// CA signs the broker leaves and is the broker's client-trust anchor, signs
+// the registry's REST + kafkastore leaves and is the registry's REST
+// client-trust anchor, and signs two client leaves: one for the kafka-wire
+// producer/consumer and one for the REST schema-resolution client. Both client
+// profiles present a leaf that validates against the same root.
+func freshMtlsAvroStack(ctx context.Context, kafkaImageTag string) (
+	*dagger.KafkaCluster, *dagger.KafkaSchemaRegistrySecurity, *dagger.KafkaSchemaRegistryClientSecurity, *dagger.KafkaClientSecurity, error,
+) {
+	ca, err := freshCa(ctx, "mtls-avro")
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	caKs := ca.KeyStore()
+	ts := ca.TrustStore()
+
+	clusterId, err := newClusterId(ctx)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	k := dag.Kafka()
+	cluster := k.ApacheNativeCluster(clusterId,
+		k.MtlsServerSecurity(caKs.Pkcs12(), caKs.Password(), ts.Pkcs12(), ts.Password()),
+		dagger.KafkaApacheNativeClusterOpts{Tag: kafkaImageTag, Brokers: 1})
+	srSec := k.MtlsSchemaRegistrySecurity(caKs.Pkcs12(), caKs.Password(), ts.Pkcs12(), ts.Password())
+
+	restKs, restKsPwd, err := issueClientKeystore(ctx, ca, "sr-rest-client")
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	registryClientSec := k.MtlsSchemaRegistryClientSecurity(restKs, restKsPwd, ts.Pkcs12(), ts.Password())
+
+	wireKs, wireKsPwd, err := issueClientKeystore(ctx, ca, "kafka-wire-client")
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	wireClientSec := k.MtlsClientSecurity(wireKs, wireKsPwd, ts.Pkcs12(), ts.Password())
+	return cluster, srSec, registryClientSec, wireClientSec, nil
 }
 
 // schemaRegistryRoundTripOn exercises the core register → lookup-by-id →


### PR DESCRIPTION
Closes #141.

Follow-up to #43 / #142. Threads a TLS/mTLS Schema Registry client profile
through the franz-go avro `Produce`/`Consume` path so avro schema resolution
works against a secured registry.

## Problem

`avroSchemas.get` (`daggerverse/kafka/avro.go`) hard-coded
`a.registry.Client(nil)`, which defaults to a PLAINTEXT client. Against a
TLS/mTLS registry, avro schema resolution failed in `SchemaRegistryClient.do`
with `"schema registry serves HTTPS but the client security is PLAINTEXT"`.
`Produce`/`Consume` had no channel for a `*SchemaRegistryClientSecurity`, so
#142 deliberately carved this seam out of scope.

## What changed

- **`avro.go`** — `avroSchemas` carries a `*SchemaRegistryClientSecurity` and
  passes it to `registry.Client(...)` instead of `nil`. Everything downstream of
  `SchemaRegistry.Client` (`tlsConfig`, `do`, transport cloning) was already
  TLS/mTLS-capable, so this was the only missing wiring.
- **`client.go`** — `Produce` and `Consume` gain an `+optional registrySecurity
  *SchemaRegistryClientSecurity` param (alongside the existing `registry`),
  threaded into `newAvroSchemas`. Both land as the optional `RegistrySecurity`
  opt, so existing callers are unaffected.
- **Tests** — `AvroTlsFramedProduceConsumeRoundTrip` and
  `AvroMtlsFramedProduceConsumeRoundTrip` drive the full
  JSON→Avro-binary→JSON round-trip against a TLS / mTLS registry, via new
  single-CA `freshTlsAvroStack` / `freshMtlsAvroStack` helpers and a shared
  `avroFramedRoundTripOn` body (mirrors the plaintext
  `AvroFramedProduceConsumeRoundTrip`). Registered in the `SchemaRegistry`
  test group.
- **README** — documents the `RegistrySecurity` opt for TLS/mTLS registries and
  updates the inline avro example.
- **Generated** — regenerated kafka, kafka/tests, and root `ci` bindings with
  the pinned dagger `v0.21.7` so the CI `Generated` drift check passes.

## Backwards compatibility

A nil / omitted `RegistrySecurity` resolves over plaintext HTTP, reproducing
today's behaviour; the untouched plaintext `AvroFramedProduceConsumeRoundTrip`
regression still passes.

## Tests (green against the pinned v0.21.7 engine)

- `avro-tls-framed-produce-consume-round-trip` — ✅ 21.2s
- `avro-mtls-framed-produce-consume-round-trip` — ✅ 23.1s
- `avro-framed-produce-consume-round-trip` (plaintext regression) — ✅ 14.3s
- All three modules build + `go vet` clean; no `dagger.json` / core-binding
  pollution, no engineVersion churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)