### PR TITLE
story(issue-131): add topic & consumer-group introspection to kafka Client

### DIFF
--- a/daggerverse/kafka/README.md
+++ b/daggerverse/kafka/README.md
@@ -547,6 +547,43 @@ unframe → deserialize → encode on `Consume`.
 Topic auto-creation is disabled on the broker — call `CreateTopic` before
 `Produce` / `Consume`.
 
+### Introspection
+
+Three live-cluster introspection primitives return their richer payloads as a
+`*dagger.File` of JSON (a core type, so it crosses the module boundary; export
+it and unmarshal the bytes). All three carry `+cache="never"` so they always
+reflect current cluster state.
+
+```go
+// Per-topic metadata: partition layout (leader / replicas / ISR), the derived
+// partition count and replication factor, and the full topic-level config set
+// (retention.ms, cleanup.policy, ...), configs sorted by key.
+topicJSON, err := client.DescribeTopic(ctx, "my-topic").Contents(ctx)
+
+// Consumer group names (sorted). Empty on a fresh cluster; a group appears
+// once a consumer has joined and persists while it retains committed offsets.
+groups, err := client.ListConsumerGroups(ctx)
+
+// Per-group detail: coordinator / state / protocol, members with their
+// per-topic partition assignments, and per-partition committed-offset lag
+// (with the total).
+groupJSON, err := client.DescribeConsumerGroup(ctx, "my-group").Contents(ctx)
+```
+
+`DescribeConsumerGroup` only reports lag for partitions the group has
+**committed** offsets for. `Consume` does not commit by default (it stays
+idempotent under `+cache="never"`); pass `CommitOffsets: true` alongside a
+`Group` to commit exactly the records returned, so the group persists in the
+`Empty` state with reportable lag afterwards:
+
+```go
+_, err := client.Consume(ctx, "my-topic", dagger.KafkaClientConsumeOpts{
+    MaxMessages: 3, Timeout: "10s",
+    KeyEncoding: "raw", ValueEncoding: "raw",
+    Group: "my-group", CommitOffsets: true,
+})
+```
+
 ## TLS / mTLS notes
 
 - The internal CA is fresh per `ApacheNativeCluster()` invocation. Cert material

--- a/daggerverse/kafka/client.go
+++ b/daggerverse/kafka/client.go
@@ -609,9 +609,13 @@ func (c *Client) Produce(
 //
 // When group is non-empty, the consume runs as a member of that consumer
 // group: the broker assigns partitions and the join itself writes group
-// metadata to __consumer_offsets (offsets are not committed — the function
-// stays idempotent under +cache="never"). When group is empty (the
-// default), partitions are consumed directly with no group state.
+// metadata to __consumer_offsets. By default offsets are not committed, so
+// the function stays idempotent under +cache="never". When commitOffsets is
+// true (and group is set), the consumed records' offsets are committed before
+// returning, so the group persists in the Empty state with committed offsets
+// afterwards — enough for DescribeConsumerGroup to report non-zero lag. When
+// group is empty (the default), partitions are consumed directly with no group
+// state and commitOffsets is ignored.
 //
 // When schemaRegistryAware is true, each record's key and value are
 // inspected for the Confluent Schema Registry wire-format header
@@ -656,6 +660,12 @@ func (c *Client) Consume(
 	valueEncoding string,
 	// +default=""
 	group string,
+	// commitOffsets, when true and group is set, commits the consumed
+	// records' offsets before returning so the group persists with committed
+	// offsets (and thus reportable lag). Ignored when group is empty.
+	//
+	// +default=false
+	commitOffsets bool,
 	// +default=false
 	schemaRegistryAware bool,
 	// +default=""
@@ -698,12 +708,16 @@ func (c *Client) Consume(
 		kgo.ConsumeResetOffset(kgo.NewOffset().AtStart()),
 	}
 	if group != "" {
-		// DisableAutoCommit keeps Consume idempotent under
-		// +cache="never": re-runs triggered by lazy record loading
-		// always re-read from the start instead of resuming past a
-		// committed offset. The group join itself still exercises
-		// __consumer_offsets, which is what proves the system-topic
-		// replication-factor defaults are correct.
+		// DisableAutoCommit in both modes: auto-commit would mark the
+		// whole polled fetch (which can hold more records than maxMessages)
+		// as consumed, so a partial read would commit past the records we
+		// actually returned. Default mode keeps Consume idempotent under
+		// +cache="never" — re-runs triggered by lazy record loading always
+		// re-read from the start instead of resuming past a committed
+		// offset — while still exercising __consumer_offsets on join (which
+		// proves the system-topic replication-factor defaults are correct).
+		// When commitOffsets is set the exact records returned are committed
+		// explicitly (see finish), so the committed offset matches the read.
 		opts = append(opts, kgo.ConsumerGroup(group), kgo.DisableAutoCommit())
 	}
 	cl, err := c.newKgoClient(ctx, opts...)
@@ -720,6 +734,25 @@ func (c *Client) Consume(
 	codecs := newAvroSchemas(registry, registrySecurity)
 
 	out := make([]ConsumedRecord, 0, maxMessages)
+	// committed retains the exact *kgo.Records returned to the caller so
+	// finish can commit their offsets (offset+1 per partition) — and no more
+	// — when commitOffsets is set.
+	var committed []*kgo.Record
+
+	// finish commits the returned records' offsets when the caller opted into
+	// durable offsets, then marshals the gathered records. It runs at both
+	// return-with-records sites. A fresh context is used for the commit
+	// because deadlineCtx may already be expired at the deadline-hit path.
+	finish := func() (string, error) {
+		if group != "" && commitOffsets && len(committed) > 0 {
+			commitCtx, commitCancel := context.WithTimeout(ctx, 15*time.Second)
+			defer commitCancel()
+			if err := cl.CommitRecords(commitCtx, committed...); err != nil {
+				return "", fmt.Errorf("commit offsets for group %q: %w", group, err)
+			}
+		}
+		return marshalRecords(out)
+	}
 	for len(out) < maxMessages {
 		fetches := cl.PollFetches(deadlineCtx)
 		if errs := fetches.Errors(); len(errs) > 0 {
@@ -729,7 +762,7 @@ func (c *Client) Consume(
 				}
 				return "", fmt.Errorf("poll fetches: %w", e.Err)
 			}
-			return marshalRecords(out)
+			return finish()
 		}
 		iter := fetches.RecordIter()
 		for !iter.Done() && len(out) < maxMessages {
@@ -768,9 +801,12 @@ func (c *Client) Consume(
 				KeySchemaID:   keyID,
 				ValueSchemaID: valID,
 			})
+			if group != "" && commitOffsets {
+				committed = append(committed, r)
+			}
 		}
 	}
-	return marshalRecords(out)
+	return finish()
 }
 
 // marshalRecords encodes the consumed records as a JSON array string. See

--- a/daggerverse/kafka/dagger.gen.go
+++ b/daggerverse/kafka/dagger.gen.go
@@ -640,6 +640,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg group", err))
 				}
 			}
+			var commitOffsets bool
+			if inputArgs["commitOffsets"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["commitOffsets"]), &commitOffsets)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg commitOffsets", err))
+				}
+			}
 			var schemaRegistryAware bool
 			if inputArgs["schemaRegistryAware"] != nil {
 				err = json.Unmarshal([]byte(inputArgs["schemaRegistryAware"]), &schemaRegistryAware)
@@ -675,7 +682,7 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg registrySecurity", err))
 				}
 			}
-			return (*Client).Consume(&parent, ctx, topic, maxMessages, timeout, keyEncoding, valueEncoding, group, schemaRegistryAware, keyDeserializeAs, valueDeserializeAs, registry, registrySecurity)
+			return (*Client).Consume(&parent, ctx, topic, maxMessages, timeout, keyEncoding, valueEncoding, group, commitOffsets, schemaRegistryAware, keyDeserializeAs, valueDeserializeAs, registry, registrySecurity)
 		case "CreateTopic":
 			var parent Client
 			err = json.Unmarshal(parentJSON, &parent)
@@ -718,6 +725,41 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Client).DeleteTopic(&parent, ctx, name)
+		case "DescribeConsumerGroup":
+			var parent Client
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var group string
+			if inputArgs["group"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["group"]), &group)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg group", err))
+				}
+			}
+			return (*Client).DescribeConsumerGroup(&parent, ctx, group)
+		case "DescribeTopic":
+			var parent Client
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var name string
+			if inputArgs["name"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["name"]), &name)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg name", err))
+				}
+			}
+			return (*Client).DescribeTopic(&parent, ctx, name)
+		case "ListConsumerGroups":
+			var parent Client
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Client).ListConsumerGroups(&parent, ctx)
 		case "ListTopics":
 			var parent Client
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/kafka/introspection.go
+++ b/daggerverse/kafka/introspection.go
@@ -1,0 +1,272 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"sort"
+
+	"dagger/kafka/internal/dagger"
+
+	"github.com/twmb/franz-go/pkg/kadm"
+)
+
+// topicDescription is the JSON shape DescribeTopic writes to its returned
+// *dagger.File: per-partition leader/replica/ISR layout, the derived partition
+// count and replication factor, and the full topic-level config set (so a
+// downstream skill generator can render retention, cleanup policy, and the
+// rest deterministically). Configs are sorted by key so the output is stable
+// across calls.
+type topicDescription struct {
+	Name              string             `json:"name"`
+	PartitionCount    int                `json:"partitionCount"`
+	ReplicationFactor int                `json:"replicationFactor"`
+	Partitions        []topicPartition   `json:"partitions"`
+	Configs           []topicConfigEntry `json:"configs"`
+}
+
+// topicPartition is one partition's replica layout as reported by the broker
+// metadata: the elected leader broker, the assigned replica set, and the
+// in-sync replica subset.
+type topicPartition struct {
+	Partition int32   `json:"partition"`
+	Leader    int32   `json:"leader"`
+	Replicas  []int32 `json:"replicas"`
+	Isr       []int32 `json:"isr"`
+}
+
+// topicConfigEntry is a single topic configuration key/value plus the source
+// the broker attributes it to (e.g. DYNAMIC_TOPIC_CONFIG for an explicitly-set
+// override vs DEFAULT_CONFIG for a broker default). Sensitive configs report
+// an empty value.
+type topicConfigEntry struct {
+	Key    string `json:"key"`
+	Value  string `json:"value"`
+	Source string `json:"source"`
+}
+
+// groupDescription is the JSON shape DescribeConsumerGroup writes: the group's
+// coordinator/state/protocol, its live members with their partition
+// assignments, and the per-partition committed-offset lag (plus the total).
+// Lag entries are only populated for partitions the group has committed
+// offsets for; an Empty group with committed offsets still reports lag against
+// the current end offset.
+type groupDescription struct {
+	Group        string         `json:"group"`
+	State        string         `json:"state"`
+	ProtocolType string         `json:"protocolType"`
+	Protocol     string         `json:"protocol"`
+	Coordinator  int32          `json:"coordinator"`
+	Members      []groupMember  `json:"members"`
+	Lag          []partitionLag `json:"lag"`
+	TotalLag     int64          `json:"totalLag"`
+}
+
+// groupMember is one member of a consumer group, with the partitions the
+// leader assigned it grouped by topic.
+type groupMember struct {
+	MemberID   string             `json:"memberId"`
+	ClientID   string             `json:"clientId"`
+	ClientHost string             `json:"clientHost"`
+	InstanceID string             `json:"instanceId,omitempty"`
+	Assigned   []memberAssignment `json:"assigned"`
+}
+
+// memberAssignment is the set of partitions of a single topic assigned to a
+// group member.
+type memberAssignment struct {
+	Topic      string  `json:"topic"`
+	Partitions []int32 `json:"partitions"`
+}
+
+// partitionLag is the committed-offset lag for one topic partition within a
+// group: the group's committed offset, the partition's current end offset, and
+// the difference. Member is the member id currently assigned the partition, or
+// empty when the group is Empty.
+type partitionLag struct {
+	Topic     string `json:"topic"`
+	Partition int32  `json:"partition"`
+	Commit    int64  `json:"commit"`
+	End       int64  `json:"end"`
+	Lag       int64  `json:"lag"`
+	Member    string `json:"member,omitempty"`
+}
+
+// DescribeTopic returns per-topic metadata as JSON: the partition layout
+// (leader, replicas, ISR per partition), the derived partition count and
+// replication factor, and the topic-level configuration set (retention,
+// cleanup policy, and so on). The JSON is returned as a *dagger.File so it
+// crosses the module boundary as a core type; callers export it and unmarshal
+// the bytes themselves.
+//
+// +cache="never"
+func (c *Client) DescribeTopic(ctx context.Context, name string) (*dagger.File, error) {
+	cl, err := c.newKgoClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("new kafka client: %w", err)
+	}
+	defer cl.Close()
+
+	adm := kadm.NewClient(cl)
+
+	details, err := adm.ListTopics(ctx, name)
+	if err != nil {
+		return nil, fmt.Errorf("describe topic %q: %w", name, err)
+	}
+	detail, ok := details[name]
+	if !ok {
+		return nil, fmt.Errorf("topic %q not found", name)
+	}
+	if detail.Err != nil {
+		return nil, fmt.Errorf("describe topic %q: %w", name, detail.Err)
+	}
+
+	desc := topicDescription{
+		Name:              name,
+		PartitionCount:    len(detail.Partitions),
+		ReplicationFactor: detail.Partitions.NumReplicas(),
+	}
+	for _, p := range detail.Partitions.Sorted() {
+		desc.Partitions = append(desc.Partitions, topicPartition{
+			Partition: p.Partition,
+			Leader:    p.Leader,
+			Replicas:  p.Replicas,
+			Isr:       p.ISR,
+		})
+	}
+
+	configs, err := adm.DescribeTopicConfigs(ctx, name)
+	if err != nil {
+		return nil, fmt.Errorf("describe configs for topic %q: %w", name, err)
+	}
+	rc, err := configs.On(name, nil)
+	if err != nil {
+		return nil, fmt.Errorf("configs for topic %q: %w", name, err)
+	}
+	if rc.Err != nil {
+		return nil, fmt.Errorf("configs for topic %q: %w", name, rc.Err)
+	}
+	for _, cfg := range rc.Configs {
+		desc.Configs = append(desc.Configs, topicConfigEntry{
+			Key:    cfg.Key,
+			Value:  cfg.MaybeValue(),
+			Source: cfg.Source.String(),
+		})
+	}
+	sort.Slice(desc.Configs, func(i, j int) bool {
+		return desc.Configs[i].Key < desc.Configs[j].Key
+	})
+
+	return marshalToWorkdirFile("topic", "topic.json", desc)
+}
+
+// ListConsumerGroups returns the names of every consumer group the cluster
+// reports, sorted. A fresh cluster reports none; a group appears once a
+// consumer has joined it and persists (in the Empty state) while it retains
+// committed offsets.
+//
+// +cache="never"
+func (c *Client) ListConsumerGroups(ctx context.Context) ([]string, error) {
+	cl, err := c.newKgoClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("new kafka client: %w", err)
+	}
+	defer cl.Close()
+
+	adm := kadm.NewClient(cl)
+	groups, err := adm.ListGroups(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list consumer groups: %w", err)
+	}
+	return groups.Groups(), nil
+}
+
+// DescribeConsumerGroup returns a consumer group's detail as JSON: its
+// coordinator, state, and assignment protocol; its live members with the
+// partitions assigned to each; and the per-partition committed-offset lag
+// (with the total). Lag is only reported for partitions the group has
+// committed offsets for. The JSON is returned as a *dagger.File so it crosses
+// the module boundary as a core type.
+//
+// +cache="never"
+func (c *Client) DescribeConsumerGroup(ctx context.Context, group string) (*dagger.File, error) {
+	cl, err := c.newKgoClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("new kafka client: %w", err)
+	}
+	defer cl.Close()
+
+	adm := kadm.NewClient(cl)
+	lags, err := adm.Lag(ctx, group)
+	if err != nil {
+		return nil, fmt.Errorf("describe consumer group %q: %w", group, err)
+	}
+	dl, ok := lags[group]
+	if !ok {
+		return nil, fmt.Errorf("consumer group %q not found", group)
+	}
+	if err := dl.Error(); err != nil {
+		return nil, fmt.Errorf("describe consumer group %q: %w", group, err)
+	}
+
+	desc := groupDescription{
+		Group:        dl.Group,
+		State:        dl.State,
+		ProtocolType: dl.ProtocolType,
+		Protocol:     dl.Protocol,
+		Coordinator:  dl.Coordinator.NodeID,
+	}
+	for _, m := range dl.Members {
+		gm := groupMember{
+			MemberID:   m.MemberID,
+			ClientID:   m.ClientID,
+			ClientHost: m.ClientHost,
+		}
+		if m.InstanceID != nil {
+			gm.InstanceID = *m.InstanceID
+		}
+		if ca, ok := m.Assigned.AsConsumer(); ok {
+			for _, t := range ca.Topics {
+				parts := append([]int32(nil), t.Partitions...)
+				slices.Sort(parts)
+				gm.Assigned = append(gm.Assigned, memberAssignment{
+					Topic:      t.Topic,
+					Partitions: parts,
+				})
+			}
+			sort.Slice(gm.Assigned, func(i, j int) bool {
+				return gm.Assigned[i].Topic < gm.Assigned[j].Topic
+			})
+		}
+		desc.Members = append(desc.Members, gm)
+	}
+	for _, gl := range dl.Lag.Sorted() {
+		pl := partitionLag{
+			Topic:     gl.Topic,
+			Partition: gl.Partition,
+			Commit:    gl.Commit.At,
+			End:       gl.End.Offset,
+			Lag:       gl.Lag,
+		}
+		if gl.Member != nil {
+			pl.Member = gl.Member.MemberID
+		}
+		desc.Lag = append(desc.Lag, pl)
+	}
+	desc.TotalLag = dl.Lag.Total()
+
+	return marshalToWorkdirFile("group", "group.json", desc)
+}
+
+// marshalToWorkdirFile encodes v as indented JSON and writes it into the
+// module runtime's scratch workdir as a *dagger.File, reusing the
+// content-addressed writeWorkdirBytes helper so identical descriptions
+// collapse to one file.
+func marshalToWorkdirFile(label, name string, v any) (*dagger.File, error) {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal %s json: %w", label, err)
+	}
+	return writeWorkdirBytes(label, name, b)
+}

--- a/daggerverse/kafka/tests/dagger.gen.go
+++ b/daggerverse/kafka/tests/dagger.gen.go
@@ -570,6 +570,34 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Tests).DedicatedControllerAndBrokerProduceConsume(&parent, ctx, kafkaImageTag)
+		case "DescribeConsumerGroupReportsLag":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var kafkaImageTag string
+			if inputArgs["kafkaImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["kafkaImageTag"]), &kafkaImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg kafkaImageTag", err))
+				}
+			}
+			return nil, (*Tests).DescribeConsumerGroupReportsLag(&parent, ctx, kafkaImageTag)
+		case "DescribeTopicReportsPartitionsAndConfigs":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var kafkaImageTag string
+			if inputArgs["kafkaImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["kafkaImageTag"]), &kafkaImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg kafkaImageTag", err))
+				}
+			}
+			return nil, (*Tests).DescribeTopicReportsPartitionsAndConfigs(&parent, ctx, kafkaImageTag)
 		case "InternalListenersAreEncrypted":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -612,6 +640,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Tests).KarapaceSchemaRegistryTlsRegisterLookupRoundTrip(&parent, ctx, kafkaImageTag)
+		case "ListConsumerGroupsReportsCommittedGroup":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var kafkaImageTag string
+			if inputArgs["kafkaImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["kafkaImageTag"]), &kafkaImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg kafkaImageTag", err))
+				}
+			}
+			return nil, (*Tests).ListConsumerGroupsReportsCommittedGroup(&parent, ctx, kafkaImageTag)
 		case "MtlsRequiresClientCert":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/kafka/tests/internal/dagger/kafka.gen.go
+++ b/daggerverse/kafka/tests/internal/dagger/kafka.gen.go
@@ -1124,35 +1124,41 @@ func (r *KafkaClient) WithGraphQLQuery(q *querybuilder.Selection) *KafkaClient {
 type KafkaClientConsumeOpts struct {
 
 	// Default: 1
-	MaxMessages int // kafka (../../../../../daggerverse/kafka/client.go:650:2)
+	MaxMessages int // kafka (../../../../../daggerverse/kafka/client.go:654:2)
 
 	// Default: "10s"
-	Timeout string // kafka (../../../../../daggerverse/kafka/client.go:652:2)
+	Timeout string // kafka (../../../../../daggerverse/kafka/client.go:656:2)
 
 	// Default: "raw"
-	KeyEncoding string // kafka (../../../../../daggerverse/kafka/client.go:654:2)
+	KeyEncoding string // kafka (../../../../../daggerverse/kafka/client.go:658:2)
 
 	// Default: "raw"
-	ValueEncoding string // kafka (../../../../../daggerverse/kafka/client.go:656:2)
+	ValueEncoding string // kafka (../../../../../daggerverse/kafka/client.go:660:2)
 
-	Group string // kafka (../../../../../daggerverse/kafka/client.go:658:2)
+	Group string // kafka (../../../../../daggerverse/kafka/client.go:662:2)
+	//
+	// commitOffsets, when true and group is set, commits the consumed
+	// records' offsets before returning so the group persists with committed
+	// offsets (and thus reportable lag). Ignored when group is empty.
+	//
+	CommitOffsets bool // kafka (../../../../../daggerverse/kafka/client.go:668:2)
 
-	SchemaRegistryAware bool // kafka (../../../../../daggerverse/kafka/client.go:660:2)
+	SchemaRegistryAware bool // kafka (../../../../../daggerverse/kafka/client.go:670:2)
 
-	KeyDeserializeAs string // kafka (../../../../../daggerverse/kafka/client.go:662:2)
+	KeyDeserializeAs string // kafka (../../../../../daggerverse/kafka/client.go:672:2)
 
-	ValueDeserializeAs string // kafka (../../../../../daggerverse/kafka/client.go:664:2)
+	ValueDeserializeAs string // kafka (../../../../../daggerverse/kafka/client.go:674:2)
 	//
 	// registry resolves the Avro schema text by id when keyDeserializeAs /
 	// valueDeserializeAs is "AVRO". Required in that mode; ignored otherwise.
 	//
-	Registry *KafkaSchemaRegistry // kafka (../../../../../daggerverse/kafka/client.go:669:2)
+	Registry *KafkaSchemaRegistry // kafka (../../../../../daggerverse/kafka/client.go:679:2)
 	//
 	// registrySecurity is the TLS/mTLS client profile used to resolve Avro
 	// schema text against a secured registry. Nil (the default) resolves over
 	// plaintext HTTP, reproducing today's behaviour.
 	//
-	RegistrySecurity *KafkaSchemaRegistryClientSecurity // kafka (../../../../../daggerverse/kafka/client.go:675:2)
+	RegistrySecurity *KafkaSchemaRegistryClientSecurity // kafka (../../../../../daggerverse/kafka/client.go:685:2)
 }
 
 // Consume reads up to maxMessages records from the topic, starting at the
@@ -1164,8 +1170,12 @@ type KafkaClientConsumeOpts struct {
 //
 // When group is non-empty, the consume runs as a member of that consumer
 // group: the broker assigns partitions and the join itself writes group
-// metadata to __consumer_offsets (offsets are not committed — the function
-// stays idempotent underdefault), partitions are consumed directly with no group state.
+// metadata to __consumer_offsets. By default offsets are not committed, so
+// the function stays idempotent undertrue (and group is set), the consumed records' offsets are committed before
+// returning, so the group persists in the Empty state with committed offsets
+// afterwards — enough for DescribeConsumerGroup to report non-zero lag. When
+// group is empty (the default), partitions are consumed directly with no group
+// state and commitOffsets is ignored.
 //
 // When schemaRegistryAware is true, each record's key and value are
 // inspected for the Confluent Schema Registry wire-format header
@@ -1195,7 +1205,7 @@ type KafkaClientConsumeOpts struct {
 // per id for the duration of the call. The JSON shape follows the Avro
 // spec's JSON encoding; logical types, decimal, and fixed are not yet
 // supported.
-func (r *KafkaClient) Consume(ctx context.Context, topic string, opts ...KafkaClientConsumeOpts) (string, error) { // kafka (../../../../../daggerverse/kafka/client.go:646:1)
+func (r *KafkaClient) Consume(ctx context.Context, topic string, opts ...KafkaClientConsumeOpts) (string, error) { // kafka (../../../../../daggerverse/kafka/client.go:650:1)
 	if r.consume != nil {
 		return *r.consume, nil
 	}
@@ -1220,6 +1230,10 @@ func (r *KafkaClient) Consume(ctx context.Context, topic string, opts ...KafkaCl
 		// `group` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Group) {
 			q = q.Arg("group", opts[i].Group)
+		}
+		// `commitOffsets` optional argument
+		if !querybuilder.IsZeroValue(opts[i].CommitOffsets) {
+			q = q.Arg("commitOffsets", opts[i].CommitOffsets)
 		}
 		// `schemaRegistryAware` optional argument
 		if !querybuilder.IsZeroValue(opts[i].SchemaRegistryAware) {
@@ -1293,6 +1307,36 @@ func (r *KafkaClient) DeleteTopic(ctx context.Context, name string) error { // k
 	return q.Execute(ctx)
 }
 
+// DescribeConsumerGroup returns a consumer group's detail as JSON: its
+// coordinator, state, and assignment protocol; its live members with the
+// partitions assigned to each; and the per-partition committed-offset lag
+// (with the total). Lag is only reported for partitions the group has
+// committed offsets for. The JSON is returned as a *dagger.File so it crosses
+// the module boundary as a core type.
+func (r *KafkaClient) DescribeConsumerGroup(group string) *File { // kafka (../../../../../daggerverse/kafka/introspection.go:193:1)
+	q := r.query.Select("describeConsumerGroup")
+	q = q.Arg("group", group)
+
+	return &File{
+		query: q,
+	}
+}
+
+// DescribeTopic returns per-topic metadata as JSON: the partition layout
+// (leader, replicas, ISR per partition), the derived partition count and
+// replication factor, and the topic-level configuration set (retention,
+// cleanup policy, and so on). The JSON is returned as a *dagger.File so it
+// crosses the module boundary as a core type; callers export it and unmarshal
+// the bytes themselves.
+func (r *KafkaClient) DescribeTopic(name string) *File { // kafka (../../../../../daggerverse/kafka/introspection.go:104:1)
+	q := r.query.Select("describeTopic")
+	q = q.Arg("name", name)
+
+	return &File{
+		query: q,
+	}
+}
+
 // A unique identifier for this KafkaClient.
 func (r *KafkaClient) ID(ctx context.Context) (ID, error) {
 	if r.id != nil {
@@ -1342,8 +1386,21 @@ func (r *KafkaClient) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
+// ListConsumerGroups returns the names of every consumer group the cluster
+// reports, sorted. A fresh cluster reports none; a group appears once a
+// consumer has joined it and persists (in the Empty state) while it retains
+// committed offsets.
+func (r *KafkaClient) ListConsumerGroups(ctx context.Context) ([]string, error) { // kafka (../../../../../daggerverse/kafka/introspection.go:170:1)
+	q := r.query.Select("listConsumerGroups")
+
+	var response []string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
 // ListTopics returns the names of every topic the broker reports.
-func (r *KafkaClient) ListTopics(ctx context.Context) ([]string, error) { // kafka (../../../../../daggerverse/kafka/client.go:789:1)
+func (r *KafkaClient) ListTopics(ctx context.Context) ([]string, error) { // kafka (../../../../../daggerverse/kafka/client.go:825:1)
 	q := r.query.Select("listTopics")
 
 	var response []string

--- a/daggerverse/kafka/tests/main.go
+++ b/daggerverse/kafka/tests/main.go
@@ -256,6 +256,15 @@ func (t *Tests) Native(
 	jobs = jobs.WithJob("ConsumerGroupOnSingleBrokerWorks", func(ctx context.Context) error {
 		return consumerGroupOnSingleBrokerWorksOn(ctx, sharedPlaintext)
 	})
+	jobs = jobs.WithJob("DescribeTopicReportsPartitionsAndConfigs", func(ctx context.Context) error {
+		return describeTopicReportsPartitionsAndConfigsOn(ctx, sharedPlaintext)
+	})
+	jobs = jobs.WithJob("ListConsumerGroupsReportsCommittedGroup", func(ctx context.Context) error {
+		return listConsumerGroupsReportsCommittedGroupOn(ctx, sharedPlaintext)
+	})
+	jobs = jobs.WithJob("DescribeConsumerGroupReportsLag", func(ctx context.Context) error {
+		return describeConsumerGroupReportsLagOn(ctx, sharedPlaintext)
+	})
 	jobs = jobs.WithJob("TlsClusterStarts", func(ctx context.Context) error {
 		return tlsClusterStartsOn(ctx, sharedTls)
 	})

--- a/daggerverse/kafka/tests/tests_introspection.go
+++ b/daggerverse/kafka/tests/tests_introspection.go
@@ -1,0 +1,328 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"dagger/tests/internal/dagger"
+)
+
+// topicDescription / groupDescription mirror the JSON shapes the kafka
+// module's DescribeTopic and DescribeConsumerGroup write to their returned
+// *dagger.File. The tests export the file's contents and unmarshal into these
+// local types.
+type topicDescription struct {
+	Name              string             `json:"name"`
+	PartitionCount    int                `json:"partitionCount"`
+	ReplicationFactor int                `json:"replicationFactor"`
+	Partitions        []topicPartition   `json:"partitions"`
+	Configs           []topicConfigEntry `json:"configs"`
+}
+
+type topicPartition struct {
+	Partition int32   `json:"partition"`
+	Leader    int32   `json:"leader"`
+	Replicas  []int32 `json:"replicas"`
+	Isr       []int32 `json:"isr"`
+}
+
+type topicConfigEntry struct {
+	Key    string `json:"key"`
+	Value  string `json:"value"`
+	Source string `json:"source"`
+}
+
+type groupDescription struct {
+	Group        string         `json:"group"`
+	State        string         `json:"state"`
+	ProtocolType string         `json:"protocolType"`
+	Protocol     string         `json:"protocol"`
+	Coordinator  int32          `json:"coordinator"`
+	Members      []groupMember  `json:"members"`
+	Lag          []partitionLag `json:"lag"`
+	TotalLag     int64          `json:"totalLag"`
+}
+
+type groupMember struct {
+	MemberID   string             `json:"memberId"`
+	ClientID   string             `json:"clientId"`
+	ClientHost string             `json:"clientHost"`
+	InstanceID string             `json:"instanceId,omitempty"`
+	Assigned   []memberAssignment `json:"assigned"`
+}
+
+type memberAssignment struct {
+	Topic      string  `json:"topic"`
+	Partitions []int32 `json:"partitions"`
+}
+
+type partitionLag struct {
+	Topic     string `json:"topic"`
+	Partition int32  `json:"partition"`
+	Commit    int64  `json:"commit"`
+	End       int64  `json:"end"`
+	Lag       int64  `json:"lag"`
+	Member    string `json:"member,omitempty"`
+}
+
+func describeTopic(ctx context.Context, client *dagger.KafkaClient, topic string) (topicDescription, error) {
+	raw, err := client.DescribeTopic(topic).Contents(ctx)
+	if err != nil {
+		return topicDescription{}, fmt.Errorf("describe topic %q: %w", topic, err)
+	}
+	var td topicDescription
+	if err := json.Unmarshal([]byte(raw), &td); err != nil {
+		return topicDescription{}, fmt.Errorf("unmarshal topic description: %w", err)
+	}
+	return td, nil
+}
+
+func describeConsumerGroup(ctx context.Context, client *dagger.KafkaClient, group string) (groupDescription, error) {
+	raw, err := client.DescribeConsumerGroup(group).Contents(ctx)
+	if err != nil {
+		return groupDescription{}, fmt.Errorf("describe consumer group %q: %w", group, err)
+	}
+	var gd groupDescription
+	if err := json.Unmarshal([]byte(raw), &gd); err != nil {
+		return groupDescription{}, fmt.Errorf("unmarshal group description: %w", err)
+	}
+	return gd, nil
+}
+
+// DescribeTopicReportsPartitionsAndConfigs creates a 3-partition RF=1 topic
+// and asserts DescribeTopic reports the derived partition count / replication
+// factor, one partition entry per partition, and a non-empty topic-level
+// config set (proving the configs path is wired).
+func (t *Tests) DescribeTopicReportsPartitionsAndConfigs(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, err := freshCluster(ctx, kafkaImageTag)
+	if err != nil {
+		return fmt.Errorf("create cluster: %w", err)
+	}
+	defer cluster.Stop(ctx)
+	return describeTopicReportsPartitionsAndConfigsOn(ctx, cluster)
+}
+
+func describeTopicReportsPartitionsAndConfigsOn(ctx context.Context, cluster *dagger.KafkaCluster) error {
+	client := cluster.Client(dag.Kafka().PlaintextClientSecurity())
+
+	topic, err := randomTopicName(ctx)
+	if err != nil {
+		return err
+	}
+	if err := client.CreateTopic(ctx, topic, dagger.KafkaClientCreateTopicOpts{
+		Partitions:        3,
+		ReplicationFactor: 1,
+	}); err != nil {
+		return fmt.Errorf("create topic %q: %w", topic, err)
+	}
+
+	td, err := describeTopic(ctx, client, topic)
+	if err != nil {
+		return err
+	}
+	if td.Name != topic {
+		return fmt.Errorf("name mismatch: want %q, got %q", topic, td.Name)
+	}
+	if td.PartitionCount != 3 {
+		return fmt.Errorf("partitionCount mismatch: want 3, got %d", td.PartitionCount)
+	}
+	if td.ReplicationFactor != 1 {
+		return fmt.Errorf("replicationFactor mismatch: want 1, got %d", td.ReplicationFactor)
+	}
+	if len(td.Partitions) != 3 {
+		return fmt.Errorf("expected 3 partition entries, got %d", len(td.Partitions))
+	}
+	for _, p := range td.Partitions {
+		if len(p.Replicas) != 1 {
+			return fmt.Errorf("partition %d: expected 1 replica, got %v", p.Partition, p.Replicas)
+		}
+	}
+	// A topic always carries broker-defaulted configs (cleanup.policy,
+	// retention.ms, ...); an empty set means the configs path never ran.
+	if len(td.Configs) == 0 {
+		return fmt.Errorf("expected non-empty topic configs, got none")
+	}
+	if !hasConfigKey(td.Configs, "cleanup.policy") {
+		return fmt.Errorf("expected a cleanup.policy config entry, got %v", configKeys(td.Configs))
+	}
+	return nil
+}
+
+// ListConsumerGroupsReportsCommittedGroup produces a record, consumes it back
+// through a committing consumer group, and asserts the group then appears in
+// ListConsumerGroups. A fresh cluster reports no groups, so the group's
+// presence proves the join + commit reached __consumer_offsets.
+func (t *Tests) ListConsumerGroupsReportsCommittedGroup(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, err := freshCluster(ctx, kafkaImageTag)
+	if err != nil {
+		return fmt.Errorf("create cluster: %w", err)
+	}
+	defer cluster.Stop(ctx)
+	return listConsumerGroupsReportsCommittedGroupOn(ctx, cluster)
+}
+
+func listConsumerGroupsReportsCommittedGroupOn(ctx context.Context, cluster *dagger.KafkaCluster) error {
+	client := cluster.Client(dag.Kafka().PlaintextClientSecurity())
+
+	topic, err := randomTopicName(ctx)
+	if err != nil {
+		return err
+	}
+	if err := client.CreateTopic(ctx, topic, dagger.KafkaClientCreateTopicOpts{
+		Partitions:        1,
+		ReplicationFactor: 1,
+	}); err != nil {
+		return fmt.Errorf("create topic %q: %w", topic, err)
+	}
+	if err := client.Produce(ctx, topic, "k", "v", dagger.KafkaClientProduceOpts{
+		KeyEncoding:   "raw",
+		ValueEncoding: "raw",
+	}); err != nil {
+		return fmt.Errorf("produce: %w", err)
+	}
+
+	group, err := randomTopicName(ctx)
+	if err != nil {
+		return err
+	}
+	if _, err := consume(ctx, client, topic, dagger.KafkaClientConsumeOpts{
+		MaxMessages:   1,
+		Timeout:       "20s",
+		KeyEncoding:   "raw",
+		ValueEncoding: "raw",
+		Group:         group,
+		CommitOffsets: true,
+	}); err != nil {
+		return fmt.Errorf("consume with committing group: %w", err)
+	}
+
+	groups, err := client.ListConsumerGroups(ctx)
+	if err != nil {
+		return fmt.Errorf("list consumer groups: %w", err)
+	}
+	if !contains(groups, group) {
+		return fmt.Errorf("expected group %q in %v", group, groups)
+	}
+	return nil
+}
+
+// DescribeConsumerGroupReportsLag produces five records, consumes three of
+// them through a committing consumer group, and asserts DescribeConsumerGroup
+// reports the group in the Empty state with committed-offset lag of 2 (end
+// offset 5 minus committed offset 3) on the single partition.
+func (t *Tests) DescribeConsumerGroupReportsLag(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, err := freshCluster(ctx, kafkaImageTag)
+	if err != nil {
+		return fmt.Errorf("create cluster: %w", err)
+	}
+	defer cluster.Stop(ctx)
+	return describeConsumerGroupReportsLagOn(ctx, cluster)
+}
+
+func describeConsumerGroupReportsLagOn(ctx context.Context, cluster *dagger.KafkaCluster) error {
+	client := cluster.Client(dag.Kafka().PlaintextClientSecurity())
+
+	topic, err := randomTopicName(ctx)
+	if err != nil {
+		return err
+	}
+	if err := client.CreateTopic(ctx, topic, dagger.KafkaClientCreateTopicOpts{
+		Partitions:        1,
+		ReplicationFactor: 1,
+	}); err != nil {
+		return fmt.Errorf("create topic %q: %w", topic, err)
+	}
+
+	const produced = 5
+	for i := range produced {
+		if err := client.Produce(ctx, topic, "k", fmt.Sprintf("v%d", i), dagger.KafkaClientProduceOpts{
+			KeyEncoding:   "raw",
+			ValueEncoding: "raw",
+		}); err != nil {
+			return fmt.Errorf("produce record %d: %w", i, err)
+		}
+	}
+
+	group, err := randomTopicName(ctx)
+	if err != nil {
+		return err
+	}
+	const consumed = 3
+	records, err := consume(ctx, client, topic, dagger.KafkaClientConsumeOpts{
+		MaxMessages:   consumed,
+		Timeout:       "20s",
+		KeyEncoding:   "raw",
+		ValueEncoding: "raw",
+		Group:         group,
+		CommitOffsets: true,
+	})
+	if err != nil {
+		return fmt.Errorf("consume with committing group: %w", err)
+	}
+	if len(records) != consumed {
+		return fmt.Errorf("expected %d records consumed, got %d", consumed, len(records))
+	}
+
+	gd, err := describeConsumerGroup(ctx, client, group)
+	if err != nil {
+		return err
+	}
+	if gd.Group != group {
+		return fmt.Errorf("group name mismatch: want %q, got %q", group, gd.Group)
+	}
+	// All members have left after the consume returned, so the group is Empty
+	// but retains its committed offsets.
+	if gd.State != "Empty" {
+		return fmt.Errorf("expected Empty group state, got %q", gd.State)
+	}
+	if gd.TotalLag != produced-consumed {
+		return fmt.Errorf("total lag mismatch: want %d, got %d", produced-consumed, gd.TotalLag)
+	}
+	if len(gd.Lag) != 1 {
+		return fmt.Errorf("expected lag for 1 partition, got %d entries: %+v", len(gd.Lag), gd.Lag)
+	}
+	pl := gd.Lag[0]
+	if pl.Topic != topic || pl.Partition != 0 {
+		return fmt.Errorf("lag entry targets wrong partition: %+v", pl)
+	}
+	if pl.Commit != consumed {
+		return fmt.Errorf("committed offset mismatch: want %d, got %d", consumed, pl.Commit)
+	}
+	if pl.End != produced {
+		return fmt.Errorf("end offset mismatch: want %d, got %d", produced, pl.End)
+	}
+	if pl.Lag != produced-consumed {
+		return fmt.Errorf("partition lag mismatch: want %d, got %d", produced-consumed, pl.Lag)
+	}
+	return nil
+}
+
+func hasConfigKey(configs []topicConfigEntry, key string) bool {
+	for _, c := range configs {
+		if c.Key == key {
+			return true
+		}
+	}
+	return false
+}
+
+func configKeys(configs []topicConfigEntry) []string {
+	keys := make([]string, 0, len(configs))
+	for _, c := range configs {
+		keys = append(keys, c.Key)
+	}
+	return keys
+}


### PR DESCRIPTION
## Summary

Closes #131. Adds three live-cluster introspection primitives to the kafka module's `Client` so a downstream skill generator can render reference docs deterministically. Each returns its richer payload as a `*dagger.File` of JSON (a core type, so it crosses the module boundary) under `+cache="never"`:

- **`DescribeTopic(ctx, name)`** — partition layout (leader / replicas / ISR), the derived partition count and replication factor, and the full topic-level config set (retention, cleanup policy, ...), configs sorted by key.
- **`ListConsumerGroups(ctx)`** — sorted consumer group names.
- **`DescribeConsumerGroup(ctx, group)`** — coordinator / state / protocol, members with their per-topic partition assignments, and per-partition committed-offset lag (with the total), via `kadm.Client.Lag`.

JSON is written through the existing content-addressed `writeWorkdirBytes` workdir helper.

## `Consume` gains opt-in `commitOffsets`

Lag is only meaningful against **committed** offsets, and `Consume`'s default never commits (it stays idempotent under `+cache="never"`). Added `commitOffsets bool` (default `false`, so existing behavior and every existing test are unchanged). When set alongside a `Group`, exactly the returned records' offsets are committed via `CommitRecords` — auto-commit stays disabled so a partial read (`maxMessages` < fetched batch) never commits past what it returned — leaving the group `Empty` with reportable lag.

## Tests

Three round-trip tests (wired into the `Native` group) create a topic/group and read the metadata back:

- `DescribeTopicReportsPartitionsAndConfigs` — 3-partition RF=1 topic → asserts counts, per-partition replica set, and a non-empty config set incl. `cleanup.policy`.
- `ListConsumerGroupsReportsCommittedGroup` — produce → committing consume → group appears.
- `DescribeConsumerGroupReportsLag` — produce 5, consume+commit 3 → `Empty` state, deterministic total lag 2 (end 5 − commit 3) on the single partition.

## Acceptance criteria

- [x] The three functions return live data against a `kafka` module `Cluster` (verified individually).
- [x] JSON outputs are `*dagger.File` (core type, crosses module boundaries).
- [x] `+cache="never"`; round-trip tests create a topic/group and read it back.
- [x] `dagger develop` run in `kafka` and `kafka/tests`; generated code committed.

Existing `ConsumerGroupOnSingleBrokerWorks` re-verified green after the `Consume` refactor. No new toolchain, so root CI bindings are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)