### PR TITLE
story(issue-149): stand up real multi-controller KRaft quorum in kafka module

### DIFF
--- a/daggerverse/kafka/README.md
+++ b/daggerverse/kafka/README.md
@@ -56,7 +56,7 @@ cluster := dag.Kafka().ApacheNativeCluster(
     serverSec,
     dagger.KafkaApacheNativeClusterOpts{
         Tag:         "4.2.0",
-        Controllers: 1,    // multi-controller is rejected; see below
+        Controllers: 3,    // odd voter count: 1, 3, 5, ... (see below)
         Brokers:     2,
         Registry:    "docker.io",
     },
@@ -88,17 +88,35 @@ observe the same underlying broker services and the same internal CA.
 | INTERNAL   | 19092 | inter-broker  | always SSL with mTLS (internal CA)    |
 | CONTROLLER | 9093  | KRaft quorum  | always SSL with mTLS (internal CA)    |
 
-Stable hostnames (`controller-1-<suffix>`, `broker-100-<suffix>`, ...) are
-assigned via `Service.WithHostname` — the suffix is a short hash derived
-from `clusterId` so parallel cluster spawns within one engine session
-don't collide on alias names.
+Stable hostnames (`controller-1-<suffix>`, `controller-2-<suffix>`, ...,
+`broker-100-<suffix>`, ...) are assigned via `Service.WithHostname` — the
+suffix is a short hash derived from `clusterId` so parallel cluster spawns
+within one engine session don't collide on alias names.
 
-### Topology limit
+### Controller quorum (HA)
 
-`controllers > 1` is **rejected**: a true HA quorum needs every
-controller to know every other controller at static config time, which
-Dagger's `WithServiceBinding` model can't express without an unresolvable
-cycle. Multi-controller HA lands in a follow-up.
+`controllers` sets the size of the KRaft controller quorum: `1` is a
+single-node quorum, `3` or `5` a highly-available one that tolerates
+`floor((N-1)/2)` controller failures. Each controller runs in its own
+container with a unique `KAFKA_NODE_ID` (`1..N`).
+
+The count **must be odd** (`1, 3, 5, ...`). An even count is rejected with
+an error: it buys no extra fault tolerance over the next-lower odd count
+while enlarging the majority every commit must reach.
+
+Multi-controller HA works without any controller-to-controller
+`WithServiceBinding` — which would be an unresolvable build cycle, since
+each controller would have to reference every other as a service before any
+of them exists. Instead, controller hostnames are deterministic
+(`controller-<n>-<suffix>`, derived from `clusterId`), so the full
+quorum-voters string
+(`1@controller-1-<suffix>:9093,2@controller-2-<suffix>:9093,...`) is
+computed **before** any container is built and pinned identically onto
+every controller and broker. At runtime each controller resolves its peers
+by hostname over the engine's session-wide DNS (populated by
+`WithHostname`), and the quorum forms over the always-mTLS CONTROLLER
+listeners — the internal CA mints a verifying leaf for every controller
+host's SAN.
 
 ## ConfluentCluster
 

--- a/daggerverse/kafka/cluster_kafka.go
+++ b/daggerverse/kafka/cluster_kafka.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"strings"
 
 	"dagger/kafka/internal/dagger"
 )
@@ -16,7 +17,7 @@ type Cluster struct {
 	// +private
 	ClusterID string
 	// +private
-	ControllerSvc *dagger.Service
+	ControllerSvcs []*dagger.Service
 	// +private
 	BrokerSvcs []*dagger.Service
 	// +private
@@ -29,15 +30,21 @@ type Cluster struct {
 // size with dedicated controller and broker containers, using the
 // `apache/kafka-native` GraalVM-compiled image.
 //
-// Topology: a single controller forms a one-node KRaft quorum; one or more
-// brokers connect to it and discover each other over the engine's
-// session-wide DNS — no broker-to-broker WithServiceBinding needed.
+// Topology: controllers form a KRaft quorum (1 controller = a one-node
+// quorum, 3 or 5 = an HA quorum); one or more brokers connect to it and
+// every node discovers every other over the engine's session-wide DNS — no
+// controller-to-controller or broker-to-broker WithServiceBinding needed.
 //
-// Multi-controller (controllers > 1) is rejected for now: a true HA quorum
-// needs every controller to know every other controller at static config
-// time, which Dagger's WithServiceBinding model can't express without an
-// unresolvable cycle. TLS / mTLS and multi-controller both land in a
-// follow-up.
+// Multi-controller HA works because controller hostnames are deterministic
+// (controller-<n>-<suffix>, derived from clusterId), so the full
+// quorum-voters string is computed before any container is built and pinned
+// onto every controller and broker via WithHostname + session-wide DNS —
+// sidestepping the WithServiceBinding cycle a true peer mesh would need.
+//
+// controllers must be odd (1, 3, 5, ...): a KRaft quorum tolerates
+// floor((N-1)/2) controller failures, so an even count buys no extra fault
+// tolerance over the next-lower odd count while enlarging the majority a
+// commit must reach — even values are rejected with an error.
 //
 // Session-cached so that repeated chained method calls on the returned
 // cluster (Client.Produce → Consume → ListTopics) all observe the SAME
@@ -158,9 +165,9 @@ func buildKafkaCluster(
 	if controllers < 1 {
 		return nil, fmt.Errorf("at least one controller is required, got %d", controllers)
 	}
-	if controllers > 1 {
+	if controllers%2 == 0 {
 		return nil, fmt.Errorf(
-			"multi-controller clusters are not supported in this story (got controllers=%d); see README for details",
+			"a KRaft controller quorum needs an odd voter count for a clean majority (use 1, 3, 5, ...); got controllers=%d",
 			controllers,
 		)
 	}
@@ -195,16 +202,30 @@ func buildKafkaCluster(
 	// substituting `_` → `-`) so two distinct clusters in the same engine
 	// session get distinct hostnames AND each cluster's cert SANs match its
 	// own services.
+	//
+	// Controller hostnames (controller-<n>-<suffix>, node IDs 1..N) are
+	// deterministic, so the entire quorum-voters string is assembled here —
+	// before any container exists — and pinned identically onto every
+	// controller and broker. At runtime each controller resolves its peers
+	// by hostname over the engine's session-wide DNS (populated by
+	// WithHostname), so a real HA quorum forms with no controller-to-
+	// controller WithServiceBinding and thus no unresolvable build cycle.
 	hostSuffix := clusterHostSuffix(clusterId)
-	controllerAlias := "controller-1-" + hostSuffix
-	quorumVoters := "1@" + controllerAlias + ":9093"
+	controllerHosts := make([]string, controllers)
+	voters := make([]string, controllers)
+	for i := range controllerHosts {
+		nodeID := i + 1
+		controllerHosts[i] = fmt.Sprintf("controller-%d-%s", nodeID, hostSuffix)
+		voters[i] = fmt.Sprintf("%d@%s:9093", nodeID, controllerHosts[i])
+	}
+	quorumVoters := strings.Join(voters, ",")
 
 	brokerHosts := make([]string, brokers)
 	for i := range brokerHosts {
 		brokerHosts[i] = fmt.Sprintf("broker-%d-%s", 100+i, hostSuffix)
 	}
 
-	internal, err := mintInternalCA(ctx, controllerAlias, brokerHosts)
+	internal, err := mintInternalCA(ctx, controllerHosts, brokerHosts)
 	if err != nil {
 		return nil, fmt.Errorf("mint internal CA: %w", err)
 	}
@@ -222,26 +243,35 @@ func buildKafkaCluster(
 		externalProto = "SSL"
 	}
 
-	ctrlCtr := dag.Container().
-		From(image).
-		// confluentinc/cp-kafka pre-sets KAFKA_ADVERTISED_LISTENERS=""
-		// in the image; the Scala config validator rejects the empty
-		// value even on controller-only nodes that have no advertised
-		// listeners. Strip it so the controller boots regardless of
-		// distro (no-op for the Apache images, which don't pre-set it).
-		WithoutEnvVariable("KAFKA_ADVERTISED_LISTENERS").
-		WithEnvVariable("KAFKA_NODE_ID", "1").
-		WithEnvVariable("KAFKA_PROCESS_ROLES", "controller").
-		WithEnvVariable("KAFKA_LISTENERS", "CONTROLLER://0.0.0.0:9093").
-		WithEnvVariable("KAFKA_CONTROLLER_LISTENER_NAMES", "CONTROLLER").
-		WithEnvVariable("KAFKA_LISTENER_SECURITY_PROTOCOL_MAP", "CONTROLLER:SSL").
-		WithEnvVariable("KAFKA_CONTROLLER_QUORUM_VOTERS", quorumVoters).
-		WithEnvVariable("CLUSTER_ID", clusterId).
-		WithExposedPort(9093)
-	ctrlCtr = applyInternalListenerSsl(ctrlCtr, "CONTROLLER", internal.Controller)
-	ctrlSvc := ctrlCtr.
-		AsService(dagger.ContainerAsServiceOpts{UseEntrypoint: true}).
-		WithHostname(controllerAlias)
+	// Each controller advertises the SAME shared quorum-voters string and a
+	// unique KAFKA_NODE_ID (1..N) matching its voter entry. No controller
+	// binds another controller as a service — they find each other by
+	// hostname via session-wide DNS, which is what lets an HA quorum form
+	// without an unresolvable WithServiceBinding cycle.
+	controllerSvcs := make([]*dagger.Service, controllers)
+	for i := 0; i < controllers; i++ {
+		nodeID := i + 1
+		ctrlCtr := dag.Container().
+			From(image).
+			// confluentinc/cp-kafka pre-sets KAFKA_ADVERTISED_LISTENERS=""
+			// in the image; the Scala config validator rejects the empty
+			// value even on controller-only nodes that have no advertised
+			// listeners. Strip it so the controller boots regardless of
+			// distro (no-op for the Apache images, which don't pre-set it).
+			WithoutEnvVariable("KAFKA_ADVERTISED_LISTENERS").
+			WithEnvVariable("KAFKA_NODE_ID", fmt.Sprintf("%d", nodeID)).
+			WithEnvVariable("KAFKA_PROCESS_ROLES", "controller").
+			WithEnvVariable("KAFKA_LISTENERS", "CONTROLLER://0.0.0.0:9093").
+			WithEnvVariable("KAFKA_CONTROLLER_LISTENER_NAMES", "CONTROLLER").
+			WithEnvVariable("KAFKA_LISTENER_SECURITY_PROTOCOL_MAP", "CONTROLLER:SSL").
+			WithEnvVariable("KAFKA_CONTROLLER_QUORUM_VOTERS", quorumVoters).
+			WithEnvVariable("CLUSTER_ID", clusterId).
+			WithExposedPort(9093)
+		ctrlCtr = applyInternalListenerSsl(ctrlCtr, "CONTROLLER", internal.Controllers[i])
+		controllerSvcs[i] = ctrlCtr.
+			AsService(dagger.ContainerAsServiceOpts{UseEntrypoint: true}).
+			WithHostname(controllerHosts[i])
+	}
 
 	brokerSvcs := make([]*dagger.Service, brokers)
 	for i := 0; i < brokers; i++ {
@@ -249,8 +279,16 @@ func buildKafkaCluster(
 		brokerHost := brokerHosts[i]
 		advertised := fmt.Sprintf("INTERNAL://%s:19092,EXTERNAL://%s:9092", brokerHost, brokerHost)
 		brkCtr := dag.Container().
-			From(image).
-			WithServiceBinding(controllerAlias, ctrlSvc).
+			From(image)
+		// Bind every controller into the broker so all of them start (a
+		// controller service boots when a container that binds it runs) and
+		// resolve at their pinned hostnames. Dagger dedups the shared service
+		// handles, so N brokers each binding the same N controllers still
+		// boots each controller exactly once.
+		for j, ctrlSvc := range controllerSvcs {
+			brkCtr = brkCtr.WithServiceBinding(controllerHosts[j], ctrlSvc)
+		}
+		brkCtr = brkCtr.
 			WithEnvVariable("KAFKA_NODE_ID", fmt.Sprintf("%d", nodeID)).
 			WithEnvVariable("KAFKA_PROCESS_ROLES", "broker").
 			WithEnvVariable("KAFKA_LISTENERS", "INTERNAL://0.0.0.0:19092,EXTERNAL://0.0.0.0:9092").
@@ -287,17 +325,17 @@ func buildKafkaCluster(
 
 	return &Cluster{
 		ClusterID:          clusterId,
-		ControllerSvc:      ctrlSvc,
+		ControllerSvcs:     controllerSvcs,
 		BrokerSvcs:         brokerSvcs,
 		BrokerHosts:        brokerHosts,
 		ClientSecurityMode: clientListenerSecurity.Mode,
 	}, nil
 }
 
-// Stop tears down every service container backing this cluster (the
-// controller plus every broker). Tests should call this in a defer so each
-// broker `Container.asService` span closes when the test work is done,
-// rather than running out to the parent parallel group's lifetime.
+// Stop tears down every service container backing this cluster (every
+// controller in the quorum plus every broker). Tests should call this in a
+// defer so each broker `Container.asService` span closes when the test work
+// is done, rather than running out to the parent parallel group's lifetime.
 //
 // Kill is set so Service.Stop skips graceful shutdown — Kafka's broker
 // shutdown path waits on replica-drain timeouts that on a torn-down test
@@ -309,9 +347,12 @@ func buildKafkaCluster(
 func (c *Cluster) Stop(ctx context.Context) error {
 	opts := dagger.ServiceStopOpts{Kill: true}
 	var errs []error
-	if c.ControllerSvc != nil {
-		if _, err := c.ControllerSvc.Stop(ctx, opts); err != nil {
-			errs = append(errs, fmt.Errorf("stop controller: %w", err))
+	for i, svc := range c.ControllerSvcs {
+		if svc == nil {
+			continue
+		}
+		if _, err := svc.Stop(ctx, opts); err != nil {
+			errs = append(errs, fmt.Errorf("stop controller %d: %w", i, err))
 		}
 	}
 	for i, svc := range c.BrokerSvcs {

--- a/daggerverse/kafka/dagger.gen.go
+++ b/daggerverse/kafka/dagger.gen.go
@@ -76,13 +76,13 @@ func (r *Kafka) UnmarshalJSON(bs []byte) error {
 func (r Cluster) MarshalJSON() ([]byte, error) {
 	var concrete struct {
 		ClusterID          string
-		ControllerSvc      *dagger.Service
+		ControllerSvcs     []*dagger.Service
 		BrokerSvcs         []*dagger.Service
 		BrokerHosts        []string
 		ClientSecurityMode string
 	}
 	concrete.ClusterID = r.ClusterID
-	concrete.ControllerSvc = r.ControllerSvc
+	concrete.ControllerSvcs = r.ControllerSvcs
 	concrete.BrokerSvcs = r.BrokerSvcs
 	concrete.BrokerHosts = r.BrokerHosts
 	concrete.ClientSecurityMode = r.ClientSecurityMode
@@ -92,7 +92,7 @@ func (r Cluster) MarshalJSON() ([]byte, error) {
 func (r *Cluster) UnmarshalJSON(bs []byte) error {
 	var concrete struct {
 		ClusterID          string
-		ControllerSvc      *dagger.Service
+		ControllerSvcs     []*dagger.Service
 		BrokerSvcs         []*dagger.Service
 		BrokerHosts        []string
 		ClientSecurityMode string
@@ -102,7 +102,7 @@ func (r *Cluster) UnmarshalJSON(bs []byte) error {
 		return err
 	}
 	r.ClusterID = concrete.ClusterID
-	r.ControllerSvc = concrete.ControllerSvc
+	r.ControllerSvcs = concrete.ControllerSvcs
 	r.BrokerSvcs = concrete.BrokerSvcs
 	r.BrokerHosts = concrete.BrokerHosts
 	r.ClientSecurityMode = concrete.ClientSecurityMode

--- a/daggerverse/kafka/internal_ca.go
+++ b/daggerverse/kafka/internal_ca.go
@@ -21,10 +21,10 @@ type nodePkis struct {
 }
 
 // internalMaterial holds per-cluster CA-derived mTLS material, one entry per
-// node (controller + every broker). Truststore is shared across nodes.
+// node (every controller + every broker). Truststore is shared across nodes.
 type internalMaterial struct {
-	Controller nodePkis
-	Brokers    []nodePkis
+	Controllers []nodePkis
+	Brokers     []nodePkis
 }
 
 // externalLeaf bundles a per-broker external-listener leaf certificate
@@ -101,9 +101,10 @@ func applyExternalListenerSsl(ctr *dagger.Container, leaf externalLeaf, sec *Ser
 }
 
 // mintInternalCA mints a fresh per-cluster CA and a leaf certificate for
-// every node. Each leaf carries both serverAuth and clientAuth EKUs so the
-// node can both accept peer connections and originate connections to peers
-// or to the controller, all under the same internal trust domain. The CA's
+// every node — one per controller in the KRaft quorum plus one per broker.
+// Each leaf carries both serverAuth and clientAuth EKUs so the node can both
+// accept peer connections and originate connections to peers or to the
+// controller quorum, all under the same internal trust domain. The CA's
 // truststore is shared across nodes; it never crosses the module boundary.
 //
 // All PKCS#12 archives (truststore + per-node keystores) are eagerly
@@ -115,7 +116,7 @@ func applyExternalListenerSsl(ctr *dagger.Container, leaf externalLeaf, sec *Ser
 // re-derived (different) CA.
 func mintInternalCA(
 	ctx context.Context,
-	controllerHost string,
+	controllerHosts []string,
 	brokerHosts []string,
 ) (*internalMaterial, error) {
 	caKeyPem, err := dag.Crypto().GenerateRsaKey(dagger.CryptoGenerateRsaKeyOpts{Bits: 4096}).Pem().Contents(ctx)
@@ -192,9 +193,12 @@ func mintInternalCA(
 		}, nil
 	}
 
-	ctrl, err := mintNode(controllerHost)
-	if err != nil {
-		return nil, err
+	ctrls := make([]nodePkis, len(controllerHosts))
+	for i, h := range controllerHosts {
+		ctrls[i], err = mintNode(h)
+		if err != nil {
+			return nil, err
+		}
 	}
 	brks := make([]nodePkis, len(brokerHosts))
 	for i, h := range brokerHosts {
@@ -203,7 +207,7 @@ func mintInternalCA(
 			return nil, err
 		}
 	}
-	return &internalMaterial{Controller: ctrl, Brokers: brks}, nil
+	return &internalMaterial{Controllers: ctrls, Brokers: brks}, nil
 }
 
 // mintExternalLeaves loads the caller-supplied CA and signs one leaf

--- a/daggerverse/kafka/tests/dagger.gen.go
+++ b/daggerverse/kafka/tests/dagger.gen.go
@@ -598,6 +598,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Tests).DescribeTopicReportsPartitionsAndConfigs(&parent, ctx, kafkaImageTag)
+		case "FiveControllerQuorumAccepted":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var kafkaImageTag string
+			if inputArgs["kafkaImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["kafkaImageTag"]), &kafkaImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg kafkaImageTag", err))
+				}
+			}
+			return nil, (*Tests).FiveControllerQuorumAccepted(&parent, ctx, kafkaImageTag)
 		case "InternalListenersAreEncrypted":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -612,6 +626,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Tests).InternalListenersAreEncrypted(&parent, ctx, kafkaImageTag)
+		case "InvalidControllerCountIsRejected":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var kafkaImageTag string
+			if inputArgs["kafkaImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["kafkaImageTag"]), &kafkaImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg kafkaImageTag", err))
+				}
+			}
+			return nil, (*Tests).InvalidControllerCountIsRejected(&parent, ctx, kafkaImageTag)
 		case "KarapaceSchemaRegistryRegisterLookupRoundTrip":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -682,20 +710,6 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Tests).MtlsRoundTrip(&parent, ctx, kafkaImageTag)
-		case "MultiControllerIsRejected":
-			var parent Tests
-			err = json.Unmarshal(parentJSON, &parent)
-			if err != nil {
-				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
-			}
-			var kafkaImageTag string
-			if inputArgs["kafkaImageTag"] != nil {
-				err = json.Unmarshal([]byte(inputArgs["kafkaImageTag"]), &kafkaImageTag)
-				if err != nil {
-					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg kafkaImageTag", err))
-				}
-			}
-			return nil, (*Tests).MultiControllerIsRejected(&parent, ctx, kafkaImageTag)
 		case "Native":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -1039,6 +1053,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Tests).SingleNodeClusterStarts(&parent, ctx, kafkaImageTag)
+		case "ThreeControllerQuorumProduceConsume":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var kafkaImageTag string
+			if inputArgs["kafkaImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["kafkaImageTag"]), &kafkaImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg kafkaImageTag", err))
+				}
+			}
+			return nil, (*Tests).ThreeControllerQuorumProduceConsume(&parent, ctx, kafkaImageTag)
 		case "TlsClientWithWrongCaFails":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/kafka/tests/internal/dagger/kafka.gen.go
+++ b/daggerverse/kafka/tests/internal/dagger/kafka.gen.go
@@ -37,7 +37,7 @@ func (r *Binding) AsKafkaClientSecurity() *KafkaClientSecurity { // kafka (../..
 }
 
 // Retrieve the binding value, as type KafkaCluster
-func (r *Binding) AsKafkaCluster() *KafkaCluster { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:15:6)
+func (r *Binding) AsKafkaCluster() *KafkaCluster { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:16:6)
 	q := r.query.Select("asKafkaCluster")
 
 	return &KafkaCluster{
@@ -166,7 +166,7 @@ func (r *Env) WithKafkaClientSecurityOutput(name string, description string) *En
 }
 
 // Create or update a binding of type KafkaCluster in the environment
-func (r *Env) WithKafkaClusterInput(name string, value *KafkaCluster, description string) *Env { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:15:6)
+func (r *Env) WithKafkaClusterInput(name string, value *KafkaCluster, description string) *Env { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:16:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withKafkaClusterInput")
 	q = q.Arg("name", name)
@@ -179,7 +179,7 @@ func (r *Env) WithKafkaClusterInput(name string, value *KafkaCluster, descriptio
 }
 
 // Declare a desired KafkaCluster output to be assigned in the environment
-func (r *Env) WithKafkaClusterOutput(name string, description string) *Env { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:15:6)
+func (r *Env) WithKafkaClusterOutput(name string, description string) *Env { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:16:6)
 	q := r.query.Select("withKafkaClusterOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -424,16 +424,16 @@ func (r *Kafka) WithGraphQLQuery(q *querybuilder.Selection) *Kafka {
 type KafkaApacheClusterOpts struct {
 
 	// Default: 1
-	Controllers int // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:91:2)
+	Controllers int // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:98:2)
 
 	// Default: 1
-	Brokers int // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:93:2)
+	Brokers int // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:100:2)
 
 	// Default: "docker.io"
-	Registry string // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:95:2)
+	Registry string // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:102:2)
 
 	// Default: "4.2.0"
-	Tag string // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:97:2)
+	Tag string // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:104:2)
 }
 
 // ApacheCluster spins up a KRaft Kafka cluster of the requested size with
@@ -448,7 +448,7 @@ type KafkaApacheClusterOpts struct {
 // been observed to segfault during broker startup — see Dagger Cloud
 // trace `377f2e176c4f0e9844cb7f958c1e911b`. Prefer this constructor
 // whenever startup robustness matters more than cold-start latency.
-func (r *Kafka) ApacheCluster(clusterId string, clientListenerSecurity *KafkaServerSecurity, opts ...KafkaApacheClusterOpts) *KafkaCluster { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:87:1)
+func (r *Kafka) ApacheCluster(clusterId string, clientListenerSecurity *KafkaServerSecurity, opts ...KafkaApacheClusterOpts) *KafkaCluster { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:94:1)
 	assertNotNil("clientListenerSecurity", clientListenerSecurity)
 	q := r.query.Select("apacheCluster")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -481,31 +481,37 @@ func (r *Kafka) ApacheCluster(clusterId string, clientListenerSecurity *KafkaSer
 type KafkaApacheNativeClusterOpts struct {
 
 	// Default: 1
-	Controllers int // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:60:2)
+	Controllers int // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:67:2)
 
 	// Default: 1
-	Brokers int // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:62:2)
+	Brokers int // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:69:2)
 
 	// Default: "docker.io"
-	Registry string // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:64:2)
+	Registry string // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:71:2)
 
 	// Default: "4.2.0"
-	Tag string // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:66:2)
+	Tag string // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:73:2)
 }
 
 // ApacheNativeCluster spins up a KRaft Kafka cluster of the requested
 // size with dedicated controller and broker containers, using the
 // `apache/kafka-native` GraalVM-compiled image.
 //
-// Topology: a single controller forms a one-node KRaft quorum; one or more
-// brokers connect to it and discover each other over the engine's
-// session-wide DNS — no broker-to-broker WithServiceBinding needed.
+// Topology: controllers form a KRaft quorum (1 controller = a one-node
+// quorum, 3 or 5 = an HA quorum); one or more brokers connect to it and
+// every node discovers every other over the engine's session-wide DNS — no
+// controller-to-controller or broker-to-broker WithServiceBinding needed.
 //
-// Multi-controller (controllers > 1) is rejected for now: a true HA quorum
-// needs every controller to know every other controller at static config
-// time, which Dagger's WithServiceBinding model can't express without an
-// unresolvable cycle. TLS / mTLS and multi-controller both land in a
-// follow-up.
+// Multi-controller HA works because controller hostnames are deterministic
+// (controller-<n>-<suffix>, derived from clusterId), so the full
+// quorum-voters string is computed before any container is built and pinned
+// onto every controller and broker via WithHostname + session-wide DNS —
+// sidestepping the WithServiceBinding cycle a true peer mesh would need.
+//
+// controllers must be odd (1, 3, 5, ...): a KRaft quorum tolerates
+// floor((N-1)/2) controller failures, so an even count buys no extra fault
+// tolerance over the next-lower odd count while enlarging the majority a
+// commit must reach — even values are rejected with an error.
 //
 // Session-cached so that repeated chained method calls on the returned
 // cluster (Client.Produce → Consume → ListTopics) all observe the SAME
@@ -518,7 +524,7 @@ type KafkaApacheNativeClusterOpts struct {
 // `setup` step under load — see Dagger Cloud trace
 // `377f2e176c4f0e9844cb7f958c1e911b`. If you need the JVM image instead,
 // use `ApacheCluster()`.
-func (r *Kafka) ApacheNativeCluster(clusterId string, clientListenerSecurity *KafkaServerSecurity, opts ...KafkaApacheNativeClusterOpts) *KafkaCluster { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:56:1)
+func (r *Kafka) ApacheNativeCluster(clusterId string, clientListenerSecurity *KafkaServerSecurity, opts ...KafkaApacheNativeClusterOpts) *KafkaCluster { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:63:1)
 	assertNotNil("clientListenerSecurity", clientListenerSecurity)
 	q := r.query.Select("apacheNativeCluster")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -615,16 +621,16 @@ func (r *Kafka) Client(bootstrapServers []string, security *KafkaClientSecurity)
 type KafkaConfluentClusterOpts struct {
 
 	// Default: 1
-	Controllers int // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:122:2)
+	Controllers int // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:129:2)
 
 	// Default: 1
-	Brokers int // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:124:2)
+	Brokers int // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:131:2)
 
 	// Default: "docker.io"
-	Registry string // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:126:2)
+	Registry string // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:133:2)
 
 	// Default: "8.2.0"
-	Tag string // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:128:2)
+	Tag string // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:135:2)
 }
 
 // ConfluentCluster spins up a KRaft Kafka cluster of the requested size
@@ -639,7 +645,7 @@ type KafkaConfluentClusterOpts struct {
 // The constructor silently disables Confluent's phone-home telemetry
 // (`KAFKA_CONFLUENT_SUPPORT_METRICS_ENABLE=false`) on every broker so
 // the cluster behaves the same way the Apache variants do at startup.
-func (r *Kafka) ConfluentCluster(clusterId string, clientListenerSecurity *KafkaServerSecurity, opts ...KafkaConfluentClusterOpts) *KafkaCluster { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:118:1)
+func (r *Kafka) ConfluentCluster(clusterId string, clientListenerSecurity *KafkaServerSecurity, opts ...KafkaConfluentClusterOpts) *KafkaCluster { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:125:1)
 	assertNotNil("clientListenerSecurity", clientListenerSecurity)
 	q := r.query.Select("confluentCluster")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -1610,7 +1616,7 @@ func (r *KafkaClientSecurity) AsNode() Node {
 // Cluster represents a running KRaft Kafka cluster, holding references to
 // every broker service so callers can bind them into their own containers or
 // open a franz-go Client against them.
-type KafkaCluster struct { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:15:6)
+type KafkaCluster struct { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:16:6)
 	query *querybuilder.Selection
 
 	id   *ID
@@ -1627,7 +1633,7 @@ func (r *KafkaCluster) WithGraphQLQuery(q *querybuilder.Selection) *KafkaCluster
 // same hostname BootstrapServers reports, so the container can dial brokers
 // using the same address strings as a franz-go Client returned from
 // Cluster.Client.
-func (r *KafkaCluster) BindBrokers(ctr *Container) *Container { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:346:1)
+func (r *KafkaCluster) BindBrokers(ctr *Container) *Container { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:387:1)
 	assertNotNil("ctr", ctr)
 	q := r.query.Select("bindBrokers")
 	q = q.Arg("ctr", ctr)
@@ -1639,7 +1645,7 @@ func (r *KafkaCluster) BindBrokers(ctr *Container) *Container { // kafka (../../
 
 // BootstrapServers returns the host:port pairs each broker advertises on its
 // client-facing listener.
-func (r *KafkaCluster) BootstrapServers(ctx context.Context) ([]string, error) { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:332:1)
+func (r *KafkaCluster) BootstrapServers(ctx context.Context) ([]string, error) { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:373:1)
 	q := r.query.Select("bootstrapServers")
 
 	var response []string
@@ -1650,7 +1656,7 @@ func (r *KafkaCluster) BootstrapServers(ctx context.Context) ([]string, error) {
 
 // Client starts every broker service in the cluster and returns a franz-go
 // Client wired with their bootstrap addresses.
-func (r *KafkaCluster) Client(security *KafkaClientSecurity) *KafkaClient { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:357:1)
+func (r *KafkaCluster) Client(security *KafkaClientSecurity) *KafkaClient { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:398:1)
 	assertNotNil("security", security)
 	q := r.query.Select("client")
 	q = q.Arg("security", security)
@@ -1709,17 +1715,17 @@ func (r *KafkaCluster) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
-// Stop tears down every service container backing this cluster (the
-// controller plus every broker). Tests should call this in a defer so each
-// broker `Container.asService` span closes when the test work is done,
-// rather than running out to the parent parallel group's lifetime.
+// Stop tears down every service container backing this cluster (every
+// controller in the quorum plus every broker). Tests should call this in a
+// defer so each broker `Container.asService` span closes when the test work
+// is done, rather than running out to the parent parallel group's lifetime.
 //
 // Kill is set so Service.Stop skips graceful shutdown — Kafka's broker
 // shutdown path waits on replica-drain timeouts that on a torn-down test
 // cluster just run out the clock (~5 min observed in Dagger trace
 // `972bc311bf374f817b7c88481229a10c`). SIGKILL returns immediately, which
 // is all a test needs.
-func (r *KafkaCluster) Stop(ctx context.Context) error { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:309:1)
+func (r *KafkaCluster) Stop(ctx context.Context) error { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:347:1)
 	if r.stop != nil {
 		return nil
 	}

--- a/daggerverse/kafka/tests/main.go
+++ b/daggerverse/kafka/tests/main.go
@@ -247,8 +247,14 @@ func (t *Tests) Native(
 	jobs = jobs.WithJob("OneControllerTwoBrokersReplicationFactorTwo", func(ctx context.Context) error {
 		return t.OneControllerTwoBrokersReplicationFactorTwo(ctx, kafkaImageTag)
 	})
-	jobs = jobs.WithJob("MultiControllerIsRejected", func(ctx context.Context) error {
-		return t.MultiControllerIsRejected(ctx, kafkaImageTag)
+	jobs = jobs.WithJob("InvalidControllerCountIsRejected", func(ctx context.Context) error {
+		return t.InvalidControllerCountIsRejected(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("FiveControllerQuorumAccepted", func(ctx context.Context) error {
+		return t.FiveControllerQuorumAccepted(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("ThreeControllerQuorumProduceConsume", func(ctx context.Context) error {
+		return t.ThreeControllerQuorumProduceConsume(ctx, kafkaImageTag)
 	})
 	jobs = jobs.WithJob("AutoCreateTopicsDisabled", func(ctx context.Context) error {
 		return autoCreateTopicsDisabledOn(ctx, sharedPlaintext)

--- a/daggerverse/kafka/tests/tests_native.go
+++ b/daggerverse/kafka/tests/tests_native.go
@@ -920,12 +920,42 @@ func propertiesFileContainsBootstrapAndSecurityProtocolOn(ctx context.Context, c
 	return nil
 }
 
-// MultiControllerIsRejected pins the current contract: this story only
-// supports a single-controller quorum (controllers=1), and the constructor
-// must reject any larger value with a clear error rather than silently
-// spinning up a broken topology. Multi-controller HA is gated behind a
-// follow-up story; see daggerverse/kafka/README.md.
-func (t *Tests) MultiControllerIsRejected(
+// InvalidControllerCountIsRejected pins the voter-count policy: a KRaft
+// quorum wants an odd voter count for a clean majority, so even controller
+// counts are rejected, and a sub-1 count is nonsensical. Both must fail at
+// construction time with a clear error rather than spinning up a broken
+// topology. (Controllers=0 can't be exercised from the Go SDK — Dagger drops
+// the zero value and applies the +default=1 — so the sub-1 case uses -1.)
+func (t *Tests) InvalidControllerCountIsRejected(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	k := dag.Kafka()
+	for _, controllers := range []int{2, -1} {
+		clusterId, err := newClusterId(ctx)
+		if err != nil {
+			return err
+		}
+		cluster := k.ApacheNativeCluster(clusterId, k.PlaintextServerSecurity(), dagger.KafkaApacheNativeClusterOpts{
+			Tag:         kafkaImageTag,
+			Controllers: controllers,
+			Brokers:     1,
+		})
+		if _, err := cluster.BootstrapServers(ctx); err == nil {
+			return fmt.Errorf("expected Cluster(controllers=%d) to fail, got nil error", controllers)
+		}
+	}
+	return nil
+}
+
+// FiveControllerQuorumAccepted proves the constructor accepts a five-voter
+// quorum (odd, > 3) and returns a *Cluster: resolving BootstrapServers forces
+// the server-side constructor — validation, internal-CA minting of a leaf per
+// controller, and the full container graph — to run without booting the
+// containers, so the accept path is exercised cheaply. The 3-controller
+// end-to-end quorum is covered by ThreeControllerQuorumProduceConsume.
+func (t *Tests) FiveControllerQuorumAccepted(
 	ctx context.Context,
 	// +default="4.2.0"
 	kafkaImageTag string,
@@ -937,13 +967,55 @@ func (t *Tests) MultiControllerIsRejected(
 	k := dag.Kafka()
 	cluster := k.ApacheNativeCluster(clusterId, k.PlaintextServerSecurity(), dagger.KafkaApacheNativeClusterOpts{
 		Tag:         kafkaImageTag,
-		Controllers: 3,
+		Controllers: 5,
 		Brokers:     1,
 	})
-	if _, err := cluster.BootstrapServers(ctx); err == nil {
-		return fmt.Errorf("expected Cluster(controllers=3) to fail, got nil error")
+	bs, err := cluster.BootstrapServers(ctx)
+	if err != nil {
+		return fmt.Errorf("expected Cluster(controllers=5) to construct, got: %w", err)
+	}
+	if len(bs) == 0 {
+		return fmt.Errorf("expected at least one bootstrap server, got none")
 	}
 	return nil
+}
+
+// ThreeControllerQuorumProduceConsume stands up a real three-node KRaft
+// controller quorum (plus one broker) and drives a produce → consume
+// round-trip through it, mirroring the single-controller round-trip. A
+// successful round-trip proves the three controllers formed a quorum and
+// elected a leader over their (always-mTLS) CONTROLLER listeners — which in
+// turn proves the internal CA minted a verifying leaf for every controller
+// host and that all three discovered each other over session-wide DNS with
+// no controller-to-controller WithServiceBinding. Cluster.Stop then tears
+// down all three controller services plus the broker.
+func (t *Tests) ThreeControllerQuorumProduceConsume(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, err := freshNativeClusterMultiController(ctx, kafkaImageTag, 3, 1)
+	if err != nil {
+		return fmt.Errorf("create cluster: %w", err)
+	}
+	defer cluster.Stop(ctx)
+	return roundTripBinaryOn(ctx, cluster, "raw", "k", "v")
+}
+
+// freshNativeClusterMultiController builds a PLAINTEXT ApacheNativeCluster with
+// caller-controlled controller and broker counts. Used by the multi-controller
+// HA quorum tests.
+func freshNativeClusterMultiController(ctx context.Context, kafkaImageTag string, controllers, brokers int) (*dagger.KafkaCluster, error) {
+	clusterId, err := newClusterId(ctx)
+	if err != nil {
+		return nil, err
+	}
+	k := dag.Kafka()
+	return k.ApacheNativeCluster(clusterId, k.PlaintextServerSecurity(), dagger.KafkaApacheNativeClusterOpts{
+		Tag:         kafkaImageTag,
+		Controllers: controllers,
+		Brokers:     brokers,
+	}), nil
 }
 
 // OneControllerTwoBrokersReplicationFactorTwo spins up a 1+2 cluster and


### PR DESCRIPTION
Closes #149.

Lifts the `controllers > 1` restriction in `buildKafkaCluster` and stands up a
**real multi-node KRaft controller quorum** (3 or 5 controllers) so the kafka
module can exercise HA / failover topologies.

## Approach

Controller hostnames are deterministic (`controller-<n>-<suffix>`, derived from
`clusterId`), so the full quorum-voters string
(`1@controller-1-<suffix>:9093,2@controller-2-<suffix>:9093,...`) is computed
**before** any container is built and pinned identically onto every controller
and broker. At runtime each controller resolves its peers by hostname over the
engine's session-wide DNS (populated by `WithHostname`), and the quorum forms
over the always-mTLS CONTROLLER listeners — no controller-to-controller
`WithServiceBinding`, so no unresolvable build cycle (the exact gate the
original carve-out documented).

## Changes

- **`cluster_kafka.go`** — generalize the hostname scheme + shared quorum-voters
  string to N controllers; build N controller containers with unique
  `KAFKA_NODE_ID`s (1..N); brokers bind all controllers so each boots and
  resolves. `Cluster.ControllerSvc` → `ControllerSvcs []*dagger.Service`, torn
  down in `Stop`.
- **Voter-count policy** — even `controllers` is rejected with a clear error
  (no extra fault tolerance over the next-lower odd count while enlarging the
  commit majority); `< 1` still rejected. Documented in the doc comment + README.
- **`internal_ca.go`** — `mintInternalCA` mints a leaf per controller so
  internal-listener mTLS verifies against every controller host's SAN.
- **Tests** — replace `MultiControllerIsRejected` with
  `InvalidControllerCountIsRejected` (even + sub-1), add
  `FiveControllerQuorumAccepted` (odd N>3 accept path) and
  `ThreeControllerQuorumProduceConsume` (end-to-end produce → consume over a
  real 3-node quorum).
- Regenerated `kafka` + `kafka/tests` bindings; updated doc comments + README.

## Acceptance criteria

- [x] `ApacheNativeCluster` / `ApacheCluster` / `ConfluentCluster` accept
      `controllers=3` and `5` (shared `buildKafkaCluster` body).
- [x] A test produces → consumes against a 3-controller cluster end-to-end
      (`ThreeControllerQuorumProduceConsume`, verified green).
- [x] `controllers < 1` still rejected; even/odd policy enforced + explained
      (`InvalidControllerCountIsRejected`).
- [x] `Cluster.Stop` tears down every controller service.
- [x] TLS / mTLS internal listeners still verify — internal-CA SANs cover every
      controller host (the 3-node quorum forming over the always-mTLS CONTROLLER
      listener proves this directly).
- [x] `dagger develop` run in `kafka` and `kafka/tests`; generated code
      committed. Doc comments + README updated.

## Verification

All three new tests pass against live clusters (Dagger Cloud traces):
- `invalid-controller-count-is-rejected` ✅
- `three-controller-quorum-produce-consume` ✅ — three controllers formed a real
  quorum and the round-trip succeeded
- `five-controller-quorum-accepted` ✅

Both modules build and `go vet` clean; generated-code diff is limited to the
`ControllerSvcs` field + new test wiring (no engine-version churn).

### Note

The `controllers=5` case is covered by a construction-only accept check
(`FiveControllerQuorumAccepted`) rather than a full 5-container boot, to keep CI
cost bounded — the 3-controller test already exercises the end-to-end quorum
path, and there is no exposed API to assert voter count directly. Happy to swap
in a full 5-node boot round-trip if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)