### PR TITLE
story(issue-134): add psqlImage param to skill-gen Postgres

### DIFF
--- a/ci/internal/dagger/dgraph-tests.gen.go
+++ b/ci/internal/dagger/dgraph-tests.gen.go
@@ -22,23 +22,29 @@ type DgraphTests struct { // dgraph-tests (../../../daggerverse/dgraph/tests/mai
 	query *querybuilder.Selection
 
 	all                                      *Void
+	bindAlphasResolvesFromUserContainerTls   *Void
 	clientAlterSchemaRoundTrip               *Void
 	clientMutateThenQueryRoundTrip           *Void
 	clientMutateWithoutCommitDoesNotPersist  *Void
 	clientQueryWithVarsRoundTrip             *Void
 	cluster                                  *Void
+	clusterMtlsRoundTripFromClient           *Void
 	clusterRejectsEvenReplicas               *Void
 	clusterRejectsInvalidAlphasReplicasRatio *Void
 	clusterRejectsMultipleZeros              *Void
 	clusterRejectsNilSecurity                *Void
+	clusterTlsRoundTripFromClient            *Void
 	defaultsProduceWorkingSingleNodeCluster  *Void
 	grpcEndpointsShouldNotBeCached           *Void
 	httpEndpointsShouldNotBeCached           *Void
 	id                                       *ID
+	mtlsClusterRejectsTlsOnlyClient          *Void
 	multiAlphaShardedTopology                *Void
 	multiAlphaSingleGroupAllReachable        *Void
 	mutateShouldNotBeCached                  *Void
 	remoteClientCanTargetExistingCluster     *Void
+	security                                 *Void
+	tlsClusterRejectsPlaintextClient         *Void
 	validation                               *Void
 }
 
@@ -72,9 +78,23 @@ func (r *DgraphTests) All(ctx context.Context, opts ...DgraphTestsAllOpts) error
 	return q.Execute(ctx)
 }
 
+// BindAlphasResolvesFromUserContainerTls boots a one-way-TLS cluster,
+// binds its Alphas into an alpine container, and proves the Alpha's HTTPS
+// /health listener is reachable there: `wget --ca-certificate` (trusting
+// the test CA) succeeds, while the same `wget` without the CA fails
+// certificate verification.
+func (r *DgraphTests) BindAlphasResolvesFromUserContainerTLS(ctx context.Context) error { // dgraph-tests (../../../daggerverse/dgraph/tests/security.go:333:1)
+	if r.bindAlphasResolvesFromUserContainerTls != nil {
+		return nil
+	}
+	q := r.query.Select("bindAlphasResolvesFromUserContainerTls")
+
+	return q.Execute(ctx)
+}
+
 // ClientAlterSchemaRoundTrip verifies AlterSchema accepts a non-trivial
 // DQL schema and the cluster reports it on subsequent schema queries.
-func (r *DgraphTests) ClientAlterSchemaRoundTrip(ctx context.Context) error { // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:394:1)
+func (r *DgraphTests) ClientAlterSchemaRoundTrip(ctx context.Context) error { // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:423:1)
 	if r.clientAlterSchemaRoundTrip != nil {
 		return nil
 	}
@@ -85,7 +105,7 @@ func (r *DgraphTests) ClientAlterSchemaRoundTrip(ctx context.Context) error { //
 
 // ClientMutateThenQueryRoundTrip applies a schema, sets a triple with
 // a random value, and verifies the value reads back via Query.
-func (r *DgraphTests) ClientMutateThenQueryRoundTrip(ctx context.Context) error { // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:421:1)
+func (r *DgraphTests) ClientMutateThenQueryRoundTrip(ctx context.Context) error { // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:450:1)
 	if r.clientMutateThenQueryRoundTrip != nil {
 		return nil
 	}
@@ -96,7 +116,7 @@ func (r *DgraphTests) ClientMutateThenQueryRoundTrip(ctx context.Context) error 
 
 // ClientMutateWithoutCommitDoesNotPersist mutates with commit=false
 // and verifies a subsequent Query does NOT see the value.
-func (r *DgraphTests) ClientMutateWithoutCommitDoesNotPersist(ctx context.Context) error { // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:461:1)
+func (r *DgraphTests) ClientMutateWithoutCommitDoesNotPersist(ctx context.Context) error { // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:490:1)
 	if r.clientMutateWithoutCommitDoesNotPersist != nil {
 		return nil
 	}
@@ -108,7 +128,7 @@ func (r *DgraphTests) ClientMutateWithoutCommitDoesNotPersist(ctx context.Contex
 // ClientQueryWithVarsRoundTrip exercises the variable-substitution path
 // of QueryWithVars, which crosses the Dagger boundary as a JSON-encoded
 // map.
-func (r *DgraphTests) ClientQueryWithVarsRoundTrip(ctx context.Context) error { // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:494:1)
+func (r *DgraphTests) ClientQueryWithVarsRoundTrip(ctx context.Context) error { // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:523:1)
 	if r.clientQueryWithVarsRoundTrip != nil {
 		return nil
 	}
@@ -119,14 +139,14 @@ func (r *DgraphTests) ClientQueryWithVarsRoundTrip(ctx context.Context) error { 
 
 // DgraphTestsClusterOpts contains options for DgraphTests.Cluster
 type DgraphTestsClusterOpts struct {
-	Parallel int // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:85:2)
+	Parallel int // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:88:2)
 }
 
 // Cluster runs the topology and client round-trip tests. Each test
 // passes its own name to `freshCluster`, which folds into Dgraph.Cluster's
 // session-cache key so concurrent tests boot independent backing
 // services and never share schema or storage.
-func (r *DgraphTests) Cluster(ctx context.Context, opts ...DgraphTestsClusterOpts) error { // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:82:1)
+func (r *DgraphTests) Cluster(ctx context.Context, opts ...DgraphTestsClusterOpts) error { // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:85:1)
 	if r.cluster != nil {
 		return nil
 	}
@@ -141,11 +161,25 @@ func (r *DgraphTests) Cluster(ctx context.Context, opts ...DgraphTestsClusterOpt
 	return q.Execute(ctx)
 }
 
+// ClusterMtlsRoundTripFromClient boots a mutual-TLS cluster and proves a
+// matching mTLS client (presenting a client cert signed by the trusted
+// CA) can AlterSchema + Mutate + Query. One CA both signs the server leaf
+// and anchors the accepted client certs — the simplest symmetric mTLS
+// trust setup.
+func (r *DgraphTests) ClusterMtlsRoundTripFromClient(ctx context.Context) error { // dgraph-tests (../../../daggerverse/dgraph/tests/security.go:206:1)
+	if r.clusterMtlsRoundTripFromClient != nil {
+		return nil
+	}
+	q := r.query.Select("clusterMtlsRoundTripFromClient")
+
+	return q.Execute(ctx)
+}
+
 // ClusterRejectsEvenReplicas verifies that an even replicas value > 1
 // is rejected — Dgraph's Raft consensus needs an odd replica count per
 // group (or replicas=1 for no replication). Alphas=2 keeps
 // alphas%replicas==0 so only the odd-replicas rule can trip.
-func (r *DgraphTests) ClusterRejectsEvenReplicas(ctx context.Context) error { // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:183:1)
+func (r *DgraphTests) ClusterRejectsEvenReplicas(ctx context.Context) error { // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:212:1)
 	if r.clusterRejectsEvenReplicas != nil {
 		return nil
 	}
@@ -155,7 +189,7 @@ func (r *DgraphTests) ClusterRejectsEvenReplicas(ctx context.Context) error { //
 }
 
 // ClusterRejectsInvalidAlphasReplicasRatio verifies alphas % replicas != 0 is rejected.
-func (r *DgraphTests) ClusterRejectsInvalidAlphasReplicasRatio(ctx context.Context) error { // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:162:1)
+func (r *DgraphTests) ClusterRejectsInvalidAlphasReplicasRatio(ctx context.Context) error { // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:191:1)
 	if r.clusterRejectsInvalidAlphasReplicasRatio != nil {
 		return nil
 	}
@@ -165,7 +199,7 @@ func (r *DgraphTests) ClusterRejectsInvalidAlphasReplicasRatio(ctx context.Conte
 }
 
 // ClusterRejectsMultipleZeros verifies zeros != 1 surfaces a descriptive error.
-func (r *DgraphTests) ClusterRejectsMultipleZeros(ctx context.Context) error { // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:144:1)
+func (r *DgraphTests) ClusterRejectsMultipleZeros(ctx context.Context) error { // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:173:1)
 	if r.clusterRejectsMultipleZeros != nil {
 		return nil
 	}
@@ -178,7 +212,7 @@ func (r *DgraphTests) ClusterRejectsMultipleZeros(ctx context.Context) error { /
 // rejected. The Dagger SDK's binding panics via assertNotNil before the
 // call leaves the test module; recover and assert the panic mentions
 // the rejected argument.
-func (r *DgraphTests) ClusterRejectsNilSecurity(ctx context.Context) error { // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:204:1)
+func (r *DgraphTests) ClusterRejectsNilSecurity(ctx context.Context) error { // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:233:1)
 	if r.clusterRejectsNilSecurity != nil {
 		return nil
 	}
@@ -187,10 +221,22 @@ func (r *DgraphTests) ClusterRejectsNilSecurity(ctx context.Context) error { // 
 	return q.Execute(ctx)
 }
 
+// ClusterTlsRoundTripFromClient boots a one-way-TLS cluster and proves a
+// matching TLS client (pinning the server CA) can AlterSchema + Mutate +
+// Query end to end.
+func (r *DgraphTests) ClusterTLSRoundTripFromClient(ctx context.Context) error { // dgraph-tests (../../../daggerverse/dgraph/tests/security.go:158:1)
+	if r.clusterTlsRoundTripFromClient != nil {
+		return nil
+	}
+	q := r.query.Select("clusterTlsRoundTripFromClient")
+
+	return q.Execute(ctx)
+}
+
 // DefaultsProduceWorkingSingleNodeCluster boots a 1-Zero, 1-Alpha,
 // replicas=1 cluster (the constructor defaults) and runs a schema
 // alteration against it to prove it's serving requests.
-func (r *DgraphTests) DefaultsProduceWorkingSingleNodeCluster(ctx context.Context) error { // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:336:1)
+func (r *DgraphTests) DefaultsProduceWorkingSingleNodeCluster(ctx context.Context) error { // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:365:1)
 	if r.defaultsProduceWorkingSingleNodeCluster != nil {
 		return nil
 	}
@@ -208,7 +254,7 @@ func (r *DgraphTests) DefaultsProduceWorkingSingleNodeCluster(ctx context.Contex
 // AlterSchema against the cluster: if start() didn't run because
 // GrpcEndpoints returned a cached result, the alphas remain dead and
 // the alter dials a hung port.
-func (r *DgraphTests) GrpcEndpointsShouldNotBeCached(ctx context.Context) error { // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:236:1)
+func (r *DgraphTests) GrpcEndpointsShouldNotBeCached(ctx context.Context) error { // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:265:1)
 	if r.grpcEndpointsShouldNotBeCached != nil {
 		return nil
 	}
@@ -221,7 +267,7 @@ func (r *DgraphTests) GrpcEndpointsShouldNotBeCached(ctx context.Context) error 
 // but for the HTTP listener. The liveness probe is the same gRPC-based
 // AlterSchema — both endpoint methods share start(), so any restart
 // proves either never-cache directive fired.
-func (r *DgraphTests) HTTPEndpointsShouldNotBeCached(ctx context.Context) error { // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:268:1)
+func (r *DgraphTests) HTTPEndpointsShouldNotBeCached(ctx context.Context) error { // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:297:1)
 	if r.httpEndpointsShouldNotBeCached != nil {
 		return nil
 	}
@@ -279,12 +325,27 @@ func (r *DgraphTests) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
+// MtlsClusterRejectsTlsOnlyClient boots an mTLS cluster and proves a
+// TLS-only client (verifies the server but presents no client cert) fails
+// at the gRPC handshake — the REQUIREANDVERIFY listener demands a client
+// certificate. This goes through the standalone Dgraph.Client, which has
+// no cluster reference and so cannot short-circuit with a mode-mismatch
+// error: the failure must come from the wire.
+func (r *DgraphTests) MtlsClusterRejectsTLSOnlyClient(ctx context.Context) error { // dgraph-tests (../../../daggerverse/dgraph/tests/security.go:294:1)
+	if r.mtlsClusterRejectsTlsOnlyClient != nil {
+		return nil
+	}
+	q := r.query.Select("mtlsClusterRejectsTlsOnlyClient")
+
+	return q.Execute(ctx)
+}
+
 // MultiAlphaShardedTopology boots a 2-Alpha cluster at replicas=1 (two
 // groups, one Alpha each — sharded, no replication) and verifies the
 // cluster serves a trivial schema alteration. Dgraph's Raft consensus
 // requires replicas to be odd, so the smallest valid sharded topology
 // is 2 Alphas at replicas=1.
-func (r *DgraphTests) MultiAlphaShardedTopology(ctx context.Context) error { // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:377:1)
+func (r *DgraphTests) MultiAlphaShardedTopology(ctx context.Context) error { // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:406:1)
 	if r.multiAlphaShardedTopology != nil {
 		return nil
 	}
@@ -296,7 +357,7 @@ func (r *DgraphTests) MultiAlphaShardedTopology(ctx context.Context) error { // 
 // MultiAlphaSingleGroupAllReachable boots a 3-Alpha cluster at
 // replicas=3 (single group of three Alphas, fully replicated) and
 // verifies every endpoint serves queries.
-func (r *DgraphTests) MultiAlphaSingleGroupAllReachable(ctx context.Context) error { // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:350:1)
+func (r *DgraphTests) MultiAlphaSingleGroupAllReachable(ctx context.Context) error { // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:379:1)
 	if r.multiAlphaSingleGroupAllReachable != nil {
 		return nil
 	}
@@ -310,7 +371,7 @@ func (r *DgraphTests) MultiAlphaSingleGroupAllReachable(ctx context.Context) err
 // engine cached the call, both would return identical UID JSON. The
 // payload value is randomised per-run so re-running the suite never
 // reuses a probe name across engine sessions.
-func (r *DgraphTests) MutateShouldNotBeCached(ctx context.Context) error { // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:301:1)
+func (r *DgraphTests) MutateShouldNotBeCached(ctx context.Context) error { // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:330:1)
 	if r.mutateShouldNotBeCached != nil {
 		return nil
 	}
@@ -323,7 +384,7 @@ func (r *DgraphTests) MutateShouldNotBeCached(ctx context.Context) error { // dg
 // constructs a top-level Dgraph.Client (not Cluster.Client) against
 // the cluster's endpoints — proving the constructor works against any
 // reachable address list.
-func (r *DgraphTests) RemoteClientCanTargetExistingCluster(ctx context.Context) error { // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:530:1)
+func (r *DgraphTests) RemoteClientCanTargetExistingCluster(ctx context.Context) error { // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:559:1)
 	if r.remoteClientCanTargetExistingCluster != nil {
 		return nil
 	}
@@ -332,16 +393,53 @@ func (r *DgraphTests) RemoteClientCanTargetExistingCluster(ctx context.Context) 
 	return q.Execute(ctx)
 }
 
+// DgraphTestsSecurityOpts contains options for DgraphTests.Security
+type DgraphTestsSecurityOpts struct {
+	Parallel int // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:117:2)
+}
+
+// Security runs the TLS / mTLS round-trip, mode-coupling, and container-
+// binding tests. Each mints its own per-test CA and cert material and
+// (for the round-trip / bind tests) boots an independent backing cluster
+// keyed by a unique name, so the jobs are safe to fan out.
+func (r *DgraphTests) Security(ctx context.Context, opts ...DgraphTestsSecurityOpts) error { // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:114:1)
+	if r.security != nil {
+		return nil
+	}
+	q := r.query.Select("security")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `parallel` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Parallel) {
+			q = q.Arg("parallel", opts[i].Parallel)
+		}
+	}
+
+	return q.Execute(ctx)
+}
+
+// TlsClusterRejectsPlaintextClient verifies the mode-coupling check:
+// asking a TLS cluster for a plaintext client returns an error naming
+// both modes, before any wire activity. The requireMode guard fires ahead
+// of GrpcEndpoints, so no cluster boots.
+func (r *DgraphTests) TLSClusterRejectsPlaintextClient(ctx context.Context) error { // dgraph-tests (../../../daggerverse/dgraph/tests/security.go:257:1)
+	if r.tlsClusterRejectsPlaintextClient != nil {
+		return nil
+	}
+	q := r.query.Select("tlsClusterRejectsPlaintextClient")
+
+	return q.Execute(ctx)
+}
+
 // DgraphTestsValidationOpts contains options for DgraphTests.Validation
 type DgraphTestsValidationOpts struct {
-	Parallel int // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:57:2)
+	Parallel int // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:60:2)
 }
 
 // Validation runs the pure-validation tests (ClusterRejects*) plus the
 // cache-directive tests (*ShouldNotBeCached) that explicitly Stop their
 // cluster after use. These don't share session-cached cluster state, so
 // they're safe to fan out unbounded.
-func (r *DgraphTests) Validation(ctx context.Context, opts ...DgraphTestsValidationOpts) error { // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:54:1)
+func (r *DgraphTests) Validation(ctx context.Context, opts ...DgraphTestsValidationOpts) error { // dgraph-tests (../../../daggerverse/dgraph/tests/main.go:57:1)
 	if r.validation != nil {
 		return nil
 	}

--- a/ci/internal/dagger/kafka-tests.gen.go
+++ b/ci/internal/dagger/kafka-tests.gen.go
@@ -45,70 +45,75 @@ func (r *Env) WithKafkaTestsOutput(name string, description string) *Env { // ka
 type KafkaTests struct { // kafka-tests (../../../daggerverse/kafka/tests/main.go:39:6)
 	query *querybuilder.Selection
 
-	all                                                *Void
-	apacheClusterMtlsRoundTrip                         *Void
-	apacheClusterProduceListTopicsRoundTrip            *Void
-	apacheClusterTlsRoundTrip                          *Void
-	apacheJvm                                          *Void
-	apicurioSchemaRegistryRegisterLookupRoundTrip      *Void
-	apicurioSchemaRegistryTlsRegisterLookupRoundTrip   *Void
-	autoCreateTopicsDisabled                           *Void
-	avroBytesFieldRoundTrip                            *Void
-	avroConsumeUnframedErrors                          *Void
-	avroFramedProduceConsumeRoundTrip                  *Void
-	avroMtlsFramedProduceConsumeRoundTrip              *Void
-	avroSerializeRequiresSchemaId                      *Void
-	avroTlsFramedProduceConsumeRoundTrip               *Void
-	bindBrokersExposesBothListeners                    *Void
-	clusterClientCanListTopicsOnFreshCluster           *Void
-	confluent                                          *Void
-	confluentClusterMtlsRoundTrip                      *Void
-	confluentClusterProduceListTopicsRoundTrip         *Void
-	confluentClusterTlsRoundTrip                       *Void
-	confluentSchemaRegistryMtlsRegisterLookupRoundTrip *Void
-	confluentSchemaRegistryTlsRegisterLookupRoundTrip  *Void
-	consumerGroupOnSingleBrokerWorks                   *Void
-	createAndDeleteTopicRoundTrip                      *Void
-	dedicatedControllerAndBrokerProduceConsume         *Void
-	describeConsumerGroupReportsLag                    *Void
-	describeTopicReportsPartitionsAndConfigs           *Void
-	fiveControllerQuorumAccepted                       *Void
-	id                                                 *ID
-	internalListenersAreEncrypted                      *Void
-	invalidControllerCountIsRejected                   *Void
-	karapaceSchemaRegistryRegisterLookupRoundTrip      *Void
-	karapaceSchemaRegistryTlsRegisterLookupRoundTrip   *Void
-	listConsumerGroupsReportsCommittedGroup            *Void
-	mtlsRequiresClientCert                             *Void
-	mtlsRoundTrip                                      *Void
-	native                                             *Void
-	oneControllerTwoBrokersReplicationFactorTwo        *Void
-	plaintextSecurityProfilesAreNonNil                 *Void
-	produceConsumeRoundTripBase64                      *Void
-	produceConsumeRoundTripHex                         *Void
-	produceConsumeRoundTripRaw                         *Void
-	produceRejectsUnknownEncoding                      *Void
-	propertiesFileContainsBootstrapAndSecurityProtocol *Void
-	propertiesFileContainsMtlsSettings                 *Void
-	propertiesFileContainsTlsSettings                  *Void
-	redpanda                                           *Void
-	redpandaClusterProduceListTopicsRoundTrip          *Void
-	redpandaClusterTlsRoundTrip                        *Void
-	redpandaSchemaRegistryBundledStopIsNoOp            *Void
-	redpandaSchemaRegistryRegisterLookupRoundTrip      *Void
-	redpandaSchemaRegistryTlsRegisterLookupRoundTrip   *Void
-	schemaRegistry                                     *Void
-	schemaRegistryFramedProduceConsumeRoundTrip        *Void
-	schemaRegistryJsonframedProduceConsumeRoundTrip    *Void
-	schemaRegistryJsonserializeRejectsMalformedInput   *Void
-	schemaRegistryPlaintextConsumeUnframed             *Void
-	schemaRegistryRegisterLookupRoundTrip              *Void
-	schemaRegistryRejectsClusterModeMismatch           *Void
-	singleNodeClusterStarts                            *Void
-	threeControllerQuorumProduceConsume                *Void
-	tlsClientWithWrongCaFails                          *Void
-	tlsClusterStarts                                   *Void
-	tlsRoundTrip                                       *Void
+	all                                                        *Void
+	apacheClusterMtlsRoundTrip                                 *Void
+	apacheClusterProduceListTopicsRoundTrip                    *Void
+	apacheClusterTlsRoundTrip                                  *Void
+	apacheJvm                                                  *Void
+	apicurioSchemaRegistryRegisterLookupRoundTrip              *Void
+	apicurioSchemaRegistryTlsRegisterLookupRoundTrip           *Void
+	autoCreateTopicsDisabled                                   *Void
+	avroBytesFieldRoundTrip                                    *Void
+	avroConsumeUnframedErrors                                  *Void
+	avroFramedProduceConsumeRoundTrip                          *Void
+	avroMtlsFramedProduceConsumeRoundTrip                      *Void
+	avroSerializeRequiresSchemaId                              *Void
+	avroTlsFramedProduceConsumeRoundTrip                       *Void
+	bindBrokersExposesBothListeners                            *Void
+	clusterClientCanListTopicsOnFreshCluster                   *Void
+	confluent                                                  *Void
+	confluentClusterMtlsRoundTrip                              *Void
+	confluentClusterProduceListTopicsRoundTrip                 *Void
+	confluentClusterTlsRoundTrip                               *Void
+	confluentSchemaRegistryMtlsRegisterLookupRoundTrip         *Void
+	confluentSchemaRegistryTlsRegisterLookupRoundTrip          *Void
+	consumerGroupOnSingleBrokerWorks                           *Void
+	createAndDeleteTopicRoundTrip                              *Void
+	dedicatedControllerAndBrokerProduceConsume                 *Void
+	describeConsumerGroupReportsLag                            *Void
+	describeTopicReportsPartitionsAndConfigs                   *Void
+	fiveControllerQuorumAccepted                               *Void
+	id                                                         *ID
+	internalListenersAreEncrypted                              *Void
+	invalidControllerCountIsRejected                           *Void
+	karapaceSchemaRegistryRegisterLookupRoundTrip              *Void
+	karapaceSchemaRegistryTlsRegisterLookupRoundTrip           *Void
+	listConsumerGroupsReportsCommittedGroup                    *Void
+	mtlsRequiresClientCert                                     *Void
+	mtlsRoundTrip                                              *Void
+	native                                                     *Void
+	oneControllerTwoBrokersReplicationFactorTwo                *Void
+	plaintextSecurityProfilesAreNonNil                         *Void
+	produceConsumeRoundTripBase64                              *Void
+	produceConsumeRoundTripHex                                 *Void
+	produceConsumeRoundTripRaw                                 *Void
+	produceRejectsUnknownEncoding                              *Void
+	propertiesFileContainsBootstrapAndSecurityProtocol         *Void
+	propertiesFileContainsMtlsSettings                         *Void
+	propertiesFileContainsTlsSettings                          *Void
+	redpanda                                                   *Void
+	redpandaClusterProduceListTopicsRoundTrip                  *Void
+	redpandaClusterTlsRoundTrip                                *Void
+	redpandaMultiBrokerBootstrapServersListsEveryNode          *Void
+	redpandaMultiBrokerControllerPolicyRejected                *Void
+	redpandaMultiBrokerSchemaRegistryRoundTrip                 *Void
+	redpandaSchemaRegistryBundledStopIsNoOp                    *Void
+	redpandaSchemaRegistryRegisterLookupRoundTrip              *Void
+	redpandaSchemaRegistryTlsRegisterLookupRoundTrip           *Void
+	redpandaThreeBrokerReplicationFactorThreeProduceConsume    *Void
+	redpandaThreeBrokerTlsReplicationFactorThreeProduceConsume *Void
+	schemaRegistry                                             *Void
+	schemaRegistryFramedProduceConsumeRoundTrip                *Void
+	schemaRegistryJsonframedProduceConsumeRoundTrip            *Void
+	schemaRegistryJsonserializeRejectsMalformedInput           *Void
+	schemaRegistryPlaintextConsumeUnframed                     *Void
+	schemaRegistryRegisterLookupRoundTrip                      *Void
+	schemaRegistryRejectsClusterModeMismatch                   *Void
+	singleNodeClusterStarts                                    *Void
+	threeControllerQuorumProduceConsume                        *Void
+	tlsClientWithWrongCaFails                                  *Void
+	tlsClusterStarts                                           *Void
+	tlsRoundTrip                                               *Void
 }
 
 func (r *KafkaTests) WithGraphQLQuery(q *querybuilder.Selection) *KafkaTests {
@@ -1410,7 +1415,7 @@ func (r *KafkaTests) Redpanda(ctx context.Context, opts ...KafkaTestsRedpandaOpt
 type KafkaTestsRedpandaClusterProduceListTopicsRoundTripOpts struct {
 
 	// Default: "v26.1.7"
-	RedpandaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:64:2)
+	RedpandaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:294:2)
 }
 
 // RedpandaClusterProduceListTopicsRoundTrip is the PLAINTEXT happy-path
@@ -1418,7 +1423,7 @@ type KafkaTestsRedpandaClusterProduceListTopicsRoundTripOpts struct {
 // create a topic, produce one record, then assert the freshly-created
 // topic shows up in ListTopics. Pins down "redpanda actually serves
 // Kafka-wire traffic on the external listener".
-func (r *KafkaTests) RedpandaClusterProduceListTopicsRoundTrip(ctx context.Context, opts ...KafkaTestsRedpandaClusterProduceListTopicsRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:61:1)
+func (r *KafkaTests) RedpandaClusterProduceListTopicsRoundTrip(ctx context.Context, opts ...KafkaTestsRedpandaClusterProduceListTopicsRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:291:1)
 	if r.redpandaClusterProduceListTopicsRoundTrip != nil {
 		return nil
 	}
@@ -1437,7 +1442,7 @@ func (r *KafkaTests) RedpandaClusterProduceListTopicsRoundTrip(ctx context.Conte
 type KafkaTestsRedpandaClusterTLSRoundTripOpts struct {
 
 	// Default: "v26.1.7"
-	RedpandaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:113:2)
+	RedpandaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:343:2)
 }
 
 // RedpandaClusterTlsRoundTrip is the TLS happy-path round-trip for
@@ -1445,7 +1450,7 @@ type KafkaTestsRedpandaClusterTLSRoundTripOpts struct {
 // using PEM cert/key/CA mounted into /etc/redpanda/certs, then produce
 // and consume one record over the TLS listener with the franz-go client
 // verifying the broker leaf against the matching truststore.
-func (r *KafkaTests) RedpandaClusterTLSRoundTrip(ctx context.Context, opts ...KafkaTestsRedpandaClusterTLSRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:110:1)
+func (r *KafkaTests) RedpandaClusterTLSRoundTrip(ctx context.Context, opts ...KafkaTestsRedpandaClusterTLSRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:340:1)
 	if r.redpandaClusterTlsRoundTrip != nil {
 		return nil
 	}
@@ -1460,11 +1465,96 @@ func (r *KafkaTests) RedpandaClusterTLSRoundTrip(ctx context.Context, opts ...Ka
 	return q.Execute(ctx)
 }
 
+// KafkaTestsRedpandaMultiBrokerBootstrapServersListsEveryNodeOpts contains options for KafkaTests.RedpandaMultiBrokerBootstrapServersListsEveryNode
+type KafkaTestsRedpandaMultiBrokerBootstrapServersListsEveryNodeOpts struct {
+
+	// Default: "v26.1.7"
+	RedpandaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:154:2)
+}
+
+// RedpandaMultiBrokerBootstrapServersListsEveryNode proves the constructor
+// accepts brokers=3 and returns a cluster advertising all three broker
+// bootstrap addresses. Resolving BootstrapServers forces the server-side
+// constructor (validation + the full container graph, including the per-node
+// seed list) to run without booting the containers, so the accept path is
+// exercised cheaply — the real three-node Raft round-trip is covered by
+// RedpandaThreeBrokerReplicationFactorThreeProduceConsume.
+func (r *KafkaTests) RedpandaMultiBrokerBootstrapServersListsEveryNode(ctx context.Context, opts ...KafkaTestsRedpandaMultiBrokerBootstrapServersListsEveryNodeOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:151:1)
+	if r.redpandaMultiBrokerBootstrapServersListsEveryNode != nil {
+		return nil
+	}
+	q := r.query.Select("redpandaMultiBrokerBootstrapServersListsEveryNode")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `redpandaImageTag` optional argument
+		if !querybuilder.IsZeroValue(opts[i].RedpandaImageTag) {
+			q = q.Arg("redpandaImageTag", opts[i].RedpandaImageTag)
+		}
+	}
+
+	return q.Execute(ctx)
+}
+
+// KafkaTestsRedpandaMultiBrokerControllerPolicyRejectedOpts contains options for KafkaTests.RedpandaMultiBrokerControllerPolicyRejected
+type KafkaTestsRedpandaMultiBrokerControllerPolicyRejectedOpts struct {
+
+	// Default: "v26.1.7"
+	RedpandaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:108:2)
+}
+
+// RedpandaMultiBrokerControllerPolicyRejected pins the two construction-time
+// policies Redpanda enforces: `controllers != 1` is rejected (Redpanda has no
+// separate controller role) and `brokers < 1` is rejected. Resolving
+// BootstrapServers forces the server-side constructor to run its validation
+// without booting any container, so both rejections are exercised cheaply.
+func (r *KafkaTests) RedpandaMultiBrokerControllerPolicyRejected(ctx context.Context, opts ...KafkaTestsRedpandaMultiBrokerControllerPolicyRejectedOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:105:1)
+	if r.redpandaMultiBrokerControllerPolicyRejected != nil {
+		return nil
+	}
+	q := r.query.Select("redpandaMultiBrokerControllerPolicyRejected")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `redpandaImageTag` optional argument
+		if !querybuilder.IsZeroValue(opts[i].RedpandaImageTag) {
+			q = q.Arg("redpandaImageTag", opts[i].RedpandaImageTag)
+		}
+	}
+
+	return q.Execute(ctx)
+}
+
+// KafkaTestsRedpandaMultiBrokerSchemaRegistryRoundTripOpts contains options for KafkaTests.RedpandaMultiBrokerSchemaRegistryRoundTrip
+type KafkaTestsRedpandaMultiBrokerSchemaRegistryRoundTripOpts struct {
+
+	// Default: "v26.1.7"
+	RedpandaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:273:2)
+}
+
+// RedpandaMultiBrokerSchemaRegistryRoundTrip proves Redpanda's bundled Schema
+// Registry still works against a multi-node cluster: it stands up a three-node
+// cluster, registers a schema against cluster.SchemaRegistry() (which points
+// at node 0, whose service cascades the whole cluster online), and asserts the
+// lookup-by-id round-trip. The `_schemas` topic itself is replicated across the
+// cluster, so a successful round-trip proves the registry reaches a formed
+// multi-node Raft group.
+func (r *KafkaTests) RedpandaMultiBrokerSchemaRegistryRoundTrip(ctx context.Context, opts ...KafkaTestsRedpandaMultiBrokerSchemaRegistryRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:270:1)
+	if r.redpandaMultiBrokerSchemaRegistryRoundTrip != nil {
+		return nil
+	}
+	q := r.query.Select("redpandaMultiBrokerSchemaRegistryRoundTrip")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `redpandaImageTag` optional argument
+		if !querybuilder.IsZeroValue(opts[i].RedpandaImageTag) {
+			q = q.Arg("redpandaImageTag", opts[i].RedpandaImageTag)
+		}
+	}
+
+	return q.Execute(ctx)
+}
+
 // KafkaTestsRedpandaSchemaRegistryBundledStopIsNoOpOpts contains options for KafkaTests.RedpandaSchemaRegistryBundledStopIsNoOp
 type KafkaTestsRedpandaSchemaRegistryBundledStopIsNoOpOpts struct {
 
 	// Default: "v26.1.7"
-	RedpandaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:285:2)
+	RedpandaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:515:2)
 }
 
 // RedpandaSchemaRegistryBundledStopIsNoOp pins the bundled-registry lifecycle
@@ -1473,7 +1563,7 @@ type KafkaTestsRedpandaSchemaRegistryBundledStopIsNoOpOpts struct {
 // register/lookup round-trip, calls sr.Stop, then exercises the registry
 // again through the same handle. If sr.Stop had torn down the shared broker
 // service, that follow-up call would fail.
-func (r *KafkaTests) RedpandaSchemaRegistryBundledStopIsNoOp(ctx context.Context, opts ...KafkaTestsRedpandaSchemaRegistryBundledStopIsNoOpOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:282:1)
+func (r *KafkaTests) RedpandaSchemaRegistryBundledStopIsNoOp(ctx context.Context, opts ...KafkaTestsRedpandaSchemaRegistryBundledStopIsNoOpOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:512:1)
 	if r.redpandaSchemaRegistryBundledStopIsNoOp != nil {
 		return nil
 	}
@@ -1492,7 +1582,7 @@ func (r *KafkaTests) RedpandaSchemaRegistryBundledStopIsNoOp(ctx context.Context
 type KafkaTestsRedpandaSchemaRegistryRegisterLookupRoundTripOpts struct {
 
 	// Default: "v26.1.7"
-	RedpandaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:236:2)
+	RedpandaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:466:2)
 }
 
 // RedpandaSchemaRegistryRegisterLookupRoundTrip is the PLAINTEXT happy-path
@@ -1503,7 +1593,7 @@ type KafkaTestsRedpandaSchemaRegistryRegisterLookupRoundTripOpts struct {
 // separate-container ConfluentSchemaRegistry. The SR service is the broker
 // itself, so cluster.Stop tears it down — sr.Stop is a no-op for a bundled
 // registry.
-func (r *KafkaTests) RedpandaSchemaRegistryRegisterLookupRoundTrip(ctx context.Context, opts ...KafkaTestsRedpandaSchemaRegistryRegisterLookupRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:233:1)
+func (r *KafkaTests) RedpandaSchemaRegistryRegisterLookupRoundTrip(ctx context.Context, opts ...KafkaTestsRedpandaSchemaRegistryRegisterLookupRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:463:1)
 	if r.redpandaSchemaRegistryRegisterLookupRoundTrip != nil {
 		return nil
 	}
@@ -1522,7 +1612,7 @@ func (r *KafkaTests) RedpandaSchemaRegistryRegisterLookupRoundTrip(ctx context.C
 type KafkaTestsRedpandaSchemaRegistryTLSRegisterLookupRoundTripOpts struct {
 
 	// Default: "v26.1.7"
-	RedpandaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:259:2)
+	RedpandaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:489:2)
 }
 
 // RedpandaSchemaRegistryTlsRegisterLookupRoundTrip is the TLS-cluster
@@ -1532,11 +1622,66 @@ type KafkaTestsRedpandaSchemaRegistryTLSRegisterLookupRoundTripOpts struct {
 // separately-rendered redpanda.yaml schema_registry_api_tls block), so this
 // exercises that YAML path end-to-end and drives register/lookup over HTTPS,
 // verifying the SR cert against the cluster CA truststore.
-func (r *KafkaTests) RedpandaSchemaRegistryTLSRegisterLookupRoundTrip(ctx context.Context, opts ...KafkaTestsRedpandaSchemaRegistryTLSRegisterLookupRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:256:1)
+func (r *KafkaTests) RedpandaSchemaRegistryTLSRegisterLookupRoundTrip(ctx context.Context, opts ...KafkaTestsRedpandaSchemaRegistryTLSRegisterLookupRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:486:1)
 	if r.redpandaSchemaRegistryTlsRegisterLookupRoundTrip != nil {
 		return nil
 	}
 	q := r.query.Select("redpandaSchemaRegistryTlsRegisterLookupRoundTrip")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `redpandaImageTag` optional argument
+		if !querybuilder.IsZeroValue(opts[i].RedpandaImageTag) {
+			q = q.Arg("redpandaImageTag", opts[i].RedpandaImageTag)
+		}
+	}
+
+	return q.Execute(ctx)
+}
+
+// KafkaTestsRedpandaThreeBrokerReplicationFactorThreeProduceConsumeOpts contains options for KafkaTests.RedpandaThreeBrokerReplicationFactorThreeProduceConsume
+type KafkaTestsRedpandaThreeBrokerReplicationFactorThreeProduceConsumeOpts struct {
+
+	// Default: "v26.1.7"
+	RedpandaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:179:2)
+}
+
+// RedpandaThreeBrokerReplicationFactorThreeProduceConsume stands up a real
+// three-node Redpanda cluster and drives a produce → consume round-trip over
+// an RF=3 topic. A successful round-trip proves the three nodes formed a
+// single Raft group over the internal RPC listener (seed-driven bootstrap) and
+// that inter-node replication is actually exercised — an RF=3 topic can only be
+// created and written if all three brokers reach each other.
+func (r *KafkaTests) RedpandaThreeBrokerReplicationFactorThreeProduceConsume(ctx context.Context, opts ...KafkaTestsRedpandaThreeBrokerReplicationFactorThreeProduceConsumeOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:176:1)
+	if r.redpandaThreeBrokerReplicationFactorThreeProduceConsume != nil {
+		return nil
+	}
+	q := r.query.Select("redpandaThreeBrokerReplicationFactorThreeProduceConsume")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `redpandaImageTag` optional argument
+		if !querybuilder.IsZeroValue(opts[i].RedpandaImageTag) {
+			q = q.Arg("redpandaImageTag", opts[i].RedpandaImageTag)
+		}
+	}
+
+	return q.Execute(ctx)
+}
+
+// KafkaTestsRedpandaThreeBrokerTLSReplicationFactorThreeProduceConsumeOpts contains options for KafkaTests.RedpandaThreeBrokerTLSReplicationFactorThreeProduceConsume
+type KafkaTestsRedpandaThreeBrokerTLSReplicationFactorThreeProduceConsumeOpts struct {
+
+	// Default: "v26.1.7"
+	RedpandaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:197:2)
+}
+
+// RedpandaThreeBrokerTlsReplicationFactorThreeProduceConsume is the TLS
+// counterpart: a three-node Redpanda cluster with TLS on every node's external
+// Kafka listener, driving a produce → consume round-trip over an RF=3 topic.
+// The franz-go client verifies whichever node it is routed to against the
+// cluster truststore, proving every node's leaf is SAN'd to its own hostname.
+func (r *KafkaTests) RedpandaThreeBrokerTLSReplicationFactorThreeProduceConsume(ctx context.Context, opts ...KafkaTestsRedpandaThreeBrokerTLSReplicationFactorThreeProduceConsumeOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_redpanda.go:194:1)
+	if r.redpandaThreeBrokerTlsReplicationFactorThreeProduceConsume != nil {
+		return nil
+	}
+	q := r.query.Select("redpandaThreeBrokerTlsReplicationFactorThreeProduceConsume")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `redpandaImageTag` optional argument
 		if !querybuilder.IsZeroValue(opts[i].RedpandaImageTag) {

--- a/ci/internal/dagger/skill-gen-tests.gen.go
+++ b/ci/internal/dagger/skill-gen-tests.gen.go
@@ -61,6 +61,8 @@ type SkillGenTests struct { // skill-gen-tests (../../../daggerverse/skill-gen/t
 	query *querybuilder.Selection
 
 	all                               *Void
+	bakesCustomPsqlImage              *Void
+	defaultsPsqlImage                 *Void
 	generatesPgSkillFromCluster       *Void
 	generatesPgSkillOverMtls          *Void
 	generatesPgSkillOverTls           *Void
@@ -71,6 +73,7 @@ type SkillGenTests struct { // skill-gen-tests (../../../daggerverse/skill-gen/t
 	regenChangesetEmptyWhenUnchanged  *Void
 	regenChangesetReflectsSchemaDrift *Void
 	rejectsInvalidDbName              *Void
+	rejectsInvalidPsqlImage           *Void
 }
 
 func (r *SkillGenTests) WithGraphQLQuery(q *querybuilder.Selection) *SkillGenTests {
@@ -100,10 +103,34 @@ func (r *SkillGenTests) All(ctx context.Context, opts ...SkillGenTestsAllOpts) e
 	return q.Execute(ctx)
 }
 
+// BakesCustomPsqlImage pins that a caller-supplied psqlImage lands in the
+// generated scripts/query.sh and scripts/.env.example in place of the default,
+// so a team on a private registry gets a skill that runs out of the box
+// without every consumer exporting PSQL_IMAGE by hand.
+func (r *SkillGenTests) BakesCustomPsqlImage(ctx context.Context) error { // skill-gen-tests (../../../daggerverse/skill-gen/tests/tests.go:201:1)
+	if r.bakesCustomPsqlImage != nil {
+		return nil
+	}
+	q := r.query.Select("bakesCustomPsqlImage")
+
+	return q.Execute(ctx)
+}
+
+// DefaultsPsqlImage pins the v1 default: omitting psqlImage bakes
+// docker.io/alpine/psql:17.7 and leaves the regen command free of the flag.
+func (r *SkillGenTests) DefaultsPsqlImage(ctx context.Context) error { // skill-gen-tests (../../../daggerverse/skill-gen/tests/tests.go:255:1)
+	if r.defaultsPsqlImage != nil {
+		return nil
+	}
+	q := r.query.Select("defaultsPsqlImage")
+
+	return q.Execute(ctx)
+}
+
 // GeneratesPgSkillFromCluster pins the happy path: the full tree is present and
 // fully substituted, the frontmatter is correct and model-invocable, and
 // enums.md exists because the schema defines an enum.
-func (r *SkillGenTests) GeneratesPgSkillFromCluster(ctx context.Context) error { // skill-gen-tests (../../../daggerverse/skill-gen/tests/tests.go:196:1)
+func (r *SkillGenTests) GeneratesPgSkillFromCluster(ctx context.Context) error { // skill-gen-tests (../../../daggerverse/skill-gen/tests/tests.go:317:1)
 	if r.generatesPgSkillFromCluster != nil {
 		return nil
 	}
@@ -115,7 +142,7 @@ func (r *SkillGenTests) GeneratesPgSkillFromCluster(ctx context.Context) error {
 // GeneratesPgSkillOverMtls pins that SkillGen.Postgres introspects a mutual-TLS
 // cluster when handed the server CA plus a client cert/key whose CN matches the
 // role (clientcert=verify-full), producing the full skill tree.
-func (r *SkillGenTests) GeneratesPgSkillOverMtls(ctx context.Context) error { // skill-gen-tests (../../../daggerverse/skill-gen/tests/tests.go:456:1)
+func (r *SkillGenTests) GeneratesPgSkillOverMtls(ctx context.Context) error { // skill-gen-tests (../../../daggerverse/skill-gen/tests/tests.go:577:1)
 	if r.generatesPgSkillOverMtls != nil {
 		return nil
 	}
@@ -127,7 +154,7 @@ func (r *SkillGenTests) GeneratesPgSkillOverMtls(ctx context.Context) error { //
 // GeneratesPgSkillOverTls pins that SkillGen.Postgres introspects a one-way-TLS
 // cluster (sslmode=verify-full) when handed only the server CA, producing the
 // full skill tree. The server cert's SAN must cover the dialed clusterHost.
-func (r *SkillGenTests) GeneratesPgSkillOverTLS(ctx context.Context) error { // skill-gen-tests (../../../daggerverse/skill-gen/tests/tests.go:419:1)
+func (r *SkillGenTests) GeneratesPgSkillOverTLS(ctx context.Context) error { // skill-gen-tests (../../../daggerverse/skill-gen/tests/tests.go:540:1)
 	if r.generatesPgSkillOverTls != nil {
 		return nil
 	}
@@ -188,7 +215,7 @@ func (r *SkillGenTests) UnmarshalJSON(bs []byte) error {
 // IntrospectionFailureAborts pins that an introspection failure (here, a wrong
 // password against a live cluster) aborts with a non-zero error and yields no
 // Directory.
-func (r *SkillGenTests) IntrospectionFailureAborts(ctx context.Context) error { // skill-gen-tests (../../../daggerverse/skill-gen/tests/tests.go:168:1)
+func (r *SkillGenTests) IntrospectionFailureAborts(ctx context.Context) error { // skill-gen-tests (../../../daggerverse/skill-gen/tests/tests.go:289:1)
 	if r.introspectionFailureAborts != nil {
 		return nil
 	}
@@ -201,7 +228,7 @@ func (r *SkillGenTests) IntrospectionFailureAborts(ctx context.Context) error { 
 // with no cert params (plaintext) aborts: the primary's hostssl-only pg_hba.conf
 // refuses the unencrypted connection, so generation fails and yields no
 // Directory rather than silently producing partial output.
-func (r *SkillGenTests) PlaintextParamsAgainstTLSAbort(ctx context.Context) error { // skill-gen-tests (../../../daggerverse/skill-gen/tests/tests.go:502:1)
+func (r *SkillGenTests) PlaintextParamsAgainstTLSAbort(ctx context.Context) error { // skill-gen-tests (../../../daggerverse/skill-gen/tests/tests.go:623:1)
 	if r.plaintextParamsAgainstTlsAbort != nil {
 		return nil
 	}
@@ -213,7 +240,7 @@ func (r *SkillGenTests) PlaintextParamsAgainstTLSAbort(ctx context.Context) erro
 // PostgresShouldNotBeCached pins the non-caching contract: regenerating after a
 // schema change reflects the change rather than serving a stale cached
 // Directory.
-func (r *SkillGenTests) PostgresShouldNotBeCached(ctx context.Context) error { // skill-gen-tests (../../../daggerverse/skill-gen/tests/tests.go:276:1)
+func (r *SkillGenTests) PostgresShouldNotBeCached(ctx context.Context) error { // skill-gen-tests (../../../daggerverse/skill-gen/tests/tests.go:397:1)
 	if r.postgresShouldNotBeCached != nil {
 		return nil
 	}
@@ -224,7 +251,7 @@ func (r *SkillGenTests) PostgresShouldNotBeCached(ctx context.Context) error { /
 
 // RegenChangesetEmptyWhenUnchanged pins byte-stability: two generations over an
 // unchanged schema produce an empty changeset.
-func (r *SkillGenTests) RegenChangesetEmptyWhenUnchanged(ctx context.Context) error { // skill-gen-tests (../../../daggerverse/skill-gen/tests/tests.go:317:1)
+func (r *SkillGenTests) RegenChangesetEmptyWhenUnchanged(ctx context.Context) error { // skill-gen-tests (../../../daggerverse/skill-gen/tests/tests.go:438:1)
 	if r.regenChangesetEmptyWhenUnchanged != nil {
 		return nil
 	}
@@ -236,7 +263,7 @@ func (r *SkillGenTests) RegenChangesetEmptyWhenUnchanged(ctx context.Context) er
 // RegenChangesetReflectsSchemaDrift pins that a schema change yields a non-empty
 // changeset: a new table modifies the references, and adding the first enum
 // adds references/enums.md as a brand-new path.
-func (r *SkillGenTests) RegenChangesetReflectsSchemaDrift(ctx context.Context) error { // skill-gen-tests (../../../daggerverse/skill-gen/tests/tests.go:348:1)
+func (r *SkillGenTests) RegenChangesetReflectsSchemaDrift(ctx context.Context) error { // skill-gen-tests (../../../daggerverse/skill-gen/tests/tests.go:469:1)
 	if r.regenChangesetReflectsSchemaDrift != nil {
 		return nil
 	}
@@ -248,11 +275,25 @@ func (r *SkillGenTests) RegenChangesetReflectsSchemaDrift(ctx context.Context) e
 // RejectsInvalidDbName pins that a db name violating ^[A-Za-z0-9_-]+$ is
 // rejected before any introspection (no cluster needed — validation precedes
 // the network).
-func (r *SkillGenTests) RejectsInvalidDbName(ctx context.Context) error { // skill-gen-tests (../../../daggerverse/skill-gen/tests/tests.go:146:1)
+func (r *SkillGenTests) RejectsInvalidDbName(ctx context.Context) error { // skill-gen-tests (../../../daggerverse/skill-gen/tests/tests.go:152:1)
 	if r.rejectsInvalidDbName != nil {
 		return nil
 	}
 	q := r.query.Select("rejectsInvalidDbName")
+
+	return q.Execute(ctx)
+}
+
+// RejectsInvalidPsqlImage pins that a psql image outside the inert charset is
+// rejected before any introspection. The image is substituted raw into the
+// generated query.sh (inside a "${PSQL_IMAGE:-…}" default word, where the shell
+// still expands), so a value carrying shell metacharacters must never reach
+// rendering. No cluster is needed — validation precedes the network.
+func (r *SkillGenTests) RejectsInvalidPsqlImage(ctx context.Context) error { // skill-gen-tests (../../../daggerverse/skill-gen/tests/tests.go:176:1)
+	if r.rejectsInvalidPsqlImage != nil {
+		return nil
+	}
+	q := r.query.Select("rejectsInvalidPsqlImage")
 
 	return q.Execute(ctx)
 }

--- a/ci/internal/dagger/zig-tests.gen.go
+++ b/ci/internal/dagger/zig-tests.gen.go
@@ -56,39 +56,41 @@ func (r *Query) ZigTests() *ZigTests { // zig-tests (../../../daggerverse/zig/te
 type ZigTests struct { // zig-tests (../../../daggerverse/zig/tests/main.go:19:6)
 	query *querybuilder.Selection
 
-	all                            *Void
-	buildCrossTargetProducesBinary *Void
-	buildExeProducesExecutable     *Void
-	buildExeRejectsEmptyRoot       *Void
-	buildHelloProducesBinary       *Void
-	buildOptimizeReleaseSmall      *Void
-	buildRejectsInvalidOptimize    *Void
-	ccCompilesHelloC               *Void
-	ccCrossWindowsProducesExe      *Void
-	ccRejectsEmptyFiles            *Void
-	ccRejectsPathOutputName        *Void
-	ciCheckRunsChecksAndSkipsBuild *Void
-	ciRunAggregatesFailures        *Void
-	ciRunAllStagesProducesBinary   *Void
-	ciWithFmtPasses                *Void
-	ciWithTestPasses               *Void
-	containerHasZigToolchain       *Void
-	containerInfersVersionFromZon  *Void
-	cxxCompilesHelloCpp            *Void
-	envContainsVersionKey          *Void
-	fmtHelloIsClean                *Void
-	fmtUnformattedReportsFile      *Void
-	id                             *ID
-	objCopyProducesBinary          *Void
-	objCopyProducesIntelHex        *Void
-	objCopyRejectsUnknownFormat    *Void
-	runHelloPrintsHello            *Void
-	sizeRejectsNonElf              *Void
-	sizeReportsSections            *Void
-	targetsListsKnownArch          *Void
-	testDirectFilePasses           *Void
-	testHelloBuildStepPasses       *Void
-	toolVersionReturnsVersion      *Void
+	all                                  *Void
+	buildCrossTargetProducesBinary       *Void
+	buildExeProducesExecutable           *Void
+	buildExeRejectsEmptyRoot             *Void
+	buildHelloProducesBinary             *Void
+	buildOptimizeReleaseSmall            *Void
+	buildRejectsInvalidOptimize          *Void
+	ccCompilesHelloC                     *Void
+	ccCrossWindowsProducesExe            *Void
+	ccRejectsEmptyFiles                  *Void
+	ccRejectsPathOutputName              *Void
+	ciCheckWithBuildCatchesCompileError  *Void
+	ciCheckWithBuildPassesOnCleanProject *Void
+	ciCheckWithoutBuildIsFmtOnly         *Void
+	ciRunAggregatesFailures              *Void
+	ciRunAllStagesProducesBinary         *Void
+	ciWithFmtPasses                      *Void
+	ciWithTestPasses                     *Void
+	containerHasZigToolchain             *Void
+	containerInfersVersionFromZon        *Void
+	cxxCompilesHelloCpp                  *Void
+	envContainsVersionKey                *Void
+	fmtHelloIsClean                      *Void
+	fmtUnformattedReportsFile            *Void
+	id                                   *ID
+	objCopyProducesBinary                *Void
+	objCopyProducesIntelHex              *Void
+	objCopyRejectsUnknownFormat          *Void
+	runHelloPrintsHello                  *Void
+	sizeRejectsNonElf                    *Void
+	sizeReportsSections                  *Void
+	targetsListsKnownArch                *Void
+	testDirectFilePasses                 *Void
+	testHelloBuildStepPasses             *Void
+	toolVersionReturnsVersion            *Void
 }
 
 func (r *ZigTests) WithGraphQLQuery(q *querybuilder.Selection) *ZigTests {
@@ -126,7 +128,7 @@ func (r *ZigTests) All(ctx context.Context, opts ...ZigTestsAllOpts) error { // 
 // BuildCrossTargetProducesBinary cross-compiles the hello fixture for
 // aarch64-linux and asserts an artifact is produced. The binary is not
 // host-runnable, so only its size is checked.
-func (r *ZigTests) BuildCrossTargetProducesBinary(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:223:1)
+func (r *ZigTests) BuildCrossTargetProducesBinary(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:225:1)
 	if r.buildCrossTargetProducesBinary != nil {
 		return nil
 	}
@@ -137,7 +139,7 @@ func (r *ZigTests) BuildCrossTargetProducesBinary(ctx context.Context) error { /
 
 // BuildExeProducesExecutable builds the single-file fixture via build-exe and
 // asserts the produced file is named "main" and non-empty.
-func (r *ZigTests) BuildExeProducesExecutable(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:247:1)
+func (r *ZigTests) BuildExeProducesExecutable(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:249:1)
 	if r.buildExeProducesExecutable != nil {
 		return nil
 	}
@@ -148,7 +150,7 @@ func (r *ZigTests) BuildExeProducesExecutable(ctx context.Context) error { // zi
 
 // BuildExeRejectsEmptyRoot asserts BuildExe rejects an empty root. BuildExe
 // returns a lazy file, so the error surfaces on resolve.
-func (r *ZigTests) BuildExeRejectsEmptyRoot(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:268:1)
+func (r *ZigTests) BuildExeRejectsEmptyRoot(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:270:1)
 	if r.buildExeRejectsEmptyRoot != nil {
 		return nil
 	}
@@ -159,7 +161,7 @@ func (r *ZigTests) BuildExeRejectsEmptyRoot(ctx context.Context) error { // zig-
 
 // BuildHelloProducesBinary builds the hello fixture for the host and asserts
 // the installed executable (zig-out/bin/hello) is non-empty.
-func (r *ZigTests) BuildHelloProducesBinary(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:195:1)
+func (r *ZigTests) BuildHelloProducesBinary(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:197:1)
 	if r.buildHelloProducesBinary != nil {
 		return nil
 	}
@@ -170,7 +172,7 @@ func (r *ZigTests) BuildHelloProducesBinary(ctx context.Context) error { // zig-
 
 // BuildOptimizeReleaseSmall builds the hello fixture with
 // -Doptimize=ReleaseSmall and asserts an executable is produced.
-func (r *ZigTests) BuildOptimizeReleaseSmall(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:208:1)
+func (r *ZigTests) BuildOptimizeReleaseSmall(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:210:1)
 	if r.buildOptimizeReleaseSmall != nil {
 		return nil
 	}
@@ -181,7 +183,7 @@ func (r *ZigTests) BuildOptimizeReleaseSmall(ctx context.Context) error { // zig
 
 // BuildRejectsInvalidOptimize asserts Build rejects an invalid optimize value.
 // Build returns a lazy directory, so the validation error surfaces on resolve.
-func (r *ZigTests) BuildRejectsInvalidOptimize(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:237:1)
+func (r *ZigTests) BuildRejectsInvalidOptimize(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:239:1)
 	if r.buildRejectsInvalidOptimize != nil {
 		return nil
 	}
@@ -192,7 +194,7 @@ func (r *ZigTests) BuildRejectsInvalidOptimize(ctx context.Context) error { // z
 
 // CcCompilesHelloC compiles the C fixture for the host with `zig cc` and
 // asserts the produced artifact is non-empty.
-func (r *ZigTests) CcCompilesHelloC(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:334:1)
+func (r *ZigTests) CcCompilesHelloC(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:336:1)
 	if r.ccCompilesHelloC != nil {
 		return nil
 	}
@@ -205,7 +207,7 @@ func (r *ZigTests) CcCompilesHelloC(ctx context.Context) error { // zig-tests (.
 // x86_64-windows-gnu and asserts the artifact carries the requested output
 // name. Resolving .Name runs the cross-compile, so a successful Name read also
 // proves the cross build succeeded.
-func (r *ZigTests) CcCrossWindowsProducesExe(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:464:1)
+func (r *ZigTests) CcCrossWindowsProducesExe(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:466:1)
 	if r.ccCrossWindowsProducesExe != nil {
 		return nil
 	}
@@ -216,7 +218,7 @@ func (r *ZigTests) CcCrossWindowsProducesExe(ctx context.Context) error { // zig
 
 // CcRejectsEmptyFiles asserts Cc rejects an empty files slice. Cc returns a
 // lazy file, so the validation error surfaces on resolve.
-func (r *ZigTests) CcRejectsEmptyFiles(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:481:1)
+func (r *ZigTests) CcRejectsEmptyFiles(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:483:1)
 	if r.ccRejectsEmptyFiles != nil {
 		return nil
 	}
@@ -228,7 +230,7 @@ func (r *ZigTests) CcRejectsEmptyFiles(ctx context.Context) error { // zig-tests
 // CcRejectsPathOutputName asserts Cc rejects a path-like outputName (the
 // parameter is a bare filename, not a path). The validation error surfaces on
 // resolve, before any zig exec runs.
-func (r *ZigTests) CcRejectsPathOutputName(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:498:1)
+func (r *ZigTests) CcRejectsPathOutputName(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:500:1)
 	if r.ccRejectsPathOutputName != nil {
 		return nil
 	}
@@ -237,17 +239,46 @@ func (r *ZigTests) CcRejectsPathOutputName(ctx context.Context) error { // zig-t
 	return q.Execute(ctx)
 }
 
-// CiCheckRunsChecksAndSkipsBuild configures every stage against the clean hello
-// fixture and calls Check (not Run), asserting no error. To actively prove
-// Check does not invoke the build stage, WithBuild is configured with a
-// nonexistent build step: if Check were to call runBuild, `zig build
-// nonexistent-step` would fail and surface here. A nil return therefore proves
-// both (a) the checks passed and (b) the build was skipped.
-func (r *ZigTests) CiCheckRunsChecksAndSkipsBuild(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:581:1)
-	if r.ciCheckRunsChecksAndSkipsBuild != nil {
+// CiCheckWithBuildCatchesCompileError is the core regression test for issue
+// #161: Ci.Check must compile when WithBuild was requested. The no-compile
+// fixture is fmt-clean but does not type-check, so with only Fmt enabled Check
+// reports a false green (see CiCheckWithoutBuildIsFmtOnly). Adding WithBuild
+// must make Check run the build stage and surface the compile error.
+func (r *ZigTests) CiCheckWithBuildCatchesCompileError(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:591:1)
+	if r.ciCheckWithBuildCatchesCompileError != nil {
 		return nil
 	}
-	q := r.query.Select("ciCheckRunsChecksAndSkipsBuild")
+	q := r.query.Select("ciCheckWithBuildCatchesCompileError")
+
+	return q.Execute(ctx)
+}
+
+// CiCheckWithBuildPassesOnCleanProject configures every stage against the clean
+// hello fixture and calls Check (not Run), asserting no error. With WithBuild
+// enabled, Check runs fmt, test, and the build stage; a nil return proves all
+// three passed. Together with CiCheckWithBuildCatchesCompileError (build catches
+// a compile error) this proves the build stage genuinely runs under Check when
+// requested, rather than being silently skipped.
+func (r *ZigTests) CiCheckWithBuildPassesOnCleanProject(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:621:1)
+	if r.ciCheckWithBuildPassesOnCleanProject != nil {
+		return nil
+	}
+	q := r.query.Select("ciCheckWithBuildPassesOnCleanProject")
+
+	return q.Execute(ctx)
+}
+
+// CiCheckWithoutBuildIsFmtOnly is the counterpart to
+// CiCheckWithBuildCatchesCompileError and pins the opt-in semantics: without
+// WithBuild, Check runs only the enabled static checks and never compiles. The
+// no-compile fixture is fmt-clean, so Fmt-only Check passes even though the
+// project does not build. This preserves the documented build-free Check for
+// multi-target pipelines that share one check run across N target builds.
+func (r *ZigTests) CiCheckWithoutBuildIsFmtOnly(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:608:1)
+	if r.ciCheckWithoutBuildIsFmtOnly != nil {
+		return nil
+	}
+	q := r.query.Select("ciCheckWithoutBuildIsFmtOnly")
 
 	return q.Execute(ctx)
 }
@@ -258,7 +289,7 @@ func (r *ZigTests) CiCheckRunsChecksAndSkipsBuild(ctx context.Context) error { /
 // and Test fails with a withExec "exit code" error; the parallel aggregator
 // concatenates both, so requiring both signatures in the message proves both
 // jobs ran and both errors propagated (and the build was skipped).
-func (r *ZigTests) CiRunAggregatesFailures(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:599:1)
+func (r *ZigTests) CiRunAggregatesFailures(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:639:1)
 	if r.ciRunAggregatesFailures != nil {
 		return nil
 	}
@@ -269,7 +300,7 @@ func (r *ZigTests) CiRunAggregatesFailures(ctx context.Context) error { // zig-t
 
 // CiRunAllStagesProducesBinary runs Ci with every stage enabled against the
 // hello fixture and asserts a non-empty binary is produced.
-func (r *ZigTests) CiRunAllStagesProducesBinary(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:560:1)
+func (r *ZigTests) CiRunAllStagesProducesBinary(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:571:1)
 	if r.ciRunAllStagesProducesBinary != nil {
 		return nil
 	}
@@ -281,7 +312,7 @@ func (r *ZigTests) CiRunAllStagesProducesBinary(ctx context.Context) error { // 
 // CiWithFmtPasses runs Ci with only the Fmt check enabled against the
 // fmt-clean hello fixture and asserts the build stage still produces a
 // non-empty binary.
-func (r *ZigTests) CiWithFmtPasses(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:534:1)
+func (r *ZigTests) CiWithFmtPasses(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:545:1)
 	if r.ciWithFmtPasses != nil {
 		return nil
 	}
@@ -292,7 +323,7 @@ func (r *ZigTests) CiWithFmtPasses(ctx context.Context) error { // zig-tests (..
 
 // CiWithTestPasses runs Ci with only the Test check enabled (zig build test)
 // against the hello fixture and asserts a non-empty binary is produced.
-func (r *ZigTests) CiWithTestPasses(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:547:1)
+func (r *ZigTests) CiWithTestPasses(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:558:1)
 	if r.ciWithTestPasses != nil {
 		return nil
 	}
@@ -305,7 +336,7 @@ func (r *ZigTests) CiWithTestPasses(ctx context.Context) error { // zig-tests (.
 // downloaded toolchain is on PATH, the source is mounted at /src, and `zig`
 // runs. This is the canary for every other test — if it fails, the rest can't
 // possibly pass.
-func (r *ZigTests) ContainerHasZigToolchain(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:122:1)
+func (r *ZigTests) ContainerHasZigToolchain(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:124:1)
 	if r.containerHasZigToolchain != nil {
 		return nil
 	}
@@ -320,7 +351,7 @@ func (r *ZigTests) ContainerHasZigToolchain(ctx context.Context) error { // zig-
 // i.e. resolveVersion + ZON parsing wire through to toolchain selection.
 // zonVersion is a different patch than the pinned default, so a match proves
 // inference rather than the fallback.
-func (r *ZigTests) ContainerInfersVersionFromZon(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:141:1)
+func (r *ZigTests) ContainerInfersVersionFromZon(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:143:1)
 	if r.containerInfersVersionFromZon != nil {
 		return nil
 	}
@@ -331,7 +362,7 @@ func (r *ZigTests) ContainerInfersVersionFromZon(ctx context.Context) error { //
 
 // CxxCompilesHelloCpp compiles the C++ fixture for the host with `zig c++` and
 // asserts the produced artifact is non-empty.
-func (r *ZigTests) CxxCompilesHelloCpp(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:513:1)
+func (r *ZigTests) CxxCompilesHelloCpp(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:515:1)
 	if r.cxxCompilesHelloCpp != nil {
 		return nil
 	}
@@ -342,7 +373,7 @@ func (r *ZigTests) CxxCompilesHelloCpp(ctx context.Context) error { // zig-tests
 
 // EnvContainsVersionKey calls the source-less Env and asserts the `zig env`
 // JSON contains the version key.
-func (r *ZigTests) EnvContainsVersionKey(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:169:1)
+func (r *ZigTests) EnvContainsVersionKey(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:171:1)
 	if r.envContainsVersionKey != nil {
 		return nil
 	}
@@ -353,7 +384,7 @@ func (r *ZigTests) EnvContainsVersionKey(ctx context.Context) error { // zig-tes
 
 // FmtHelloIsClean runs Fmt against the fmt-clean hello fixture and asserts no
 // error is returned.
-func (r *ZigTests) FmtHelloIsClean(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:309:1)
+func (r *ZigTests) FmtHelloIsClean(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:311:1)
 	if r.fmtHelloIsClean != nil {
 		return nil
 	}
@@ -367,7 +398,7 @@ func (r *ZigTests) FmtHelloIsClean(ctx context.Context) error { // zig-tests (..
 // offending paths only via the error (it returns error alone, since a Dagger
 // function's non-error return value is dropped at the GraphQL boundary when it
 // also returns a non-nil error).
-func (r *ZigTests) FmtUnformattedReportsFile(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:321:1)
+func (r *ZigTests) FmtUnformattedReportsFile(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:323:1)
 	if r.fmtUnformattedReportsFile != nil {
 		return nil
 	}
@@ -427,7 +458,7 @@ func (r *ZigTests) UnmarshalJSON(bs []byte) error {
 
 // ObjCopyProducesBinary converts the BuildExe ELF to a raw .bin and asserts the
 // result is non-empty and no longer carries the ELF magic.
-func (r *ZigTests) ObjCopyProducesBinary(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:353:1)
+func (r *ZigTests) ObjCopyProducesBinary(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:355:1)
 	if r.objCopyProducesBinary != nil {
 		return nil
 	}
@@ -438,7 +469,7 @@ func (r *ZigTests) ObjCopyProducesBinary(ctx context.Context) error { // zig-tes
 
 // ObjCopyProducesIntelHex converts the BuildExe ELF to Intel HEX and asserts the
 // first record begins with ':' (the Intel HEX record start code).
-func (r *ZigTests) ObjCopyProducesIntelHex(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:386:1)
+func (r *ZigTests) ObjCopyProducesIntelHex(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:388:1)
 	if r.objCopyProducesIntelHex != nil {
 		return nil
 	}
@@ -449,7 +480,7 @@ func (r *ZigTests) ObjCopyProducesIntelHex(ctx context.Context) error { // zig-t
 
 // ObjCopyRejectsUnknownFormat asserts ObjCopy rejects an unsupported format
 // (e.g. "uf2"). ObjCopy returns a lazy file, so the error surfaces on resolve.
-func (r *ZigTests) ObjCopyRejectsUnknownFormat(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:399:1)
+func (r *ZigTests) ObjCopyRejectsUnknownFormat(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:401:1)
 	if r.objCopyRejectsUnknownFormat != nil {
 		return nil
 	}
@@ -460,7 +491,7 @@ func (r *ZigTests) ObjCopyRejectsUnknownFormat(ctx context.Context) error { // z
 
 // RunHelloPrintsHello runs the hello fixture and asserts its stdout contains
 // "hello".
-func (r *ZigTests) RunHelloPrintsHello(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:296:1)
+func (r *ZigTests) RunHelloPrintsHello(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:298:1)
 	if r.runHelloPrintsHello != nil {
 		return nil
 	}
@@ -471,7 +502,7 @@ func (r *ZigTests) RunHelloPrintsHello(ctx context.Context) error { // zig-tests
 
 // SizeRejectsNonElf feeds a raw .bin (produced by ObjCopy) into Size and asserts
 // a clear non-ELF error.
-func (r *ZigTests) SizeRejectsNonElf(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:448:1)
+func (r *ZigTests) SizeRejectsNonElf(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:450:1)
 	if r.sizeRejectsNonElf != nil {
 		return nil
 	}
@@ -482,7 +513,7 @@ func (r *ZigTests) SizeRejectsNonElf(ctx context.Context) error { // zig-tests (
 
 // SizeReportsSections asserts Size on the BuildExe host ELF returns Text > 0 and
 // internally consistent Flash/Ram rollups.
-func (r *ZigTests) SizeReportsSections(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:412:1)
+func (r *ZigTests) SizeReportsSections(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:414:1)
 	if r.sizeReportsSections != nil {
 		return nil
 	}
@@ -493,7 +524,7 @@ func (r *ZigTests) SizeReportsSections(ctx context.Context) error { // zig-tests
 
 // TargetsListsKnownArch calls the source-less Targets and asserts a known
 // architecture appears in the output.
-func (r *ZigTests) TargetsListsKnownArch(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:182:1)
+func (r *ZigTests) TargetsListsKnownArch(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:184:1)
 	if r.targetsListsKnownArch != nil {
 		return nil
 	}
@@ -504,7 +535,7 @@ func (r *ZigTests) TargetsListsKnownArch(ctx context.Context) error { // zig-tes
 
 // TestDirectFilePasses runs `zig test main.zig` against the single-file
 // fixture and asserts it succeeds.
-func (r *ZigTests) TestDirectFilePasses(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:287:1)
+func (r *ZigTests) TestDirectFilePasses(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:289:1)
 	if r.testDirectFilePasses != nil {
 		return nil
 	}
@@ -515,7 +546,7 @@ func (r *ZigTests) TestDirectFilePasses(ctx context.Context) error { // zig-test
 
 // TestHelloBuildStepPasses runs `zig build test` against the hello fixture and
 // asserts it succeeds.
-func (r *ZigTests) TestHelloBuildStepPasses(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:278:1)
+func (r *ZigTests) TestHelloBuildStepPasses(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:280:1)
 	if r.testHelloBuildStepPasses != nil {
 		return nil
 	}
@@ -526,7 +557,7 @@ func (r *ZigTests) TestHelloBuildStepPasses(ctx context.Context) error { // zig-
 
 // ToolVersionReturnsVersion calls the source-less ToolVersion and asserts it
 // returns a dotted version string.
-func (r *ZigTests) ToolVersionReturnsVersion(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:156:1)
+func (r *ZigTests) ToolVersionReturnsVersion(ctx context.Context) error { // zig-tests (../../../daggerverse/zig/tests/main.go:158:1)
 	if r.toolVersionReturnsVersion != nil {
 		return nil
 	}

--- a/daggerverse/skill-gen/dagger.gen.go
+++ b/daggerverse/skill-gen/dagger.gen.go
@@ -254,7 +254,14 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg clientKey", err))
 				}
 			}
-			return (*SkillGen).Postgres(&parent, ctx, host, port, user, db, password, serverCa, clientCert, clientKey)
+			var psqlImage string
+			if inputArgs["psqlImage"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["psqlImage"]), &psqlImage)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg psqlImage", err))
+				}
+			}
+			return (*SkillGen).Postgres(&parent, ctx, host, port, user, db, password, serverCa, clientCert, clientKey, psqlImage)
 		default:
 			return nil, fmt.Errorf("unknown function %s", fnName)
 		}

--- a/daggerverse/skill-gen/main.go
+++ b/daggerverse/skill-gen/main.go
@@ -49,6 +49,13 @@ type SkillGen struct{}
 // serverCa and clientCert are public PEM certs (*dagger.File); clientKey is the
 // PEM PKCS#8 private key kept as a *dagger.Secret end-to-end.
 //
+// psqlImage overrides the psql container image baked into the generated
+// scripts/query.sh and scripts/.env.example. The generated script already
+// honours a PSQL_IMAGE override at runtime, so this is purely a
+// generation-time convenience: teams on a private or locked-down registry can
+// bake their own default in so the skill works out of the box. It is
+// substituted raw into the script and so is charset-validated up front.
+//
 // +cache="never"
 func (s *SkillGen) Postgres(
 	ctx context.Context,
@@ -67,8 +74,14 @@ func (s *SkillGen) Postgres(
 	// clientKey is the PEM PKCS#8 client private key for mTLS. Provide with clientCert.
 	// +optional
 	clientKey *dagger.Secret,
+	// psqlImage is the container image the generated scripts/query.sh runs psql in.
+	// +default="docker.io/alpine/psql:17.7"
+	psqlImage string,
 ) (*dagger.Directory, error) {
 	if err := skill.ValidateDBName(db); err != nil {
+		return nil, err
+	}
+	if err := skill.ValidatePsqlImage(psqlImage); err != nil {
 		return nil, err
 	}
 
@@ -82,7 +95,7 @@ func (s *SkillGen) Postgres(
 		dagger.PostgresClientOpts{Port: port},
 	)
 
-	model := &skill.Model{DBName: db, Host: host, Port: port, User: user}
+	model := &skill.Model{DBName: db, Host: host, Port: port, User: user, PsqlImage: psqlImage}
 	queries := []struct {
 		name  string
 		sql   string

--- a/daggerverse/skill-gen/skill/model.go
+++ b/daggerverse/skill-gen/skill/model.go
@@ -24,6 +24,11 @@ type Model struct {
 	Port   int
 	User   string
 
+	// PsqlImage is the container image the generated query.sh runs psql in.
+	// Empty means DefaultPsqlImage, so a Model that predates this field still
+	// renders the original bytes.
+	PsqlImage string
+
 	// Raw introspection rows, each in the deterministic order the queries
 	// imposed (ORDER BY schema, table, ordinal — see the parent module).
 	Columns     []Column

--- a/daggerverse/skill-gen/skill/render.go
+++ b/daggerverse/skill-gen/skill/render.go
@@ -97,12 +97,16 @@ func Render(m *Model) (map[string]string, error) {
 	}
 	// Host/user/db flow into a bash script and an .env example, so they are
 	// substituted as single-quoted shell literals; port is a rendered integer
-	// and needs no quoting.
+	// and needs no quoting. The psql image is substituted raw — it lands inside
+	// query.sh's `"${PSQL_IMAGE:-…}"` default word, where quoting it would
+	// change the byte output — and is instead constrained to an inert charset
+	// by ValidatePsqlImage before it ever reaches here.
 	subst := strings.NewReplacer(
 		"<host>", shellSingleQuote(m.Host),
 		"<port>", fmt.Sprintf("%d", m.Port),
 		"<user>", shellSingleQuote(m.User),
 		"<dbname>", shellSingleQuote(m.DBName),
+		"<psql-image>", m.psqlImage(),
 	)
 
 	files := map[string]string{
@@ -140,15 +144,33 @@ func baseName(p string) string {
 	return p
 }
 
+// psqlImage is the effective psql image: the Model's value, or the default
+// when unset.
+func (m *Model) psqlImage() string {
+	if m.PsqlImage == "" {
+		return DefaultPsqlImage
+	}
+	return m.PsqlImage
+}
+
 // regenCommand builds a deterministic `dagger call` regeneration command with
 // the given trailing subcommand. The password is referenced as
 // env:PGPASSWORD — never the secret value — so the command is safe to commit.
 // Host/user/db are single-quoted so a value with shell metacharacters stays a
 // single, inert argument when the command is copy-pasted from the README.
+//
+// --psql-image is emitted only when it differs from the default, so a skill
+// generated without it keeps the shorter v1 command. Emitting it when it does
+// differ matters: the README's drift check regenerates and diffs against the
+// committed tree, and dropping the flag would report spurious drift.
 func (m *Model) regenCommand(_ string, trailer string) string {
+	image := ""
+	if m.psqlImage() != DefaultPsqlImage {
+		image = " --psql-image " + shellSingleQuote(m.psqlImage())
+	}
 	return fmt.Sprintf(
-		"dagger call skill-gen postgres --host %s --port %d --user %s --db %s --password env:PGPASSWORD %s",
-		shellSingleQuote(m.Host), m.Port, shellSingleQuote(m.User), shellSingleQuote(m.DBName), trailer,
+		"dagger call skill-gen postgres --host %s --port %d --user %s --db %s --password env:PGPASSWORD%s %s",
+		shellSingleQuote(m.Host), m.Port, shellSingleQuote(m.User), shellSingleQuote(m.DBName), image, trailer,
 	)
 }
 

--- a/daggerverse/skill-gen/skill/skill_test.go
+++ b/daggerverse/skill-gen/skill/skill_test.go
@@ -186,6 +186,88 @@ func TestRowCountExampleIsShellSafe(t *testing.T) {
 	}
 }
 
+// TestRenderCustomPsqlImage pins that a caller-supplied image replaces the
+// baked default in both generated script files, and that the README's regen
+// command carries the flag forward — without it, the drift check the README
+// documents would regenerate with the default image and report false drift.
+func TestRenderCustomPsqlImage(t *testing.T) {
+	m := fixtureModel()
+	m.PsqlImage = "registry.internal:5000/team/psql:16.4"
+	files := mustRender(t, m)
+
+	want := `PSQL_IMAGE="${PSQL_IMAGE:-registry.internal:5000/team/psql:16.4}"`
+	if !strings.Contains(files[PathQuery], want) {
+		t.Errorf("query.sh missing custom psql image line %q:\n%s", want, files[PathQuery])
+	}
+	if strings.Contains(files[PathQuery], DefaultPsqlImage) {
+		t.Errorf("query.sh still carries the default psql image:\n%s", files[PathQuery])
+	}
+	if !strings.Contains(files[PathEnvExample], "# PSQL_IMAGE=registry.internal:5000/team/psql:16.4") {
+		t.Errorf(".env.example missing custom psql image key:\n%s", files[PathEnvExample])
+	}
+	if !strings.Contains(files[PathREADME], "--psql-image 'registry.internal:5000/team/psql:16.4'") {
+		t.Errorf("README regen command missing --psql-image:\n%s", files[PathREADME])
+	}
+	if err := Verify(files, m.DBName); err != nil {
+		t.Errorf("Verify on custom-image tree: %v", err)
+	}
+}
+
+// TestRenderDefaultPsqlImage pins that an unset PsqlImage renders exactly what
+// an explicit default does, so omitting the module param reproduces v1 output.
+func TestRenderDefaultPsqlImage(t *testing.T) {
+	implicit := mustRender(t, fixtureModel())
+
+	m := fixtureModel()
+	m.PsqlImage = DefaultPsqlImage
+	explicit := mustRender(t, m)
+
+	for _, p := range []string{PathQuery, PathEnvExample, PathREADME} {
+		if implicit[p] != explicit[p] {
+			t.Errorf("%s differs between unset and explicitly-default PsqlImage", p)
+		}
+	}
+	want := `PSQL_IMAGE="${PSQL_IMAGE:-` + DefaultPsqlImage + `}"`
+	if !strings.Contains(implicit[PathQuery], want) {
+		t.Errorf("query.sh missing default psql image line %q:\n%s", want, implicit[PathQuery])
+	}
+	// The default must not bloat the regen command documented in the README.
+	if strings.Contains(implicit[PathREADME], "--psql-image") {
+		t.Errorf("README regen command names --psql-image for the default image:\n%s", implicit[PathREADME])
+	}
+}
+
+// TestValidatePsqlImage pins the charset that keeps a raw-substituted image
+// inert inside query.sh's "${PSQL_IMAGE:-…}" default word.
+func TestValidatePsqlImage(t *testing.T) {
+	valid := []string{
+		DefaultPsqlImage,
+		"psql",
+		"registry.internal:5000/team/psql:16.4",
+		"docker.io/alpine/psql@sha256:" + strings.Repeat("a", 64),
+	}
+	for _, img := range valid {
+		if err := ValidatePsqlImage(img); err != nil {
+			t.Errorf("ValidatePsqlImage(%q) = %v, want nil", img, err)
+		}
+	}
+	invalid := []string{
+		"",
+		"psql:17.7 --privileged",       // word splitting
+		"$(touch /tmp/pwn)",            // command substitution
+		"psql:`id`",                    // backtick substitution
+		"psql:${HOME}",                 // parameter expansion
+		"psql:17.7}\"; touch /tmp/pwn", // closes the expansion and the string
+		`psql:17.7\n`,                  // backslash escape
+		"-psql:17.7",                   // leading dash reads as a flag
+	}
+	for _, img := range invalid {
+		if err := ValidatePsqlImage(img); err == nil {
+			t.Errorf("ValidatePsqlImage(%q) = nil, want error", img)
+		}
+	}
+}
+
 func mustRender(t *testing.T, m *Model) map[string]string {
 	t.Helper()
 	files, err := Render(m)

--- a/daggerverse/skill-gen/skill/templates/env.example
+++ b/daggerverse/skill-gen/skill/templates/env.example
@@ -10,6 +10,10 @@
 # PGUSER=<user>
 # PGPASSWORD=
 
+# Container image psql runs in. Overriding this needs no regeneration — the
+# value set here wins over the default baked into query.sh at generation time.
+# PSQL_IMAGE=<psql-image>
+
 # Any other libpq env var (PGSSLMODE, PGSSLROOTCERT, PGSERVICE, PGOPTIONS,
 # PGTARGETSESSIONATTRS, PGAPPNAME, PGCONNECT_TIMEOUT, …) set here is also
 # forwarded to psql inside the container.

--- a/daggerverse/skill-gen/skill/templates/query.sh
+++ b/daggerverse/skill-gen/skill/templates/query.sh
@@ -112,7 +112,7 @@ else
   echo "neither docker nor podman found on PATH" >&2
   exit 1
 fi
-PSQL_IMAGE="${PSQL_IMAGE:-docker.io/alpine/psql:17.7}"
+PSQL_IMAGE="${PSQL_IMAGE:-<psql-image>}"
 
 read -r -a EXTRA_ARGS <<< "${PG_DOCKER_ARGS:-}"
 

--- a/daggerverse/skill-gen/skill/testdata/golden/scripts/.env.example
+++ b/daggerverse/skill-gen/skill/testdata/golden/scripts/.env.example
@@ -10,6 +10,10 @@
 # PGUSER='analyst'
 # PGPASSWORD=
 
+# Container image psql runs in. Overriding this needs no regeneration — the
+# value set here wins over the default baked into query.sh at generation time.
+# PSQL_IMAGE=docker.io/alpine/psql:17.7
+
 # Any other libpq env var (PGSSLMODE, PGSSLROOTCERT, PGSERVICE, PGOPTIONS,
 # PGTARGETSESSIONATTRS, PGAPPNAME, PGCONNECT_TIMEOUT, …) set here is also
 # forwarded to psql inside the container.

--- a/daggerverse/skill-gen/skill/validate.go
+++ b/daggerverse/skill-gen/skill/validate.go
@@ -19,3 +19,29 @@ func ValidateDBName(db string) error {
 	}
 	return nil
 }
+
+// DefaultPsqlImage is the psql container image baked into a generated skill
+// when the caller doesn't override it. Keeping it here (rather than only in
+// the template) lets both the module's +default and Render agree on one value.
+const DefaultPsqlImage = "docker.io/alpine/psql:17.7"
+
+// psqlImagePattern constrains the psql image reference. Unlike host/user/db,
+// the image is substituted *raw* into query.sh's `"${PSQL_IMAGE:-<image>}"`
+// default word — quoting it would change the byte output for the default value
+// — so the safety has to come from the charset instead. This set covers every
+// legal OCI reference character (registry[:port]/namespace/name:tag@digest)
+// while excluding everything the shell would act on inside double quotes ($,
+// backtick, backslash, quotes) as well as `}`, which would otherwise close the
+// parameter expansion early, and whitespace, which would split the word.
+var psqlImagePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._:/@-]*$`)
+
+// ValidatePsqlImage rejects a psql image reference that isn't inert when
+// substituted into the generated bash script and .env example. Like
+// ValidateDBName it runs before any introspection, so a bad value aborts
+// before touching the network or producing any output.
+func ValidatePsqlImage(image string) error {
+	if !psqlImagePattern.MatchString(image) {
+		return fmt.Errorf("invalid psql image %q: must match %s", image, psqlImagePattern.String())
+	}
+	return nil
+}

--- a/daggerverse/skill-gen/skill/verify.go
+++ b/daggerverse/skill-gen/skill/verify.go
@@ -11,7 +11,7 @@ import (
 // (`done < "$file"`, `< <(compgen …)`) don't read as unsubstituted placeholders.
 var placeholderTokens = []string{
 	"<dbname>", "<db>", "<skill-dir>", "<host>", "<port>", "<user>",
-	"<regen-command>", "<top tables>", "<top-table>",
+	"<psql-image>", "<regen-command>", "<top tables>", "<top-table>",
 	"<table count>", "<view count>", "<enum count>", "<count>",
 	"<schema>", "<table>", "<view>", "<enum_type>",
 }
@@ -39,7 +39,7 @@ func Verify(files map[string]string, db string) error {
 		}
 	}
 
-	for _, p := range []string{PathSKILL, PathREADME, PathQuery} {
+	for _, p := range []string{PathSKILL, PathREADME, PathQuery, PathEnvExample} {
 		for _, tok := range placeholderTokens {
 			if strings.Contains(files[p], tok) {
 				return fmt.Errorf("verify: %s contains unsubstituted placeholder %q", p, tok)

--- a/daggerverse/skill-gen/tests/dagger.gen.go
+++ b/daggerverse/skill-gen/tests/dagger.gen.go
@@ -206,6 +206,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Tests).All(&parent, ctx, parallel)
+		case "BakesCustomPsqlImage":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).BakesCustomPsqlImage(&parent, ctx)
+		case "DefaultsPsqlImage":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).DefaultsPsqlImage(&parent, ctx)
 		case "GeneratesPgSkillFromCluster":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -269,6 +283,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).RejectsInvalidDbName(&parent, ctx)
+		case "RejectsInvalidPsqlImage":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).RejectsInvalidPsqlImage(&parent, ctx)
 		default:
 			return nil, fmt.Errorf("unknown function %s", fnName)
 		}

--- a/daggerverse/skill-gen/tests/internal/dagger/skill-gen.gen.go
+++ b/daggerverse/skill-gen/tests/internal/dagger/skill-gen.gen.go
@@ -117,19 +117,25 @@ func (r *SkillGen) UnmarshalJSON(bs []byte) error {
 type SkillGenPostgresOpts struct {
 
 	// Default: 5432
-	Port int // skill-gen (../../../../../daggerverse/skill-gen/main.go:57:2)
+	Port int // skill-gen (../../../../../daggerverse/skill-gen/main.go:64:2)
 	//
 	// serverCa pins the server's CA (sslmode=verify-full). Required for TLS/mTLS; omit for plaintext.
 	//
-	ServerCa *File // skill-gen (../../../../../daggerverse/skill-gen/main.go:63:2)
+	ServerCa *File // skill-gen (../../../../../daggerverse/skill-gen/main.go:70:2)
 	//
 	// clientCert is the PEM client leaf for mTLS; its CN must equal `user`. Provide with clientKey.
 	//
-	ClientCert *File // skill-gen (../../../../../daggerverse/skill-gen/main.go:66:2)
+	ClientCert *File // skill-gen (../../../../../daggerverse/skill-gen/main.go:73:2)
 	//
 	// clientKey is the PEM PKCS#8 client private key for mTLS. Provide with clientCert.
 	//
-	ClientKey *Secret // skill-gen (../../../../../daggerverse/skill-gen/main.go:69:2)
+	ClientKey *Secret // skill-gen (../../../../../daggerverse/skill-gen/main.go:76:2)
+	//
+	// psqlImage is the container image the generated scripts/query.sh runs psql in.
+	//
+	//
+	// Default: "docker.io/alpine/psql:17.7"
+	PsqlImage string // skill-gen (../../../../../daggerverse/skill-gen/main.go:79:2)
 }
 
 // Postgres introspects the PostgreSQL database at host:port and returns a
@@ -159,7 +165,14 @@ type SkillGenPostgresOpts struct {
 //
 // serverCa and clientCert are public PEM certs (*dagger.File); clientKey is the
 // PEM PKCS#8 private key kept as a *dagger.Secret end-to-end.
-func (r *SkillGen) Postgres(host string, user string, db string, password *Secret, opts ...SkillGenPostgresOpts) *Directory { // skill-gen (../../../../../daggerverse/skill-gen/main.go:53:1)
+//
+// psqlImage overrides the psql container image baked into the generated
+// scripts/query.sh and scripts/.env.example. The generated script already
+// honours a PSQL_IMAGE override at runtime, so this is purely a
+// generation-time convenience: teams on a private or locked-down registry can
+// bake their own default in so the skill works out of the box. It is
+// substituted raw into the script and so is charset-validated up front.
+func (r *SkillGen) Postgres(host string, user string, db string, password *Secret, opts ...SkillGenPostgresOpts) *Directory { // skill-gen (../../../../../daggerverse/skill-gen/main.go:60:1)
 	assertNotNil("password", password)
 	q := r.query.Select("postgres")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -178,6 +191,10 @@ func (r *SkillGen) Postgres(host string, user string, db string, password *Secre
 		// `clientKey` optional argument
 		if !querybuilder.IsZeroValue(opts[i].ClientKey) {
 			q = q.Arg("clientKey", opts[i].ClientKey)
+		}
+		// `psqlImage` optional argument
+		if !querybuilder.IsZeroValue(opts[i].PsqlImage) {
+			q = q.Arg("psqlImage", opts[i].PsqlImage)
 		}
 	}
 	q = q.Arg("host", host)

--- a/daggerverse/skill-gen/tests/main.go
+++ b/daggerverse/skill-gen/tests/main.go
@@ -33,6 +33,9 @@ func (t *Tests) All(
 		jobs = jobs.WithLimit(parallel)
 	}
 	jobs = jobs.WithJob("rejects-invalid-db-name", t.RejectsInvalidDbName)
+	jobs = jobs.WithJob("rejects-invalid-psql-image", t.RejectsInvalidPsqlImage)
+	jobs = jobs.WithJob("bakes-custom-psql-image", t.BakesCustomPsqlImage)
+	jobs = jobs.WithJob("defaults-psql-image", t.DefaultsPsqlImage)
 	jobs = jobs.WithJob("introspection-failure-aborts", t.IntrospectionFailureAborts)
 	jobs = jobs.WithJob("generates-pg-skill-from-cluster", t.GeneratesPgSkillFromCluster)
 	jobs = jobs.WithJob("postgres-should-not-be-cached", t.PostgresShouldNotBeCached)

--- a/daggerverse/skill-gen/tests/tests.go
+++ b/daggerverse/skill-gen/tests/tests.go
@@ -106,6 +106,12 @@ func genSkillSec(ctx context.Context, cluster *dagger.PostgresCluster, pass *dag
 	return dir, db, nil
 }
 
+// defaultPsqlImage mirrors skill.DefaultPsqlImage — the psql image baked into
+// a generated skill when the caller doesn't override psqlImage. It is spelled
+// out here rather than imported because tests/ is its own Go module; that's
+// the point, since these tests pin the default as a caller-visible contract.
+const defaultPsqlImage = "docker.io/alpine/psql:17.7"
+
 // ddlFull builds a schema with two tables, an FK, an enum, a view, an index,
 // and comments — enough to populate every reference file.
 var ddlFull = []string{
@@ -156,6 +162,121 @@ func (t *Tests) RejectsInvalidDbName(ctx context.Context) error {
 	}
 	if !strings.Contains(err.Error(), "invalid db name") {
 		return fmt.Errorf("expected 'invalid db name' error, got: %v", err)
+	}
+	return nil
+}
+
+// RejectsInvalidPsqlImage pins that a psql image outside the inert charset is
+// rejected before any introspection. The image is substituted raw into the
+// generated query.sh (inside a "${PSQL_IMAGE:-…}" default word, where the shell
+// still expands), so a value carrying shell metacharacters must never reach
+// rendering. No cluster is needed — validation precedes the network.
+//
+// +cache="never"
+func (t *Tests) RejectsInvalidPsqlImage(ctx context.Context) error {
+	pass, err := randSecret(ctx)
+	if err != nil {
+		return err
+	}
+	_, err = dag.SkillGen().
+		Postgres("unused-host", "postgres", "postgres", pass, dagger.SkillGenPostgresOpts{
+			PsqlImage: "psql:17.7}\"; touch /tmp/pwn",
+		}).
+		Sync(ctx)
+	if err == nil {
+		return fmt.Errorf("expected rejection of invalid psql image, got nil error")
+	}
+	if !strings.Contains(err.Error(), "invalid psql image") {
+		return fmt.Errorf("expected 'invalid psql image' error, got: %v", err)
+	}
+	return nil
+}
+
+// BakesCustomPsqlImage pins that a caller-supplied psqlImage lands in the
+// generated scripts/query.sh and scripts/.env.example in place of the default,
+// so a team on a private registry gets a skill that runs out of the box
+// without every consumer exporting PSQL_IMAGE by hand.
+//
+// +cache="never"
+func (t *Tests) BakesCustomPsqlImage(ctx context.Context) error {
+	const image = "registry.internal:5000/team/psql:16.4"
+
+	cluster, pass, err := bootCluster(ctx)
+	if err != nil {
+		return err
+	}
+	if err := applyDDL(ctx, cluster, ddlBase...); err != nil {
+		return err
+	}
+	host, port, user, db, err := coords(ctx, cluster)
+	if err != nil {
+		return err
+	}
+	dir := dag.SkillGen().Postgres(host, user, db, pass, dagger.SkillGenPostgresOpts{
+		Port:      port,
+		PsqlImage: image,
+	})
+
+	query, err := dir.File("scripts/query.sh").Contents(ctx)
+	if err != nil {
+		return err
+	}
+	if want := `PSQL_IMAGE="${PSQL_IMAGE:-` + image + `}"`; !strings.Contains(query, want) {
+		return fmt.Errorf("query.sh missing %q:\n%s", want, query)
+	}
+	if strings.Contains(query, defaultPsqlImage) {
+		return fmt.Errorf("query.sh still carries the default psql image:\n%s", query)
+	}
+
+	env, err := dir.File("scripts/.env.example").Contents(ctx)
+	if err != nil {
+		return err
+	}
+	if want := "# PSQL_IMAGE=" + image; !strings.Contains(env, want) {
+		return fmt.Errorf(".env.example missing %q:\n%s", want, env)
+	}
+
+	// The regen command must carry the flag forward, or the drift check the
+	// README documents would regenerate with the default and report false drift.
+	readme, err := dir.File("README.md").Contents(ctx)
+	if err != nil {
+		return err
+	}
+	if want := "--psql-image '" + image + "'"; !strings.Contains(readme, want) {
+		return fmt.Errorf("README regen command missing %q:\n%s", want, readme)
+	}
+	return nil
+}
+
+// DefaultsPsqlImage pins the v1 default: omitting psqlImage bakes
+// docker.io/alpine/psql:17.7 and leaves the regen command free of the flag.
+//
+// +cache="never"
+func (t *Tests) DefaultsPsqlImage(ctx context.Context) error {
+	cluster, pass, err := bootCluster(ctx)
+	if err != nil {
+		return err
+	}
+	if err := applyDDL(ctx, cluster, ddlBase...); err != nil {
+		return err
+	}
+	dir, _, err := genSkill(ctx, cluster, pass)
+	if err != nil {
+		return err
+	}
+	query, err := dir.File("scripts/query.sh").Contents(ctx)
+	if err != nil {
+		return err
+	}
+	if want := `PSQL_IMAGE="${PSQL_IMAGE:-` + defaultPsqlImage + `}"`; !strings.Contains(query, want) {
+		return fmt.Errorf("query.sh missing default psql image line %q:\n%s", want, query)
+	}
+	readme, err := dir.File("README.md").Contents(ctx)
+	if err != nil {
+		return err
+	}
+	if strings.Contains(readme, "--psql-image") {
+		return fmt.Errorf("README regen command names --psql-image for the default image:\n%s", readme)
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #134.

Teams on a private or locked-down registry had to make every consumer of a generated skill export `PSQL_IMAGE` by hand. `SkillGen.Postgres` now takes an optional `psqlImage` that bakes their image into the generated `scripts/query.sh` and `scripts/.env.example` at generation time.

## Two judgment calls worth reviewing

**The image is substituted raw, not shell-quoted.** It lands inside `query.sh`'s `"${PSQL_IMAGE:-…}"` default word, where shell-quoting it would change the byte output for the default value and break the byte-for-byte criterion. Safety therefore comes from a charset instead: `ValidatePsqlImage` constrains the reference to `^[A-Za-z0-9][A-Za-z0-9._:/@-]*$` — legal OCI reference characters, excluding everything the shell acts on inside double quotes (`$`, backtick, backslash, quotes) plus `}` (which would close the expansion early) and whitespace. Like `ValidateDBName`, it runs before any introspection, so a bad value aborts before touching the network.

**The README regen command emits `--psql-image` only when non-default.** It has to emit it when the image *does* differ: the drift check that same README documents (`changes --from pg-<db> is-empty`) regenerates and diffs against the committed tree, so dropping the flag would report spurious drift.

## A resolved conflict in the acceptance criteria

AC#2 asks for the value to be substituted into `.env.example`; AC#3 asks that omitting the param reproduce v1 output byte-for-byte. The generated `.env.example` had **no** `PSQL_IMAGE` line at all, so both could not hold. Per author's call, the key is now documented there:

```
# Container image psql runs in. Overriding this needs no regeneration — the
# value set here wins over the default baked into query.sh at generation time.
# PSQL_IMAGE=docker.io/alpine/psql:17.7
```

`query.sh`'s env loader already exports whatever it parses before the `PSQL_IMAGE:-` fallback, so this documents behaviour that already worked. Every other golden file is byte-identical; `scripts/.env.example` is the only one that changed, by these 4 lines.

## Scope note on the `ci/` bindings

The root `dagger develop` also picked up **pre-existing** staleness in the dgraph, kafka, and zig test-suite bindings, unrelated to this change. They are included because `ci:generated` is workspace-wide — leaving them out fails the check. Under #181's new attribution logic these will select those three suites into this PR's matrix.

## Verification

- `go test -race ./skill/...` green, incl. new `TestRenderCustomPsqlImage`, `TestRenderDefaultPsqlImage`, `TestValidatePsqlImage`.
- `dagger check skill-gen-tests:all` green, incl. new `rejects-invalid-psql-image`, `bakes-custom-psql-image`, `defaults-psql-image` (each also run individually).
- `dagger check Generated` and `ci:selection-self-test` green, re-run after rebasing onto `4d0635a`.

## Follow-up found but not fixed

The pure-Go `./skill` unit tests — including `TestGoldenRender`, the actual guard for the byte-for-byte criterion — are not wired into any Dagger check, so CI never runs them. `go-tests:all` is the `daggerverse/go` module's own suite, not a repo-wide `go test`. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)