### PR TITLE
story(issue-179): reattribute per-toolchain ci/ aggregator bindings to their module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,10 @@ jobs:
         # A check is skipped only when it provably cannot be affected — any doubt
         # and it runs:
         #   - a change outside a daggerverse module (CI infra, ci/, root
-        #     dagger.json, docs, ...) or an uncomputable diff -> the FULL suite;
+        #     dagger.json, docs, ...) or an uncomputable diff -> the FULL suite.
+        #     The one exception (#179) is a regenerated per-toolchain aggregator
+        #     binding, ci/internal/dagger/<toolchain>.gen.go, which is provably
+        #     owned by that toolchain and so is attributed to it;
         #   - a check whose module can't be resolved -> kept;
         #   - ci:* checks -> always run.
         # If enumeration itself fails there is no independent universe to fall back

--- a/ci/README.md
+++ b/ci/README.md
@@ -28,9 +28,18 @@ When you add `daggerverse/<m>/` with a sibling `tests/` module:
    { "name": "<m>-tests", "source": "daggerverse/<m>/tests" }
    ```
 
-3. Run `dagger develop` at the repo root to regenerate bindings.
+3. Run `dagger develop` at the repo root to regenerate bindings, and
+   commit the new `ci/internal/dagger/<m>-tests.gen.go`.
 
 No `ci/main.go` edit needed — toolchains surface their `+check`
 functions directly. No `.github/workflows/ci.yml` edit needed either —
 the matrix picks up the new check from `dagger check -l` output
 automatically.
+
+That committed binding is the only file under `ci/` that does *not*
+force the change-aware selector onto the full suite: `affectedpkg`
+attributes `ci/internal/dagger/<toolchain>.gen.go` back to the toolchain
+it was generated from (see `AggregatorBindings`), so a toolchain-adding
+PR runs that toolchain's checks rather than the whole universe. Every
+other path under `ci/` — including the module's own `dagger.gen.go` —
+still fails open to the full suite.

--- a/ci/affected.go
+++ b/ci/affected.go
@@ -98,7 +98,8 @@ func (ci *Ci) AffectedChecks(ctx context.Context, base string, head string) (str
 	}
 
 	closure := affectedpkg.BuildClosures(checkModule, adj)
-	kept, full := affectedpkg.Select(universe, closure, changedFiles, moduleDirs)
+	bindings := affectedpkg.AggregatorBindings(checkModule)
+	kept, full := affectedpkg.Select(universe, closure, changedFiles, moduleDirs, bindings)
 	if full {
 		kept = universe
 	}

--- a/ci/affectedpkg/affected.go
+++ b/ci/affectedpkg/affected.go
@@ -71,22 +71,29 @@ func closureOf(root string, adj map[string][]string, memo map[string]map[string]
 // moduleDirs is the set of all known daggerverse module directories, used to map
 // each changed file to its owning module by longest-prefix match.
 //
+// bindings is the per-toolchain aggregator-binding reattribution map from
+// AggregatorBindings: those few generated files under ci/ are provably owned by a
+// single toolchain, so they resolve to it instead of tripping the ci/ fail-safe.
+//
 // The result is full (run everything) when any fail-safe condition holds:
 //   - changedFiles is empty (no diff available or it could not be computed);
-//   - any changed file does not resolve to a daggerverse module directory — i.e.
-//     a change to CI infra, the ci/ aggregator, root dagger.json, or other
-//     broadly-shared code.
+//   - any changed file does not resolve to a daggerverse module directory (nor to
+//     a known toolchain binding) — i.e. a change to CI infra, the ci/ aggregator
+//     itself, root dagger.json, or other broadly-shared code.
 //
 // Otherwise only affected checks — plus every ci:* check, which always runs
 // (repo-wide generated-code freshness and this package's own self-test) — are
 // returned, in universe order.
-func Select(universe []string, closure map[string]map[string]bool, changedFiles []string, moduleDirs []string) (kept []string, full bool) {
+func Select(universe []string, closure map[string]map[string]bool, changedFiles []string, moduleDirs []string, bindings map[string]string) (kept []string, full bool) {
 	if len(changedFiles) == 0 {
 		return universe, true
 	}
 	changed := make(map[string]bool)
 	for _, f := range changedFiles {
-		dir, ok := OwningModule(f, moduleDirs)
+		dir, ok := bindings[f]
+		if !ok {
+			dir, ok = OwningModule(f, moduleDirs)
+		}
 		if !ok {
 			return universe, true
 		}
@@ -103,6 +110,62 @@ func Select(universe []string, closure map[string]map[string]bool, changedFiles 
 		}
 	}
 	return kept, false
+}
+
+// bindingDir/bindingExt bracket the root ci module's generated dependency
+// bindings: dagger emits one ci/internal/dagger/<toolchain>.gen.go per installed
+// toolchain, plus the module's own core dagger.gen.go.
+const (
+	bindingDir = "ci/internal/dagger/"
+	bindingExt = ".gen.go"
+	// coreBinding is the ci module's own core binding. It is not attributable to
+	// any single toolchain, so it must keep failing open even in the pathological
+	// case of a toolchain literally named "dagger".
+	coreBinding = bindingDir + "dagger" + bindingExt
+)
+
+// AggregatorBindings maps each per-toolchain aggregator binding path to the
+// toolchain module directory it is generated from, so that regenerating a single
+// binding — which repo convention requires when adding or changing a tests
+// toolchain (see ci/README.md) — is attributed to that toolchain instead of
+// tripping Select's ci/ fail-safe and forcing the whole universe to run (#179).
+//
+// checkModule is the same check-name -> owning-module-directory map fed to
+// BuildClosures. The binding's file name and the check-name prefix are both the
+// toolchain name after dagger's kebab-casing (which splits letter<->digit
+// boundaries: toolchain z5labs-tests -> z-5-labs-tests:all and
+// ci/internal/dagger/z-5-labs-tests.gen.go), so the prefix can be reused verbatim
+// and there is no second copy of that casing rule to drift — the only other copy
+// lives in the route step of .github/workflows/ci.yml, which maps the very same
+// prefix back to its source path.
+//
+// The mapping deliberately covers nothing else: any other path under ci/, and any
+// binding for a toolchain not currently in the check universe, is absent here and
+// so still runs the full suite.
+func AggregatorBindings(checkModule map[string]string) map[string]string {
+	out := make(map[string]string, len(checkModule))
+	ambiguous := map[string]bool{}
+	for name, dir := range checkModule {
+		if isCiCheck(name) {
+			continue
+		}
+		prefix, _, _ := strings.Cut(name, ":")
+		if prefix == "" {
+			continue
+		}
+		path := bindingDir + prefix + bindingExt
+		if prev, seen := out[path]; seen && prev != dir {
+			// Two toolchains cannot share a binding; if the universe says
+			// otherwise, something is off — fail open rather than guess.
+			ambiguous[path] = true
+		}
+		out[path] = dir
+	}
+	for path := range ambiguous {
+		delete(out, path)
+	}
+	delete(out, coreBinding)
+	return out
 }
 
 // OwningModule returns the directory in moduleDirs that owns path, chosen by

--- a/ci/affectedpkg/affected_test.go
+++ b/ci/affectedpkg/affected_test.go
@@ -58,6 +58,110 @@ func TestBuildClosuresTransitive(t *testing.T) {
 	}
 }
 
+func TestAggregatorBindings(t *testing.T) {
+	checkModule := map[string]string{
+		"kicad-tests:all":        "daggerverse/kicad/tests",
+		"kafka-tests:native":     "daggerverse/kafka/tests",
+		"kafka-tests:cluster":    "daggerverse/kafka/tests", // same toolchain, two checks
+		"z-5-labs-tests:all":     "daggerverse/z5labs/tests",
+		"ci:generated":           ".",
+		"ci:selection-self-test": ".",
+	}
+	got := AggregatorBindings(checkModule)
+	want := map[string]string{
+		"ci/internal/dagger/kicad-tests.gen.go":    "daggerverse/kicad/tests",
+		"ci/internal/dagger/kafka-tests.gen.go":    "daggerverse/kafka/tests",
+		"ci/internal/dagger/z-5-labs-tests.gen.go": "daggerverse/z5labs/tests",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("AggregatorBindings() = %v, want %v", got, want)
+	}
+	for path, dir := range want {
+		if got[path] != dir {
+			t.Errorf("AggregatorBindings()[%q] = %q, want %q", path, got[path], dir)
+		}
+	}
+}
+
+func TestAggregatorBindingsExcludesAmbiguous(t *testing.T) {
+	// A toolchain named "dagger" would collide with the ci module's own core
+	// binding, and two module dirs claiming one binding is nonsense — both must
+	// fall through to the ci/ full-suite fail-safe rather than reattribute.
+	got := AggregatorBindings(map[string]string{
+		"dagger:all":  "daggerverse/dagger/tests",
+		"dup-tests:a": "daggerverse/dup/tests",
+		"dup-tests:b": "daggerverse/other/tests",
+	})
+	for _, path := range []string{
+		"ci/internal/dagger/dagger.gen.go",
+		"ci/internal/dagger/dup-tests.gen.go",
+	} {
+		if dir, ok := got[path]; ok {
+			t.Errorf("AggregatorBindings() reattributed %q to %q; want it excluded", path, dir)
+		}
+	}
+}
+
+func TestSelectReattributesToolchainBinding(t *testing.T) {
+	universe := []string{"ci:generated", "kicad-tests:all", "kafka-tests:native"}
+	closure := map[string]map[string]bool{
+		"kicad-tests:all":    {"daggerverse/kicad/tests": true, "daggerverse/kicad": true},
+		"kafka-tests:native": {"daggerverse/kafka/tests": true, "daggerverse/kafka": true},
+	}
+	dirs := []string{"daggerverse/kicad", "daggerverse/kicad/tests", "daggerverse/kafka", "daggerverse/kafka/tests"}
+	bindings := AggregatorBindings(map[string]string{
+		"kicad-tests:all":    "daggerverse/kicad/tests",
+		"kafka-tests:native": "daggerverse/kafka/tests",
+	})
+
+	cases := []struct {
+		name     string
+		changed  []string
+		wantFull bool
+		want     []string
+	}{
+		{
+			name:    "toolchain binding narrows to its own suite",
+			changed: []string{"ci/internal/dagger/kicad-tests.gen.go"},
+			want:    []string{"ci:generated", "kicad-tests:all"},
+		},
+		{
+			name:     "core binding still forces the full suite",
+			changed:  []string{"ci/internal/dagger/dagger.gen.go"},
+			wantFull: true,
+		},
+		{
+			name:     "unknown toolchain binding still forces the full suite",
+			changed:  []string{"ci/internal/dagger/removed-tests.gen.go"},
+			wantFull: true,
+		},
+		{
+			name:     "a non-.gen.go file in the binding dir still forces the full suite",
+			changed:  []string{"ci/internal/dagger/kicad-tests.go"},
+			wantFull: true,
+		},
+		{
+			name:     "other ci/ sources still force the full suite",
+			changed:  []string{"ci/internal/dagger/kicad-tests.gen.go", "ci/main.go"},
+			wantFull: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			kept, full := Select(universe, closure, tc.changed, dirs, bindings)
+			if full != tc.wantFull {
+				t.Fatalf("full = %v, want %v", full, tc.wantFull)
+			}
+			if tc.wantFull {
+				return
+			}
+			if !sameSet(kept, tc.want) {
+				t.Errorf("selected %v, want %v", sortedCopy(kept), sortedCopy(tc.want))
+			}
+		})
+	}
+}
+
 func TestDiffRange(t *testing.T) {
 	const zero = "0000000000000000000000000000000000000000"
 	cases := []struct {
@@ -90,7 +194,7 @@ func TestSelectUnresolvedIsKept(t *testing.T) {
 		"kicad-tests:all": {"daggerverse/kicad/tests": true, "daggerverse/kicad": true},
 	}
 	dirs := []string{"daggerverse/kicad", "daggerverse/kicad/tests"}
-	kept, full := Select(universe, closure, []string{"daggerverse/kicad/main.go"}, dirs)
+	kept, full := Select(universe, closure, []string{"daggerverse/kicad/main.go"}, dirs, nil)
 	if full {
 		t.Fatal("did not expect full-suite fallback")
 	}

--- a/ci/affectedpkg/selfcheck.go
+++ b/ci/affectedpkg/selfcheck.go
@@ -42,6 +42,10 @@ func repoFixture() fixture {
 		"daggerverse/envoy/tests":                  {"daggerverse/envoy", "daggerverse/certificate-management", "daggerverse/crypto", "daggerverse/random"},
 		"daggerverse/otel/tests":                   {"daggerverse/otel", "daggerverse/certificate-management", "daggerverse/crypto", "daggerverse/grafana-stack", "daggerverse/random"},
 		"daggerverse/kicad/tests":                  {"daggerverse/kicad"},
+		// Kept dependency-free so it stays out of every other case's expected
+		// set; it is here for its digit-bearing name (see below).
+		"daggerverse/z5labs":       nil,
+		"daggerverse/z5labs/tests": {"daggerverse/z5labs"},
 	}
 	checkModule := map[string]string{
 		"certificate-management-tests:all": "daggerverse/certificate-management/tests",
@@ -52,8 +56,12 @@ func repoFixture() fixture {
 		"envoy-tests:admin":                "daggerverse/envoy/tests",
 		"otel-tests:core":                  "daggerverse/otel/tests",
 		"kicad-tests:all":                  "daggerverse/kicad/tests",
-		"ci:generated":                     ".",
-		"ci:selection-self-test":           ".",
+		// Dagger kebab-cases toolchain names across letter<->digit boundaries, so
+		// the toolchain z5labs-tests surfaces as z-5-labs-tests:all — matching the
+		// ci/internal/dagger/z-5-labs-tests.gen.go binding file name byte for byte.
+		"z-5-labs-tests:all":     "daggerverse/z5labs/tests",
+		"ci:generated":           ".",
+		"ci:selection-self-test": ".",
 	}
 	return fixture{adj: adj, checkModule: checkModule}
 }
@@ -151,6 +159,41 @@ func selfCheckCases() []selfCheckCase {
 				"certificate-management-tests:all",
 			},
 		},
+		{
+			// The regenerated binding is attributable to exactly one toolchain, so
+			// it no longer drags in the whole universe (#179).
+			name:       "a per-toolchain aggregator binding narrows to its own suite",
+			changed:    []string{"ci/internal/dagger/kicad-tests.gen.go"},
+			wantChecks: []string{ci1, ci2, "kicad-tests:all"},
+		},
+		{
+			// The binding file name and the check-name prefix share dagger's
+			// letter<->digit kebab-casing, so no separate mangling is needed.
+			name:       "a digit-bearing toolchain binding narrows to its own suite",
+			changed:    []string{"ci/internal/dagger/z-5-labs-tests.gen.go"},
+			wantChecks: []string{ci1, ci2, "z-5-labs-tests:all"},
+		},
+		{
+			// The shape of a real toolchain-adding PR: tests tree plus its binding.
+			name:       "adding a tests toolchain runs only that toolchain's checks",
+			changed:    []string{"daggerverse/kicad/tests/main.go", "ci/internal/dagger/kicad-tests.gen.go"},
+			wantChecks: []string{ci1, ci2, "kicad-tests:all"},
+		},
+		{
+			name:     "the ci module's own core binding runs the full suite",
+			changed:  []string{"ci/internal/dagger/dagger.gen.go"},
+			wantFull: true,
+		},
+		{
+			name:     "a binding for an unknown toolchain runs the full suite",
+			changed:  []string{"ci/internal/dagger/mystery-tests.gen.go"},
+			wantFull: true,
+		},
+		{
+			name:     "a toolchain binding mixed with a ci/ source change runs the full suite",
+			changed:  []string{"ci/internal/dagger/kicad-tests.gen.go", "ci/affectedpkg/affected.go"},
+			wantFull: true,
+		},
 		{name: "CI workflow change runs the full suite", changed: []string{".github/workflows/ci.yml"}, wantFull: true},
 		{name: "ci aggregator change runs the full suite", changed: []string{"ci/main.go"}, wantFull: true},
 		{name: "root dagger.json change runs the full suite", changed: []string{"dagger.json"}, wantFull: true},
@@ -171,9 +214,10 @@ func SelfCheck() error {
 	closure := BuildClosures(f.checkModule, f.adj)
 	universe := f.universe()
 	dirs := f.moduleDirs()
+	bindings := AggregatorBindings(f.checkModule)
 
 	for _, tc := range selfCheckCases() {
-		kept, full := Select(universe, closure, tc.changed, dirs)
+		kept, full := Select(universe, closure, tc.changed, dirs, bindings)
 		if full != tc.wantFull {
 			return fmt.Errorf("%s: full=%v, want %v", tc.name, full, tc.wantFull)
 		}


### PR DESCRIPTION
Closes #179.

## Problem

Adding or changing a tests toolchain requires regenerating and committing the root aggregator's binding for it, `ci/internal/dagger/<toolchain>.gen.go`. That path resolves to no daggerverse module, so the change-aware selector (#170) tripped its `ci/` fail-safe and ran the entire check universe — every toolchain-touching PR was unnarrowable. Observed on #177, whose only `ci/`-scoped change was `ci/internal/dagger/grafana-stack-tests.gen.go`.

## Change

Such a binding is provably owned by exactly one toolchain, so attribute it there instead of failing open.

New `affectedpkg.AggregatorBindings(checkModule)` derives the mapping from the check universe itself, and `Select` consults it before falling through to `OwningModule`.

Notably this needs **no reimplementation of the kebab/letter↔digit casing rule**. Dagger derives both the binding file name and the check-name prefix from the toolchain name with the same casing, so the prefix already present in `checkModule` *is* the file name, byte for byte:

| toolchain (`dagger.json`) | check name | binding file |
| --- | --- | --- |
| `grafana-stack-tests` | `grafana-stack-tests:…` | `ci/internal/dagger/grafana-stack-tests.gen.go` |
| `z5labs-tests` | `z-5-labs-tests:all` | `ci/internal/dagger/z-5-labs-tests.gen.go` |

The prefix is reused verbatim, so there is no second copy of that rule to drift from the `route` step in `ci.yml` — which maps the very same prefix back to its source path.

## Scope of the loosening

Deliberately minimal. Still the full suite for:

- any other path under `ci/` (`ci/main.go`, `ci/affectedpkg/*`, `ci/gitdiff/*`, …)
- `ci/internal/dagger/dagger.gen.go` — explicitly excluded, so even a toolchain literally named `dagger` cannot claim it
- a binding whose toolchain is not in the current check universe (removed/unknown)
- an ambiguous mapping (two module dirs claiming one binding)
- root `dagger.json`, CI infra, docs

## Verification

- **Against the live repo**: all 17 toolchains' kebabbed names match an on-disk binding file, and #177's exact change set now selects `ci:generated` + `grafana-stack-tests:*` instead of the full universe — the acceptance criterion.
- **Unit tests** (`ci/affectedpkg/affected_test.go`): `AggregatorBindings` mapping and its exclusions; a `Select` table covering reattribution, core binding, unknown toolchain, a non-`.gen.go` file in the binding dir, and binding-mixed-with-`ci/`-source.
- **`ci:selection-self-test`**: six new invariants, including the digit-bearing z5labs case and the realistic toolchain-add shape (tests tree + its binding). Check passes locally.
- `go vet` and `go test ./...` clean in `ci/`.

## Docs

`ci/README.md` step 3 now says to commit the regenerated binding and explains why it is the one exempt path under `ci/`; the `select` step comment in `.github/workflows/ci.yml` notes the exception.

## Aside (not fixed here)

Running `dagger call affected-checks` from a **git worktree** always returns the full suite: `.git` is a file there rather than a directory, so `Workspace.directory(".git")` errors and the fail-safe fires. Pre-existing #170 limitation, orthogonal to this change, and it does not affect CI (`actions/checkout` produces a real `.git` directory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)