### PR TITLE
story(issue-171): pin controller listener host to fix flaky KRaft quorum startup

### DIFF
--- a/daggerverse/kafka/cluster_kafka.go
+++ b/daggerverse/kafka/cluster_kafka.go
@@ -258,10 +258,24 @@ func buildKafkaCluster(
 			// value even on controller-only nodes that have no advertised
 			// listeners. Strip it so the controller boots regardless of
 			// distro (no-op for the Apache images, which don't pre-set it).
+			// A controller must NOT set advertised.listeners at all — the
+			// Apache docker entrypoint hard-rejects it ("KAFKA_ADVERTISED_-
+			// LISTENERS is not supported on a KRaft controller").
 			WithoutEnvVariable("KAFKA_ADVERTISED_LISTENERS").
 			WithEnvVariable("KAFKA_NODE_ID", fmt.Sprintf("%d", nodeID)).
 			WithEnvVariable("KAFKA_PROCESS_ROLES", "controller").
-			WithEnvVariable("KAFKA_LISTENERS", "CONTROLLER://0.0.0.0:9093").
+			// Bind the CONTROLLER listener to this controller's pinned DNS
+			// hostname rather than 0.0.0.0. A controller-only node can't set
+			// advertised.listeners, so Kafka 4.x derives the advertised
+			// controller endpoint it registers into the quorum metadata from
+			// the `listeners` host. With 0.0.0.0 (no hostname) that endpoint
+			// falls back to localhost:9093 (KAFKA-20228); the localhost then
+			// propagates through the quorum, peers dial themselves, the
+			// quorum never forms, and the leg flakes (issue #171). Pinning
+			// the resolvable hostname here (it resolves to this container's
+			// own IP via WithHostname + session DNS, so the bind succeeds)
+			// keeps the registered endpoint the DNS name, never localhost.
+			WithEnvVariable("KAFKA_LISTENERS", fmt.Sprintf("CONTROLLER://%s:9093", controllerHosts[i])).
 			WithEnvVariable("KAFKA_CONTROLLER_LISTENER_NAMES", "CONTROLLER").
 			WithEnvVariable("KAFKA_LISTENER_SECURITY_PROTOCOL_MAP", "CONTROLLER:SSL").
 			WithEnvVariable("KAFKA_CONTROLLER_QUORUM_VOTERS", quorumVoters).


### PR DESCRIPTION
## Summary

Fixes the flaky multi-controller KRaft quorum startup introduced by #165. Controllers intermittently registered their quorum endpoint as `localhost:9093`, so brokers/peers dialed themselves, the quorum never formed, and `kafka-tests:native` / `kafka-tests:schema-registry` legs failed (6m step timeout or SR `500 "not ready after 30 attempts"`). **This was failing `main`**, and blocked kicad #167 via its `@pull/167/merge` ref.

## Root cause

Controllers bound `KAFKA_LISTENERS=CONTROLLER://0.0.0.0:9093` with no advertised controller listener. A controller-only node can't set `advertised.listeners`, so Kafka 4.x derives the controller endpoint it registers into the quorum metadata from the `listeners` host — and `0.0.0.0` (no hostname) falls back to `localhost:9093` ([KAFKA-20228](https://issues.apache.org/jira/browse/KAFKA-20228)). That localhost propagated through the quorum (`Hostname for node N changed from controller-N-<suffix> to localhost`), and whether a given leg won the race varied per run.

## Fix

Bind each controller's CONTROLLER listener to its **pinned DNS hostname** (`controller-<n>-<suffix>:9093`) instead of `0.0.0.0`. The name resolves to the container's own IP via `WithHostname` + session DNS so the bind succeeds, and the derived/registered voter endpoint is the resolvable name, never localhost. This is structural — the localhost-fallback path no longer exists.

Setting `KAFKA_ADVERTISED_LISTENERS` on a controller (the issue's hypothesized fix) is **not** an option: the Apache docker entrypoint hard-rejects it (`"KAFKA_ADVERTISED_LISTENERS is not supported on a KRaft controller"`, container exits in ~0.5s). `effectiveAdvertisedControllerListeners` reads the `listeners` host when advertised is absent ([KAFKA-18281](https://github.com/apache/kafka/pull/18387)), which is what this fix leverages.

## Verification

Trace confirms static voters register as the DNS names, not localhost:
```
Starting request manager with static voters:
  [controller-1-…:9093, controller-2-…:9093, controller-3-…:9093]
... Completed transition to Leader(... id=2 ... epoch=1 ...)
```

- `three-controller-quorum-produce-consume` (3-controller HA): **5/5 consecutive passes**
- `apache-cluster-produce-list-topics-round-trip` (Apache-JVM): pass
- `confluent-cluster-produce-list-topics-round-trip` (Confluent): pass
- `schema-registry-register-lookup-round-trip` (Confluent SR, controllers=1 — the exact #167 flake path): pass
- `karapace-schema-registry-register-lookup-round-trip` (controllers=1): pass

No codegen change (value-only change inside a function body).

## Acceptance criteria

- [x] Raft clients dial controllers by pinned DNS hostname only — `localhost/127.0.0.1:9093` never appears in raft connection logs
- [x] `kafka-tests:native` (3-controller quorum) passes repeatedly (5/5)
- [x] `kafka-tests:schema-registry` passes (Confluent + Karapace SR reach a ready `_schemas` topic)
- [x] Works for `controllers=1` and `controllers=3` across Apache-native, Apache-JVM, and Confluent
- [x] No change needed in consuming modules/PRs (e.g. #167)

Fixes #171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)