### PR TITLE
story(issue-180): export the affected-checks selection to Dagger Cloud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,12 @@ jobs:
         env:
           BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
           HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
+          # Export this selection to Dagger Cloud so a run's check set can be
+          # traced back to the decision that produced it (#180). A raw
+          # `dagger call` reads the token from its environment, unlike the
+          # dagger/checks action the run legs use, which takes it as a
+          # cloud-token input. Empty for fork PRs -> no telemetry, no failure.
+          DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
         run: |
           set -euo pipefail
           jobs="$(dagger -m . call affected-checks --base="$BASE" --head="$HEAD")"


### PR DESCRIPTION
Closes #180.

## What

Set `DAGGER_CLOUD_TOKEN` on the `list` job's `select` step's `env:` block, alongside `BASE`/`HEAD`.

## Why

`select` runs a raw `dagger call affected-checks`, which reads the Cloud token from its environment — unlike the `dagger/checks` action the `run` legs use, which takes it as a `cloud-token` input. Without it, the one Dagger operation that *decides which checks run* exported no telemetry: the sole untraced step in an otherwise fully traced pipeline. Debugging an under-run or over-run meant re-deriving the selection locally instead of opening the trace that made it.

`affected-checks` is not a forwarder — it enumerates the check universe and dependency graph from the live Workspace (`dag.CurrentWorkspace()`) and diffs `base...head` with go-git (#170), so the enumeration, dep-graph walk, and diff are all worth having in a trace.

## Notes

- Scoped to the step's `env`, not the job, so the token isn't in scope for the engine-load / CLI-install steps that don't need it.
- Fork PRs get an empty secret and simply run without exporting telemetry — same graceful degradation as any token-gated step.
- Purely observability; no change to which checks are selected.

Follow-up to #170.

🤖 Generated with [Claude Code](https://claude.com/claude-code)