### PR TITLE
story(issue-75): add Protobuf serde to kafka Client Produce/Consume

### DIFF
--- a/ci/internal/dagger/kafka-tests.gen.go
+++ b/ci/internal/dagger/kafka-tests.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type KafkaTests
-func (r *Binding) AsKafkaTests() *KafkaTests { // kafka-tests (../../../daggerverse/kafka/tests/main.go:39:6)
+func (r *Binding) AsKafkaTests() *KafkaTests { // kafka-tests (../../../daggerverse/kafka/tests/main.go:44:6)
 	q := r.query.Select("asKafkaTests")
 
 	return &KafkaTests{
@@ -19,7 +19,7 @@ func (r *Binding) AsKafkaTests() *KafkaTests { // kafka-tests (../../../daggerve
 }
 
 // Create or update a binding of type KafkaTests in the environment
-func (r *Env) WithKafkaTestsInput(name string, value *KafkaTests, description string) *Env { // kafka-tests (../../../daggerverse/kafka/tests/main.go:39:6)
+func (r *Env) WithKafkaTestsInput(name string, value *KafkaTests, description string) *Env { // kafka-tests (../../../daggerverse/kafka/tests/main.go:44:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withKafkaTestsInput")
 	q = q.Arg("name", name)
@@ -32,7 +32,7 @@ func (r *Env) WithKafkaTestsInput(name string, value *KafkaTests, description st
 }
 
 // Declare a desired KafkaTests output to be assigned in the environment
-func (r *Env) WithKafkaTestsOutput(name string, description string) *Env { // kafka-tests (../../../daggerverse/kafka/tests/main.go:39:6)
+func (r *Env) WithKafkaTestsOutput(name string, description string) *Env { // kafka-tests (../../../daggerverse/kafka/tests/main.go:44:6)
 	q := r.query.Select("withKafkaTestsOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -42,7 +42,7 @@ func (r *Env) WithKafkaTestsOutput(name string, description string) *Env { // ka
 	}
 }
 
-type KafkaTests struct { // kafka-tests (../../../daggerverse/kafka/tests/main.go:39:6)
+type KafkaTests struct { // kafka-tests (../../../daggerverse/kafka/tests/main.go:44:6)
 	query *querybuilder.Selection
 
 	all                                                        *Void
@@ -91,6 +91,16 @@ type KafkaTests struct { // kafka-tests (../../../daggerverse/kafka/tests/main.g
 	propertiesFileContainsBootstrapAndSecurityProtocol         *Void
 	propertiesFileContainsMtlsSettings                         *Void
 	propertiesFileContainsTlsSettings                          *Void
+	protobufConsumeMessageIndexMismatchErrors                  *Void
+	protobufConsumeUnframedErrors                              *Void
+	protobufDeserializeRequiresDescriptorSet                   *Void
+	protobufDeserializeRequiresSchemaRegistryAware             *Void
+	protobufFramedProduceConsumeRoundTrip                      *Void
+	protobufKeyFramedProduceConsumeRoundTrip                   *Void
+	protobufNonZeroMessageIndexRoundTrip                       *Void
+	protobufSerializeRequiresDescriptorSet                     *Void
+	protobufSerializeRequiresMessageName                       *Void
+	protobufSerializeRequiresSchemaId                          *Void
 	redpanda                                                   *Void
 	redpandaClusterProduceListTopicsRoundTrip                  *Void
 	redpandaClusterTlsRoundTrip                                *Void
@@ -126,15 +136,15 @@ func (r *KafkaTests) WithGraphQLQuery(q *querybuilder.Selection) *KafkaTests {
 type KafkaTestsAllOpts struct {
 
 	// Default: "4.2.0"
-	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/main.go:63:2)
+	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/main.go:68:2)
 
 	// Default: "8.2.0"
-	ConfluentImageTag string // kafka-tests (../../../daggerverse/kafka/tests/main.go:65:2)
+	ConfluentImageTag string // kafka-tests (../../../daggerverse/kafka/tests/main.go:70:2)
 
 	// Default: "v26.1.7"
-	RedpandaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/main.go:67:2)
+	RedpandaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/main.go:72:2)
 
-	Parallel int // kafka-tests (../../../daggerverse/kafka/tests/main.go:69:2)
+	Parallel int // kafka-tests (../../../daggerverse/kafka/tests/main.go:74:2)
 }
 
 // All runs every kafka round-trip test as a convenience for local
@@ -154,7 +164,7 @@ type KafkaTestsAllOpts struct {
 // groups run at once and how many tests run at once within each group.
 // Defaults to 0 (unbounded). Pass any positive integer for a specific
 // cap.
-func (r *KafkaTests) All(ctx context.Context, opts ...KafkaTestsAllOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/main.go:60:1)
+func (r *KafkaTests) All(ctx context.Context, opts ...KafkaTestsAllOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/main.go:65:1)
 	if r.all != nil {
 		return nil
 	}
@@ -266,15 +276,15 @@ func (r *KafkaTests) ApacheClusterTLSRoundTrip(ctx context.Context, opts ...Kafk
 type KafkaTestsApacheJvmOpts struct {
 
 	// Default: "4.2.0"
-	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/main.go:311:2)
+	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/main.go:346:2)
 
-	Parallel int // kafka-tests (../../../daggerverse/kafka/tests/main.go:313:2)
+	Parallel int // kafka-tests (../../../daggerverse/kafka/tests/main.go:348:2)
 }
 
 // ApacheJVM runs the three apache/kafka JVM-image round-trip tests.
 // Each test owns a fresh ApacheCluster, so the group holds no shared
 // clusters of its own.
-func (r *KafkaTests) ApacheJvm(ctx context.Context, opts ...KafkaTestsApacheJvmOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/main.go:308:1)
+func (r *KafkaTests) ApacheJvm(ctx context.Context, opts ...KafkaTestsApacheJvmOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/main.go:343:1)
 	if r.apacheJvm != nil {
 		return nil
 	}
@@ -585,14 +595,14 @@ func (r *KafkaTests) ClusterClientCanListTopicsOnFreshCluster(ctx context.Contex
 type KafkaTestsConfluentOpts struct {
 
 	// Default: "8.2.0"
-	ConfluentImageTag string // kafka-tests (../../../daggerverse/kafka/tests/main.go:343:2)
+	ConfluentImageTag string // kafka-tests (../../../daggerverse/kafka/tests/main.go:378:2)
 
-	Parallel int // kafka-tests (../../../daggerverse/kafka/tests/main.go:345:2)
+	Parallel int // kafka-tests (../../../daggerverse/kafka/tests/main.go:380:2)
 }
 
 // Confluent runs the three confluentinc/cp-kafka round-trip tests.
 // Each test owns a fresh ConfluentCluster.
-func (r *KafkaTests) Confluent(ctx context.Context, opts ...KafkaTestsConfluentOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/main.go:340:1)
+func (r *KafkaTests) Confluent(ctx context.Context, opts ...KafkaTestsConfluentOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/main.go:375:1)
 	if r.confluent != nil {
 		return nil
 	}
@@ -1143,16 +1153,16 @@ func (r *KafkaTests) MtlsRoundTrip(ctx context.Context, opts ...KafkaTestsMtlsRo
 type KafkaTestsNativeOpts struct {
 
 	// Default: "4.2.0"
-	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/main.go:187:2)
+	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/main.go:222:2)
 
-	Parallel int // kafka-tests (../../../daggerverse/kafka/tests/main.go:189:2)
+	Parallel int // kafka-tests (../../../daggerverse/kafka/tests/main.go:224:2)
 }
 
 // Native runs every apache/kafka-native test as one group. It boots
 // the three shared ApacheNativeClusters up front, fans the shared-cluster
 // and fresh-cluster native tests across a par pool capped at parallel,
 // and tears the shared clusters down on return.
-func (r *KafkaTests) Native(ctx context.Context, opts ...KafkaTestsNativeOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/main.go:184:1)
+func (r *KafkaTests) Native(ctx context.Context, opts ...KafkaTestsNativeOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/main.go:219:1)
 	if r.native != nil {
 		return nil
 	}
@@ -1380,19 +1390,233 @@ func (r *KafkaTests) PropertiesFileContainsTLSSettings(ctx context.Context, opts
 	return q.Execute(ctx)
 }
 
+// KafkaTestsProtobufConsumeMessageIndexMismatchErrorsOpts contains options for KafkaTests.ProtobufConsumeMessageIndexMismatchErrors
+type KafkaTestsProtobufConsumeMessageIndexMismatchErrorsOpts struct {
+
+	// Default: "4.2.0"
+	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_protobuf.go:423:2)
+}
+
+// ProtobufConsumeMessageIndexMismatchErrors pins the guard that makes the
+// message-index array load-bearing rather than decorative. A record produced
+// as devex.kafka.test.User (index [0]) but consumed as devex.kafka.test.Event
+// (index [1]) must be rejected: protobuf wire bytes are not self-describing,
+// so decoding one message type's bytes against another's descriptor would
+// otherwise succeed and hand back silent garbage.
+func (r *KafkaTests) ProtobufConsumeMessageIndexMismatchErrors(ctx context.Context, opts ...KafkaTestsProtobufConsumeMessageIndexMismatchErrorsOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_protobuf.go:420:1)
+	if r.protobufConsumeMessageIndexMismatchErrors != nil {
+		return nil
+	}
+	q := r.query.Select("protobufConsumeMessageIndexMismatchErrors")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `kafkaImageTag` optional argument
+		if !querybuilder.IsZeroValue(opts[i].KafkaImageTag) {
+			q = q.Arg("kafkaImageTag", opts[i].KafkaImageTag)
+		}
+	}
+
+	return q.Execute(ctx)
+}
+
+// KafkaTestsProtobufConsumeUnframedErrorsOpts contains options for KafkaTests.ProtobufConsumeUnframedErrors
+type KafkaTestsProtobufConsumeUnframedErrorsOpts struct {
+
+	// Default: "4.2.0"
+	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_protobuf.go:367:2)
+}
+
+// ProtobufConsumeUnframedErrors pins the negative consume path: a record
+// produced without a Confluent wire header, consumed with
+// valueDeserializeAs="PROTOBUF"pointing at the missing header rather than trying to parse arbitrary bytes
+// as a protobuf message. No registry is started — PROTOBUF decoding never
+// needs one, and the header check fires before the descriptor set is even
+// read.
+func (r *KafkaTests) ProtobufConsumeUnframedErrors(ctx context.Context, opts ...KafkaTestsProtobufConsumeUnframedErrorsOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_protobuf.go:364:1)
+	if r.protobufConsumeUnframedErrors != nil {
+		return nil
+	}
+	q := r.query.Select("protobufConsumeUnframedErrors")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `kafkaImageTag` optional argument
+		if !querybuilder.IsZeroValue(opts[i].KafkaImageTag) {
+			q = q.Arg("kafkaImageTag", opts[i].KafkaImageTag)
+		}
+	}
+
+	return q.Execute(ctx)
+}
+
+// ProtobufDeserializeRequiresDescriptorSet mirrors the produce-side guard on
+// the consume path. It must fail before a broker connection is opened, which
+// the unroutable bootstrap address proves: a missing guard would surface as a
+// dial timeout rather than a validation error.
+func (r *KafkaTests) ProtobufDeserializeRequiresDescriptorSet(ctx context.Context) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_protobuf.go:133:1)
+	if r.protobufDeserializeRequiresDescriptorSet != nil {
+		return nil
+	}
+	q := r.query.Select("protobufDeserializeRequiresDescriptorSet")
+
+	return q.Execute(ctx)
+}
+
+// ProtobufDeserializeRequiresSchemaRegistryAware pins that PROTOBUF consume
+// needs schemaRegistryAware=true: without it the 5-byte header is never
+// stripped, so neither the wire id nor the message-index array that follows it
+// is reachable.
+func (r *KafkaTests) ProtobufDeserializeRequiresSchemaRegistryAware(ctx context.Context) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_protobuf.go:162:1)
+	if r.protobufDeserializeRequiresSchemaRegistryAware != nil {
+		return nil
+	}
+	q := r.query.Select("protobufDeserializeRequiresSchemaRegistryAware")
+
+	return q.Execute(ctx)
+}
+
+// KafkaTestsProtobufFramedProduceConsumeRoundTripOpts contains options for KafkaTests.ProtobufFramedProduceConsumeRoundTrip
+type KafkaTestsProtobufFramedProduceConsumeRoundTripOpts struct {
+
+	// Default: "4.2.0"
+	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_protobuf.go:203:2)
+}
+
+// ProtobufFramedProduceConsumeRoundTrip is the happy-path data round-trip for
+// PROTOBUF serde: register user.proto to get a schema id, Produce a JSON
+// document with valueSerializeAs="PROTOBUF" + the descriptor set + the message
+// name (so it is protobuf-encoded, then framed with the header *and* the
+// message-index array), and Consume it back with valueDeserializeAs="PROTOBUF"
+//
+// The asserted invariant is byte-equality of the consumed value to the
+// canonical JSON form of the original input, proving the
+// JSON->protobuf-binary->JSON pipeline preserves the datum. devex.kafka.test.User
+// is the first message in the file, so this exercises the single-zero-byte
+// shortcut form of the message-index array.
+func (r *KafkaTests) ProtobufFramedProduceConsumeRoundTrip(ctx context.Context, opts ...KafkaTestsProtobufFramedProduceConsumeRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_protobuf.go:200:1)
+	if r.protobufFramedProduceConsumeRoundTrip != nil {
+		return nil
+	}
+	q := r.query.Select("protobufFramedProduceConsumeRoundTrip")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `kafkaImageTag` optional argument
+		if !querybuilder.IsZeroValue(opts[i].KafkaImageTag) {
+			q = q.Arg("kafkaImageTag", opts[i].KafkaImageTag)
+		}
+	}
+
+	return q.Execute(ctx)
+}
+
+// KafkaTestsProtobufKeyFramedProduceConsumeRoundTripOpts contains options for KafkaTests.ProtobufKeyFramedProduceConsumeRoundTrip
+type KafkaTestsProtobufKeyFramedProduceConsumeRoundTripOpts struct {
+
+	// Default: "4.2.0"
+	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_protobuf.go:246:2)
+}
+
+// ProtobufKeyFramedProduceConsumeRoundTrip drives PROTOBUF serde on the *key*
+// rather than the value. Key and value are plumbed through independent
+// protoMessages instances, independent validation calls, and independent
+// framing branches, so the value round-trip alone would not catch a
+// copy-paste slip on the key side. Both fields are encoded here — with
+// different message types, so a crossed wire between them fails rather than
+// coincidentally passing.
+func (r *KafkaTests) ProtobufKeyFramedProduceConsumeRoundTrip(ctx context.Context, opts ...KafkaTestsProtobufKeyFramedProduceConsumeRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_protobuf.go:243:1)
+	if r.protobufKeyFramedProduceConsumeRoundTrip != nil {
+		return nil
+	}
+	q := r.query.Select("protobufKeyFramedProduceConsumeRoundTrip")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `kafkaImageTag` optional argument
+		if !querybuilder.IsZeroValue(opts[i].KafkaImageTag) {
+			q = q.Arg("kafkaImageTag", opts[i].KafkaImageTag)
+		}
+	}
+
+	return q.Execute(ctx)
+}
+
+// KafkaTestsProtobufNonZeroMessageIndexRoundTripOpts contains options for KafkaTests.ProtobufNonZeroMessageIndexRoundTrip
+type KafkaTestsProtobufNonZeroMessageIndexRoundTripOpts struct {
+
+	// Default: "4.2.0"
+	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/tests_protobuf.go:228:2)
+}
+
+// ProtobufNonZeroMessageIndexRoundTrip drives the same pipeline against
+// devex.kafka.test.Event, the *second* top-level message in user.proto. Its
+// Confluent message-index path is [1] rather than [0], so the frame carries
+// the length-prefixed varint form of the index array instead of the
+// single-zero-byte shortcut. Without a correctly written and re-read index the
+// consume side would either mis-parse the payload or reject the record, so a
+// green round-trip here is what proves the index round-trips rather than being
+// accidentally skipped.
+func (r *KafkaTests) ProtobufNonZeroMessageIndexRoundTrip(ctx context.Context, opts ...KafkaTestsProtobufNonZeroMessageIndexRoundTripOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_protobuf.go:225:1)
+	if r.protobufNonZeroMessageIndexRoundTrip != nil {
+		return nil
+	}
+	q := r.query.Select("protobufNonZeroMessageIndexRoundTrip")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `kafkaImageTag` optional argument
+		if !querybuilder.IsZeroValue(opts[i].KafkaImageTag) {
+			q = q.Arg("kafkaImageTag", opts[i].KafkaImageTag)
+		}
+	}
+
+	return q.Execute(ctx)
+}
+
+// ProtobufSerializeRequiresDescriptorSet pins the up-front validation contract
+// of valueSerializeAs="PROTOBUF": Produce must reject a missing descriptor set
+// before any broker, registry, or file I/O. dag.Kafka().Client(...) builds
+// without I/O and the bootstrap address is unroutable, so a nil error here
+// would mean the guard never fired.
+func (r *KafkaTests) ProtobufSerializeRequiresDescriptorSet(ctx context.Context) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_protobuf.go:51:1)
+	if r.protobufSerializeRequiresDescriptorSet != nil {
+		return nil
+	}
+	q := r.query.Select("protobufSerializeRequiresDescriptorSet")
+
+	return q.Execute(ctx)
+}
+
+// ProtobufSerializeRequiresMessageName is the sibling guard: a descriptor set
+// alone is not enough, because a FileDescriptorSet can hold many message types
+// and nothing in it says which one the payload is.
+func (r *KafkaTests) ProtobufSerializeRequiresMessageName(ctx context.Context) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_protobuf.go:77:1)
+	if r.protobufSerializeRequiresMessageName != nil {
+		return nil
+	}
+	q := r.query.Select("protobufSerializeRequiresMessageName")
+
+	return q.Execute(ctx)
+}
+
+// ProtobufSerializeRequiresSchemaID pins that PROTOBUF mode also demands a
+// positive schema id. The id is not optional the way it arguably is for a bare
+// JSON payload: the Confluent message-index array lives inside the frame, so
+// an unframed Protobuf record has nowhere to record which message type it
+// holds and no consumer could decode it.
+func (r *KafkaTests) ProtobufSerializeRequiresSchemaID(ctx context.Context) error { // kafka-tests (../../../daggerverse/kafka/tests/tests_protobuf.go:105:1)
+	if r.protobufSerializeRequiresSchemaId != nil {
+		return nil
+	}
+	q := r.query.Select("protobufSerializeRequiresSchemaId")
+
+	return q.Execute(ctx)
+}
+
 // KafkaTestsRedpandaOpts contains options for KafkaTests.Redpanda
 type KafkaTestsRedpandaOpts struct {
 
 	// Default: "v26.1.7"
-	RedpandaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/main.go:376:2)
+	RedpandaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/main.go:411:2)
 
-	Parallel int // kafka-tests (../../../daggerverse/kafka/tests/main.go:378:2)
+	Parallel int // kafka-tests (../../../daggerverse/kafka/tests/main.go:413:2)
 }
 
 // Redpanda runs the redpandadata/redpanda round-trip tests — the two
 // Kafka-wire round-trips, the PLAINTEXT and TLS bundled-Schema-Registry
 // round-trips, and the bundled-registry Stop-is-a-no-op lifecycle test.
-func (r *KafkaTests) Redpanda(ctx context.Context, opts ...KafkaTestsRedpandaOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/main.go:373:1)
+func (r *KafkaTests) Redpanda(ctx context.Context, opts ...KafkaTestsRedpandaOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/main.go:408:1)
 	if r.redpanda != nil {
 		return nil
 	}
@@ -1696,9 +1920,9 @@ func (r *KafkaTests) RedpandaThreeBrokerTLSReplicationFactorThreeProduceConsume(
 type KafkaTestsSchemaRegistryOpts struct {
 
 	// Default: "4.2.0"
-	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/main.go:108:2)
+	KafkaImageTag string // kafka-tests (../../../daggerverse/kafka/tests/main.go:113:2)
 
-	Parallel int // kafka-tests (../../../daggerverse/kafka/tests/main.go:110:2)
+	Parallel int // kafka-tests (../../../daggerverse/kafka/tests/main.go:115:2)
 }
 
 // SchemaRegistry runs the Schema Registry tests — ConfluentSchemaRegistry,
@@ -1706,7 +1930,7 @@ type KafkaTestsSchemaRegistryOpts struct {
 // owns the cluster (and, for the round-trips, the registry service) it boots,
 // so the group's only lifetime guarantee is that both are torn down once it
 // returns.
-func (r *KafkaTests) SchemaRegistry(ctx context.Context, opts ...KafkaTestsSchemaRegistryOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/main.go:105:1)
+func (r *KafkaTests) SchemaRegistry(ctx context.Context, opts ...KafkaTestsSchemaRegistryOpts) error { // kafka-tests (../../../daggerverse/kafka/tests/main.go:110:1)
 	if r.schemaRegistry != nil {
 		return nil
 	}
@@ -2049,7 +2273,12 @@ func (r *KafkaTests) AsNode() Node {
 //   - tests_schema_registry.go — ConfluentSchemaRegistry tests: the
 //     register/lookup/delete round-trip and the
 //     non-PLAINTEXT-cluster rejection.
-func (r *Query) KafkaTests() *KafkaTests { // kafka-tests (../../../daggerverse/kafka/tests/main.go:39:6)
+//   - tests_protobuf.go  — PROTOBUF serde tests: the descriptor-set /
+//     message-name / schema-id validation guards, the
+//     framed produce->consume round-trips (value, key,
+//     and non-zero message index), and the unframed +
+//     index-mismatch negative paths.
+func (r *Query) KafkaTests() *KafkaTests { // kafka-tests (../../../daggerverse/kafka/tests/main.go:44:6)
 	q := r.query.Select("kafkaTests")
 
 	return &KafkaTests{

--- a/daggerverse/kafka/README.md
+++ b/daggerverse/kafka/README.md
@@ -565,6 +565,30 @@ decoded, err := client.Consume(ctx, "my-topic", dagger.KafkaClientConsumeOpts{
     RegistrySecurity:    srClientSec, // same client profile as Produce
 })
 
+// Protobuf wire format: the JSON input is marshalled to Protobuf wire
+// bytes against a caller-supplied FileDescriptorSet and framed on Produce
+// (header + message-index array); framed bytes are decoded back to JSON on
+// Consume. Note there is no Registry on either call — the descriptor set,
+// not the registry, is what resolves the message type.
+id, err = srClient.RegisterSchema(ctx, "my-topic-value", protoText, dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{
+    SchemaType: "PROTOBUF",
+})
+err = client.Produce(ctx, "my-topic", "k", `{"name":"ada","age":36}`, dagger.KafkaClientProduceOpts{
+    KeyEncoding: "raw", ValueEncoding: "raw",
+    ValueSchemaID:      id,
+    ValueSerializeAs:   "PROTOBUF", // JSON -> protobuf binary, then frame
+    ValueDescriptorSet: descSet,    // *dagger.File: `protoc --descriptor_set_out`
+    ValueMessageName:   "my.pkg.User",
+})
+msg, err := client.Consume(ctx, "my-topic", dagger.KafkaClientConsumeOpts{
+    MaxMessages: 1, Timeout: "10s",
+    KeyEncoding: "raw", ValueEncoding: "raw",
+    SchemaRegistryAware: true,       // required: supplies the wire id + index
+    ValueDeserializeAs:  "PROTOBUF", // protobuf binary -> JSON
+    ValueDescriptorSet:  descSet,
+    ValueMessageName:    "my.pkg.User",
+})
+
 // java client.properties (+ p12 sidecars in TLS / mTLS modes) for the
 // Apache Kafka CLI tools — export the parent directory so the relative
 // truststore.p12 / keystore.p12 references resolve.
@@ -576,7 +600,7 @@ props := client.PropertiesFile() // *dagger.File — resolve via .Contents(ctx) 
 
 The serde opts (`keySerializeAs` / `valueSerializeAs` on `Produce`,
 `keyDeserializeAs` / `valueDeserializeAs` on `Consume`) accept `""`
-(pass-through, the default), `"JSON"`, or `"AVRO"`.
+(pass-through, the default), `"JSON"`, `"AVRO"`, or `"PROTOBUF"`.
 
 `"JSON"` is wire-format enforcement only — it does not fetch or apply a
 registered schema. The producer side canonicalises (parse + re-marshal
@@ -602,6 +626,89 @@ shape follows the Avro spec's JSON encoding (unions as
 `{"<type>": value}`, bare `null` for the null branch, `bytes` as a
 one-char-per-byte string); logical types, `decimal`, and `fixed` are not
 yet supported.
+
+`"PROTOBUF"` is schema-bound like `"AVRO"`, but resolves its schema from a
+**caller-supplied descriptor set** rather than from the registry — see
+[The descriptor-set tradeoff](#the-descriptor-set-tradeoff) for why. The
+caller's string is treated as a [protobuf JSON][protojson] document and
+marshalled to Protobuf wire bytes on `Produce`, then framed; on `Consume`
+the framed payload is decoded and re-serialised back to JSON. Four opts
+drive it:
+
+| Opt | Meaning |
+| --- | --- |
+| `…SerializeAs` / `…DeserializeAs` | `"PROTOBUF"` |
+| `…SchemaID` | required on `Produce` (names the schema *and* frames the record) |
+| `…DescriptorSet` | `*dagger.File` — a precompiled `FileDescriptorSet` |
+| `…MessageName` | fully-qualified message name, e.g. `"my.pkg.User"` |
+
+`Produce` rejects a missing descriptor set, a missing message name, or a
+zero id **before any broker, registry, or file I/O**; `Consume` requires
+`schemaRegistryAware=true` (the wire id and message index both live in the
+frame) and rejects an unframed record. Unlike `"AVRO"`, **no `Registry` is
+needed on either call** — nothing resolves schema text by id, so a
+`Consume` in this mode never talks to a registry at all. The wire schema id
+is still surfaced on `ConsumedRecord.ValueSchemaID` / `KeySchemaID`.
+
+The JSON shape is protojson's canonical protobuf JSON mapping: field names
+are lowerCamelCase JSON names, 64-bit integers are JSON **strings**, enums
+are symbol names, and proto3 fields holding the zero value are **omitted**
+on output — so a round-tripped document is not always byte-identical to
+what went in. Unknown fields in the input are rejected rather than silently
+dropped. Decoded output is re-marshalled through `encoding/json`, which
+sorts object keys, so consumed values come back with alphabetically ordered
+keys rather than in proto field-number order.
+
+#### The descriptor-set tradeoff
+
+Schema Registry stores Protobuf schemas as `.proto` **text**, but decoding
+one fundamentally needs a compiled `FileDescriptor`. Compiling that text at
+runtime would mean shipping `protoc` and its well-known-type includes
+inside the module. This module does not: the caller compiles out-of-band
+and passes the result in, which keeps the daggerverse Go-only.
+
+```sh
+protoc --descriptor_set_out=user.desc --include_imports user.proto
+```
+
+Then hand `user.desc` over as a `*dagger.File` — from the host, from a
+build step, or from a module's own sources:
+
+```go
+descSet := dag.CurrentModule().Source().File("fixtures/protobuf/user.desc")
+```
+
+`--include_imports` matters whenever the `.proto` imports anything (well-known
+types included): the set must be self-contained or descriptor resolution
+fails with a clear error. Two consequences follow from the module never
+reading the registry:
+
+- Registering the matching `.proto` under a subject is still worth doing —
+  it is what mints the id and what makes the records legible to a stock
+  Confluent Protobuf consumer — but the module does not read that
+  registration back.
+- Nothing verifies the descriptor set actually matches the schema
+  registered under the wire id. A mismatched pair decodes to garbage
+  exactly as it would for any other Protobuf consumer handed the wrong
+  descriptor.
+
+#### Message-index wire format
+
+Unlike Avro and JSON, the Confluent Protobuf wire format is not just the
+5-byte `0x00 || uint32be(schemaID)` header. A **message-index array** sits
+between the header and the payload, naming which message inside the
+schema's `.proto` file the payload is an instance of — `[0]` for the first
+top-level message (encoded as a single `0` byte), `[1]` for the second,
+`[1, 0]` for a message nested inside the second. This module writes and
+reads it, so records interoperate with stock Confluent Protobuf serdes in
+both directions.
+
+The index is also checked: consuming a record whose index names a
+different message than `…MessageName` is an error rather than a decode into
+silent garbage, since Protobuf wire bytes are not self-describing enough to
+catch the mismatch on their own.
+
+[protojson]: https://protobuf.dev/programming-guides/json/
 
 Composition order is decode → serialize → frame on `Produce`,
 unframe → deserialize → encode on `Consume`.

--- a/daggerverse/kafka/client.go
+++ b/daggerverse/kafka/client.go
@@ -184,18 +184,36 @@ func applySerializeAs(b []byte, mode, field string) ([]byte, error) {
 // registry, and codec cache that only the Produce call has, so it is handled
 // here: the schema id is required (a zero / negative id errors before any
 // broker or registry I/O), then the bytes are mapped from JSON and
-// Avro-binary-encoded.
-func serializeField(ctx context.Context, b []byte, mode, field string, schemaID int, codecs *avroSchemas) ([]byte, error) {
+// Avro-binary-encoded. "PROTOBUF" likewise requires the id and maps the JSON
+// against the caller-supplied descriptor set in protos.
+//
+// The second return value is the Confluent message-index path the framing step
+// must embed between the header and the payload. It is non-nil only in
+// PROTOBUF mode — Avro and JSON payloads carry no index.
+func serializeField(ctx context.Context, b []byte, mode, field string, schemaID int, codecs *avroSchemas, protos *protoMessages) ([]byte, []int, error) {
 	switch mode {
 	case "", "JSON":
-		return applySerializeAs(b, mode, field)
+		out, err := applySerializeAs(b, mode, field)
+		return out, nil, err
 	case "AVRO":
 		if schemaID <= 0 {
-			return nil, fmt.Errorf("%sSerializeAs=\"AVRO\" requires %sSchemaID > 0, got %d", field, field, schemaID)
+			return nil, nil, fmt.Errorf("%sSerializeAs=\"AVRO\" requires %sSchemaID > 0, got %d", field, field, schemaID)
 		}
-		return codecs.encode(ctx, schemaID, b)
+		out, err := codecs.encode(ctx, schemaID, b)
+		return out, nil, err
+	case "PROTOBUF":
+		// The id is required because the message index has nowhere to live
+		// without a frame: an unframed Protobuf payload is undecodable by any
+		// consumer, including this module's own PROTOBUF deserializer.
+		if schemaID <= 0 {
+			return nil, nil, fmt.Errorf("%sSerializeAs=\"PROTOBUF\" requires %sSchemaID > 0, got %d", field, field, schemaID)
+		}
+		if err := protos.validate(field, field+"SerializeAs"); err != nil {
+			return nil, nil, err
+		}
+		return protos.encode(ctx, b)
 	default:
-		return nil, fmt.Errorf("unsupported %sSerializeAs %q (want \"\"|\"JSON\"|\"AVRO\")", field, mode)
+		return nil, nil, fmt.Errorf("unsupported %sSerializeAs %q (want \"\"|\"JSON\"|\"AVRO\"|\"PROTOBUF\")", field, mode)
 	}
 }
 
@@ -205,7 +223,14 @@ func serializeField(ctx context.Context, b []byte, mode, field string, schemaID 
 // schema identified by the wire id and re-serialises it to JSON. schemaID is
 // the id extracted from the frame (0 when the record was unframed); a zero id
 // in AVRO mode means the record carried no wire header and cannot be decoded.
-func deserializeField(ctx context.Context, b []byte, mode, field string, schemaID int, schemaRegistryAware bool, codecs *avroSchemas) ([]byte, error) {
+//
+// "PROTOBUF" first strips the message-index array that the Confluent wire
+// format places between the header and a Protobuf payload, then decodes the
+// remainder against the caller-supplied descriptor set in protos. The wire id
+// is required only as proof the record was framed at all — unlike AVRO the
+// schema text is never fetched, because the descriptor set already carries the
+// message definition.
+func deserializeField(ctx context.Context, b []byte, mode, field string, schemaID int, schemaRegistryAware bool, codecs *avroSchemas, protos *protoMessages) ([]byte, error) {
 	switch mode {
 	case "", "JSON":
 		return applyDeserializeAs(b, mode, field)
@@ -217,8 +242,23 @@ func deserializeField(ctx context.Context, b []byte, mode, field string, schemaI
 			return nil, fmt.Errorf("%s record is missing the Confluent wire header (no schema id); cannot AVRO-decode", field)
 		}
 		return codecs.decode(ctx, schemaID, b)
+	case "PROTOBUF":
+		if !schemaRegistryAware {
+			return nil, fmt.Errorf("%sDeserializeAs=\"PROTOBUF\" requires schemaRegistryAware=true", field)
+		}
+		if schemaID <= 0 {
+			return nil, fmt.Errorf("%s record is missing the Confluent wire header (no schema id); cannot PROTOBUF-decode", field)
+		}
+		if err := protos.validate(field, field+"DeserializeAs"); err != nil {
+			return nil, err
+		}
+		payload, err := protos.stripIndex(ctx, b, field)
+		if err != nil {
+			return nil, err
+		}
+		return protos.decode(ctx, payload, field)
 	default:
-		return nil, fmt.Errorf("unsupported %sDeserializeAs %q (want \"\"|\"JSON\"|\"AVRO\")", field, mode)
+		return nil, fmt.Errorf("unsupported %sDeserializeAs %q (want \"\"|\"JSON\"|\"AVRO\"|\"PROTOBUF\")", field, mode)
 	}
 }
 
@@ -515,6 +555,20 @@ func (c *Client) DeleteTopic(ctx context.Context, name string) error {
 // by id. The JSON shape follows the Avro spec's JSON encoding; logical
 // types, decimal, and fixed are not yet supported.
 //
+// keySerializeAs / valueSerializeAs set to "PROTOBUF" interpret the decoded
+// bytes as a protobuf-JSON document and marshal it to Protobuf wire bytes
+// against a *caller-supplied* descriptor set. The module never runs protoc:
+// keyDescriptorSet / valueDescriptorSet must be a precompiled
+// FileDescriptorSet (`protoc --descriptor_set_out=x.desc --include_imports
+// x.proto`) and keyMessageName / valueMessageName the fully-qualified message
+// name within it. Both are required in this mode and are checked before any
+// broker, registry, or file I/O. The id is required too, because framing a
+// Protobuf payload also carries the Confluent message-index array that names
+// which message in the .proto file the payload is — records produced this way
+// are readable by stock Confluent Protobuf consumers. Unlike "AVRO", registry
+// is not consulted: the descriptor set already carries the message definition.
+// The JSON shape is protojson's canonical protobuf JSON mapping.
+//
 // +cache="never"
 func (c *Client) Produce(
 	ctx context.Context,
@@ -544,6 +598,30 @@ func (c *Client) Produce(
 	//
 	// +optional
 	registrySecurity *SchemaRegistryClientSecurity,
+	// keyDescriptorSet is a precompiled protobuf FileDescriptorSet covering
+	// keyMessageName. Required when keySerializeAs is "PROTOBUF"; ignored
+	// otherwise.
+	//
+	// +optional
+	keyDescriptorSet *dagger.File,
+	// keyMessageName is the fully-qualified protobuf message name (e.g.
+	// "my.pkg.MyMessage") to resolve inside keyDescriptorSet. Required when
+	// keySerializeAs is "PROTOBUF"; ignored otherwise.
+	//
+	// +default=""
+	keyMessageName string,
+	// valueDescriptorSet is a precompiled protobuf FileDescriptorSet covering
+	// valueMessageName. Required when valueSerializeAs is "PROTOBUF"; ignored
+	// otherwise.
+	//
+	// +optional
+	valueDescriptorSet *dagger.File,
+	// valueMessageName is the fully-qualified protobuf message name (e.g.
+	// "my.pkg.MyMessage") to resolve inside valueDescriptorSet. Required when
+	// valueSerializeAs is "PROTOBUF"; ignored otherwise.
+	//
+	// +default=""
+	valueMessageName string,
 ) error {
 	if keySchemaID < 0 {
 		return fmt.Errorf("keySchemaID must be >= 0, got %d", keySchemaID)
@@ -562,25 +640,29 @@ func (c *Client) Produce(
 	}
 
 	codecs := newAvroSchemas(registry, registrySecurity)
-	keyBytes, err = serializeField(ctx, keyBytes, keySerializeAs, "key", keySchemaID, codecs)
+	keyBytes, keyIndex, err := serializeField(ctx, keyBytes, keySerializeAs, "key", keySchemaID, codecs, newProtoMessages(keyDescriptorSet, keyMessageName))
 	if err != nil {
 		return fmt.Errorf("serialize key: %w", err)
 	}
-	valBytes, err = serializeField(ctx, valBytes, valueSerializeAs, "value", valueSchemaID, codecs)
+	valBytes, valIndex, err := serializeField(ctx, valBytes, valueSerializeAs, "value", valueSchemaID, codecs, newProtoMessages(valueDescriptorSet, valueMessageName))
 	if err != nil {
 		return fmt.Errorf("serialize value: %w", err)
 	}
 
+	// keyIndex / valIndex are non-nil only in PROTOBUF mode, where the
+	// Confluent frame carries a message-index array between the 5-byte header
+	// and the payload. AppendEncode writes nothing extra for a nil index, so
+	// Avro / JSON / pass-through framing is byte-identical to before.
 	var hdr sr.ConfluentHeader
 	if keySchemaID > 0 {
-		framed, err := hdr.AppendEncode(nil, keySchemaID, nil)
+		framed, err := hdr.AppendEncode(nil, keySchemaID, keyIndex)
 		if err != nil {
 			return fmt.Errorf("frame key with schema id %d: %w", keySchemaID, err)
 		}
 		keyBytes = append(framed, keyBytes...)
 	}
 	if valueSchemaID > 0 {
-		framed, err := hdr.AppendEncode(nil, valueSchemaID, nil)
+		framed, err := hdr.AppendEncode(nil, valueSchemaID, valIndex)
 		if err != nil {
 			return fmt.Errorf("frame value with schema id %d: %w", valueSchemaID, err)
 		}
@@ -646,6 +728,19 @@ func (c *Client) Produce(
 // spec's JSON encoding; logical types, decimal, and fixed are not yet
 // supported.
 //
+// keyDeserializeAs / valueDeserializeAs set to "PROTOBUF" strip the
+// Confluent message-index array that follows the wire header, then decode
+// the remaining Protobuf wire bytes against a *caller-supplied* descriptor
+// set and re-serialise them to JSON via protojson. keyDescriptorSet /
+// valueDescriptorSet (a precompiled FileDescriptorSet) and keyMessageName /
+// valueMessageName are required in this mode and are validated before any
+// broker I/O, as is schemaRegistryAware=true. registry is *not* required —
+// the descriptor set already carries the message definition, so no schema
+// text is ever fetched; the wire id is still surfaced on ConsumedRecord.
+// The descriptor set is exported and parsed at most once per call, not once
+// per record. A record whose message-index names a different message than
+// the one requested is rejected rather than decoded into garbage.
+//
 // +cache="never"
 func (c *Client) Consume(
 	ctx context.Context,
@@ -683,6 +778,30 @@ func (c *Client) Consume(
 	//
 	// +optional
 	registrySecurity *SchemaRegistryClientSecurity,
+	// keyDescriptorSet is a precompiled protobuf FileDescriptorSet covering
+	// keyMessageName. Required when keyDeserializeAs is "PROTOBUF"; ignored
+	// otherwise.
+	//
+	// +optional
+	keyDescriptorSet *dagger.File,
+	// keyMessageName is the fully-qualified protobuf message name (e.g.
+	// "my.pkg.MyMessage") to resolve inside keyDescriptorSet. Required when
+	// keyDeserializeAs is "PROTOBUF"; ignored otherwise.
+	//
+	// +default=""
+	keyMessageName string,
+	// valueDescriptorSet is a precompiled protobuf FileDescriptorSet covering
+	// valueMessageName. Required when valueDeserializeAs is "PROTOBUF";
+	// ignored otherwise.
+	//
+	// +optional
+	valueDescriptorSet *dagger.File,
+	// valueMessageName is the fully-qualified protobuf message name (e.g.
+	// "my.pkg.MyMessage") to resolve inside valueDescriptorSet. Required when
+	// valueDeserializeAs is "PROTOBUF"; ignored otherwise.
+	//
+	// +default=""
+	valueMessageName string,
 ) (string, error) {
 	if maxMessages <= 0 {
 		return "", fmt.Errorf("maxMessages must be > 0, got %d", maxMessages)
@@ -693,6 +812,29 @@ func (c *Client) Consume(
 		}
 		if registry == nil {
 			return "", fmt.Errorf("AVRO deserialize requires a schema registry to resolve schema text by id")
+		}
+	}
+	// One protoMessages per field, built up front so the descriptor set is
+	// exported and parsed at most once for the whole poll loop rather than
+	// once per record.
+	keyProtos := newProtoMessages(keyDescriptorSet, keyMessageName)
+	valProtos := newProtoMessages(valueDescriptorSet, valueMessageName)
+	if keyDeserializeAs == "PROTOBUF" || valueDeserializeAs == "PROTOBUF" {
+		if !schemaRegistryAware {
+			return "", fmt.Errorf(`PROTOBUF deserialize requires schemaRegistryAware=true so the wire schema id and message index are available`)
+		}
+		// Validate the descriptor-set arguments here, not just inside
+		// deserializeField, so a missing argument fails before a broker
+		// connection is opened rather than after the first record arrives.
+		if keyDeserializeAs == "PROTOBUF" {
+			if err := keyProtos.validate("key", "keyDeserializeAs"); err != nil {
+				return "", err
+			}
+		}
+		if valueDeserializeAs == "PROTOBUF" {
+			if err := valProtos.validate("value", "valueDeserializeAs"); err != nil {
+				return "", err
+			}
 		}
 	}
 	d, err := time.ParseDuration(timeout)
@@ -779,11 +921,11 @@ func (c *Client) Consume(
 				}
 			}
 			var err error
-			keyRaw, err = deserializeField(deadlineCtx, keyRaw, keyDeserializeAs, "key", keyID, schemaRegistryAware, codecs)
+			keyRaw, err = deserializeField(deadlineCtx, keyRaw, keyDeserializeAs, "key", keyID, schemaRegistryAware, codecs, keyProtos)
 			if err != nil {
 				return "", fmt.Errorf("deserialize key: %w", err)
 			}
-			valRaw, err = deserializeField(deadlineCtx, valRaw, valueDeserializeAs, "value", valID, schemaRegistryAware, codecs)
+			valRaw, err = deserializeField(deadlineCtx, valRaw, valueDeserializeAs, "value", valID, schemaRegistryAware, codecs, valProtos)
 			if err != nil {
 				return "", fmt.Errorf("deserialize value: %w", err)
 			}

--- a/daggerverse/kafka/dagger.gen.go
+++ b/daggerverse/kafka/dagger.gen.go
@@ -682,7 +682,35 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg registrySecurity", err))
 				}
 			}
-			return (*Client).Consume(&parent, ctx, topic, maxMessages, timeout, keyEncoding, valueEncoding, group, commitOffsets, schemaRegistryAware, keyDeserializeAs, valueDeserializeAs, registry, registrySecurity)
+			var keyDescriptorSet *dagger.File
+			if inputArgs["keyDescriptorSet"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["keyDescriptorSet"]), &keyDescriptorSet)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg keyDescriptorSet", err))
+				}
+			}
+			var keyMessageName string
+			if inputArgs["keyMessageName"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["keyMessageName"]), &keyMessageName)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg keyMessageName", err))
+				}
+			}
+			var valueDescriptorSet *dagger.File
+			if inputArgs["valueDescriptorSet"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["valueDescriptorSet"]), &valueDescriptorSet)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg valueDescriptorSet", err))
+				}
+			}
+			var valueMessageName string
+			if inputArgs["valueMessageName"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["valueMessageName"]), &valueMessageName)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg valueMessageName", err))
+				}
+			}
+			return (*Client).Consume(&parent, ctx, topic, maxMessages, timeout, keyEncoding, valueEncoding, group, commitOffsets, schemaRegistryAware, keyDeserializeAs, valueDeserializeAs, registry, registrySecurity, keyDescriptorSet, keyMessageName, valueDescriptorSet, valueMessageName)
 		case "CreateTopic":
 			var parent Client
 			err = json.Unmarshal(parentJSON, &parent)
@@ -850,7 +878,35 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg registrySecurity", err))
 				}
 			}
-			return nil, (*Client).Produce(&parent, ctx, topic, key, value, keyEncoding, valueEncoding, keySchemaId, valueSchemaId, keySerializeAs, valueSerializeAs, registry, registrySecurity)
+			var keyDescriptorSet *dagger.File
+			if inputArgs["keyDescriptorSet"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["keyDescriptorSet"]), &keyDescriptorSet)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg keyDescriptorSet", err))
+				}
+			}
+			var keyMessageName string
+			if inputArgs["keyMessageName"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["keyMessageName"]), &keyMessageName)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg keyMessageName", err))
+				}
+			}
+			var valueDescriptorSet *dagger.File
+			if inputArgs["valueDescriptorSet"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["valueDescriptorSet"]), &valueDescriptorSet)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg valueDescriptorSet", err))
+				}
+			}
+			var valueMessageName string
+			if inputArgs["valueMessageName"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["valueMessageName"]), &valueMessageName)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg valueMessageName", err))
+				}
+			}
+			return nil, (*Client).Produce(&parent, ctx, topic, key, value, keyEncoding, valueEncoding, keySchemaId, valueSchemaId, keySerializeAs, valueSerializeAs, registry, registrySecurity, keyDescriptorSet, keyMessageName, valueDescriptorSet, valueMessageName)
 		case "PropertiesFile":
 			var parent Client
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/kafka/go.mod
+++ b/daggerverse/kafka/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/twmb/franz-go/pkg/sr v1.7.0
 	github.com/z5labs/avro-go v0.5.0
 	go.opentelemetry.io/otel/sdk v1.43.0
+	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
 	software.sslmate.com/src/go-pkcs12 v0.7.1
 )
@@ -32,7 +33,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260226221140-a57be14db171 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260226221140-a57be14db171 // indirect
 	google.golang.org/grpc v1.79.3 // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
 )
 
 require (

--- a/daggerverse/kafka/main.go
+++ b/daggerverse/kafka/main.go
@@ -27,6 +27,10 @@
 //                          and ApicurioSchemaRegistry constructors, and the
 //                          pure-Go net/http admin client for the Schema
 //                          Registry REST API.
+//   - protobuf.go        — PROTOBUF serde: caller-supplied FileDescriptorSet
+//                          loading via protodesc/protoregistry, JSON <->
+//                          dynamicpb via protojson, and the Confluent
+//                          message-index path that Protobuf framing carries.
 //   - util.go            — shared helpers (writeWorkdirBytes,
 //                          clusterHostSuffix, randSuffix, dagFileBytes).
 package main

--- a/daggerverse/kafka/protobuf.go
+++ b/daggerverse/kafka/protobuf.go
@@ -1,0 +1,216 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"dagger/kafka/internal/dagger"
+
+	"github.com/twmb/franz-go/pkg/sr"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/dynamicpb"
+)
+
+// protobuf.go bridges the kafka module's JSON string boundary to the Protobuf
+// binary wire format carried by Schema-Registry-aware Kafka.
+//
+// Decoding a registered Protobuf schema fundamentally needs a compiled
+// FileDescriptor, and Schema Registry only stores `.proto` *text*. Compiling
+// that text at runtime would mean shipping protoc (and its well-known-type
+// includes) inside the module. Instead the caller compiles out-of-band —
+// `protoc --descriptor_set_out=...` — and hands the module the resulting
+// FileDescriptorSet as a *dagger.File plus the fully-qualified message name.
+// The module loads it via protodesc/protoregistry and builds a dynamicpb
+// message from the resolved descriptor. This keeps the daggerverse Go-only
+// and defers compiler bootstrapping to the caller.
+//
+// Consequences of that tradeoff, all of which the README repeats:
+//   - The registry is never consulted to resolve a Protobuf message type, so
+//     PROTOBUF consume does not require a `registry` (unlike AVRO). The wire
+//     schema id is still surfaced on ConsumedRecord.
+//   - Nothing checks that the descriptor set actually matches the schema
+//     registered under the wire id. A mismatch decodes to garbage exactly as
+//     it would with any other Protobuf consumer given the wrong descriptor.
+//
+// Unlike Avro and JSON, the Confluent Protobuf wire format is not just the
+// 5-byte `0x00 || uint32be(schemaID)` header: a *message-index array* sits
+// between the header and the payload, naming which message inside the schema's
+// `.proto` file the payload is an instance of. franz-go's sr.ConfluentHeader
+// encodes and decodes it (AppendEncode's `index` argument / DecodeIndex), so
+// records produced here are readable by stock Confluent Protobuf consumers and
+// vice versa. See messageIndexPath for how the path is derived.
+//
+// The JSON shape is protojson's, i.e. the canonical protobuf JSON mapping:
+// field names are lowerCamelCase JSON names, 64-bit integers are JSON strings,
+// enums are their symbol names, and proto3 fields holding the zero value are
+// omitted on output.
+
+// protoMessages resolves a caller-supplied FileDescriptorSet down to a single
+// protobuf message type and memoizes the result for the lifetime of one
+// Produce / Consume call. Consume polls many records against the same
+// descriptor set, and resolving it means exporting a *dagger.File and parsing
+// it, so the descriptor is resolved at most once per call rather than once per
+// record. One protoMessages serves one field — key and value carry independent
+// descriptor sets and message names.
+type protoMessages struct {
+	descriptorSet *dagger.File
+	messageName   string
+
+	// md and index are the memoized resolution; md != nil means resolved.
+	md    protoreflect.MessageDescriptor
+	index []int
+}
+
+func newProtoMessages(descriptorSet *dagger.File, messageName string) *protoMessages {
+	return &protoMessages{descriptorSet: descriptorSet, messageName: messageName}
+}
+
+// validate rejects a PROTOBUF-mode call that is missing its descriptor set or
+// message name. Both checks are pure struct inspection, so callers can run
+// this before touching a broker, the registry, or the *dagger.File itself.
+// directive is the caller-facing parameter name ("valueSerializeAs",
+// "keyDeserializeAs", ...) and field is "key" or "value".
+func (p *protoMessages) validate(field, directive string) error {
+	if p.descriptorSet == nil {
+		return fmt.Errorf("%s=%q requires %sDescriptorSet (a precompiled protobuf FileDescriptorSet, e.g. from `protoc --descriptor_set_out`)", directive, "PROTOBUF", field)
+	}
+	if p.messageName == "" {
+		return fmt.Errorf("%s=%q requires %sMessageName (the fully-qualified protobuf message name, e.g. \"my.pkg.MyMessage\")", directive, "PROTOBUF", field)
+	}
+	return nil
+}
+
+// resolve exports and parses the descriptor set on first call, looks the named
+// message up in it, and caches the descriptor plus its Confluent message-index
+// path.
+func (p *protoMessages) resolve(ctx context.Context) (protoreflect.MessageDescriptor, []int, error) {
+	if p.md != nil {
+		return p.md, p.index, nil
+	}
+	raw, err := dagFileBytes(ctx, p.descriptorSet)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read descriptor set: %w", err)
+	}
+	var fds descriptorpb.FileDescriptorSet
+	if err := proto.Unmarshal(raw, &fds); err != nil {
+		return nil, nil, fmt.Errorf("parse descriptor set (expected a protobuf FileDescriptorSet, as produced by `protoc --descriptor_set_out`): %w", err)
+	}
+	// NewFiles resolves every import in the set; a set built without
+	// --include_imports for a .proto that imports others fails here rather
+	// than silently producing a half-resolved descriptor.
+	files, err := protodesc.NewFiles(&fds)
+	if err != nil {
+		return nil, nil, fmt.Errorf("build descriptor registry (a .proto with imports needs `protoc --include_imports`): %w", err)
+	}
+	d, err := files.FindDescriptorByName(protoreflect.FullName(p.messageName))
+	if err != nil {
+		return nil, nil, fmt.Errorf("message %q not found in descriptor set: %w", p.messageName, err)
+	}
+	md, ok := d.(protoreflect.MessageDescriptor)
+	if !ok {
+		return nil, nil, fmt.Errorf("%q resolves to a %T, not a message type", p.messageName, d)
+	}
+	p.md, p.index = md, messageIndexPath(md)
+	return p.md, p.index, nil
+}
+
+// messageIndexPath derives the Confluent message-index path for md: the
+// sequence of declaration indexes to walk from the top of its .proto file down
+// to md. A first top-level message is [0]; the second is [1]; a message nested
+// once inside the second is [1, 0].
+//
+// https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
+func messageIndexPath(md protoreflect.MessageDescriptor) []int {
+	var path []int
+	for cur := md; ; {
+		path = append(path, cur.Index())
+		parent, ok := cur.Parent().(protoreflect.MessageDescriptor)
+		if !ok {
+			// Parent is the FileDescriptor: cur is top-level, so the walk is
+			// done and cur.Index() (already appended) is the last element.
+			break
+		}
+		cur = parent
+	}
+	slices.Reverse(path)
+	return path
+}
+
+// encode interprets raw as a protobuf-JSON document, unmarshals it into a
+// dynamic message of the resolved type, and returns the protobuf wire bytes
+// alongside the message-index path the framing step must embed.
+func (p *protoMessages) encode(ctx context.Context, raw []byte) ([]byte, []int, error) {
+	md, index, err := p.resolve(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	msg := dynamicpb.NewMessage(md)
+	// DiscardUnknown stays false (the default) so a typo'd or stale field name
+	// in the caller's JSON is an error rather than a silently dropped value.
+	if err := protojson.Unmarshal(raw, msg); err != nil {
+		return nil, nil, fmt.Errorf("map json to protobuf message %q: %w", p.messageName, err)
+	}
+	// Deterministic keeps map-valued fields in a stable order so the same JSON
+	// input always yields the same wire bytes. Protobuf does not promise a
+	// canonical encoding across implementations, but within this module it
+	// makes Produce reproducible.
+	out, err := proto.MarshalOptions{Deterministic: true}.Marshal(msg)
+	if err != nil {
+		return nil, nil, fmt.Errorf("protobuf-encode: %w", err)
+	}
+	return out, index, nil
+}
+
+// decode reads protobuf wire bytes bin (message-index already stripped)
+// against the resolved message type and returns its canonical compact JSON
+// encoding.
+func (p *protoMessages) decode(ctx context.Context, bin []byte, field string) ([]byte, error) {
+	md, _, err := p.resolve(ctx)
+	if err != nil {
+		return nil, err
+	}
+	msg := dynamicpb.NewMessage(md)
+	if err := proto.Unmarshal(bin, msg); err != nil {
+		return nil, fmt.Errorf("protobuf-decode against %q: %w", p.messageName, err)
+	}
+	out, err := protojson.Marshal(msg)
+	if err != nil {
+		return nil, fmt.Errorf("map protobuf to json: %w", err)
+	}
+	// protojson deliberately emits unstable whitespace (it randomly varies the
+	// space after ":" and "," to discourage byte-comparing its output), so the
+	// same message can marshal to two different strings within one process.
+	// Re-marshalling through canonicalJSON pins a single compact form, which
+	// is what makes a consumed value comparable at all — and matches what the
+	// "JSON" and "AVRO" modes hand back.
+	return canonicalJSON(out, field)
+}
+
+// stripIndex removes the Confluent message-index array that sits between the
+// 5-byte schema-id header and the protobuf payload, and checks it names the
+// message the caller asked for. A mismatch means the record holds a different
+// message type from the same .proto file; decoding it against the named
+// descriptor would silently yield garbage (protobuf wire bytes are not
+// self-describing enough to catch it), so it is an error instead.
+func (p *protoMessages) stripIndex(ctx context.Context, b []byte, field string) ([]byte, error) {
+	_, want, err := p.resolve(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var hdr sr.ConfluentHeader
+	// maxLength 0 leaves the index length unbounded; the descriptor set, not
+	// an arbitrary cap, is what decides whether the path resolves.
+	got, rest, err := hdr.DecodeIndex(b, 0)
+	if err != nil {
+		return nil, fmt.Errorf("decode %s protobuf message-index: %w", field, err)
+	}
+	if !slices.Equal(got, want) {
+		return nil, fmt.Errorf("%s record carries protobuf message-index %v but %q is at index %v in the descriptor set; the record holds a different message type", field, got, p.messageName, want)
+	}
+	return rest, nil
+}

--- a/daggerverse/kafka/tests/dagger.gen.go
+++ b/daggerverse/kafka/tests/dagger.gen.go
@@ -850,6 +850,111 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Tests).PropertiesFileContainsTlsSettings(&parent, ctx, kafkaImageTag)
+		case "ProtobufConsumeMessageIndexMismatchErrors":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var kafkaImageTag string
+			if inputArgs["kafkaImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["kafkaImageTag"]), &kafkaImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg kafkaImageTag", err))
+				}
+			}
+			return nil, (*Tests).ProtobufConsumeMessageIndexMismatchErrors(&parent, ctx, kafkaImageTag)
+		case "ProtobufConsumeUnframedErrors":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var kafkaImageTag string
+			if inputArgs["kafkaImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["kafkaImageTag"]), &kafkaImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg kafkaImageTag", err))
+				}
+			}
+			return nil, (*Tests).ProtobufConsumeUnframedErrors(&parent, ctx, kafkaImageTag)
+		case "ProtobufDeserializeRequiresDescriptorSet":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ProtobufDeserializeRequiresDescriptorSet(&parent, ctx)
+		case "ProtobufDeserializeRequiresSchemaRegistryAware":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ProtobufDeserializeRequiresSchemaRegistryAware(&parent, ctx)
+		case "ProtobufFramedProduceConsumeRoundTrip":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var kafkaImageTag string
+			if inputArgs["kafkaImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["kafkaImageTag"]), &kafkaImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg kafkaImageTag", err))
+				}
+			}
+			return nil, (*Tests).ProtobufFramedProduceConsumeRoundTrip(&parent, ctx, kafkaImageTag)
+		case "ProtobufKeyFramedProduceConsumeRoundTrip":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var kafkaImageTag string
+			if inputArgs["kafkaImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["kafkaImageTag"]), &kafkaImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg kafkaImageTag", err))
+				}
+			}
+			return nil, (*Tests).ProtobufKeyFramedProduceConsumeRoundTrip(&parent, ctx, kafkaImageTag)
+		case "ProtobufNonZeroMessageIndexRoundTrip":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var kafkaImageTag string
+			if inputArgs["kafkaImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["kafkaImageTag"]), &kafkaImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg kafkaImageTag", err))
+				}
+			}
+			return nil, (*Tests).ProtobufNonZeroMessageIndexRoundTrip(&parent, ctx, kafkaImageTag)
+		case "ProtobufSerializeRequiresDescriptorSet":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ProtobufSerializeRequiresDescriptorSet(&parent, ctx)
+		case "ProtobufSerializeRequiresMessageName":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ProtobufSerializeRequiresMessageName(&parent, ctx)
+		case "ProtobufSerializeRequiresSchemaID":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ProtobufSerializeRequiresSchemaID(&parent, ctx)
 		case "Redpanda":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/kafka/tests/fixtures/protobuf/README.md
+++ b/daggerverse/kafka/tests/fixtures/protobuf/README.md
@@ -1,0 +1,42 @@
+# Protobuf serde fixtures
+
+`user.desc` is a precompiled [`FileDescriptorSet`][fds] covering `user.proto`.
+It is the fixture the kafka module's `PROTOBUF` serde tests hand to
+`Client.Produce` / `Client.Consume` as `valueDescriptorSet` /
+`keyDescriptorSet`.
+
+It is checked in as a binary artifact on purpose: the kafka module resolves
+Protobuf message types via `protoreflect` / `protoregistry` and never invokes
+`protoc` at runtime, so compiling `.proto` text is the caller's job. Shipping
+the compiled descriptor set keeps the test suite free of a `protoc` toolchain.
+
+## Regenerating
+
+From this directory, with any reasonably recent `protoc` on `PATH`:
+
+```sh
+protoc --descriptor_set_out=user.desc --proto_path=. user.proto
+```
+
+`user.desc` was last generated with `libprotoc 35.0-dev`. The output is stable
+across protoc versions for a file this simple — it is just the serialized
+`FileDescriptorProto` for `user.proto` — so a regeneration on a different
+protoc should produce an identical (or near-identical) file. Re-run the
+`protobuf-*` tests after regenerating.
+
+If the message type lived in a `.proto` that imported others, every transitive
+import would need to be in the same set; add `--include_imports` in that case.
+`user.proto` imports nothing, so the flag is unnecessary here.
+
+## What the messages cover
+
+| Message | Index path | Why it exists |
+| --- | --- | --- |
+| `devex.kafka.test.User` | `[0]` | Happy-path round-trip. First message in the file, so the Confluent message-index array uses the single-zero-byte shortcut. |
+| `devex.kafka.test.Event` | `[1]` | Second top-level message, so the index array takes the length-prefixed varint form instead of the shortcut. |
+| `devex.kafka.test.Event.Nested` | `[1, 0]` | A nested message, so the index path is more than one element deep. |
+
+Between them the three messages exercise both encodings of the Confluent
+Protobuf message-index array plus a multi-element index path.
+
+[fds]: https://protobuf.com/docs/descriptors#file-descriptor-set

--- a/daggerverse/kafka/tests/fixtures/protobuf/user.desc
+++ b/daggerverse/kafka/tests/fixtures/protobuf/user.desc
@@ -1,0 +1,13 @@
+
+×
+
+user.protodevex.kafka.test"@
+User
+name (	Rname
+age (Rage
+tags (	Rtags"m
+Event
+id (	Rid6
+nested (2.devex.kafka.test.Event.NestedRnested
+Nested
+note (	Rnotebproto3

--- a/daggerverse/kafka/tests/fixtures/protobuf/user.proto
+++ b/daggerverse/kafka/tests/fixtures/protobuf/user.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+
+package devex.kafka.test;
+
+// User is the primary message used by the kafka module's PROTOBUF serde
+// round-trip tests. It is the first message declared in the file, so its
+// Confluent message-index path is [0] — the single-zero-byte shortcut form
+// of the wire-format index array.
+//
+// Every field is deliberately a type whose protojson rendering is stable and
+// unsurprising: a single-word field name needs no lowerCamelCase remapping,
+// and int32 renders as a JSON number (only 64-bit integer types render as
+// JSON strings).
+message User {
+  string name = 1;
+  int32 age = 2;
+  repeated string tags = 3;
+}
+
+// Event is the second top-level message. Its message-index path is [1], which
+// forces the length-prefixed varint form of the index array rather than the
+// first-message shortcut, so the tests cover both index encodings.
+message Event {
+  string id = 1;
+  Nested nested = 2;
+
+  // Nested is a nested message, reached at index path [1, 0].
+  message Nested {
+    string note = 1;
+  }
+}

--- a/daggerverse/kafka/tests/internal/dagger/kafka.gen.go
+++ b/daggerverse/kafka/tests/internal/dagger/kafka.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type Kafka
-func (r *Binding) AsKafka() *Kafka { // kafka (../../../../../daggerverse/kafka/main.go:37:6)
+func (r *Binding) AsKafka() *Kafka { // kafka (../../../../../daggerverse/kafka/main.go:41:6)
 	q := r.query.Select("asKafka")
 
 	return &Kafka{
@@ -190,7 +190,7 @@ func (r *Env) WithKafkaClusterOutput(name string, description string) *Env { // 
 }
 
 // Create or update a binding of type Kafka in the environment
-func (r *Env) WithKafkaInput(name string, value *Kafka, description string) *Env { // kafka (../../../../../daggerverse/kafka/main.go:37:6)
+func (r *Env) WithKafkaInput(name string, value *Kafka, description string) *Env { // kafka (../../../../../daggerverse/kafka/main.go:41:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withKafkaInput")
 	q = q.Arg("name", name)
@@ -203,7 +203,7 @@ func (r *Env) WithKafkaInput(name string, value *Kafka, description string) *Env
 }
 
 // Declare a desired Kafka output to be assigned in the environment
-func (r *Env) WithKafkaOutput(name string, description string) *Env { // kafka (../../../../../daggerverse/kafka/main.go:37:6)
+func (r *Env) WithKafkaOutput(name string, description string) *Env { // kafka (../../../../../daggerverse/kafka/main.go:41:6)
 	q := r.query.Select("withKafkaOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -408,7 +408,7 @@ func (r *Env) WithKafkaServerSecurityOutput(name string, description string) *En
 // Kafka is the root namespace for every exported function in this module.
 // All cluster constructors and security helpers hang off *Kafka so the
 // generated Dagger SDK surfaces them under `dag.Kafka().<Func>(...)`.
-type Kafka struct { // kafka (../../../../../daggerverse/kafka/main.go:37:6)
+type Kafka struct { // kafka (../../../../../daggerverse/kafka/main.go:41:6)
 	query *querybuilder.Selection
 
 	id *ID
@@ -1154,41 +1154,65 @@ func (r *KafkaClient) WithGraphQLQuery(q *querybuilder.Selection) *KafkaClient {
 type KafkaClientConsumeOpts struct {
 
 	// Default: 1
-	MaxMessages int // kafka (../../../../../daggerverse/kafka/client.go:654:2)
+	MaxMessages int // kafka (../../../../../daggerverse/kafka/client.go:749:2)
 
 	// Default: "10s"
-	Timeout string // kafka (../../../../../daggerverse/kafka/client.go:656:2)
+	Timeout string // kafka (../../../../../daggerverse/kafka/client.go:751:2)
 
 	// Default: "raw"
-	KeyEncoding string // kafka (../../../../../daggerverse/kafka/client.go:658:2)
+	KeyEncoding string // kafka (../../../../../daggerverse/kafka/client.go:753:2)
 
 	// Default: "raw"
-	ValueEncoding string // kafka (../../../../../daggerverse/kafka/client.go:660:2)
+	ValueEncoding string // kafka (../../../../../daggerverse/kafka/client.go:755:2)
 
-	Group string // kafka (../../../../../daggerverse/kafka/client.go:662:2)
+	Group string // kafka (../../../../../daggerverse/kafka/client.go:757:2)
 	//
 	// commitOffsets, when true and group is set, commits the consumed
 	// records' offsets before returning so the group persists with committed
 	// offsets (and thus reportable lag). Ignored when group is empty.
 	//
-	CommitOffsets bool // kafka (../../../../../daggerverse/kafka/client.go:668:2)
+	CommitOffsets bool // kafka (../../../../../daggerverse/kafka/client.go:763:2)
 
-	SchemaRegistryAware bool // kafka (../../../../../daggerverse/kafka/client.go:670:2)
+	SchemaRegistryAware bool // kafka (../../../../../daggerverse/kafka/client.go:765:2)
 
-	KeyDeserializeAs string // kafka (../../../../../daggerverse/kafka/client.go:672:2)
+	KeyDeserializeAs string // kafka (../../../../../daggerverse/kafka/client.go:767:2)
 
-	ValueDeserializeAs string // kafka (../../../../../daggerverse/kafka/client.go:674:2)
+	ValueDeserializeAs string // kafka (../../../../../daggerverse/kafka/client.go:769:2)
 	//
 	// registry resolves the Avro schema text by id when keyDeserializeAs /
 	// valueDeserializeAs is "AVRO". Required in that mode; ignored otherwise.
 	//
-	Registry *KafkaSchemaRegistry // kafka (../../../../../daggerverse/kafka/client.go:679:2)
+	Registry *KafkaSchemaRegistry // kafka (../../../../../daggerverse/kafka/client.go:774:2)
 	//
 	// registrySecurity is the TLS/mTLS client profile used to resolve Avro
 	// schema text against a secured registry. Nil (the default) resolves over
 	// plaintext HTTP, reproducing today's behaviour.
 	//
-	RegistrySecurity *KafkaSchemaRegistryClientSecurity // kafka (../../../../../daggerverse/kafka/client.go:685:2)
+	RegistrySecurity *KafkaSchemaRegistryClientSecurity // kafka (../../../../../daggerverse/kafka/client.go:780:2)
+	//
+	// keyDescriptorSet is a precompiled protobuf FileDescriptorSet covering
+	// keyMessageName. Required when keyDeserializeAs is "PROTOBUF"; ignored
+	// otherwise.
+	//
+	KeyDescriptorSet *File // kafka (../../../../../daggerverse/kafka/client.go:786:2)
+	//
+	// keyMessageName is the fully-qualified protobuf message name (e.g.
+	// "my.pkg.MyMessage") to resolve inside keyDescriptorSet. Required when
+	// keyDeserializeAs is "PROTOBUF"; ignored otherwise.
+	//
+	KeyMessageName string // kafka (../../../../../daggerverse/kafka/client.go:792:2)
+	//
+	// valueDescriptorSet is a precompiled protobuf FileDescriptorSet covering
+	// valueMessageName. Required when valueDeserializeAs is "PROTOBUF";
+	// ignored otherwise.
+	//
+	ValueDescriptorSet *File // kafka (../../../../../daggerverse/kafka/client.go:798:2)
+	//
+	// valueMessageName is the fully-qualified protobuf message name (e.g.
+	// "my.pkg.MyMessage") to resolve inside valueDescriptorSet. Required when
+	// valueDeserializeAs is "PROTOBUF"; ignored otherwise.
+	//
+	ValueMessageName string // kafka (../../../../../daggerverse/kafka/client.go:804:2)
 }
 
 // Consume reads up to maxMessages records from the topic, starting at the
@@ -1235,7 +1259,20 @@ type KafkaClientConsumeOpts struct {
 // per id for the duration of the call. The JSON shape follows the Avro
 // spec's JSON encoding; logical types, decimal, and fixed are not yet
 // supported.
-func (r *KafkaClient) Consume(ctx context.Context, topic string, opts ...KafkaClientConsumeOpts) (string, error) { // kafka (../../../../../daggerverse/kafka/client.go:650:1)
+//
+// keyDeserializeAs / valueDeserializeAs set to "PROTOBUF" strip the
+// Confluent message-index array that follows the wire header, then decode
+// the remaining Protobuf wire bytes against a *caller-supplied* descriptor
+// set and re-serialise them to JSON via protojson. keyDescriptorSet /
+// valueDescriptorSet (a precompiled FileDescriptorSet) and keyMessageName /
+// valueMessageName are required in this mode and are validated before any
+// broker I/O, as is schemaRegistryAware=true. registry is *not* required —
+// the descriptor set already carries the message definition, so no schema
+// text is ever fetched; the wire id is still surfaced on ConsumedRecord.
+// The descriptor set is exported and parsed at most once per call, not once
+// per record. A record whose message-index names a different message than
+// the one requested is rejected rather than decoded into garbage.
+func (r *KafkaClient) Consume(ctx context.Context, topic string, opts ...KafkaClientConsumeOpts) (string, error) { // kafka (../../../../../daggerverse/kafka/client.go:745:1)
 	if r.consume != nil {
 		return *r.consume, nil
 	}
@@ -1285,6 +1322,22 @@ func (r *KafkaClient) Consume(ctx context.Context, topic string, opts ...KafkaCl
 		if !querybuilder.IsZeroValue(opts[i].RegistrySecurity) {
 			q = q.Arg("registrySecurity", opts[i].RegistrySecurity)
 		}
+		// `keyDescriptorSet` optional argument
+		if !querybuilder.IsZeroValue(opts[i].KeyDescriptorSet) {
+			q = q.Arg("keyDescriptorSet", opts[i].KeyDescriptorSet)
+		}
+		// `keyMessageName` optional argument
+		if !querybuilder.IsZeroValue(opts[i].KeyMessageName) {
+			q = q.Arg("keyMessageName", opts[i].KeyMessageName)
+		}
+		// `valueDescriptorSet` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ValueDescriptorSet) {
+			q = q.Arg("valueDescriptorSet", opts[i].ValueDescriptorSet)
+		}
+		// `valueMessageName` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ValueMessageName) {
+			q = q.Arg("valueMessageName", opts[i].ValueMessageName)
+		}
 	}
 	q = q.Arg("topic", topic)
 
@@ -1298,15 +1351,15 @@ func (r *KafkaClient) Consume(ctx context.Context, topic string, opts ...KafkaCl
 type KafkaClientCreateTopicOpts struct {
 
 	// Default: 1
-	Partitions int // kafka (../../../../../daggerverse/kafka/client.go:441:2)
+	Partitions int // kafka (../../../../../daggerverse/kafka/client.go:481:2)
 
 	// Default: 1
-	ReplicationFactor int // kafka (../../../../../daggerverse/kafka/client.go:443:2)
+	ReplicationFactor int // kafka (../../../../../daggerverse/kafka/client.go:483:2)
 }
 
 // CreateTopic creates a new topic with the given partition count and
 // replication factor. Errors out if the topic already exists.
-func (r *KafkaClient) CreateTopic(ctx context.Context, name string, opts ...KafkaClientCreateTopicOpts) error { // kafka (../../../../../daggerverse/kafka/client.go:437:1)
+func (r *KafkaClient) CreateTopic(ctx context.Context, name string, opts ...KafkaClientCreateTopicOpts) error { // kafka (../../../../../daggerverse/kafka/client.go:477:1)
 	if r.createTopic != nil {
 		return nil
 	}
@@ -1327,7 +1380,7 @@ func (r *KafkaClient) CreateTopic(ctx context.Context, name string, opts ...Kafk
 }
 
 // DeleteTopic deletes the named topic.
-func (r *KafkaClient) DeleteTopic(ctx context.Context, name string) error { // kafka (../../../../../daggerverse/kafka/client.go:471:1)
+func (r *KafkaClient) DeleteTopic(ctx context.Context, name string) error { // kafka (../../../../../daggerverse/kafka/client.go:511:1)
 	if r.deleteTopic != nil {
 		return nil
 	}
@@ -1430,7 +1483,7 @@ func (r *KafkaClient) ListConsumerGroups(ctx context.Context) ([]string, error) 
 }
 
 // ListTopics returns the names of every topic the broker reports.
-func (r *KafkaClient) ListTopics(ctx context.Context) ([]string, error) { // kafka (../../../../../daggerverse/kafka/client.go:825:1)
+func (r *KafkaClient) ListTopics(ctx context.Context) ([]string, error) { // kafka (../../../../../daggerverse/kafka/client.go:967:1)
 	q := r.query.Select("listTopics")
 
 	var response []string
@@ -1443,29 +1496,53 @@ func (r *KafkaClient) ListTopics(ctx context.Context) ([]string, error) { // kaf
 type KafkaClientProduceOpts struct {
 
 	// Default: "raw"
-	KeyEncoding string // kafka (../../../../../daggerverse/kafka/client.go:525:2)
+	KeyEncoding string // kafka (../../../../../daggerverse/kafka/client.go:579:2)
 
 	// Default: "raw"
-	ValueEncoding string // kafka (../../../../../daggerverse/kafka/client.go:527:2)
+	ValueEncoding string // kafka (../../../../../daggerverse/kafka/client.go:581:2)
 
-	KeySchemaID int // kafka (../../../../../daggerverse/kafka/client.go:529:2)
+	KeySchemaID int // kafka (../../../../../daggerverse/kafka/client.go:583:2)
 
-	ValueSchemaID int // kafka (../../../../../daggerverse/kafka/client.go:531:2)
+	ValueSchemaID int // kafka (../../../../../daggerverse/kafka/client.go:585:2)
 
-	KeySerializeAs string // kafka (../../../../../daggerverse/kafka/client.go:533:2)
+	KeySerializeAs string // kafka (../../../../../daggerverse/kafka/client.go:587:2)
 
-	ValueSerializeAs string // kafka (../../../../../daggerverse/kafka/client.go:535:2)
+	ValueSerializeAs string // kafka (../../../../../daggerverse/kafka/client.go:589:2)
 	//
 	// registry resolves the Avro schema text by id when keySerializeAs /
 	// valueSerializeAs is "AVRO". Required in that mode; ignored otherwise.
 	//
-	Registry *KafkaSchemaRegistry // kafka (../../../../../daggerverse/kafka/client.go:540:2)
+	Registry *KafkaSchemaRegistry // kafka (../../../../../daggerverse/kafka/client.go:594:2)
 	//
 	// registrySecurity is the TLS/mTLS client profile used to resolve Avro
 	// schema text against a secured registry. Nil (the default) resolves over
 	// plaintext HTTP, reproducing today's behaviour.
 	//
-	RegistrySecurity *KafkaSchemaRegistryClientSecurity // kafka (../../../../../daggerverse/kafka/client.go:546:2)
+	RegistrySecurity *KafkaSchemaRegistryClientSecurity // kafka (../../../../../daggerverse/kafka/client.go:600:2)
+	//
+	// keyDescriptorSet is a precompiled protobuf FileDescriptorSet covering
+	// keyMessageName. Required when keySerializeAs is "PROTOBUF"; ignored
+	// otherwise.
+	//
+	KeyDescriptorSet *File // kafka (../../../../../daggerverse/kafka/client.go:606:2)
+	//
+	// keyMessageName is the fully-qualified protobuf message name (e.g.
+	// "my.pkg.MyMessage") to resolve inside keyDescriptorSet. Required when
+	// keySerializeAs is "PROTOBUF"; ignored otherwise.
+	//
+	KeyMessageName string // kafka (../../../../../daggerverse/kafka/client.go:612:2)
+	//
+	// valueDescriptorSet is a precompiled protobuf FileDescriptorSet covering
+	// valueMessageName. Required when valueSerializeAs is "PROTOBUF"; ignored
+	// otherwise.
+	//
+	ValueDescriptorSet *File // kafka (../../../../../daggerverse/kafka/client.go:618:2)
+	//
+	// valueMessageName is the fully-qualified protobuf message name (e.g.
+	// "my.pkg.MyMessage") to resolve inside valueDescriptorSet. Required when
+	// valueSerializeAs is "PROTOBUF"; ignored otherwise.
+	//
+	ValueMessageName string // kafka (../../../../../daggerverse/kafka/client.go:624:2)
 }
 
 // Produce synchronously writes one record to the topic. Key and value are
@@ -1494,7 +1571,21 @@ type KafkaClientProduceOpts struct {
 // I/O — and registry must be supplied so the schema text can be resolved
 // by id. The JSON shape follows the Avro spec's JSON encoding; logical
 // types, decimal, and fixed are not yet supported.
-func (r *KafkaClient) Produce(ctx context.Context, topic string, key string, value string, opts ...KafkaClientProduceOpts) error { // kafka (../../../../../daggerverse/kafka/client.go:519:1)
+//
+// keySerializeAs / valueSerializeAs set to "PROTOBUF" interpret the decoded
+// bytes as a protobuf-JSON document and marshal it to Protobuf wire bytes
+// against a *caller-supplied* descriptor set. The module never runs protoc:
+// keyDescriptorSet / valueDescriptorSet must be a precompiled
+// FileDescriptorSet (`protoc --descriptor_set_out=x.desc --include_imports
+// x.proto`) and keyMessageName / valueMessageName the fully-qualified message
+// name within it. Both are required in this mode and are checked before any
+// broker, registry, or file I/O. The id is required too, because framing a
+// Protobuf payload also carries the Confluent message-index array that names
+// which message in the .proto file the payload is — records produced this way
+// are readable by stock Confluent Protobuf consumers. Unlike "AVRO", registry
+// is not consulted: the descriptor set already carries the message definition.
+// The JSON shape is protojson's canonical protobuf JSON mapping.
+func (r *KafkaClient) Produce(ctx context.Context, topic string, key string, value string, opts ...KafkaClientProduceOpts) error { // kafka (../../../../../daggerverse/kafka/client.go:573:1)
 	if r.produce != nil {
 		return nil
 	}
@@ -1532,6 +1623,22 @@ func (r *KafkaClient) Produce(ctx context.Context, topic string, key string, val
 		if !querybuilder.IsZeroValue(opts[i].RegistrySecurity) {
 			q = q.Arg("registrySecurity", opts[i].RegistrySecurity)
 		}
+		// `keyDescriptorSet` optional argument
+		if !querybuilder.IsZeroValue(opts[i].KeyDescriptorSet) {
+			q = q.Arg("keyDescriptorSet", opts[i].KeyDescriptorSet)
+		}
+		// `keyMessageName` optional argument
+		if !querybuilder.IsZeroValue(opts[i].KeyMessageName) {
+			q = q.Arg("keyMessageName", opts[i].KeyMessageName)
+		}
+		// `valueDescriptorSet` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ValueDescriptorSet) {
+			q = q.Arg("valueDescriptorSet", opts[i].ValueDescriptorSet)
+		}
+		// `valueMessageName` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ValueMessageName) {
+			q = q.Arg("valueMessageName", opts[i].ValueMessageName)
+		}
 	}
 	q = q.Arg("topic", topic)
 	q = q.Arg("key", key)
@@ -1550,7 +1657,7 @@ func (r *KafkaClient) Produce(ctx context.Context, topic string, key string, val
 // export the parent directory (`props.Directory()`) so the relative
 // references resolve. Passwords appear plaintext, which is a Kafka CLI
 // constraint.
-func (r *KafkaClient) PropertiesFile() *File { // kafka (../../../../../daggerverse/kafka/client.go:256:1)
+func (r *KafkaClient) PropertiesFile() *File { // kafka (../../../../../daggerverse/kafka/client.go:296:1)
 	q := r.query.Select("propertiesFile")
 
 	return &File{
@@ -2699,7 +2806,7 @@ func (r *KafkaServerSecurity) AsNode() Node {
 // Kafka is the root namespace for every exported function in this module.
 // All cluster constructors and security helpers hang off *Kafka so the
 // generated Dagger SDK surfaces them under `dag.Kafka().<Func>(...)`.
-func (r *Query) Kafka() *Kafka { // kafka (../../../../../daggerverse/kafka/main.go:37:6)
+func (r *Query) Kafka() *Kafka { // kafka (../../../../../daggerverse/kafka/main.go:41:6)
 	q := r.query.Select("kafka")
 
 	return &Kafka{

--- a/daggerverse/kafka/tests/main.go
+++ b/daggerverse/kafka/tests/main.go
@@ -27,6 +27,11 @@
 //   - tests_schema_registry.go — ConfluentSchemaRegistry tests: the
 //                          register/lookup/delete round-trip and the
 //                          non-PLAINTEXT-cluster rejection.
+//   - tests_protobuf.go  — PROTOBUF serde tests: the descriptor-set /
+//                          message-name / schema-id validation guards, the
+//                          framed produce->consume round-trips (value, key,
+//                          and non-zero message index), and the unframed +
+//                          index-mismatch negative paths.
 package main
 
 import (
@@ -169,6 +174,36 @@ func (t *Tests) SchemaRegistry(
 	})
 	jobs = jobs.WithJob("AvroBytesFieldRoundTrip", func(ctx context.Context) error {
 		return t.AvroBytesFieldRoundTrip(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("ProtobufSerializeRequiresDescriptorSet", func(ctx context.Context) error {
+		return t.ProtobufSerializeRequiresDescriptorSet(ctx)
+	})
+	jobs = jobs.WithJob("ProtobufSerializeRequiresMessageName", func(ctx context.Context) error {
+		return t.ProtobufSerializeRequiresMessageName(ctx)
+	})
+	jobs = jobs.WithJob("ProtobufSerializeRequiresSchemaID", func(ctx context.Context) error {
+		return t.ProtobufSerializeRequiresSchemaID(ctx)
+	})
+	jobs = jobs.WithJob("ProtobufDeserializeRequiresDescriptorSet", func(ctx context.Context) error {
+		return t.ProtobufDeserializeRequiresDescriptorSet(ctx)
+	})
+	jobs = jobs.WithJob("ProtobufDeserializeRequiresSchemaRegistryAware", func(ctx context.Context) error {
+		return t.ProtobufDeserializeRequiresSchemaRegistryAware(ctx)
+	})
+	jobs = jobs.WithJob("ProtobufConsumeUnframedErrors", func(ctx context.Context) error {
+		return t.ProtobufConsumeUnframedErrors(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("ProtobufConsumeMessageIndexMismatchErrors", func(ctx context.Context) error {
+		return t.ProtobufConsumeMessageIndexMismatchErrors(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("ProtobufFramedProduceConsumeRoundTrip", func(ctx context.Context) error {
+		return t.ProtobufFramedProduceConsumeRoundTrip(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("ProtobufNonZeroMessageIndexRoundTrip", func(ctx context.Context) error {
+		return t.ProtobufNonZeroMessageIndexRoundTrip(ctx, kafkaImageTag)
+	})
+	jobs = jobs.WithJob("ProtobufKeyFramedProduceConsumeRoundTrip", func(ctx context.Context) error {
+		return t.ProtobufKeyFramedProduceConsumeRoundTrip(ctx, kafkaImageTag)
 	})
 
 	return jobs.Run(ctx)

--- a/daggerverse/kafka/tests/tests_protobuf.go
+++ b/daggerverse/kafka/tests/tests_protobuf.go
@@ -1,0 +1,591 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"dagger/tests/internal/dagger"
+)
+
+// The PROTOBUF serde tests drive the kafka module's third Schema-Registry
+// payload format. Unlike AVRO, the module never resolves a Protobuf message
+// type through the registry — Schema Registry stores `.proto` *text* and
+// decoding needs a compiled FileDescriptor, so the caller compiles one
+// out-of-band and hands it over as a *dagger.File. See
+// fixtures/protobuf/README.md for how the checked-in descriptor set was built.
+
+const (
+	// protobufUserMessage is the first message declared in user.proto, so its
+	// Confluent message-index path is [0] — the single-zero-byte shortcut.
+	protobufUserMessage = "devex.kafka.test.User"
+	// protobufEventMessage is the second top-level message, at index path [1],
+	// which forces the length-prefixed varint form of the index array.
+	protobufEventMessage = "devex.kafka.test.Event"
+)
+
+// protobufDescriptorSet returns the checked-in FileDescriptorSet fixture as a
+// *dagger.File, which is exactly how a caller would supply their own after
+// running `protoc --descriptor_set_out`.
+func protobufDescriptorSet() *dagger.File {
+	return dag.CurrentModule().Source().File("fixtures/protobuf/user.desc")
+}
+
+// protobufSchemaText returns the `.proto` source the descriptor set was
+// compiled from. It is what gets registered with the Schema Registry so the
+// registered schema and the descriptor set genuinely describe the same
+// messages, even though the module only ever reads the descriptor set.
+func protobufSchemaText(ctx context.Context) (string, error) {
+	text, err := dag.CurrentModule().Source().File("fixtures/protobuf/user.proto").Contents(ctx)
+	if err != nil {
+		return "", fmt.Errorf("read user.proto fixture: %w", err)
+	}
+	return text, nil
+}
+
+// ProtobufSerializeRequiresDescriptorSet pins the up-front validation contract
+// of valueSerializeAs="PROTOBUF": Produce must reject a missing descriptor set
+// before any broker, registry, or file I/O. dag.Kafka().Client(...) builds
+// without I/O and the bootstrap address is unroutable, so a nil error here
+// would mean the guard never fired.
+func (t *Tests) ProtobufSerializeRequiresDescriptorSet(
+	ctx context.Context,
+) error {
+	client := dag.Kafka().Client(
+		[]string{"127.0.0.1:1"},
+		dag.Kafka().PlaintextClientSecurity(),
+	)
+	err := client.Produce(ctx, "any-topic", "k", `{"name":"ada"}`, dagger.KafkaClientProduceOpts{
+		KeyEncoding:      "raw",
+		ValueEncoding:    "raw",
+		ValueSerializeAs: "PROTOBUF",
+		ValueSchemaID:    1,
+		ValueMessageName: protobufUserMessage,
+	})
+	if err == nil {
+		return fmt.Errorf("expected Produce to reject PROTOBUF without a descriptor set, got nil error")
+	}
+	if !strings.Contains(err.Error(), "valueDescriptorSet") {
+		return fmt.Errorf("expected error to mention the required valueDescriptorSet, got: %v", err)
+	}
+	return nil
+}
+
+// ProtobufSerializeRequiresMessageName is the sibling guard: a descriptor set
+// alone is not enough, because a FileDescriptorSet can hold many message types
+// and nothing in it says which one the payload is.
+func (t *Tests) ProtobufSerializeRequiresMessageName(
+	ctx context.Context,
+) error {
+	client := dag.Kafka().Client(
+		[]string{"127.0.0.1:1"},
+		dag.Kafka().PlaintextClientSecurity(),
+	)
+	err := client.Produce(ctx, "any-topic", "k", `{"name":"ada"}`, dagger.KafkaClientProduceOpts{
+		KeyEncoding:        "raw",
+		ValueEncoding:      "raw",
+		ValueSerializeAs:   "PROTOBUF",
+		ValueSchemaID:      1,
+		ValueDescriptorSet: protobufDescriptorSet(),
+	})
+	if err == nil {
+		return fmt.Errorf("expected Produce to reject PROTOBUF without a message name, got nil error")
+	}
+	if !strings.Contains(err.Error(), "valueMessageName") {
+		return fmt.Errorf("expected error to mention the required valueMessageName, got: %v", err)
+	}
+	return nil
+}
+
+// ProtobufSerializeRequiresSchemaID pins that PROTOBUF mode also demands a
+// positive schema id. The id is not optional the way it arguably is for a bare
+// JSON payload: the Confluent message-index array lives inside the frame, so
+// an unframed Protobuf record has nowhere to record which message type it
+// holds and no consumer could decode it.
+func (t *Tests) ProtobufSerializeRequiresSchemaID(
+	ctx context.Context,
+) error {
+	client := dag.Kafka().Client(
+		[]string{"127.0.0.1:1"},
+		dag.Kafka().PlaintextClientSecurity(),
+	)
+	err := client.Produce(ctx, "any-topic", "k", `{"name":"ada"}`, dagger.KafkaClientProduceOpts{
+		KeyEncoding:        "raw",
+		ValueEncoding:      "raw",
+		ValueSerializeAs:   "PROTOBUF",
+		ValueSchemaID:      0,
+		ValueDescriptorSet: protobufDescriptorSet(),
+		ValueMessageName:   protobufUserMessage,
+	})
+	if err == nil {
+		return fmt.Errorf("expected Produce to reject PROTOBUF with a zero schema id, got nil error")
+	}
+	if !strings.Contains(err.Error(), "valueSchemaID") {
+		return fmt.Errorf("expected error to mention the required valueSchemaID, got: %v", err)
+	}
+	return nil
+}
+
+// ProtobufDeserializeRequiresDescriptorSet mirrors the produce-side guard on
+// the consume path. It must fail before a broker connection is opened, which
+// the unroutable bootstrap address proves: a missing guard would surface as a
+// dial timeout rather than a validation error.
+func (t *Tests) ProtobufDeserializeRequiresDescriptorSet(
+	ctx context.Context,
+) error {
+	client := dag.Kafka().Client(
+		[]string{"127.0.0.1:1"},
+		dag.Kafka().PlaintextClientSecurity(),
+	)
+	_, err := client.Consume(ctx, "any-topic", dagger.KafkaClientConsumeOpts{
+		MaxMessages:         1,
+		Timeout:             "10s",
+		KeyEncoding:         "raw",
+		ValueEncoding:       "raw",
+		SchemaRegistryAware: true,
+		ValueDeserializeAs:  "PROTOBUF",
+		ValueMessageName:    protobufUserMessage,
+	})
+	if err == nil {
+		return fmt.Errorf("expected Consume to reject PROTOBUF without a descriptor set, got nil error")
+	}
+	if !strings.Contains(err.Error(), "valueDescriptorSet") {
+		return fmt.Errorf("expected error to mention the required valueDescriptorSet, got: %v", err)
+	}
+	return nil
+}
+
+// ProtobufDeserializeRequiresSchemaRegistryAware pins that PROTOBUF consume
+// needs schemaRegistryAware=true: without it the 5-byte header is never
+// stripped, so neither the wire id nor the message-index array that follows it
+// is reachable.
+func (t *Tests) ProtobufDeserializeRequiresSchemaRegistryAware(
+	ctx context.Context,
+) error {
+	client := dag.Kafka().Client(
+		[]string{"127.0.0.1:1"},
+		dag.Kafka().PlaintextClientSecurity(),
+	)
+	_, err := client.Consume(ctx, "any-topic", dagger.KafkaClientConsumeOpts{
+		MaxMessages:         1,
+		Timeout:             "10s",
+		KeyEncoding:         "raw",
+		ValueEncoding:       "raw",
+		SchemaRegistryAware: false,
+		ValueDeserializeAs:  "PROTOBUF",
+		ValueDescriptorSet:  protobufDescriptorSet(),
+		ValueMessageName:    protobufUserMessage,
+	})
+	if err == nil {
+		return fmt.Errorf("expected Consume to reject PROTOBUF without schemaRegistryAware, got nil error")
+	}
+	if !strings.Contains(err.Error(), "schemaRegistryAware") {
+		return fmt.Errorf("expected error to mention the required schemaRegistryAware, got: %v", err)
+	}
+	return nil
+}
+
+// ProtobufFramedProduceConsumeRoundTrip is the happy-path data round-trip for
+// PROTOBUF serde: register user.proto to get a schema id, Produce a JSON
+// document with valueSerializeAs="PROTOBUF" + the descriptor set + the message
+// name (so it is protobuf-encoded, then framed with the header *and* the
+// message-index array), and Consume it back with valueDeserializeAs="PROTOBUF"
+// + schemaRegistryAware=true.
+//
+// The asserted invariant is byte-equality of the consumed value to the
+// canonical JSON form of the original input, proving the
+// JSON->protobuf-binary->JSON pipeline preserves the datum. devex.kafka.test.User
+// is the first message in the file, so this exercises the single-zero-byte
+// shortcut form of the message-index array.
+func (t *Tests) ProtobufFramedProduceConsumeRoundTrip(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	return protobufRoundTrip(ctx, kafkaImageTag, protobufUserMessage,
+		// Whitespace differs from the canonical form so the round-trip proves
+		// the payload is genuinely re-encoded, not passed through.
+		`{ "name" :  "ada" , "age": 36, "tags": ["lovelace", "analytical-engine"] }`,
+		// protojson renders int32 as a JSON number and single-word field names
+		// unchanged; the module then re-marshals through encoding/json, which
+		// sorts object keys, so the canonical form is alphabetical rather than
+		// in proto field-number order.
+		`{"age":36,"name":"ada","tags":["lovelace","analytical-engine"]}`,
+	)
+}
+
+// ProtobufNonZeroMessageIndexRoundTrip drives the same pipeline against
+// devex.kafka.test.Event, the *second* top-level message in user.proto. Its
+// Confluent message-index path is [1] rather than [0], so the frame carries
+// the length-prefixed varint form of the index array instead of the
+// single-zero-byte shortcut. Without a correctly written and re-read index the
+// consume side would either mis-parse the payload or reject the record, so a
+// green round-trip here is what proves the index round-trips rather than being
+// accidentally skipped.
+func (t *Tests) ProtobufNonZeroMessageIndexRoundTrip(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	return protobufRoundTrip(ctx, kafkaImageTag, protobufEventMessage,
+		`{"id":"evt-1","nested":{"note":"hello"}}`,
+		`{"id":"evt-1","nested":{"note":"hello"}}`,
+	)
+}
+
+// ProtobufKeyFramedProduceConsumeRoundTrip drives PROTOBUF serde on the *key*
+// rather than the value. Key and value are plumbed through independent
+// protoMessages instances, independent validation calls, and independent
+// framing branches, so the value round-trip alone would not catch a
+// copy-paste slip on the key side. Both fields are encoded here — with
+// different message types, so a crossed wire between them fails rather than
+// coincidentally passing.
+func (t *Tests) ProtobufKeyFramedProduceConsumeRoundTrip(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, err := freshCluster(ctx, kafkaImageTag)
+	if err != nil {
+		return fmt.Errorf("create cluster: %w", err)
+	}
+	defer cluster.Stop(ctx)
+
+	sr := dag.Kafka().ConfluentSchemaRegistry(cluster, plaintextSchemaRegistrySecurity())
+	defer sr.Stop(ctx)
+
+	subject, err := randomTopicName(ctx)
+	if err != nil {
+		return err
+	}
+	topic := subject
+
+	schemaText, err := protobufSchemaText(ctx)
+	if err != nil {
+		return err
+	}
+	srClient := sr.Client(plaintextSchemaRegistryClientSecurity())
+	keyID, err := srClient.RegisterSchema(ctx, subject+"-key", schemaText, dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{
+		SchemaType: "PROTOBUF",
+	})
+	if err != nil {
+		return fmt.Errorf("register key schema: %w", err)
+	}
+	valueID, err := srClient.RegisterSchema(ctx, subject+"-value", schemaText, dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{
+		SchemaType: "PROTOBUF",
+	})
+	if err != nil {
+		return fmt.Errorf("register value schema: %w", err)
+	}
+
+	client := cluster.Client(dag.Kafka().PlaintextClientSecurity())
+	if err := client.CreateTopic(ctx, topic, dagger.KafkaClientCreateTopicOpts{
+		Partitions:        1,
+		ReplicationFactor: 1,
+	}); err != nil {
+		return fmt.Errorf("create topic %q: %w", topic, err)
+	}
+
+	// The key is an Event (message-index [1]) and the value a User
+	// (message-index [0]), so each field must carry its own index — swapping
+	// them would trip the index check on consume.
+	const (
+		keyInput      = `{"id":"evt-7"}`
+		wantKey       = `{"id":"evt-7"}`
+		valueInput    = `{ "name": "grace" , "age": 45 }`
+		wantCanonical = `{"age":45,"name":"grace"}`
+	)
+
+	if err := client.Produce(ctx, topic, keyInput, valueInput, dagger.KafkaClientProduceOpts{
+		KeyEncoding:        "raw",
+		ValueEncoding:      "raw",
+		KeySchemaID:        keyID,
+		KeySerializeAs:     "PROTOBUF",
+		KeyDescriptorSet:   protobufDescriptorSet(),
+		KeyMessageName:     protobufEventMessage,
+		ValueSchemaID:      valueID,
+		ValueSerializeAs:   "PROTOBUF",
+		ValueDescriptorSet: protobufDescriptorSet(),
+		ValueMessageName:   protobufUserMessage,
+	}); err != nil {
+		return fmt.Errorf("produce: %w", err)
+	}
+
+	records, err := consume(ctx, client, topic, dagger.KafkaClientConsumeOpts{
+		MaxMessages:         1,
+		Timeout:             "10s",
+		KeyEncoding:         "raw",
+		ValueEncoding:       "raw",
+		SchemaRegistryAware: true,
+		KeyDeserializeAs:    "PROTOBUF",
+		KeyDescriptorSet:    protobufDescriptorSet(),
+		KeyMessageName:      protobufEventMessage,
+		ValueDeserializeAs:  "PROTOBUF",
+		ValueDescriptorSet:  protobufDescriptorSet(),
+		ValueMessageName:    protobufUserMessage,
+	})
+	if err != nil {
+		return fmt.Errorf("consume: %w", err)
+	}
+	if len(records) != 1 {
+		return fmt.Errorf("expected 1 record, got %d", len(records))
+	}
+	gotKey, err := records[0].Key(ctx)
+	if err != nil {
+		return fmt.Errorf("read key: %w", err)
+	}
+	gotVal, err := records[0].Value(ctx)
+	if err != nil {
+		return fmt.Errorf("read value: %w", err)
+	}
+	gotKeyID, err := records[0].KeySchemaID(ctx)
+	if err != nil {
+		return fmt.Errorf("read key schema id: %w", err)
+	}
+	if gotKey != wantKey {
+		return fmt.Errorf("key mismatch: want canonical %q, got %q", wantKey, gotKey)
+	}
+	if gotVal != wantCanonical {
+		return fmt.Errorf("value mismatch: want canonical %q, got %q", wantCanonical, gotVal)
+	}
+	if gotKeyID != keyID {
+		return fmt.Errorf("key schema id mismatch: want %d, got %d", keyID, gotKeyID)
+	}
+	return nil
+}
+
+// ProtobufConsumeUnframedErrors pins the negative consume path: a record
+// produced without a Confluent wire header, consumed with
+// valueDeserializeAs="PROTOBUF" + schemaRegistryAware=true, must error out
+// pointing at the missing header rather than trying to parse arbitrary bytes
+// as a protobuf message. No registry is started — PROTOBUF decoding never
+// needs one, and the header check fires before the descriptor set is even
+// read.
+func (t *Tests) ProtobufConsumeUnframedErrors(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, err := freshCluster(ctx, kafkaImageTag)
+	if err != nil {
+		return fmt.Errorf("create cluster: %w", err)
+	}
+	defer cluster.Stop(ctx)
+
+	client := cluster.Client(dag.Kafka().PlaintextClientSecurity())
+
+	topic, err := randomTopicName(ctx)
+	if err != nil {
+		return err
+	}
+	if err := client.CreateTopic(ctx, topic, dagger.KafkaClientCreateTopicOpts{
+		Partitions:        1,
+		ReplicationFactor: 1,
+	}); err != nil {
+		return fmt.Errorf("create topic %q: %w", topic, err)
+	}
+
+	if err := client.Produce(ctx, topic, "k", "plain", dagger.KafkaClientProduceOpts{
+		KeyEncoding:   "raw",
+		ValueEncoding: "raw",
+	}); err != nil {
+		return fmt.Errorf("produce: %w", err)
+	}
+
+	_, err = client.Consume(ctx, topic, dagger.KafkaClientConsumeOpts{
+		MaxMessages:         1,
+		Timeout:             "10s",
+		KeyEncoding:         "raw",
+		ValueEncoding:       "raw",
+		SchemaRegistryAware: true,
+		ValueDeserializeAs:  "PROTOBUF",
+		ValueDescriptorSet:  protobufDescriptorSet(),
+		ValueMessageName:    protobufUserMessage,
+	})
+	if err == nil {
+		return fmt.Errorf("expected Consume to reject an unframed record under PROTOBUF, got nil error")
+	}
+	if !strings.Contains(err.Error(), "wire header") {
+		return fmt.Errorf("expected error to point at the missing wire header, got: %v", err)
+	}
+	return nil
+}
+
+// ProtobufConsumeMessageIndexMismatchErrors pins the guard that makes the
+// message-index array load-bearing rather than decorative. A record produced
+// as devex.kafka.test.User (index [0]) but consumed as devex.kafka.test.Event
+// (index [1]) must be rejected: protobuf wire bytes are not self-describing,
+// so decoding one message type's bytes against another's descriptor would
+// otherwise succeed and hand back silent garbage.
+func (t *Tests) ProtobufConsumeMessageIndexMismatchErrors(
+	ctx context.Context,
+	// +default="4.2.0"
+	kafkaImageTag string,
+) error {
+	cluster, err := freshCluster(ctx, kafkaImageTag)
+	if err != nil {
+		return fmt.Errorf("create cluster: %w", err)
+	}
+	defer cluster.Stop(ctx)
+
+	sr := dag.Kafka().ConfluentSchemaRegistry(cluster, plaintextSchemaRegistrySecurity())
+	defer sr.Stop(ctx)
+
+	subject, err := randomTopicName(ctx)
+	if err != nil {
+		return err
+	}
+	topic := subject
+	subject += "-value"
+
+	schemaText, err := protobufSchemaText(ctx)
+	if err != nil {
+		return err
+	}
+	id, err := sr.Client(plaintextSchemaRegistryClientSecurity()).RegisterSchema(ctx, subject, schemaText, dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{
+		SchemaType: "PROTOBUF",
+	})
+	if err != nil {
+		return fmt.Errorf("register schema: %w", err)
+	}
+
+	client := cluster.Client(dag.Kafka().PlaintextClientSecurity())
+	if err := client.CreateTopic(ctx, topic, dagger.KafkaClientCreateTopicOpts{
+		Partitions:        1,
+		ReplicationFactor: 1,
+	}); err != nil {
+		return fmt.Errorf("create topic %q: %w", topic, err)
+	}
+
+	if err := client.Produce(ctx, topic, "k", `{"name":"ada","age":36}`, dagger.KafkaClientProduceOpts{
+		KeyEncoding:        "raw",
+		ValueEncoding:      "raw",
+		ValueSchemaID:      id,
+		ValueSerializeAs:   "PROTOBUF",
+		ValueDescriptorSet: protobufDescriptorSet(),
+		ValueMessageName:   protobufUserMessage,
+	}); err != nil {
+		return fmt.Errorf("produce: %w", err)
+	}
+
+	_, err = client.Consume(ctx, topic, dagger.KafkaClientConsumeOpts{
+		MaxMessages:         1,
+		Timeout:             "10s",
+		KeyEncoding:         "raw",
+		ValueEncoding:       "raw",
+		SchemaRegistryAware: true,
+		ValueDeserializeAs:  "PROTOBUF",
+		ValueDescriptorSet:  protobufDescriptorSet(),
+		ValueMessageName:    protobufEventMessage,
+	})
+	if err == nil {
+		return fmt.Errorf("expected Consume to reject a message-index mismatch, got nil error")
+	}
+	if !strings.Contains(err.Error(), "message-index") {
+		return fmt.Errorf("expected error to point at the message-index mismatch, got: %v", err)
+	}
+	return nil
+}
+
+// protobufRoundTrip is the shared body of the PROTOBUF round-trip tests: stand
+// up a cluster and registry, register user.proto, produce inputJSON as
+// messageName, consume it back, and assert the consumed value equals
+// wantCanonical and carries the registered schema id.
+func protobufRoundTrip(ctx context.Context, kafkaImageTag, messageName, inputJSON, wantCanonical string) error {
+	cluster, err := freshCluster(ctx, kafkaImageTag)
+	if err != nil {
+		return fmt.Errorf("create cluster: %w", err)
+	}
+	defer cluster.Stop(ctx)
+
+	sr := dag.Kafka().ConfluentSchemaRegistry(cluster, plaintextSchemaRegistrySecurity())
+	defer sr.Stop(ctx)
+
+	subject, err := randomTopicName(ctx)
+	if err != nil {
+		return err
+	}
+	topic := subject
+	subject += "-value"
+
+	schemaText, err := protobufSchemaText(ctx)
+	if err != nil {
+		return err
+	}
+	// The module never reads this registration back — the descriptor set is
+	// what drives encoding and decoding. Registering the matching .proto is
+	// what makes the produced records legible to a stock Confluent Protobuf
+	// consumer, which *does* resolve the id, and it is what mints the id the
+	// frame carries.
+	id, err := sr.Client(plaintextSchemaRegistryClientSecurity()).RegisterSchema(ctx, subject, schemaText, dagger.KafkaSchemaRegistryClientRegisterSchemaOpts{
+		SchemaType: "PROTOBUF",
+	})
+	if err != nil {
+		return fmt.Errorf("register schema: %w", err)
+	}
+	if id <= 0 {
+		return fmt.Errorf("expected a positive schema id, got %d", id)
+	}
+
+	client := cluster.Client(dag.Kafka().PlaintextClientSecurity())
+	if err := client.CreateTopic(ctx, topic, dagger.KafkaClientCreateTopicOpts{
+		Partitions:        1,
+		ReplicationFactor: 1,
+	}); err != nil {
+		return fmt.Errorf("create topic %q: %w", topic, err)
+	}
+
+	const wantKey = "k"
+	if err := client.Produce(ctx, topic, wantKey, inputJSON, dagger.KafkaClientProduceOpts{
+		KeyEncoding:        "raw",
+		ValueEncoding:      "raw",
+		ValueSchemaID:      id,
+		ValueSerializeAs:   "PROTOBUF",
+		ValueDescriptorSet: protobufDescriptorSet(),
+		ValueMessageName:   messageName,
+	}); err != nil {
+		return fmt.Errorf("produce: %w", err)
+	}
+
+	// No Registry is passed: PROTOBUF decoding resolves the message type from
+	// the descriptor set alone, so a green consume here also proves the mode
+	// does not secretly depend on registry resolution the way AVRO does.
+	records, err := consume(ctx, client, topic, dagger.KafkaClientConsumeOpts{
+		MaxMessages:         1,
+		Timeout:             "10s",
+		KeyEncoding:         "raw",
+		ValueEncoding:       "raw",
+		SchemaRegistryAware: true,
+		ValueDeserializeAs:  "PROTOBUF",
+		ValueDescriptorSet:  protobufDescriptorSet(),
+		ValueMessageName:    messageName,
+	})
+	if err != nil {
+		return fmt.Errorf("consume: %w", err)
+	}
+	if len(records) != 1 {
+		return fmt.Errorf("expected 1 record, got %d", len(records))
+	}
+	gotKey, err := records[0].Key(ctx)
+	if err != nil {
+		return fmt.Errorf("read key: %w", err)
+	}
+	gotVal, err := records[0].Value(ctx)
+	if err != nil {
+		return fmt.Errorf("read value: %w", err)
+	}
+	gotValID, err := records[0].ValueSchemaID(ctx)
+	if err != nil {
+		return fmt.Errorf("read value schema id: %w", err)
+	}
+	if gotKey != wantKey {
+		return fmt.Errorf("key mismatch: want %q, got %q", wantKey, gotKey)
+	}
+	if gotVal != wantCanonical {
+		return fmt.Errorf("value mismatch: want canonical %q, got %q", wantCanonical, gotVal)
+	}
+	if gotValID != id {
+		return fmt.Errorf("value schema id mismatch: want %d, got %d", id, gotValID)
+	}
+	return nil
+}


### PR DESCRIPTION
Closes #75.

Adds `PROTOBUF` as the third Schema-Registry payload format on `*Client.Produce` / `*Client.Consume`, alongside the existing `JSON` (#73) and `AVRO` (#74) modes.

## The descriptor-set tradeoff

Schema Registry stores `.proto` **text**, but decoding a registered Protobuf schema needs a compiled `FileDescriptor` — invoking `protoc` at runtime would pull a non-trivial toolchain into the module. Instead the caller compiles out-of-band and hands the module a `FileDescriptorSet` as a `*dagger.File` plus a fully-qualified message name:

```sh
protoc --descriptor_set_out=user.desc --include_imports user.proto
```

The module resolves it via `protodesc`/`protoregistry` and converts through `dynamicpb` + `protojson`. This keeps the daggerverse Go-only. Two consequences, both documented in the README:

- **No `Registry` is needed on either call** — unlike `AVRO`, nothing resolves schema text by id, so a `PROTOBUF` `Consume` never talks to a registry. The wire schema id is still surfaced on `ConsumedRecord`.
- Nothing verifies the descriptor set matches the schema registered under the wire id. A mismatched pair decodes to garbage exactly as it would for any other Protobuf consumer handed the wrong descriptor.

## Deviation from the acceptance criteria: the message-index array

The AC said to frame Protobuf with the existing `keySchemaId` / `valueSchemaId` primitive. That would have produced records **no stock Confluent Protobuf consumer could read**: the Confluent Protobuf wire format places a *message-index array* between the 5-byte header and the payload, naming which message in the `.proto` the payload is an instance of.

franz-go's `sr.ConfluentHeader` already encodes and decodes it (`AppendEncode`'s `index` argument / `DecodeIndex`), so the cost was small and this PR implements it properly. A record whose index names a different message than the caller requested is **rejected** rather than decoded into silent garbage — Protobuf wire bytes are not self-describing enough to catch that on their own.

Avro/JSON framing bytes are unchanged: a nil index makes `AppendEncode` a no-op.

## Other notes

- **`fixtures/` rather than the `testdata/` the AC specified** — all six other daggerverse test modules use `fixtures/`, so this follows repo convention. One-line move if preferred.
- Round-tripped documents are not always byte-identical to the input: protojson omits proto3 zero values and renders 64-bit ints as strings, and decoded output is re-marshalled through `encoding/json`, which sorts keys. Documented; the round-trip tests assert the canonical form.
- The descriptor set is resolved at most once per call, not once per record, so a multi-record `Consume` doesn't re-export the file each time.
- Avro has TLS/mTLS round-trip variants; Protobuf has none. The registry-TLS dimension is moot (no registry involved) and the Kafka-wire TLS path is orthogonal to serde and already covered by the Avro tests. Happy to file a follow-up if you'd rather have them.

## Tests

Ten new tests in `daggerverse/kafka/tests/tests_protobuf.go`, all registered in the `SchemaRegistry` `+check` group:

- five validation guards (missing descriptor set / message name / schema id, on both produce and consume paths; missing `schemaRegistryAware`)
- two negative consume paths (unframed record, message-index mismatch)
- three round-trips: value, key (both fields encoded with *different* message types so a crossed wire fails), and a non-zero message index that exercises the varint form of the index array rather than the single-zero-byte shortcut

Fixture is a checked-in `FileDescriptorSet` under `tests/fixtures/protobuf/` with a README on regenerating it.

## Verification

- `dagger -m daggerverse/kafka/tests call schema-registry` — green (exit 0, 1m37s)
- each of the ten Protobuf tests also run individually — green
- `dagger -m ci call generated` — green (root `ci` aggregator bindings for `kafka-tests` regenerated and committed)
- `dagger develop` re-run in `daggerverse/kafka/` and `daggerverse/kafka/tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)