### PR TITLE
story(issue-184): make ci:generated actually verify codegen freshness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,9 @@ jobs:
                   timeout: 6 }
               end
             )
+            # jobTimeout is the job cap: the step bound plus setup headroom.
+            # Computed here because GitHub expressions have no arithmetic.
+            | map(. + { jobTimeout: (.timeout + 4) })
           ')
           echo "jobs=$jobs" >> "$GITHUB_OUTPUT"
 
@@ -144,7 +147,7 @@ jobs:
     # above the leg's dagger/checks step bound (matrix.job.timeout) + setup, so
     # the step's timeout is what fails a telemetry-drain hang fast, not this job
     # cap.
-    timeout-minutes: ${{ matrix.job.timeout + 4 }}
+    timeout-minutes: ${{ matrix.job.jobTimeout }}
     strategy:
       fail-fast: false
       # Burst-throttling mitigation (#125): the matrix fans out one leg per

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,9 +96,16 @@ jobs:
           echo "checks=$jobs" >> "$GITHUB_OUTPUT"
 
       - id: route
-        # Re-shape the (already-filtered) check list into {name, module, filter}
-        # objects so each run job can load only its own tests module instead of
-        # the whole ci/ aggregator. ci:* checks stay on the root module.
+        # Re-shape the (already-filtered) check list into
+        # {name, module, filter, timeout} objects so each run job can load only
+        # its own tests module instead of the whole ci/ aggregator. ci:* checks
+        # stay on the root module.
+        #
+        # timeout is the leg's dagger/checks step bound in minutes. 6 fits every
+        # leg that runs one module's suite; ci:generated is the exception (#184)
+        # because it runs codegen for every module in the workspace, so it pays
+        # in one leg the module-build cost the other legs spread across
+        # themselves — measured at ~5m of engine work on a cold engine.
         env:
           CHECKS: ${{ steps.select.outputs.checks }}
         run: |
@@ -119,9 +126,11 @@ jobs:
             $checks | map(
               (split(":")[0]) as $prefix |
               if $prefix == "ci" then
-                { name: ., module: ".", filter: . }
+                { name: ., module: ".", filter: .,
+                  timeout: ({"ci:generated": 15, "ci:generated-self-test": 8}[.] // 6) }
               else
-                { name: ., module: $module_for[$prefix], filter: ("tests:" + (split(":")[1])) }
+                { name: ., module: $module_for[$prefix], filter: ("tests:" + (split(":")[1])),
+                  timeout: 6 }
               end
             )
           ')
@@ -132,9 +141,10 @@ jobs:
     needs: [list]
     runs-on: ubuntu-latest
     # Per matrix leg. Observed real legs finish in <4m; this is only a backstop
-    # above the 6m dagger/checks step bound + setup, so the step's timeout is
-    # what fails a telemetry-drain hang fast, not this job cap.
-    timeout-minutes: 10
+    # above the leg's dagger/checks step bound (matrix.job.timeout) + setup, so
+    # the step's timeout is what fails a telemetry-drain hang fast, not this job
+    # cap.
+    timeout-minutes: ${{ matrix.job.timeout + 4 }}
     strategy:
       fail-fast: false
       # Burst-throttling mitigation (#125): the matrix fans out one leg per
@@ -177,7 +187,9 @@ jobs:
           fi
 
       # Fail fast on the Dagger Cloud telemetry-drain hang. The check itself runs
-      # in ~1-4m; a leg still going at 6m is almost certainly stuck draining
+      # in ~1-4m (matrix.job.timeout, set by the route step, is that leg's bound:
+      # 6m for a normal suite, 15m for the whole-workspace ci:generated codegen
+      # sweep); a leg still going past it is almost certainly stuck draining
       # telemetry to api.dagger.cloud (upstream dagger/dagger#7048, #12178),
       # which otherwise hangs the leg until the job timeout. Bounding the step
       # makes the job fail quickly so ci-auto-rerun.yml re-runs the failed leg on
@@ -186,7 +198,7 @@ jobs:
       # same stuck engine and re-hits the ongoing stall). Telemetry stays on
       # (cloud-token set); we only bound how long a stuck drain may hang.
       - uses: dagger/checks@64525befa1c36dd55577dae083df5c8968d9325a # v1.1.0
-        timeout-minutes: 6
+        timeout-minutes: ${{ matrix.job.timeout }}
         with:
           version: ${{ env.DAGGER_VERSION }}
           module: ${{ matrix.job.module }}

--- a/ci/README.md
+++ b/ci/README.md
@@ -16,6 +16,35 @@ dagger check                      # run them all (one engine)
 CI fans each check onto its own runner via the `list` → `run` matrix in
 `.github/workflows/ci.yml`, which keeps the per-suite engines isolated.
 
+## Codegen freshness
+
+`ci:generated` fails when a module's committed `dagger.gen.go` or
+`internal/dagger/*.gen.go` differ from what `dagger develop` produces at
+the pinned `engineVersion`. It covers every `dagger.json` in the
+workspace — the root module's per-toolchain aggregator bindings under
+`ci/internal/dagger/` included — and names each stale module, printing
+its patch:
+
+```
+==> daggerverse/kafka/tests is not up-to-date:
+<patch>
+generated files are not up-to-date; run `dagger develop` in: daggerverse/kafka/tests
+```
+
+Dependency bindings embed the source location of every function
+(`// kafka (../../../../../daggerverse/kafka/cluster_kafka.go:401:1)`), so
+an edit that only shifts line numbers in `daggerverse/<m>` still leaves
+every dependent module stale. Re-run `dagger develop` in the module *and*
+in each dependent.
+
+`ci:generated-self-test` guards that check: it runs the same comparison
+against one module twice, pristine and then deliberately made stale, and
+fails unless the stale copy is reported. `ci:generated` previously routed
+through `Workspace.Generators()` — empty unless a module declares a
+`+generator` function — and so passed unconditionally for months (#184);
+the self-test is what makes that failure mode impossible to repeat
+silently.
+
 ## Adding a new daggerverse module
 
 When you add `daggerverse/<m>/` with a sibling `tests/` module:

--- a/ci/dagger.gen.go
+++ b/ci/dagger.gen.go
@@ -219,14 +219,14 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 			if err != nil {
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
-			var ws *dagger.Workspace
-			if inputArgs["ws"] != nil {
-				err = json.Unmarshal([]byte(inputArgs["ws"]), &ws)
-				if err != nil {
-					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg ws", err))
-				}
+			return nil, (*Ci).Generated(&parent, ctx)
+		case "GeneratedSelfTest":
+			var parent Ci
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
-			return nil, (*Ci).Generated(&parent, ctx, ws)
+			return nil, (*Ci).GeneratedSelfTest(&parent, ctx)
 		case "SelectionSelfTest":
 			var parent Ci
 			err = json.Unmarshal(parentJSON, &parent)

--- a/ci/generated.go
+++ b/ci/generated.go
@@ -1,0 +1,265 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"dagger/ci/internal/dagger"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// codegenParallelism bounds how many module codegens are in flight at once.
+// Codegen is engine-side work (one Go SDK container per module), so the useful
+// ceiling is engine capacity rather than CPU count in this container.
+const codegenParallelism = 8
+
+// selfTestProbeModule is the module the self-test deliberately makes stale. It
+// is the smallest module in the repo (no dependencies), so regenerating it is
+// the cheapest way to prove the check can fail.
+const selfTestProbeModule = "daggerverse/random"
+
+// drift is one module whose committed generated files differ from what codegen
+// produces at the pinned engineVersion.
+type drift struct {
+	module string // repo-relative module source root ("." for the root ci module)
+	patch  string
+}
+
+// Verify that committed dagger.gen.go and internal/dagger/*.gen.go files
+// match what `dagger develop` would produce at the pinned engineVersion.
+//
+// Every module in the workspace is checked -- the root ci module (whose
+// per-toolchain aggregator bindings live in ci/internal/dagger/) as well as
+// every daggerverse/<mod>, its tests toolchain and any examples module.
+//
+// The result is deliberately never cached: the workspace is read at call time
+// rather than passed as an argument, so a cached pass would be a pass for a
+// tree the check never looked at.
+//
+// +check
+// +cache="never"
+func (ci *Ci) Generated(ctx context.Context) error {
+	root, cleanup, err := materializeWorkspace(ctx)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	modules, err := moduleRoots(root)
+	if err != nil {
+		return err
+	}
+
+	drifted, err := codegenDrift(ctx, root, modules)
+	if err != nil {
+		return err
+	}
+	if len(drifted) == 0 {
+		return nil
+	}
+
+	names := make([]string, 0, len(drifted))
+	for _, d := range drifted {
+		fmt.Fprintf(os.Stderr, "==> %s is not up-to-date:\n%s\n", d.module, d.patch)
+		names = append(names, d.module)
+	}
+	return fmt.Errorf("generated files are not up-to-date; run `dagger develop` in: %s", strings.Join(names, ", "))
+}
+
+// GeneratedSelfTest pins that Generated can actually fail. The check it guards
+// silently verified nothing for months (it routed through Workspace.Generators,
+// which is empty unless a module declares a +generator function), so a green
+// ci:generated is only worth as much as the proof that a stale module turns it
+// red.
+//
+// It runs the same codegen comparison Generated does against a single module,
+// first pristine (expecting no drift) and then with its committed bindings
+// deliberately made stale (expecting drift naming that file).
+//
+// +check
+// +cache="never"
+func (ci *Ci) GeneratedSelfTest(ctx context.Context) error {
+	probeFile := filepath.Join(selfTestProbeModule, "internal", "dagger", "dagger.gen.go")
+
+	pristine, cleanPristine, err := materializeWorkspace(ctx)
+	if err != nil {
+		return err
+	}
+	defer cleanPristine()
+
+	clean, err := codegenDrift(ctx, pristine, []string{selfTestProbeModule})
+	if err != nil {
+		return err
+	}
+	if len(clean) != 0 {
+		return fmt.Errorf("self-test: %s reports drift on an unmodified workspace:\n%s", selfTestProbeModule, clean[0].patch)
+	}
+
+	// A second export, rather than mutating the first, so the engine cannot
+	// serve the tampered tree from its snapshot of the pristine path.
+	tampered, cleanTampered, err := materializeWorkspace(ctx)
+	if err != nil {
+		return err
+	}
+	defer cleanTampered()
+
+	if err := appendLine(filepath.Join(tampered, probeFile), "// ci:generated-self-test: deliberately stale"); err != nil {
+		return err
+	}
+
+	stale, err := codegenDrift(ctx, tampered, []string{selfTestProbeModule})
+	if err != nil {
+		return err
+	}
+	if len(stale) == 0 {
+		return fmt.Errorf("self-test: no drift reported for %s after making %s stale; ci:generated verifies nothing", selfTestProbeModule, probeFile)
+	}
+	if !strings.Contains(stale[0].patch, probeFile) {
+		return fmt.Errorf("self-test: drift reported for %s does not name %s:\n%s", selfTestProbeModule, probeFile, stale[0].patch)
+	}
+	return nil
+}
+
+// codegenDrift runs codegen for each module source root (repo-relative, "." for
+// the root module) against the workspace copy at root, and returns those whose
+// committed files differ from the generated output, ordered like modules.
+//
+// The module sources are loaded from root -- a copy of the workspace exported
+// into this container -- rather than from the live Workspace, because loading a
+// module's toolchains resolves their default-path context against a host path
+// the module runtime cannot see. Everything under root is visible to it.
+func codegenDrift(ctx context.Context, root string, modules []string) ([]drift, error) {
+	found := make([]*drift, len(modules))
+
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(codegenParallelism)
+	for i, mod := range modules {
+		g.Go(func() error {
+			changes := dag.ModuleSource(filepath.Join(root, mod)).GeneratedContextChangeset()
+			empty, err := changes.IsEmpty(ctx)
+			if err != nil {
+				return fmt.Errorf("codegen %s: %w", mod, err)
+			}
+			if empty {
+				return nil
+			}
+			patch, err := changes.AsPatch().Contents(ctx)
+			if err != nil {
+				return fmt.Errorf("patch %s: %w", mod, err)
+			}
+			found[i] = &drift{module: mod, patch: patch}
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	drifted := make([]drift, 0, len(modules))
+	for _, d := range found {
+		if d != nil {
+			drifted = append(drifted, *d)
+		}
+	}
+	return drifted, nil
+}
+
+// materializeWorkspace exports the workspace into a scratch directory and
+// returns its absolute path. Codegen reads module sources as local paths, which
+// resolve inside this container, so the tree has to exist on disk -- a lazy
+// Directory handle is not enough.
+func materializeWorkspace(ctx context.Context) (string, func(), error) {
+	suffix, err := uniqueSuffix()
+	if err != nil {
+		return "", nil, err
+	}
+	scratch := "generated-" + suffix
+	cleanup := func() { os.RemoveAll(scratch) }
+
+	// "/" -- an absolute path, which resolves from the workspace boundary. A
+	// relative "." resolves from the workspace's current directory, which is the
+	// module source dir (ci/) whenever the module is loaded from there, and that
+	// tree contains no dagger.json at all.
+	//
+	// .git is excluded because it is dead weight for codegen, but an empty one
+	// is put back: a module's context directory is found by walking up to the
+	// repository root, and without that marker every module would take its own
+	// source root as the context and dependencies like "../../crypto" would
+	// escape it.
+	ws := dag.CurrentWorkspace().Directory("/", dagger.WorkspaceDirectoryOpts{
+		Exclude: []string{".git"},
+	})
+	if _, err := ws.Export(ctx, scratch); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("export workspace: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Join(scratch, ".git"), 0o755); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+
+	abs, err := filepath.Abs(scratch)
+	if err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	return abs, cleanup, nil
+}
+
+// moduleRoots returns every module source root under root, repo-relative and
+// sorted, with the root module reported as ".".
+func moduleRoots(root string) ([]string, error) {
+	var modules []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if d.Name() != "dagger.json" {
+			return nil
+		}
+		rel, err := filepath.Rel(root, filepath.Dir(path))
+		if err != nil {
+			return err
+		}
+		modules = append(modules, rel)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walk workspace: %w", err)
+	}
+	if len(modules) == 0 {
+		entries, _ := os.ReadDir(root)
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		return nil, fmt.Errorf("no dagger.json found in the workspace (root=%s entries=%v)", root, names)
+	}
+	sort.Strings(modules)
+	return modules, nil
+}
+
+// appendLine appends line, newline-terminated, to an existing file.
+func appendLine(path, line string) error {
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(f, line); err != nil {
+		f.Close()
+		return err
+	}
+	return f.Close()
+}

--- a/ci/go.mod
+++ b/ci/go.mod
@@ -59,7 +59,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
+	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401001100-f93e5f3e9f0f // indirect

--- a/ci/main.go
+++ b/ci/main.go
@@ -4,34 +4,4 @@
 // wrapper methods are needed here.
 package main
 
-import (
-	"context"
-	"errors"
-	"fmt"
-	"os"
-
-	"dagger/ci/internal/dagger"
-)
-
 type Ci struct{}
-
-// Verify that committed dagger.gen.go and internal/dagger/*.gen.go files
-// match what `dagger develop` would produce at the pinned engineVersion.
-//
-// +check
-func (ci *Ci) Generated(ctx context.Context, ws *dagger.Workspace) error {
-	generated := ws.Generators().Run()
-	empty, err := generated.IsEmpty(ctx)
-	if err != nil {
-		return err
-	}
-	if empty {
-		return nil
-	}
-	patch, err := generated.Changes().AsPatch().Contents(ctx)
-	if err != nil {
-		return err
-	}
-	fmt.Fprintln(os.Stderr, patch)
-	return errors.New("generated files are not up-to-date; run `dagger develop` in the affected module(s)")
-}

--- a/daggerverse/grafana-stack/tests/dagger.gen.go
+++ b/daggerverse/grafana-stack/tests/dagger.gen.go
@@ -255,6 +255,62 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Tests).GrafanaProxiesLokiQuery(&parent, ctx, lokiTag, grafanaTag)
+		case "GrafanaProxiesLokiQueryOverMtls":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var lokiTag string
+			if inputArgs["lokiTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["lokiTag"]), &lokiTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg lokiTag", err))
+				}
+			}
+			var grafanaTag string
+			if inputArgs["grafanaTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["grafanaTag"]), &grafanaTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg grafanaTag", err))
+				}
+			}
+			return nil, (*Tests).GrafanaProxiesLokiQueryOverMtls(&parent, ctx, lokiTag, grafanaTag)
+		case "GrafanaProxiesLokiQueryOverTls":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var lokiTag string
+			if inputArgs["lokiTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["lokiTag"]), &lokiTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg lokiTag", err))
+				}
+			}
+			var grafanaTag string
+			if inputArgs["grafanaTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["grafanaTag"]), &grafanaTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg grafanaTag", err))
+				}
+			}
+			return nil, (*Tests).GrafanaProxiesLokiQueryOverTls(&parent, ctx, lokiTag, grafanaTag)
+		case "GrafanaTlsRejectsPlaintext":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var grafanaTag string
+			if inputArgs["grafanaTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["grafanaTag"]), &grafanaTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg grafanaTag", err))
+				}
+			}
+			return nil, (*Tests).GrafanaTlsRejectsPlaintext(&parent, ctx, grafanaTag)
 		case "LokiAcceptsOtlpLogs":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -269,6 +325,34 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Tests).LokiAcceptsOtlpLogs(&parent, ctx, tag)
+		case "LokiMtlsRequiresClientCert":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var tag string
+			if inputArgs["tag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["tag"]), &tag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg tag", err))
+				}
+			}
+			return nil, (*Tests).LokiMtlsRequiresClientCert(&parent, ctx, tag)
+		case "LokiTlsRoundTrip":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var tag string
+			if inputArgs["tag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["tag"]), &tag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg tag", err))
+				}
+			}
+			return nil, (*Tests).LokiTlsRoundTrip(&parent, ctx, tag)
 		case "MimirAcceptsOtlpMetrics":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -283,6 +367,34 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Tests).MimirAcceptsOtlpMetrics(&parent, ctx, tag)
+		case "MimirMtlsRequiresClientCert":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var tag string
+			if inputArgs["tag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["tag"]), &tag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg tag", err))
+				}
+			}
+			return nil, (*Tests).MimirMtlsRequiresClientCert(&parent, ctx, tag)
+		case "MimirTlsRoundTrip":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var tag string
+			if inputArgs["tag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["tag"]), &tag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg tag", err))
+				}
+			}
+			return nil, (*Tests).MimirTlsRoundTrip(&parent, ctx, tag)
 		case "TempoAcceptsOtlpTraces":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -297,6 +409,34 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Tests).TempoAcceptsOtlpTraces(&parent, ctx, tag)
+		case "TempoMtlsRequiresClientCert":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var tag string
+			if inputArgs["tag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["tag"]), &tag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg tag", err))
+				}
+			}
+			return nil, (*Tests).TempoMtlsRequiresClientCert(&parent, ctx, tag)
+		case "TempoTlsRoundTrip":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var tag string
+			if inputArgs["tag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["tag"]), &tag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg tag", err))
+				}
+			}
+			return nil, (*Tests).TempoTlsRoundTrip(&parent, ctx, tag)
 		default:
 			return nil, fmt.Errorf("unknown function %s", fnName)
 		}

--- a/daggerverse/grafana-stack/tests/internal/dagger/grafana-stack.gen.go
+++ b/daggerverse/grafana-stack/tests/internal/dagger/grafana-stack.gen.go
@@ -1390,7 +1390,7 @@ func (r *GrafanaStackTempo) WithMtls(clientCa *File) *GrafanaStackTempo { // gra
 }
 
 // WithTls enables TLS on every Tempo listener: the native HTTP query API
-// (:3200, via server.tls_config) and both OTLP receivers (gRPC :4317 and
+// (:3200, via server.http_tls_config) and both OTLP receivers (gRPC :4317 and
 // HTTP :4318, via distributor.receivers.otlp.protocols.{grpc,http}.tls).
 // serverCert is the PEM server certificate and serverKey its PEM private key.
 // After this call HttpEndpoint / OtlpHttpEndpoint return https:// URLs;

--- a/daggerverse/kafka/tests/internal/dagger/kafka.gen.go
+++ b/daggerverse/kafka/tests/internal/dagger/kafka.gen.go
@@ -1657,7 +1657,7 @@ func (r *KafkaCluster) WithGraphQLQuery(q *querybuilder.Selection) *KafkaCluster
 // same hostname BootstrapServers reports, so the container can dial brokers
 // using the same address strings as a franz-go Client returned from
 // Cluster.Client.
-func (r *KafkaCluster) BindBrokers(ctr *Container) *Container { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:387:1)
+func (r *KafkaCluster) BindBrokers(ctr *Container) *Container { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:401:1)
 	assertNotNil("ctr", ctr)
 	q := r.query.Select("bindBrokers")
 	q = q.Arg("ctr", ctr)
@@ -1669,7 +1669,7 @@ func (r *KafkaCluster) BindBrokers(ctr *Container) *Container { // kafka (../../
 
 // BootstrapServers returns the host:port pairs each broker advertises on its
 // client-facing listener.
-func (r *KafkaCluster) BootstrapServers(ctx context.Context) ([]string, error) { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:373:1)
+func (r *KafkaCluster) BootstrapServers(ctx context.Context) ([]string, error) { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:387:1)
 	q := r.query.Select("bootstrapServers")
 
 	var response []string
@@ -1680,7 +1680,7 @@ func (r *KafkaCluster) BootstrapServers(ctx context.Context) ([]string, error) {
 
 // Client starts every broker service in the cluster and returns a franz-go
 // Client wired with their bootstrap addresses.
-func (r *KafkaCluster) Client(security *KafkaClientSecurity) *KafkaClient { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:398:1)
+func (r *KafkaCluster) Client(security *KafkaClientSecurity) *KafkaClient { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:412:1)
 	assertNotNil("security", security)
 	q := r.query.Select("client")
 	q = q.Arg("security", security)
@@ -1749,7 +1749,7 @@ func (r *KafkaCluster) UnmarshalJSON(bs []byte) error {
 // cluster just run out the clock (~5 min observed in Dagger trace
 // `972bc311bf374f817b7c88481229a10c`). SIGKILL returns immediately, which
 // is all a test needs.
-func (r *KafkaCluster) Stop(ctx context.Context) error { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:347:1)
+func (r *KafkaCluster) Stop(ctx context.Context) error { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:361:1)
 	if r.stop != nil {
 		return nil
 	}

--- a/daggerverse/otel/tests/internal/dagger/grafana-stack.gen.go
+++ b/daggerverse/otel/tests/internal/dagger/grafana-stack.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type GrafanaStack
-func (r *Binding) AsGrafanaStack() *GrafanaStack { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:23:6)
+func (r *Binding) AsGrafanaStack() *GrafanaStack { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:34:6)
 	q := r.query.Select("asGrafanaStack")
 
 	return &GrafanaStack{
@@ -19,7 +19,7 @@ func (r *Binding) AsGrafanaStack() *GrafanaStack { // grafana-stack (../../../..
 }
 
 // Retrieve the binding value, as type GrafanaStackGrafana
-func (r *Binding) AsGrafanaStackGrafana() *GrafanaStackGrafana { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:336:6)
+func (r *Binding) AsGrafanaStackGrafana() *GrafanaStackGrafana { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:543:6)
 	q := r.query.Select("asGrafanaStackGrafana")
 
 	return &GrafanaStackGrafana{
@@ -28,7 +28,7 @@ func (r *Binding) AsGrafanaStackGrafana() *GrafanaStackGrafana { // grafana-stac
 }
 
 // Retrieve the binding value, as type GrafanaStackLoki
-func (r *Binding) AsGrafanaStackLoki() *GrafanaStackLoki { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:60:6)
+func (r *Binding) AsGrafanaStackLoki() *GrafanaStackLoki { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:96:6)
 	q := r.query.Select("asGrafanaStackLoki")
 
 	return &GrafanaStackLoki{
@@ -37,7 +37,7 @@ func (r *Binding) AsGrafanaStackLoki() *GrafanaStackLoki { // grafana-stack (../
 }
 
 // Retrieve the binding value, as type GrafanaStackMimir
-func (r *Binding) AsGrafanaStackMimir() *GrafanaStackMimir { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:245:6)
+func (r *Binding) AsGrafanaStackMimir() *GrafanaStackMimir { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:400:6)
 	q := r.query.Select("asGrafanaStackMimir")
 
 	return &GrafanaStackMimir{
@@ -46,7 +46,7 @@ func (r *Binding) AsGrafanaStackMimir() *GrafanaStackMimir { // grafana-stack (.
 }
 
 // Retrieve the binding value, as type GrafanaStackTempo
-func (r *Binding) AsGrafanaStackTempo() *GrafanaStackTempo { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:149:6)
+func (r *Binding) AsGrafanaStackTempo() *GrafanaStackTempo { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:241:6)
 	q := r.query.Select("asGrafanaStackTempo")
 
 	return &GrafanaStackTempo{
@@ -55,7 +55,7 @@ func (r *Binding) AsGrafanaStackTempo() *GrafanaStackTempo { // grafana-stack (.
 }
 
 // Create or update a binding of type GrafanaStackGrafana in the environment
-func (r *Env) WithGrafanaStackGrafanaInput(name string, value *GrafanaStackGrafana, description string) *Env { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:336:6)
+func (r *Env) WithGrafanaStackGrafanaInput(name string, value *GrafanaStackGrafana, description string) *Env { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:543:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withGrafanaStackGrafanaInput")
 	q = q.Arg("name", name)
@@ -68,7 +68,7 @@ func (r *Env) WithGrafanaStackGrafanaInput(name string, value *GrafanaStackGrafa
 }
 
 // Declare a desired GrafanaStackGrafana output to be assigned in the environment
-func (r *Env) WithGrafanaStackGrafanaOutput(name string, description string) *Env { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:336:6)
+func (r *Env) WithGrafanaStackGrafanaOutput(name string, description string) *Env { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:543:6)
 	q := r.query.Select("withGrafanaStackGrafanaOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -79,7 +79,7 @@ func (r *Env) WithGrafanaStackGrafanaOutput(name string, description string) *En
 }
 
 // Create or update a binding of type GrafanaStack in the environment
-func (r *Env) WithGrafanaStackInput(name string, value *GrafanaStack, description string) *Env { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:23:6)
+func (r *Env) WithGrafanaStackInput(name string, value *GrafanaStack, description string) *Env { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:34:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withGrafanaStackInput")
 	q = q.Arg("name", name)
@@ -92,7 +92,7 @@ func (r *Env) WithGrafanaStackInput(name string, value *GrafanaStack, descriptio
 }
 
 // Create or update a binding of type GrafanaStackLoki in the environment
-func (r *Env) WithGrafanaStackLokiInput(name string, value *GrafanaStackLoki, description string) *Env { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:60:6)
+func (r *Env) WithGrafanaStackLokiInput(name string, value *GrafanaStackLoki, description string) *Env { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:96:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withGrafanaStackLokiInput")
 	q = q.Arg("name", name)
@@ -105,7 +105,7 @@ func (r *Env) WithGrafanaStackLokiInput(name string, value *GrafanaStackLoki, de
 }
 
 // Declare a desired GrafanaStackLoki output to be assigned in the environment
-func (r *Env) WithGrafanaStackLokiOutput(name string, description string) *Env { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:60:6)
+func (r *Env) WithGrafanaStackLokiOutput(name string, description string) *Env { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:96:6)
 	q := r.query.Select("withGrafanaStackLokiOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -116,7 +116,7 @@ func (r *Env) WithGrafanaStackLokiOutput(name string, description string) *Env {
 }
 
 // Create or update a binding of type GrafanaStackMimir in the environment
-func (r *Env) WithGrafanaStackMimirInput(name string, value *GrafanaStackMimir, description string) *Env { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:245:6)
+func (r *Env) WithGrafanaStackMimirInput(name string, value *GrafanaStackMimir, description string) *Env { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:400:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withGrafanaStackMimirInput")
 	q = q.Arg("name", name)
@@ -129,7 +129,7 @@ func (r *Env) WithGrafanaStackMimirInput(name string, value *GrafanaStackMimir, 
 }
 
 // Declare a desired GrafanaStackMimir output to be assigned in the environment
-func (r *Env) WithGrafanaStackMimirOutput(name string, description string) *Env { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:245:6)
+func (r *Env) WithGrafanaStackMimirOutput(name string, description string) *Env { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:400:6)
 	q := r.query.Select("withGrafanaStackMimirOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -140,7 +140,7 @@ func (r *Env) WithGrafanaStackMimirOutput(name string, description string) *Env 
 }
 
 // Declare a desired GrafanaStack output to be assigned in the environment
-func (r *Env) WithGrafanaStackOutput(name string, description string) *Env { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:23:6)
+func (r *Env) WithGrafanaStackOutput(name string, description string) *Env { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:34:6)
 	q := r.query.Select("withGrafanaStackOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -151,7 +151,7 @@ func (r *Env) WithGrafanaStackOutput(name string, description string) *Env { // 
 }
 
 // Create or update a binding of type GrafanaStackTempo in the environment
-func (r *Env) WithGrafanaStackTempoInput(name string, value *GrafanaStackTempo, description string) *Env { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:149:6)
+func (r *Env) WithGrafanaStackTempoInput(name string, value *GrafanaStackTempo, description string) *Env { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:241:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withGrafanaStackTempoInput")
 	q = q.Arg("name", name)
@@ -164,7 +164,7 @@ func (r *Env) WithGrafanaStackTempoInput(name string, value *GrafanaStackTempo, 
 }
 
 // Declare a desired GrafanaStackTempo output to be assigned in the environment
-func (r *Env) WithGrafanaStackTempoOutput(name string, description string) *Env { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:149:6)
+func (r *Env) WithGrafanaStackTempoOutput(name string, description string) *Env { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:241:6)
 	q := r.query.Select("withGrafanaStackTempoOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -176,7 +176,7 @@ func (r *Env) WithGrafanaStackTempoOutput(name string, description string) *Env 
 
 // GrafanaStack is the module entry point. Use the per-backend constructor
 // functions (Loki, Tempo, Mimir) to obtain a service handle.
-type GrafanaStack struct { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:23:6)
+type GrafanaStack struct { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:34:6)
 	query *querybuilder.Selection
 
 	id *ID
@@ -195,22 +195,22 @@ type GrafanaStackGrafanaOpts struct {
 	//
 	//
 	// Default: "docker.io"
-	Registry string // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:378:2)
+	Registry string // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:643:2)
 	//
 	// Image tag for grafana/grafana.
 	//
 	//
 	// Default: "12.0.0"
-	Tag string // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:381:2)
+	Tag string // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:646:2)
 	//
 	// grafana.ini config; replaces the embedded default when supplied.
 	//
-	ConfigFile *File // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:384:2)
+	ConfigFile *File // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:649:2)
 	//
 	// Persistence volume mounted at /var/lib/grafana. When nil the data
 	// dir is ephemeral.
 	//
-	Storage *CacheVolume // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:390:2)
+	Storage *CacheVolume // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:655:2)
 }
 
 // Grafana configures a grafana/grafana service with file-based datasource
@@ -223,7 +223,7 @@ type GrafanaStackGrafanaOpts struct {
 // plaintext never enters generated bindings. storage, when non-nil, is
 // mounted at /var/lib/grafana for persistence; when nil, an ephemeral
 // empty Directory is mounted instead.
-func (r *GrafanaStack) Grafana(adminPassword *Secret, opts ...GrafanaStackGrafanaOpts) *GrafanaStackGrafana { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:375:1)
+func (r *GrafanaStack) Grafana(adminPassword *Secret, opts ...GrafanaStackGrafanaOpts) *GrafanaStackGrafana { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:640:1)
 	assertNotNil("adminPassword", adminPassword)
 	q := r.query.Select("grafana")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -307,22 +307,22 @@ type GrafanaStackLokiOpts struct {
 	//
 	//
 	// Default: "docker.io"
-	Registry string // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:82:2)
+	Registry string // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:132:2)
 	//
 	// Image tag for grafana/loki.
 	//
 	//
 	// Default: "3.4.1"
-	Tag string // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:85:2)
+	Tag string // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:135:2)
 	//
 	// Loki YAML config; replaces the embedded default when supplied.
 	//
-	ConfigFile *File // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:88:2)
+	ConfigFile *File // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:138:2)
 	//
 	// Persistence volume mounted at /var/lib/loki. When nil the data
 	// dir is ephemeral.
 	//
-	Storage *CacheVolume // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:92:2)
+	Storage *CacheVolume // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:142:2)
 }
 
 // Loki configures a grafana/loki service running in monolithic mode with
@@ -333,7 +333,7 @@ type GrafanaStackLokiOpts struct {
 // version. configFile fully replaces the embedded default when supplied.
 // storage, when non-nil, is mounted at /var/lib/loki for persistence;
 // when nil, an ephemeral empty Directory is mounted instead.
-func (r *GrafanaStack) Loki(opts ...GrafanaStackLokiOpts) *GrafanaStackLoki { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:79:1)
+func (r *GrafanaStack) Loki(opts ...GrafanaStackLokiOpts) *GrafanaStackLoki { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:129:1)
 	q := r.query.Select("loki")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `registry` optional argument
@@ -366,22 +366,22 @@ type GrafanaStackMimirOpts struct {
 	//
 	//
 	// Default: "docker.io"
-	Registry string // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:268:2)
+	Registry string // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:435:2)
 	//
 	// Image tag for grafana/mimir.
 	//
 	//
 	// Default: "2.15.1"
-	Tag string // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:271:2)
+	Tag string // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:438:2)
 	//
 	// Mimir YAML config; replaces the embedded default when supplied.
 	//
-	ConfigFile *File // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:274:2)
+	ConfigFile *File // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:441:2)
 	//
 	// Persistence volume mounted at /var/lib/mimir. When nil the data
 	// dir is ephemeral.
 	//
-	Storage *CacheVolume // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:278:2)
+	Storage *CacheVolume // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:445:2)
 }
 
 // Mimir configures a grafana/mimir service in monolithic mode (the binary
@@ -394,7 +394,7 @@ type GrafanaStackMimirOpts struct {
 // version. configFile fully replaces the embedded default when supplied.
 // storage, when non-nil, is mounted at /var/lib/mimir for persistence;
 // when nil, an ephemeral empty Directory is mounted instead.
-func (r *GrafanaStack) Mimir(opts ...GrafanaStackMimirOpts) *GrafanaStackMimir { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:265:1)
+func (r *GrafanaStack) Mimir(opts ...GrafanaStackMimirOpts) *GrafanaStackMimir { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:432:1)
 	q := r.query.Select("mimir")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `registry` optional argument
@@ -427,22 +427,22 @@ type GrafanaStackTempoOpts struct {
 	//
 	//
 	// Default: "docker.io"
-	Registry string // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:170:2)
+	Registry string // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:274:2)
 	//
 	// Image tag for grafana/tempo.
 	//
 	//
 	// Default: "2.7.1"
-	Tag string // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:173:2)
+	Tag string // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:277:2)
 	//
 	// Tempo YAML config; replaces the embedded default when supplied.
 	//
-	ConfigFile *File // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:176:2)
+	ConfigFile *File // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:280:2)
 	//
 	// Persistence volume mounted at /var/lib/tempo. When nil the data
 	// dir is ephemeral.
 	//
-	Storage *CacheVolume // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:180:2)
+	Storage *CacheVolume // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:284:2)
 }
 
 // Tempo configures a grafana/tempo service running in monolithic mode
@@ -453,7 +453,7 @@ type GrafanaStackTempoOpts struct {
 // version. configFile fully replaces the embedded default when supplied.
 // storage, when non-nil, is mounted at /var/lib/tempo for persistence;
 // when nil, an ephemeral empty Directory is mounted instead.
-func (r *GrafanaStack) Tempo(opts ...GrafanaStackTempoOpts) *GrafanaStackTempo { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:167:1)
+func (r *GrafanaStack) Tempo(opts ...GrafanaStackTempoOpts) *GrafanaStackTempo { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:271:1)
 	q := r.query.Select("tempo")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `registry` optional argument
@@ -491,7 +491,7 @@ func (r *GrafanaStack) AsNode() Node {
 // datasource and dashboard provisioning. Datasources and dashboards are
 // accumulated via the WithX builder methods and rendered into the
 // container's /etc/grafana/provisioning tree at Service() time.
-type GrafanaStackGrafana struct { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:336:6)
+type GrafanaStackGrafana struct { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:543:6)
 	query *querybuilder.Selection
 
 	endpoint *string
@@ -516,7 +516,7 @@ func (r *GrafanaStackGrafana) WithGraphQLQuery(q *querybuilder.Selection) *Grafa
 // AdminPassword is mounted into the container as a file and pointed
 // at via GF_SECURITY_ADMIN_PASSWORD__FILE so plaintext never enters
 // generated bindings.
-func (r *GrafanaStackGrafana) AdminPassword() *Secret { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:345:2)
+func (r *GrafanaStackGrafana) AdminPassword() *Secret { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:552:2)
 	q := r.query.Select("adminPassword")
 
 	return &Secret{
@@ -526,7 +526,7 @@ func (r *GrafanaStackGrafana) AdminPassword() *Secret { // grafana-stack (../../
 
 // ConfigFile is the grafana.ini config: caller-supplied override or
 // the embedded default.
-func (r *GrafanaStackGrafana) ConfigFile() *File { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:341:2)
+func (r *GrafanaStackGrafana) ConfigFile() *File { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:548:2)
 	q := r.query.Select("configFile")
 
 	return &File{
@@ -537,7 +537,7 @@ func (r *GrafanaStackGrafana) ConfigFile() *File { // grafana-stack (../../../..
 // Dashboards is the accumulated set of dashboard JSON files, mounted
 // at /var/lib/grafana/dashboards on the Grafana container at
 // Service() time. Starts empty.
-func (r *GrafanaStackGrafana) Dashboards() *Directory { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:362:2)
+func (r *GrafanaStackGrafana) Dashboards() *Directory { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:582:2)
 	q := r.query.Select("dashboards")
 
 	return &Directory{
@@ -545,8 +545,9 @@ func (r *GrafanaStackGrafana) Dashboards() *Directory { // grafana-stack (../../
 	}
 }
 
-// Endpoint returns the Grafana HTTP base URL, e.g. http://<host>:3000.
-func (r *GrafanaStackGrafana) Endpoint(ctx context.Context) (string, error) { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:505:1)
+// Endpoint returns the Grafana HTTP base URL, e.g. http://<host>:3000, or
+// https://<host>:3000 once WithTls has been called.
+func (r *GrafanaStackGrafana) Endpoint(ctx context.Context) (string, error) { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:887:1)
 	if r.endpoint != nil {
 		return *r.endpoint, nil
 	}
@@ -608,7 +609,7 @@ func (r *GrafanaStackGrafana) UnmarshalJSON(bs []byte) error {
 }
 
 // Image is the resolved <registry>/grafana/grafana:<tag> reference.
-func (r *GrafanaStackGrafana) Image(ctx context.Context) (string, error) { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:338:2)
+func (r *GrafanaStackGrafana) Image(ctx context.Context) (string, error) { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:545:2)
 	if r.image != nil {
 		return *r.image, nil
 	}
@@ -620,97 +621,12 @@ func (r *GrafanaStackGrafana) Image(ctx context.Context) (string, error) { // gr
 	return response, q.Execute(ctx)
 }
 
-// LokiNames[i] is the in-network hostname bound to LokiSvcs[i] and
-// is also used as the Grafana datasource name + uid. Same shape for
-// Tempo and Mimir.
-func (r *GrafanaStackGrafana) LokiNames(ctx context.Context) ([]string, error) { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:352:2)
-	q := r.query.Select("lokiNames")
-
-	var response []string
-
-	q = q.Bind(&response)
-	return response, q.Execute(ctx)
-}
-
-func (r *GrafanaStackGrafana) LokiSvcs(ctx context.Context) ([]Service, error) { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:353:2)
-	q := r.query.Select("lokiSvcs")
-
-	q = q.Select("id")
-
-	type lokiSvcs struct {
-		Id ID
-	}
-
-	convert := func(fields []lokiSvcs) []Service {
-		out := []Service{}
-
-		for i := range fields {
-			val := Service{id: &fields[i].Id}
-			val.query = selectNode(q.Root(), fields[i].Id, "Service")
-			out = append(out, val)
-		}
-
-		return out
-	}
-	var response []lokiSvcs
-
-	q = q.Bind(&response)
-
-	err := q.Execute(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return convert(response), nil
-}
-
-func (r *GrafanaStackGrafana) MimirNames(ctx context.Context) ([]string, error) { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:356:2)
-	q := r.query.Select("mimirNames")
-
-	var response []string
-
-	q = q.Bind(&response)
-	return response, q.Execute(ctx)
-}
-
-func (r *GrafanaStackGrafana) MimirSvcs(ctx context.Context) ([]Service, error) { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:357:2)
-	q := r.query.Select("mimirSvcs")
-
-	q = q.Select("id")
-
-	type mimirSvcs struct {
-		Id ID
-	}
-
-	convert := func(fields []mimirSvcs) []Service {
-		out := []Service{}
-
-		for i := range fields {
-			val := Service{id: &fields[i].Id}
-			val.query = selectNode(q.Root(), fields[i].Id, "Service")
-			out = append(out, val)
-		}
-
-		return out
-	}
-	var response []mimirSvcs
-
-	q = q.Bind(&response)
-
-	err := q.Execute(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return convert(response), nil
-}
-
 // Service returns the Grafana Dagger service. The container is run as
 // root (see Loki.Service for the rationale). The accumulated datasource
 // and dashboard state is rendered into the container's provisioning
 // tree at this point — subsequent WithX calls on the same *Grafana
 // receiver are not visible to the returned service.
-func (r *GrafanaStackGrafana) Service() *Service { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:468:1)
+func (r *GrafanaStackGrafana) Service() *Service { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:804:1)
 	q := r.query.Select("service")
 
 	return &Service{
@@ -719,7 +635,7 @@ func (r *GrafanaStackGrafana) Service() *Service { // grafana-stack (../../../..
 }
 
 // Storage is the optional persistence volume for /var/lib/grafana.
-func (r *GrafanaStackGrafana) Storage() *CacheVolume { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:347:2)
+func (r *GrafanaStackGrafana) Storage() *CacheVolume { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:554:2)
 	q := r.query.Select("storage")
 
 	return &CacheVolume{
@@ -727,51 +643,10 @@ func (r *GrafanaStackGrafana) Storage() *CacheVolume { // grafana-stack (../../.
 	}
 }
 
-func (r *GrafanaStackGrafana) TempoNames(ctx context.Context) ([]string, error) { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:354:2)
-	q := r.query.Select("tempoNames")
-
-	var response []string
-
-	q = q.Bind(&response)
-	return response, q.Execute(ctx)
-}
-
-func (r *GrafanaStackGrafana) TempoSvcs(ctx context.Context) ([]Service, error) { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:355:2)
-	q := r.query.Select("tempoSvcs")
-
-	q = q.Select("id")
-
-	type tempoSvcs struct {
-		Id ID
-	}
-
-	convert := func(fields []tempoSvcs) []Service {
-		out := []Service{}
-
-		for i := range fields {
-			val := Service{id: &fields[i].Id}
-			val.query = selectNode(q.Root(), fields[i].Id, "Service")
-			out = append(out, val)
-		}
-
-		return out
-	}
-	var response []tempoSvcs
-
-	q = q.Bind(&response)
-
-	err := q.Execute(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return convert(response), nil
-}
-
 // WithDashboard adds a single dashboard JSON file to the provisioned
 // dashboards directory under the supplied name. `.json` is appended if
 // the supplied name does not already end with it.
-func (r *GrafanaStackGrafana) WithDashboard(name string, file *File) *GrafanaStackGrafana { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:444:1)
+func (r *GrafanaStackGrafana) WithDashboard(name string, file *File) *GrafanaStackGrafana { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:780:1)
 	assertNotNil("file", file)
 	q := r.query.Select("withDashboard")
 	q = q.Arg("name", name)
@@ -784,7 +659,7 @@ func (r *GrafanaStackGrafana) WithDashboard(name string, file *File) *GrafanaSta
 
 // WithDashboards adds every *.json entry in dir to the provisioned
 // dashboards directory, preserving filenames.
-func (r *GrafanaStackGrafana) WithDashboards(dir *Directory) *GrafanaStackGrafana { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:455:1)
+func (r *GrafanaStackGrafana) WithDashboards(dir *Directory) *GrafanaStackGrafana { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:791:1)
 	assertNotNil("dir", dir)
 	q := r.query.Select("withDashboards")
 	q = q.Arg("dir", dir)
@@ -792,6 +667,22 @@ func (r *GrafanaStackGrafana) WithDashboards(dir *Directory) *GrafanaStackGrafan
 	return &GrafanaStackGrafana{
 		query: q,
 	}
+}
+
+// GrafanaStackGrafanaWithLokiDatasourceOpts contains options for GrafanaStackGrafana.WithLokiDatasource
+type GrafanaStackGrafanaWithLokiDatasourceOpts struct {
+	//
+	// PEM CA that signed the backend's server certificate.
+	//
+	CaCert *File // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:709:2)
+	//
+	// PEM client certificate Grafana presents to an mTLS backend.
+	//
+	ClientCert *File // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:712:2)
+	//
+	// PEM client private key paired with clientCert.
+	//
+	ClientKey *Secret // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:715:2)
 }
 
 // WithLokiDatasource binds loki into Grafana's network at hostname `name`
@@ -802,9 +693,31 @@ func (r *GrafanaStackGrafana) WithDashboards(dir *Directory) *GrafanaStackGrafan
 // `name` must be a valid DNS label: it is used as the in-network
 // hostname (enforced by Dagger's WithServiceBinding), as the Grafana
 // datasource uid, and is interpolated into provisioning YAML.
-func (r *GrafanaStackGrafana) WithLokiDatasource(name string, loki *GrafanaStackLoki) *GrafanaStackGrafana { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:413:1)
+//
+// TLS is derived from the loki builder: when loki has WithTls, the datasource
+// URL becomes https:// and the entry pins the backend's CA. Supply caCert (the
+// PEM CA that signed loki's server certificate) so Grafana can verify the
+// backend; when omitted, loki's own server certificate is pinned instead
+// (correct only for a self-signed server cert). When loki has WithMtls, also
+// supply clientCert / clientKey (the PEM certificate + key Grafana presents to
+// the backend); Service returns an error if they are missing.
+func (r *GrafanaStackGrafana) WithLokiDatasource(name string, loki *GrafanaStackLoki, opts ...GrafanaStackGrafanaWithLokiDatasourceOpts) *GrafanaStackGrafana { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:704:1)
 	assertNotNil("loki", loki)
 	q := r.query.Select("withLokiDatasource")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `caCert` optional argument
+		if !querybuilder.IsZeroValue(opts[i].CaCert) {
+			q = q.Arg("caCert", opts[i].CaCert)
+		}
+		// `clientCert` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ClientCert) {
+			q = q.Arg("clientCert", opts[i].ClientCert)
+		}
+		// `clientKey` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ClientKey) {
+			q = q.Arg("clientKey", opts[i].ClientKey)
+		}
+	}
 	q = q.Arg("name", name)
 	q = q.Arg("loki", loki)
 
@@ -813,13 +726,36 @@ func (r *GrafanaStackGrafana) WithLokiDatasource(name string, loki *GrafanaStack
 	}
 }
 
-// WithMimirDatasource binds mimir into Grafana's network at hostname
-// `name` and accumulates a Prometheus-type datasource entry pointing at
+// GrafanaStackGrafanaWithMimirDatasourceOpts contains options for GrafanaStackGrafana.WithMimirDatasource
+type GrafanaStackGrafanaWithMimirDatasourceOpts struct {
+	CaCert *File // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:760:2)
+
+	ClientCert *File // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:762:2)
+
+	ClientKey *Secret // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:764:2)
+}
+
+// WithMimirDatasource binds mimir into Grafana's network at hostname `name`
+// and accumulates a Prometheus-type datasource entry pointing at
 // Mimir's Prometheus-compatible API endpoint. See WithLokiDatasource
-// for the constraints on `name`.
-func (r *GrafanaStackGrafana) WithMimirDatasource(name string, mimir *GrafanaStackMimir) *GrafanaStackGrafana { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:434:1)
+// for the constraints on `name` and the TLS args.
+func (r *GrafanaStackGrafana) WithMimirDatasource(name string, mimir *GrafanaStackMimir, opts ...GrafanaStackGrafanaWithMimirDatasourceOpts) *GrafanaStackGrafana { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:756:1)
 	assertNotNil("mimir", mimir)
 	q := r.query.Select("withMimirDatasource")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `caCert` optional argument
+		if !querybuilder.IsZeroValue(opts[i].CaCert) {
+			q = q.Arg("caCert", opts[i].CaCert)
+		}
+		// `clientCert` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ClientCert) {
+			q = q.Arg("clientCert", opts[i].ClientCert)
+		}
+		// `clientKey` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ClientKey) {
+			q = q.Arg("clientKey", opts[i].ClientKey)
+		}
+	}
 	q = q.Arg("name", name)
 	q = q.Arg("mimir", mimir)
 
@@ -828,14 +764,59 @@ func (r *GrafanaStackGrafana) WithMimirDatasource(name string, mimir *GrafanaSta
 	}
 }
 
+// GrafanaStackGrafanaWithTempoDatasourceOpts contains options for GrafanaStackGrafana.WithTempoDatasource
+type GrafanaStackGrafanaWithTempoDatasourceOpts struct {
+	CaCert *File // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:735:2)
+
+	ClientCert *File // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:737:2)
+
+	ClientKey *Secret // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:739:2)
+}
+
 // WithTempoDatasource binds tempo into Grafana's network at hostname
 // `name` and accumulates a Tempo datasource entry under the same name.
-// See WithLokiDatasource for the constraints on `name`.
-func (r *GrafanaStackGrafana) WithTempoDatasource(name string, tempo *GrafanaStackTempo) *GrafanaStackGrafana { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:423:1)
+// See WithLokiDatasource for the constraints on `name` and the TLS args.
+func (r *GrafanaStackGrafana) WithTempoDatasource(name string, tempo *GrafanaStackTempo, opts ...GrafanaStackGrafanaWithTempoDatasourceOpts) *GrafanaStackGrafana { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:731:1)
 	assertNotNil("tempo", tempo)
 	q := r.query.Select("withTempoDatasource")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `caCert` optional argument
+		if !querybuilder.IsZeroValue(opts[i].CaCert) {
+			q = q.Arg("caCert", opts[i].CaCert)
+		}
+		// `clientCert` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ClientCert) {
+			q = q.Arg("clientCert", opts[i].ClientCert)
+		}
+		// `clientKey` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ClientKey) {
+			q = q.Arg("clientKey", opts[i].ClientKey)
+		}
+	}
 	q = q.Arg("name", name)
 	q = q.Arg("tempo", tempo)
+
+	return &GrafanaStackGrafana{
+		query: q,
+	}
+}
+
+// WithTls switches the Grafana UI's :3000 listener from HTTP to HTTPS by
+// setting [server] protocol = https plus cert_file / cert_key in grafana.ini.
+// serverCert is the PEM server certificate and serverKey its PEM private key.
+// After this call Endpoint returns an https:// URL.
+//
+// Note: Grafana core does not support requiring client certificates on its
+// own listener, so there is no Grafana.WithMtls. To reach an mTLS-required
+// backend, supply the client certificate to the datasource instead (see
+// WithLokiDatasource). Ignored when a custom config file was supplied to
+// Grafana().
+func (r *GrafanaStackGrafana) WithTLS(serverCert *File, serverKey *Secret) *GrafanaStackGrafana { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:681:1)
+	assertNotNil("serverCert", serverCert)
+	assertNotNil("serverKey", serverKey)
+	q := r.query.Select("withTls")
+	q = q.Arg("serverCert", serverCert)
+	q = q.Arg("serverKey", serverKey)
 
 	return &GrafanaStackGrafana{
 		query: q,
@@ -853,13 +834,21 @@ func (r *GrafanaStackGrafana) AsNode() Node {
 // Loki wraps a configured grafana/loki container. Use Service() to obtain
 // the *dagger.Service for binding into other containers, and Endpoint() /
 // OtlpHttpEndpoint() to derive client URLs.
-type GrafanaStackLoki struct { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:60:6)
+type GrafanaStackLoki struct { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:96:6)
 	query *querybuilder.Selection
 
 	endpoint         *string
 	id               *ID
 	image            *string
 	otlpHttpEndpoint *string
+}
+type WithGrafanaStackLokiFunc func(r *GrafanaStackLoki) *GrafanaStackLoki
+
+// With calls the provided function with current GrafanaStackLoki.
+//
+// This is useful for reusability and readability by not breaking the calling chain.
+func (r *GrafanaStackLoki) With(f WithGrafanaStackLokiFunc) *GrafanaStackLoki {
+	return f(r)
 }
 
 func (r *GrafanaStackLoki) WithGraphQLQuery(q *querybuilder.Selection) *GrafanaStackLoki {
@@ -870,7 +859,7 @@ func (r *GrafanaStackLoki) WithGraphQLQuery(q *querybuilder.Selection) *GrafanaS
 
 // ConfigFile is the Loki YAML config: either the caller-supplied
 // override or the embedded default staged into the module workdir.
-func (r *GrafanaStackLoki) ConfigFile() *File { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:65:2)
+func (r *GrafanaStackLoki) ConfigFile() *File { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:101:2)
 	q := r.query.Select("configFile")
 
 	return &File{
@@ -878,8 +867,9 @@ func (r *GrafanaStackLoki) ConfigFile() *File { // grafana-stack (../../../../..
 	}
 }
 
-// Endpoint returns the Loki HTTP base URL, e.g. http://<host>:3100.
-func (r *GrafanaStackLoki) Endpoint(ctx context.Context) (string, error) { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:127:1)
+// Endpoint returns the Loki HTTP base URL, e.g. http://<host>:3100, or
+// https://<host>:3100 once WithTls has been called.
+func (r *GrafanaStackLoki) Endpoint(ctx context.Context) (string, error) { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:214:1)
 	if r.endpoint != nil {
 		return *r.endpoint, nil
 	}
@@ -941,7 +931,7 @@ func (r *GrafanaStackLoki) UnmarshalJSON(bs []byte) error {
 }
 
 // Image is the resolved <registry>/grafana/loki:<tag> reference.
-func (r *GrafanaStackLoki) Image(ctx context.Context) (string, error) { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:62:2)
+func (r *GrafanaStackLoki) Image(ctx context.Context) (string, error) { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:98:2)
 	if r.image != nil {
 		return *r.image, nil
 	}
@@ -954,8 +944,9 @@ func (r *GrafanaStackLoki) Image(ctx context.Context) (string, error) { // grafa
 }
 
 // OtlpHttpEndpoint returns the Loki OTLP/HTTP logs receiver URL, suitable
-// as the `endpoint` for an OpenTelemetry exporter posting log data.
-func (r *GrafanaStackLoki) OtlpHTTPEndpoint(ctx context.Context) (string, error) { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:138:1)
+// as the `endpoint` for an OpenTelemetry exporter posting log data. The
+// scheme is https once WithTls has been called.
+func (r *GrafanaStackLoki) OtlpHTTPEndpoint(ctx context.Context) (string, error) { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:230:1)
 	if r.otlpHttpEndpoint != nil {
 		return *r.otlpHttpEndpoint, nil
 	}
@@ -974,7 +965,7 @@ func (r *GrafanaStackLoki) OtlpHTTPEndpoint(ctx context.Context) (string, error)
 // without us having to second-guess the upstream image's USER. This is
 // safe for ephemeral dev/test services and avoids per-image UID drift
 // across Loki / Tempo / Mimir.
-func (r *GrafanaStackLoki) Service() *Service { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:112:1)
+func (r *GrafanaStackLoki) Service() *Service { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:186:1)
 	q := r.query.Select("service")
 
 	return &Service{
@@ -984,10 +975,42 @@ func (r *GrafanaStackLoki) Service() *Service { // grafana-stack (../../../../..
 
 // Storage is the optional persistence volume for /var/lib/loki.
 // When nil the data dir is mounted as an empty Directory (ephemeral).
-func (r *GrafanaStackLoki) Storage() *CacheVolume { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:68:2)
+func (r *GrafanaStackLoki) Storage() *CacheVolume { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:104:2)
 	q := r.query.Select("storage")
 
 	return &CacheVolume{
+		query: q,
+	}
+}
+
+// WithMtls additionally requires every client to present a certificate signed
+// by clientCa (PEM). Must be combined with WithTls; Service returns an error
+// otherwise.
+func (r *GrafanaStackLoki) WithMtls(clientCa *File) *GrafanaStackLoki { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:173:1)
+	assertNotNil("clientCa", clientCa)
+	q := r.query.Select("withMtls")
+	q = q.Arg("clientCa", clientCa)
+
+	return &GrafanaStackLoki{
+		query: q,
+	}
+}
+
+// WithTls enables TLS on Loki's HTTP listener (:3100) — which serves both the
+// native LogQL/ingest API and the OTLP/HTTP logs receiver — by rendering
+// server.http_tls_config into the config. serverCert is the PEM server
+// certificate (its SAN must cover the hostname clients dial) and serverKey its
+// PEM private key. After this call Endpoint / OtlpHttpEndpoint return https://
+// URLs. Ignored when a custom config file was supplied to Loki(); that config
+// owns its own TLS.
+func (r *GrafanaStackLoki) WithTLS(serverCert *File, serverKey *Secret) *GrafanaStackLoki { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:163:1)
+	assertNotNil("serverCert", serverCert)
+	assertNotNil("serverKey", serverKey)
+	q := r.query.Select("withTls")
+	q = q.Arg("serverCert", serverCert)
+	q = q.Arg("serverKey", serverKey)
+
+	return &GrafanaStackLoki{
 		query: q,
 	}
 }
@@ -1003,13 +1026,21 @@ func (r *GrafanaStackLoki) AsNode() Node {
 // Mimir wraps a configured grafana/mimir container running in monolithic
 // (single-binary, target=all) mode with the OTLP HTTP ingester enabled,
 // anonymous tenant, and filesystem block storage.
-type GrafanaStackMimir struct { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:245:6)
+type GrafanaStackMimir struct { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:400:6)
 	query *querybuilder.Selection
 
 	endpoint         *string
 	id               *ID
 	image            *string
 	otlpHttpEndpoint *string
+}
+type WithGrafanaStackMimirFunc func(r *GrafanaStackMimir) *GrafanaStackMimir
+
+// With calls the provided function with current GrafanaStackMimir.
+//
+// This is useful for reusability and readability by not breaking the calling chain.
+func (r *GrafanaStackMimir) With(f WithGrafanaStackMimirFunc) *GrafanaStackMimir {
+	return f(r)
 }
 
 func (r *GrafanaStackMimir) WithGraphQLQuery(q *querybuilder.Selection) *GrafanaStackMimir {
@@ -1020,7 +1051,7 @@ func (r *GrafanaStackMimir) WithGraphQLQuery(q *querybuilder.Selection) *Grafana
 
 // ConfigFile is the Mimir YAML config: either the caller-supplied
 // override or the embedded default.
-func (r *GrafanaStackMimir) ConfigFile() *File { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:250:2)
+func (r *GrafanaStackMimir) ConfigFile() *File { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:405:2)
 	q := r.query.Select("configFile")
 
 	return &File{
@@ -1028,10 +1059,11 @@ func (r *GrafanaStackMimir) ConfigFile() *File { // grafana-stack (../../../../.
 	}
 }
 
-// Endpoint returns the Mimir HTTP base URL, e.g. http://<host>:9009.
-// This endpoint serves both the Prometheus-compatible query API and
-// the OTLP HTTP metrics ingester.
-func (r *GrafanaStackMimir) Endpoint(ctx context.Context) (string, error) { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:312:1)
+// Endpoint returns the Mimir HTTP base URL, e.g. http://<host>:9009, or
+// https://<host>:9009 once WithTls has been called. This endpoint serves
+// both the Prometheus-compatible query API and the OTLP HTTP metrics
+// ingester.
+func (r *GrafanaStackMimir) Endpoint(ctx context.Context) (string, error) { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:515:1)
 	if r.endpoint != nil {
 		return *r.endpoint, nil
 	}
@@ -1093,7 +1125,7 @@ func (r *GrafanaStackMimir) UnmarshalJSON(bs []byte) error {
 }
 
 // Image is the resolved <registry>/grafana/mimir:<tag> reference.
-func (r *GrafanaStackMimir) Image(ctx context.Context) (string, error) { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:247:2)
+func (r *GrafanaStackMimir) Image(ctx context.Context) (string, error) { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:402:2)
 	if r.image != nil {
 		return *r.image, nil
 	}
@@ -1107,8 +1139,8 @@ func (r *GrafanaStackMimir) Image(ctx context.Context) (string, error) { // graf
 
 // OtlpHttpEndpoint returns the Mimir OTLP/HTTP metrics receiver URL,
 // suitable as the `endpoint` for an OpenTelemetry exporter posting
-// metric data.
-func (r *GrafanaStackMimir) OtlpHTTPEndpoint(ctx context.Context) (string, error) { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:324:1)
+// metric data. The scheme is https once WithTls has been called.
+func (r *GrafanaStackMimir) OtlpHTTPEndpoint(ctx context.Context) (string, error) { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:531:1)
 	if r.otlpHttpEndpoint != nil {
 		return *r.otlpHttpEndpoint, nil
 	}
@@ -1124,7 +1156,7 @@ func (r *GrafanaStackMimir) OtlpHTTPEndpoint(ctx context.Context) (string, error
 // `-target=all` so the binary runs in monolithic mode regardless of the
 // upstream image's default CMD. See Loki.Service for notes on the
 // WithUser("0:0") choice.
-func (r *GrafanaStackMimir) Service() *Service { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:295:1)
+func (r *GrafanaStackMimir) Service() *Service { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:485:1)
 	q := r.query.Select("service")
 
 	return &Service{
@@ -1133,10 +1165,41 @@ func (r *GrafanaStackMimir) Service() *Service { // grafana-stack (../../../../.
 }
 
 // Storage is the optional persistence volume for /var/lib/mimir.
-func (r *GrafanaStackMimir) Storage() *CacheVolume { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:252:2)
+func (r *GrafanaStackMimir) Storage() *CacheVolume { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:407:2)
 	q := r.query.Select("storage")
 
 	return &CacheVolume{
+		query: q,
+	}
+}
+
+// WithMtls additionally requires every client to present a certificate signed
+// by clientCa (PEM). Must be combined with WithTls; Service returns an error
+// otherwise.
+func (r *GrafanaStackMimir) WithMtls(clientCa *File) *GrafanaStackMimir { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:475:1)
+	assertNotNil("clientCa", clientCa)
+	q := r.query.Select("withMtls")
+	q = q.Arg("clientCa", clientCa)
+
+	return &GrafanaStackMimir{
+		query: q,
+	}
+}
+
+// WithTls enables TLS on Mimir's HTTP listener (:9009) — which serves both the
+// Prometheus-compatible API and the OTLP/HTTP metrics receiver — by rendering
+// server.http_tls_config into the config. serverCert is the PEM server
+// certificate and serverKey its PEM private key. After this call Endpoint /
+// OtlpHttpEndpoint return https:// URLs. Ignored when a custom config file was
+// supplied to Mimir().
+func (r *GrafanaStackMimir) WithTLS(serverCert *File, serverKey *Secret) *GrafanaStackMimir { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:465:1)
+	assertNotNil("serverCert", serverCert)
+	assertNotNil("serverKey", serverKey)
+	q := r.query.Select("withTls")
+	q = q.Arg("serverCert", serverCert)
+	q = q.Arg("serverKey", serverKey)
+
+	return &GrafanaStackMimir{
 		query: q,
 	}
 }
@@ -1152,7 +1215,7 @@ func (r *GrafanaStackMimir) AsNode() Node {
 // Tempo wraps a configured grafana/tempo container running in monolithic
 // mode with the OTLP gRPC and HTTP receivers enabled and local filesystem
 // trace storage.
-type GrafanaStackTempo struct { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:149:6)
+type GrafanaStackTempo struct { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:241:6)
 	query *querybuilder.Selection
 
 	httpEndpoint     *string
@@ -1160,6 +1223,14 @@ type GrafanaStackTempo struct { // grafana-stack (../../../../../daggerverse/gra
 	image            *string
 	otlpGrpcEndpoint *string
 	otlpHttpEndpoint *string
+}
+type WithGrafanaStackTempoFunc func(r *GrafanaStackTempo) *GrafanaStackTempo
+
+// With calls the provided function with current GrafanaStackTempo.
+//
+// This is useful for reusability and readability by not breaking the calling chain.
+func (r *GrafanaStackTempo) With(f WithGrafanaStackTempoFunc) *GrafanaStackTempo {
+	return f(r)
 }
 
 func (r *GrafanaStackTempo) WithGraphQLQuery(q *querybuilder.Selection) *GrafanaStackTempo {
@@ -1170,7 +1241,7 @@ func (r *GrafanaStackTempo) WithGraphQLQuery(q *querybuilder.Selection) *Grafana
 
 // ConfigFile is the Tempo YAML config: either the caller-supplied
 // override or the embedded default.
-func (r *GrafanaStackTempo) ConfigFile() *File { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:154:2)
+func (r *GrafanaStackTempo) ConfigFile() *File { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:246:2)
 	q := r.query.Select("configFile")
 
 	return &File{
@@ -1179,8 +1250,9 @@ func (r *GrafanaStackTempo) ConfigFile() *File { // grafana-stack (../../../../.
 }
 
 // HttpEndpoint returns the Tempo HTTP query/push base URL,
-// e.g. http://<host>:3200.
-func (r *GrafanaStackTempo) HTTPEndpoint(ctx context.Context) (string, error) { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:213:1)
+// e.g. http://<host>:3200, or https://<host>:3200 once WithTls has been
+// called.
+func (r *GrafanaStackTempo) HTTPEndpoint(ctx context.Context) (string, error) { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:354:1)
 	if r.httpEndpoint != nil {
 		return *r.httpEndpoint, nil
 	}
@@ -1242,7 +1314,7 @@ func (r *GrafanaStackTempo) UnmarshalJSON(bs []byte) error {
 }
 
 // Image is the resolved <registry>/grafana/tempo:<tag> reference.
-func (r *GrafanaStackTempo) Image(ctx context.Context) (string, error) { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:151:2)
+func (r *GrafanaStackTempo) Image(ctx context.Context) (string, error) { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:243:2)
 	if r.image != nil {
 		return *r.image, nil
 	}
@@ -1255,8 +1327,9 @@ func (r *GrafanaStackTempo) Image(ctx context.Context) (string, error) { // graf
 }
 
 // OtlpGrpcEndpoint returns the Tempo OTLP/gRPC receiver address,
-// e.g. <host>:4317. No URL scheme — gRPC clients want host:port.
-func (r *GrafanaStackTempo) OtlpGrpcEndpoint(ctx context.Context) (string, error) { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:224:1)
+// e.g. <host>:4317. No URL scheme — gRPC clients want host:port and must
+// configure TLS themselves (the receiver enforces it once WithTls is set).
+func (r *GrafanaStackTempo) OtlpGrpcEndpoint(ctx context.Context) (string, error) { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:370:1)
 	if r.otlpGrpcEndpoint != nil {
 		return *r.otlpGrpcEndpoint, nil
 	}
@@ -1269,9 +1342,10 @@ func (r *GrafanaStackTempo) OtlpGrpcEndpoint(ctx context.Context) (string, error
 }
 
 // OtlpHttpEndpoint returns the Tempo OTLP/HTTP receiver base URL,
-// e.g. http://<host>:4318. The OpenTelemetry HTTP exporter appends
-// the per-signal path itself (e.g. /v1/traces).
-func (r *GrafanaStackTempo) OtlpHTTPEndpoint(ctx context.Context) (string, error) { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:235:1)
+// e.g. http://<host>:4318, or https://<host>:4318 once WithTls has been
+// called. The OpenTelemetry HTTP exporter appends the per-signal path
+// itself (e.g. /v1/traces).
+func (r *GrafanaStackTempo) OtlpHTTPEndpoint(ctx context.Context) (string, error) { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:386:1)
 	if r.otlpHttpEndpoint != nil {
 		return *r.otlpHttpEndpoint, nil
 	}
@@ -1285,7 +1359,7 @@ func (r *GrafanaStackTempo) OtlpHTTPEndpoint(ctx context.Context) (string, error
 
 // Service returns the Tempo Dagger service. See Loki.Service for notes
 // on the WithUser("0:0") choice.
-func (r *GrafanaStackTempo) Service() *Service { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:195:1)
+func (r *GrafanaStackTempo) Service() *Service { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:323:1)
 	q := r.query.Select("service")
 
 	return &Service{
@@ -1294,10 +1368,42 @@ func (r *GrafanaStackTempo) Service() *Service { // grafana-stack (../../../../.
 }
 
 // Storage is the optional persistence volume for /var/lib/tempo.
-func (r *GrafanaStackTempo) Storage() *CacheVolume { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:156:2)
+func (r *GrafanaStackTempo) Storage() *CacheVolume { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:248:2)
 	q := r.query.Select("storage")
 
 	return &CacheVolume{
+		query: q,
+	}
+}
+
+// WithMtls additionally requires every client to present a certificate signed
+// by clientCa (PEM) on every listener. Must be combined with WithTls; Service
+// returns an error otherwise.
+func (r *GrafanaStackTempo) WithMtls(clientCa *File) *GrafanaStackTempo { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:315:1)
+	assertNotNil("clientCa", clientCa)
+	q := r.query.Select("withMtls")
+	q = q.Arg("clientCa", clientCa)
+
+	return &GrafanaStackTempo{
+		query: q,
+	}
+}
+
+// WithTls enables TLS on every Tempo listener: the native HTTP query API
+// (:3200, via server.http_tls_config) and both OTLP receivers (gRPC :4317 and
+// HTTP :4318, via distributor.receivers.otlp.protocols.{grpc,http}.tls).
+// serverCert is the PEM server certificate and serverKey its PEM private key.
+// After this call HttpEndpoint / OtlpHttpEndpoint return https:// URLs;
+// OtlpGrpcEndpoint stays scheme-less (gRPC callers configure TLS themselves).
+// Ignored when a custom config file was supplied to Tempo().
+func (r *GrafanaStackTempo) WithTLS(serverCert *File, serverKey *Secret) *GrafanaStackTempo { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:305:1)
+	assertNotNil("serverCert", serverCert)
+	assertNotNil("serverKey", serverKey)
+	q := r.query.Select("withTls")
+	q = q.Arg("serverCert", serverCert)
+	q = q.Arg("serverKey", serverKey)
+
+	return &GrafanaStackTempo{
 		query: q,
 	}
 }
@@ -1312,7 +1418,7 @@ func (r *GrafanaStackTempo) AsNode() Node {
 
 // GrafanaStack is the module entry point. Use the per-backend constructor
 // functions (Loki, Tempo, Mimir) to obtain a service handle.
-func (r *Query) GrafanaStack() *GrafanaStack { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:23:6)
+func (r *Query) GrafanaStack() *GrafanaStack { // grafana-stack (../../../../../daggerverse/grafana-stack/main.go:34:6)
 	q := r.query.Select("grafanaStack")
 
 	return &GrafanaStack{

--- a/daggerverse/qemu/tests/internal/dagger/zig.gen.go
+++ b/daggerverse/qemu/tests/internal/dagger/zig.gen.go
@@ -19,7 +19,7 @@ func (r *Binding) AsZig() *Zig { // zig (../../../../../daggerverse/zig/main.go:
 }
 
 // Retrieve the binding value, as type ZigCi
-func (r *Binding) AsZigCi() *ZigCi { // zig (../../../../../daggerverse/zig/ci.go:19:6)
+func (r *Binding) AsZigCi() *ZigCi { // zig (../../../../../daggerverse/zig/ci.go:25:6)
 	q := r.query.Select("asZigCi")
 
 	return &ZigCi{
@@ -37,7 +37,7 @@ func (r *Binding) AsZigSectionSizes() *ZigSectionSizes { // zig (../../../../../
 }
 
 // Create or update a binding of type ZigCi in the environment
-func (r *Env) WithZigCiInput(name string, value *ZigCi, description string) *Env { // zig (../../../../../daggerverse/zig/ci.go:19:6)
+func (r *Env) WithZigCiInput(name string, value *ZigCi, description string) *Env { // zig (../../../../../daggerverse/zig/ci.go:25:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withZigCiInput")
 	q = q.Arg("name", name)
@@ -50,7 +50,7 @@ func (r *Env) WithZigCiInput(name string, value *ZigCi, description string) *Env
 }
 
 // Declare a desired ZigCi output to be assigned in the environment
-func (r *Env) WithZigCiOutput(name string, description string) *Env { // zig (../../../../../daggerverse/zig/ci.go:19:6)
+func (r *Env) WithZigCiOutput(name string, description string) *Env { // zig (../../../../../daggerverse/zig/ci.go:25:6)
 	q := r.query.Select("withZigCiOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -302,7 +302,7 @@ func (r *Zig) Cc(source *Directory, files []string, opts ...ZigCcOpts) *File { /
 }
 
 // Ci returns a new pipeline builder bound to the supplied source.
-func (r *Zig) Ci(source *Directory) *ZigCi { // zig (../../../../../daggerverse/zig/ci.go:41:1)
+func (r *Zig) Ci(source *Directory) *ZigCi { // zig (../../../../../daggerverse/zig/ci.go:49:1)
 	assertNotNil("source", source)
 	q := r.query.Select("ci")
 	q = q.Arg("source", source)
@@ -636,11 +636,17 @@ func (r *Zig) AsNode() Node {
 // Zig.Ci(source); enable check stages via the With* methods; call Run to
 // execute checks-then-build, or Check to run only the parallel checks.
 //
-// Stage 1 runs the enabled static checks in parallel (Fmt, Test); errors are
-// aggregated. Stage 2 builds the source and Run returns the produced zig-out
-// directory. Downstream consumers compose that directory into their own
-// pipelines (package, sign, publish, ...).
-type ZigCi struct { // zig (../../../../../daggerverse/zig/ci.go:19:6)
+// Stage 1 runs the enabled checks in parallel (Fmt, Test, and — when WithBuild
+// was called — a Build check that compiles the source); errors are aggregated.
+// Stage 2 builds the source and Run returns the produced zig-out directory.
+// Downstream consumers compose that directory into their own pipelines
+// (package, sign, publish, ...).
+//
+// The Build check exists because fmt and test alone do not gate compilation:
+// fmt checks syntax, not types, and many projects (firmware especially) have no
+// test step, so a build-free Check reports a false green on code that does not
+// compile. See issue #161.
+type ZigCi struct { // zig (../../../../../daggerverse/zig/ci.go:25:6)
 	query *querybuilder.Selection
 
 	check *Void
@@ -661,11 +667,21 @@ func (r *ZigCi) WithGraphQLQuery(q *querybuilder.Selection) *ZigCi {
 	}
 }
 
-// Check runs the enabled check stages (Fmt, Test) in parallel via
-// github.com/dagger/dagger/util/parallel and returns the aggregated error. Use
-// when callers want to run the checks independently of the build (for example
-// multi-target pipelines that share one check run across N target builds).
-func (r *ZigCi) Check(ctx context.Context) error { // zig (../../../../../daggerverse/zig/ci.go:87:1)
+// Check runs the enabled check stages in parallel via
+// github.com/dagger/dagger/util/parallel and returns the aggregated error. The
+// enabled stages are Fmt (WithFmt), Test (WithTest), and Build (WithBuild).
+//
+// The Build stage compiles the source (`zig build`) and discards the artifact —
+// it exists so Check gates on "does it compile?", the fundamental correctness
+// check for a compiled language. Without it, a project whose only failure is a
+// compile error passes Check on the strength of fmt alone (a false green): fmt
+// checks syntax, not types, and firmware projects frequently have no test step.
+// See issue #161.
+//
+// Build is opt-in via WithBuild so callers can still run a build-free Check —
+// for example multi-target pipelines that share one target-independent check
+// run (fmt, test) across N target builds.
+func (r *ZigCi) Check(ctx context.Context) error { // zig (../../../../../daggerverse/zig/ci.go:117:1)
 	if r.check != nil {
 		return nil
 	}
@@ -726,7 +742,12 @@ func (r *ZigCi) UnmarshalJSON(bs []byte) error {
 // Run executes the pipeline: stage 1 (Check) → stage 2 (build). Returns the
 // produced zig-out directory. On stage-1 failure, returns the aggregated error
 // from Check and a nil directory (stage 2 is skipped).
-func (r *ZigCi) Run() *Directory { // zig (../../../../../daggerverse/zig/ci.go:106:1)
+//
+// Run always builds regardless of WithBuild — it must produce the directory it
+// returns. When WithBuild was called, Check also builds (stage 1); that build
+// and stage 2 share inputs, so session caching makes stage 2 a cache hit rather
+// than a second compile.
+func (r *ZigCi) Run() *Directory { // zig (../../../../../daggerverse/zig/ci.go:144:1)
 	q := r.query.Select("run")
 
 	return &Directory{
@@ -736,18 +757,29 @@ func (r *ZigCi) Run() *Directory { // zig (../../../../../daggerverse/zig/ci.go:
 
 // ZigCiWithBuildOpts contains options for ZigCi.WithBuild
 type ZigCiWithBuildOpts struct {
-	Optimize string // zig (../../../../../daggerverse/zig/ci.go:68:2)
+	Optimize string // zig (../../../../../daggerverse/zig/ci.go:87:2)
 
-	Target string // zig (../../../../../daggerverse/zig/ci.go:70:2)
+	Target string // zig (../../../../../daggerverse/zig/ci.go:89:2)
 
-	Steps []string // zig (../../../../../daggerverse/zig/ci.go:72:2)
+	Steps []string // zig (../../../../../daggerverse/zig/ci.go:91:2)
 }
 
-// WithBuild configures the build stage parameters (forwarded to Zig.Build).
-// optimize, when non-empty, must be one of Debug, ReleaseSafe, ReleaseFast,
-// ReleaseSmall; target sets -Dtarget; steps names build steps. Build is always
-// executed by Run regardless of whether this method is called.
-func (r *ZigCi) WithBuild(opts ...ZigCiWithBuildOpts) *ZigCi { // zig (../../../../../daggerverse/zig/ci.go:66:1)
+// WithBuild enables the build check stage and configures its parameters
+// (forwarded to Zig.Build). optimize, when non-empty, must be one of Debug,
+// ReleaseSafe, ReleaseFast, ReleaseSmall; target sets -Dtarget; steps names
+// build steps.
+//
+// Calling WithBuild makes Check compile the source (`zig build`) as one of its
+// parallel checks, so a project that does not type-check fails Check rather
+// than reporting a false green — the fmt and (optional) test checks alone do
+// not compile the code. Without WithBuild, Check runs only the enabled static
+// checks and never builds, preserving a build-free Check for multi-target
+// pipelines that share one check run across N target builds.
+//
+// Run always builds regardless of whether this method is called (it must
+// produce the zig-out directory it returns); WithBuild's optimize/target/steps
+// configure that build too.
+func (r *ZigCi) WithBuild(opts ...ZigCiWithBuildOpts) *ZigCi { // zig (../../../../../daggerverse/zig/ci.go:85:1)
 	q := r.query.Select("withBuild")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `optimize` optional argument
@@ -770,7 +802,7 @@ func (r *ZigCi) WithBuild(opts ...ZigCiWithBuildOpts) *ZigCi { // zig (../../../
 }
 
 // WithFmt enables the `zig fmt --check` check stage.
-func (r *ZigCi) WithFmt() *ZigCi { // zig (../../../../../daggerverse/zig/ci.go:46:1)
+func (r *ZigCi) WithFmt() *ZigCi { // zig (../../../../../daggerverse/zig/ci.go:54:1)
 	q := r.query.Select("withFmt")
 
 	return &ZigCi{
@@ -780,12 +812,12 @@ func (r *ZigCi) WithFmt() *ZigCi { // zig (../../../../../daggerverse/zig/ci.go:
 
 // ZigCiWithTestOpts contains options for ZigCi.WithTest
 type ZigCiWithTestOpts struct {
-	Root string // zig (../../../../../daggerverse/zig/ci.go:55:2)
+	Root string // zig (../../../../../daggerverse/zig/ci.go:63:2)
 }
 
 // WithTest enables the test check stage. root maps onto Zig.Test's optional
 // root: empty runs `zig build test`; non-empty runs `zig test <root>`.
-func (r *ZigCi) WithTest(opts ...ZigCiWithTestOpts) *ZigCi { // zig (../../../../../daggerverse/zig/ci.go:53:1)
+func (r *ZigCi) WithTest(opts ...ZigCiWithTestOpts) *ZigCi { // zig (../../../../../daggerverse/zig/ci.go:61:1)
 	q := r.query.Select("withTest")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `root` optional argument

--- a/daggerverse/zig/tests/internal/dagger/zig.gen.go
+++ b/daggerverse/zig/tests/internal/dagger/zig.gen.go
@@ -19,7 +19,7 @@ func (r *Binding) AsZig() *Zig { // zig (../../../../../daggerverse/zig/main.go:
 }
 
 // Retrieve the binding value, as type ZigCi
-func (r *Binding) AsZigCi() *ZigCi { // zig (../../../../../daggerverse/zig/ci.go:19:6)
+func (r *Binding) AsZigCi() *ZigCi { // zig (../../../../../daggerverse/zig/ci.go:25:6)
 	q := r.query.Select("asZigCi")
 
 	return &ZigCi{
@@ -37,7 +37,7 @@ func (r *Binding) AsZigSectionSizes() *ZigSectionSizes { // zig (../../../../../
 }
 
 // Create or update a binding of type ZigCi in the environment
-func (r *Env) WithZigCiInput(name string, value *ZigCi, description string) *Env { // zig (../../../../../daggerverse/zig/ci.go:19:6)
+func (r *Env) WithZigCiInput(name string, value *ZigCi, description string) *Env { // zig (../../../../../daggerverse/zig/ci.go:25:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withZigCiInput")
 	q = q.Arg("name", name)
@@ -50,7 +50,7 @@ func (r *Env) WithZigCiInput(name string, value *ZigCi, description string) *Env
 }
 
 // Declare a desired ZigCi output to be assigned in the environment
-func (r *Env) WithZigCiOutput(name string, description string) *Env { // zig (../../../../../daggerverse/zig/ci.go:19:6)
+func (r *Env) WithZigCiOutput(name string, description string) *Env { // zig (../../../../../daggerverse/zig/ci.go:25:6)
 	q := r.query.Select("withZigCiOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -302,7 +302,7 @@ func (r *Zig) Cc(source *Directory, files []string, opts ...ZigCcOpts) *File { /
 }
 
 // Ci returns a new pipeline builder bound to the supplied source.
-func (r *Zig) Ci(source *Directory) *ZigCi { // zig (../../../../../daggerverse/zig/ci.go:41:1)
+func (r *Zig) Ci(source *Directory) *ZigCi { // zig (../../../../../daggerverse/zig/ci.go:49:1)
 	assertNotNil("source", source)
 	q := r.query.Select("ci")
 	q = q.Arg("source", source)
@@ -636,11 +636,17 @@ func (r *Zig) AsNode() Node {
 // Zig.Ci(source); enable check stages via the With* methods; call Run to
 // execute checks-then-build, or Check to run only the parallel checks.
 //
-// Stage 1 runs the enabled static checks in parallel (Fmt, Test); errors are
-// aggregated. Stage 2 builds the source and Run returns the produced zig-out
-// directory. Downstream consumers compose that directory into their own
-// pipelines (package, sign, publish, ...).
-type ZigCi struct { // zig (../../../../../daggerverse/zig/ci.go:19:6)
+// Stage 1 runs the enabled checks in parallel (Fmt, Test, and — when WithBuild
+// was called — a Build check that compiles the source); errors are aggregated.
+// Stage 2 builds the source and Run returns the produced zig-out directory.
+// Downstream consumers compose that directory into their own pipelines
+// (package, sign, publish, ...).
+//
+// The Build check exists because fmt and test alone do not gate compilation:
+// fmt checks syntax, not types, and many projects (firmware especially) have no
+// test step, so a build-free Check reports a false green on code that does not
+// compile. See issue #161.
+type ZigCi struct { // zig (../../../../../daggerverse/zig/ci.go:25:6)
 	query *querybuilder.Selection
 
 	check *Void
@@ -661,11 +667,21 @@ func (r *ZigCi) WithGraphQLQuery(q *querybuilder.Selection) *ZigCi {
 	}
 }
 
-// Check runs the enabled check stages (Fmt, Test) in parallel via
-// github.com/dagger/dagger/util/parallel and returns the aggregated error. Use
-// when callers want to run the checks independently of the build (for example
-// multi-target pipelines that share one check run across N target builds).
-func (r *ZigCi) Check(ctx context.Context) error { // zig (../../../../../daggerverse/zig/ci.go:87:1)
+// Check runs the enabled check stages in parallel via
+// github.com/dagger/dagger/util/parallel and returns the aggregated error. The
+// enabled stages are Fmt (WithFmt), Test (WithTest), and Build (WithBuild).
+//
+// The Build stage compiles the source (`zig build`) and discards the artifact —
+// it exists so Check gates on "does it compile?", the fundamental correctness
+// check for a compiled language. Without it, a project whose only failure is a
+// compile error passes Check on the strength of fmt alone (a false green): fmt
+// checks syntax, not types, and firmware projects frequently have no test step.
+// See issue #161.
+//
+// Build is opt-in via WithBuild so callers can still run a build-free Check —
+// for example multi-target pipelines that share one target-independent check
+// run (fmt, test) across N target builds.
+func (r *ZigCi) Check(ctx context.Context) error { // zig (../../../../../daggerverse/zig/ci.go:117:1)
 	if r.check != nil {
 		return nil
 	}
@@ -726,7 +742,12 @@ func (r *ZigCi) UnmarshalJSON(bs []byte) error {
 // Run executes the pipeline: stage 1 (Check) → stage 2 (build). Returns the
 // produced zig-out directory. On stage-1 failure, returns the aggregated error
 // from Check and a nil directory (stage 2 is skipped).
-func (r *ZigCi) Run() *Directory { // zig (../../../../../daggerverse/zig/ci.go:106:1)
+//
+// Run always builds regardless of WithBuild — it must produce the directory it
+// returns. When WithBuild was called, Check also builds (stage 1); that build
+// and stage 2 share inputs, so session caching makes stage 2 a cache hit rather
+// than a second compile.
+func (r *ZigCi) Run() *Directory { // zig (../../../../../daggerverse/zig/ci.go:144:1)
 	q := r.query.Select("run")
 
 	return &Directory{
@@ -736,18 +757,29 @@ func (r *ZigCi) Run() *Directory { // zig (../../../../../daggerverse/zig/ci.go:
 
 // ZigCiWithBuildOpts contains options for ZigCi.WithBuild
 type ZigCiWithBuildOpts struct {
-	Optimize string // zig (../../../../../daggerverse/zig/ci.go:68:2)
+	Optimize string // zig (../../../../../daggerverse/zig/ci.go:87:2)
 
-	Target string // zig (../../../../../daggerverse/zig/ci.go:70:2)
+	Target string // zig (../../../../../daggerverse/zig/ci.go:89:2)
 
-	Steps []string // zig (../../../../../daggerverse/zig/ci.go:72:2)
+	Steps []string // zig (../../../../../daggerverse/zig/ci.go:91:2)
 }
 
-// WithBuild configures the build stage parameters (forwarded to Zig.Build).
-// optimize, when non-empty, must be one of Debug, ReleaseSafe, ReleaseFast,
-// ReleaseSmall; target sets -Dtarget; steps names build steps. Build is always
-// executed by Run regardless of whether this method is called.
-func (r *ZigCi) WithBuild(opts ...ZigCiWithBuildOpts) *ZigCi { // zig (../../../../../daggerverse/zig/ci.go:66:1)
+// WithBuild enables the build check stage and configures its parameters
+// (forwarded to Zig.Build). optimize, when non-empty, must be one of Debug,
+// ReleaseSafe, ReleaseFast, ReleaseSmall; target sets -Dtarget; steps names
+// build steps.
+//
+// Calling WithBuild makes Check compile the source (`zig build`) as one of its
+// parallel checks, so a project that does not type-check fails Check rather
+// than reporting a false green — the fmt and (optional) test checks alone do
+// not compile the code. Without WithBuild, Check runs only the enabled static
+// checks and never builds, preserving a build-free Check for multi-target
+// pipelines that share one check run across N target builds.
+//
+// Run always builds regardless of whether this method is called (it must
+// produce the zig-out directory it returns); WithBuild's optimize/target/steps
+// configure that build too.
+func (r *ZigCi) WithBuild(opts ...ZigCiWithBuildOpts) *ZigCi { // zig (../../../../../daggerverse/zig/ci.go:85:1)
 	q := r.query.Select("withBuild")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `optimize` optional argument
@@ -770,7 +802,7 @@ func (r *ZigCi) WithBuild(opts ...ZigCiWithBuildOpts) *ZigCi { // zig (../../../
 }
 
 // WithFmt enables the `zig fmt --check` check stage.
-func (r *ZigCi) WithFmt() *ZigCi { // zig (../../../../../daggerverse/zig/ci.go:46:1)
+func (r *ZigCi) WithFmt() *ZigCi { // zig (../../../../../daggerverse/zig/ci.go:54:1)
 	q := r.query.Select("withFmt")
 
 	return &ZigCi{
@@ -780,12 +812,12 @@ func (r *ZigCi) WithFmt() *ZigCi { // zig (../../../../../daggerverse/zig/ci.go:
 
 // ZigCiWithTestOpts contains options for ZigCi.WithTest
 type ZigCiWithTestOpts struct {
-	Root string // zig (../../../../../daggerverse/zig/ci.go:55:2)
+	Root string // zig (../../../../../daggerverse/zig/ci.go:63:2)
 }
 
 // WithTest enables the test check stage. root maps onto Zig.Test's optional
 // root: empty runs `zig build test`; non-empty runs `zig test <root>`.
-func (r *ZigCi) WithTest(opts ...ZigCiWithTestOpts) *ZigCi { // zig (../../../../../daggerverse/zig/ci.go:53:1)
+func (r *ZigCi) WithTest(opts ...ZigCiWithTestOpts) *ZigCi { // zig (../../../../../daggerverse/zig/ci.go:61:1)
 	q := r.query.Select("withTest")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `root` optional argument


### PR DESCRIPTION
Closes #184

## The bug

`Ci.Generated` routed through `ws.Generators().Run()`. `Workspace.generators` lists module functions flagged `+generator`; no module in this repo declares one, so the list — and the changeset it ran — was always empty and the check passed unconditionally. It verified nothing for as long as it existed, which is how three root aggregator bindings drifted in behind a green check.

## The fix

Diff codegen output directly. The workspace is exported into the module's scratch dir, every `dagger.json` under it is loaded as a module source, and `generatedContextChangeset()` — exactly what `dagger develop` would write — is asserted empty. Drift is reported with the module name and its patch, as the old implementation intended.

Three details the implementation is shaped around, each established by probing the v0.21.7 API:

- **Module sources come from the exported copy, not the live Workspace.** Loading the root module's toolchains calls `asModule(defaultPathContextSourceRef: "<host abs path>")`, which a module runtime cannot resolve; and `Directory.asModuleSource()` silently resolves **0** toolchains, which would drop `ci/internal/dagger/*.gen.go` from coverage — the one place #184 was actually observed.
- **`.git` is excluded from the export, then an empty one is recreated.** A module's context directory is found by walking up to the repository root; without that marker every module takes its own source root as context and deps like `"../../crypto"` escape it.
- **The workspace directory is read as `"/"`, not `"."`.** `Workspace.Path()` is `ci`, so a relative path exports `ci/` — a tree with no `dagger.json` in it. This surfaced as an intermittent "no dagger.json found in the workspace".

Both checks are `+cache="never"`: the workspace is read at call time rather than passed as an argument, so a cached pass would be a pass for a tree the check never looked at.

## Self-test

`ci:generated-self-test` runs the same comparison against one module twice — pristine (expecting no drift) and with its committed bindings deliberately made stale (expecting drift naming that file) — so a regression back to a no-op is itself a CI failure. `ci:selection-self-test` is the precedent.

Mutation-tested: stubbing `codegenDrift` to return nothing makes the self-test fail with `self-test: no drift reported ... ci:generated verifies nothing`.

## Verification

- The issue's end-to-end probe (unregenerated exported function appended to `daggerverse/random/main.go`) fails the check, naming all 16 modules whose bindings went stale.
- `dagger check ci:generated ci:generated-self-test ci:selection-self-test` green on this branch; `go build` / `go vet` / `go test ./...` green in `ci/`.

## Bindings regenerated

The staleness the fixed check found on `main`: `grafana-stack/tests` (including its own `dagger.gen.go`), `kafka/tests`, `otel/tests`, `qemu/tests`, `zig/tests`. The `dgraph`/`kafka`/`zig` root aggregator bindings named in the issue were already clean at `81a2996`.

Dependency bindings embed each function's source location (`// kafka (../../../../../daggerverse/kafka/cluster_kafka.go:401:1)`), so an edit that only shifts line numbers in `daggerverse/<m>` leaves every dependent module stale. `ci/README.md` documents that.

## CI timing

Measured against a deliberately cold engine: **4m47s of engine work, 8m wall**. That exceeds the workflow's 6m `dagger/checks` step bound, so this leg would have timed out on every run. The `route` step now emits a per-leg `timeout` and the job cap becomes `timeout + 4`:

| leg | step bound |
| --- | --- |
| `ci:generated` | 15m |
| `ci:generated-self-test` | 8m |
| everything else | 6m (unchanged) |

The cost is structural: this one leg pays the module-build work the other legs spread across themselves. The alternative — scoping the sweep to the PR diff, the way #170 scopes the rest of CI — needs base/head plumbed in like `affected-checks` and was not taken here, since the issue specifies `ci:generated` as a check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)