### PR TITLE
story(issue-159): add kicad -full image and long-tail exports

### DIFF
--- a/ci/internal/dagger/kicad-tests.gen.go
+++ b/ci/internal/dagger/kicad-tests.gen.go
@@ -45,48 +45,67 @@ func (r *Env) WithKicadTestsOutput(name string, description string) *Env { // ki
 type KicadTests struct { // kicad-tests (../../../daggerverse/kicad/tests/main.go:25:6)
 	query *querybuilder.Selection
 
-	all                                *Void
-	bomDefaultFieldsProduceCsvHeader   *Void
-	ciCheckFailsOnViolations           *Void
-	ciCheckRunsErcAndDrc               *Void
-	ciRunProducesFabricationOutputs    *Void
-	ciRunShortCircuitsOnFailingCheck   *Void
-	containerHasKicadCli               *Void
-	drcCleanProjectPasses              *Void
-	drcReportsViolations               *Void
-	drcSchematicParityDetectsMismatch  *Void
-	drillProducesExcellonFiles         *Void
-	drillRejectsInvalidFormat          *Void
-	ercCleanProjectPasses              *Void
-	ercReportsViolations               *Void
-	gerbersDefaultExportsAllLayers     *Void
-	gerbersProduceOneFilePerLayer      *Void
-	id                                 *ID
-	ipc2581ProducesXml                 *Void
-	jobsetRejectsMissingFile           *Void
-	jobsetRunProducesDeclaredOutputs   *Void
-	netlistDefaultsToKicadSexpr        *Void
-	netlistRejectsInvalidFormat        *Void
-	pcbAutoDiscoversSingleBoard        *Void
-	pcbPdfIsSingleMultipageFile        *Void
-	pcbPdfPerLayerProducesFilePerLayer *Void
-	pcbRejectsAmbiguousAutoDiscovery   *Void
-	pcbRejectsExplicitPathNotFound     *Void
-	pcbRejectsMissingBoard             *Void
-	pcbSvgProducesSingleSvg            *Void
-	posDefaultsToAsciiBothSides        *Void
-	rejectsOutputNameWithPathSeparator *Void
-	schAutoDiscoversSingleSchematic    *Void
-	schPdfProducesPdf                  *Void
-	schSvgProducesOneFilePerSheet      *Void
-	stepBoardOnlyProducesStepFile      *Void
-	versionReportsKicadRelease         *Void
-	withDrawingSheetAppliesCustomSheet *Void
-	withVarRejectsNameContainingEquals *Void
-	withVarSubstitutesTextVariable     *Void
-	withVariantIgnoredByChecks         *Void
-	withVariantRejectsUnknownVariant   *Void
-	withVariantSelectsDesignVariant    *Void
+	all                                   *Void
+	bomDefaultFieldsProduceCsvHeader      *Void
+	ciCheckFailsOnViolations              *Void
+	ciCheckRunsErcAndDrc                  *Void
+	ciRunProducesFabricationOutputs       *Void
+	ciRunShortCircuitsOnFailingCheck      *Void
+	containerHasKicadCli                  *Void
+	drcCleanProjectPasses                 *Void
+	drcReportsViolations                  *Void
+	drcSchematicParityDetectsMismatch     *Void
+	drillProducesExcellonFiles            *Void
+	drillRejectsInvalidFormat             *Void
+	ercCleanProjectPasses                 *Void
+	ercReportsViolations                  *Void
+	fpSvgExportsFootprint                 *Void
+	fpUpgradeResavesLibrary               *Void
+	gencadProducesGencad                  *Void
+	gerbersDefaultExportsAllLayers        *Void
+	gerbersProduceOneFilePerLayer         *Void
+	glbBoardOnlyProducesGlb               *Void
+	id                                    *ID
+	importRejectsUnknownFormat            *Void
+	ipc2581ProducesXml                    *Void
+	ipcd356ProducesNetlist                *Void
+	jobsetRejectsMissingFile              *Void
+	jobsetRunProducesDeclaredOutputs      *Void
+	netlistDefaultsToKicadSexpr           *Void
+	netlistRejectsInvalidFormat           *Void
+	odbProducesArchive                    *Void
+	pcbAutoDiscoversSingleBoard           *Void
+	pcbDxfProducesDxf                     *Void
+	pcbPdfIsSingleMultipageFile           *Void
+	pcbPdfPerLayerProducesFilePerLayer    *Void
+	pcbPsProducesPostscript               *Void
+	pcbRejectsAmbiguousAutoDiscovery      *Void
+	pcbRejectsExplicitPathNotFound        *Void
+	pcbRejectsMissingBoard                *Void
+	pcbSvgProducesSingleSvg               *Void
+	pcbUpgradeProducesBoard               *Void
+	posDefaultsToAsciiBothSides           *Void
+	rejectsOutputNameWithPathSeparator    *Void
+	renderProducesPng                     *Void
+	schAutoDiscoversSingleSchematic       *Void
+	schDxfProducesFilePerSheet            *Void
+	schPdfProducesPdf                     *Void
+	schPsProducesFilePerSheet             *Void
+	schSvgProducesOneFilePerSheet         *Void
+	statsProducesReport                   *Void
+	stepBoardOnlyProducesStepFile         *Void
+	stepWithComponentModelsIncludesModels *Void
+	symSvgExportsSymbol                   *Void
+	symUpgradeResavesLibrary              *Void
+	threeDexportRequiresFullImage         *Void
+	versionReportsKicadRelease            *Void
+	vrmlBoardOnlyProducesVrml             *Void
+	withDrawingSheetAppliesCustomSheet    *Void
+	withVarRejectsNameContainingEquals    *Void
+	withVarSubstitutesTextVariable        *Void
+	withVariantIgnoredByChecks            *Void
+	withVariantRejectsUnknownVariant      *Void
+	withVariantSelectsDesignVariant       *Void
 }
 
 func (r *KicadTests) WithGraphQLQuery(q *querybuilder.Selection) *KicadTests {
@@ -123,7 +142,7 @@ func (r *KicadTests) All(ctx context.Context, opts ...KicadTestsAllOpts) error {
 
 // BomDefaultFieldsProduceCsvHeader asserts the default field list produces
 // the matching CSV header and one row per component.
-func (r *KicadTests) BomDefaultFieldsProduceCsvHeader(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:390:1)
+func (r *KicadTests) BomDefaultFieldsProduceCsvHeader(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:410:1)
 	if r.bomDefaultFieldsProduceCsvHeader != nil {
 		return nil
 	}
@@ -137,7 +156,7 @@ func (r *KicadTests) BomDefaultFieldsProduceCsvHeader(ctx context.Context) error
 // failures rather than short-circuiting on the first. ERC fails with a
 // pin_not_connected violation and DRC fails with its "DRC violations" report;
 // requiring both signatures proves both jobs ran and both errors propagated.
-func (r *KicadTests) CiCheckFailsOnViolations(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:686:1)
+func (r *KicadTests) CiCheckFailsOnViolations(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:706:1)
 	if r.ciCheckFailsOnViolations != nil {
 		return nil
 	}
@@ -150,7 +169,7 @@ func (r *KicadTests) CiCheckFailsOnViolations(ctx context.Context) error { // ki
 // against a clean project and returns nil. blinky passes both ERC and DRC on
 // its own, so a nil return proves the fan-out ran the enabled stages and
 // aggregated no error.
-func (r *KicadTests) CiCheckRunsErcAndDrc(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:670:1)
+func (r *KicadTests) CiCheckRunsErcAndDrc(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:690:1)
 	if r.ciCheckRunsErcAndDrc != nil {
 		return nil
 	}
@@ -163,7 +182,7 @@ func (r *KicadTests) CiCheckRunsErcAndDrc(ctx context.Context) error { // kicad-
 // blinky project — checks then outputs — and asserts Run returns one directory
 // holding the whole fabrication package: gerbers/ and drill/ subdirectories,
 // plus pos.pos and bom.csv at the root.
-func (r *KicadTests) CiRunProducesFabricationOutputs(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:708:1)
+func (r *KicadTests) CiRunProducesFabricationOutputs(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:728:1)
 	if r.ciRunProducesFabricationOutputs != nil {
 		return nil
 	}
@@ -177,7 +196,7 @@ func (r *KicadTests) CiRunProducesFabricationOutputs(ctx context.Context) error 
 // and fabrication outputs requested must return the aggregated check error and
 // no directory. The error carries the ERC report, proving the failure came
 // from stage 1 rather than from an export.
-func (r *KicadTests) CiRunShortCircuitsOnFailingCheck(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:749:1)
+func (r *KicadTests) CiRunShortCircuitsOnFailingCheck(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:769:1)
 	if r.ciRunShortCircuitsOnFailingCheck != nil {
 		return nil
 	}
@@ -188,7 +207,7 @@ func (r *KicadTests) CiRunShortCircuitsOnFailingCheck(ctx context.Context) error
 
 // ContainerHasKicadCli asserts the base image exposes kicad-cli on PATH, so
 // the escape hatch documented on Container() actually works.
-func (r *KicadTests) ContainerHasKicadCli(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:101:1)
+func (r *KicadTests) ContainerHasKicadCli(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:121:1)
 	if r.containerHasKicadCli != nil {
 		return nil
 	}
@@ -198,7 +217,7 @@ func (r *KicadTests) ContainerHasKicadCli(ctx context.Context) error { // kicad-
 }
 
 // DrcCleanProjectPasses asserts a clean board returns nil.
-func (r *KicadTests) DrcCleanProjectPasses(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:222:1)
+func (r *KicadTests) DrcCleanProjectPasses(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:242:1)
 	if r.drcCleanProjectPasses != nil {
 		return nil
 	}
@@ -209,7 +228,7 @@ func (r *KicadTests) DrcCleanProjectPasses(ctx context.Context) error { // kicad
 
 // DrcReportsViolations asserts a board with overlapping footprints fails and
 // that the violation list makes it into the error.
-func (r *KicadTests) DrcReportsViolations(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:231:1)
+func (r *KicadTests) DrcReportsViolations(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:251:1)
 	if r.drcReportsViolations != nil {
 		return nil
 	}
@@ -221,7 +240,7 @@ func (r *KicadTests) DrcReportsViolations(ctx context.Context) error { // kicad-
 // DrcSchematicParityDetectsMismatch asserts schematicParity surfaces a board
 // whose pad nets disagree with the schematic — a class of defect plain DRC
 // never looks for.
-func (r *KicadTests) DrcSchematicParityDetectsMismatch(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:245:1)
+func (r *KicadTests) DrcSchematicParityDetectsMismatch(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:265:1)
 	if r.drcSchematicParityDetectsMismatch != nil {
 		return nil
 	}
@@ -232,7 +251,7 @@ func (r *KicadTests) DrcSchematicParityDetectsMismatch(ctx context.Context) erro
 
 // DrillProducesExcellonFiles asserts the default drill export writes an
 // Excellon file for the board.
-func (r *KicadTests) DrillProducesExcellonFiles(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:299:1)
+func (r *KicadTests) DrillProducesExcellonFiles(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:319:1)
 	if r.drillProducesExcellonFiles != nil {
 		return nil
 	}
@@ -243,7 +262,7 @@ func (r *KicadTests) DrillProducesExcellonFiles(ctx context.Context) error { // 
 
 // DrillRejectsInvalidFormat asserts an out-of-range enum is rejected with the
 // legal set spelled out, rather than passed through to kicad-cli.
-func (r *KicadTests) DrillRejectsInvalidFormat(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:513:1)
+func (r *KicadTests) DrillRejectsInvalidFormat(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:533:1)
 	if r.drillRejectsInvalidFormat != nil {
 		return nil
 	}
@@ -253,7 +272,7 @@ func (r *KicadTests) DrillRejectsInvalidFormat(ctx context.Context) error { // k
 }
 
 // ErcCleanProjectPasses asserts a clean schematic returns nil.
-func (r *KicadTests) ErcCleanProjectPasses(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:201:1)
+func (r *KicadTests) ErcCleanProjectPasses(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:221:1)
 	if r.ercCleanProjectPasses != nil {
 		return nil
 	}
@@ -264,7 +283,7 @@ func (r *KicadTests) ErcCleanProjectPasses(ctx context.Context) error { // kicad
 
 // ErcReportsViolations asserts a schematic with a dangling pin fails and that
 // the violation list — not just a count — makes it into the error.
-func (r *KicadTests) ErcReportsViolations(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:210:1)
+func (r *KicadTests) ErcReportsViolations(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:230:1)
 	if r.ercReportsViolations != nil {
 		return nil
 	}
@@ -273,9 +292,42 @@ func (r *KicadTests) ErcReportsViolations(ctx context.Context) error { // kicad-
 	return q.Execute(ctx)
 }
 
+// FpSvgExportsFootprint asserts the footprint-library SVG export lands one SVG
+// per footprint, named after the footprint, in the returned directory.
+func (r *KicadTests) FpSvgExportsFootprint(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:993:1)
+	if r.fpSvgExportsFootprint != nil {
+		return nil
+	}
+	q := r.query.Select("fpSvgExportsFootprint")
+
+	return q.Execute(ctx)
+}
+
+// FpUpgradeResavesLibrary asserts the footprint-library upgrade returns the
+// resaved .pretty directory with its .kicad_mod file in place.
+func (r *KicadTests) FpUpgradeResavesLibrary(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:1006:1)
+	if r.fpUpgradeResavesLibrary != nil {
+		return nil
+	}
+	q := r.query.Select("fpUpgradeResavesLibrary")
+
+	return q.Execute(ctx)
+}
+
+// GencadProducesGencad asserts the GenCAD export produces a GenCAD file, which
+// opens with a $HEADER section naming the format.
+func (r *KicadTests) GencadProducesGencad(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:894:1)
+	if r.gencadProducesGencad != nil {
+		return nil
+	}
+	q := r.query.Select("gencadProducesGencad")
+
+	return q.Execute(ctx)
+}
+
 // GerbersDefaultExportsAllLayers asserts an empty layer list plots every
 // layer the board defines rather than silently plotting none.
-func (r *KicadTests) GerbersDefaultExportsAllLayers(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:281:1)
+func (r *KicadTests) GerbersDefaultExportsAllLayers(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:301:1)
 	if r.gerbersDefaultExportsAllLayers != nil {
 		return nil
 	}
@@ -286,11 +338,22 @@ func (r *KicadTests) GerbersDefaultExportsAllLayers(ctx context.Context) error {
 
 // GerbersProduceOneFilePerLayer asserts an explicit layer list plots exactly
 // those layers (plus the job file that ties them together).
-func (r *KicadTests) GerbersProduceOneFilePerLayer(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:261:1)
+func (r *KicadTests) GerbersProduceOneFilePerLayer(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:281:1)
 	if r.gerbersProduceOneFilePerLayer != nil {
 		return nil
 	}
 	q := r.query.Select("gerbersProduceOneFilePerLayer")
+
+	return q.Execute(ctx)
+}
+
+// GlbBoardOnlyProducesGlb asserts the board-only GLB export produces a real
+// binary glTF, whose files open with the "glTF" magic.
+func (r *KicadTests) GlbBoardOnlyProducesGlb(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:836:1)
+	if r.glbBoardOnlyProducesGlb != nil {
+		return nil
+	}
+	q := r.query.Select("glbBoardOnlyProducesGlb")
 
 	return q.Execute(ctx)
 }
@@ -344,9 +407,21 @@ func (r *KicadTests) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
+// ImportRejectsUnknownFormat asserts the import format enum is validated,
+// listing every format kicad-cli accepts, rather than passed through. Import
+// converts a foreign board and needs no real fixture to prove the validation.
+func (r *KicadTests) ImportRejectsUnknownFormat(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:936:1)
+	if r.importRejectsUnknownFormat != nil {
+		return nil
+	}
+	q := r.query.Select("importRejectsUnknownFormat")
+
+	return q.Execute(ctx)
+}
+
 // Ipc2581ProducesXml asserts the IPC-2581 export produces an XML document at
 // the requested revision.
-func (r *KicadTests) Ipc2581ProducesXML(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:424:1)
+func (r *KicadTests) Ipc2581ProducesXML(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:444:1)
 	if r.ipc2581ProducesXml != nil {
 		return nil
 	}
@@ -355,9 +430,20 @@ func (r *KicadTests) Ipc2581ProducesXML(ctx context.Context) error { // kicad-te
 	return q.Execute(ctx)
 }
 
+// Ipcd356ProducesNetlist asserts the IPC-D-356 export produces a bare-board
+// test netlist, whose records carry the format's CODE/UNITS parameters.
+func (r *KicadTests) Ipcd356ProducesNetlist(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:907:1)
+	if r.ipcd356ProducesNetlist != nil {
+		return nil
+	}
+	q := r.query.Select("ipcd356ProducesNetlist")
+
+	return q.Execute(ctx)
+}
+
 // JobsetRejectsMissingFile asserts a jobset path that is not in the tree is
 // reported as such, naming the path.
-func (r *KicadTests) JobsetRejectsMissingFile(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:557:1)
+func (r *KicadTests) JobsetRejectsMissingFile(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:577:1)
 	if r.jobsetRejectsMissingFile != nil {
 		return nil
 	}
@@ -368,7 +454,7 @@ func (r *KicadTests) JobsetRejectsMissingFile(ctx context.Context) error { // ki
 
 // JobsetRunProducesDeclaredOutputs asserts a jobset runs and its declared
 // output folder comes back populated.
-func (r *KicadTests) JobsetRunProducesDeclaredOutputs(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:541:1)
+func (r *KicadTests) JobsetRunProducesDeclaredOutputs(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:561:1)
 	if r.jobsetRunProducesDeclaredOutputs != nil {
 		return nil
 	}
@@ -379,7 +465,7 @@ func (r *KicadTests) JobsetRunProducesDeclaredOutputs(ctx context.Context) error
 
 // NetlistDefaultsToKicadSexpr asserts the default netlist format is KiCad's
 // own s-expression export, carrying the nets the schematic declares.
-func (r *KicadTests) NetlistDefaultsToKicadSexpr(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:406:1)
+func (r *KicadTests) NetlistDefaultsToKicadSexpr(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:426:1)
 	if r.netlistDefaultsToKicadSexpr != nil {
 		return nil
 	}
@@ -390,7 +476,7 @@ func (r *KicadTests) NetlistDefaultsToKicadSexpr(ctx context.Context) error { //
 
 // NetlistRejectsInvalidFormat asserts the netlist format enum is validated
 // the same way, listing every format kicad-cli accepts.
-func (r *KicadTests) NetlistRejectsInvalidFormat(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:527:1)
+func (r *KicadTests) NetlistRejectsInvalidFormat(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:547:1)
 	if r.netlistRejectsInvalidFormat != nil {
 		return nil
 	}
@@ -399,10 +485,21 @@ func (r *KicadTests) NetlistRejectsInvalidFormat(ctx context.Context) error { //
 	return q.Execute(ctx)
 }
 
+// OdbProducesArchive asserts the ODB++ export produces a zip archive, which
+// opens with the "PK" local-file-header magic.
+func (r *KicadTests) OdbProducesArchive(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:920:1)
+	if r.odbProducesArchive != nil {
+		return nil
+	}
+	q := r.query.Select("odbProducesArchive")
+
+	return q.Execute(ctx)
+}
+
 // PcbAutoDiscoversSingleBoard asserts an empty path finds the project's only
 // board — the produced drill file is named after it, so a wrong pick would
 // show up in the output name.
-func (r *KicadTests) PcbAutoDiscoversSingleBoard(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:130:1)
+func (r *KicadTests) PcbAutoDiscoversSingleBoard(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:150:1)
 	if r.pcbAutoDiscoversSingleBoard != nil {
 		return nil
 	}
@@ -411,10 +508,21 @@ func (r *KicadTests) PcbAutoDiscoversSingleBoard(ctx context.Context) error { //
 	return q.Execute(ctx)
 }
 
+// PcbDxfProducesDxf asserts the single-file DXF plot produces a DXF drawing,
+// whose ASCII form opens with a SECTION record.
+func (r *KicadTests) PcbDxfProducesDxf(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:860:1)
+	if r.pcbDxfProducesDxf != nil {
+		return nil
+	}
+	q := r.query.Select("pcbDxfProducesDxf")
+
+	return q.Execute(ctx)
+}
+
 // PcbPdfIsSingleMultipageFile asserts --mode-single produces one real PDF.
 // The assertion goes through Export + os.ReadFile rather than Contents()
 // because Contents mangles non-UTF-8 bytes.
-func (r *KicadTests) PcbPdfIsSingleMultipageFile(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:345:1)
+func (r *KicadTests) PcbPdfIsSingleMultipageFile(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:365:1)
 	if r.pcbPdfIsSingleMultipageFile != nil {
 		return nil
 	}
@@ -425,7 +533,7 @@ func (r *KicadTests) PcbPdfIsSingleMultipageFile(ctx context.Context) error { //
 
 // PcbPdfPerLayerProducesFilePerLayer asserts --mode-separate lands one PDF
 // per requested layer in the returned directory.
-func (r *KicadTests) PcbPdfPerLayerProducesFilePerLayer(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:312:1)
+func (r *KicadTests) PcbPdfPerLayerProducesFilePerLayer(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:332:1)
 	if r.pcbPdfPerLayerProducesFilePerLayer != nil {
 		return nil
 	}
@@ -434,9 +542,20 @@ func (r *KicadTests) PcbPdfPerLayerProducesFilePerLayer(ctx context.Context) err
 	return q.Execute(ctx)
 }
 
+// PcbPsProducesPostscript asserts the single-file PostScript plot produces a
+// document opening with the "%!PS" magic.
+func (r *KicadTests) PcbPsProducesPostscript(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:874:1)
+	if r.pcbPsProducesPostscript != nil {
+		return nil
+	}
+	q := r.query.Select("pcbPsProducesPostscript")
+
+	return q.Execute(ctx)
+}
+
 // PcbRejectsAmbiguousAutoDiscovery asserts a project with two boards and no
 // board named after the project file errors, naming both candidates.
-func (r *KicadTests) PcbRejectsAmbiguousAutoDiscovery(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:143:1)
+func (r *KicadTests) PcbRejectsAmbiguousAutoDiscovery(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:163:1)
 	if r.pcbRejectsAmbiguousAutoDiscovery != nil {
 		return nil
 	}
@@ -447,7 +566,7 @@ func (r *KicadTests) PcbRejectsAmbiguousAutoDiscovery(ctx context.Context) error
 
 // PcbRejectsExplicitPathNotFound asserts an explicit path that is not in the
 // tree is reported as such, naming the path.
-func (r *KicadTests) PcbRejectsExplicitPathNotFound(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:171:1)
+func (r *KicadTests) PcbRejectsExplicitPathNotFound(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:191:1)
 	if r.pcbRejectsExplicitPathNotFound != nil {
 		return nil
 	}
@@ -458,7 +577,7 @@ func (r *KicadTests) PcbRejectsExplicitPathNotFound(ctx context.Context) error {
 
 // PcbRejectsMissingBoard asserts a project with no board at all errors,
 // rather than letting kicad-cli fail on an empty argument.
-func (r *KicadTests) PcbRejectsMissingBoard(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:158:1)
+func (r *KicadTests) PcbRejectsMissingBoard(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:178:1)
 	if r.pcbRejectsMissingBoard != nil {
 		return nil
 	}
@@ -468,7 +587,7 @@ func (r *KicadTests) PcbRejectsMissingBoard(ctx context.Context) error { // kica
 }
 
 // PcbSvgProducesSingleSvg asserts --mode-single produces one SVG document.
-func (r *KicadTests) PcbSvgProducesSingleSvg(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:352:1)
+func (r *KicadTests) PcbSvgProducesSingleSvg(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:372:1)
 	if r.pcbSvgProducesSingleSvg != nil {
 		return nil
 	}
@@ -477,9 +596,21 @@ func (r *KicadTests) PcbSvgProducesSingleSvg(ctx context.Context) error { // kic
 	return q.Execute(ctx)
 }
 
+// PcbUpgradeProducesBoard asserts the in-place board upgrade returns a resaved
+// .kicad_pcb. kicad-cli's upgrade has no output flag and rewrites the file in
+// place, so a returned board proves the writable-copy path worked.
+func (r *KicadTests) PcbUpgradeProducesBoard(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:951:1)
+	if r.pcbUpgradeProducesBoard != nil {
+		return nil
+	}
+	q := r.query.Select("pcbUpgradeProducesBoard")
+
+	return q.Execute(ctx)
+}
+
 // PosDefaultsToAsciiBothSides asserts the default position file is the ascii
 // format covering both sides, and lists the board's footprints.
-func (r *KicadTests) PosDefaultsToASCIIBothSides(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:372:1)
+func (r *KicadTests) PosDefaultsToASCIIBothSides(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:392:1)
 	if r.posDefaultsToAsciiBothSides != nil {
 		return nil
 	}
@@ -490,7 +621,7 @@ func (r *KicadTests) PosDefaultsToASCIIBothSides(ctx context.Context) error { //
 
 // RejectsOutputNameWithPathSeparator asserts an artifact name that would walk
 // out of the module-owned output directory is rejected up front.
-func (r *KicadTests) RejectsOutputNameWithPathSeparator(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:499:1)
+func (r *KicadTests) RejectsOutputNameWithPathSeparator(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:519:1)
 	if r.rejectsOutputNameWithPathSeparator != nil {
 		return nil
 	}
@@ -499,10 +630,22 @@ func (r *KicadTests) RejectsOutputNameWithPathSeparator(ctx context.Context) err
 	return q.Execute(ctx)
 }
 
+// RenderProducesPng asserts the 3D render produces a PNG image, which opens
+// with the PNG signature. On the slim image this is a bare-board render, which
+// is a valid PNG all the same.
+func (r *KicadTests) RenderProducesPng(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:928:1)
+	if r.renderProducesPng != nil {
+		return nil
+	}
+	q := r.query.Select("renderProducesPng")
+
+	return q.Execute(ctx)
+}
+
 // SchAutoDiscoversSingleSchematic asserts an empty path finds the project's
 // schematic; the netlist records the source sheet, so it names what was
 // picked.
-func (r *KicadTests) SchAutoDiscoversSingleSchematic(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:187:1)
+func (r *KicadTests) SchAutoDiscoversSingleSchematic(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:207:1)
 	if r.schAutoDiscoversSingleSchematic != nil {
 		return nil
 	}
@@ -511,8 +654,19 @@ func (r *KicadTests) SchAutoDiscoversSingleSchematic(ctx context.Context) error 
 	return q.Execute(ctx)
 }
 
+// SchDxfProducesFilePerSheet asserts the schematic DXF plot lands one file per
+// sheet in the returned directory.
+func (r *KicadTests) SchDxfProducesFilePerSheet(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:965:1)
+	if r.schDxfProducesFilePerSheet != nil {
+		return nil
+	}
+	q := r.query.Select("schDxfProducesFilePerSheet")
+
+	return q.Execute(ctx)
+}
+
 // SchPdfProducesPdf asserts the schematic PDF export produces a real PDF.
-func (r *KicadTests) SchPdfProducesPdf(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:365:1)
+func (r *KicadTests) SchPdfProducesPdf(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:385:1)
 	if r.schPdfProducesPdf != nil {
 		return nil
 	}
@@ -521,10 +675,21 @@ func (r *KicadTests) SchPdfProducesPdf(ctx context.Context) error { // kicad-tes
 	return q.Execute(ctx)
 }
 
+// SchPsProducesFilePerSheet asserts the schematic PostScript plot lands one
+// file per sheet in the returned directory.
+func (r *KicadTests) SchPsProducesFilePerSheet(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:978:1)
+	if r.schPsProducesFilePerSheet != nil {
+		return nil
+	}
+	q := r.query.Select("schPsProducesFilePerSheet")
+
+	return q.Execute(ctx)
+}
+
 // SchSvgProducesOneFilePerSheet asserts a hierarchical schematic plots one
 // SVG per sheet, which also proves the root sheet — not a sub-sheet — was the
 // one auto-discovered.
-func (r *KicadTests) SchSvgProducesOneFilePerSheet(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:329:1)
+func (r *KicadTests) SchSvgProducesOneFilePerSheet(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:349:1)
 	if r.schSvgProducesOneFilePerSheet != nil {
 		return nil
 	}
@@ -533,9 +698,20 @@ func (r *KicadTests) SchSvgProducesOneFilePerSheet(ctx context.Context) error { 
 	return q.Execute(ctx)
 }
 
+// StatsProducesReport asserts the board statistics report is produced and reads
+// as a human-readable report.
+func (r *KicadTests) StatsProducesReport(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:881:1)
+	if r.statsProducesReport != nil {
+		return nil
+	}
+	q := r.query.Select("statsProducesReport")
+
+	return q.Execute(ctx)
+}
+
 // StepBoardOnlyProducesStepFile asserts the board-only STEP export produces a
 // real ISO-10303-21 file. Asserted via Export + os.ReadFile, not Contents.
-func (r *KicadTests) StepBoardOnlyProducesStepFile(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:440:1)
+func (r *KicadTests) StepBoardOnlyProducesStepFile(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:460:1)
 	if r.stepBoardOnlyProducesStepFile != nil {
 		return nil
 	}
@@ -544,13 +720,75 @@ func (r *KicadTests) StepBoardOnlyProducesStepFile(ctx context.Context) error { 
 	return q.Execute(ctx)
 }
 
+// StepWithComponentModelsIncludesModels asserts a with-models STEP on the -full
+// image differs from the boardOnly output. The blinky R1 footprint references a
+// component 3D model that only the -full image bundles, so the populated
+// assembly carries geometry the bare board does not — proving the with-models
+// path actually resolved and embedded the model rather than falling back to
+// board geometry.
+func (r *KicadTests) StepWithComponentModelsIncludesModels(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:810:1)
+	if r.stepWithComponentModelsIncludesModels != nil {
+		return nil
+	}
+	q := r.query.Select("stepWithComponentModelsIncludesModels")
+
+	return q.Execute(ctx)
+}
+
+// SymSvgExportsSymbol asserts the symbol-library SVG export lands one SVG per
+// symbol unit in the returned directory.
+func (r *KicadTests) SymSvgExportsSymbol(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:1020:1)
+	if r.symSvgExportsSymbol != nil {
+		return nil
+	}
+	q := r.query.Select("symSvgExportsSymbol")
+
+	return q.Execute(ctx)
+}
+
+// SymUpgradeResavesLibrary asserts the symbol-library upgrade returns the
+// resaved .kicad_sym file.
+func (r *KicadTests) SymUpgradeResavesLibrary(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:1033:1)
+	if r.symUpgradeResavesLibrary != nil {
+		return nil
+	}
+	q := r.query.Select("symUpgradeResavesLibrary")
+
+	return q.Execute(ctx)
+}
+
+// ThreeDExportRequiresFullImage asserts a with-models 3D export on the slim
+// image fails with an error naming the -full tag, rather than silently emitting
+// a board-only model. Glb stands in for the whole step-family here; every one
+// of them routes through the same require3DModels guard.
+func (r *KicadTests) ThreeDexportRequiresFullImage(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:790:1)
+	if r.threeDexportRequiresFullImage != nil {
+		return nil
+	}
+	q := r.query.Select("threeDexportRequiresFullImage")
+
+	return q.Execute(ctx)
+}
+
 // VersionReportsKicadRelease asserts Version reports the release the pinned
 // image ships, i.e. a 10.x version for the default 10.0 tag.
-func (r *KicadTests) VersionReportsKicadRelease(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:116:1)
+func (r *KicadTests) VersionReportsKicadRelease(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:136:1)
 	if r.versionReportsKicadRelease != nil {
 		return nil
 	}
 	q := r.query.Select("versionReportsKicadRelease")
+
+	return q.Execute(ctx)
+}
+
+// VrmlBoardOnlyProducesVrml asserts the board-only VRML export produces a VRML
+// v2.0 document. VRML has no kicad-cli board-only flag, so boardOnly here only
+// skips the -full guard; on the slim image the output is board geometry alone.
+func (r *KicadTests) VrmlBoardOnlyProducesVrml(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:844:1)
+	if r.vrmlBoardOnlyProducesVrml != nil {
+		return nil
+	}
+	q := r.query.Select("vrmlBoardOnlyProducesVrml")
 
 	return q.Execute(ctx)
 }
@@ -560,7 +798,7 @@ func (r *KicadTests) VersionReportsKicadRelease(ctx context.Context) error { // 
 // it. The board's SVG plot renders worksheet text as literal <text> elements
 // (unlike the PDF plot, which strokes it to geometry), so the marker string is
 // greppable in the exported document rather than only in rendered pixels.
-func (r *KicadTests) WithDrawingSheetAppliesCustomSheet(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:575:1)
+func (r *KicadTests) WithDrawingSheetAppliesCustomSheet(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:595:1)
 	if r.withDrawingSheetAppliesCustomSheet != nil {
 		return nil
 	}
@@ -572,7 +810,7 @@ func (r *KicadTests) WithDrawingSheetAppliesCustomSheet(ctx context.Context) err
 // WithVarRejectsNameContainingEquals asserts a name that would corrupt
 // kicad-cli's `name=value` encoding is rejected. WithVar is a builder with no
 // error return, so the error has to surface on the exec that uses it.
-func (r *KicadTests) WithVarRejectsNameContainingEquals(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:476:1)
+func (r *KicadTests) WithVarRejectsNameContainingEquals(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:496:1)
 	if r.withVarRejectsNameContainingEquals != nil {
 		return nil
 	}
@@ -585,7 +823,7 @@ func (r *KicadTests) WithVarRejectsNameContainingEquals(ctx context.Context) err
 // project file declares. The blinky board carries a `${LEDCOLOR}` silkscreen
 // text; the IPC-2581 export records resolved text verbatim, so it shows which
 // value won.
-func (r *KicadTests) WithVarSubstitutesTextVariable(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:452:1)
+func (r *KicadTests) WithVarSubstitutesTextVariable(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:472:1)
 	if r.withVarSubstitutesTextVariable != nil {
 		return nil
 	}
@@ -598,7 +836,7 @@ func (r *KicadTests) WithVarSubstitutesTextVariable(ctx context.Context) error {
 // and DRC with a variant selected. kicad-cli rejects --variant on sch erc and
 // pcb drc, so the module drops the flag there; a clean pass proves it was
 // dropped rather than passed through, which would fail as a usage error.
-func (r *KicadTests) WithVariantIgnoredByChecks(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:653:1)
+func (r *KicadTests) WithVariantIgnoredByChecks(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:673:1)
 	if r.withVariantIgnoredByChecks != nil {
 		return nil
 	}
@@ -611,7 +849,7 @@ func (r *KicadTests) WithVariantIgnoredByChecks(ctx context.Context) error { // 
 // a clear error naming the variants the project does declare. kicad-cli
 // silently falls back to the default variant for an unknown name, so this is
 // the module's own validation rather than a passed-through kicad-cli error.
-func (r *KicadTests) WithVariantRejectsUnknownVariant(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:631:1)
+func (r *KicadTests) WithVariantRejectsUnknownVariant(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:651:1)
 	if r.withVariantRejectsUnknownVariant != nil {
 		return nil
 	}
@@ -624,7 +862,7 @@ func (r *KicadTests) WithVariantRejectsUnknownVariant(ctx context.Context) error
 // project produce different BOMs. The variants fixture overrides R1's value per
 // variant (1k vs 10k), which the default BOM's Value column records verbatim,
 // so the selected variant is observable in exported text rather than geometry.
-func (r *KicadTests) WithVariantSelectsDesignVariant(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:604:1)
+func (r *KicadTests) WithVariantSelectsDesignVariant(ctx context.Context) error { // kicad-tests (../../../daggerverse/kicad/tests/main.go:624:1)
 	if r.withVariantSelectsDesignVariant != nil {
 		return nil
 	}

--- a/daggerverse/kicad/README.md
+++ b/daggerverse/kicad/README.md
@@ -12,16 +12,29 @@ renders — so the image runs unmodified.
 
 The image is composed as `<registry>/kicad/kicad:<tag>`, following the
 `registry`+`tag` idiom used by `kafka` and `envoy`. The default `10.0` tag is
-the slim CI image (~770MB). The `-full` variant additionally bundles the 3D
-component model libraries; without them a `Step` export carries only board
-geometry, which is why `Step(boardOnly: true)` is the sensible default pairing
-with the slim image.
+the slim CI image (~770MB). The `-full` variant (~1.34GB) additionally bundles
+the 3D component-model libraries.
+
+Select `-full` with the `full` boolean on `New`, which appends the suffix to
+whatever tag is in play (so it composes with a pinned tag or a mirror). Passing
+a tag that already ends in `-full` works too and is treated identically.
 
 ```go
-dag.Kicad()                                              // docker.io/kicad/kicad:10.0
-dag.Kicad(dagger.KicadOpts{Tag: "10.0-full"})            // 3D models included
+dag.Kicad()                                              // docker.io/kicad/kicad:10.0 (slim)
+dag.Kicad(dagger.KicadOpts{Full: true})                  // docker.io/kicad/kicad:10.0-full
+dag.Kicad(dagger.KicadOpts{Tag: "10.0-full"})            // same image, tag spelled out
 dag.Kicad(dagger.KicadOpts{Registry: "ghcr.io"})         // mirror
 ```
+
+The `-full` variant is required for any 3D export that includes component
+models — `Step`/`Glb`/`Stl`/… without `boardOnly`, and every `Vrml`. On the
+slim image those models cannot resolve, so kicad-cli would silently emit a
+board-only model. The module refuses that instead: a with-models 3D export on
+the slim image fails with an error naming the `-full` tag as the fix. Pass
+`boardOnly` to export board geometry alone on the slim image, or select `-full`
+for populated assemblies. `Render` is the one exception — it degrades to a
+bare-board render rather than failing, because a board-only render is still a
+useful artifact.
 
 ## The UID-1000 constraint
 
@@ -70,15 +83,28 @@ ambiguous is an error naming the candidates.
 | `Pcb.Gerbers(layers, precision, checkZones)` | Gerber plot as a `Directory`; empty `layers` plots every layer plus the `.gbrjob`. |
 | `Pcb.Drill(format, units, origin, separatePlatedHoles, generateMap)` | Drill files as a `Directory`. |
 | `Pcb.Pos(side, format, units, smdOnly, outputName)` | Pick-and-place file. |
-| `Pcb.Step(boardOnly, excludeDnp, outputName)` | STEP model. |
 | `Pcb.Ipc2581(version, units, outputName)` | IPC-2581 XML. Exposed as `ipc-2581` on the CLI. |
+| `Pcb.Odb(compression, units, outputName)` | ODB++ archive. |
 | `Pcb.Pdf(layers, outputName)` / `Pcb.PdfPerLayer(layers)` | `--mode-single` / `--mode-separate`. |
 | `Pcb.Svg(layers, outputName)` / `Pcb.SvgPerLayer(layers)` | `--mode-single` / `--mode-multi`. |
+| `Pcb.Dxf(layers, units, outputName)` / `Pcb.Ps(layers, outputName)` | Single-file DXF / PostScript plots. |
+| `Pcb.Stats(format, units, outputName)` | Board statistics report (`report` or `json`). |
+| `Pcb.Gencad(outputName)` / `Pcb.Ipcd356(outputName)` | GenCAD interchange / IPC-D-356 bare-board test netlist. |
+| `Pcb.Render(side, quality, width, height, outputName)` | 3D render to PNG/JPEG (format follows the extension). |
+| `Pcb.Import(inputPath, format, outputName)` | Convert a non-KiCad board to a `.kicad_pcb`. |
+| `Pcb.Upgrade(force)` | Resave the board in the current KiCad format. |
+| `Pcb.Step(boardOnly, excludeDnp, outputName)` | STEP model. |
+| `Pcb.Glb` / `Stl` / `Brep` / `Ply` / `U3d` / `Xao` / `Stpz` / `Pdf3d` `(boardOnly, excludeDnp, outputName)` | The 3D model exports; `Pdf3d` is `pdf-3-d` on the CLI. |
+| `Pcb.Vrml(boardOnly, excludeDnp, units, outputName)` | VRML model. `boardOnly` only gates the `-full` guard — VRML has no kicad-cli board-only mode. |
 | `Sch.Erc(severity)` | Electrical Rule Check. Returns a bare `error` carrying the violation report. |
 | `Sch.Bom(fields, groupBy, sortField, excludeDnp, outputName)` | BOM as CSV. |
 | `Sch.Netlist(format, outputName)` | Netlist. |
 | `Sch.Pdf(outputName)` | Multi-page schematic PDF. |
-| `Sch.Svg()` | One SVG per sheet, as a `Directory`. |
+| `Sch.Svg()` / `Sch.Dxf()` / `Sch.Ps()` | One file per sheet, as a `Directory`. |
+| `Fp(source)` | Bind a footprint library (a `.pretty` directory) for the `fp` family. |
+| `Fp.Svg(footprint)` / `Fp.Upgrade(force)` | Export the library to SVG / resave it in the current format. |
+| `Sym(source)` | Bind a symbol library (a `.kicad_sym` file) for the `sym` family. |
+| `Sym.Svg(symbol)` / `Sym.Upgrade(force)` | Export the library to SVG / resave it in the current format. |
 | `Ci(source)` | Chained builder composing the checks and outputs into one staged pipeline (parallel checks → fabrication outputs). |
 | `Ci.WithErc()` / `Ci.WithDrc(schematicParity)` | Enable the ERC / DRC check stages. |
 | `Ci.WithFabricationOutputs()` | Enable the fabrication package output (gerbers, drill, pos, BOM). |
@@ -106,18 +132,39 @@ single-file case. They are split instead.
 validated to reject `/`, so an artifact cannot be written outside the
 module-owned staging directory.
 
+## Footprint and symbol libraries (`fp`, `sym`)
+
+`fp` and `sym` operate on a *library*, not on a board or schematic within a
+project, so they attach to `Kicad` directly rather than to `Project`/`Pcb`/`Sch`:
+
+- `Kicad.Fp(source)` takes a `*Directory` — a `.pretty` footprint library is a
+  folder of `.kicad_mod` files. (The library is mounted at a `.pretty` path
+  internally, because kicad-cli recognises a footprint library by that
+  extension and silently finds zero footprints without it.)
+- `Kicad.Sym(source)` takes a `*File` — a `.kicad_sym` symbol library is a
+  single self-contained file.
+
+That directory-vs-file split mirrors what each artifact actually is on disk,
+and it keeps the project-scoped hoisted options (`--variant`,
+`--drawing-sheet`), which neither command accepts, off their surface. Each
+family exposes `Svg` (export the library, or one named footprint/symbol, to
+SVG) and `Upgrade` (resave in the current KiCad format).
+
 ## Not wrapped
 
-The long tail of exotic and legacy exports (`brep`, `ply`, `u3d`, `vrml`,
-`xao`, `stpz`, `3dpdf`, `gencad`, `ipcd356`, `stl`, `glb`, `dxf`, `ps`,
-`stats`, `python-bom`, `odb`) plus `fp`, `sym`, `pcb import`, `pcb upgrade`
-and `pcb render` are all reachable today via `Container()`:
+`hpgl` is the only `pcb export` format deliberately left out: KiCad 10's
+`pcb export hpgl` self-reports as *"No longer supported as of KiCad 10.0"*, so
+wrapping it would only surface a dead command. `python-bom` is likewise omitted
+— it is the legacy XML-plus-plugin BOM path that `sch export bom` (see
+`Sch.Bom`) supersedes.
+
+Anything still unwrapped remains reachable via `Container()`, the escape hatch:
 
 ```sh
 dagger -m daggerverse/kicad call container \
     with-directory --path=/project --source=./hardware \
     with-workdir --path=/project \
-    with-exec --args="kicad-cli,pcb,export,stats,board.kicad_pcb"
+    with-exec --args="kicad-cli,pcb,export,hpgl,board.kicad_pcb"
 ```
 
 ## CLI quick reference
@@ -152,7 +199,16 @@ if err := p.Pcb().Drc(ctx, dagger.KicadPcbDrcOpts{SchematicParity: true}); err !
 
 // Exports are lazy; validation errors surface on resolve.
 gerbers := p.Pcb().Gerbers(dagger.KicadPcbGerbersOpts{Layers: []string{"F.Cu", "B.Cu"}})
-step := p.Pcb().Step(dagger.KicadPcbStepOpts{BoardOnly: true})
+step := p.Pcb().Step(dagger.KicadPcbStepOpts{BoardOnly: true}) // board geometry on the slim image
+
+// A populated assembly needs the -full image; without boardOnly on the slim
+// image this errors, naming the -full tag.
+full := dag.Kicad(dagger.KicadOpts{Full: true}).Project(src)
+glb := full.Pcb().Glb() // component models included
+
+// fp/sym act on libraries, so they hang off Kicad, not Project.
+fpSvgs := dag.Kicad().Fp(prettyDir).Svg()          // *Directory, one SVG per footprint
+symSvgs := dag.Kicad().Sym(symLibFile).Svg()       // *Directory, one SVG per symbol unit
 
 // Text variables override what the .kicad_pro declares.
 xml := p.WithVar("REV", "B").Pcb().Ipc2581()

--- a/daggerverse/kicad/dagger.gen.go
+++ b/daggerverse/kicad/dagger.gen.go
@@ -63,9 +63,11 @@ func (r Kicad) MarshalJSON() ([]byte, error) {
 	var concrete struct {
 		Registry string
 		Tag      string
+		Full     bool
 	}
 	concrete.Registry = r.Registry
 	concrete.Tag = r.Tag
+	concrete.Full = r.Full
 	return json.Marshal(&concrete)
 }
 
@@ -73,6 +75,7 @@ func (r *Kicad) UnmarshalJSON(bs []byte) error {
 	var concrete struct {
 		Registry string
 		Tag      string
+		Full     bool
 	}
 	err := json.Unmarshal(bs, &concrete)
 	if err != nil {
@@ -80,6 +83,7 @@ func (r *Kicad) UnmarshalJSON(bs []byte) error {
 	}
 	r.Registry = concrete.Registry
 	r.Tag = concrete.Tag
+	r.Full = concrete.Full
 	return nil
 }
 
@@ -116,6 +120,30 @@ func (r *Ci) UnmarshalJSON(bs []byte) error {
 	r.DrcEnabled = concrete.DrcEnabled
 	r.DrcSchematicParity = concrete.DrcSchematicParity
 	r.Outputs = concrete.Outputs
+	return nil
+}
+
+func (r Fp) MarshalJSON() ([]byte, error) {
+	var concrete struct {
+		Kicad  *Kicad
+		Source *dagger.Directory
+	}
+	concrete.Kicad = r.Kicad
+	concrete.Source = r.Source
+	return json.Marshal(&concrete)
+}
+
+func (r *Fp) UnmarshalJSON(bs []byte) error {
+	var concrete struct {
+		Kicad  *Kicad
+		Source *dagger.Directory
+	}
+	err := json.Unmarshal(bs, &concrete)
+	if err != nil {
+		return err
+	}
+	r.Kicad = concrete.Kicad
+	r.Source = concrete.Source
 	return nil
 }
 
@@ -156,6 +184,30 @@ func (r *Project) UnmarshalJSON(bs []byte) error {
 	r.VarValues = concrete.VarValues
 	r.Variant = concrete.Variant
 	r.DrawingSheet = concrete.DrawingSheet
+	return nil
+}
+
+func (r Sym) MarshalJSON() ([]byte, error) {
+	var concrete struct {
+		Kicad  *Kicad
+		Source *dagger.File
+	}
+	concrete.Kicad = r.Kicad
+	concrete.Source = r.Source
+	return json.Marshal(&concrete)
+}
+
+func (r *Sym) UnmarshalJSON(bs []byte) error {
+	var concrete struct {
+		Kicad  *Kicad
+		Source *dagger.File
+	}
+	err := json.Unmarshal(bs, &concrete)
+	if err != nil {
+		return err
+	}
+	r.Kicad = concrete.Kicad
+	r.Source = concrete.Source
 	return nil
 }
 
@@ -371,6 +423,39 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 		default:
 			return nil, fmt.Errorf("unknown function %s", fnName)
 		}
+	case "Fp":
+		switch fnName {
+		case "Svg":
+			var parent Fp
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var footprint string
+			if inputArgs["footprint"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["footprint"]), &footprint)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg footprint", err))
+				}
+			}
+			return (*Fp).Svg(&parent, ctx, footprint)
+		case "Upgrade":
+			var parent Fp
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var force bool
+			if inputArgs["force"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["force"]), &force)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg force", err))
+				}
+			}
+			return (*Fp).Upgrade(&parent, ctx, force)
+		default:
+			return nil, fmt.Errorf("unknown function %s", fnName)
+		}
 	case "Kicad":
 		switch fnName {
 		case "Ci":
@@ -394,6 +479,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return (*Kicad).Container(&parent), nil
+		case "Fp":
+			var parent Kicad
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var source *dagger.Directory
+			if inputArgs["source"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["source"]), &source)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg source", err))
+				}
+			}
+			return (*Kicad).Fp(&parent, source), nil
 		case "Project":
 			var parent Kicad
 			err = json.Unmarshal(parentJSON, &parent)
@@ -408,6 +507,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Kicad).Project(&parent, source), nil
+		case "Sym":
+			var parent Kicad
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var source *dagger.File
+			if inputArgs["source"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["source"]), &source)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg source", err))
+				}
+			}
+			return (*Kicad).Sym(&parent, source), nil
 		case "Version":
 			var parent Kicad
 			err = json.Unmarshal(parentJSON, &parent)
@@ -435,12 +548,47 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg tag", err))
 				}
 			}
-			return New(registry, tag), nil
+			var full bool
+			if inputArgs["full"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["full"]), &full)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg full", err))
+				}
+			}
+			return New(registry, tag, full), nil
 		default:
 			return nil, fmt.Errorf("unknown function %s", fnName)
 		}
 	case "Pcb":
 		switch fnName {
+		case "Brep":
+			var parent Pcb
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var boardOnly bool
+			if inputArgs["boardOnly"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["boardOnly"]), &boardOnly)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg boardOnly", err))
+				}
+			}
+			var excludeDnp bool
+			if inputArgs["excludeDnp"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["excludeDnp"]), &excludeDnp)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg excludeDnp", err))
+				}
+			}
+			var outputName string
+			if inputArgs["outputName"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["outputName"]), &outputName)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg outputName", err))
+				}
+			}
+			return (*Pcb).Brep(&parent, ctx, boardOnly, excludeDnp, outputName)
 		case "Drc":
 			var parent Pcb
 			err = json.Unmarshal(parentJSON, &parent)
@@ -511,6 +659,48 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Pcb).Drill(&parent, ctx, format, units, origin, separatePlatedHoles, generateMap)
+		case "Dxf":
+			var parent Pcb
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var layers []string
+			if inputArgs["layers"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["layers"]), &layers)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg layers", err))
+				}
+			}
+			var units string
+			if inputArgs["units"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["units"]), &units)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg units", err))
+				}
+			}
+			var outputName string
+			if inputArgs["outputName"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["outputName"]), &outputName)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg outputName", err))
+				}
+			}
+			return (*Pcb).Dxf(&parent, ctx, layers, units, outputName)
+		case "Gencad":
+			var parent Pcb
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var outputName string
+			if inputArgs["outputName"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["outputName"]), &outputName)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg outputName", err))
+				}
+			}
+			return (*Pcb).Gencad(&parent, ctx, outputName)
 		case "Gerbers":
 			var parent Pcb
 			err = json.Unmarshal(parentJSON, &parent)
@@ -539,6 +729,62 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Pcb).Gerbers(&parent, ctx, layers, precision, checkZones)
+		case "Glb":
+			var parent Pcb
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var boardOnly bool
+			if inputArgs["boardOnly"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["boardOnly"]), &boardOnly)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg boardOnly", err))
+				}
+			}
+			var excludeDnp bool
+			if inputArgs["excludeDnp"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["excludeDnp"]), &excludeDnp)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg excludeDnp", err))
+				}
+			}
+			var outputName string
+			if inputArgs["outputName"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["outputName"]), &outputName)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg outputName", err))
+				}
+			}
+			return (*Pcb).Glb(&parent, ctx, boardOnly, excludeDnp, outputName)
+		case "Import":
+			var parent Pcb
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var inputPath string
+			if inputArgs["inputPath"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["inputPath"]), &inputPath)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg inputPath", err))
+				}
+			}
+			var format string
+			if inputArgs["format"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["format"]), &format)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg format", err))
+				}
+			}
+			var outputName string
+			if inputArgs["outputName"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["outputName"]), &outputName)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg outputName", err))
+				}
+			}
+			return (*Pcb).Import(&parent, ctx, inputPath, format, outputName)
 		case "Ipc2581":
 			var parent Pcb
 			err = json.Unmarshal(parentJSON, &parent)
@@ -567,6 +813,48 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Pcb).Ipc2581(&parent, ctx, version, units, outputName)
+		case "Ipcd356":
+			var parent Pcb
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var outputName string
+			if inputArgs["outputName"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["outputName"]), &outputName)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg outputName", err))
+				}
+			}
+			return (*Pcb).Ipcd356(&parent, ctx, outputName)
+		case "Odb":
+			var parent Pcb
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var compression string
+			if inputArgs["compression"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["compression"]), &compression)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg compression", err))
+				}
+			}
+			var units string
+			if inputArgs["units"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["units"]), &units)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg units", err))
+				}
+			}
+			var outputName string
+			if inputArgs["outputName"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["outputName"]), &outputName)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg outputName", err))
+				}
+			}
+			return (*Pcb).Odb(&parent, ctx, compression, units, outputName)
 		case "Pdf":
 			var parent Pcb
 			err = json.Unmarshal(parentJSON, &parent)
@@ -588,6 +876,34 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Pcb).Pdf(&parent, ctx, layers, outputName)
+		case "Pdf3d":
+			var parent Pcb
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var boardOnly bool
+			if inputArgs["boardOnly"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["boardOnly"]), &boardOnly)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg boardOnly", err))
+				}
+			}
+			var excludeDnp bool
+			if inputArgs["excludeDnp"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["excludeDnp"]), &excludeDnp)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg excludeDnp", err))
+				}
+			}
+			var outputName string
+			if inputArgs["outputName"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["outputName"]), &outputName)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg outputName", err))
+				}
+			}
+			return (*Pcb).Pdf3d(&parent, ctx, boardOnly, excludeDnp, outputName)
 		case "PdfPerLayer":
 			var parent Pcb
 			err = json.Unmarshal(parentJSON, &parent)
@@ -602,6 +918,34 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Pcb).PdfPerLayer(&parent, ctx, layers)
+		case "Ply":
+			var parent Pcb
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var boardOnly bool
+			if inputArgs["boardOnly"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["boardOnly"]), &boardOnly)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg boardOnly", err))
+				}
+			}
+			var excludeDnp bool
+			if inputArgs["excludeDnp"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["excludeDnp"]), &excludeDnp)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg excludeDnp", err))
+				}
+			}
+			var outputName string
+			if inputArgs["outputName"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["outputName"]), &outputName)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg outputName", err))
+				}
+			}
+			return (*Pcb).Ply(&parent, ctx, boardOnly, excludeDnp, outputName)
 		case "Pos":
 			var parent Pcb
 			err = json.Unmarshal(parentJSON, &parent)
@@ -644,6 +988,97 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Pcb).Pos(&parent, ctx, side, format, units, smdOnly, outputName)
+		case "Ps":
+			var parent Pcb
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var layers []string
+			if inputArgs["layers"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["layers"]), &layers)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg layers", err))
+				}
+			}
+			var outputName string
+			if inputArgs["outputName"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["outputName"]), &outputName)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg outputName", err))
+				}
+			}
+			return (*Pcb).Ps(&parent, ctx, layers, outputName)
+		case "Render":
+			var parent Pcb
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var side string
+			if inputArgs["side"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["side"]), &side)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg side", err))
+				}
+			}
+			var quality string
+			if inputArgs["quality"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["quality"]), &quality)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg quality", err))
+				}
+			}
+			var width int
+			if inputArgs["width"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["width"]), &width)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg width", err))
+				}
+			}
+			var height int
+			if inputArgs["height"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["height"]), &height)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg height", err))
+				}
+			}
+			var outputName string
+			if inputArgs["outputName"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["outputName"]), &outputName)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg outputName", err))
+				}
+			}
+			return (*Pcb).Render(&parent, ctx, side, quality, width, height, outputName)
+		case "Stats":
+			var parent Pcb
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var format string
+			if inputArgs["format"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["format"]), &format)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg format", err))
+				}
+			}
+			var units string
+			if inputArgs["units"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["units"]), &units)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg units", err))
+				}
+			}
+			var outputName string
+			if inputArgs["outputName"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["outputName"]), &outputName)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg outputName", err))
+				}
+			}
+			return (*Pcb).Stats(&parent, ctx, format, units, outputName)
 		case "Step":
 			var parent Pcb
 			err = json.Unmarshal(parentJSON, &parent)
@@ -672,6 +1107,62 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Pcb).Step(&parent, ctx, boardOnly, excludeDnp, outputName)
+		case "Stl":
+			var parent Pcb
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var boardOnly bool
+			if inputArgs["boardOnly"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["boardOnly"]), &boardOnly)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg boardOnly", err))
+				}
+			}
+			var excludeDnp bool
+			if inputArgs["excludeDnp"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["excludeDnp"]), &excludeDnp)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg excludeDnp", err))
+				}
+			}
+			var outputName string
+			if inputArgs["outputName"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["outputName"]), &outputName)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg outputName", err))
+				}
+			}
+			return (*Pcb).Stl(&parent, ctx, boardOnly, excludeDnp, outputName)
+		case "Stpz":
+			var parent Pcb
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var boardOnly bool
+			if inputArgs["boardOnly"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["boardOnly"]), &boardOnly)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg boardOnly", err))
+				}
+			}
+			var excludeDnp bool
+			if inputArgs["excludeDnp"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["excludeDnp"]), &excludeDnp)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg excludeDnp", err))
+				}
+			}
+			var outputName string
+			if inputArgs["outputName"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["outputName"]), &outputName)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg outputName", err))
+				}
+			}
+			return (*Pcb).Stpz(&parent, ctx, boardOnly, excludeDnp, outputName)
 		case "Svg":
 			var parent Pcb
 			err = json.Unmarshal(parentJSON, &parent)
@@ -707,6 +1198,111 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Pcb).SvgPerLayer(&parent, ctx, layers)
+		case "U3d":
+			var parent Pcb
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var boardOnly bool
+			if inputArgs["boardOnly"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["boardOnly"]), &boardOnly)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg boardOnly", err))
+				}
+			}
+			var excludeDnp bool
+			if inputArgs["excludeDnp"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["excludeDnp"]), &excludeDnp)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg excludeDnp", err))
+				}
+			}
+			var outputName string
+			if inputArgs["outputName"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["outputName"]), &outputName)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg outputName", err))
+				}
+			}
+			return (*Pcb).U3d(&parent, ctx, boardOnly, excludeDnp, outputName)
+		case "Upgrade":
+			var parent Pcb
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var force bool
+			if inputArgs["force"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["force"]), &force)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg force", err))
+				}
+			}
+			return (*Pcb).Upgrade(&parent, ctx, force)
+		case "Vrml":
+			var parent Pcb
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var boardOnly bool
+			if inputArgs["boardOnly"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["boardOnly"]), &boardOnly)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg boardOnly", err))
+				}
+			}
+			var excludeDnp bool
+			if inputArgs["excludeDnp"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["excludeDnp"]), &excludeDnp)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg excludeDnp", err))
+				}
+			}
+			var units string
+			if inputArgs["units"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["units"]), &units)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg units", err))
+				}
+			}
+			var outputName string
+			if inputArgs["outputName"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["outputName"]), &outputName)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg outputName", err))
+				}
+			}
+			return (*Pcb).Vrml(&parent, ctx, boardOnly, excludeDnp, units, outputName)
+		case "Xao":
+			var parent Pcb
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var boardOnly bool
+			if inputArgs["boardOnly"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["boardOnly"]), &boardOnly)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg boardOnly", err))
+				}
+			}
+			var excludeDnp bool
+			if inputArgs["excludeDnp"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["excludeDnp"]), &excludeDnp)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg excludeDnp", err))
+				}
+			}
+			var outputName string
+			if inputArgs["outputName"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["outputName"]), &outputName)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg outputName", err))
+				}
+			}
+			return (*Pcb).Xao(&parent, ctx, boardOnly, excludeDnp, outputName)
 		default:
 			return nil, fmt.Errorf("unknown function %s", fnName)
 		}
@@ -850,6 +1446,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Sch).Bom(&parent, ctx, fields, groupBy, sortField, excludeDnp, outputName)
+		case "Dxf":
+			var parent Sch
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Sch).Dxf(&parent, ctx)
 		case "Erc":
 			var parent Sch
 			err = json.Unmarshal(parentJSON, &parent)
@@ -899,6 +1502,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Sch).Pdf(&parent, ctx, outputName)
+		case "Ps":
+			var parent Sch
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Sch).Ps(&parent, ctx)
 		case "Svg":
 			var parent Sch
 			err = json.Unmarshal(parentJSON, &parent)
@@ -906,6 +1516,39 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return (*Sch).Svg(&parent, ctx)
+		default:
+			return nil, fmt.Errorf("unknown function %s", fnName)
+		}
+	case "Sym":
+		switch fnName {
+		case "Svg":
+			var parent Sym
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var symbol string
+			if inputArgs["symbol"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["symbol"]), &symbol)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg symbol", err))
+				}
+			}
+			return (*Sym).Svg(&parent, ctx, symbol)
+		case "Upgrade":
+			var parent Sym
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var force bool
+			if inputArgs["force"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["force"]), &force)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg force", err))
+				}
+			}
+			return (*Sym).Upgrade(&parent, ctx, force)
 		default:
 			return nil, fmt.Errorf("unknown function %s", fnName)
 		}

--- a/daggerverse/kicad/library.go
+++ b/daggerverse/kicad/library.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"context"
+
+	"dagger/kicad/internal/dagger"
+)
+
+// The footprint (fp) and symbol (sym) library command families. Unlike every
+// other command in this module these operate on a library, not on a board or
+// schematic within a project, so they attach to Kicad directly rather than to
+// Project/Pcb/Sch: Kicad.Fp(dir) binds a .pretty footprint library (a
+// directory of .kicad_mod files), Kicad.Sym(file) binds a .kicad_sym symbol
+// library (a single file). That split mirrors what the two artifacts actually
+// are on disk, and keeps the project-scoped hoisted options (--variant,
+// --drawing-sheet) — which these commands do not accept — off their surface.
+
+const (
+	// libraryDir is where a footprint library directory is mounted. The
+	// .pretty suffix is load-bearing: kicad-cli recognises a footprint library
+	// by that extension and silently finds zero footprints without it.
+	libraryDir = "/tmp/kicad-lib.pretty"
+
+	// symLibPath is where a symbol library file is mounted.
+	symLibPath = "/tmp/kicad-lib.kicad_sym"
+
+	// fpUpgradeDir and symUpgradePath are the output targets for the upgrade
+	// commands. kicad-cli refuses to upgrade into an existing path, so these
+	// must be fresh locations the container never creates up front.
+	fpUpgradeDir   = "/tmp/kicad-fp-upgraded"
+	symUpgradePath = "/tmp/kicad-sym-upgraded.kicad_sym"
+)
+
+// Fp is a footprint library (a .pretty directory of .kicad_mod files) bound to
+// the toolchain.
+type Fp struct {
+	// +private
+	Kicad *Kicad
+	// +private
+	Source *dagger.Directory
+}
+
+// Fp binds a footprint library directory (a .pretty folder, or any directory
+// of .kicad_mod files) to the toolchain for the `fp` command family.
+func (k *Kicad) Fp(source *dagger.Directory) *Fp {
+	return &Fp{Kicad: k, Source: source}
+}
+
+// Svg exports the footprint library to SVG, one file per footprint, and
+// returns the directory. Pass footprint to export a single footprint by name
+// instead of the whole library.
+//
+// +cache="session"
+func (f *Fp) Svg(
+	ctx context.Context,
+	// Export only this footprint from the library; empty exports all.
+	// +default=""
+	footprint string,
+) (*dagger.Directory, error) {
+	ctr := f.Kicad.Container().
+		WithMountedDirectory(libraryDir, f.Source).
+		WithExec([]string{"mkdir", "-p", outputDir})
+	args := []string{"kicad-cli", "fp", "export", "svg", "--output", outputDir + "/"}
+	if footprint != "" {
+		args = append(args, "--footprint", footprint)
+	}
+	exec, err := runExport(ctx, ctr, "kicad-cli fp export svg", append(args, libraryDir))
+	if err != nil {
+		return nil, err
+	}
+	return exec.Directory(outputDir), nil
+}
+
+// Upgrade resaves the footprint library in the current KiCad format and returns
+// the upgraded .pretty directory.
+//
+// +cache="session"
+func (f *Fp) Upgrade(
+	ctx context.Context,
+	// Resave even when the library is already at the latest format version.
+	// +default=false
+	force bool,
+) (*dagger.Directory, error) {
+	ctr := f.Kicad.Container().WithMountedDirectory(libraryDir, f.Source)
+	args := []string{"kicad-cli", "fp", "upgrade"}
+	if force {
+		args = append(args, "--force")
+	}
+	args = append(args, "--output", fpUpgradeDir, libraryDir)
+	exec, err := runExport(ctx, ctr, "kicad-cli fp upgrade", args)
+	if err != nil {
+		return nil, err
+	}
+	return exec.Directory(fpUpgradeDir), nil
+}
+
+// Sym is a symbol library (a .kicad_sym file) bound to the toolchain.
+type Sym struct {
+	// +private
+	Kicad *Kicad
+	// +private
+	Source *dagger.File
+}
+
+// Sym binds a symbol library file (.kicad_sym) to the toolchain for the `sym`
+// command family. It takes a lone *File, not a directory, because a symbol
+// library is a single self-contained file — the footprint library's on-disk
+// counterpart is a directory, which is why Fp takes a *Directory instead.
+func (k *Kicad) Sym(source *dagger.File) *Sym {
+	return &Sym{Kicad: k, Source: source}
+}
+
+// Svg exports the symbol library to SVG, one file per symbol unit, and returns
+// the directory. Pass symbol to export a single symbol by name instead of the
+// whole library.
+//
+// +cache="session"
+func (s *Sym) Svg(
+	ctx context.Context,
+	// Export only this symbol from the library; empty exports all.
+	// +default=""
+	symbol string,
+) (*dagger.Directory, error) {
+	ctr := s.Kicad.Container().
+		WithMountedFile(symLibPath, s.Source).
+		WithExec([]string{"mkdir", "-p", outputDir})
+	args := []string{"kicad-cli", "sym", "export", "svg", "--output", outputDir + "/"}
+	if symbol != "" {
+		args = append(args, "--symbol", symbol)
+	}
+	exec, err := runExport(ctx, ctr, "kicad-cli sym export svg", append(args, symLibPath))
+	if err != nil {
+		return nil, err
+	}
+	return exec.Directory(outputDir), nil
+}
+
+// Upgrade resaves the symbol library in the current KiCad format and returns
+// the upgraded .kicad_sym file.
+//
+// +cache="session"
+func (s *Sym) Upgrade(
+	ctx context.Context,
+	// Resave even when the library is already at the latest format version.
+	// +default=false
+	force bool,
+) (*dagger.File, error) {
+	ctr := s.Kicad.Container().WithMountedFile(symLibPath, s.Source)
+	args := []string{"kicad-cli", "sym", "upgrade"}
+	if force {
+		args = append(args, "--force")
+	}
+	args = append(args, "--output", symUpgradePath, symLibPath)
+	exec, err := runExport(ctx, ctr, "kicad-cli sym upgrade", args)
+	if err != nil {
+		return nil, err
+	}
+	return exec.File(symUpgradePath), nil
+}

--- a/daggerverse/kicad/main.go
+++ b/daggerverse/kicad/main.go
@@ -28,10 +28,14 @@ import (
 const (
 	// kicadImagePath is the repository under the configured registry. The
 	// default `10.0` tag is the slim CI image (~770MB); the `-full` variant
-	// bundles 3D component models and is a follow-up.
+	// (~1.34GB) additionally bundles the 3D component-model libraries.
 	kicadImagePath  = "kicad/kicad"
 	defaultRegistry = "docker.io"
 	defaultTag      = "10.0"
+
+	// fullSuffix is appended to the tag to select the -full image variant,
+	// which bundles the 3D component-model libraries the slim image omits.
+	fullSuffix = "-full"
 
 	// projectDir is where the caller's source is mounted. It is root-owned
 	// and the container runs as UID 1000, so it is read-only in practice.
@@ -67,6 +71,8 @@ type Kicad struct {
 	Registry string
 	// +private
 	Tag string
+	// +private
+	Full bool
 }
 
 // New returns a Kicad module backed by <registry>/kicad/kicad:<tag>.
@@ -77,6 +83,13 @@ func New(
 	// Image tag for kicad/kicad.
 	// +default="10.0"
 	tag string,
+	// Select the -full image variant, which bundles the 3D component-model
+	// libraries the slim image omits. The suffix is appended to tag, so
+	// full=true with the default 10.0 tag resolves 10.0-full. Required for any
+	// 3D export that includes component models (Step without boardOnly, Glb,
+	// Stl, ...); ~1.34GB against the slim image's ~770MB.
+	// +default=false
+	full bool,
 ) *Kicad {
 	if registry == "" {
 		registry = defaultRegistry
@@ -84,7 +97,7 @@ func New(
 	if tag == "" {
 		tag = defaultTag
 	}
-	return &Kicad{Registry: registry, Tag: tag}
+	return &Kicad{Registry: registry, Tag: tag, Full: full}
 }
 
 // Container returns the bare kicad image. This is the escape hatch for every
@@ -118,7 +131,24 @@ func (k *Kicad) Project(source *dagger.Directory) *Project {
 }
 
 func (k *Kicad) image() string {
-	return fmt.Sprintf("%s/%s:%s", k.Registry, kicadImagePath, k.Tag)
+	return fmt.Sprintf("%s/%s:%s", k.Registry, kicadImagePath, k.resolvedTag())
+}
+
+// resolvedTag applies the -full suffix when full is set, unless the tag
+// already carries it (so New(tag: "10.0-full") and New(full: true) agree).
+func (k *Kicad) resolvedTag() string {
+	if k.Full && !strings.HasSuffix(k.Tag, fullSuffix) {
+		return k.Tag + fullSuffix
+	}
+	return k.Tag
+}
+
+// hasComponentModels reports whether the selected image bundles the 3D
+// component-model libraries — true for the -full variant, whether reached via
+// full=true or a tag that already ends in -full. 3D exports consult this to
+// fail loudly rather than silently emit a board-only model on the slim image.
+func (k *Kicad) hasComponentModels() bool {
+	return strings.HasSuffix(k.resolvedTag(), fullSuffix)
 }
 
 // Project is a KiCad project tree plus the options that apply to nearly every

--- a/daggerverse/kicad/pcb.go
+++ b/daggerverse/kicad/pcb.go
@@ -206,8 +206,10 @@ func (b *Pcb) Pos(
 }
 
 // Step exports the board as a STEP model. The default `10.0` image is the
-// slim variant, which ships no 3D component models — pass boardOnly to make
-// that explicit, or use the `-full` image tag for populated assemblies.
+// slim variant, which ships no 3D component models: a with-models export
+// (boardOnly=false) fails there naming the -full image, rather than silently
+// emitting a board-only model. Pass boardOnly for board geometry alone, or
+// select the -full image for populated assemblies.
 //
 // +cache="session"
 func (b *Pcb) Step(
@@ -221,27 +223,7 @@ func (b *Pcb) Step(
 	// +default="board.step"
 	outputName string,
 ) (*dagger.File, error) {
-	if err := checkOutputName(outputName); err != nil {
-		return nil, err
-	}
-	board, ctr, err := b.resolve(ctx)
-	if err != nil {
-		return nil, err
-	}
-	out := outputDir + "/" + outputName
-	args := []string{"kicad-cli", "pcb", "export", "step", "--force", "--output", out}
-	args = append(args, b.Project.hoisted(cmdFlags{defineVar: true, variant: true})...)
-	if boardOnly {
-		args = append(args, "--board-only")
-	}
-	if excludeDnp {
-		args = append(args, "--no-dnp")
-	}
-	exec, err := runExport(ctx, ctr, "kicad-cli pcb export step", append(args, board))
-	if err != nil {
-		return nil, err
-	}
-	return exec.File(out), nil
+	return b.export3D(ctx, "step", outputName, boardOnly, excludeDnp)
 }
 
 // Ipc2581 exports the board in IPC-2581 format — a single XML file carrying

--- a/daggerverse/kicad/pcb_3d.go
+++ b/daggerverse/kicad/pcb_3d.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"dagger/kicad/internal/dagger"
+)
+
+// The 3D board exports. Every format here resolves the same component 3D
+// models, which only the -full image bundles: on the slim image an export that
+// includes models would silently emit board-only geometry, so this file guards
+// that path (require3DModels) and fails naming the -full tag instead.
+//
+// step, glb, stl, brep, ply, u3d, xao, stpz and 3dpdf share one flag family
+// (--board-only, --no-dnp, --force); export3D renders all of them. vrml is the
+// odd one out — kicad-cli's `pcb export vrml` has no --board-only flag — so it
+// has its own function below.
+
+// require3DModels guards a with-models 3D export. The slim image ships no 3D
+// component models, so kicad-cli would resolve none and quietly write a
+// board-only model; this turns that into an actionable error naming the -full
+// image, which bundles the model libraries.
+func (b *Pcb) require3DModels(format string) error {
+	k := b.Project.Kicad
+	if k.hasComponentModels() {
+		return nil
+	}
+	return fmt.Errorf(
+		"pcb export %s requests component 3D models, but the %q image ships none; "+
+			"select the -full image (New with full=true, or a -full tag such as %q), "+
+			"or pass boardOnly to export board geometry alone",
+		format, k.resolvedTag(), k.resolvedTag()+fullSuffix)
+}
+
+// export3D runs one of the step-family 3D exports (every format but vrml). The
+// with-models path is gated by require3DModels; boardOnly opts out of models
+// and so out of the guard.
+func (b *Pcb) export3D(ctx context.Context, format, outputName string, boardOnly, excludeDnp bool) (*dagger.File, error) {
+	if err := checkOutputName(outputName); err != nil {
+		return nil, err
+	}
+	if !boardOnly {
+		if err := b.require3DModels(format); err != nil {
+			return nil, err
+		}
+	}
+	board, ctr, err := b.resolve(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := outputDir + "/" + outputName
+	args := []string{"kicad-cli", "pcb", "export", format, "--force", "--output", out}
+	args = append(args, b.Project.hoisted(cmdFlags{defineVar: true, variant: true})...)
+	if boardOnly {
+		args = append(args, "--board-only")
+	}
+	if excludeDnp {
+		args = append(args, "--no-dnp")
+	}
+	exec, err := runExport(ctx, ctr, "kicad-cli pcb export "+format, append(args, board))
+	if err != nil {
+		return nil, err
+	}
+	return exec.File(out), nil
+}
+
+// Glb exports the board as a binary glTF (GLB) model. Like every 3D export it
+// needs the -full image for component models; pass boardOnly for board
+// geometry alone on the slim image.
+//
+// +cache="session"
+func (b *Pcb) Glb(
+	ctx context.Context,
+	// Export the bare board, with no component models.
+	// +default=false
+	boardOnly bool,
+	// Exclude models for components flagged Do Not Populate.
+	// +default=false
+	excludeDnp bool,
+	// +default="board.glb"
+	outputName string,
+) (*dagger.File, error) {
+	return b.export3D(ctx, "glb", outputName, boardOnly, excludeDnp)
+}
+
+// Stl exports the board as an STL mesh.
+//
+// +cache="session"
+func (b *Pcb) Stl(
+	ctx context.Context,
+	// +default=false
+	boardOnly bool,
+	// +default=false
+	excludeDnp bool,
+	// +default="board.stl"
+	outputName string,
+) (*dagger.File, error) {
+	return b.export3D(ctx, "stl", outputName, boardOnly, excludeDnp)
+}
+
+// Brep exports the board as an OpenCASCADE BREP model.
+//
+// +cache="session"
+func (b *Pcb) Brep(
+	ctx context.Context,
+	// +default=false
+	boardOnly bool,
+	// +default=false
+	excludeDnp bool,
+	// +default="board.brep"
+	outputName string,
+) (*dagger.File, error) {
+	return b.export3D(ctx, "brep", outputName, boardOnly, excludeDnp)
+}
+
+// Ply exports the board as a PLY mesh.
+//
+// +cache="session"
+func (b *Pcb) Ply(
+	ctx context.Context,
+	// +default=false
+	boardOnly bool,
+	// +default=false
+	excludeDnp bool,
+	// +default="board.ply"
+	outputName string,
+) (*dagger.File, error) {
+	return b.export3D(ctx, "ply", outputName, boardOnly, excludeDnp)
+}
+
+// U3d exports the board as a Universal 3D (U3D) model.
+//
+// +cache="session"
+func (b *Pcb) U3d(
+	ctx context.Context,
+	// +default=false
+	boardOnly bool,
+	// +default=false
+	excludeDnp bool,
+	// +default="board.u3d"
+	outputName string,
+) (*dagger.File, error) {
+	return b.export3D(ctx, "u3d", outputName, boardOnly, excludeDnp)
+}
+
+// Xao exports the board as an XAO model (Salome geometry exchange).
+//
+// +cache="session"
+func (b *Pcb) Xao(
+	ctx context.Context,
+	// +default=false
+	boardOnly bool,
+	// +default=false
+	excludeDnp bool,
+	// +default="board.xao"
+	outputName string,
+) (*dagger.File, error) {
+	return b.export3D(ctx, "xao", outputName, boardOnly, excludeDnp)
+}
+
+// Stpz exports the board as a zip-compressed STEP (STPZ) model.
+//
+// +cache="session"
+func (b *Pcb) Stpz(
+	ctx context.Context,
+	// +default=false
+	boardOnly bool,
+	// +default=false
+	excludeDnp bool,
+	// +default="board.stpz"
+	outputName string,
+) (*dagger.File, error) {
+	return b.export3D(ctx, "stpz", outputName, boardOnly, excludeDnp)
+}
+
+// Pdf3d exports the board as a 3D PDF (a PDF carrying an embedded U3D model).
+// Exposed as `pdf-3d` on the CLI.
+//
+// +cache="session"
+func (b *Pcb) Pdf3d(
+	ctx context.Context,
+	// +default=false
+	boardOnly bool,
+	// +default=false
+	excludeDnp bool,
+	// +default="board-3d.pdf"
+	outputName string,
+) (*dagger.File, error) {
+	return b.export3D(ctx, "3dpdf", outputName, boardOnly, excludeDnp)
+}
+
+// Vrml exports the board as a VRML model. Unlike the other 3D exports
+// kicad-cli's `pcb export vrml` has no --board-only flag, so boardOnly here is
+// a module-level acknowledgement rather than a kicad-cli switch: it gates the
+// -full-image guard only. On the slim image no component models resolve, so
+// boardOnly=true yields the board geometry alone; on the -full image the
+// models are always embedded regardless, which is why boardOnly cannot suppress
+// them for VRML.
+//
+// +cache="session"
+func (b *Pcb) Vrml(
+	ctx context.Context,
+	// Acknowledge board-geometry-only output on the slim image, skipping the
+	// -full guard. VRML has no board-only mode, so this cannot exclude models
+	// on the -full image.
+	// +default=false
+	boardOnly bool,
+	// Exclude models for components flagged Do Not Populate.
+	// +default=false
+	excludeDnp bool,
+	// Output units: mm, m, in or tenths.
+	// +default="mm"
+	units string,
+	// +default="board.wrl"
+	outputName string,
+) (*dagger.File, error) {
+	if err := oneOf("units", units, "mm", "m", "in", "tenths"); err != nil {
+		return nil, err
+	}
+	if err := checkOutputName(outputName); err != nil {
+		return nil, err
+	}
+	if !boardOnly {
+		if err := b.require3DModels("vrml"); err != nil {
+			return nil, err
+		}
+	}
+	board, ctr, err := b.resolve(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := outputDir + "/" + outputName
+	args := []string{"kicad-cli", "pcb", "export", "vrml", "--force", "--output", out, "--units", units}
+	args = append(args, b.Project.hoisted(cmdFlags{defineVar: true, variant: true})...)
+	if excludeDnp {
+		args = append(args, "--no-dnp")
+	}
+	exec, err := runExport(ctx, ctr, "kicad-cli pcb export vrml", append(args, board))
+	if err != nil {
+		return nil, err
+	}
+	return exec.File(out), nil
+}

--- a/daggerverse/kicad/pcb_util.go
+++ b/daggerverse/kicad/pcb_util.go
@@ -1,0 +1,336 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"dagger/kicad/internal/dagger"
+)
+
+// The long-tail 2D and utility board commands: the exotic and legacy plot
+// formats (dxf, ps), the board reports and exchange formats (stats, gencad,
+// ipcd356, odb), the 3D render, and the two in-place transforms (import,
+// upgrade). `pcb export hpgl` is deliberately absent — it self-reports as
+// "No longer supported as of KiCad 10.0".
+
+// Dxf plots the given layers into a single DXF drawing (`--mode-single`).
+//
+// +cache="session"
+func (b *Pcb) Dxf(
+	ctx context.Context,
+	// Untranslated layer names to plot, e.g. F.Cu, Edge.Cuts.
+	layers []string,
+	// Output units: mm or in.
+	// +default="mm"
+	units string,
+	// +default="board.dxf"
+	outputName string,
+) (*dagger.File, error) {
+	if len(layers) == 0 {
+		return nil, fmt.Errorf("layers is required")
+	}
+	if err := oneOf("units", units, "mm", "in"); err != nil {
+		return nil, err
+	}
+	if err := checkOutputName(outputName); err != nil {
+		return nil, err
+	}
+	board, ctr, err := b.resolve(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := outputDir + "/" + outputName
+	args := []string{"kicad-cli", "pcb", "export", "dxf",
+		"--mode-single", "--output", out, "--layers", strings.Join(layers, ","), "--output-units", units}
+	args = append(args, b.Project.hoisted(cmdFlags{defineVar: true, variant: true, drawingSheet: true})...)
+	exec, err := runExport(ctx, ctr, "kicad-cli pcb export dxf", append(args, board))
+	if err != nil {
+		return nil, err
+	}
+	return exec.File(out), nil
+}
+
+// Ps plots the given layers into a single PostScript file (`--mode-single`).
+//
+// +cache="session"
+func (b *Pcb) Ps(
+	ctx context.Context,
+	// Untranslated layer names to plot, e.g. F.Cu, Edge.Cuts.
+	layers []string,
+	// +default="board.ps"
+	outputName string,
+) (*dagger.File, error) {
+	if len(layers) == 0 {
+		return nil, fmt.Errorf("layers is required")
+	}
+	if err := checkOutputName(outputName); err != nil {
+		return nil, err
+	}
+	board, ctr, err := b.resolve(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := outputDir + "/" + outputName
+	args := []string{"kicad-cli", "pcb", "export", "ps",
+		"--mode-single", "--output", out, "--layers", strings.Join(layers, ",")}
+	args = append(args, b.Project.hoisted(cmdFlags{defineVar: true, variant: true, drawingSheet: true})...)
+	exec, err := runExport(ctx, ctr, "kicad-cli pcb export ps", append(args, board))
+	if err != nil {
+		return nil, err
+	}
+	return exec.File(out), nil
+}
+
+// Stats generates a board statistics report (pad, via, track and area counts).
+//
+// +cache="session"
+func (b *Pcb) Stats(
+	ctx context.Context,
+	// Report format: report (human-readable) or json.
+	// +default="report"
+	format string,
+	// Report units: mm or in.
+	// +default="mm"
+	units string,
+	// +default="stats.txt"
+	outputName string,
+) (*dagger.File, error) {
+	if err := oneOf("format", format, "report", "json"); err != nil {
+		return nil, err
+	}
+	if err := oneOf("units", units, "mm", "in"); err != nil {
+		return nil, err
+	}
+	if err := checkOutputName(outputName); err != nil {
+		return nil, err
+	}
+	board, ctr, err := b.resolve(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := outputDir + "/" + outputName
+	args := []string{"kicad-cli", "pcb", "export", "stats",
+		"--output", out, "--format", format, "--units", units}
+	exec, err := runExport(ctx, ctr, "kicad-cli pcb export stats", append(args, board))
+	if err != nil {
+		return nil, err
+	}
+	return exec.File(out), nil
+}
+
+// Gencad exports the board in GenCAD format — a legacy interchange format still
+// used by some test-fixture and assembly houses.
+//
+// +cache="session"
+func (b *Pcb) Gencad(
+	ctx context.Context,
+	// +default="board.cad"
+	outputName string,
+) (*dagger.File, error) {
+	if err := checkOutputName(outputName); err != nil {
+		return nil, err
+	}
+	board, ctr, err := b.resolve(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := outputDir + "/" + outputName
+	args := []string{"kicad-cli", "pcb", "export", "gencad", "--output", out}
+	args = append(args, b.Project.hoisted(cmdFlags{defineVar: true})...)
+	exec, err := runExport(ctx, ctr, "kicad-cli pcb export gencad", append(args, board))
+	if err != nil {
+		return nil, err
+	}
+	return exec.File(out), nil
+}
+
+// Ipcd356 generates an IPC-D-356 netlist file, the bare-board electrical test
+// format a fab house uses to flying-probe an unpopulated board.
+//
+// +cache="session"
+func (b *Pcb) Ipcd356(
+	ctx context.Context,
+	// +default="board.d356"
+	outputName string,
+) (*dagger.File, error) {
+	if err := checkOutputName(outputName); err != nil {
+		return nil, err
+	}
+	board, ctr, err := b.resolve(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := outputDir + "/" + outputName
+	args := []string{"kicad-cli", "pcb", "export", "ipcd356", "--output", out}
+	exec, err := runExport(ctx, ctr, "kicad-cli pcb export ipcd356", append(args, board))
+	if err != nil {
+		return nil, err
+	}
+	return exec.File(out), nil
+}
+
+// Odb exports the board in ODB++ format as a single compressed archive — the
+// fabrication data package many modern fab houses prefer over Gerbers.
+//
+// +cache="session"
+func (b *Pcb) Odb(
+	ctx context.Context,
+	// Archive compression: zip, tgz or none. none writes an uncompressed
+	// directory tree rather than a single file.
+	// +default="zip"
+	compression string,
+	// Units: mm or in.
+	// +default="mm"
+	units string,
+	// +default="odb.zip"
+	outputName string,
+) (*dagger.File, error) {
+	if err := oneOf("compression", compression, "zip", "tgz", "none"); err != nil {
+		return nil, err
+	}
+	if err := checkOutputName(outputName); err != nil {
+		return nil, err
+	}
+	board, ctr, err := b.resolve(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := outputDir + "/" + outputName
+	args := []string{"kicad-cli", "pcb", "export", "odb",
+		"--output", out, "--compression", compression, "--units", units}
+	args = append(args, b.Project.hoisted(cmdFlags{defineVar: true, variant: true, drawingSheet: true})...)
+	exec, err := runExport(ctx, ctr, "kicad-cli pcb export odb", append(args, board))
+	if err != nil {
+		return nil, err
+	}
+	return exec.File(out), nil
+}
+
+// Render ray-traces the board's 3D view to a PNG or JPEG image; the output
+// format follows the outputName extension. Like the 3D model exports it is
+// only meaningful with component models, so it wants the -full image — but
+// unlike them it degrades to a bare-board render on the slim image rather than
+// failing, because a board-only render is still a useful artifact.
+//
+// +cache="session"
+func (b *Pcb) Render(
+	ctx context.Context,
+	// Camera side: top, bottom, left, right, front or back.
+	// +default="top"
+	side string,
+	// Render quality: basic, high, user or job_settings.
+	// +default="basic"
+	quality string,
+	// Image width in pixels.
+	// +default=1600
+	width int,
+	// Image height in pixels.
+	// +default=900
+	height int,
+	// +default="render.png"
+	outputName string,
+) (*dagger.File, error) {
+	if err := oneOf("side", side, "top", "bottom", "left", "right", "front", "back"); err != nil {
+		return nil, err
+	}
+	if err := oneOf("quality", quality, "basic", "high", "user", "job_settings"); err != nil {
+		return nil, err
+	}
+	if err := checkOutputName(outputName); err != nil {
+		return nil, err
+	}
+	board, ctr, err := b.resolve(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := outputDir + "/" + outputName
+	args := []string{"kicad-cli", "pcb", "render",
+		"--output", out, "--side", side, "--quality", quality,
+		"--width", fmt.Sprint(width), "--height", fmt.Sprint(height)}
+	args = append(args, b.Project.hoisted(cmdFlags{defineVar: true, variant: true})...)
+	exec, err := runExport(ctx, ctr, "kicad-cli pcb render", append(args, board))
+	if err != nil {
+		return nil, err
+	}
+	return exec.File(out), nil
+}
+
+// Import converts a non-KiCad board file into KiCad format and returns the
+// produced .kicad_pcb. inputPath names the foreign file within the project
+// source; unlike the export commands it is not auto-discovered, since it is not
+// a .kicad_pcb and the board selected by Pcb() is irrelevant here.
+//
+// +cache="session"
+func (b *Pcb) Import(
+	ctx context.Context,
+	// Project-relative path to the non-KiCad board file to convert.
+	inputPath string,
+	// Input format hint: auto, pads, altium, eagle, cadstar, fabmaster, pcad
+	// or solidworks.
+	// +default="auto"
+	format string,
+	// +default="imported.kicad_pcb"
+	outputName string,
+) (*dagger.File, error) {
+	if err := oneOf("format", format,
+		"auto", "pads", "altium", "eagle", "cadstar", "fabmaster", "pcad", "solidworks"); err != nil {
+		return nil, err
+	}
+	if err := checkOutputName(outputName); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(inputPath) == "" {
+		return nil, fmt.Errorf("inputPath is required")
+	}
+	if err := b.Project.validate(); err != nil {
+		return nil, err
+	}
+	if err := b.Project.requireFile(ctx, inputPath, "input board"); err != nil {
+		return nil, err
+	}
+	out := outputDir + "/" + outputName
+	args := []string{"kicad-cli", "pcb", "import",
+		"--output", out, "--format", format, inputPath}
+	exec, err := runExport(ctx, b.Project.container(), "kicad-cli pcb import", args)
+	if err != nil {
+		return nil, err
+	}
+	return exec.File(out), nil
+}
+
+// Upgrade resaves the board in the current KiCad file format and returns the
+// upgraded .kicad_pcb. kicad-cli's `pcb upgrade` rewrites the file in place and
+// has no output flag, so the board runs against a writable copy (owned by the
+// image's UID-1000 user) rather than the read-only mounted source.
+//
+// +cache="session"
+func (b *Pcb) Upgrade(
+	ctx context.Context,
+	// Resave even when the board is already at the latest format version.
+	// +default=false
+	force bool,
+) (*dagger.File, error) {
+	if err := b.Project.validate(); err != nil {
+		return nil, err
+	}
+	board, err := b.Project.discover(ctx, "kicad_pcb", b.Path)
+	if err != nil {
+		return nil, err
+	}
+	const workDir = "/tmp/kicad-upgrade"
+	args := []string{"kicad-cli", "pcb", "upgrade"}
+	if force {
+		args = append(args, "--force")
+	}
+	args = append(args, board)
+	exec, err := runExport(ctx,
+		b.Project.Kicad.Container().
+			WithDirectory(workDir, b.Project.Source, dagger.ContainerWithDirectoryOpts{Owner: kicadUser}).
+			WithWorkdir(workDir),
+		"kicad-cli pcb upgrade", args)
+	if err != nil {
+		return nil, err
+	}
+	return exec.File(workDir + "/" + board), nil
+}

--- a/daggerverse/kicad/sch.go
+++ b/daggerverse/kicad/sch.go
@@ -171,6 +171,43 @@ func (s *Sch) Svg(ctx context.Context) (*dagger.Directory, error) {
 	return exec.Directory(outputDir), nil
 }
 
+// Dxf plots the schematic to DXF, one file per sheet, and returns the
+// directory. Like Svg there is no single-file counterpart: kicad-cli always
+// plots schematics per sheet.
+//
+// +cache="session"
+func (s *Sch) Dxf(ctx context.Context) (*dagger.Directory, error) {
+	sheet, ctr, err := s.resolve(ctx)
+	if err != nil {
+		return nil, err
+	}
+	args := []string{"kicad-cli", "sch", "export", "dxf", "--output", outputDir + "/"}
+	args = append(args, s.Project.hoisted(cmdFlags{defineVar: true, variant: true, drawingSheet: true})...)
+	exec, err := runExport(ctx, ctr, "kicad-cli sch export dxf", append(args, sheet))
+	if err != nil {
+		return nil, err
+	}
+	return exec.Directory(outputDir), nil
+}
+
+// Ps plots the schematic to PostScript, one file per sheet, and returns the
+// directory.
+//
+// +cache="session"
+func (s *Sch) Ps(ctx context.Context) (*dagger.Directory, error) {
+	sheet, ctr, err := s.resolve(ctx)
+	if err != nil {
+		return nil, err
+	}
+	args := []string{"kicad-cli", "sch", "export", "ps", "--output", outputDir + "/"}
+	args = append(args, s.Project.hoisted(cmdFlags{defineVar: true, variant: true, drawingSheet: true})...)
+	exec, err := runExport(ctx, ctr, "kicad-cli sch export ps", append(args, sheet))
+	if err != nil {
+		return nil, err
+	}
+	return exec.Directory(outputDir), nil
+}
+
 // resolve validates the deferred Project config and turns the (possibly
 // empty) schematic path into a concrete one, alongside a prepared container.
 func (s *Sch) resolve(ctx context.Context) (string, *dagger.Container, error) {

--- a/daggerverse/kicad/tests/dagger.gen.go
+++ b/daggerverse/kicad/tests/dagger.gen.go
@@ -297,6 +297,27 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).ErcReportsViolations(&parent, ctx)
+		case "FpSvgExportsFootprint":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).FpSvgExportsFootprint(&parent, ctx)
+		case "FpUpgradeResavesLibrary":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).FpUpgradeResavesLibrary(&parent, ctx)
+		case "GencadProducesGencad":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).GencadProducesGencad(&parent, ctx)
 		case "GerbersDefaultExportsAllLayers":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -311,6 +332,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).GerbersProduceOneFilePerLayer(&parent, ctx)
+		case "GlbBoardOnlyProducesGlb":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).GlbBoardOnlyProducesGlb(&parent, ctx)
+		case "ImportRejectsUnknownFormat":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ImportRejectsUnknownFormat(&parent, ctx)
 		case "Ipc2581ProducesXml":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -318,6 +353,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).Ipc2581ProducesXml(&parent, ctx)
+		case "Ipcd356ProducesNetlist":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).Ipcd356ProducesNetlist(&parent, ctx)
 		case "JobsetRejectsMissingFile":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -346,6 +388,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).NetlistRejectsInvalidFormat(&parent, ctx)
+		case "OdbProducesArchive":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).OdbProducesArchive(&parent, ctx)
 		case "PcbAutoDiscoversSingleBoard":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -353,6 +402,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).PcbAutoDiscoversSingleBoard(&parent, ctx)
+		case "PcbDxfProducesDxf":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).PcbDxfProducesDxf(&parent, ctx)
 		case "PcbPdfIsSingleMultipageFile":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -367,6 +423,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).PcbPdfPerLayerProducesFilePerLayer(&parent, ctx)
+		case "PcbPsProducesPostscript":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).PcbPsProducesPostscript(&parent, ctx)
 		case "PcbRejectsAmbiguousAutoDiscovery":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -395,6 +458,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).PcbSvgProducesSingleSvg(&parent, ctx)
+		case "PcbUpgradeProducesBoard":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).PcbUpgradeProducesBoard(&parent, ctx)
 		case "PosDefaultsToAsciiBothSides":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -409,6 +479,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).RejectsOutputNameWithPathSeparator(&parent, ctx)
+		case "RenderProducesPng":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).RenderProducesPng(&parent, ctx)
 		case "SchAutoDiscoversSingleSchematic":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -416,6 +493,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).SchAutoDiscoversSingleSchematic(&parent, ctx)
+		case "SchDxfProducesFilePerSheet":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).SchDxfProducesFilePerSheet(&parent, ctx)
 		case "SchPdfProducesPdf":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -423,6 +507,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).SchPdfProducesPdf(&parent, ctx)
+		case "SchPsProducesFilePerSheet":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).SchPsProducesFilePerSheet(&parent, ctx)
 		case "SchSvgProducesOneFilePerSheet":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -430,6 +521,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).SchSvgProducesOneFilePerSheet(&parent, ctx)
+		case "StatsProducesReport":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).StatsProducesReport(&parent, ctx)
 		case "StepBoardOnlyProducesStepFile":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -437,6 +535,34 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).StepBoardOnlyProducesStepFile(&parent, ctx)
+		case "StepWithComponentModelsIncludesModels":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).StepWithComponentModelsIncludesModels(&parent, ctx)
+		case "SymSvgExportsSymbol":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).SymSvgExportsSymbol(&parent, ctx)
+		case "SymUpgradeResavesLibrary":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).SymUpgradeResavesLibrary(&parent, ctx)
+		case "ThreeDExportRequiresFullImage":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ThreeDExportRequiresFullImage(&parent, ctx)
 		case "VersionReportsKicadRelease":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -444,6 +570,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).VersionReportsKicadRelease(&parent, ctx)
+		case "VrmlBoardOnlyProducesVrml":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).VrmlBoardOnlyProducesVrml(&parent, ctx)
 		case "WithDrawingSheetAppliesCustomSheet":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/kicad/tests/fixtures/blinky/blinky.kicad_pcb
+++ b/daggerverse/kicad/tests/fixtures/blinky/blinky.kicad_pcb
@@ -109,6 +109,17 @@
 			(pintype "passive")
 			(uuid "66666666-0000-4000-8000-000000000016")
 		)
+		(model "/usr/share/kicad/3dmodels/Resistor_SMD.3dshapes/R_0805_2012Metric.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
 		(embedded_fonts no)
 	)
 	(footprint "blinky:LED_0805"

--- a/daggerverse/kicad/tests/fixtures/fplib/test.pretty/R_0805.kicad_mod
+++ b/daggerverse/kicad/tests/fixtures/fplib/test.pretty/R_0805.kicad_mod
@@ -1,0 +1,43 @@
+(footprint "R_0805"
+	(version 20240108)
+	(generator "pcbnew")
+	(generator_version "9.0")
+	(layer "F.Cu")
+	(descr "0805 resistor, hand-authored test fixture")
+	(attr smd)
+	(fp_line
+		(start -1.6 -0.9)
+		(end 1.6 -0.9)
+		(stroke
+			(width 0.1)
+			(type solid)
+		)
+		(layer "F.SilkS")
+		(uuid "aaaaaaaa-0000-4000-8000-000000000001")
+	)
+	(fp_line
+		(start -1.6 0.9)
+		(end 1.6 0.9)
+		(stroke
+			(width 0.1)
+			(type solid)
+		)
+		(layer "F.SilkS")
+		(uuid "aaaaaaaa-0000-4000-8000-000000000002")
+	)
+	(pad "1" smd roundrect
+		(at -0.9375 0)
+		(size 1.025 1.4)
+		(layers "F.Cu" "F.Paste" "F.Mask")
+		(roundrect_rratio 0.243902)
+		(uuid "aaaaaaaa-0000-4000-8000-000000000011")
+	)
+	(pad "2" smd roundrect
+		(at 0.9375 0)
+		(size 1.025 1.4)
+		(layers "F.Cu" "F.Paste" "F.Mask")
+		(roundrect_rratio 0.243902)
+		(uuid "aaaaaaaa-0000-4000-8000-000000000012")
+	)
+	(embedded_fonts no)
+)

--- a/daggerverse/kicad/tests/fixtures/symlib/test.kicad_sym
+++ b/daggerverse/kicad/tests/fixtures/symlib/test.kicad_sym
@@ -1,0 +1,93 @@
+(kicad_symbol_lib
+	(version 20241209)
+	(generator "kicad_symbol_editor")
+	(generator_version "9.0")
+	(symbol "R"
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "R"
+			(at 2.032 0 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "R"
+			(at 0 0 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at -1.778 0 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "R_0_1"
+			(rectangle
+				(start -1.016 -2.54)
+				(end 1.016 2.54)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "R_1_1"
+			(pin passive line
+				(at 0 3.81 270)
+				(length 1.27)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 0 -3.81 90)
+				(length 1.27)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+)

--- a/daggerverse/kicad/tests/internal/dagger/dagger.gen.go
+++ b/daggerverse/kicad/tests/internal/dagger/dagger.gen.go
@@ -266,6 +266,9 @@ type JSONValueID string
 type KicadCiID string
 
 // A unique identifier for an object.
+type KicadFpID string
+
+// A unique identifier for an object.
 type KicadID string
 
 // A unique identifier for an object.
@@ -276,6 +279,9 @@ type KicadProjectID string
 
 // A unique identifier for an object.
 type KicadSchID string
+
+// A unique identifier for an object.
+type KicadSymID string
 
 // A unique identifier for an object.
 type LLMID string
@@ -13164,6 +13170,16 @@ func (r *Query) LoadKicadCiFromID(id KicadCiID) *KicadCi {
 	}
 }
 
+// Load a KicadFp from its ID.
+func (r *Query) LoadKicadFpFromID(id KicadFpID) *KicadFp {
+	q := r.query.Select("loadKicadFpFromID")
+	q = q.Arg("id", id)
+
+	return &KicadFp{
+		query: q,
+	}
+}
+
 // Load a Kicad from its ID.
 func (r *Query) LoadKicadFromID(id KicadID) *Kicad {
 	q := r.query.Select("loadKicadFromID")
@@ -13200,6 +13216,16 @@ func (r *Query) LoadKicadSchFromID(id KicadSchID) *KicadSch {
 	q = q.Arg("id", id)
 
 	return &KicadSch{
+		query: q,
+	}
+}
+
+// Load a KicadSym from its ID.
+func (r *Query) LoadKicadSymFromID(id KicadSymID) *KicadSym {
+	q := r.query.Select("loadKicadSymFromID")
+	q = q.Arg("id", id)
+
+	return &KicadSym{
 		query: q,
 	}
 }

--- a/daggerverse/kicad/tests/internal/dagger/kicad.gen.go
+++ b/daggerverse/kicad/tests/internal/dagger/kicad.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type Kicad
-func (r *Binding) AsKicad() *Kicad { // kicad (../../../../../daggerverse/kicad/main.go:65:6)
+func (r *Binding) AsKicad() *Kicad { // kicad (../../../../../daggerverse/kicad/main.go:69:6)
 	q := r.query.Select("asKicad")
 
 	return &Kicad{
@@ -27,6 +27,15 @@ func (r *Binding) AsKicadCi() *KicadCi { // kicad (../../../../../daggerverse/ki
 	}
 }
 
+// Retrieve the binding value, as type KicadFp
+func (r *Binding) AsKicadFp() *KicadFp { // kicad (../../../../../daggerverse/kicad/library.go:36:6)
+	q := r.query.Select("asKicadFp")
+
+	return &KicadFp{
+		query: q,
+	}
+}
+
 // Retrieve the binding value, as type KicadPcb
 func (r *Binding) AsKicadPcb() *KicadPcb { // kicad (../../../../../daggerverse/kicad/pcb.go:14:6)
 	q := r.query.Select("asKicadPcb")
@@ -37,7 +46,7 @@ func (r *Binding) AsKicadPcb() *KicadPcb { // kicad (../../../../../daggerverse/
 }
 
 // Retrieve the binding value, as type KicadProject
-func (r *Binding) AsKicadProject() *KicadProject { // kicad (../../../../../daggerverse/kicad/main.go:126:6)
+func (r *Binding) AsKicadProject() *KicadProject { // kicad (../../../../../daggerverse/kicad/main.go:156:6)
 	q := r.query.Select("asKicadProject")
 
 	return &KicadProject{
@@ -50,6 +59,15 @@ func (r *Binding) AsKicadSch() *KicadSch { // kicad (../../../../../daggerverse/
 	q := r.query.Select("asKicadSch")
 
 	return &KicadSch{
+		query: q,
+	}
+}
+
+// Retrieve the binding value, as type KicadSym
+func (r *Binding) AsKicadSym() *KicadSym { // kicad (../../../../../daggerverse/kicad/library.go:98:6)
+	q := r.query.Select("asKicadSym")
+
+	return &KicadSym{
 		query: q,
 	}
 }
@@ -78,8 +96,32 @@ func (r *Env) WithKicadCiOutput(name string, description string) *Env { // kicad
 	}
 }
 
+// Create or update a binding of type KicadFp in the environment
+func (r *Env) WithKicadFpInput(name string, value *KicadFp, description string) *Env { // kicad (../../../../../daggerverse/kicad/library.go:36:6)
+	assertNotNil("value", value)
+	q := r.query.Select("withKicadFpInput")
+	q = q.Arg("name", name)
+	q = q.Arg("value", value)
+	q = q.Arg("description", description)
+
+	return &Env{
+		query: q,
+	}
+}
+
+// Declare a desired KicadFp output to be assigned in the environment
+func (r *Env) WithKicadFpOutput(name string, description string) *Env { // kicad (../../../../../daggerverse/kicad/library.go:36:6)
+	q := r.query.Select("withKicadFpOutput")
+	q = q.Arg("name", name)
+	q = q.Arg("description", description)
+
+	return &Env{
+		query: q,
+	}
+}
+
 // Create or update a binding of type Kicad in the environment
-func (r *Env) WithKicadInput(name string, value *Kicad, description string) *Env { // kicad (../../../../../daggerverse/kicad/main.go:65:6)
+func (r *Env) WithKicadInput(name string, value *Kicad, description string) *Env { // kicad (../../../../../daggerverse/kicad/main.go:69:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withKicadInput")
 	q = q.Arg("name", name)
@@ -92,7 +134,7 @@ func (r *Env) WithKicadInput(name string, value *Kicad, description string) *Env
 }
 
 // Declare a desired Kicad output to be assigned in the environment
-func (r *Env) WithKicadOutput(name string, description string) *Env { // kicad (../../../../../daggerverse/kicad/main.go:65:6)
+func (r *Env) WithKicadOutput(name string, description string) *Env { // kicad (../../../../../daggerverse/kicad/main.go:69:6)
 	q := r.query.Select("withKicadOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -127,7 +169,7 @@ func (r *Env) WithKicadPcbOutput(name string, description string) *Env { // kica
 }
 
 // Create or update a binding of type KicadProject in the environment
-func (r *Env) WithKicadProjectInput(name string, value *KicadProject, description string) *Env { // kicad (../../../../../daggerverse/kicad/main.go:126:6)
+func (r *Env) WithKicadProjectInput(name string, value *KicadProject, description string) *Env { // kicad (../../../../../daggerverse/kicad/main.go:156:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withKicadProjectInput")
 	q = q.Arg("name", name)
@@ -140,7 +182,7 @@ func (r *Env) WithKicadProjectInput(name string, value *KicadProject, descriptio
 }
 
 // Declare a desired KicadProject output to be assigned in the environment
-func (r *Env) WithKicadProjectOutput(name string, description string) *Env { // kicad (../../../../../daggerverse/kicad/main.go:126:6)
+func (r *Env) WithKicadProjectOutput(name string, description string) *Env { // kicad (../../../../../daggerverse/kicad/main.go:156:6)
 	q := r.query.Select("withKicadProjectOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -174,10 +216,34 @@ func (r *Env) WithKicadSchOutput(name string, description string) *Env { // kica
 	}
 }
 
+// Create or update a binding of type KicadSym in the environment
+func (r *Env) WithKicadSymInput(name string, value *KicadSym, description string) *Env { // kicad (../../../../../daggerverse/kicad/library.go:98:6)
+	assertNotNil("value", value)
+	q := r.query.Select("withKicadSymInput")
+	q = q.Arg("name", name)
+	q = q.Arg("value", value)
+	q = q.Arg("description", description)
+
+	return &Env{
+		query: q,
+	}
+}
+
+// Declare a desired KicadSym output to be assigned in the environment
+func (r *Env) WithKicadSymOutput(name string, description string) *Env { // kicad (../../../../../daggerverse/kicad/library.go:98:6)
+	q := r.query.Select("withKicadSymOutput")
+	q = q.Arg("name", name)
+	q = q.Arg("description", description)
+
+	return &Env{
+		query: q,
+	}
+}
+
 // Kicad wraps kicad-cli as Dagger functions. Construct via New(); call
 // Container() for the raw image, or Project(source) to reach the typed
 // pcb/sch helpers.
-type Kicad struct { // kicad (../../../../../daggerverse/kicad/main.go:65:6)
+type Kicad struct { // kicad (../../../../../daggerverse/kicad/main.go:69:6)
 	query *querybuilder.Selection
 
 	id      *ID
@@ -206,10 +272,22 @@ func (r *Kicad) Ci(source *Directory) *KicadCi { // kicad (../../../../../dagger
 // Container returns the bare kicad image. This is the escape hatch for every
 // subcommand this module does not wrap — kicad-cli's long tail of exotic and
 // legacy exports stays reachable via `container with-exec`.
-func (r *Kicad) Container() *Container { // kicad (../../../../../daggerverse/kicad/main.go:95:1)
+func (r *Kicad) Container() *Container { // kicad (../../../../../daggerverse/kicad/main.go:108:1)
 	q := r.query.Select("container")
 
 	return &Container{
+		query: q,
+	}
+}
+
+// Fp binds a footprint library directory (a .pretty folder, or any directory
+// of .kicad_mod files) to the toolchain for the `fp` command family.
+func (r *Kicad) Fp(source *Directory) *KicadFp { // kicad (../../../../../daggerverse/kicad/library.go:45:1)
+	assertNotNil("source", source)
+	q := r.query.Select("fp")
+	q = q.Arg("source", source)
+
+	return &KicadFp{
 		query: q,
 	}
 }
@@ -266,7 +344,7 @@ func (r *Kicad) UnmarshalJSON(bs []byte) error {
 // Project binds a KiCad project directory to the toolchain. source is the
 // whole project tree, not a single file, because kicad-cli resolves
 // sub-sheets, footprint libraries and drawing sheets relative to it.
-func (r *Kicad) Project(source *Directory) *KicadProject { // kicad (../../../../../daggerverse/kicad/main.go:116:1)
+func (r *Kicad) Project(source *Directory) *KicadProject { // kicad (../../../../../daggerverse/kicad/main.go:129:1)
 	assertNotNil("source", source)
 	q := r.query.Select("project")
 	q = q.Arg("source", source)
@@ -276,9 +354,23 @@ func (r *Kicad) Project(source *Directory) *KicadProject { // kicad (../../../..
 	}
 }
 
+// Sym binds a symbol library file (.kicad_sym) to the toolchain for the `sym`
+// command family. It takes a lone *File, not a directory, because a symbol
+// library is a single self-contained file — the footprint library's on-disk
+// counterpart is a directory, which is why Fp takes a *Directory instead.
+func (r *Kicad) Sym(source *File) *KicadSym { // kicad (../../../../../daggerverse/kicad/library.go:109:1)
+	assertNotNil("source", source)
+	q := r.query.Select("sym")
+	q = q.Arg("source", source)
+
+	return &KicadSym{
+		query: q,
+	}
+}
+
 // Version returns the KiCad release the pinned image ships, as reported by
 // `kicad-cli version`.
-func (r *Kicad) Version(ctx context.Context) (string, error) { // kicad (../../../../../daggerverse/kicad/main.go:103:1)
+func (r *Kicad) Version(ctx context.Context) (string, error) { // kicad (../../../../../daggerverse/kicad/main.go:116:1)
 	if r.version != nil {
 		return *r.version, nil
 	}
@@ -456,6 +548,126 @@ func (r *KicadCi) AsNode() Node {
 	}
 }
 
+// Fp is a footprint library (a .pretty directory of .kicad_mod files) bound to
+// the toolchain.
+type KicadFp struct { // kicad (../../../../../daggerverse/kicad/library.go:36:6)
+	query *querybuilder.Selection
+
+	id *ID
+}
+
+func (r *KicadFp) WithGraphQLQuery(q *querybuilder.Selection) *KicadFp {
+	return &KicadFp{
+		query: q,
+	}
+}
+
+// A unique identifier for this KicadFp.
+func (r *KicadFp) ID(ctx context.Context) (ID, error) {
+	if r.id != nil {
+		return *r.id, nil
+	}
+	q := r.query.Select("id")
+
+	var response ID
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// XXX_GraphQLType is an internal function. It returns the native GraphQL type name
+func (r *KicadFp) XXX_GraphQLType() string {
+	return "KicadFp"
+}
+
+// XXX_GraphQLIDType is an internal function. It returns the native GraphQL type name for the ID of this object
+func (r *KicadFp) XXX_GraphQLIDType() string {
+	return "ID"
+}
+
+// XXX_GraphQLID is an internal function. It returns the underlying type ID
+func (r *KicadFp) XXX_GraphQLID(ctx context.Context) (string, error) {
+	id, err := r.ID(ctx)
+	if err != nil {
+		return "", err
+	}
+	return string(id), nil
+}
+
+func (r *KicadFp) MarshalJSON() ([]byte, error) {
+	id, err := r.ID(marshalCtx)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(id)
+}
+func (r *KicadFp) UnmarshalJSON(bs []byte) error {
+	var id string
+	err := json.Unmarshal(bs, &id)
+	if err != nil {
+		return err
+	}
+	*r = KicadFp{query: selectNode(dag.query, id, "KicadFp")}
+	return nil
+}
+
+// KicadFpSvgOpts contains options for KicadFp.Svg
+type KicadFpSvgOpts struct {
+	//
+	// Export only this footprint from the library; empty exports all.
+	//
+	Footprint string // kicad (../../../../../daggerverse/kicad/library.go:58:2)
+}
+
+// Svg exports the footprint library to SVG, one file per footprint, and
+// returns the directory. Pass footprint to export a single footprint by name
+// instead of the whole library.
+func (r *KicadFp) Svg(opts ...KicadFpSvgOpts) *Directory { // kicad (../../../../../daggerverse/kicad/library.go:54:1)
+	q := r.query.Select("svg")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `footprint` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Footprint) {
+			q = q.Arg("footprint", opts[i].Footprint)
+		}
+	}
+
+	return &Directory{
+		query: q,
+	}
+}
+
+// KicadFpUpgradeOpts contains options for KicadFp.Upgrade
+type KicadFpUpgradeOpts struct {
+	//
+	// Resave even when the library is already at the latest format version.
+	//
+	Force bool // kicad (../../../../../daggerverse/kicad/library.go:82:2)
+}
+
+// Upgrade resaves the footprint library in the current KiCad format and returns
+// the upgraded .pretty directory.
+func (r *KicadFp) Upgrade(opts ...KicadFpUpgradeOpts) *Directory { // kicad (../../../../../daggerverse/kicad/library.go:78:1)
+	q := r.query.Select("upgrade")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `force` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Force) {
+			q = q.Arg("force", opts[i].Force)
+		}
+	}
+
+	return &Directory{
+		query: q,
+	}
+}
+
+// AsNode returns this KicadFp as a Node.
+// This is a local type conversion — no GraphQL call.
+func (r *KicadFp) AsNode() Node {
+	return &NodeClient{
+		query: r.query,
+	}
+}
+
 // Pcb is a board selected within a Project. Every method here execs
 // kicad-cli, so each carries a session cache directive; selecting the board
 // itself is pure config and carries none.
@@ -468,6 +680,39 @@ type KicadPcb struct { // kicad (../../../../../daggerverse/kicad/pcb.go:14:6)
 
 func (r *KicadPcb) WithGraphQLQuery(q *querybuilder.Selection) *KicadPcb {
 	return &KicadPcb{
+		query: q,
+	}
+}
+
+// KicadPcbBrepOpts contains options for KicadPcb.Brep
+type KicadPcbBrepOpts struct {
+	BoardOnly bool // kicad (../../../../../daggerverse/kicad/pcb_3d.go:108:2)
+
+	ExcludeDnp bool // kicad (../../../../../daggerverse/kicad/pcb_3d.go:110:2)
+
+	// Default: "board.brep"
+	OutputName string // kicad (../../../../../daggerverse/kicad/pcb_3d.go:112:2)
+}
+
+// Brep exports the board as an OpenCASCADE BREP model.
+func (r *KicadPcb) Brep(opts ...KicadPcbBrepOpts) *File { // kicad (../../../../../daggerverse/kicad/pcb_3d.go:105:1)
+	q := r.query.Select("brep")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `boardOnly` optional argument
+		if !querybuilder.IsZeroValue(opts[i].BoardOnly) {
+			q = q.Arg("boardOnly", opts[i].BoardOnly)
+		}
+		// `excludeDnp` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ExcludeDnp) {
+			q = q.Arg("excludeDnp", opts[i].ExcludeDnp)
+		}
+		// `outputName` optional argument
+		if !querybuilder.IsZeroValue(opts[i].OutputName) {
+			q = q.Arg("outputName", opts[i].OutputName)
+		}
+	}
+
+	return &File{
 		query: q,
 	}
 }
@@ -583,6 +828,62 @@ func (r *KicadPcb) Drill(opts ...KicadPcbDrillOpts) *Directory { // kicad (../..
 	}
 }
 
+// KicadPcbDxfOpts contains options for KicadPcb.Dxf
+type KicadPcbDxfOpts struct {
+	//
+	// Output units: mm or in.
+	//
+	//
+	// Default: "mm"
+	Units string // kicad (../../../../../daggerverse/kicad/pcb_util.go:26:2)
+
+	// Default: "board.dxf"
+	OutputName string // kicad (../../../../../daggerverse/kicad/pcb_util.go:28:2)
+}
+
+// Dxf plots the given layers into a single DXF drawing (`--mode-single`).
+func (r *KicadPcb) Dxf(layers []string, opts ...KicadPcbDxfOpts) *File { // kicad (../../../../../daggerverse/kicad/pcb_util.go:20:1)
+	q := r.query.Select("dxf")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `units` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Units) {
+			q = q.Arg("units", opts[i].Units)
+		}
+		// `outputName` optional argument
+		if !querybuilder.IsZeroValue(opts[i].OutputName) {
+			q = q.Arg("outputName", opts[i].OutputName)
+		}
+	}
+	q = q.Arg("layers", layers)
+
+	return &File{
+		query: q,
+	}
+}
+
+// KicadPcbGencadOpts contains options for KicadPcb.Gencad
+type KicadPcbGencadOpts struct {
+
+	// Default: "board.cad"
+	OutputName string // kicad (../../../../../daggerverse/kicad/pcb_util.go:129:2)
+}
+
+// Gencad exports the board in GenCAD format — a legacy interchange format still
+// used by some test-fixture and assembly houses.
+func (r *KicadPcb) Gencad(opts ...KicadPcbGencadOpts) *File { // kicad (../../../../../daggerverse/kicad/pcb_util.go:126:1)
+	q := r.query.Select("gencad")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `outputName` optional argument
+		if !querybuilder.IsZeroValue(opts[i].OutputName) {
+			q = q.Arg("outputName", opts[i].OutputName)
+		}
+	}
+
+	return &File{
+		query: q,
+	}
+}
+
 // KicadPcbGerbersOpts contains options for KicadPcb.Gerbers
 type KicadPcbGerbersOpts struct {
 	//
@@ -622,6 +923,46 @@ func (r *KicadPcb) Gerbers(opts ...KicadPcbGerbersOpts) *Directory { // kicad (.
 	}
 
 	return &Directory{
+		query: q,
+	}
+}
+
+// KicadPcbGlbOpts contains options for KicadPcb.Glb
+type KicadPcbGlbOpts struct {
+	//
+	// Export the bare board, with no component models.
+	//
+	BoardOnly bool // kicad (../../../../../daggerverse/kicad/pcb_3d.go:77:2)
+	//
+	// Exclude models for components flagged Do Not Populate.
+	//
+	ExcludeDnp bool // kicad (../../../../../daggerverse/kicad/pcb_3d.go:80:2)
+
+	// Default: "board.glb"
+	OutputName string // kicad (../../../../../daggerverse/kicad/pcb_3d.go:82:2)
+}
+
+// Glb exports the board as a binary glTF (GLB) model. Like every 3D export it
+// needs the -full image for component models; pass boardOnly for board
+// geometry alone on the slim image.
+func (r *KicadPcb) Glb(opts ...KicadPcbGlbOpts) *File { // kicad (../../../../../daggerverse/kicad/pcb_3d.go:73:1)
+	q := r.query.Select("glb")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `boardOnly` optional argument
+		if !querybuilder.IsZeroValue(opts[i].BoardOnly) {
+			q = q.Arg("boardOnly", opts[i].BoardOnly)
+		}
+		// `excludeDnp` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ExcludeDnp) {
+			q = q.Arg("excludeDnp", opts[i].ExcludeDnp)
+		}
+		// `outputName` optional argument
+		if !querybuilder.IsZeroValue(opts[i].OutputName) {
+			q = q.Arg("outputName", opts[i].OutputName)
+		}
+	}
+
+	return &File{
 		query: q,
 	}
 }
@@ -675,6 +1016,43 @@ func (r *KicadPcb) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
+// KicadPcbImportOpts contains options for KicadPcb.Import
+type KicadPcbImportOpts struct {
+	//
+	// Input format hint: auto, pads, altium, eagle, cadstar, fabmaster, pcad
+	// or solidworks.
+	//
+	//
+	// Default: "auto"
+	Format string // kicad (../../../../../daggerverse/kicad/pcb_util.go:272:2)
+
+	// Default: "imported.kicad_pcb"
+	OutputName string // kicad (../../../../../daggerverse/kicad/pcb_util.go:274:2)
+}
+
+// Import converts a non-KiCad board file into KiCad format and returns the
+// produced .kicad_pcb. inputPath names the foreign file within the project
+// source; unlike the export commands it is not auto-discovered, since it is not
+// a .kicad_pcb and the board selected by Pcb() is irrelevant here.
+func (r *KicadPcb) Import(inputPath string, opts ...KicadPcbImportOpts) *File { // kicad (../../../../../daggerverse/kicad/pcb_util.go:265:1)
+	q := r.query.Select("import")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `format` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Format) {
+			q = q.Arg("format", opts[i].Format)
+		}
+		// `outputName` optional argument
+		if !querybuilder.IsZeroValue(opts[i].OutputName) {
+			q = q.Arg("outputName", opts[i].OutputName)
+		}
+	}
+	q = q.Arg("inputPath", inputPath)
+
+	return &File{
+		query: q,
+	}
+}
+
 // KicadPcbIpc2581Opts contains options for KicadPcb.Ipc2581
 type KicadPcbIpc2581Opts struct {
 	//
@@ -682,22 +1060,22 @@ type KicadPcbIpc2581Opts struct {
 	//
 	//
 	// Default: "C"
-	Version string // kicad (../../../../../daggerverse/kicad/pcb.go:256:2)
+	Version string // kicad (../../../../../daggerverse/kicad/pcb.go:238:2)
 	//
 	// Units: mm or in.
 	//
 	//
 	// Default: "mm"
-	Units string // kicad (../../../../../daggerverse/kicad/pcb.go:259:2)
+	Units string // kicad (../../../../../daggerverse/kicad/pcb.go:241:2)
 
 	// Default: "board.xml"
-	OutputName string // kicad (../../../../../daggerverse/kicad/pcb.go:261:2)
+	OutputName string // kicad (../../../../../daggerverse/kicad/pcb.go:243:2)
 }
 
 // Ipc2581 exports the board in IPC-2581 format — a single XML file carrying
 // the fabrication and assembly data that would otherwise be spread across
 // Gerbers, drill files and a BOM.
-func (r *KicadPcb) Ipc2581(opts ...KicadPcbIpc2581Opts) *File { // kicad (../../../../../daggerverse/kicad/pcb.go:252:1)
+func (r *KicadPcb) Ipc2581(opts ...KicadPcbIpc2581Opts) *File { // kicad (../../../../../daggerverse/kicad/pcb.go:234:1)
 	q := r.query.Select("ipc2581")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `version` optional argument
@@ -719,11 +1097,78 @@ func (r *KicadPcb) Ipc2581(opts ...KicadPcbIpc2581Opts) *File { // kicad (../../
 	}
 }
 
+// KicadPcbIpcd356Opts contains options for KicadPcb.Ipcd356
+type KicadPcbIpcd356Opts struct {
+
+	// Default: "board.d356"
+	OutputName string // kicad (../../../../../daggerverse/kicad/pcb_util.go:155:2)
+}
+
+// Ipcd356 generates an IPC-D-356 netlist file, the bare-board electrical test
+// format a fab house uses to flying-probe an unpopulated board.
+func (r *KicadPcb) Ipcd356(opts ...KicadPcbIpcd356Opts) *File { // kicad (../../../../../daggerverse/kicad/pcb_util.go:152:1)
+	q := r.query.Select("ipcd356")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `outputName` optional argument
+		if !querybuilder.IsZeroValue(opts[i].OutputName) {
+			q = q.Arg("outputName", opts[i].OutputName)
+		}
+	}
+
+	return &File{
+		query: q,
+	}
+}
+
+// KicadPcbOdbOpts contains options for KicadPcb.Odb
+type KicadPcbOdbOpts struct {
+	//
+	// Archive compression: zip, tgz or none. none writes an uncompressed
+	// directory tree rather than a single file.
+	//
+	//
+	// Default: "zip"
+	Compression string // kicad (../../../../../daggerverse/kicad/pcb_util.go:182:2)
+	//
+	// Units: mm or in.
+	//
+	//
+	// Default: "mm"
+	Units string // kicad (../../../../../daggerverse/kicad/pcb_util.go:185:2)
+
+	// Default: "odb.zip"
+	OutputName string // kicad (../../../../../daggerverse/kicad/pcb_util.go:187:2)
+}
+
+// Odb exports the board in ODB++ format as a single compressed archive — the
+// fabrication data package many modern fab houses prefer over Gerbers.
+func (r *KicadPcb) Odb(opts ...KicadPcbOdbOpts) *File { // kicad (../../../../../daggerverse/kicad/pcb_util.go:177:1)
+	q := r.query.Select("odb")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `compression` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Compression) {
+			q = q.Arg("compression", opts[i].Compression)
+		}
+		// `units` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Units) {
+			q = q.Arg("units", opts[i].Units)
+		}
+		// `outputName` optional argument
+		if !querybuilder.IsZeroValue(opts[i].OutputName) {
+			q = q.Arg("outputName", opts[i].OutputName)
+		}
+	}
+
+	return &File{
+		query: q,
+	}
+}
+
 // KicadPcbPdfOpts contains options for KicadPcb.Pdf
 type KicadPcbPdfOpts struct {
 
 	// Default: "board.pdf"
-	OutputName string // kicad (../../../../../daggerverse/kicad/pcb.go:300:2)
+	OutputName string // kicad (../../../../../daggerverse/kicad/pcb.go:282:2)
 }
 
 // Pdf plots the given layers into a single PDF.
@@ -732,7 +1177,7 @@ type KicadPcbPdfOpts struct {
 // rather than one function taking a mode flag: a Dagger function has exactly
 // one return type, so modelling `--mode-single` vs `--mode-separate` as a
 // parameter would force *Directory onto the common single-file case.
-func (r *KicadPcb) Pdf(layers []string, opts ...KicadPcbPdfOpts) *File { // kicad (../../../../../daggerverse/kicad/pcb.go:295:1)
+func (r *KicadPcb) Pdf(layers []string, opts ...KicadPcbPdfOpts) *File { // kicad (../../../../../daggerverse/kicad/pcb.go:277:1)
 	q := r.query.Select("pdf")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `outputName` optional argument
@@ -747,12 +1192,79 @@ func (r *KicadPcb) Pdf(layers []string, opts ...KicadPcbPdfOpts) *File { // kica
 	}
 }
 
+// KicadPcbPdf3DOpts contains options for KicadPcb.Pdf3D
+type KicadPcbPdf3DOpts struct {
+	BoardOnly bool // kicad (../../../../../daggerverse/kicad/pcb_3d.go:184:2)
+
+	ExcludeDnp bool // kicad (../../../../../daggerverse/kicad/pcb_3d.go:186:2)
+
+	// Default: "board-3d.pdf"
+	OutputName string // kicad (../../../../../daggerverse/kicad/pcb_3d.go:188:2)
+}
+
+// Pdf3d exports the board as a 3D PDF (a PDF carrying an embedded U3D model).
+// Exposed as `pdf-3d` on the CLI.
+func (r *KicadPcb) Pdf3D(opts ...KicadPcbPdf3DOpts) *File { // kicad (../../../../../daggerverse/kicad/pcb_3d.go:181:1)
+	q := r.query.Select("pdf3D")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `boardOnly` optional argument
+		if !querybuilder.IsZeroValue(opts[i].BoardOnly) {
+			q = q.Arg("boardOnly", opts[i].BoardOnly)
+		}
+		// `excludeDnp` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ExcludeDnp) {
+			q = q.Arg("excludeDnp", opts[i].ExcludeDnp)
+		}
+		// `outputName` optional argument
+		if !querybuilder.IsZeroValue(opts[i].OutputName) {
+			q = q.Arg("outputName", opts[i].OutputName)
+		}
+	}
+
+	return &File{
+		query: q,
+	}
+}
+
 // PdfPerLayer plots each layer into its own PDF and returns the directory.
-func (r *KicadPcb) PdfPerLayer(layers []string) *Directory { // kicad (../../../../../daggerverse/kicad/pcb.go:326:1)
+func (r *KicadPcb) PdfPerLayer(layers []string) *Directory { // kicad (../../../../../daggerverse/kicad/pcb.go:308:1)
 	q := r.query.Select("pdfPerLayer")
 	q = q.Arg("layers", layers)
 
 	return &Directory{
+		query: q,
+	}
+}
+
+// KicadPcbPlyOpts contains options for KicadPcb.Ply
+type KicadPcbPlyOpts struct {
+	BoardOnly bool // kicad (../../../../../daggerverse/kicad/pcb_3d.go:123:2)
+
+	ExcludeDnp bool // kicad (../../../../../daggerverse/kicad/pcb_3d.go:125:2)
+
+	// Default: "board.ply"
+	OutputName string // kicad (../../../../../daggerverse/kicad/pcb_3d.go:127:2)
+}
+
+// Ply exports the board as a PLY mesh.
+func (r *KicadPcb) Ply(opts ...KicadPcbPlyOpts) *File { // kicad (../../../../../daggerverse/kicad/pcb_3d.go:120:1)
+	q := r.query.Select("ply")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `boardOnly` optional argument
+		if !querybuilder.IsZeroValue(opts[i].BoardOnly) {
+			q = q.Arg("boardOnly", opts[i].BoardOnly)
+		}
+		// `excludeDnp` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ExcludeDnp) {
+			q = q.Arg("excludeDnp", opts[i].ExcludeDnp)
+		}
+		// `outputName` optional argument
+		if !querybuilder.IsZeroValue(opts[i].OutputName) {
+			q = q.Arg("outputName", opts[i].OutputName)
+		}
+	}
+
+	return &File{
 		query: q,
 	}
 }
@@ -821,26 +1333,225 @@ func (r *KicadPcb) Pos(opts ...KicadPcbPosOpts) *File { // kicad (../../../../..
 	}
 }
 
+// KicadPcbPsOpts contains options for KicadPcb.Ps
+type KicadPcbPsOpts struct {
+
+	// Default: "board.ps"
+	OutputName string // kicad (../../../../../daggerverse/kicad/pcb_util.go:62:2)
+}
+
+// Ps plots the given layers into a single PostScript file (`--mode-single`).
+func (r *KicadPcb) Ps(layers []string, opts ...KicadPcbPsOpts) *File { // kicad (../../../../../daggerverse/kicad/pcb_util.go:57:1)
+	q := r.query.Select("ps")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `outputName` optional argument
+		if !querybuilder.IsZeroValue(opts[i].OutputName) {
+			q = q.Arg("outputName", opts[i].OutputName)
+		}
+	}
+	q = q.Arg("layers", layers)
+
+	return &File{
+		query: q,
+	}
+}
+
+// KicadPcbRenderOpts contains options for KicadPcb.Render
+type KicadPcbRenderOpts struct {
+	//
+	// Camera side: top, bottom, left, right, front or back.
+	//
+	//
+	// Default: "top"
+	Side string // kicad (../../../../../daggerverse/kicad/pcb_util.go:221:2)
+	//
+	// Render quality: basic, high, user or job_settings.
+	//
+	//
+	// Default: "basic"
+	Quality string // kicad (../../../../../daggerverse/kicad/pcb_util.go:224:2)
+	//
+	// Image width in pixels.
+	//
+	//
+	// Default: 1600
+	Width int // kicad (../../../../../daggerverse/kicad/pcb_util.go:227:2)
+	//
+	// Image height in pixels.
+	//
+	//
+	// Default: 900
+	Height int // kicad (../../../../../daggerverse/kicad/pcb_util.go:230:2)
+
+	// Default: "render.png"
+	OutputName string // kicad (../../../../../daggerverse/kicad/pcb_util.go:232:2)
+}
+
+// Render ray-traces the board's 3D view to a PNG or JPEG image; the output
+// format follows the outputName extension. Like the 3D model exports it is
+// only meaningful with component models, so it wants the -full image — but
+// unlike them it degrades to a bare-board render on the slim image rather than
+// failing, because a board-only render is still a useful artifact.
+func (r *KicadPcb) Render(opts ...KicadPcbRenderOpts) *File { // kicad (../../../../../daggerverse/kicad/pcb_util.go:217:1)
+	q := r.query.Select("render")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `side` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Side) {
+			q = q.Arg("side", opts[i].Side)
+		}
+		// `quality` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Quality) {
+			q = q.Arg("quality", opts[i].Quality)
+		}
+		// `width` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Width) {
+			q = q.Arg("width", opts[i].Width)
+		}
+		// `height` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Height) {
+			q = q.Arg("height", opts[i].Height)
+		}
+		// `outputName` optional argument
+		if !querybuilder.IsZeroValue(opts[i].OutputName) {
+			q = q.Arg("outputName", opts[i].OutputName)
+		}
+	}
+
+	return &File{
+		query: q,
+	}
+}
+
+// KicadPcbStatsOpts contains options for KicadPcb.Stats
+type KicadPcbStatsOpts struct {
+	//
+	// Report format: report (human-readable) or json.
+	//
+	//
+	// Default: "report"
+	Format string // kicad (../../../../../daggerverse/kicad/pcb_util.go:92:2)
+	//
+	// Report units: mm or in.
+	//
+	//
+	// Default: "mm"
+	Units string // kicad (../../../../../daggerverse/kicad/pcb_util.go:95:2)
+
+	// Default: "stats.txt"
+	OutputName string // kicad (../../../../../daggerverse/kicad/pcb_util.go:97:2)
+}
+
+// Stats generates a board statistics report (pad, via, track and area counts).
+func (r *KicadPcb) Stats(opts ...KicadPcbStatsOpts) *File { // kicad (../../../../../daggerverse/kicad/pcb_util.go:88:1)
+	q := r.query.Select("stats")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `format` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Format) {
+			q = q.Arg("format", opts[i].Format)
+		}
+		// `units` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Units) {
+			q = q.Arg("units", opts[i].Units)
+		}
+		// `outputName` optional argument
+		if !querybuilder.IsZeroValue(opts[i].OutputName) {
+			q = q.Arg("outputName", opts[i].OutputName)
+		}
+	}
+
+	return &File{
+		query: q,
+	}
+}
+
 // KicadPcbStepOpts contains options for KicadPcb.Step
 type KicadPcbStepOpts struct {
 	//
 	// Export the bare board, with no component models.
 	//
-	BoardOnly bool // kicad (../../../../../daggerverse/kicad/pcb.go:217:2)
+	BoardOnly bool // kicad (../../../../../daggerverse/kicad/pcb.go:219:2)
 	//
 	// Exclude models for components flagged Do Not Populate.
 	//
-	ExcludeDnp bool // kicad (../../../../../daggerverse/kicad/pcb.go:220:2)
+	ExcludeDnp bool // kicad (../../../../../daggerverse/kicad/pcb.go:222:2)
 
 	// Default: "board.step"
-	OutputName string // kicad (../../../../../daggerverse/kicad/pcb.go:222:2)
+	OutputName string // kicad (../../../../../daggerverse/kicad/pcb.go:224:2)
 }
 
 // Step exports the board as a STEP model. The default `10.0` image is the
-// slim variant, which ships no 3D component models — pass boardOnly to make
-// that explicit, or use the `-full` image tag for populated assemblies.
-func (r *KicadPcb) Step(opts ...KicadPcbStepOpts) *File { // kicad (../../../../../daggerverse/kicad/pcb.go:213:1)
+// slim variant, which ships no 3D component models: a with-models export
+// (boardOnly=false) fails there naming the -full image, rather than silently
+// emitting a board-only model. Pass boardOnly for board geometry alone, or
+// select the -full image for populated assemblies.
+func (r *KicadPcb) Step(opts ...KicadPcbStepOpts) *File { // kicad (../../../../../daggerverse/kicad/pcb.go:215:1)
 	q := r.query.Select("step")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `boardOnly` optional argument
+		if !querybuilder.IsZeroValue(opts[i].BoardOnly) {
+			q = q.Arg("boardOnly", opts[i].BoardOnly)
+		}
+		// `excludeDnp` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ExcludeDnp) {
+			q = q.Arg("excludeDnp", opts[i].ExcludeDnp)
+		}
+		// `outputName` optional argument
+		if !querybuilder.IsZeroValue(opts[i].OutputName) {
+			q = q.Arg("outputName", opts[i].OutputName)
+		}
+	}
+
+	return &File{
+		query: q,
+	}
+}
+
+// KicadPcbStlOpts contains options for KicadPcb.Stl
+type KicadPcbStlOpts struct {
+	BoardOnly bool // kicad (../../../../../daggerverse/kicad/pcb_3d.go:93:2)
+
+	ExcludeDnp bool // kicad (../../../../../daggerverse/kicad/pcb_3d.go:95:2)
+
+	// Default: "board.stl"
+	OutputName string // kicad (../../../../../daggerverse/kicad/pcb_3d.go:97:2)
+}
+
+// Stl exports the board as an STL mesh.
+func (r *KicadPcb) Stl(opts ...KicadPcbStlOpts) *File { // kicad (../../../../../daggerverse/kicad/pcb_3d.go:90:1)
+	q := r.query.Select("stl")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `boardOnly` optional argument
+		if !querybuilder.IsZeroValue(opts[i].BoardOnly) {
+			q = q.Arg("boardOnly", opts[i].BoardOnly)
+		}
+		// `excludeDnp` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ExcludeDnp) {
+			q = q.Arg("excludeDnp", opts[i].ExcludeDnp)
+		}
+		// `outputName` optional argument
+		if !querybuilder.IsZeroValue(opts[i].OutputName) {
+			q = q.Arg("outputName", opts[i].OutputName)
+		}
+	}
+
+	return &File{
+		query: q,
+	}
+}
+
+// KicadPcbStpzOpts contains options for KicadPcb.Stpz
+type KicadPcbStpzOpts struct {
+	BoardOnly bool // kicad (../../../../../daggerverse/kicad/pcb_3d.go:168:2)
+
+	ExcludeDnp bool // kicad (../../../../../daggerverse/kicad/pcb_3d.go:170:2)
+
+	// Default: "board.stpz"
+	OutputName string // kicad (../../../../../daggerverse/kicad/pcb_3d.go:172:2)
+}
+
+// Stpz exports the board as a zip-compressed STEP (STPZ) model.
+func (r *KicadPcb) Stpz(opts ...KicadPcbStpzOpts) *File { // kicad (../../../../../daggerverse/kicad/pcb_3d.go:165:1)
+	q := r.query.Select("stpz")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `boardOnly` optional argument
 		if !querybuilder.IsZeroValue(opts[i].BoardOnly) {
@@ -865,11 +1576,11 @@ func (r *KicadPcb) Step(opts ...KicadPcbStepOpts) *File { // kicad (../../../../
 type KicadPcbSvgOpts struct {
 
 	// Default: "board.svg"
-	OutputName string // kicad (../../../../../daggerverse/kicad/pcb.go:356:2)
+	OutputName string // kicad (../../../../../daggerverse/kicad/pcb.go:338:2)
 }
 
 // Svg plots the given layers into a single SVG.
-func (r *KicadPcb) Svg(layers []string, opts ...KicadPcbSvgOpts) *File { // kicad (../../../../../daggerverse/kicad/pcb.go:351:1)
+func (r *KicadPcb) Svg(layers []string, opts ...KicadPcbSvgOpts) *File { // kicad (../../../../../daggerverse/kicad/pcb.go:333:1)
 	q := r.query.Select("svg")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `outputName` optional argument
@@ -885,11 +1596,159 @@ func (r *KicadPcb) Svg(layers []string, opts ...KicadPcbSvgOpts) *File { // kica
 }
 
 // SvgPerLayer plots each layer into its own SVG and returns the directory.
-func (r *KicadPcb) SvgPerLayer(layers []string) *Directory { // kicad (../../../../../daggerverse/kicad/pcb.go:382:1)
+func (r *KicadPcb) SvgPerLayer(layers []string) *Directory { // kicad (../../../../../daggerverse/kicad/pcb.go:364:1)
 	q := r.query.Select("svgPerLayer")
 	q = q.Arg("layers", layers)
 
 	return &Directory{
+		query: q,
+	}
+}
+
+// KicadPcbU3DOpts contains options for KicadPcb.U3D
+type KicadPcbU3DOpts struct {
+	BoardOnly bool // kicad (../../../../../daggerverse/kicad/pcb_3d.go:138:2)
+
+	ExcludeDnp bool // kicad (../../../../../daggerverse/kicad/pcb_3d.go:140:2)
+
+	// Default: "board.u3d"
+	OutputName string // kicad (../../../../../daggerverse/kicad/pcb_3d.go:142:2)
+}
+
+// U3d exports the board as a Universal 3D (U3D) model.
+func (r *KicadPcb) U3D(opts ...KicadPcbU3DOpts) *File { // kicad (../../../../../daggerverse/kicad/pcb_3d.go:135:1)
+	q := r.query.Select("u3D")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `boardOnly` optional argument
+		if !querybuilder.IsZeroValue(opts[i].BoardOnly) {
+			q = q.Arg("boardOnly", opts[i].BoardOnly)
+		}
+		// `excludeDnp` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ExcludeDnp) {
+			q = q.Arg("excludeDnp", opts[i].ExcludeDnp)
+		}
+		// `outputName` optional argument
+		if !querybuilder.IsZeroValue(opts[i].OutputName) {
+			q = q.Arg("outputName", opts[i].OutputName)
+		}
+	}
+
+	return &File{
+		query: q,
+	}
+}
+
+// KicadPcbUpgradeOpts contains options for KicadPcb.Upgrade
+type KicadPcbUpgradeOpts struct {
+	//
+	// Resave even when the board is already at the latest format version.
+	//
+	Force bool // kicad (../../../../../daggerverse/kicad/pcb_util.go:312:2)
+}
+
+// Upgrade resaves the board in the current KiCad file format and returns the
+// upgraded .kicad_pcb. kicad-cli's `pcb upgrade` rewrites the file in place and
+// has no output flag, so the board runs against a writable copy (owned by the
+// image's UID-1000 user) rather than the read-only mounted source.
+func (r *KicadPcb) Upgrade(opts ...KicadPcbUpgradeOpts) *File { // kicad (../../../../../daggerverse/kicad/pcb_util.go:308:1)
+	q := r.query.Select("upgrade")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `force` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Force) {
+			q = q.Arg("force", opts[i].Force)
+		}
+	}
+
+	return &File{
+		query: q,
+	}
+}
+
+// KicadPcbVrmlOpts contains options for KicadPcb.Vrml
+type KicadPcbVrmlOpts struct {
+	//
+	// Acknowledge board-geometry-only output on the slim image, skipping the
+	// -full guard. VRML has no board-only mode, so this cannot exclude models
+	// on the -full image.
+	//
+	BoardOnly bool // kicad (../../../../../daggerverse/kicad/pcb_3d.go:208:2)
+	//
+	// Exclude models for components flagged Do Not Populate.
+	//
+	ExcludeDnp bool // kicad (../../../../../daggerverse/kicad/pcb_3d.go:211:2)
+	//
+	// Output units: mm, m, in or tenths.
+	//
+	//
+	// Default: "mm"
+	Units string // kicad (../../../../../daggerverse/kicad/pcb_3d.go:214:2)
+
+	// Default: "board.wrl"
+	OutputName string // kicad (../../../../../daggerverse/kicad/pcb_3d.go:216:2)
+}
+
+// Vrml exports the board as a VRML model. Unlike the other 3D exports
+// kicad-cli's `pcb export vrml` has no --board-only flag, so boardOnly here is
+// a module-level acknowledgement rather than a kicad-cli switch: it gates the
+// -full-image guard only. On the slim image no component models resolve, so
+// boardOnly=true yields the board geometry alone; on the -full image the
+// models are always embedded regardless, which is why boardOnly cannot suppress
+// them for VRML.
+func (r *KicadPcb) Vrml(opts ...KicadPcbVrmlOpts) *File { // kicad (../../../../../daggerverse/kicad/pcb_3d.go:202:1)
+	q := r.query.Select("vrml")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `boardOnly` optional argument
+		if !querybuilder.IsZeroValue(opts[i].BoardOnly) {
+			q = q.Arg("boardOnly", opts[i].BoardOnly)
+		}
+		// `excludeDnp` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ExcludeDnp) {
+			q = q.Arg("excludeDnp", opts[i].ExcludeDnp)
+		}
+		// `units` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Units) {
+			q = q.Arg("units", opts[i].Units)
+		}
+		// `outputName` optional argument
+		if !querybuilder.IsZeroValue(opts[i].OutputName) {
+			q = q.Arg("outputName", opts[i].OutputName)
+		}
+	}
+
+	return &File{
+		query: q,
+	}
+}
+
+// KicadPcbXaoOpts contains options for KicadPcb.Xao
+type KicadPcbXaoOpts struct {
+	BoardOnly bool // kicad (../../../../../daggerverse/kicad/pcb_3d.go:153:2)
+
+	ExcludeDnp bool // kicad (../../../../../daggerverse/kicad/pcb_3d.go:155:2)
+
+	// Default: "board.xao"
+	OutputName string // kicad (../../../../../daggerverse/kicad/pcb_3d.go:157:2)
+}
+
+// Xao exports the board as an XAO model (Salome geometry exchange).
+func (r *KicadPcb) Xao(opts ...KicadPcbXaoOpts) *File { // kicad (../../../../../daggerverse/kicad/pcb_3d.go:150:1)
+	q := r.query.Select("xao")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `boardOnly` optional argument
+		if !querybuilder.IsZeroValue(opts[i].BoardOnly) {
+			q = q.Arg("boardOnly", opts[i].BoardOnly)
+		}
+		// `excludeDnp` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ExcludeDnp) {
+			q = q.Arg("excludeDnp", opts[i].ExcludeDnp)
+		}
+		// `outputName` optional argument
+		if !querybuilder.IsZeroValue(opts[i].OutputName) {
+			q = q.Arg("outputName", opts[i].OutputName)
+		}
+	}
+
+	return &File{
 		query: q,
 	}
 }
@@ -904,7 +1763,7 @@ func (r *KicadPcb) AsNode() Node {
 
 // Project is a KiCad project tree plus the options that apply to nearly every
 // kicad-cli subcommand. It is immutable: every With* returns a copy.
-type KicadProject struct { // kicad (../../../../../daggerverse/kicad/main.go:126:6)
+type KicadProject struct { // kicad (../../../../../daggerverse/kicad/main.go:156:6)
 	query *querybuilder.Selection
 
 	id *ID
@@ -980,7 +1839,7 @@ func (r *KicadProject) UnmarshalJSON(bs []byte) error {
 // The jobset's outputs are written relative to the project, which is why the
 // whole tree comes back rather than a lone output folder: the jobset — not
 // this module — decides where its artifacts land.
-func (r *KicadProject) Jobset(path string) *Directory { // kicad (../../../../../daggerverse/kicad/main.go:211:1)
+func (r *KicadProject) Jobset(path string) *Directory { // kicad (../../../../../daggerverse/kicad/main.go:241:1)
 	q := r.query.Select("jobset")
 	q = q.Arg("path", path)
 
@@ -994,14 +1853,14 @@ type KicadProjectPcbOpts struct {
 	//
 	// Project-relative path to the .kicad_pcb; empty auto-discovers.
 	//
-	Path string // kicad (../../../../../daggerverse/kicad/main.go:186:2)
+	Path string // kicad (../../../../../daggerverse/kicad/main.go:216:2)
 }
 
 // Pcb selects a board within the project. An empty path auto-discovers the
 // single *.kicad_pcb in the tree and errors when there are zero or more than
 // one; discovery is deferred to the exec so the error surfaces on the call
 // that needed the board.
-func (r *KicadProject) Pcb(opts ...KicadProjectPcbOpts) *KicadPcb { // kicad (../../../../../daggerverse/kicad/main.go:183:1)
+func (r *KicadProject) Pcb(opts ...KicadProjectPcbOpts) *KicadPcb { // kicad (../../../../../daggerverse/kicad/main.go:213:1)
 	q := r.query.Select("pcb")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `path` optional argument
@@ -1020,13 +1879,13 @@ type KicadProjectSchOpts struct {
 	//
 	// Project-relative path to the .kicad_sch; empty auto-discovers.
 	//
-	Path string // kicad (../../../../../daggerverse/kicad/main.go:197:2)
+	Path string // kicad (../../../../../daggerverse/kicad/main.go:227:2)
 }
 
 // Sch selects a schematic within the project. An empty path auto-discovers
 // the single *.kicad_sch in the tree, ignoring the sub-sheets of a
 // hierarchical design, and errors when there are zero or more than one root.
-func (r *KicadProject) Sch(opts ...KicadProjectSchOpts) *KicadSch { // kicad (../../../../../daggerverse/kicad/main.go:194:1)
+func (r *KicadProject) Sch(opts ...KicadProjectSchOpts) *KicadSch { // kicad (../../../../../daggerverse/kicad/main.go:224:1)
 	q := r.query.Select("sch")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `path` optional argument
@@ -1043,7 +1902,7 @@ func (r *KicadProject) Sch(opts ...KicadProjectSchOpts) *KicadSch { // kicad (..
 // WithDrawingSheet overrides the project's drawing sheet with the supplied
 // .kicad_wks file (`--drawing-sheet`). It applies to the plotting exports;
 // subcommands that do not accept the flag ignore it.
-func (r *KicadProject) WithDrawingSheet(sheet *File) *KicadProject { // kicad (../../../../../daggerverse/kicad/main.go:173:1)
+func (r *KicadProject) WithDrawingSheet(sheet *File) *KicadProject { // kicad (../../../../../daggerverse/kicad/main.go:203:1)
 	assertNotNil("sheet", sheet)
 	q := r.query.Select("withDrawingSheet")
 	q = q.Arg("sheet", sheet)
@@ -1060,7 +1919,7 @@ func (r *KicadProject) WithDrawingSheet(sheet *File) *KicadProject { // kicad (.
 // cannot accept map parameters. Validation is deferred to the exec: builder
 // methods have no error return, so a bad name surfaces when the export or
 // check that would have used it runs.
-func (r *KicadProject) WithVar(name string, value string) *KicadProject { // kicad (../../../../../daggerverse/kicad/main.go:148:1)
+func (r *KicadProject) WithVar(name string, value string) *KicadProject { // kicad (../../../../../daggerverse/kicad/main.go:178:1)
 	q := r.query.Select("withVar")
 	q = q.Arg("name", name)
 	q = q.Arg("value", value)
@@ -1079,7 +1938,7 @@ func (r *KicadProject) WithVar(name string, value string) *KicadProject { // kic
 // name, so an unrecognised variant would otherwise produce a wrong export with
 // no signal. Like WithVar, the check is deferred to the exec that uses it,
 // because a builder method has no error return.
-func (r *KicadProject) WithVariant(variant string) *KicadProject { // kicad (../../../../../daggerverse/kicad/main.go:164:1)
+func (r *KicadProject) WithVariant(variant string) *KicadProject { // kicad (../../../../../daggerverse/kicad/main.go:194:1)
 	q := r.query.Select("withVariant")
 	q = q.Arg("variant", variant)
 
@@ -1167,6 +2026,17 @@ func (r *KicadSch) Bom(opts ...KicadSchBomOpts) *File { // kicad (../../../../..
 	}
 
 	return &File{
+		query: q,
+	}
+}
+
+// Dxf plots the schematic to DXF, one file per sheet, and returns the
+// directory. Like Svg there is no single-file counterpart: kicad-cli always
+// plots schematics per sheet.
+func (r *KicadSch) Dxf() *Directory { // kicad (../../../../../daggerverse/kicad/sch.go:179:1)
+	q := r.query.Select("dxf")
+
+	return &Directory{
 		query: q,
 	}
 }
@@ -1308,6 +2178,16 @@ func (r *KicadSch) Pdf(opts ...KicadSchPdfOpts) *File { // kicad (../../../../..
 	}
 }
 
+// Ps plots the schematic to PostScript, one file per sheet, and returns the
+// directory.
+func (r *KicadSch) Ps() *Directory { // kicad (../../../../../daggerverse/kicad/sch.go:197:1)
+	q := r.query.Select("ps")
+
+	return &Directory{
+		query: q,
+	}
+}
+
 // Svg plots the schematic to SVG, one file per sheet, and returns the
 // directory. Unlike Pcb.Svg there is no single-file counterpart: kicad-cli
 // always plots schematics per sheet.
@@ -1327,6 +2207,125 @@ func (r *KicadSch) AsNode() Node {
 	}
 }
 
+// Sym is a symbol library (a .kicad_sym file) bound to the toolchain.
+type KicadSym struct { // kicad (../../../../../daggerverse/kicad/library.go:98:6)
+	query *querybuilder.Selection
+
+	id *ID
+}
+
+func (r *KicadSym) WithGraphQLQuery(q *querybuilder.Selection) *KicadSym {
+	return &KicadSym{
+		query: q,
+	}
+}
+
+// A unique identifier for this KicadSym.
+func (r *KicadSym) ID(ctx context.Context) (ID, error) {
+	if r.id != nil {
+		return *r.id, nil
+	}
+	q := r.query.Select("id")
+
+	var response ID
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// XXX_GraphQLType is an internal function. It returns the native GraphQL type name
+func (r *KicadSym) XXX_GraphQLType() string {
+	return "KicadSym"
+}
+
+// XXX_GraphQLIDType is an internal function. It returns the native GraphQL type name for the ID of this object
+func (r *KicadSym) XXX_GraphQLIDType() string {
+	return "ID"
+}
+
+// XXX_GraphQLID is an internal function. It returns the underlying type ID
+func (r *KicadSym) XXX_GraphQLID(ctx context.Context) (string, error) {
+	id, err := r.ID(ctx)
+	if err != nil {
+		return "", err
+	}
+	return string(id), nil
+}
+
+func (r *KicadSym) MarshalJSON() ([]byte, error) {
+	id, err := r.ID(marshalCtx)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(id)
+}
+func (r *KicadSym) UnmarshalJSON(bs []byte) error {
+	var id string
+	err := json.Unmarshal(bs, &id)
+	if err != nil {
+		return err
+	}
+	*r = KicadSym{query: selectNode(dag.query, id, "KicadSym")}
+	return nil
+}
+
+// KicadSymSvgOpts contains options for KicadSym.Svg
+type KicadSymSvgOpts struct {
+	//
+	// Export only this symbol from the library; empty exports all.
+	//
+	Symbol string // kicad (../../../../../daggerverse/kicad/library.go:122:2)
+}
+
+// Svg exports the symbol library to SVG, one file per symbol unit, and returns
+// the directory. Pass symbol to export a single symbol by name instead of the
+// whole library.
+func (r *KicadSym) Svg(opts ...KicadSymSvgOpts) *Directory { // kicad (../../../../../daggerverse/kicad/library.go:118:1)
+	q := r.query.Select("svg")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `symbol` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Symbol) {
+			q = q.Arg("symbol", opts[i].Symbol)
+		}
+	}
+
+	return &Directory{
+		query: q,
+	}
+}
+
+// KicadSymUpgradeOpts contains options for KicadSym.Upgrade
+type KicadSymUpgradeOpts struct {
+	//
+	// Resave even when the library is already at the latest format version.
+	//
+	Force bool // kicad (../../../../../daggerverse/kicad/library.go:146:2)
+}
+
+// Upgrade resaves the symbol library in the current KiCad format and returns
+// the upgraded .kicad_sym file.
+func (r *KicadSym) Upgrade(opts ...KicadSymUpgradeOpts) *File { // kicad (../../../../../daggerverse/kicad/library.go:142:1)
+	q := r.query.Select("upgrade")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `force` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Force) {
+			q = q.Arg("force", opts[i].Force)
+		}
+	}
+
+	return &File{
+		query: q,
+	}
+}
+
+// AsNode returns this KicadSym as a Node.
+// This is a local type conversion — no GraphQL call.
+func (r *KicadSym) AsNode() Node {
+	return &NodeClient{
+		query: r.query,
+	}
+}
+
 // KicadOpts contains options for Query.Kicad
 type KicadOpts struct {
 	//
@@ -1334,17 +2333,25 @@ type KicadOpts struct {
 	//
 	//
 	// Default: "docker.io"
-	Registry string // kicad (../../../../../daggerverse/kicad/main.go:76:2)
+	Registry string // kicad (../../../../../daggerverse/kicad/main.go:82:2)
 	//
 	// Image tag for kicad/kicad.
 	//
 	//
 	// Default: "10.0"
-	Tag string // kicad (../../../../../daggerverse/kicad/main.go:79:2)
+	Tag string // kicad (../../../../../daggerverse/kicad/main.go:85:2)
+	//
+	// Select the -full image variant, which bundles the 3D component-model
+	// libraries the slim image omits. The suffix is appended to tag, so
+	// full=true with the default 10.0 tag resolves 10.0-full. Required for any
+	// 3D export that includes component models (Step without boardOnly, Glb,
+	// Stl, ...); ~1.34GB against the slim image's ~770MB.
+	//
+	Full bool // kicad (../../../../../daggerverse/kicad/main.go:92:2)
 }
 
 // New returns a Kicad module backed by <registry>/kicad/kicad:<tag>.
-func (r *Query) Kicad(opts ...KicadOpts) *Kicad { // kicad (../../../../../daggerverse/kicad/main.go:73:1)
+func (r *Query) Kicad(opts ...KicadOpts) *Kicad { // kicad (../../../../../daggerverse/kicad/main.go:79:1)
 	q := r.query.Select("kicad")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `registry` optional argument
@@ -1354,6 +2361,10 @@ func (r *Query) Kicad(opts ...KicadOpts) *Kicad { // kicad (../../../../../dagge
 		// `tag` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Tag) {
 			q = q.Arg("tag", opts[i].Tag)
+		}
+		// `full` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Full) {
+			q = q.Arg("full", opts[i].Full)
 		}
 	}
 

--- a/daggerverse/kicad/tests/main.go
+++ b/daggerverse/kicad/tests/main.go
@@ -91,6 +91,26 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("CiRunProducesFabricationOutputs", t.CiRunProducesFabricationOutputs)
 	jobs = jobs.WithJob("CiRunShortCircuitsOnFailingCheck", t.CiRunShortCircuitsOnFailingCheck)
 
+	jobs = jobs.WithJob("ThreeDExportRequiresFullImage", t.ThreeDExportRequiresFullImage)
+	jobs = jobs.WithJob("StepWithComponentModelsIncludesModels", t.StepWithComponentModelsIncludesModels)
+	jobs = jobs.WithJob("GlbBoardOnlyProducesGlb", t.GlbBoardOnlyProducesGlb)
+	jobs = jobs.WithJob("VrmlBoardOnlyProducesVrml", t.VrmlBoardOnlyProducesVrml)
+	jobs = jobs.WithJob("PcbDxfProducesDxf", t.PcbDxfProducesDxf)
+	jobs = jobs.WithJob("PcbPsProducesPostscript", t.PcbPsProducesPostscript)
+	jobs = jobs.WithJob("StatsProducesReport", t.StatsProducesReport)
+	jobs = jobs.WithJob("GencadProducesGencad", t.GencadProducesGencad)
+	jobs = jobs.WithJob("Ipcd356ProducesNetlist", t.Ipcd356ProducesNetlist)
+	jobs = jobs.WithJob("OdbProducesArchive", t.OdbProducesArchive)
+	jobs = jobs.WithJob("RenderProducesPng", t.RenderProducesPng)
+	jobs = jobs.WithJob("ImportRejectsUnknownFormat", t.ImportRejectsUnknownFormat)
+	jobs = jobs.WithJob("PcbUpgradeProducesBoard", t.PcbUpgradeProducesBoard)
+	jobs = jobs.WithJob("SchDxfProducesFilePerSheet", t.SchDxfProducesFilePerSheet)
+	jobs = jobs.WithJob("SchPsProducesFilePerSheet", t.SchPsProducesFilePerSheet)
+	jobs = jobs.WithJob("FpSvgExportsFootprint", t.FpSvgExportsFootprint)
+	jobs = jobs.WithJob("FpUpgradeResavesLibrary", t.FpUpgradeResavesLibrary)
+	jobs = jobs.WithJob("SymSvgExportsSymbol", t.SymSvgExportsSymbol)
+	jobs = jobs.WithJob("SymUpgradeResavesLibrary", t.SymUpgradeResavesLibrary)
+
 	return jobs.Run(ctx)
 }
 
@@ -761,6 +781,267 @@ func (t *Tests) CiRunShortCircuitsOnFailingCheck(ctx context.Context) error {
 	return nil
 }
 
+// ------------------------------------------- 3D exports, image variant
+
+// ThreeDExportRequiresFullImage asserts a with-models 3D export on the slim
+// image fails with an error naming the -full tag, rather than silently emitting
+// a board-only model. Glb stands in for the whole step-family here; every one
+// of them routes through the same require3DModels guard.
+func (t *Tests) ThreeDExportRequiresFullImage(ctx context.Context) error {
+	_, err := dag.Kicad().Project(fixture("blinky")).Pcb().Glb().Sync(ctx)
+	if err == nil {
+		return fmt.Errorf("expected a with-models Glb on the slim image to fail, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{"component 3D models", "10.0-full"} {
+		if !strings.Contains(msg, want) {
+			return fmt.Errorf("expected the guard error to mention %q, got: %v", want, err)
+		}
+	}
+	return nil
+}
+
+// StepWithComponentModelsIncludesModels asserts a with-models STEP on the -full
+// image differs from the boardOnly output. The blinky R1 footprint references a
+// component 3D model that only the -full image bundles, so the populated
+// assembly carries geometry the bare board does not — proving the with-models
+// path actually resolved and embedded the model rather than falling back to
+// board geometry.
+func (t *Tests) StepWithComponentModelsIncludesModels(ctx context.Context) error {
+	pcb := dag.Kicad(dagger.KicadOpts{Full: true}).Project(fixture("blinky")).Pcb()
+
+	withModels, err := exportBytes(ctx, pcb.Step(), "with-models.step")
+	if err != nil {
+		return fmt.Errorf("with-models Step: %w", err)
+	}
+	boardOnly, err := exportBytes(ctx, pcb.Step(dagger.KicadPcbStepOpts{BoardOnly: true}), "board-only.step")
+	if err != nil {
+		return fmt.Errorf("board-only Step: %w", err)
+	}
+	if bytes.Equal(withModels, boardOnly) {
+		return fmt.Errorf("expected the with-models STEP to differ from the board-only STEP, got identical output")
+	}
+	if len(withModels) <= len(boardOnly) {
+		return fmt.Errorf("expected the with-models STEP (%d bytes) to be larger than the board-only STEP (%d bytes)",
+			len(withModels), len(boardOnly))
+	}
+	if !bytes.HasPrefix(withModels, []byte("ISO-10303-21;")) {
+		return fmt.Errorf("expected the with-models output to be a STEP file, got %q", firstBytes(withModels, 13))
+	}
+	return nil
+}
+
+// GlbBoardOnlyProducesGlb asserts the board-only GLB export produces a real
+// binary glTF, whose files open with the "glTF" magic.
+func (t *Tests) GlbBoardOnlyProducesGlb(ctx context.Context) error {
+	f := dag.Kicad().Project(fixture("blinky")).Pcb().Glb(dagger.KicadPcbGlbOpts{BoardOnly: true})
+	return assertMagic(ctx, f, "board.glb", []byte("glTF"))
+}
+
+// VrmlBoardOnlyProducesVrml asserts the board-only VRML export produces a VRML
+// v2.0 document. VRML has no kicad-cli board-only flag, so boardOnly here only
+// skips the -full guard; on the slim image the output is board geometry alone.
+func (t *Tests) VrmlBoardOnlyProducesVrml(ctx context.Context) error {
+	out, err := dag.Kicad().Project(fixture("blinky")).Pcb().
+		Vrml(dagger.KicadPcbVrmlOpts{BoardOnly: true}).Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("Vrml: %w", err)
+	}
+	if !strings.HasPrefix(out, "#VRML") {
+		return fmt.Errorf("expected a VRML document, got:\n%s", head(out))
+	}
+	return nil
+}
+
+// ------------------------------------------- long-tail 2D and utility
+
+// PcbDxfProducesDxf asserts the single-file DXF plot produces a DXF drawing,
+// whose ASCII form opens with a SECTION record.
+func (t *Tests) PcbDxfProducesDxf(ctx context.Context) error {
+	out, err := dag.Kicad().Project(fixture("blinky")).Pcb().
+		Dxf([]string{"F.Cu", "Edge.Cuts"}).Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("Dxf: %w", err)
+	}
+	if !strings.Contains(out, "SECTION") {
+		return fmt.Errorf("expected a DXF drawing, got:\n%s", head(out))
+	}
+	return nil
+}
+
+// PcbPsProducesPostscript asserts the single-file PostScript plot produces a
+// document opening with the "%!PS" magic.
+func (t *Tests) PcbPsProducesPostscript(ctx context.Context) error {
+	f := dag.Kicad().Project(fixture("blinky")).Pcb().Ps([]string{"F.Cu", "Edge.Cuts"})
+	return assertMagic(ctx, f, "board.ps", []byte("%!PS"))
+}
+
+// StatsProducesReport asserts the board statistics report is produced and reads
+// as a human-readable report.
+func (t *Tests) StatsProducesReport(ctx context.Context) error {
+	out, err := dag.Kicad().Project(fixture("blinky")).Pcb().Stats().Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("Stats: %w", err)
+	}
+	if !strings.Contains(out, "PCB statistics") {
+		return fmt.Errorf("expected a board statistics report, got:\n%s", head(out))
+	}
+	return nil
+}
+
+// GencadProducesGencad asserts the GenCAD export produces a GenCAD file, which
+// opens with a $HEADER section naming the format.
+func (t *Tests) GencadProducesGencad(ctx context.Context) error {
+	out, err := dag.Kicad().Project(fixture("blinky")).Pcb().Gencad().Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("Gencad: %w", err)
+	}
+	if !strings.Contains(out, "$HEADER") || !strings.Contains(out, "GENCAD") {
+		return fmt.Errorf("expected a GenCAD document, got:\n%s", head(out))
+	}
+	return nil
+}
+
+// Ipcd356ProducesNetlist asserts the IPC-D-356 export produces a bare-board
+// test netlist, whose records carry the format's CODE/UNITS parameters.
+func (t *Tests) Ipcd356ProducesNetlist(ctx context.Context) error {
+	out, err := dag.Kicad().Project(fixture("blinky")).Pcb().Ipcd356().Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("Ipcd356: %w", err)
+	}
+	if !strings.Contains(out, "UNITS") {
+		return fmt.Errorf("expected an IPC-D-356 netlist, got:\n%s", head(out))
+	}
+	return nil
+}
+
+// OdbProducesArchive asserts the ODB++ export produces a zip archive, which
+// opens with the "PK" local-file-header magic.
+func (t *Tests) OdbProducesArchive(ctx context.Context) error {
+	f := dag.Kicad().Project(fixture("blinky")).Pcb().Odb()
+	return assertMagic(ctx, f, "odb.zip", []byte("PK\x03\x04"))
+}
+
+// RenderProducesPng asserts the 3D render produces a PNG image, which opens
+// with the PNG signature. On the slim image this is a bare-board render, which
+// is a valid PNG all the same.
+func (t *Tests) RenderProducesPng(ctx context.Context) error {
+	f := dag.Kicad().Project(fixture("blinky")).Pcb().Render()
+	return assertMagic(ctx, f, "render.png", []byte("\x89PNG\r\n\x1a\n"))
+}
+
+// ImportRejectsUnknownFormat asserts the import format enum is validated,
+// listing every format kicad-cli accepts, rather than passed through. Import
+// converts a foreign board and needs no real fixture to prove the validation.
+func (t *Tests) ImportRejectsUnknownFormat(ctx context.Context) error {
+	_, err := dag.Kicad().Project(fixture("blinky")).Pcb().
+		Import("foreign.brd", dagger.KicadPcbImportOpts{Format: "verilog"}).Sync(ctx)
+	if err == nil {
+		return fmt.Errorf("expected an error for an invalid import format, got nil")
+	}
+	if !strings.Contains(err.Error(), "must be one of") || !strings.Contains(err.Error(), "eagle") {
+		return fmt.Errorf("expected the legal format set in the error, got: %v", err)
+	}
+	return nil
+}
+
+// PcbUpgradeProducesBoard asserts the in-place board upgrade returns a resaved
+// .kicad_pcb. kicad-cli's upgrade has no output flag and rewrites the file in
+// place, so a returned board proves the writable-copy path worked.
+func (t *Tests) PcbUpgradeProducesBoard(ctx context.Context) error {
+	out, err := dag.Kicad().Project(fixture("blinky")).Pcb().
+		Upgrade(dagger.KicadPcbUpgradeOpts{Force: true}).Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("Upgrade: %w", err)
+	}
+	if !strings.Contains(out, "(kicad_pcb") {
+		return fmt.Errorf("expected an upgraded .kicad_pcb, got:\n%s", head(out))
+	}
+	return nil
+}
+
+// SchDxfProducesFilePerSheet asserts the schematic DXF plot lands one file per
+// sheet in the returned directory.
+func (t *Tests) SchDxfProducesFilePerSheet(ctx context.Context) error {
+	entries, err := dag.Kicad().Project(fixture("blinky")).Sch().Dxf().Entries(ctx)
+	if err != nil {
+		return fmt.Errorf("Sch.Dxf: %w", err)
+	}
+	if !contains(entries, "blinky.dxf") {
+		return fmt.Errorf("expected blinky.dxf, got %v", entries)
+	}
+	return nil
+}
+
+// SchPsProducesFilePerSheet asserts the schematic PostScript plot lands one
+// file per sheet in the returned directory.
+func (t *Tests) SchPsProducesFilePerSheet(ctx context.Context) error {
+	entries, err := dag.Kicad().Project(fixture("blinky")).Sch().Ps().Entries(ctx)
+	if err != nil {
+		return fmt.Errorf("Sch.Ps: %w", err)
+	}
+	if !contains(entries, "blinky.ps") {
+		return fmt.Errorf("expected blinky.ps, got %v", entries)
+	}
+	return nil
+}
+
+// --------------------------------------------- fp and sym libraries
+
+// FpSvgExportsFootprint asserts the footprint-library SVG export lands one SVG
+// per footprint, named after the footprint, in the returned directory.
+func (t *Tests) FpSvgExportsFootprint(ctx context.Context) error {
+	entries, err := dag.Kicad().Fp(fixtureDir("fplib/test.pretty")).Svg().Entries(ctx)
+	if err != nil {
+		return fmt.Errorf("Fp.Svg: %w", err)
+	}
+	if !contains(entries, "R_0805.svg") {
+		return fmt.Errorf("expected R_0805.svg, got %v", entries)
+	}
+	return nil
+}
+
+// FpUpgradeResavesLibrary asserts the footprint-library upgrade returns the
+// resaved .pretty directory with its .kicad_mod file in place.
+func (t *Tests) FpUpgradeResavesLibrary(ctx context.Context) error {
+	entries, err := dag.Kicad().Fp(fixtureDir("fplib/test.pretty")).
+		Upgrade(dagger.KicadFpUpgradeOpts{Force: true}).Entries(ctx)
+	if err != nil {
+		return fmt.Errorf("Fp.Upgrade: %w", err)
+	}
+	if !contains(entries, "R_0805.kicad_mod") {
+		return fmt.Errorf("expected R_0805.kicad_mod, got %v", entries)
+	}
+	return nil
+}
+
+// SymSvgExportsSymbol asserts the symbol-library SVG export lands one SVG per
+// symbol unit in the returned directory.
+func (t *Tests) SymSvgExportsSymbol(ctx context.Context) error {
+	entries, err := dag.Kicad().Sym(fixtureFile("symlib/test.kicad_sym")).Svg().Entries(ctx)
+	if err != nil {
+		return fmt.Errorf("Sym.Svg: %w", err)
+	}
+	if !contains(entries, "R_unit1.svg") {
+		return fmt.Errorf("expected R_unit1.svg, got %v", entries)
+	}
+	return nil
+}
+
+// SymUpgradeResavesLibrary asserts the symbol-library upgrade returns the
+// resaved .kicad_sym file.
+func (t *Tests) SymUpgradeResavesLibrary(ctx context.Context) error {
+	out, err := dag.Kicad().Sym(fixtureFile("symlib/test.kicad_sym")).
+		Upgrade(dagger.KicadSymUpgradeOpts{Force: true}).Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("Sym.Upgrade: %w", err)
+	}
+	if !strings.Contains(out, "kicad_symbol_lib") {
+		return fmt.Errorf("expected an upgraded .kicad_sym, got:\n%s", head(out))
+	}
+	return nil
+}
+
 // ------------------------------------------------------------------ helpers
 
 // fixture returns the named hand-authored KiCad project under fixtures/.
@@ -769,10 +1050,33 @@ func fixture(name string) *dagger.Directory {
 }
 
 // fixtureFile returns a single file under fixtures/ by project-relative path,
-// for the inputs — like a drawing sheet — that WithDrawingSheet takes as a
-// lone *dagger.File rather than a project directory.
+// for the inputs — like a drawing sheet or a symbol library — that a function
+// takes as a lone *dagger.File rather than a project directory.
 func fixtureFile(path string) *dagger.File {
 	return dag.CurrentModule().Source().File("fixtures/" + path)
+}
+
+// fixtureDir returns a subdirectory under fixtures/ by project-relative path,
+// for the library inputs (a .pretty footprint library) that are a directory
+// but not a whole KiCad project.
+func fixtureDir(path string) *dagger.Directory {
+	return dag.CurrentModule().Source().Directory("fixtures/" + path)
+}
+
+// exportBytes exports a file artifact and returns its raw bytes, for the
+// assertions that compare whole files rather than just their leading magic.
+func exportBytes(ctx context.Context, f *dagger.File, name string) ([]byte, error) {
+	dir, err := os.MkdirTemp(".", "kicad-")
+	if err != nil {
+		return nil, fmt.Errorf("temp dir: %w", err)
+	}
+	defer os.RemoveAll(dir)
+
+	path := filepath.Join(dir, name)
+	if _, err := f.Export(ctx, path); err != nil {
+		return nil, fmt.Errorf("export %s: %w", name, err)
+	}
+	return os.ReadFile(path)
 }
 
 // assertMagic exports a binary artifact and compares its leading bytes.


### PR DESCRIPTION
Closes #159. Builds on #156.

Wraps the remainder of kicad-cli's fabrication surface: the `-full` image variant, the 3D exports that only mean something with its component-model libraries, and the long tail of exotic/legacy formats. Everything here was reachable via `Container()`; this makes it first-class.

## Image variant + component-model guard
- `New(full: true)` appends the `-full` suffix to the tag (composes with a pinned tag/mirror); a bare `-full` tag string is treated identically.
- A with-models 3D export on the slim image now **fails with an error naming the `-full` tag**, rather than silently emitting a board-only model (`require3DModels`). `boardOnly` opts out of models and the guard.

## 3D exports (`pcb_3d.go`)
`Glb`, `Stl`, `Brep`, `Ply`, `U3d`, `Xao`, `Stpz`, `Pdf3d` (shared `export3D`) and `Vrml`. `Step`'s with-models path routes through the guard. `Vrml` has no kicad-cli board-only flag, so its `boardOnly` only gates the guard — documented.

## Long-tail 2D / utility (`pcb_util.go`, `sch.go`)
`Pcb.Dxf/Ps/Stats/Gencad/Ipcd356/Odb/Render/Import/Upgrade` and `Sch.Dxf/Ps`. `hpgl` is deliberately **not** wrapped (self-reports as removed in KiCad 10) — README says why.

## fp / sym families (`library.go`)
Topology: these act on libraries, not a project, so they attach to `Kicad` directly. `Kicad.Fp(*Directory)` binds a `.pretty` footprint library; `Kicad.Sym(*File)` binds a `.kicad_sym` symbol library. Each exposes `Svg` and `Upgrade`. Rationale in the README.

## Tests & fixtures
- A resolvable 3D model ref on blinky's R1 (present only on `-full`), plus `fplib/test.pretty` and `symlib/test.kicad_sym`.
- 19 new smoke tests asserting output shape (magic bytes for binary), including `StepWithComponentModelsIncludesModels` (full image: with-models ≠ board-only) and the slim-image guard. `tests/All` passes.

## Acceptance criteria
- [x] Caller can select `-full`, documented in README
- [x] With-models 3D export on slim fails naming the `-full` tag
- [x] `StepWithComponentModelsIncludesModels` asserts with-models differs from `boardOnly`
- [x] New 3D + long-tail functions appear in `dagger functions`, each session-cached
- [x] `hpgl` deliberately not wrapped, README says why
- [x] `fp`/`sym` attach to a documented object, topology explained
- [x] At least one smoke test per newly wrapped family passes
- [x] `tests/All` includes the new tests and passes
- [x] `dagger develop` run in `daggerverse/kicad` and `daggerverse/kicad/tests` (+ root `kicad-tests` binding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)