### PR TITLE
story(issue-166): add multi-broker (multi-node Raft) support to kafka RedpandaCluster

### DIFF
--- a/daggerverse/kafka/README.md
+++ b/daggerverse/kafka/README.md
@@ -14,9 +14,11 @@ PKCS#12), so `RedpandaCluster` returns its own type and accepts its own
 security profile — see the dedicated section below.
 
 The module supports plaintext, TLS, and mTLS on the external client-facing
-listener. The internal listeners (inter-broker and controller-quorum) are
-**always mTLS**, secured by a per-cluster CA the module mints internally and
-never surfaces on the API.
+listener. For the `*Cluster` constructors (Apache/Confluent) the internal
+listeners (inter-broker and controller-quorum) are **always mTLS**, secured by
+a per-cluster CA the module mints internally and never surfaces on the API.
+Redpanda has no equivalent env-var PKI, so its internal RPC listener is
+plaintext — see the "RedpandaCluster" section for the rationale.
 
 ## Security profiles
 
@@ -326,29 +328,70 @@ cluster := dag.Kafka().RedpandaCluster(
     dagger.KafkaRedpandaClusterOpts{
         Tag:      "v26.1.7",
         Registry: "docker.io",
+        Brokers:  3, // omit (or 1) for a single node
     },
 )
 client := cluster.Client(dag.Kafka().PlaintextClientSecurity()) // or TLSClientSecurity(...)
 ```
 
-`RedpandaCluster` is single-node only — `controllers != 1` or `brokers
-!= 1` are rejected. Redpanda runs broker and Raft roles in the same
-process, so there is no separate controller container. The broker is
-started via `rpk redpanda start --mode dev-container` (which bundles
-`--overprovisioned`, `--reserve-memory 0M`, `--check=false`, and
-`--unsafe-bypass-fsync`).
+`RedpandaCluster` runs a genuine multi-broker cluster: `brokers` nodes
+(node IDs `0..N-1`, hostnames `redpanda-<n>-<suffix>`) form a single
+Raft group over the internal RPC listener (`:33145`). Redpanda runs
+broker and Raft roles in the same process, so there is no separate
+controller container — every node is a full broker that also
+participates in Raft. Each broker is started via `rpk redpanda start
+--mode dev-container` (which bundles `--overprovisioned`,
+`--reserve-memory 0M`, `--check=false`, and `--unsafe-bypass-fsync`).
 
-- `RedpandaCluster.BootstrapServers(ctx) ([]string, error)` —
-  `[host:9092]`.
+Node hostnames are deterministic (derived from `clusterId`), so the seed
+list is computed before any container is built and pinned onto every
+node via `WithHostname` + session-wide DNS. A multi-node cluster uses
+Redpanda's **seed-driven bootstrap**: every node shares the identical
+`seed_servers` list (all N nodes) with `empty_seed_starts_cluster=false`,
+so the nodes deterministically form one Raft group with **no**
+node-to-node `WithServiceBinding`. The nodes are symmetric Raft peers, so
+a binding can't be used to bring them up (binding A→B forces Dagger to
+fully ready B before it boots A, but B can't ready its ports until the
+cluster forms, which needs A — a deadlock); instead `Client` /
+`SchemaRegistry` start every node **concurrently** so they boot together
+and discover each other by hostname over session-wide DNS. A single-broker
+cluster keeps the legacy `empty_seed_starts_cluster=true` self-bootstrap.
+
+### Controllers policy
+
+`controllers` **must be 1** — Redpanda has no separate controller role
+(broker and Raft duties share one process), so a controller count is not
+a meaningful concept. Any other value is rejected at construction time
+with a Redpanda-specific error; size the cluster with `brokers` instead.
+`brokers < 1` is likewise rejected.
+
+### Inter-node RPC security
+
+The internal RPC listener (`:33145`) that carries Raft traffic between
+nodes is **PLAINTEXT and unauthenticated even on a TLS cluster**.
+Redpanda's RPC-listener TLS would need its own internal CA + per-node
+leaves + mutual trust — a whole parallel PKI — for traffic that never
+leaves the Dagger engine's isolated per-session network. This
+deliberately differs from the Apache path (which always mTLS-encrypts its
+internal + controller listeners) because Redpanda has no equivalent
+`KAFKA_*` PKCS#12 env-var contract to reuse. TLS here is scoped to the
+client-facing Kafka listener + bundled Schema Registry REST endpoint,
+which is what external clients actually verify; every node's external
+leaf is SAN'd to its own hostname so a client routed to any broker
+verifies successfully.
+
+- `RedpandaCluster.BootstrapServers(ctx) ([]string, error)` — one
+  `host:9092` per broker.
 - `RedpandaCluster.BindBrokers(c *dagger.Container) *dagger.Container`
-  — same shape as `Cluster.BindBrokers`.
+  — binds every broker, same shape as `Cluster.BindBrokers`.
 - `RedpandaCluster.Client(ctx, security *KafkaClientSecurity)
-  (*KafkaClient, error)` — returns the same `*Client` the Apache
-  constructors return. The Kafka wire protocol matches, so
-  producer/consumer code is shared.
-- `RedpandaCluster.SchemaRegistry(ctx) *SchemaRegistry` — the bundled
-  in-broker Schema Registry as the shared `*SchemaRegistry` type — see
-  "Bundled Schema Registry" below.
+  (*KafkaClient, error)` — starts every broker (bringing the Raft group
+  online) and returns the same `*Client` the Apache constructors return.
+  The Kafka wire protocol matches, so producer/consumer code is shared.
+- `RedpandaCluster.SchemaRegistry(ctx, security) (*SchemaRegistry, error)`
+  — the bundled in-broker Schema Registry (on node 0) as the shared
+  `*SchemaRegistry` type — see "Bundled Schema Registry" below.
+- `RedpandaCluster.Stop(ctx) error` — tears down every node service.
 
 ### Security profile
 
@@ -365,18 +408,19 @@ Redpanda reads PEM (`server.crt`, `server.key`) from its
 constructors hand to the JVM. The API surface still accepts the same
 PKCS#12 CA you'd hand to `TLSServerSecurity` — the constructor loads
 the CA via `certificate-management`'s existing PKCS#12 loader, issues
-the per-cluster server leaf, then mounts the PEM cert/key files into
-the broker container at `/etc/redpanda/certs/server.{crt,key}` and
-points the rendered `redpanda.yaml` at those paths (the YAML never
-embeds PEM material itself). Callers don't have to convert between
-formats. The server private key crosses into the broker container as
-a `*dagger.Secret` (mounted via `WithMountedSecret`) so its plaintext
-never lands in the module workdir. The CA cert *is* mounted, at
-`/etc/redpanda/certs/ca.crt` — it is the truststore for the bundled
-Schema Registry's internal broker client, which must dial the TLS-only
-Kafka listener to persist `_schemas` (see "Bundled Schema Registry"
-below). mTLS on the external listener (client-auth) is a follow-up;
-this story is server-side TLS only.
+**one server leaf per node** (each SAN'd to that node's own hostname),
+then mounts the PEM cert/key files into each broker container at
+`/etc/redpanda/certs/server.{crt,key}` and points the per-node rendered
+`redpanda.yaml` at those paths (the YAML never embeds PEM material
+itself). Callers don't have to convert between formats. Each node's
+private key crosses into its container as a `*dagger.Secret` (mounted
+via `WithMountedSecret`) so its plaintext never lands in the module
+workdir. The CA cert *is* mounted (shared across nodes) at
+`/etc/redpanda/certs/ca.crt` — it is the truststore for each node's
+bundled Schema Registry / pandaproxy broker client, which must dial the
+TLS-only Kafka listener to persist `_schemas` (see "Bundled Schema
+Registry" below). mTLS on the external listener (client-auth) is a
+follow-up; this path is server-side TLS only.
 
 ### Client
 
@@ -674,10 +718,10 @@ underneath:
   ships Kafka 4.2.0. The constructor silently disables Confluent's
   phone-home telemetry (`KAFKA_CONFLUENT_SUPPORT_METRICS_ENABLE=false`).
 - `RedpandaCluster` → `<registry>/redpandadata/redpanda:<tag>` (default
-  `docker.io/redpandadata/redpanda:v26.1.7`). Single-node only;
-  separate `*RedpandaCluster` / `*RedpandaServerSecurity` types
-  because the config layer doesn't share the `KAFKA_*` env-var
-  contract — see the "RedpandaCluster" section.
+  `docker.io/redpandadata/redpanda:v26.1.7`). Multi-broker (Raft) via
+  the `brokers` parameter; separate `*RedpandaCluster` /
+  `*RedpandaServerSecurity` types because the config layer doesn't share
+  the `KAFKA_*` env-var contract — see the "RedpandaCluster" section.
 
 `registry` (default `docker.io`) and `tag` are the only caller-
 overridable parts; the `apache/kafka{-native,}`, `confluentinc/cp-kafka`,

--- a/daggerverse/kafka/cluster_redpanda.go
+++ b/daggerverse/kafka/cluster_redpanda.go
@@ -3,7 +3,10 @@ package main
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
+	"strings"
+	"sync"
 	"time"
 
 	"dagger/kafka/internal/dagger"
@@ -15,15 +18,20 @@ import (
 // the Kafka wire protocol but is a from-scratch C++ implementation with a
 // completely different configuration layer (`rpk redpanda start`, a YAML
 // config file, PEM cert/key files instead of PKCS#12), so it gets its own
-// return type to make the divergence visible at the API surface. Single
-// node only in this story (controllers=1, brokers=1).
+// return type to make the divergence visible at the API surface.
+//
+// Supports a genuine multi-broker Raft cluster: N brokers (node IDs 0..N-1)
+// form a single Raft group over the internal RPC listener, discovering each
+// other by deterministic hostname (redpanda-<n>-<suffix>) via the engine's
+// session-wide DNS. Redpanda runs broker and Raft duties in the SAME process,
+// so there is no separate controller container.
 type RedpandaCluster struct {
 	// +private
 	ClusterID string
 	// +private
-	BrokerSvc *dagger.Service
+	BrokerSvcs []*dagger.Service
 	// +private
-	BrokerHost string
+	BrokerHosts []string
 	// +private
 	ClientSecurityMode string // PLAINTEXT | TLS
 }
@@ -52,12 +60,12 @@ func (k *Kafka) RedpandaPlaintextServerSecurity() *RedpandaServerSecurity {
 
 // RedpandaTlsServerSecurity returns a RedpandaServerSecurity profile that
 // terminates TLS on the external Kafka listener. caKeyStore is a PKCS#12
-// archive of the CA cert + private key used to mint the per-cluster server
-// leaf — same shape as Kafka.TlsServerSecurity, so callers don't have to
+// archive of the CA cert + private key used to mint the per-node server
+// leaves — same shape as Kafka.TlsServerSecurity, so callers don't have to
 // convert between formats even though Redpanda itself reads PEM internally.
-// The leaf carries the broker's stable hostname as a DNS SAN so franz-go
-// clients dialing the bootstrap address can verify the cert against the
-// matching truststore.
+// Each node's leaf carries that node's stable hostname as a DNS SAN so
+// franz-go clients dialing any broker in the bootstrap list can verify the
+// cert against the matching truststore.
 func (k *Kafka) RedpandaTlsServerSecurity(
 	caKeyStore *dagger.File,
 	caKeyStorePassword *dagger.Secret,
@@ -69,15 +77,39 @@ func (k *Kafka) RedpandaTlsServerSecurity(
 	}
 }
 
-// RedpandaCluster spins up a single-node Redpanda cluster using the
+// RedpandaCluster spins up a Redpanda cluster of `brokers` nodes using the
 // `redpandadata/redpanda` image. Redpanda runs broker and Raft duties in the
-// same process, so there is no separate controller container.
+// same process, so there is no separate controller container — every node is
+// a full broker that also participates in the Raft group.
 //
-// Multi-node (controllers != 1 or brokers != 1) is rejected — multi-broker
-// Redpanda needs `--seeds` plumbing + per-node `rpc_server` advertising
-// that doesn't fit single-story scope. The wire protocol matches Kafka,
-// so RedpandaCluster.Client() returns the same *Client type the Apache
-// constructors return.
+// Topology: node hostnames are deterministic (redpanda-<n>-<suffix>, node IDs
+// 0..N-1, suffix derived from clusterId), so the seed list is computed before
+// any container is built and pinned onto every node via WithHostname +
+// session-wide DNS. For brokers > 1 the cluster uses Redpanda's seed-driven
+// bootstrap: every node shares the identical seed_servers list (all N nodes)
+// and empty_seed_starts_cluster=false, so the nodes deterministically form one
+// Raft group over the internal RPC listener (:33145) with NO node-to-node
+// WithServiceBinding — they are started concurrently and discover each other
+// by hostname over session-wide DNS. A single-broker cluster keeps the legacy
+// empty_seed_starts_cluster=true bootstrap (empty seed list).
+//
+// controllers must be 1: Redpanda has no separate controller role, so a
+// controller count is not a meaningful concept and any other value is
+// rejected (see the constructor's error). Size the cluster with `brokers`.
+//
+// Inter-node RPC security: the internal RPC listener (:33145) that carries
+// Raft traffic is PLAINTEXT and unauthenticated even when the external Kafka
+// listener is TLS. Redpanda's RPC-listener TLS would need its own internal
+// CA + per-node leaves + mutual trust — a whole parallel PKI — for traffic
+// that never leaves the Dagger engine's isolated per-session network. This
+// deliberately differs from the Apache path (which always mTLS-encrypts its
+// internal + controller listeners) because Redpanda has no equivalent PKCS#12
+// env-var contract to reuse; TLS here is scoped to the client-facing Kafka
+// listener + bundled Schema Registry REST endpoint, which is what external
+// clients actually verify.
+//
+// The wire protocol matches Kafka, so RedpandaCluster.Client() returns the
+// same *Client type the Apache constructors return.
 //
 // +cache="session"
 func (k *Kafka) RedpandaCluster(
@@ -107,15 +139,12 @@ func buildRedpandaCluster(
 ) (*RedpandaCluster, error) {
 	if controllers != 1 {
 		return nil, fmt.Errorf(
-			"Kafka.RedpandaCluster: single-node only in this story (got controllers=%d); multi-node Redpanda is not yet supported",
+			"Kafka.RedpandaCluster: Redpanda has no separate controller role — broker and Raft duties run in the same process, so a controller count is not a meaningful concept (got controllers=%d, want 1); size the cluster with `brokers` instead",
 			controllers,
 		)
 	}
-	if brokers != 1 {
-		return nil, fmt.Errorf(
-			"Kafka.RedpandaCluster: single-node only in this story (got brokers=%d); multi-broker Redpanda is not yet supported",
-			brokers,
-		)
+	if brokers < 1 {
+		return nil, fmt.Errorf("at least one broker is required, got %d", brokers)
 	}
 	if clientListenerSecurity == nil {
 		return nil, fmt.Errorf("clientListenerSecurity must not be nil")
@@ -136,157 +165,237 @@ func buildRedpandaCluster(
 		)
 	}
 
-	brokerHost := "redpanda-1-" + clusterHostSuffix(clusterId)
-
-	ctr := dag.Container().From(image)
-
-	// rpk redpanda start args. --mode dev-container bundles
-	// --overprovisioned, --reserve-memory 0M, --check=false, and
-	// --unsafe-bypass-fsync so we don't repeat those flags.
-	args := []string{
-		"redpanda", "start",
-		"--mode", "dev-container",
-		"--smp", "1",
-		"--memory", "1G",
+	// Deterministic per-cluster hostnames (redpanda-<n>-<suffix>, node IDs
+	// 0..N-1) let the whole seed list be assembled here — before any
+	// container exists — and pinned identically onto every node via
+	// WithHostname. At runtime each node resolves its peers by hostname over
+	// the engine's session-wide DNS, so a real Raft group forms with no
+	// node-to-node WithServiceBinding and thus no unresolvable build cycle.
+	suffix := clusterHostSuffix(clusterId)
+	brokerHosts := make([]string, brokers)
+	seedHosts := make([]string, brokers)
+	for i := range brokerHosts {
+		brokerHosts[i] = fmt.Sprintf("redpanda-%d-%s", i+1, suffix)
+		seedHosts[i] = brokerHosts[i]
 	}
+	multiNode := brokers > 1
 
+	// TLS: mint a server leaf per node (each SAN'd to its own hostname) and a
+	// per-node redpanda.yaml; the CA cert is shared across nodes as the
+	// truststore for each node's bundled Schema Registry / pandaproxy client.
+	var tlsAssets []redpandaNodeTlsAssets
 	if mode == "TLS" {
-		assets, err := mintRedpandaTlsAssets(ctx, clientListenerSecurity, brokerHost)
+		var err error
+		tlsAssets, err = mintRedpandaTlsAssets(ctx, clientListenerSecurity, brokerHosts, seedHosts, multiNode)
 		if err != nil {
 			return nil, fmt.Errorf("mint redpanda tls assets: %w", err)
 		}
-		// Owned by redpanda:redpanda because the image's entrypoint
-		// drops to that uid; rpk's start path chowns the live config
-		// file to the same user and fails with EPERM if it's still
-		// owned by root.
-		ctr = ctr.
-			WithFile("/etc/redpanda/certs/server.crt", assets.ServerCert, dagger.ContainerWithFileOpts{Permissions: 0o644, Owner: "redpanda:redpanda"}).
-			WithMountedSecret("/etc/redpanda/certs/server.key", assets.ServerKey, dagger.ContainerWithMountedSecretOpts{Owner: "redpanda:redpanda", Mode: 0o400}).
-			WithFile("/etc/redpanda/certs/ca.crt", assets.CaCert, dagger.ContainerWithFileOpts{Permissions: 0o644, Owner: "redpanda:redpanda"}).
-			WithFile("/etc/redpanda/redpanda.yaml", assets.ConfigFile, dagger.ContainerWithFileOpts{Permissions: 0o644, Owner: "redpanda:redpanda"})
-	} else {
-		// PLAINTEXT: no YAML needed — pass listener flags directly.
-		args = append(args,
-			"--node-id", "0",
-			"--kafka-addr", "PLAINTEXT://0.0.0.0:9092",
-			"--advertise-kafka-addr", "PLAINTEXT://"+brokerHost+":9092",
-			"--rpc-addr", "0.0.0.0:33145",
-			"--advertise-rpc-addr", brokerHost+":33145",
-			"--schema-registry-addr", fmt.Sprintf("0.0.0.0:%d", schemaRegistryPort),
-			"--set", "redpanda.empty_seed_starts_cluster=true",
-		)
 	}
 
-	svc := ctr.
-		WithExposedPort(9092).
-		WithExposedPort(33145).
-		WithExposedPort(schemaRegistryPort).
-		AsService(dagger.ContainerAsServiceOpts{
-			Args:          args,
-			UseEntrypoint: true,
-		}).
-		WithHostname(brokerHost)
+	// Build each node's pre-service container + its `rpk redpanda start` args.
+	nodeCtrs := make([]*dagger.Container, brokers)
+	nodeArgs := make([][]string, brokers)
+	for i := 0; i < brokers; i++ {
+		host := brokerHosts[i]
+		ctr := dag.Container().From(image).
+			WithExposedPort(9092).
+			WithExposedPort(33145).
+			WithExposedPort(schemaRegistryPort)
+
+		// rpk redpanda start args. --mode dev-container bundles
+		// --overprovisioned, --reserve-memory 0M, --check=false, and
+		// --unsafe-bypass-fsync so we don't repeat those flags.
+		args := []string{
+			"redpanda", "start",
+			"--mode", "dev-container",
+			"--smp", "1",
+			"--memory", "1G",
+		}
+
+		if mode == "TLS" {
+			a := tlsAssets[i]
+			// Owned by redpanda:redpanda because the image's entrypoint
+			// drops to that uid; rpk's start path chowns the live config
+			// file to the same user and fails with EPERM if it's still
+			// owned by root.
+			ctr = ctr.
+				WithFile("/etc/redpanda/certs/server.crt", a.ServerCert, dagger.ContainerWithFileOpts{Permissions: 0o644, Owner: "redpanda:redpanda"}).
+				WithMountedSecret("/etc/redpanda/certs/server.key", a.ServerKey, dagger.ContainerWithMountedSecretOpts{Owner: "redpanda:redpanda", Mode: 0o400}).
+				WithFile("/etc/redpanda/certs/ca.crt", a.CaCert, dagger.ContainerWithFileOpts{Permissions: 0o644, Owner: "redpanda:redpanda"}).
+				WithFile("/etc/redpanda/redpanda.yaml", a.ConfigFile, dagger.ContainerWithFileOpts{Permissions: 0o644, Owner: "redpanda:redpanda"})
+		} else {
+			// PLAINTEXT: no YAML needed — pass listener flags directly.
+			args = append(args,
+				"--node-id", fmt.Sprintf("%d", i),
+				"--kafka-addr", "PLAINTEXT://0.0.0.0:9092",
+				"--advertise-kafka-addr", "PLAINTEXT://"+host+":9092",
+				"--rpc-addr", "0.0.0.0:33145",
+				"--advertise-rpc-addr", host+":33145",
+				"--schema-registry-addr", fmt.Sprintf("0.0.0.0:%d", schemaRegistryPort),
+			)
+			if multiNode {
+				// Seed-driven bootstrap: every node shares the identical
+				// seed list (all N nodes) and does NOT self-start an empty
+				// cluster, so the nodes deterministically form one Raft group.
+				seeds := make([]string, brokers)
+				for j, h := range seedHosts {
+					seeds[j] = h + ":33145"
+				}
+				args = append(args,
+					"--seeds", strings.Join(seeds, ","),
+					"--set", "redpanda.empty_seed_starts_cluster=false",
+				)
+			} else {
+				args = append(args,
+					"--set", "redpanda.empty_seed_starts_cluster=true",
+				)
+			}
+		}
+
+		nodeCtrs[i] = ctr
+		nodeArgs[i] = args
+	}
+
+	// Every node is an independent service pinned to its deterministic
+	// hostname; there is NO node-to-node WithServiceBinding. A symmetric Raft
+	// peer mesh can't use bindings: binding node A→B forces Dagger to fully
+	// ready B (all exposed ports up) before it even boots A, but B can't open
+	// its Kafka/Schema-Registry ports until the cluster forms, which needs A —
+	// a readiness deadlock. Instead the nodes are started concurrently (see
+	// startAll, used by Client and SchemaRegistry) so they boot together and
+	// discover each other by hostname over session-wide DNS, forming the Raft
+	// group over the internal RPC listener.
+	svcs := make([]*dagger.Service, brokers)
+	for i := 0; i < brokers; i++ {
+		svcs[i] = nodeCtrs[i].
+			AsService(dagger.ContainerAsServiceOpts{
+				Args:          nodeArgs[i],
+				UseEntrypoint: true,
+			}).
+			WithHostname(brokerHosts[i])
+	}
 
 	return &RedpandaCluster{
 		ClusterID:          clusterId,
-		BrokerSvc:          svc,
-		BrokerHost:         brokerHost,
+		BrokerSvcs:         svcs,
+		BrokerHosts:        brokerHosts,
 		ClientSecurityMode: mode,
 	}, nil
 }
 
-// redpandaTlsAssets bundles the PEM material + rendered redpanda.yaml for a
-// single-node Redpanda cluster with TLS termination on the external Kafka
-// listener.
-type redpandaTlsAssets struct {
+// redpandaNodeTlsAssets bundles one node's PEM material + rendered
+// redpanda.yaml for a Redpanda cluster with TLS termination on the external
+// Kafka listener. The CA cert is shared across nodes (same *dagger.File on
+// every node); the server leaf + config are per-node.
+type redpandaNodeTlsAssets struct {
 	ServerCert *dagger.File   // PEM, mounted at /etc/redpanda/certs/server.crt
 	ServerKey  *dagger.Secret // PEM PKCS#8, mounted at /etc/redpanda/certs/server.key
 	CaCert     *dagger.File   // CA PEM, mounted at /etc/redpanda/certs/ca.crt — truststore for the bundled SR's broker client
 	ConfigFile *dagger.File   // rendered redpanda.yaml, mounted at /etc/redpanda/redpanda.yaml
 }
 
-// mintRedpandaTlsAssets loads the caller-supplied CA, signs a single server
-// leaf with the broker's stable hostname as a DNS SAN, and renders the
-// matching redpanda.yaml. Mirrors mintExternalLeaves' content-addressed
-// staging via writeWorkdirBytes for the public-cert + YAML files; the
-// private key crosses the container boundary as a *dagger.Secret so its
-// plaintext never lands on disk in the module's workdir.
+// mintRedpandaTlsAssets loads the caller-supplied CA once, then for each node
+// signs a server leaf carrying that node's stable hostname as a DNS SAN and
+// renders the matching per-node redpanda.yaml. Mirrors mintExternalLeaves'
+// content-addressed staging via writeWorkdirBytes for the public-cert + YAML
+// files; each node's private key crosses the container boundary as a
+// *dagger.Secret so its plaintext never lands on disk in the module's workdir.
 func mintRedpandaTlsAssets(
 	ctx context.Context,
 	sec *RedpandaServerSecurity,
-	brokerHost string,
-) (*redpandaTlsAssets, error) {
+	brokerHosts []string,
+	seedHosts []string,
+	multiNode bool,
+) ([]redpandaNodeTlsAssets, error) {
 	ca := dag.CertificateManagement().LoadCertificateAuthority(sec.CaKeyStore, sec.CaKeyStorePassword)
 
-	leafKeyPem, err := dag.Crypto().GenerateRsaKey(dagger.CryptoGenerateRsaKeyOpts{Bits: 2048}).Pem().Contents(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("generate redpanda leaf key: %w", err)
-	}
-	leafKey := dag.SetSecret("redpanda-leaf-key-"+randSuffix(), leafKeyPem)
-
-	leafPwdHex, err := dag.Random().Sha256(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("generate redpanda leaf password: %w", err)
-	}
-	leafPwd := dag.SetSecret("redpanda-leaf-pwd-"+randSuffix(), leafPwdHex)
-
-	leafSerial, err := dag.Random().Serial(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("generate redpanda leaf serial: %w", err)
-	}
-	nb := time.Now().UTC().Format(time.RFC3339)
-
-	issued := ca.IssueServerCertificate(brokerHost, nb, leafSerial, leafPwd, leafKey,
-		dagger.CertificateManagementCertificateAuthorityIssueServerCertificateOpts{
-			DNSSans:      []string{brokerHost, "localhost"},
-			IPSans:       []string{"127.0.0.1"},
-			ValidityDays: 365,
-		})
-
-	certBytes, err := dagFileBytes(ctx, issued.CertPemFile())
-	if err != nil {
-		return nil, fmt.Errorf("materialize redpanda server cert: %w", err)
-	}
-	certFile, err := writeWorkdirBytes("redpanda-server-cert-"+brokerHost, "server.crt", certBytes)
-	if err != nil {
-		return nil, fmt.Errorf("stage redpanda server cert: %w", err)
-	}
-	// The bundled Schema Registry talks to the broker over the Kafka wire
-	// protocol; with a TLS-only external listener it must dial over TLS and
-	// trust the cluster CA, so the CA cert is mounted as its truststore.
+	// The bundled Schema Registry / pandaproxy talk to the broker over the
+	// Kafka wire protocol; with a TLS-only external listener they must dial
+	// over TLS and trust the cluster CA, so the CA cert is mounted as their
+	// truststore. Materialized once and shared across nodes.
 	caCertBytes, err := dagFileBytes(ctx, ca.CertPemFile())
 	if err != nil {
 		return nil, fmt.Errorf("materialize redpanda ca cert: %w", err)
 	}
-	caCertFile, err := writeWorkdirBytes("redpanda-ca-cert-"+brokerHost, "ca.crt", caCertBytes)
+	caCertFile, err := writeWorkdirBytes("redpanda-ca-cert", "ca.crt", caCertBytes)
 	if err != nil {
 		return nil, fmt.Errorf("stage redpanda ca cert: %w", err)
 	}
-	yamlBytes, err := renderRedpandaYaml(brokerHost, true)
-	if err != nil {
-		return nil, fmt.Errorf("render redpanda.yaml: %w", err)
-	}
-	yamlFile, err := writeWorkdirBytes("redpanda-config-"+brokerHost, "redpanda.yaml", yamlBytes)
-	if err != nil {
-		return nil, fmt.Errorf("stage redpanda.yaml: %w", err)
-	}
 
-	return &redpandaTlsAssets{
-		ServerCert: certFile,
-		ServerKey:  issued.PrivateKeyPem(),
-		CaCert:     caCertFile,
-		ConfigFile: yamlFile,
-	}, nil
+	assets := make([]redpandaNodeTlsAssets, len(brokerHosts))
+	for i, brokerHost := range brokerHosts {
+		leafKeyPem, err := dag.Crypto().GenerateRsaKey(dagger.CryptoGenerateRsaKeyOpts{Bits: 2048}).Pem().Contents(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("generate redpanda leaf key for %q: %w", brokerHost, err)
+		}
+		leafKey := dag.SetSecret("redpanda-leaf-key-"+randSuffix(), leafKeyPem)
+
+		leafPwdHex, err := dag.Random().Sha256(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("generate redpanda leaf password for %q: %w", brokerHost, err)
+		}
+		leafPwd := dag.SetSecret("redpanda-leaf-pwd-"+randSuffix(), leafPwdHex)
+
+		leafSerial, err := dag.Random().Serial(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("generate redpanda leaf serial for %q: %w", brokerHost, err)
+		}
+		nb := time.Now().UTC().Format(time.RFC3339)
+
+		issued := ca.IssueServerCertificate(brokerHost, nb, leafSerial, leafPwd, leafKey,
+			dagger.CertificateManagementCertificateAuthorityIssueServerCertificateOpts{
+				DNSSans:      []string{brokerHost, "localhost"},
+				IPSans:       []string{"127.0.0.1"},
+				ValidityDays: 365,
+			})
+
+		certBytes, err := dagFileBytes(ctx, issued.CertPemFile())
+		if err != nil {
+			return nil, fmt.Errorf("materialize redpanda server cert for %q: %w", brokerHost, err)
+		}
+		certFile, err := writeWorkdirBytes("redpanda-server-cert-"+brokerHost, "server.crt", certBytes)
+		if err != nil {
+			return nil, fmt.Errorf("stage redpanda server cert for %q: %w", brokerHost, err)
+		}
+
+		yamlBytes, err := renderRedpandaYaml(i, brokerHost, brokerHosts, seedHosts, multiNode, true)
+		if err != nil {
+			return nil, fmt.Errorf("render redpanda.yaml for %q: %w", brokerHost, err)
+		}
+		yamlFile, err := writeWorkdirBytes("redpanda-config-"+brokerHost, "redpanda.yaml", yamlBytes)
+		if err != nil {
+			return nil, fmt.Errorf("stage redpanda.yaml for %q: %w", brokerHost, err)
+		}
+
+		assets[i] = redpandaNodeTlsAssets{
+			ServerCert: certFile,
+			ServerKey:  issued.PrivateKeyPem(),
+			CaCert:     caCertFile,
+			ConfigFile: yamlFile,
+		}
+	}
+	return assets, nil
 }
 
-// renderRedpandaYaml emits the full /etc/redpanda/redpanda.yaml for a
-// single-node cluster. Rendered via yaml.v3 (not fmt.Fprintf) so any
-// hostname containing YAML metacharacters is properly quoted.
-func renderRedpandaYaml(brokerHost string, withTls bool) ([]byte, error) {
+// renderRedpandaYaml emits the full /etc/redpanda/redpanda.yaml for one node
+// (nodeID, advertised as brokerHost) of a Redpanda cluster. For a multi-node
+// cluster seedHosts lists every node and seed-driven bootstrap is used
+// (empty_seed_starts_cluster=false); for a single node the seed list is empty
+// and the node self-starts its cluster (empty_seed_starts_cluster=true).
+// Rendered via yaml.v3 (not fmt.Fprintf) so any hostname containing YAML
+// metacharacters is properly quoted.
+func renderRedpandaYaml(nodeID int, brokerHost string, brokerHosts []string, seedHosts []string, multiNode bool, withTls bool) ([]byte, error) {
 	type addr struct {
 		Address string `yaml:"address"`
 		Port    int    `yaml:"port"`
 		Name    string `yaml:"name,omitempty"`
+	}
+	type seedHost struct {
+		Address string `yaml:"address"`
+		Port    int    `yaml:"port"`
+	}
+	type seedServer struct {
+		Host seedHost `yaml:"host"`
 	}
 	type tlsEntry struct {
 		Name              string `yaml:"name"`
@@ -308,13 +417,28 @@ func renderRedpandaYaml(brokerHost string, withTls bool) ([]byte, error) {
 		Brokers   []addr    `yaml:"brokers"`
 		BrokerTLS brokerTLS `yaml:"broker_tls"`
 	}
+
+	// Seed-driven bootstrap for a multi-node cluster: every node carries the
+	// identical seed_servers list (all N nodes) and empty_seed_starts_cluster
+	// is false so no single node self-elects a one-node cluster. A single-node
+	// cluster keeps the legacy empty-seed self-bootstrap.
+	seedServers := []any{}
+	if multiNode {
+		for _, h := range seedHosts {
+			seedServers = append(seedServers, seedServer{Host: seedHost{Address: h, Port: 33145}})
+		}
+	}
+
 	rpCfg := map[string]any{
 		"data_directory":            "/var/lib/redpanda/data",
-		"node_id":                   0,
-		"empty_seed_starts_cluster": true,
-		"seed_servers":              []any{},
-		"rpc_server":                addr{Address: "0.0.0.0", Port: 33145},
-		"advertised_rpc_api":        addr{Address: brokerHost, Port: 33145},
+		"node_id":                   nodeID,
+		"empty_seed_starts_cluster": !multiNode,
+		"seed_servers":              seedServers,
+		// The internal RPC listener carries Raft traffic between nodes. It is
+		// PLAINTEXT/unauthenticated even on a TLS cluster (see the
+		// RedpandaCluster doc comment) — it never leaves the engine session.
+		"rpc_server":         addr{Address: "0.0.0.0", Port: 33145},
+		"advertised_rpc_api": addr{Address: brokerHost, Port: 33145},
 		"kafka_api": []addr{
 			{Address: "0.0.0.0", Port: 9092, Name: "external"},
 		},
@@ -364,8 +488,16 @@ func renderRedpandaYaml(brokerHost string, withTls bool) ([]byte, error) {
 		},
 	}
 	if withTls {
+		// The bundled SR / pandaproxy Kafka clients bootstrap against every
+		// broker over TLS, trusting the cluster CA. Listing all brokers keeps
+		// the client reachable even if the local node is not the leader for
+		// the internal _schemas topic.
+		brokerAddrs := make([]addr, len(brokerHosts))
+		for i, h := range brokerHosts {
+			brokerAddrs[i] = addr{Address: h, Port: 9092}
+		}
 		clientCfg := kafkaClientCfg{
-			Brokers: []addr{{Address: brokerHost, Port: 9092}},
+			Brokers: brokerAddrs,
 			BrokerTLS: brokerTLS{
 				Enabled:        true,
 				TruststoreFile: "/etc/redpanda/certs/ca.crt",
@@ -377,22 +509,55 @@ func renderRedpandaYaml(brokerHost string, withTls bool) ([]byte, error) {
 	return yaml.Marshal(full)
 }
 
-// BootstrapServers returns the bootstrap address (single broker:9092) for
-// this Redpanda cluster.
+// startAll boots every node service concurrently. Concurrency is required for
+// a multi-node cluster: the nodes are symmetric Raft peers with no service
+// bindings between them, so a node's ports (Kafka 9092, Schema Registry 8081)
+// only open once the cluster forms — which needs all peers up. Starting them
+// one at a time would block on the first node forever (it waits for its own
+// health check, which waits for peers that haven't been started yet); starting
+// them together lets the Raft group form and every node's health check pass.
+func startAll(ctx context.Context, svcs []*dagger.Service) error {
+	var wg sync.WaitGroup
+	errs := make([]error, len(svcs))
+	for i, svc := range svcs {
+		if svc == nil {
+			continue
+		}
+		wg.Add(1)
+		go func(i int, svc *dagger.Service) {
+			defer wg.Done()
+			if _, err := svc.Start(ctx); err != nil {
+				errs[i] = fmt.Errorf("start redpanda broker %d: %w", i, err)
+			}
+		}(i, svc)
+	}
+	wg.Wait()
+	return errors.Join(errs...)
+}
+
+// BootstrapServers returns the host:port bootstrap addresses for every broker
+// in this Redpanda cluster.
 //
 // +cache="never"
 func (r *RedpandaCluster) BootstrapServers() []string {
-	return []string{r.BrokerHost + ":9092"}
+	out := make([]string, len(r.BrokerHosts))
+	for i, h := range r.BrokerHosts {
+		out[i] = h + ":9092"
+	}
+	return out
 }
 
 // SchemaRegistry exposes Redpanda's bundled Schema Registry as the same
 // *SchemaRegistry type Kafka.ConfluentSchemaRegistry returns, so callers can
 // treat the bundled and separate-container registries uniformly.
 //
-// `rpk redpanda start` runs a Schema Registry inside the broker process on
-// :8081 — no extra container — so the returned *SchemaRegistry points at the
-// broker service itself. Redpanda's SR speaks the Confluent Schema Registry
-// REST API, so the *SchemaRegistryClient from Client() works unchanged.
+// `rpk redpanda start` runs a Schema Registry inside every broker process on
+// :8081 — no extra container. The returned *SchemaRegistry points at the first
+// broker (node 0); because the registry client only starts that one service,
+// this method brings the whole cluster online (startAll) before returning, so
+// the registry is backed by a formed Raft group. Redpanda's SR speaks the
+// Confluent Schema Registry REST API, so the *SchemaRegistryClient from
+// Client() works unchanged.
 //
 // security must match the cluster's mode (PLAINTEXT or TLS — Redpanda has no
 // mTLS): on a TLS cluster the bundled SR REST endpoint terminates HTTPS
@@ -401,63 +566,81 @@ func (r *RedpandaCluster) BootstrapServers() []string {
 // client. The profile's CA keystore is unused here (the leaf is already
 // minted); it is required only for API uniformity with the other registries.
 //
-// The returned registry is Bundled: its service is the broker itself, so
-// Stop is a no-op on it — call cluster.Stop to tear the registry down with
-// the cluster. A caller that uniformly `defer sr.Stop(ctx)` over the shared
+// The returned registry is Bundled: its service is a broker itself, so Stop is
+// a no-op on it — call cluster.Stop to tear the registry down with the
+// cluster. A caller that uniformly `defer sr.Stop(ctx)` over the shared
 // *SchemaRegistry type therefore can't accidentally kill the cluster.
 //
 // +cache="never"
 func (r *RedpandaCluster) SchemaRegistry(ctx context.Context, security *SchemaRegistrySecurity) (*SchemaRegistry, error) {
-	if r == nil || r.BrokerSvc == nil {
+	if r == nil || len(r.BrokerSvcs) == 0 {
 		return nil, fmt.Errorf("RedpandaCluster.SchemaRegistry: cluster has no broker service")
 	}
 	if err := validateRegistrySecurity("RedpandaCluster.SchemaRegistry", security, r.ClientSecurityMode); err != nil {
 		return nil, err
 	}
+	// The bundled registry's service is node 0, but node 0 alone can't form a
+	// multi-node cluster — the registry client (do()) only starts that one
+	// service. Bring the whole cluster online here so the returned registry is
+	// backed by a formed Raft group. For a single node this just starts it.
+	if err := startAll(ctx, r.BrokerSvcs); err != nil {
+		return nil, err
+	}
 	return &SchemaRegistry{
-		SchemaRegistrySvc: r.BrokerSvc,
-		AdvertisedHost:    r.BrokerHost,
+		SchemaRegistrySvc: r.BrokerSvcs[0],
+		AdvertisedHost:    r.BrokerHosts[0],
 		AdvertisedPort:    schemaRegistryPort,
 		Bundled:           true,
 		SecurityMode:      security.Mode,
 	}, nil
 }
 
-// BindBrokers binds the single Redpanda broker service into the given
-// container so the container can reach it by hostname.
+// BindBrokers binds every Redpanda broker service into the given container so
+// the container can reach them by the same hostnames BootstrapServers reports.
 //
 // +cache="never"
 func (r *RedpandaCluster) BindBrokers(ctr *dagger.Container) *dagger.Container {
-	return ctr.WithServiceBinding(r.BrokerHost, r.BrokerSvc)
+	for i, svc := range r.BrokerSvcs {
+		ctr = ctr.WithServiceBinding(r.BrokerHosts[i], svc)
+	}
+	return ctr
 }
 
-// Client starts the Redpanda broker service and returns a franz-go-backed
-// *Client targeting it. The Kafka wire protocol matches Apache Kafka, so
-// the existing *Client + *ClientSecurity (PKCS#12) are reused unchanged.
+// Client starts every Redpanda broker service — bringing the whole Raft group
+// online — and returns a franz-go-backed *Client targeting them. The Kafka
+// wire protocol matches Apache Kafka, so the existing *Client + *ClientSecurity
+// (PKCS#12) are reused unchanged.
 //
 // +cache="never"
 func (r *RedpandaCluster) Client(ctx context.Context, security *ClientSecurity) (*Client, error) {
-	if r == nil || r.BrokerSvc == nil {
+	if r == nil || len(r.BrokerSvcs) == 0 {
 		return nil, fmt.Errorf("RedpandaCluster.Client: cluster has no broker service")
 	}
-	if _, err := r.BrokerSvc.Start(ctx); err != nil {
-		return nil, fmt.Errorf("start redpanda broker: %w", err)
+	if err := startAll(ctx, r.BrokerSvcs); err != nil {
+		return nil, err
 	}
 	return clientFrom(r.BootstrapServers(), security), nil
 }
 
-// Stop tears down the broker container backing this Redpanda cluster.
-// Tests should call this in a defer so the broker `Container.asService`
+// Stop tears down every broker container backing this Redpanda cluster.
+// Tests should call this in a defer so each broker `Container.asService`
 // span closes when the test work is done. Kill is set so Service.Stop
 // skips graceful shutdown — see Cluster.Stop for the rationale.
 //
 // +cache="never"
 func (r *RedpandaCluster) Stop(ctx context.Context) error {
-	if r == nil || r.BrokerSvc == nil {
+	if r == nil {
 		return nil
 	}
-	if _, err := r.BrokerSvc.Stop(ctx, dagger.ServiceStopOpts{Kill: true}); err != nil {
-		return fmt.Errorf("stop redpanda broker: %w", err)
+	opts := dagger.ServiceStopOpts{Kill: true}
+	var errs []error
+	for i, svc := range r.BrokerSvcs {
+		if svc == nil {
+			continue
+		}
+		if _, err := svc.Stop(ctx, opts); err != nil {
+			errs = append(errs, fmt.Errorf("stop redpanda broker %d: %w", i, err))
+		}
 	}
-	return nil
+	return errors.Join(errs...)
 }

--- a/daggerverse/kafka/dagger.gen.go
+++ b/daggerverse/kafka/dagger.gen.go
@@ -336,13 +336,13 @@ func (r *SchemaRegistryClientSecurity) UnmarshalJSON(bs []byte) error {
 func (r RedpandaCluster) MarshalJSON() ([]byte, error) {
 	var concrete struct {
 		ClusterID          string
-		BrokerSvc          *dagger.Service
-		BrokerHost         string
+		BrokerSvcs         []*dagger.Service
+		BrokerHosts        []string
 		ClientSecurityMode string
 	}
 	concrete.ClusterID = r.ClusterID
-	concrete.BrokerSvc = r.BrokerSvc
-	concrete.BrokerHost = r.BrokerHost
+	concrete.BrokerSvcs = r.BrokerSvcs
+	concrete.BrokerHosts = r.BrokerHosts
 	concrete.ClientSecurityMode = r.ClientSecurityMode
 	return json.Marshal(&concrete)
 }
@@ -350,8 +350,8 @@ func (r RedpandaCluster) MarshalJSON() ([]byte, error) {
 func (r *RedpandaCluster) UnmarshalJSON(bs []byte) error {
 	var concrete struct {
 		ClusterID          string
-		BrokerSvc          *dagger.Service
-		BrokerHost         string
+		BrokerSvcs         []*dagger.Service
+		BrokerHosts        []string
 		ClientSecurityMode string
 	}
 	err := json.Unmarshal(bs, &concrete)
@@ -359,8 +359,8 @@ func (r *RedpandaCluster) UnmarshalJSON(bs []byte) error {
 		return err
 	}
 	r.ClusterID = concrete.ClusterID
-	r.BrokerSvc = concrete.BrokerSvc
-	r.BrokerHost = concrete.BrokerHost
+	r.BrokerSvcs = concrete.BrokerSvcs
+	r.BrokerHosts = concrete.BrokerHosts
 	r.ClientSecurityMode = concrete.ClientSecurityMode
 	return nil
 }

--- a/daggerverse/kafka/tests/dagger.gen.go
+++ b/daggerverse/kafka/tests/dagger.gen.go
@@ -899,6 +899,48 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Tests).RedpandaClusterTlsRoundTrip(&parent, ctx, redpandaImageTag)
+		case "RedpandaMultiBrokerBootstrapServersListsEveryNode":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var redpandaImageTag string
+			if inputArgs["redpandaImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["redpandaImageTag"]), &redpandaImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg redpandaImageTag", err))
+				}
+			}
+			return nil, (*Tests).RedpandaMultiBrokerBootstrapServersListsEveryNode(&parent, ctx, redpandaImageTag)
+		case "RedpandaMultiBrokerControllerPolicyRejected":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var redpandaImageTag string
+			if inputArgs["redpandaImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["redpandaImageTag"]), &redpandaImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg redpandaImageTag", err))
+				}
+			}
+			return nil, (*Tests).RedpandaMultiBrokerControllerPolicyRejected(&parent, ctx, redpandaImageTag)
+		case "RedpandaMultiBrokerSchemaRegistryRoundTrip":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var redpandaImageTag string
+			if inputArgs["redpandaImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["redpandaImageTag"]), &redpandaImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg redpandaImageTag", err))
+				}
+			}
+			return nil, (*Tests).RedpandaMultiBrokerSchemaRegistryRoundTrip(&parent, ctx, redpandaImageTag)
 		case "RedpandaSchemaRegistryBundledStopIsNoOp":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -941,6 +983,34 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Tests).RedpandaSchemaRegistryTlsRegisterLookupRoundTrip(&parent, ctx, redpandaImageTag)
+		case "RedpandaThreeBrokerReplicationFactorThreeProduceConsume":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var redpandaImageTag string
+			if inputArgs["redpandaImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["redpandaImageTag"]), &redpandaImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg redpandaImageTag", err))
+				}
+			}
+			return nil, (*Tests).RedpandaThreeBrokerReplicationFactorThreeProduceConsume(&parent, ctx, redpandaImageTag)
+		case "RedpandaThreeBrokerTlsReplicationFactorThreeProduceConsume":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var redpandaImageTag string
+			if inputArgs["redpandaImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["redpandaImageTag"]), &redpandaImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg redpandaImageTag", err))
+				}
+			}
+			return nil, (*Tests).RedpandaThreeBrokerTlsReplicationFactorThreeProduceConsume(&parent, ctx, redpandaImageTag)
 		case "SchemaRegistry":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/kafka/tests/internal/dagger/kafka.gen.go
+++ b/daggerverse/kafka/tests/internal/dagger/kafka.gen.go
@@ -46,7 +46,7 @@ func (r *Binding) AsKafkaCluster() *KafkaCluster { // kafka (../../../../../dagg
 }
 
 // Retrieve the binding value, as type KafkaRedpandaCluster
-func (r *Binding) AsKafkaRedpandaCluster() *KafkaRedpandaCluster { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:20:6)
+func (r *Binding) AsKafkaRedpandaCluster() *KafkaRedpandaCluster { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:28:6)
 	q := r.query.Select("asKafkaRedpandaCluster")
 
 	return &KafkaRedpandaCluster{
@@ -55,7 +55,7 @@ func (r *Binding) AsKafkaRedpandaCluster() *KafkaRedpandaCluster { // kafka (../
 }
 
 // Retrieve the binding value, as type KafkaRedpandaServerSecurity
-func (r *Binding) AsKafkaRedpandaServerSecurity() *KafkaRedpandaServerSecurity { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:37:6)
+func (r *Binding) AsKafkaRedpandaServerSecurity() *KafkaRedpandaServerSecurity { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:45:6)
 	q := r.query.Select("asKafkaRedpandaServerSecurity")
 
 	return &KafkaRedpandaServerSecurity{
@@ -214,7 +214,7 @@ func (r *Env) WithKafkaOutput(name string, description string) *Env { // kafka (
 }
 
 // Create or update a binding of type KafkaRedpandaCluster in the environment
-func (r *Env) WithKafkaRedpandaClusterInput(name string, value *KafkaRedpandaCluster, description string) *Env { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:20:6)
+func (r *Env) WithKafkaRedpandaClusterInput(name string, value *KafkaRedpandaCluster, description string) *Env { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:28:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withKafkaRedpandaClusterInput")
 	q = q.Arg("name", name)
@@ -227,7 +227,7 @@ func (r *Env) WithKafkaRedpandaClusterInput(name string, value *KafkaRedpandaClu
 }
 
 // Declare a desired KafkaRedpandaCluster output to be assigned in the environment
-func (r *Env) WithKafkaRedpandaClusterOutput(name string, description string) *Env { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:20:6)
+func (r *Env) WithKafkaRedpandaClusterOutput(name string, description string) *Env { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:28:6)
 	q := r.query.Select("withKafkaRedpandaClusterOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -238,7 +238,7 @@ func (r *Env) WithKafkaRedpandaClusterOutput(name string, description string) *E
 }
 
 // Create or update a binding of type KafkaRedpandaServerSecurity in the environment
-func (r *Env) WithKafkaRedpandaServerSecurityInput(name string, value *KafkaRedpandaServerSecurity, description string) *Env { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:37:6)
+func (r *Env) WithKafkaRedpandaServerSecurityInput(name string, value *KafkaRedpandaServerSecurity, description string) *Env { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:45:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withKafkaRedpandaServerSecurityInput")
 	q = q.Arg("name", name)
@@ -251,7 +251,7 @@ func (r *Env) WithKafkaRedpandaServerSecurityInput(name string, value *KafkaRedp
 }
 
 // Declare a desired KafkaRedpandaServerSecurity output to be assigned in the environment
-func (r *Env) WithKafkaRedpandaServerSecurityOutput(name string, description string) *Env { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:37:6)
+func (r *Env) WithKafkaRedpandaServerSecurityOutput(name string, description string) *Env { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:45:6)
 	q := r.query.Select("withKafkaRedpandaServerSecurityOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -949,28 +949,52 @@ func (r *Kafka) PlaintextServerSecurity() *KafkaServerSecurity { // kafka (../..
 type KafkaRedpandaClusterOpts struct {
 
 	// Default: 1
-	Controllers int // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:87:2)
+	Controllers int // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:119:2)
 
 	// Default: 1
-	Brokers int // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:89:2)
+	Brokers int // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:121:2)
 
 	// Default: "docker.io"
-	Registry string // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:91:2)
+	Registry string // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:123:2)
 
 	// Default: "v26.1.7"
-	Tag string // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:93:2)
+	Tag string // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:125:2)
 }
 
-// RedpandaCluster spins up a single-node Redpanda cluster using the
+// RedpandaCluster spins up a Redpanda cluster of `brokers` nodes using the
 // `redpandadata/redpanda` image. Redpanda runs broker and Raft duties in the
-// same process, so there is no separate controller container.
+// same process, so there is no separate controller container — every node is
+// a full broker that also participates in the Raft group.
 //
-// Multi-node (controllers != 1 or brokers != 1) is rejected — multi-broker
-// Redpanda needs `--seeds` plumbing + per-node `rpc_server` advertising
-// that doesn't fit single-story scope. The wire protocol matches Kafka,
-// so RedpandaCluster.Client() returns the same *Client type the Apache
-// constructors return.
-func (r *Kafka) RedpandaCluster(clusterId string, clientListenerSecurity *KafkaRedpandaServerSecurity, opts ...KafkaRedpandaClusterOpts) *KafkaRedpandaCluster { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:83:1)
+// Topology: node hostnames are deterministic (redpanda-<n>-<suffix>, node IDs
+// 0..N-1, suffix derived from clusterId), so the seed list is computed before
+// any container is built and pinned onto every node via WithHostname +
+// session-wide DNS. For brokers > 1 the cluster uses Redpanda's seed-driven
+// bootstrap: every node shares the identical seed_servers list (all N nodes)
+// and empty_seed_starts_cluster=false, so the nodes deterministically form one
+// Raft group over the internal RPC listener (:33145) with NO node-to-node
+// WithServiceBinding — they are started concurrently and discover each other
+// by hostname over session-wide DNS. A single-broker cluster keeps the legacy
+// empty_seed_starts_cluster=true bootstrap (empty seed list).
+//
+// controllers must be 1: Redpanda has no separate controller role, so a
+// controller count is not a meaningful concept and any other value is
+// rejected (see the constructor's error). Size the cluster with `brokers`.
+//
+// Inter-node RPC security: the internal RPC listener (:33145) that carries
+// Raft traffic is PLAINTEXT and unauthenticated even when the external Kafka
+// listener is TLS. Redpanda's RPC-listener TLS would need its own internal
+// CA + per-node leaves + mutual trust — a whole parallel PKI — for traffic
+// that never leaves the Dagger engine's isolated per-session network. This
+// deliberately differs from the Apache path (which always mTLS-encrypts its
+// internal + controller listeners) because Redpanda has no equivalent PKCS#12
+// env-var contract to reuse; TLS here is scoped to the client-facing Kafka
+// listener + bundled Schema Registry REST endpoint, which is what external
+// clients actually verify.
+//
+// The wire protocol matches Kafka, so RedpandaCluster.Client() returns the
+// same *Client type the Apache constructors return.
+func (r *Kafka) RedpandaCluster(clusterId string, clientListenerSecurity *KafkaRedpandaServerSecurity, opts ...KafkaRedpandaClusterOpts) *KafkaRedpandaCluster { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:115:1)
 	assertNotNil("clientListenerSecurity", clientListenerSecurity)
 	q := r.query.Select("redpandaCluster")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -1002,7 +1026,7 @@ func (r *Kafka) RedpandaCluster(clusterId string, clientListenerSecurity *KafkaR
 // RedpandaPlaintextServerSecurity returns a RedpandaServerSecurity profile
 // configured for unencrypted, unauthenticated traffic on the external Kafka
 // listener.
-func (r *Kafka) RedpandaPlaintextServerSecurity() *KafkaRedpandaServerSecurity { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:49:1)
+func (r *Kafka) RedpandaPlaintextServerSecurity() *KafkaRedpandaServerSecurity { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:57:1)
 	q := r.query.Select("redpandaPlaintextServerSecurity")
 
 	return &KafkaRedpandaServerSecurity{
@@ -1012,13 +1036,13 @@ func (r *Kafka) RedpandaPlaintextServerSecurity() *KafkaRedpandaServerSecurity {
 
 // RedpandaTlsServerSecurity returns a RedpandaServerSecurity profile that
 // terminates TLS on the external Kafka listener. caKeyStore is a PKCS#12
-// archive of the CA cert + private key used to mint the per-cluster server
-// leaf — same shape as Kafka.TlsServerSecurity, so callers don't have to
+// archive of the CA cert + private key used to mint the per-node server
+// leaves — same shape as Kafka.TlsServerSecurity, so callers don't have to
 // convert between formats even though Redpanda itself reads PEM internally.
-// The leaf carries the broker's stable hostname as a DNS SAN so franz-go
-// clients dialing the bootstrap address can verify the cert against the
-// matching truststore.
-func (r *Kafka) RedpandaTLSServerSecurity(caKeyStore *File, caKeyStorePassword *Secret) *KafkaRedpandaServerSecurity { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:61:1)
+// Each node's leaf carries that node's stable hostname as a DNS SAN so
+// franz-go clients dialing any broker in the bootstrap list can verify the
+// cert against the matching truststore.
+func (r *Kafka) RedpandaTLSServerSecurity(caKeyStore *File, caKeyStorePassword *Secret) *KafkaRedpandaServerSecurity { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:69:1)
 	assertNotNil("caKeyStore", caKeyStore)
 	assertNotNil("caKeyStorePassword", caKeyStorePassword)
 	q := r.query.Select("redpandaTlsServerSecurity")
@@ -1746,9 +1770,14 @@ func (r *KafkaCluster) AsNode() Node {
 // the Kafka wire protocol but is a from-scratch C++ implementation with a
 // completely different configuration layer (`rpk redpanda start`, a YAML
 // config file, PEM cert/key files instead of PKCS#12), so it gets its own
-// return type to make the divergence visible at the API surface. Single
-// node only in this story (controllers=1, brokers=1).
-type KafkaRedpandaCluster struct { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:20:6)
+// return type to make the divergence visible at the API surface.
+//
+// Supports a genuine multi-broker Raft cluster: N brokers (node IDs 0..N-1)
+// form a single Raft group over the internal RPC listener, discovering each
+// other by deterministic hostname (redpanda-<n>-<suffix>) via the engine's
+// session-wide DNS. Redpanda runs broker and Raft duties in the SAME process,
+// so there is no separate controller container.
+type KafkaRedpandaCluster struct { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:28:6)
 	query *querybuilder.Selection
 
 	id   *ID
@@ -1761,9 +1790,9 @@ func (r *KafkaRedpandaCluster) WithGraphQLQuery(q *querybuilder.Selection) *Kafk
 	}
 }
 
-// BindBrokers binds the single Redpanda broker service into the given
-// container so the container can reach it by hostname.
-func (r *KafkaRedpandaCluster) BindBrokers(ctr *Container) *Container { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:430:1)
+// BindBrokers binds every Redpanda broker service into the given container so
+// the container can reach them by the same hostnames BootstrapServers reports.
+func (r *KafkaRedpandaCluster) BindBrokers(ctr *Container) *Container { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:602:1)
 	assertNotNil("ctr", ctr)
 	q := r.query.Select("bindBrokers")
 	q = q.Arg("ctr", ctr)
@@ -1773,9 +1802,9 @@ func (r *KafkaRedpandaCluster) BindBrokers(ctr *Container) *Container { // kafka
 	}
 }
 
-// BootstrapServers returns the bootstrap address (single broker:9092) for
-// this Redpanda cluster.
-func (r *KafkaRedpandaCluster) BootstrapServers(ctx context.Context) ([]string, error) { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:384:1)
+// BootstrapServers returns the host:port bootstrap addresses for every broker
+// in this Redpanda cluster.
+func (r *KafkaRedpandaCluster) BootstrapServers(ctx context.Context) ([]string, error) { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:542:1)
 	q := r.query.Select("bootstrapServers")
 
 	var response []string
@@ -1784,10 +1813,10 @@ func (r *KafkaRedpandaCluster) BootstrapServers(ctx context.Context) ([]string, 
 	return response, q.Execute(ctx)
 }
 
-// Client starts the Redpanda broker service and returns a franz-go-backed
-// *Client targeting it. The Kafka wire protocol matches Apache Kafka, so
-// the existing *Client + *ClientSecurity (PKCS#12) are reused unchanged.
-func (r *KafkaRedpandaCluster) Client(security *KafkaClientSecurity) *KafkaClient { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:439:1)
+// Client starts every Redpanda broker service — bringing the whole Raft group
+// online — and returns a franz-go-backed *Client targeting them. The Kafka
+// wire protocol matches Apache Kafka, so the existing *Client(PKCS#12) are reused unchanged.
+func (r *KafkaRedpandaCluster) Client(security *KafkaClientSecurity) *KafkaClient { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:615:1)
 	assertNotNil("security", security)
 	q := r.query.Select("client")
 	q = q.Arg("security", security)
@@ -1850,10 +1879,13 @@ func (r *KafkaRedpandaCluster) UnmarshalJSON(bs []byte) error {
 // *SchemaRegistry type Kafka.ConfluentSchemaRegistry returns, so callers can
 // treat the bundled and separate-container registries uniformly.
 //
-// `rpk redpanda start` runs a Schema Registry inside the broker process on
-// :8081 — no extra container — so the returned *SchemaRegistry points at the
-// broker service itself. Redpanda's SR speaks the Confluent Schema Registry
-// REST API, so the *SchemaRegistryClient from Client() works unchanged.
+// `rpk redpanda start` runs a Schema Registry inside every broker process on
+// :8081 — no extra container. The returned *SchemaRegistry points at the first
+// broker (node 0); because the registry client only starts that one service,
+// this method brings the whole cluster online (startAll) before returning, so
+// the registry is backed by a formed Raft group. Redpanda's SR speaks the
+// Confluent Schema Registry REST API, so the *SchemaRegistryClient from
+// Client() works unchanged.
 //
 // security must match the cluster's mode (PLAINTEXT or TLS — Redpanda has no
 // mTLS): on a TLS cluster the bundled SR REST endpoint terminates HTTPS
@@ -1862,11 +1894,11 @@ func (r *KafkaRedpandaCluster) UnmarshalJSON(bs []byte) error {
 // client. The profile's CA keystore is unused here (the leaf is already
 // minted); it is required only for API uniformity with the other registries.
 //
-// The returned registry is Bundled: its service is the broker itself, so
-// Stop is a no-op on it — call cluster.Stop to tear the registry down with
-// the cluster. A caller that uniformly `defer sr.Stop(ctx)` over the shared
+// The returned registry is Bundled: its service is a broker itself, so Stop is
+// a no-op on it — call cluster.Stop to tear the registry down with the
+// cluster. A caller that uniformly `defer sr.Stop(ctx)` over the shared
 // *SchemaRegistry type therefore can't accidentally kill the cluster.
-func (r *KafkaRedpandaCluster) SchemaRegistry(security *KafkaSchemaRegistrySecurity) *KafkaSchemaRegistry { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:410:1)
+func (r *KafkaRedpandaCluster) SchemaRegistry(security *KafkaSchemaRegistrySecurity) *KafkaSchemaRegistry { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:575:1)
 	assertNotNil("security", security)
 	q := r.query.Select("schemaRegistry")
 	q = q.Arg("security", security)
@@ -1876,11 +1908,11 @@ func (r *KafkaRedpandaCluster) SchemaRegistry(security *KafkaSchemaRegistrySecur
 	}
 }
 
-// Stop tears down the broker container backing this Redpanda cluster.
-// Tests should call this in a defer so the broker `Container.asService`
+// Stop tears down every broker container backing this Redpanda cluster.
+// Tests should call this in a defer so each broker `Container.asService`
 // span closes when the test work is done. Kill is set so Service.Stop
 // skips graceful shutdown — see Cluster.Stop for the rationale.
-func (r *KafkaRedpandaCluster) Stop(ctx context.Context) error { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:455:1)
+func (r *KafkaRedpandaCluster) Stop(ctx context.Context) error { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:631:1)
 	if r.stop != nil {
 		return nil
 	}
@@ -1902,7 +1934,7 @@ func (r *KafkaRedpandaCluster) AsNode() Node {
 // issued leaf internally for redpanda.yaml. Separate type from
 // *ServerSecurity so a caller can't accidentally hand an Apache profile
 // (e.g. MtlsServerSecurity, not supported here yet) to RedpandaCluster.
-type KafkaRedpandaServerSecurity struct { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:37:6)
+type KafkaRedpandaServerSecurity struct { // kafka (../../../../../daggerverse/kafka/cluster_redpanda.go:45:6)
 	query *querybuilder.Selection
 
 	id *ID

--- a/daggerverse/kafka/tests/tests_redpanda.go
+++ b/daggerverse/kafka/tests/tests_redpanda.go
@@ -53,6 +53,236 @@ func freshRedpandaCluster(ctx context.Context, redpandaImageTag string) (*dagger
 	}), nil
 }
 
+// freshRedpandaClusterMultiBroker spins up a PLAINTEXT Redpanda cluster of
+// `brokers` nodes for one test. The nodes form a single Raft group via
+// Redpanda's seed-driven bootstrap over the internal RPC listener.
+func freshRedpandaClusterMultiBroker(ctx context.Context, redpandaImageTag string, brokers int) (*dagger.KafkaRedpandaCluster, error) {
+	clusterId, err := newClusterId(ctx)
+	if err != nil {
+		return nil, err
+	}
+	k := dag.Kafka()
+	return k.RedpandaCluster(clusterId, k.RedpandaPlaintextServerSecurity(), dagger.KafkaRedpandaClusterOpts{
+		Tag:     redpandaImageTag,
+		Brokers: brokers,
+	}), nil
+}
+
+// freshTlsRedpandaClusterMultiBroker is the TLS counterpart of
+// freshRedpandaClusterMultiBroker: it mints a fresh CA, stands up a
+// `brokers`-node Redpanda cluster with TLS on every node's external Kafka
+// listener (each node's leaf SAN'd to its own hostname), and returns the
+// truststore so a franz-go client can verify any broker it is routed to.
+func freshTlsRedpandaClusterMultiBroker(ctx context.Context, redpandaImageTag string, brokers int) (
+	cluster *dagger.KafkaRedpandaCluster,
+	trustStore *dagger.File, trustStorePwd *dagger.Secret,
+	err error,
+) {
+	ca, err := freshCa(ctx, "tls-redpanda-multi")
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	caKs := ca.KeyStore()
+	serverSec := dag.Kafka().RedpandaTLSServerSecurity(caKs.Pkcs12(), caKs.Password())
+	ts := ca.TrustStore()
+
+	clusterId, err := newClusterId(ctx)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	cluster = dag.Kafka().RedpandaCluster(clusterId, serverSec, dagger.KafkaRedpandaClusterOpts{
+		Tag:     redpandaImageTag,
+		Brokers: brokers,
+	})
+	return cluster, ts.Pkcs12(), ts.Password(), nil
+}
+
+// RedpandaMultiBrokerControllerPolicyRejected pins the two construction-time
+// policies Redpanda enforces: `controllers != 1` is rejected (Redpanda has no
+// separate controller role) and `brokers < 1` is rejected. Resolving
+// BootstrapServers forces the server-side constructor to run its validation
+// without booting any container, so both rejections are exercised cheaply.
+func (t *Tests) RedpandaMultiBrokerControllerPolicyRejected(
+	ctx context.Context,
+	// +default="v26.1.7"
+	redpandaImageTag string,
+) error {
+	k := dag.Kafka()
+
+	// controllers != 1 must be rejected.
+	for _, controllers := range []int{2, 3} {
+		clusterId, err := newClusterId(ctx)
+		if err != nil {
+			return err
+		}
+		cluster := k.RedpandaCluster(clusterId, k.RedpandaPlaintextServerSecurity(), dagger.KafkaRedpandaClusterOpts{
+			Tag:         redpandaImageTag,
+			Controllers: controllers,
+			Brokers:     1,
+		})
+		if _, err := cluster.BootstrapServers(ctx); err == nil {
+			return fmt.Errorf("expected RedpandaCluster(controllers=%d) to fail, got nil error", controllers)
+		}
+	}
+
+	// brokers < 1 must be rejected. Dagger drops the zero value and applies
+	// the +default=1, so the sub-1 case uses -1.
+	clusterId, err := newClusterId(ctx)
+	if err != nil {
+		return err
+	}
+	cluster := k.RedpandaCluster(clusterId, k.RedpandaPlaintextServerSecurity(), dagger.KafkaRedpandaClusterOpts{
+		Tag:     redpandaImageTag,
+		Brokers: -1,
+	})
+	if _, err := cluster.BootstrapServers(ctx); err == nil {
+		return fmt.Errorf("expected RedpandaCluster(brokers=-1) to fail, got nil error")
+	}
+	return nil
+}
+
+// RedpandaMultiBrokerBootstrapServersListsEveryNode proves the constructor
+// accepts brokers=3 and returns a cluster advertising all three broker
+// bootstrap addresses. Resolving BootstrapServers forces the server-side
+// constructor (validation + the full container graph, including the per-node
+// seed list) to run without booting the containers, so the accept path is
+// exercised cheaply — the real three-node Raft round-trip is covered by
+// RedpandaThreeBrokerReplicationFactorThreeProduceConsume.
+func (t *Tests) RedpandaMultiBrokerBootstrapServersListsEveryNode(
+	ctx context.Context,
+	// +default="v26.1.7"
+	redpandaImageTag string,
+) error {
+	cluster, err := freshRedpandaClusterMultiBroker(ctx, redpandaImageTag, 3)
+	if err != nil {
+		return fmt.Errorf("create redpanda cluster: %w", err)
+	}
+	bs, err := cluster.BootstrapServers(ctx)
+	if err != nil {
+		return fmt.Errorf("expected RedpandaCluster(brokers=3) to construct, got: %w", err)
+	}
+	if len(bs) != 3 {
+		return fmt.Errorf("expected 3 bootstrap servers for a 3-broker cluster, got %d: %v", len(bs), bs)
+	}
+	return nil
+}
+
+// RedpandaThreeBrokerReplicationFactorThreeProduceConsume stands up a real
+// three-node Redpanda cluster and drives a produce → consume round-trip over
+// an RF=3 topic. A successful round-trip proves the three nodes formed a
+// single Raft group over the internal RPC listener (seed-driven bootstrap) and
+// that inter-node replication is actually exercised — an RF=3 topic can only be
+// created and written if all three brokers reach each other.
+func (t *Tests) RedpandaThreeBrokerReplicationFactorThreeProduceConsume(
+	ctx context.Context,
+	// +default="v26.1.7"
+	redpandaImageTag string,
+) error {
+	cluster, err := freshRedpandaClusterMultiBroker(ctx, redpandaImageTag, 3)
+	if err != nil {
+		return fmt.Errorf("create redpanda cluster: %w", err)
+	}
+	defer cluster.Stop(ctx)
+	return redpandaReplicatedProduceConsumeOn(ctx, cluster, dag.Kafka().PlaintextClientSecurity(), 3)
+}
+
+// RedpandaThreeBrokerTlsReplicationFactorThreeProduceConsume is the TLS
+// counterpart: a three-node Redpanda cluster with TLS on every node's external
+// Kafka listener, driving a produce → consume round-trip over an RF=3 topic.
+// The franz-go client verifies whichever node it is routed to against the
+// cluster truststore, proving every node's leaf is SAN'd to its own hostname.
+func (t *Tests) RedpandaThreeBrokerTlsReplicationFactorThreeProduceConsume(
+	ctx context.Context,
+	// +default="v26.1.7"
+	redpandaImageTag string,
+) error {
+	cluster, ts, tsPwd, err := freshTlsRedpandaClusterMultiBroker(ctx, redpandaImageTag, 3)
+	if err != nil {
+		return fmt.Errorf("create redpanda tls cluster: %w", err)
+	}
+	defer cluster.Stop(ctx)
+	return redpandaReplicatedProduceConsumeOn(ctx, cluster, dag.Kafka().TLSClientSecurity(ts, tsPwd), 3)
+}
+
+// redpandaReplicatedProduceConsumeOn creates an RF=`rf` topic on the given
+// cluster, produces one record, and consumes it back — the shared body behind
+// the PLAINTEXT and TLS multi-broker round-trips.
+func redpandaReplicatedProduceConsumeOn(
+	ctx context.Context,
+	cluster *dagger.KafkaRedpandaCluster,
+	clientSec *dagger.KafkaClientSecurity,
+	rf int,
+) error {
+	client := cluster.Client(clientSec)
+
+	topic, err := randomTopicName(ctx)
+	if err != nil {
+		return err
+	}
+	if err := client.CreateTopic(ctx, topic, dagger.KafkaClientCreateTopicOpts{
+		Partitions:        1,
+		ReplicationFactor: rf,
+	}); err != nil {
+		return fmt.Errorf("create RF=%d topic %q: %w", rf, topic, err)
+	}
+
+	const wantKey, wantVal = "k", "v"
+	if err := client.Produce(ctx, topic, wantKey, wantVal, dagger.KafkaClientProduceOpts{
+		KeyEncoding:   "raw",
+		ValueEncoding: "raw",
+	}); err != nil {
+		return fmt.Errorf("produce: %w", err)
+	}
+
+	records, err := consume(ctx, client, topic, dagger.KafkaClientConsumeOpts{
+		MaxMessages:   1,
+		Timeout:       "15s",
+		KeyEncoding:   "raw",
+		ValueEncoding: "raw",
+	})
+	if err != nil {
+		return fmt.Errorf("consume: %w", err)
+	}
+	if len(records) != 1 {
+		return fmt.Errorf("expected 1 record, got %d", len(records))
+	}
+	gotKey, err := records[0].Key(ctx)
+	if err != nil {
+		return fmt.Errorf("read key: %w", err)
+	}
+	gotVal, err := records[0].Value(ctx)
+	if err != nil {
+		return fmt.Errorf("read value: %w", err)
+	}
+	if gotKey != wantKey || gotVal != wantVal {
+		return fmt.Errorf("redpanda replicated round-trip mismatch: got (%q, %q), want (%q, %q)", gotKey, gotVal, wantKey, wantVal)
+	}
+	return nil
+}
+
+// RedpandaMultiBrokerSchemaRegistryRoundTrip proves Redpanda's bundled Schema
+// Registry still works against a multi-node cluster: it stands up a three-node
+// cluster, registers a schema against cluster.SchemaRegistry() (which points
+// at node 0, whose service cascades the whole cluster online), and asserts the
+// lookup-by-id round-trip. The `_schemas` topic itself is replicated across the
+// cluster, so a successful round-trip proves the registry reaches a formed
+// multi-node Raft group.
+func (t *Tests) RedpandaMultiBrokerSchemaRegistryRoundTrip(
+	ctx context.Context,
+	// +default="v26.1.7"
+	redpandaImageTag string,
+) error {
+	cluster, err := freshRedpandaClusterMultiBroker(ctx, redpandaImageTag, 3)
+	if err != nil {
+		return fmt.Errorf("create redpanda cluster: %w", err)
+	}
+	defer cluster.Stop(ctx)
+
+	return redpandaSchemaRegistryRegisterLookupRoundTripOn(ctx,
+		cluster.SchemaRegistry(plaintextSchemaRegistrySecurity()),
+		plaintextSchemaRegistryClientSecurity())
+}
+
 // RedpandaClusterProduceListTopicsRoundTrip is the PLAINTEXT happy-path
 // round-trip for Kafka.RedpandaCluster: spin up a single-node Redpanda,
 // create a topic, produce one record, then assert the freshly-created


### PR DESCRIPTION
Closes #166.

`RedpandaCluster` was **single-node only** — `buildRedpandaCluster` hard-rejected `controllers/brokers != 1`. It now stands up a genuine **N-broker Redpanda cluster** whose nodes form a single Raft group, bringing Redpanda to parity with the multi-node Apache/Confluent constructors from #149/#165 (which shared none of Redpanda's wiring).

## What changed

- **Struct:** tracks `BrokerSvcs []*dagger.Service` + `BrokerHosts []string` (was a single `BrokerSvc`/`BrokerHost`); `Stop` / `BootstrapServers` / `BindBrokers` / `Client` / `SchemaRegistry` all handle N nodes.
- **Bootstrap:** deterministic hostnames (`redpanda-<n>-<suffix>`, node IDs `0..N-1`) let the seed list be computed up front. Multi-node uses Redpanda's **seed-driven bootstrap** (identical `seed_servers` on every node, `empty_seed_starts_cluster=false`); single-node keeps the legacy empty-seed self-bootstrap.
- **No node-to-node `WithServiceBinding`:** symmetric Raft peers deadlock on Dagger's per-port service readiness — binding A→B fully-readies B before booting A, but B can't open its Kafka/SR ports until the cluster forms (which needs A). Sequential `Start()` deadlocks the same way. Nodes are instead **started concurrently** (`startAll`) and discover each other by hostname over session-wide DNS. `SchemaRegistry(ctx)` eagerly `startAll`s because the bundled SR client only starts node 0.
- **TLS:** mints **one server leaf per node** (each SAN'd to its own host) + a shared CA cert + per-node `redpanda.yaml`.
- **Inter-node RPC security:** the internal RPC listener (`:33145`, Raft traffic) stays **PLAINTEXT/unauthenticated even on a TLS cluster** — it never leaves the engine's per-session network, and Redpanda has no `KAFKA_*` PKCS#12 contract to reuse. Documented in the doc comment + README (contrasted with the Apache always-mTLS internal listeners).
- **Controllers policy:** `controllers` must be `1` (Redpanda has no separate controller role); any other value — and `brokers < 1` — is rejected with a Redpanda-specific message + doc comment.

## Acceptance criteria

- [x] `RedpandaCluster` accepts `brokers=3`, nodes form a single Raft group
- [x] Produce → consume against a 3-broker cluster incl. an **RF=3** topic (inter-node replication exercised) — PLAINTEXT + TLS
- [x] `brokers < 1` rejected; `controllers` policy enforced + explained
- [x] `Stop` tears down every node service
- [x] TLS verifies against every node's SAN; inter-node RPC posture documented
- [x] `RedpandaSchemaRegistry` round-trips against a multi-node cluster
- [x] `dagger develop` run in `kafka` + `kafka/tests`; generated code committed; doc comments + README updated

## Testing

All run green locally via `dagger -m tests call ...`:

| Test | Result |
|---|---|
| `redpanda-three-broker-replication-factor-three-produce-consume` | ✅ 15s |
| `redpanda-three-broker-tls-replication-factor-three-produce-consume` | ✅ 16s |
| `redpanda-multi-broker-schema-registry-round-trip` | ✅ 11s |
| `redpanda-multi-broker-controller-policy-rejected` | ✅ |
| `redpanda-multi-broker-bootstrap-servers-lists-every-node` | ✅ |
| single-node PLAINTEXT / TLS / bundled-stop-noop / TLS-SR (regression) | ✅ |

Follow-up to #149 (PR #165), which deliberately scoped Redpanda out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)