### PR TITLE
story(issue-161): make ZigCi.Check honour WithBuild so it gates compilation

### DIFF
--- a/daggerverse/zig/ci.go
+++ b/daggerverse/zig/ci.go
@@ -12,10 +12,16 @@ import (
 // Zig.Ci(source); enable check stages via the With* methods; call Run to
 // execute checks-then-build, or Check to run only the parallel checks.
 //
-// Stage 1 runs the enabled static checks in parallel (Fmt, Test); errors are
-// aggregated. Stage 2 builds the source and Run returns the produced zig-out
-// directory. Downstream consumers compose that directory into their own
-// pipelines (package, sign, publish, ...).
+// Stage 1 runs the enabled checks in parallel (Fmt, Test, and — when WithBuild
+// was called — a Build check that compiles the source); errors are aggregated.
+// Stage 2 builds the source and Run returns the produced zig-out directory.
+// Downstream consumers compose that directory into their own pipelines
+// (package, sign, publish, ...).
+//
+// The Build check exists because fmt and test alone do not gate compilation:
+// fmt checks syntax, not types, and many projects (firmware especially) have no
+// test step, so a build-free Check reports a false green on code that does not
+// compile. See issue #161.
 type Ci struct {
 	// +private
 	Zig *Zig
@@ -29,6 +35,8 @@ type Ci struct {
 	// +private
 	TestRoot string
 
+	// +private
+	BuildEnabled bool
 	// +private
 	BuildOptimize string
 	// +private
@@ -59,10 +67,21 @@ func (c *Ci) WithTest(
 	return c
 }
 
-// WithBuild configures the build stage parameters (forwarded to Zig.Build).
-// optimize, when non-empty, must be one of Debug, ReleaseSafe, ReleaseFast,
-// ReleaseSmall; target sets -Dtarget; steps names build steps. Build is always
-// executed by Run regardless of whether this method is called.
+// WithBuild enables the build check stage and configures its parameters
+// (forwarded to Zig.Build). optimize, when non-empty, must be one of Debug,
+// ReleaseSafe, ReleaseFast, ReleaseSmall; target sets -Dtarget; steps names
+// build steps.
+//
+// Calling WithBuild makes Check compile the source (`zig build`) as one of its
+// parallel checks, so a project that does not type-check fails Check rather
+// than reporting a false green — the fmt and (optional) test checks alone do
+// not compile the code. Without WithBuild, Check runs only the enabled static
+// checks and never builds, preserving a build-free Check for multi-target
+// pipelines that share one check run across N target builds.
+//
+// Run always builds regardless of whether this method is called (it must
+// produce the zig-out directory it returns); WithBuild's optimize/target/steps
+// configure that build too.
 func (c *Ci) WithBuild(
 	// +optional
 	optimize string,
@@ -71,16 +90,27 @@ func (c *Ci) WithBuild(
 	// +optional
 	steps []string,
 ) *Ci {
+	c.BuildEnabled = true
 	c.BuildOptimize = optimize
 	c.BuildTarget = target
 	c.BuildSteps = steps
 	return c
 }
 
-// Check runs the enabled check stages (Fmt, Test) in parallel via
-// github.com/dagger/dagger/util/parallel and returns the aggregated error. Use
-// when callers want to run the checks independently of the build (for example
-// multi-target pipelines that share one check run across N target builds).
+// Check runs the enabled check stages in parallel via
+// github.com/dagger/dagger/util/parallel and returns the aggregated error. The
+// enabled stages are Fmt (WithFmt), Test (WithTest), and Build (WithBuild).
+//
+// The Build stage compiles the source (`zig build`) and discards the artifact —
+// it exists so Check gates on "does it compile?", the fundamental correctness
+// check for a compiled language. Without it, a project whose only failure is a
+// compile error passes Check on the strength of fmt alone (a false green): fmt
+// checks syntax, not types, and firmware projects frequently have no test step.
+// See issue #161.
+//
+// Build is opt-in via WithBuild so callers can still run a build-free Check —
+// for example multi-target pipelines that share one target-independent check
+// run (fmt, test) across N target builds.
 //
 // +check
 // +cache="session"
@@ -94,12 +124,20 @@ func (c *Ci) Check(ctx context.Context) error {
 	if c.TestEnabled {
 		jobs = jobs.WithJob("test", c.runTest)
 	}
+	if c.BuildEnabled {
+		jobs = jobs.WithJob("build", c.runBuildCheck)
+	}
 	return jobs.Run(ctx)
 }
 
 // Run executes the pipeline: stage 1 (Check) → stage 2 (build). Returns the
 // produced zig-out directory. On stage-1 failure, returns the aggregated error
 // from Check and a nil directory (stage 2 is skipped).
+//
+// Run always builds regardless of WithBuild — it must produce the directory it
+// returns. When WithBuild was called, Check also builds (stage 1); that build
+// and stage 2 share inputs, so session caching makes stage 2 a cache hit rather
+// than a second compile.
 //
 // +check
 // +cache="session"
@@ -121,4 +159,21 @@ func (c *Ci) runTest(ctx context.Context) error {
 
 func (c *Ci) runBuild(ctx context.Context) (*dagger.Directory, error) {
 	return c.Zig.Build(ctx, c.Source, c.BuildOptimize, c.BuildTarget, c.BuildSteps, nil)
+}
+
+// runBuildCheck is the build stage as a Check job: it builds the source and
+// forces evaluation so the compile actually runs. Build returns a lazy
+// directory whose `zig build` exec is deferred until the directory is resolved,
+// so Sync is required — without it the compile would never run and the check
+// would pass unconditionally (the very false green this stage exists to catch).
+// The produced artifact is discarded; only success/failure matters here. When
+// Run calls this before its own build, session caching makes that second build
+// a cache hit.
+func (c *Ci) runBuildCheck(ctx context.Context) error {
+	dir, err := c.runBuild(ctx)
+	if err != nil {
+		return err
+	}
+	_, err = dir.Sync(ctx)
+	return err
 }

--- a/daggerverse/zig/dagger.gen.go
+++ b/daggerverse/zig/dagger.gen.go
@@ -86,6 +86,7 @@ func (r Ci) MarshalJSON() ([]byte, error) {
 		FmtEnabled    bool
 		TestEnabled   bool
 		TestRoot      string
+		BuildEnabled  bool
 		BuildOptimize string
 		BuildTarget   string
 		BuildSteps    []string
@@ -95,6 +96,7 @@ func (r Ci) MarshalJSON() ([]byte, error) {
 	concrete.FmtEnabled = r.FmtEnabled
 	concrete.TestEnabled = r.TestEnabled
 	concrete.TestRoot = r.TestRoot
+	concrete.BuildEnabled = r.BuildEnabled
 	concrete.BuildOptimize = r.BuildOptimize
 	concrete.BuildTarget = r.BuildTarget
 	concrete.BuildSteps = r.BuildSteps
@@ -108,6 +110,7 @@ func (r *Ci) UnmarshalJSON(bs []byte) error {
 		FmtEnabled    bool
 		TestEnabled   bool
 		TestRoot      string
+		BuildEnabled  bool
 		BuildOptimize string
 		BuildTarget   string
 		BuildSteps    []string
@@ -121,6 +124,7 @@ func (r *Ci) UnmarshalJSON(bs []byte) error {
 	r.FmtEnabled = concrete.FmtEnabled
 	r.TestEnabled = concrete.TestEnabled
 	r.TestRoot = concrete.TestRoot
+	r.BuildEnabled = concrete.BuildEnabled
 	r.BuildOptimize = concrete.BuildOptimize
 	r.BuildTarget = concrete.BuildTarget
 	r.BuildSteps = concrete.BuildSteps

--- a/daggerverse/zig/tests/dagger.gen.go
+++ b/daggerverse/zig/tests/dagger.gen.go
@@ -276,13 +276,27 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).CcRejectsPathOutputName(&parent, ctx)
-		case "CiCheckRunsChecksAndSkipsBuild":
+		case "CiCheckWithBuildCatchesCompileError":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
 			if err != nil {
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
-			return nil, (*Tests).CiCheckRunsChecksAndSkipsBuild(&parent, ctx)
+			return nil, (*Tests).CiCheckWithBuildCatchesCompileError(&parent, ctx)
+		case "CiCheckWithBuildPassesOnCleanProject":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).CiCheckWithBuildPassesOnCleanProject(&parent, ctx)
+		case "CiCheckWithoutBuildIsFmtOnly":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).CiCheckWithoutBuildIsFmtOnly(&parent, ctx)
 		case "CiRunAggregatesFailures":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/zig/tests/fixtures/no-compile/build.zig
+++ b/daggerverse/zig/tests/fixtures/no-compile/build.zig
@@ -1,0 +1,33 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const exe_mod = b.createModule(.{
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const exe = b.addExecutable(.{
+        .name = "no-compile",
+        .root_module = exe_mod,
+    });
+    b.installArtifact(exe);
+
+    const run_cmd = b.addRunArtifact(exe);
+    run_cmd.step.dependOn(b.getInstallStep());
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
+    const run_step = b.step("run", "Run the app");
+    run_step.dependOn(&run_cmd.step);
+
+    const exe_unit_tests = b.addTest(.{
+        .root_module = exe_mod,
+    });
+    const run_exe_unit_tests = b.addRunArtifact(exe_unit_tests);
+    const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&run_exe_unit_tests.step);
+}

--- a/daggerverse/zig/tests/fixtures/no-compile/build.zig.zon
+++ b/daggerverse/zig/tests/fixtures/no-compile/build.zig.zon
@@ -1,0 +1,12 @@
+.{
+    .name = .no_compile,
+    .version = "0.0.0",
+    .fingerprint = 0xd98f4aee1d33986c,
+    .minimum_zig_version = "0.14.1",
+    .dependencies = .{},
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+    },
+}

--- a/daggerverse/zig/tests/fixtures/no-compile/src/main.zig
+++ b/daggerverse/zig/tests/fixtures/no-compile/src/main.zig
@@ -1,0 +1,12 @@
+const std = @import("std");
+
+pub fn main() !void {
+    const stdout = std.io.getStdOut().writer();
+    // Deliberate type error, reachable from main() so Zig cannot lazily skip
+    // it: a string literal ([]const u8) bound to a u32. The syntax is valid,
+    // so `zig fmt --check` passes; the code does not type-check, so `zig build`
+    // fails. This is the exact false-green failure mode from issue #161 — a
+    // project whose only failure is caught by the build, not by fmt.
+    const value: u32 = "definitely not a u32";
+    try stdout.print("{d}\n", .{value});
+}

--- a/daggerverse/zig/tests/main.go
+++ b/daggerverse/zig/tests/main.go
@@ -75,7 +75,9 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("CiWithFmtPasses", t.CiWithFmtPasses)
 	jobs = jobs.WithJob("CiWithTestPasses", t.CiWithTestPasses)
 	jobs = jobs.WithJob("CiRunAllStagesProducesBinary", t.CiRunAllStagesProducesBinary)
-	jobs = jobs.WithJob("CiCheckRunsChecksAndSkipsBuild", t.CiCheckRunsChecksAndSkipsBuild)
+	jobs = jobs.WithJob("CiCheckWithBuildCatchesCompileError", t.CiCheckWithBuildCatchesCompileError)
+	jobs = jobs.WithJob("CiCheckWithoutBuildIsFmtOnly", t.CiCheckWithoutBuildIsFmtOnly)
+	jobs = jobs.WithJob("CiCheckWithBuildPassesOnCleanProject", t.CiCheckWithBuildPassesOnCleanProject)
 	jobs = jobs.WithJob("CiRunAggregatesFailures", t.CiRunAggregatesFailures)
 
 	return jobs.Run(ctx)
@@ -528,6 +530,15 @@ func ciBadDir() *dagger.Directory {
 	return dag.CurrentModule().Source().Directory("fixtures/ci-bad")
 }
 
+// noCompileDir returns the fixture that reproduces issue #161: a full Zig
+// project that is fmt-clean but does not type-check (a string literal bound to
+// a u32, reachable from main). `zig fmt --check` passes; `zig build` fails. It
+// underpins the tests that prove Ci.Check honours WithBuild — building catches
+// the compile error, while a build-free Check reports a false green.
+func noCompileDir() *dagger.Directory {
+	return dag.CurrentModule().Source().Directory("fixtures/no-compile")
+}
+
 // CiWithFmtPasses runs Ci with only the Fmt check enabled against the
 // fmt-clean hello fixture and asserts the build stage still produces a
 // non-empty binary.
@@ -572,20 +583,49 @@ func (t *Tests) CiRunAllStagesProducesBinary(ctx context.Context) error {
 	return nil
 }
 
-// CiCheckRunsChecksAndSkipsBuild configures every stage against the clean hello
-// fixture and calls Check (not Run), asserting no error. To actively prove
-// Check does not invoke the build stage, WithBuild is configured with a
-// nonexistent build step: if Check were to call runBuild, `zig build
-// nonexistent-step` would fail and surface here. A nil return therefore proves
-// both (a) the checks passed and (b) the build was skipped.
-func (t *Tests) CiCheckRunsChecksAndSkipsBuild(ctx context.Context) error {
+// CiCheckWithBuildCatchesCompileError is the core regression test for issue
+// #161: Ci.Check must compile when WithBuild was requested. The no-compile
+// fixture is fmt-clean but does not type-check, so with only Fmt enabled Check
+// reports a false green (see CiCheckWithoutBuildIsFmtOnly). Adding WithBuild
+// must make Check run the build stage and surface the compile error.
+func (t *Tests) CiCheckWithBuildCatchesCompileError(ctx context.Context) error {
+	err := dag.Zig().Ci(noCompileDir()).
+		WithFmt().
+		WithBuild().
+		Check(ctx)
+	if err == nil {
+		return fmt.Errorf("expected Ci.WithFmt.WithBuild.Check to fail on a non-compiling project, got nil (false green)")
+	}
+	return nil
+}
+
+// CiCheckWithoutBuildIsFmtOnly is the counterpart to
+// CiCheckWithBuildCatchesCompileError and pins the opt-in semantics: without
+// WithBuild, Check runs only the enabled static checks and never compiles. The
+// no-compile fixture is fmt-clean, so Fmt-only Check passes even though the
+// project does not build. This preserves the documented build-free Check for
+// multi-target pipelines that share one check run across N target builds.
+func (t *Tests) CiCheckWithoutBuildIsFmtOnly(ctx context.Context) error {
+	if err := dag.Zig().Ci(noCompileDir()).WithFmt().Check(ctx); err != nil {
+		return fmt.Errorf("expected Fmt-only Check to pass on the fmt-clean no-compile fixture, got: %w", err)
+	}
+	return nil
+}
+
+// CiCheckWithBuildPassesOnCleanProject configures every stage against the clean
+// hello fixture and calls Check (not Run), asserting no error. With WithBuild
+// enabled, Check runs fmt, test, and the build stage; a nil return proves all
+// three passed. Together with CiCheckWithBuildCatchesCompileError (build catches
+// a compile error) this proves the build stage genuinely runs under Check when
+// requested, rather than being silently skipped.
+func (t *Tests) CiCheckWithBuildPassesOnCleanProject(ctx context.Context) error {
 	err := dag.Zig().Ci(helloDir()).
 		WithFmt().
 		WithTest().
-		WithBuild(dagger.ZigCiWithBuildOpts{Steps: []string{"nonexistent-step"}}).
+		WithBuild().
 		Check(ctx)
 	if err != nil {
-		return fmt.Errorf("Ci.Check on clean hello: %w", err)
+		return fmt.Errorf("Ci all-stages Check on clean hello: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #161.

## Problem

`ZigCi.Check` ran only `Fmt` (and optional `Test`) and ignored `WithBuild` entirely. For Zig, `zig fmt --check` validates syntax, not types, and firmware projects frequently have no test step — so `check` reported a **false green** on code that does not compile, the worst direction for a CI gate to fail. `with-build check` reads as "configure a build, then check it", but `WithBuild` was silently accepted and had no effect on `Check`.

(The sibling `go` module shares this builder shape but is not affected: `go vet`/`go test` compile as a side effect.)

## Fix — `Check` honours `WithBuild` (opt-in build stage)

`Check` now adds a parallel `build` job (`zig build`) whenever `WithBuild` was called, alongside `fmt`/`test`, and forces the lazy build directory to evaluate (`Sync`) so the compile actually runs. The build stays **opt-in** so a build-free `Check` remains available for multi-target pipelines that share one target-independent check run across N target builds.

```
Ci(src).WithFmt().WithBuild().Check()  -> fmt + build   (catches compile errors)
Ci(src).WithFmt().Check()              -> fmt only       (build-free, for multi-target)
Ci(src).WithBuild().Check()            -> build only     (firmware: no test/fmt)
```

`Run` is unchanged; when `WithBuild` already built in stage 1, stage 2 is a session-cache hit rather than a second compile.

## Tests

- New `tests/fixtures/no-compile/` — the issue's exact failure mode: fmt-clean but a `[]const u8` bound to a `u32` reachable from `main()`, so `zig fmt --check` passes and `zig build` fails.
- Replaced the old `CiCheckRunsChecksAndSkipsBuild` (which *asserted* the buggy skip-build behavior) with:
  - `CiCheckWithBuildCatchesCompileError` — core regression
  - `CiCheckWithoutBuildIsFmtOnly` — opt-in guard
  - `CiCheckWithBuildPassesOnCleanProject` — clean all-stages path

## Verification

- `dagger -m tests call all` → green.
- Issue CLI repro confirmed fixed: `ci --source=no-compile with-fmt with-build check` now exits **1** (was 0); `with-fmt check` still exits 0.
- Regenerated bindings contain only the `BuildEnabled` state field + renamed test methods; no `engineVersion` churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)