### PR TITLE
story(issue-46): add file-based xds support to the envoy module

### DIFF
--- a/ci/internal/dagger/envoy-tests.gen.go
+++ b/ci/internal/dagger/envoy-tests.gen.go
@@ -52,10 +52,15 @@ type EnvoyTests struct { // envoy-tests (../../../daggerverse/envoy/tests/main.g
 	customHttpFilterBodyIsSpliced                     *Void
 	customListenerBodyIsSpliced                       *Void
 	defaultClusterTypeIsStrictDns                     *Void
+	dynamicResourcesConflictsWithStatic               *Void
+	dynamicResourcesRendersDynamicBootstrap           *Void
+	dynamicResourcesRequiresLdsAndCds                 *Void
 	id                                                *ID
 	l4TcpRoundTrip                                    *Void
 	l4TcpTlsRoundTrip                                 *Void
+	l4TcpXdsRoundTrip                                 *Void
 	l7HttpRoundTrip                                   *Void
+	l7HttpXdsRoundTrip                                *Void
 	l7HttpsMtlsAcceptsAuthorizedClient                *Void
 	l7HttpsMtlsRejectsAnonymousClient                 *Void
 	l7HttpsRoundTrip                                  *Void
@@ -74,6 +79,9 @@ type EnvoyTests struct { // envoy-tests (../../../daggerverse/envoy/tests/main.g
 	upstreamMtlsRoundTrip                             *Void
 	upstreamTlsRoundTrip                              *Void
 	validation                                        *Void
+	xdsResourcesMatchStaticResources                  *Void
+	xdsResourcesRejectsInvalidResourceSet             *Void
+	xdsResourcesRejectsSecureComponents               *Void
 }
 
 func (r *EnvoyTests) WithGraphQLQuery(q *querybuilder.Selection) *EnvoyTests {
@@ -86,15 +94,15 @@ func (r *EnvoyTests) WithGraphQLQuery(q *querybuilder.Selection) *EnvoyTests {
 type EnvoyTestsAdminOpts struct {
 
 	// Default: "v1.32.1"
-	EnvoyTag string // envoy-tests (../../../daggerverse/envoy/tests/main.go:92:2)
+	EnvoyTag string // envoy-tests (../../../daggerverse/envoy/tests/main.go:98:2)
 
-	Parallel int // envoy-tests (../../../daggerverse/envoy/tests/main.go:94:2)
+	Parallel int // envoy-tests (../../../daggerverse/envoy/tests/main.go:100:2)
 }
 
 // Admin runs the boot-and-probe tests — Envoy comes up, we hit the
 // admin endpoint or assert misconfigurations fail at boot, no upstream
 // traffic.
-func (r *EnvoyTests) Admin(ctx context.Context, opts ...EnvoyTestsAdminOpts) error { // envoy-tests (../../../daggerverse/envoy/tests/main.go:89:1)
+func (r *EnvoyTests) Admin(ctx context.Context, opts ...EnvoyTestsAdminOpts) error { // envoy-tests (../../../daggerverse/envoy/tests/main.go:95:1)
 	if r.admin != nil {
 		return nil
 	}
@@ -117,14 +125,14 @@ func (r *EnvoyTests) Admin(ctx context.Context, opts ...EnvoyTestsAdminOpts) err
 type EnvoyTestsAdminEndpointServesReadyOpts struct {
 
 	// Default: "v1.32.1"
-	EnvoyTag string // envoy-tests (../../../daggerverse/envoy/tests/main.go:466:2)
+	EnvoyTag string // envoy-tests (../../../daggerverse/envoy/tests/main.go:478:2)
 }
 
 // AdminEndpointServesReady asserts the admin /ready endpoint
 // returns HTTP 200 from a fresh probe container service-bound to a
 // proxy whose minimal valid config is one HTTP listener wired to one
 // cluster.
-func (r *EnvoyTests) AdminEndpointServesReady(ctx context.Context, opts ...EnvoyTestsAdminEndpointServesReadyOpts) error { // envoy-tests (../../../daggerverse/envoy/tests/main.go:463:1)
+func (r *EnvoyTests) AdminEndpointServesReady(ctx context.Context, opts ...EnvoyTestsAdminEndpointServesReadyOpts) error { // envoy-tests (../../../daggerverse/envoy/tests/main.go:475:1)
 	if r.adminEndpointServesReady != nil {
 		return nil
 	}
@@ -174,7 +182,7 @@ func (r *EnvoyTests) All(ctx context.Context, opts ...EnvoyTestsAllOpts) error {
 // ConfigFileOverridesRendered asserts that WithConfigFile fully
 // replaces the rendered bootstrap; listeners and clusters added via
 // WithListener/WithCluster are ignored when an override is set.
-func (r *EnvoyTests) ConfigFileOverridesRendered(ctx context.Context) error { // envoy-tests (../../../daggerverse/envoy/tests/main.go:399:1)
+func (r *EnvoyTests) ConfigFileOverridesRendered(ctx context.Context) error { // envoy-tests (../../../daggerverse/envoy/tests/main.go:411:1)
 	if r.configFileOverridesRendered != nil {
 		return nil
 	}
@@ -186,7 +194,7 @@ func (r *EnvoyTests) ConfigFileOverridesRendered(ctx context.Context) error { //
 // CustomHttpFilterBodyIsSpliced asserts that a CustomHttpFilter's
 // caller-supplied YAML body lands as the filter's typed_config in
 // the rendered HCM http_filters chain.
-func (r *EnvoyTests) CustomHTTPFilterBodyIsSpliced(ctx context.Context) error { // envoy-tests (../../../daggerverse/envoy/tests/main.go:338:1)
+func (r *EnvoyTests) CustomHTTPFilterBodyIsSpliced(ctx context.Context) error { // envoy-tests (../../../daggerverse/envoy/tests/main.go:350:1)
 	if r.customHttpFilterBodyIsSpliced != nil {
 		return nil
 	}
@@ -199,7 +207,7 @@ func (r *EnvoyTests) CustomHTTPFilterBodyIsSpliced(ctx context.Context) error { 
 // caller-supplied YAML body round-trips verbatim under
 // static_resources.listeners with the builder-supplied name keyed
 // in.
-func (r *EnvoyTests) CustomListenerBodyIsSpliced(ctx context.Context) error { // envoy-tests (../../../daggerverse/envoy/tests/main.go:295:1)
+func (r *EnvoyTests) CustomListenerBodyIsSpliced(ctx context.Context) error { // envoy-tests (../../../daggerverse/envoy/tests/main.go:307:1)
 	if r.customListenerBodyIsSpliced != nil {
 		return nil
 	}
@@ -211,11 +219,49 @@ func (r *EnvoyTests) CustomListenerBodyIsSpliced(ctx context.Context) error { //
 // DefaultClusterTypeIsStrictDns asserts a cluster built with default
 // clusterType renders as `type: STRICT_DNS` in the rendered
 // bootstrap YAML.
-func (r *EnvoyTests) DefaultClusterTypeIsStrictDNS(ctx context.Context) error { // envoy-tests (../../../daggerverse/envoy/tests/main.go:227:1)
+func (r *EnvoyTests) DefaultClusterTypeIsStrictDNS(ctx context.Context) error { // envoy-tests (../../../daggerverse/envoy/tests/main.go:239:1)
 	if r.defaultClusterTypeIsStrictDns != nil {
 		return nil
 	}
 	q := r.query.Select("defaultClusterTypeIsStrictDns")
+
+	return q.Execute(ctx)
+}
+
+// DynamicResourcesConflictsWithStatic asserts that mixing
+// WithDynamicResources with any of WithListener / WithCluster /
+// WithConfigFile on the same Proxy makes ConfigFile() return a
+// non-nil error — the two configuration modes are exclusive.
+func (r *EnvoyTests) DynamicResourcesConflictsWithStatic(ctx context.Context) error { // envoy-tests (../../../daggerverse/envoy/tests/xds.go:372:1)
+	if r.dynamicResourcesConflictsWithStatic != nil {
+		return nil
+	}
+	q := r.query.Select("dynamicResourcesConflictsWithStatic")
+
+	return q.Execute(ctx)
+}
+
+// DynamicResourcesRendersDynamicBootstrap asserts WithDynamicResources
+// renders a bootstrap whose dynamic_resources block points lds/cds at
+// the mounted xds directory and which carries no static_resources.
+func (r *EnvoyTests) DynamicResourcesRendersDynamicBootstrap(ctx context.Context) error { // envoy-tests (../../../daggerverse/envoy/tests/xds.go:16:1)
+	if r.dynamicResourcesRendersDynamicBootstrap != nil {
+		return nil
+	}
+	q := r.query.Select("dynamicResourcesRendersDynamicBootstrap")
+
+	return q.Execute(ctx)
+}
+
+// DynamicResourcesRequiresLdsAndCds asserts Service() rejects a
+// resource directory missing either of the two files the bootstrap's
+// dynamic_resources block points at, rather than booting an Envoy
+// that silently discovers nothing.
+func (r *EnvoyTests) DynamicResourcesRequiresLdsAndCds(ctx context.Context) error { // envoy-tests (../../../daggerverse/envoy/tests/xds.go:349:1)
+	if r.dynamicResourcesRequiresLdsAndCds != nil {
+		return nil
+	}
+	q := r.query.Select("dynamicResourcesRequiresLdsAndCds")
 
 	return q.Execute(ctx)
 }
@@ -273,13 +319,13 @@ func (r *EnvoyTests) UnmarshalJSON(bs []byte) error {
 type EnvoyTestsL4TcpRoundTripOpts struct {
 
 	// Default: "v1.32.1"
-	EnvoyTag string // envoy-tests (../../../daggerverse/envoy/tests/main.go:581:2)
+	EnvoyTag string // envoy-tests (../../../daggerverse/envoy/tests/main.go:593:2)
 }
 
 // L4TcpRoundTrip stands up an alpine `nc` echo upstream behind an
 // Envoy TcpListener and asserts that bytes sent through Envoy come
 // back on the same TCP connection.
-func (r *EnvoyTests) L4TcpRoundTrip(ctx context.Context, opts ...EnvoyTestsL4TcpRoundTripOpts) error { // envoy-tests (../../../daggerverse/envoy/tests/main.go:578:1)
+func (r *EnvoyTests) L4TcpRoundTrip(ctx context.Context, opts ...EnvoyTestsL4TcpRoundTripOpts) error { // envoy-tests (../../../daggerverse/envoy/tests/main.go:590:1)
 	if r.l4TcpRoundTrip != nil {
 		return nil
 	}
@@ -319,21 +365,75 @@ func (r *EnvoyTests) L4TcpTLSRoundTrip(ctx context.Context, opts ...EnvoyTestsL4
 	return q.Execute(ctx)
 }
 
+// EnvoyTestsL4TcpXdsRoundTripOpts contains options for EnvoyTests.L4TcpXdsRoundTrip
+type EnvoyTestsL4TcpXdsRoundTripOpts struct {
+
+	// Default: "v1.32.1"
+	EnvoyTag string // envoy-tests (../../../daggerverse/envoy/tests/xds.go:137:2)
+}
+
+// L4TcpXdsRoundTrip stands up an alpine `nc` echo upstream behind an
+// Envoy TcpListener delivered over file-based xDS and asserts bytes
+// sent through Envoy come back on the same TCP connection. Also
+// asserts ListenerEndpoint resolves the listener's port out of the
+// mounted lds.yaml, since no Listener is registered on the Proxy in
+// this mode.
+func (r *EnvoyTests) L4TcpXdsRoundTrip(ctx context.Context, opts ...EnvoyTestsL4TcpXdsRoundTripOpts) error { // envoy-tests (../../../daggerverse/envoy/tests/xds.go:134:1)
+	if r.l4TcpXdsRoundTrip != nil {
+		return nil
+	}
+	q := r.query.Select("l4TcpXdsRoundTrip")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `envoyTag` optional argument
+		if !querybuilder.IsZeroValue(opts[i].EnvoyTag) {
+			q = q.Arg("envoyTag", opts[i].EnvoyTag)
+		}
+	}
+
+	return q.Execute(ctx)
+}
+
 // EnvoyTestsL7HttpRoundTripOpts contains options for EnvoyTests.L7HttpRoundTrip
 type EnvoyTestsL7HttpRoundTripOpts struct {
 
 	// Default: "v1.32.1"
-	EnvoyTag string // envoy-tests (../../../daggerverse/envoy/tests/main.go:534:2)
+	EnvoyTag string // envoy-tests (../../../daggerverse/envoy/tests/main.go:546:2)
 }
 
 // L7HttpRoundTrip stands up an HTTP upstream behind an Envoy
 // HttpListener and asserts a request through Envoy returns a fresh
 // random marker served by the upstream.
-func (r *EnvoyTests) L7HttpRoundTrip(ctx context.Context, opts ...EnvoyTestsL7HttpRoundTripOpts) error { // envoy-tests (../../../daggerverse/envoy/tests/main.go:531:1)
+func (r *EnvoyTests) L7HttpRoundTrip(ctx context.Context, opts ...EnvoyTestsL7HttpRoundTripOpts) error { // envoy-tests (../../../daggerverse/envoy/tests/main.go:543:1)
 	if r.l7HttpRoundTrip != nil {
 		return nil
 	}
 	q := r.query.Select("l7HttpRoundTrip")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `envoyTag` optional argument
+		if !querybuilder.IsZeroValue(opts[i].EnvoyTag) {
+			q = q.Arg("envoyTag", opts[i].EnvoyTag)
+		}
+	}
+
+	return q.Execute(ctx)
+}
+
+// EnvoyTestsL7HttpXdsRoundTripOpts contains options for EnvoyTests.L7HttpXdsRoundTrip
+type EnvoyTestsL7HttpXdsRoundTripOpts struct {
+
+	// Default: "v1.32.1"
+	EnvoyTag string // envoy-tests (../../../daggerverse/envoy/tests/xds.go:85:2)
+}
+
+// L7HttpXdsRoundTrip stands up an HTTP upstream behind an Envoy
+// proxy whose listeners and clusters arrive over file-based xDS
+// rather than static_resources, and asserts a request through Envoy
+// returns a fresh random marker served by the upstream.
+func (r *EnvoyTests) L7HttpXdsRoundTrip(ctx context.Context, opts ...EnvoyTestsL7HttpXdsRoundTripOpts) error { // envoy-tests (../../../daggerverse/envoy/tests/xds.go:82:1)
+	if r.l7HttpXdsRoundTrip != nil {
+		return nil
+	}
+	q := r.query.Select("l7HttpXdsRoundTrip")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `envoyTag` optional argument
 		if !querybuilder.IsZeroValue(opts[i].EnvoyTag) {
@@ -469,7 +569,7 @@ func (r *EnvoyTests) PlaintextUpstreamSecurityRendersNoTransportSocket(ctx conte
 // RejectsDuplicateListenerName asserts that wiring two listeners
 // sharing the same name into a Proxy causes ConfigFile() to return a
 // non-nil error.
-func (r *EnvoyTests) RejectsDuplicateListenerName(ctx context.Context) error { // envoy-tests (../../../daggerverse/envoy/tests/main.go:260:1)
+func (r *EnvoyTests) RejectsDuplicateListenerName(ctx context.Context) error { // envoy-tests (../../../daggerverse/envoy/tests/main.go:272:1)
 	if r.rejectsDuplicateListenerName != nil {
 		return nil
 	}
@@ -482,7 +582,7 @@ func (r *EnvoyTests) RejectsDuplicateListenerName(ctx context.Context) error { /
 // factories reject names that don't match [A-Za-z0-9_-]+ with a
 // non-nil error. AC calls out Envoy.Cluster and Envoy.VirtualHost
 // explicitly; RoutePrefix's cluster arg shares the same validator.
-func (r *EnvoyTests) RejectsInvalidComponentName(ctx context.Context) error { // envoy-tests (../../../daggerverse/envoy/tests/main.go:180:1)
+func (r *EnvoyTests) RejectsInvalidComponentName(ctx context.Context) error { // envoy-tests (../../../daggerverse/envoy/tests/main.go:192:1)
 	if r.rejectsInvalidComponentName != nil {
 		return nil
 	}
@@ -494,7 +594,7 @@ func (r *EnvoyTests) RejectsInvalidComponentName(ctx context.Context) error { //
 // RejectsUnknownClusterReference asserts a listener whose filter
 // chain references a cluster not registered via WithCluster causes
 // ConfigFile() to return a non-nil error.
-func (r *EnvoyTests) RejectsUnknownClusterReference(ctx context.Context) error { // envoy-tests (../../../daggerverse/envoy/tests/main.go:277:1)
+func (r *EnvoyTests) RejectsUnknownClusterReference(ctx context.Context) error { // envoy-tests (../../../daggerverse/envoy/tests/main.go:289:1)
 	if r.rejectsUnknownClusterReference != nil {
 		return nil
 	}
@@ -506,7 +606,7 @@ func (r *EnvoyTests) RejectsUnknownClusterReference(ctx context.Context) error {
 // RejectsUnknownClusterType asserts Envoy.Cluster rejects clusterType
 // values outside {STATIC, STRICT_DNS, LOGICAL_DNS} with a non-nil
 // error.
-func (r *EnvoyTests) RejectsUnknownClusterType(ctx context.Context) error { // envoy-tests (../../../daggerverse/envoy/tests/main.go:210:1)
+func (r *EnvoyTests) RejectsUnknownClusterType(ctx context.Context) error { // envoy-tests (../../../daggerverse/envoy/tests/main.go:222:1)
 	if r.rejectsUnknownClusterType != nil {
 		return nil
 	}
@@ -519,15 +619,15 @@ func (r *EnvoyTests) RejectsUnknownClusterType(ctx context.Context) error { // e
 type EnvoyTestsRoundTripsOpts struct {
 
 	// Default: "v1.32.1"
-	EnvoyTag string // envoy-tests (../../../daggerverse/envoy/tests/main.go:120:2)
+	EnvoyTag string // envoy-tests (../../../daggerverse/envoy/tests/main.go:126:2)
 
-	Parallel int // envoy-tests (../../../daggerverse/envoy/tests/main.go:122:2)
+	Parallel int // envoy-tests (../../../daggerverse/envoy/tests/main.go:128:2)
 }
 
 // RoundTrips runs every L7/L4 + TLS/mTLS round-trip — each spins an
 // Envoy proxy plus an upstream service plus a curl client. The
 // heaviest of the three groups.
-func (r *EnvoyTests) RoundTrips(ctx context.Context, opts ...EnvoyTestsRoundTripsOpts) error { // envoy-tests (../../../daggerverse/envoy/tests/main.go:117:1)
+func (r *EnvoyTests) RoundTrips(ctx context.Context, opts ...EnvoyTestsRoundTripsOpts) error { // envoy-tests (../../../daggerverse/envoy/tests/main.go:123:1)
 	if r.roundTrips != nil {
 		return nil
 	}
@@ -550,14 +650,14 @@ func (r *EnvoyTests) RoundTrips(ctx context.Context, opts ...EnvoyTestsRoundTrip
 type EnvoyTestsServiceWithoutConfigFailsOpts struct {
 
 	// Default: "v1.32.1"
-	EnvoyTag string // envoy-tests (../../../daggerverse/envoy/tests/main.go:434:2)
+	EnvoyTag string // envoy-tests (../../../daggerverse/envoy/tests/main.go:446:2)
 }
 
 // ServiceWithoutConfigFails asserts that Service() on a Proxy with
 // no listeners, clusters, or override produces a container whose
 // admin port never opens (the envoy binary refuses to start without
 // -c).
-func (r *EnvoyTests) ServiceWithoutConfigFails(ctx context.Context, opts ...EnvoyTestsServiceWithoutConfigFailsOpts) error { // envoy-tests (../../../daggerverse/envoy/tests/main.go:431:1)
+func (r *EnvoyTests) ServiceWithoutConfigFails(ctx context.Context, opts ...EnvoyTestsServiceWithoutConfigFailsOpts) error { // envoy-tests (../../../daggerverse/envoy/tests/main.go:443:1)
 	if r.serviceWithoutConfigFails != nil {
 		return nil
 	}
@@ -667,6 +767,47 @@ func (r *EnvoyTests) Validation(ctx context.Context, opts ...EnvoyTestsValidatio
 			q = q.Arg("parallel", opts[i].Parallel)
 		}
 	}
+
+	return q.Execute(ctx)
+}
+
+// XdsResourcesMatchStaticResources asserts that the lds.yaml /
+// cds.yaml discovery responses rendered by XdsResources.Directory()
+// are structurally equivalent to the static_resources block the same
+// components produce in static mode — identical apart from the
+// per-resource `@type` discriminator that only the xDS shape needs.
+func (r *EnvoyTests) XdsResourcesMatchStaticResources(ctx context.Context) error { // envoy-tests (../../../daggerverse/envoy/tests/xds.go:194:1)
+	if r.xdsResourcesMatchStaticResources != nil {
+		return nil
+	}
+	q := r.query.Select("xdsResourcesMatchStaticResources")
+
+	return q.Execute(ctx)
+}
+
+// XdsResourcesRejectsInvalidResourceSet asserts Directory() surfaces
+// the same two errors (*Proxy).ConfigFile() does: two listeners
+// sharing a name, and a listener whose filter chain references a
+// cluster that isn't in the resource set.
+func (r *EnvoyTests) XdsResourcesRejectsInvalidResourceSet(ctx context.Context) error { // envoy-tests (../../../daggerverse/envoy/tests/xds.go:277:1)
+	if r.xdsResourcesRejectsInvalidResourceSet != nil {
+		return nil
+	}
+	q := r.query.Select("xdsResourcesRejectsInvalidResourceSet")
+
+	return q.Execute(ctx)
+}
+
+// XdsResourcesRejectsSecureComponents asserts Directory() refuses
+// TLS / mTLS listeners and clusters: their rendered resources point
+// at key material under /etc/envoy/secrets that only the static
+// Service() path mounts, so a proxy fed them through an opaque
+// resource directory would boot and then fail every handshake.
+func (r *EnvoyTests) XdsResourcesRejectsSecureComponents(ctx context.Context) error { // envoy-tests (../../../daggerverse/envoy/tests/xds.go:313:1)
+	if r.xdsResourcesRejectsSecureComponents != nil {
+		return nil
+	}
+	q := r.query.Select("xdsResourcesRejectsSecureComponents")
 
 	return q.Execute(ctx)
 }

--- a/daggerverse/envoy/dagger.gen.go
+++ b/daggerverse/envoy/dagger.gen.go
@@ -335,14 +335,15 @@ func (r *ServerSecurity) UnmarshalJSON(bs []byte) error {
 
 func (r Proxy) MarshalJSON() ([]byte, error) {
 	var concrete struct {
-		Registry     string
-		Tag          string
-		AdminPort    int
-		Override     *dagger.File
-		Listeners    []*Listener
-		Clusters     []*Cluster
-		BindingHosts []string
-		BindingSvcs  []*dagger.Service
+		Registry         string
+		Tag              string
+		AdminPort        int
+		Override         *dagger.File
+		Listeners        []*Listener
+		Clusters         []*Cluster
+		BindingHosts     []string
+		BindingSvcs      []*dagger.Service
+		DynamicResources *dagger.Directory
 	}
 	concrete.Registry = r.Registry
 	concrete.Tag = r.Tag
@@ -352,19 +353,21 @@ func (r Proxy) MarshalJSON() ([]byte, error) {
 	concrete.Clusters = r.Clusters
 	concrete.BindingHosts = r.BindingHosts
 	concrete.BindingSvcs = r.BindingSvcs
+	concrete.DynamicResources = r.DynamicResources
 	return json.Marshal(&concrete)
 }
 
 func (r *Proxy) UnmarshalJSON(bs []byte) error {
 	var concrete struct {
-		Registry     string
-		Tag          string
-		AdminPort    int
-		Override     *dagger.File
-		Listeners    []*Listener
-		Clusters     []*Cluster
-		BindingHosts []string
-		BindingSvcs  []*dagger.Service
+		Registry         string
+		Tag              string
+		AdminPort        int
+		Override         *dagger.File
+		Listeners        []*Listener
+		Clusters         []*Cluster
+		BindingHosts     []string
+		BindingSvcs      []*dagger.Service
+		DynamicResources *dagger.Directory
 	}
 	err := json.Unmarshal(bs, &concrete)
 	if err != nil {
@@ -378,6 +381,7 @@ func (r *Proxy) UnmarshalJSON(bs []byte) error {
 	r.Clusters = concrete.Clusters
 	r.BindingHosts = concrete.BindingHosts
 	r.BindingSvcs = concrete.BindingSvcs
+	r.DynamicResources = concrete.DynamicResources
 	return nil
 }
 
@@ -454,6 +458,30 @@ func (r *VirtualHost) UnmarshalJSON(bs []byte) error {
 	r.Name = concrete.Name
 	r.Domains = concrete.Domains
 	r.Routes = concrete.Routes
+	return nil
+}
+
+func (r XdsResources) MarshalJSON() ([]byte, error) {
+	var concrete struct {
+		Listeners []*Listener
+		Clusters  []*Cluster
+	}
+	concrete.Listeners = r.Listeners
+	concrete.Clusters = r.Clusters
+	return json.Marshal(&concrete)
+}
+
+func (r *XdsResources) UnmarshalJSON(bs []byte) error {
+	var concrete struct {
+		Listeners []*Listener
+		Clusters  []*Cluster
+	}
+	err := json.Unmarshal(bs, &concrete)
+	if err != nil {
+		return err
+	}
+	r.Listeners = concrete.Listeners
+	r.Clusters = concrete.Clusters
 	return nil
 }
 
@@ -1036,6 +1064,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Envoy).VirtualHost(&parent, name, domains)
+		case "XdsResources":
+			var parent Envoy
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Envoy).XdsResources(&parent), nil
 		default:
 			return nil, fmt.Errorf("unknown function %s", fnName)
 		}
@@ -1094,7 +1129,7 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 			if err != nil {
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
-			return (*Proxy).Service(&parent)
+			return (*Proxy).Service(&parent, ctx)
 		case "WithCluster":
 			var parent Proxy
 			err = json.Unmarshal(parentJSON, &parent)
@@ -1123,6 +1158,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Proxy).WithConfigFile(&parent, f), nil
+		case "WithDynamicResources":
+			var parent Proxy
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var dir *dagger.Directory
+			if inputArgs["dir"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["dir"]), &dir)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg dir", err))
+				}
+			}
+			return (*Proxy).WithDynamicResources(&parent, dir), nil
 		case "WithListener":
 			var parent Proxy
 			err = json.Unmarshal(parentJSON, &parent)
@@ -1196,6 +1245,46 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*VirtualHost).WithRoute(&parent, route), nil
+		default:
+			return nil, fmt.Errorf("unknown function %s", fnName)
+		}
+	case "XdsResources":
+		switch fnName {
+		case "Directory":
+			var parent XdsResources
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*XdsResources).Directory(&parent)
+		case "WithCluster":
+			var parent XdsResources
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var c *Cluster
+			if inputArgs["c"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["c"]), &c)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg c", err))
+				}
+			}
+			return (*XdsResources).WithCluster(&parent, c), nil
+		case "WithListener":
+			var parent XdsResources
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var l *Listener
+			if inputArgs["l"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["l"]), &l)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg l", err))
+				}
+			}
+			return (*XdsResources).WithListener(&parent, l), nil
 		default:
 			return nil, fmt.Errorf("unknown function %s", fnName)
 		}

--- a/daggerverse/envoy/main.go
+++ b/daggerverse/envoy/main.go
@@ -5,8 +5,9 @@
 // bootstrap without writing the YAML by hand. TLS / mTLS terminates
 // on listeners (downstream) and authenticates clusters (upstream)
 // via per-listener / per-cluster *ServerSecurity / *UpstreamSecurity
-// profiles. Dynamic configuration (xDS) lands in a separate
-// follow-up.
+// profiles. File-based xDS is supported via XdsResources +
+// (*Proxy).WithDynamicResources; gRPC-based xDS (ADS, SDS over
+// streaming RPCs) lands in a separate follow-up.
 package main
 
 import (
@@ -622,7 +623,9 @@ func (e *Envoy) CustomListener(name, yamlBody string) (*Listener, error) {
 }
 
 // Proxy is a running Envoy instance with a composed (or
-// caller-supplied) static-resources bootstrap.
+// caller-supplied) static-resources bootstrap, or — when
+// DynamicResources is set — a file-based xDS bootstrap that
+// discovers its listeners and clusters from a mounted directory.
 type Proxy struct {
 	Registry     string
 	Tag          string
@@ -632,6 +635,11 @@ type Proxy struct {
 	Clusters     []*Cluster
 	BindingHosts []string
 	BindingSvcs  []*dagger.Service
+
+	// DynamicResources is the file-based xDS discovery-resource
+	// directory set via WithDynamicResources. Exclusive with
+	// Override / Listeners / Clusters.
+	DynamicResources *dagger.Directory
 }
 
 // Proxy returns a Proxy backed by the envoyproxy/envoy image at
@@ -689,10 +697,27 @@ func (p *Proxy) WithConfigFile(f *dagger.File) *Proxy {
 }
 
 // ConfigFile returns the file that will be mounted as Envoy's -c
-// argument: either the caller-supplied override or the rendered
-// bootstrap. Returns a non-nil error if any listener references an
-// unregistered cluster, or if two listeners share a name.
+// argument: the caller-supplied override, the rendered
+// static_resources bootstrap, or — when WithDynamicResources was
+// called — the file-based xDS bootstrap. Returns a non-nil error if
+// any listener references an unregistered cluster, if two listeners
+// share a name, or if WithDynamicResources was mixed with any of
+// WithListener / WithCluster / WithConfigFile.
 func (p *Proxy) ConfigFile() (*dagger.File, error) {
+	if p.DynamicResources != nil {
+		if err := validateDynamicProxy(p); err != nil {
+			return nil, err
+		}
+		adminPort, err := p.effectiveAdminPort()
+		if err != nil {
+			return nil, err
+		}
+		body, err := renderDynamicBootstrap(adminPort)
+		if err != nil {
+			return nil, err
+		}
+		return writeWorkdirFile("envoy.yaml", body)
+	}
 	if p.Override != nil {
 		return p.Override, nil
 	}
@@ -714,11 +739,13 @@ func (p *Proxy) ConfigFile() (*dagger.File, error) {
 }
 
 // Service returns the running Envoy container. Listens on
-// AdminPort (admin) plus each registered listener's port. When no
-// override and no listeners/clusters are registered, launches with
-// no `-c` flag so the envoy binary exits non-zero — exposed verbatim
-// so callers can detect the misconfig via service-binding probes.
-func (p *Proxy) Service() (*dagger.Service, error) {
+// AdminPort (admin) plus each registered listener's port — read from
+// the mounted lds.yaml when the proxy runs in file-based xDS mode.
+// When no override and no listeners/clusters are registered, launches
+// with no `-c` flag so the envoy binary exits non-zero — exposed
+// verbatim so callers can detect the misconfig via service-binding
+// probes.
+func (p *Proxy) Service(ctx context.Context) (*dagger.Service, error) {
 	cfg, err := p.ConfigFile()
 	if err != nil {
 		return nil, err
@@ -774,6 +801,16 @@ func (p *Proxy) Service() (*dagger.Service, error) {
 				})
 		}
 	}
+	if p.DynamicResources != nil {
+		ports, err := xdsListenerPorts(ctx, p.DynamicResources)
+		if err != nil {
+			return nil, err
+		}
+		for _, port := range ports {
+			ctr = ctr.WithExposedPort(port)
+		}
+		ctr = ctr.WithMountedDirectory(xdsMountPath, p.DynamicResources)
+	}
 	for i, host := range p.BindingHosts {
 		ctr = ctr.WithServiceBinding(host, p.BindingSvcs[i])
 	}
@@ -792,7 +829,7 @@ func (p *Proxy) Service() (*dagger.Service, error) {
 //
 // +cache="never"
 func (p *Proxy) AdminEndpoint(ctx context.Context) (string, error) {
-	svc, err := p.Service()
+	svc, err := p.Service(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -824,26 +861,18 @@ func (p *Proxy) effectiveAdminPort() (int, error) {
 }
 
 // ListenerEndpoint returns host:port for the named listener on the
-// running proxy. Returns a non-nil error if no listener matches name
-// or if the listener's body has no recognizable socket_address.port_value.
+// running proxy — resolved against the registered Listeners, or
+// against the mounted lds.yaml when the proxy runs in file-based xDS
+// mode. Returns a non-nil error if no listener matches name or if the
+// listener has no recognizable socket_address.port_value.
 //
 // +cache="never"
 func (p *Proxy) ListenerEndpoint(ctx context.Context, name string) (string, error) {
-	var match *Listener
-	for _, l := range p.Listeners {
-		if l.Name == name {
-			match = l
-			break
-		}
+	port, err := p.listenerPort(ctx, name)
+	if err != nil {
+		return "", err
 	}
-	if match == nil {
-		return "", fmt.Errorf("listener %q: not registered on proxy", name)
-	}
-	port, ok := extractListenerPort(match.Body)
-	if !ok {
-		return "", fmt.Errorf("listener %q: cannot extract socket_address.port_value from body", name)
-	}
-	svc, err := p.Service()
+	svc, err := p.Service(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -852,6 +881,26 @@ func (p *Proxy) ListenerEndpoint(ctx context.Context, name string) (string, erro
 		return "", err
 	}
 	return fmt.Sprintf("%s:%d", host, port), nil
+}
+
+// listenerPort resolves the port a named listener binds, from
+// whichever side of the static/dynamic split the proxy is configured
+// on.
+func (p *Proxy) listenerPort(ctx context.Context, name string) (int, error) {
+	if p.DynamicResources != nil {
+		return xdsListenerPort(ctx, p.DynamicResources, name)
+	}
+	for _, l := range p.Listeners {
+		if l.Name != name {
+			continue
+		}
+		port, ok := extractListenerPort(l.Body)
+		if !ok {
+			return 0, fmt.Errorf("listener %q: cannot extract socket_address.port_value from body", name)
+		}
+		return port, nil
+	}
+	return 0, fmt.Errorf("listener %q: not registered on proxy", name)
 }
 
 // extractListenerPort walks the listener body's YAML for
@@ -885,21 +934,30 @@ func extractListenerPort(body string) (int, bool) {
 // duplicate listener names and listener filter-chain references to
 // clusters that aren't registered on the proxy.
 func validateProxy(p *Proxy) error {
-	seen := make(map[string]bool, len(p.Listeners))
-	for _, l := range p.Listeners {
+	return validateResources(p.Listeners, p.Clusters, "proxy", "WithCluster")
+}
+
+// validateResources checks a listener/cluster set for duplicate
+// listener names and filter-chain references to clusters that aren't
+// part of the same set. Shared by (*Proxy).ConfigFile and
+// (*XdsResources).Directory so both surface the same two errors;
+// container and adder name the collection in the error message.
+func validateResources(listeners []*Listener, clusters []*Cluster, container, adder string) error {
+	seen := make(map[string]bool, len(listeners))
+	for _, l := range listeners {
 		if seen[l.Name] {
 			return fmt.Errorf("listener %q: declared more than once", l.Name)
 		}
 		seen[l.Name] = true
 	}
-	known := make(map[string]bool, len(p.Clusters))
-	for _, c := range p.Clusters {
+	known := make(map[string]bool, len(clusters))
+	for _, c := range clusters {
 		known[c.Name] = true
 	}
-	for _, l := range p.Listeners {
+	for _, l := range listeners {
 		for _, ref := range l.ClusterRefs {
 			if !known[ref] {
-				return fmt.Errorf("listener %q references cluster %q, which is not registered on the proxy (add it via WithCluster)", l.Name, ref)
+				return fmt.Errorf("listener %q references cluster %q, which is not registered on the %s (add it via %s)", l.Name, ref, container, adder)
 			}
 		}
 	}
@@ -925,18 +983,9 @@ func renderBootstrap(adminPort int, listeners []*Listener, clusters []*Cluster) 
 	if len(listeners) > 0 {
 		ll := make([]any, 0, len(listeners))
 		for _, l := range listeners {
-			var body map[string]any
-			if l.Body != "" {
-				if err := yaml.Unmarshal([]byte(l.Body), &body); err != nil {
-					return nil, fmt.Errorf("listener %q: parse body: %w", l.Name, err)
-				}
-			}
-			if body == nil {
-				body = map[string]any{}
-			}
-			out := map[string]any{"name": l.Name}
-			for k, v := range body {
-				out[k] = v
+			out, err := renderListener(l)
+			if err != nil {
+				return nil, err
 			}
 			ll = append(ll, out)
 		}
@@ -953,6 +1002,24 @@ func renderBootstrap(adminPort int, listeners []*Listener, clusters []*Cluster) 
 		root["static_resources"] = static
 	}
 	return yaml.Marshal(root)
+}
+
+// renderListener folds a Listener's opaque YAML body into a single
+// map with `name` keyed in from Name. The result is the listener
+// resource shared by the static_resources.listeners entry and the
+// LDS discovery response.
+func renderListener(l *Listener) (map[string]any, error) {
+	var body map[string]any
+	if l.Body != "" {
+		if err := yaml.Unmarshal([]byte(l.Body), &body); err != nil {
+			return nil, fmt.Errorf("listener %q: parse body: %w", l.Name, err)
+		}
+	}
+	out := map[string]any{"name": l.Name}
+	for k, v := range body {
+		out[k] = v
+	}
+	return out, nil
 }
 
 func renderCluster(c *Cluster) map[string]any {

--- a/daggerverse/envoy/tests/dagger.gen.go
+++ b/daggerverse/envoy/tests/dagger.gen.go
@@ -276,6 +276,27 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).DefaultClusterTypeIsStrictDns(&parent, ctx)
+		case "DynamicResourcesConflictsWithStatic":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).DynamicResourcesConflictsWithStatic(&parent, ctx)
+		case "DynamicResourcesRendersDynamicBootstrap":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).DynamicResourcesRendersDynamicBootstrap(&parent, ctx)
+		case "DynamicResourcesRequiresLdsAndCds":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).DynamicResourcesRequiresLdsAndCds(&parent, ctx)
 		case "L4TcpRoundTrip":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -304,6 +325,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Tests).L4TcpTlsRoundTrip(&parent, ctx, envoyTag)
+		case "L4TcpXdsRoundTrip":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var envoyTag string
+			if inputArgs["envoyTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["envoyTag"]), &envoyTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg envoyTag", err))
+				}
+			}
+			return nil, (*Tests).L4TcpXdsRoundTrip(&parent, ctx, envoyTag)
 		case "L7HttpRoundTrip":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -318,6 +353,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Tests).L7HttpRoundTrip(&parent, ctx, envoyTag)
+		case "L7HttpXdsRoundTrip":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var envoyTag string
+			if inputArgs["envoyTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["envoyTag"]), &envoyTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg envoyTag", err))
+				}
+			}
+			return nil, (*Tests).L7HttpXdsRoundTrip(&parent, ctx, envoyTag)
 		case "L7HttpsMtlsAcceptsAuthorizedClient":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -507,6 +556,27 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Tests).Validation(&parent, ctx, parallel)
+		case "XdsResourcesMatchStaticResources":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).XdsResourcesMatchStaticResources(&parent, ctx)
+		case "XdsResourcesRejectsInvalidResourceSet":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).XdsResourcesRejectsInvalidResourceSet(&parent, ctx)
+		case "XdsResourcesRejectsSecureComponents":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).XdsResourcesRejectsSecureComponents(&parent, ctx)
 		default:
 			return nil, fmt.Errorf("unknown function %s", fnName)
 		}

--- a/daggerverse/envoy/tests/internal/dagger/dagger.gen.go
+++ b/daggerverse/envoy/tests/internal/dagger/dagger.gen.go
@@ -266,6 +266,9 @@ type EnvoyUpstreamSecurityID string
 type EnvoyVirtualHostID string
 
 // A unique identifier for an object.
+type EnvoyXdsResourcesID string
+
+// A unique identifier for an object.
 type ErrorID string
 
 // A unique identifier for an object.
@@ -13235,6 +13238,16 @@ func (r *Query) LoadEnvoyVirtualHostFromID(id EnvoyVirtualHostID) *EnvoyVirtualH
 	q = q.Arg("id", id)
 
 	return &EnvoyVirtualHost{
+		query: q,
+	}
+}
+
+// Load a EnvoyXdsResources from its ID.
+func (r *Query) LoadEnvoyXdsResourcesFromID(id EnvoyXdsResourcesID) *EnvoyXdsResources {
+	q := r.query.Select("loadEnvoyXdsResourcesFromID")
+	q = q.Arg("id", id)
+
+	return &EnvoyXdsResources{
 		query: q,
 	}
 }

--- a/daggerverse/envoy/tests/internal/dagger/envoy.gen.go
+++ b/daggerverse/envoy/tests/internal/dagger/envoy.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type Envoy
-func (r *Binding) AsEnvoy() *Envoy { // envoy (../../../../../daggerverse/envoy/main.go:36:6)
+func (r *Binding) AsEnvoy() *Envoy { // envoy (../../../../../daggerverse/envoy/main.go:37:6)
 	q := r.query.Select("asEnvoy")
 
 	return &Envoy{
@@ -19,7 +19,7 @@ func (r *Binding) AsEnvoy() *Envoy { // envoy (../../../../../daggerverse/envoy/
 }
 
 // Retrieve the binding value, as type EnvoyCluster
-func (r *Binding) AsEnvoyCluster() *EnvoyCluster { // envoy (../../../../../daggerverse/envoy/main.go:94:6)
+func (r *Binding) AsEnvoyCluster() *EnvoyCluster { // envoy (../../../../../daggerverse/envoy/main.go:95:6)
 	q := r.query.Select("asEnvoyCluster")
 
 	return &EnvoyCluster{
@@ -28,7 +28,7 @@ func (r *Binding) AsEnvoyCluster() *EnvoyCluster { // envoy (../../../../../dagg
 }
 
 // Retrieve the binding value, as type EnvoyEndpoint
-func (r *Binding) AsEnvoyEndpoint() *EnvoyEndpoint { // envoy (../../../../../daggerverse/envoy/main.go:75:6)
+func (r *Binding) AsEnvoyEndpoint() *EnvoyEndpoint { // envoy (../../../../../daggerverse/envoy/main.go:76:6)
 	q := r.query.Select("asEnvoyEndpoint")
 
 	return &EnvoyEndpoint{
@@ -37,7 +37,7 @@ func (r *Binding) AsEnvoyEndpoint() *EnvoyEndpoint { // envoy (../../../../../da
 }
 
 // Retrieve the binding value, as type EnvoyHttpConnectionManager
-func (r *Binding) AsEnvoyHTTPConnectionManager() *EnvoyHTTPConnectionManager { // envoy (../../../../../daggerverse/envoy/main.go:283:6)
+func (r *Binding) AsEnvoyHTTPConnectionManager() *EnvoyHTTPConnectionManager { // envoy (../../../../../daggerverse/envoy/main.go:284:6)
 	q := r.query.Select("asEnvoyHttpConnectionManager")
 
 	return &EnvoyHTTPConnectionManager{
@@ -46,7 +46,7 @@ func (r *Binding) AsEnvoyHTTPConnectionManager() *EnvoyHTTPConnectionManager { /
 }
 
 // Retrieve the binding value, as type EnvoyHttpFilter
-func (r *Binding) AsEnvoyHTTPFilter() *EnvoyHTTPFilter { // envoy (../../../../../daggerverse/envoy/main.go:243:6)
+func (r *Binding) AsEnvoyHTTPFilter() *EnvoyHTTPFilter { // envoy (../../../../../daggerverse/envoy/main.go:244:6)
 	q := r.query.Select("asEnvoyHttpFilter")
 
 	return &EnvoyHTTPFilter{
@@ -55,7 +55,7 @@ func (r *Binding) AsEnvoyHTTPFilter() *EnvoyHTTPFilter { // envoy (../../../../.
 }
 
 // Retrieve the binding value, as type EnvoyListener
-func (r *Binding) AsEnvoyListener() *EnvoyListener { // envoy (../../../../../daggerverse/envoy/main.go:556:6)
+func (r *Binding) AsEnvoyListener() *EnvoyListener { // envoy (../../../../../daggerverse/envoy/main.go:557:6)
 	q := r.query.Select("asEnvoyListener")
 
 	return &EnvoyListener{
@@ -64,7 +64,7 @@ func (r *Binding) AsEnvoyListener() *EnvoyListener { // envoy (../../../../../da
 }
 
 // Retrieve the binding value, as type EnvoyProxy
-func (r *Binding) AsEnvoyProxy() *EnvoyProxy { // envoy (../../../../../daggerverse/envoy/main.go:626:6)
+func (r *Binding) AsEnvoyProxy() *EnvoyProxy { // envoy (../../../../../daggerverse/envoy/main.go:629:6)
 	q := r.query.Select("asEnvoyProxy")
 
 	return &EnvoyProxy{
@@ -73,7 +73,7 @@ func (r *Binding) AsEnvoyProxy() *EnvoyProxy { // envoy (../../../../../daggerve
 }
 
 // Retrieve the binding value, as type EnvoyRoute
-func (r *Binding) AsEnvoyRoute() *EnvoyRoute { // envoy (../../../../../daggerverse/envoy/main.go:169:6)
+func (r *Binding) AsEnvoyRoute() *EnvoyRoute { // envoy (../../../../../daggerverse/envoy/main.go:170:6)
 	q := r.query.Select("asEnvoyRoute")
 
 	return &EnvoyRoute{
@@ -82,7 +82,7 @@ func (r *Binding) AsEnvoyRoute() *EnvoyRoute { // envoy (../../../../../daggerve
 }
 
 // Retrieve the binding value, as type EnvoyRouteConfig
-func (r *Binding) AsEnvoyRouteConfig() *EnvoyRouteConfig { // envoy (../../../../../daggerverse/envoy/main.go:218:6)
+func (r *Binding) AsEnvoyRouteConfig() *EnvoyRouteConfig { // envoy (../../../../../daggerverse/envoy/main.go:219:6)
 	q := r.query.Select("asEnvoyRouteConfig")
 
 	return &EnvoyRouteConfig{
@@ -100,7 +100,7 @@ func (r *Binding) AsEnvoyServerSecurity() *EnvoyServerSecurity { // envoy (../..
 }
 
 // Retrieve the binding value, as type EnvoyTcpProxy
-func (r *Binding) AsEnvoyTCPProxy() *EnvoyTCPProxy { // envoy (../../../../../daggerverse/envoy/main.go:463:6)
+func (r *Binding) AsEnvoyTCPProxy() *EnvoyTCPProxy { // envoy (../../../../../daggerverse/envoy/main.go:464:6)
 	q := r.query.Select("asEnvoyTcpProxy")
 
 	return &EnvoyTCPProxy{
@@ -118,7 +118,7 @@ func (r *Binding) AsEnvoyUpstreamSecurity() *EnvoyUpstreamSecurity { // envoy (.
 }
 
 // Retrieve the binding value, as type EnvoyVirtualHost
-func (r *Binding) AsEnvoyVirtualHost() *EnvoyVirtualHost { // envoy (../../../../../daggerverse/envoy/main.go:188:6)
+func (r *Binding) AsEnvoyVirtualHost() *EnvoyVirtualHost { // envoy (../../../../../daggerverse/envoy/main.go:189:6)
 	q := r.query.Select("asEnvoyVirtualHost")
 
 	return &EnvoyVirtualHost{
@@ -126,8 +126,17 @@ func (r *Binding) AsEnvoyVirtualHost() *EnvoyVirtualHost { // envoy (../../../..
 	}
 }
 
+// Retrieve the binding value, as type EnvoyXdsResources
+func (r *Binding) AsEnvoyXdsResources() *EnvoyXdsResources { // envoy (../../../../../daggerverse/envoy/xds.go:124:6)
+	q := r.query.Select("asEnvoyXdsResources")
+
+	return &EnvoyXdsResources{
+		query: q,
+	}
+}
+
 // Create or update a binding of type EnvoyCluster in the environment
-func (r *Env) WithEnvoyClusterInput(name string, value *EnvoyCluster, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:94:6)
+func (r *Env) WithEnvoyClusterInput(name string, value *EnvoyCluster, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:95:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withEnvoyClusterInput")
 	q = q.Arg("name", name)
@@ -140,7 +149,7 @@ func (r *Env) WithEnvoyClusterInput(name string, value *EnvoyCluster, descriptio
 }
 
 // Declare a desired EnvoyCluster output to be assigned in the environment
-func (r *Env) WithEnvoyClusterOutput(name string, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:94:6)
+func (r *Env) WithEnvoyClusterOutput(name string, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:95:6)
 	q := r.query.Select("withEnvoyClusterOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -151,7 +160,7 @@ func (r *Env) WithEnvoyClusterOutput(name string, description string) *Env { // 
 }
 
 // Create or update a binding of type EnvoyEndpoint in the environment
-func (r *Env) WithEnvoyEndpointInput(name string, value *EnvoyEndpoint, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:75:6)
+func (r *Env) WithEnvoyEndpointInput(name string, value *EnvoyEndpoint, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:76:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withEnvoyEndpointInput")
 	q = q.Arg("name", name)
@@ -164,7 +173,7 @@ func (r *Env) WithEnvoyEndpointInput(name string, value *EnvoyEndpoint, descript
 }
 
 // Declare a desired EnvoyEndpoint output to be assigned in the environment
-func (r *Env) WithEnvoyEndpointOutput(name string, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:75:6)
+func (r *Env) WithEnvoyEndpointOutput(name string, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:76:6)
 	q := r.query.Select("withEnvoyEndpointOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -175,7 +184,7 @@ func (r *Env) WithEnvoyEndpointOutput(name string, description string) *Env { //
 }
 
 // Create or update a binding of type EnvoyHttpConnectionManager in the environment
-func (r *Env) WithEnvoyHTTPConnectionManagerInput(name string, value *EnvoyHTTPConnectionManager, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:283:6)
+func (r *Env) WithEnvoyHTTPConnectionManagerInput(name string, value *EnvoyHTTPConnectionManager, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:284:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withEnvoyHttpConnectionManagerInput")
 	q = q.Arg("name", name)
@@ -188,7 +197,7 @@ func (r *Env) WithEnvoyHTTPConnectionManagerInput(name string, value *EnvoyHTTPC
 }
 
 // Declare a desired EnvoyHttpConnectionManager output to be assigned in the environment
-func (r *Env) WithEnvoyHTTPConnectionManagerOutput(name string, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:283:6)
+func (r *Env) WithEnvoyHTTPConnectionManagerOutput(name string, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:284:6)
 	q := r.query.Select("withEnvoyHttpConnectionManagerOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -199,7 +208,7 @@ func (r *Env) WithEnvoyHTTPConnectionManagerOutput(name string, description stri
 }
 
 // Create or update a binding of type EnvoyHttpFilter in the environment
-func (r *Env) WithEnvoyHTTPFilterInput(name string, value *EnvoyHTTPFilter, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:243:6)
+func (r *Env) WithEnvoyHTTPFilterInput(name string, value *EnvoyHTTPFilter, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:244:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withEnvoyHttpFilterInput")
 	q = q.Arg("name", name)
@@ -212,7 +221,7 @@ func (r *Env) WithEnvoyHTTPFilterInput(name string, value *EnvoyHTTPFilter, desc
 }
 
 // Declare a desired EnvoyHttpFilter output to be assigned in the environment
-func (r *Env) WithEnvoyHTTPFilterOutput(name string, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:243:6)
+func (r *Env) WithEnvoyHTTPFilterOutput(name string, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:244:6)
 	q := r.query.Select("withEnvoyHttpFilterOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -223,7 +232,7 @@ func (r *Env) WithEnvoyHTTPFilterOutput(name string, description string) *Env { 
 }
 
 // Create or update a binding of type Envoy in the environment
-func (r *Env) WithEnvoyInput(name string, value *Envoy, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:36:6)
+func (r *Env) WithEnvoyInput(name string, value *Envoy, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:37:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withEnvoyInput")
 	q = q.Arg("name", name)
@@ -236,7 +245,7 @@ func (r *Env) WithEnvoyInput(name string, value *Envoy, description string) *Env
 }
 
 // Create or update a binding of type EnvoyListener in the environment
-func (r *Env) WithEnvoyListenerInput(name string, value *EnvoyListener, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:556:6)
+func (r *Env) WithEnvoyListenerInput(name string, value *EnvoyListener, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:557:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withEnvoyListenerInput")
 	q = q.Arg("name", name)
@@ -249,7 +258,7 @@ func (r *Env) WithEnvoyListenerInput(name string, value *EnvoyListener, descript
 }
 
 // Declare a desired EnvoyListener output to be assigned in the environment
-func (r *Env) WithEnvoyListenerOutput(name string, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:556:6)
+func (r *Env) WithEnvoyListenerOutput(name string, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:557:6)
 	q := r.query.Select("withEnvoyListenerOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -260,7 +269,7 @@ func (r *Env) WithEnvoyListenerOutput(name string, description string) *Env { //
 }
 
 // Declare a desired Envoy output to be assigned in the environment
-func (r *Env) WithEnvoyOutput(name string, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:36:6)
+func (r *Env) WithEnvoyOutput(name string, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:37:6)
 	q := r.query.Select("withEnvoyOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -271,7 +280,7 @@ func (r *Env) WithEnvoyOutput(name string, description string) *Env { // envoy (
 }
 
 // Create or update a binding of type EnvoyProxy in the environment
-func (r *Env) WithEnvoyProxyInput(name string, value *EnvoyProxy, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:626:6)
+func (r *Env) WithEnvoyProxyInput(name string, value *EnvoyProxy, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:629:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withEnvoyProxyInput")
 	q = q.Arg("name", name)
@@ -284,7 +293,7 @@ func (r *Env) WithEnvoyProxyInput(name string, value *EnvoyProxy, description st
 }
 
 // Declare a desired EnvoyProxy output to be assigned in the environment
-func (r *Env) WithEnvoyProxyOutput(name string, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:626:6)
+func (r *Env) WithEnvoyProxyOutput(name string, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:629:6)
 	q := r.query.Select("withEnvoyProxyOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -295,7 +304,7 @@ func (r *Env) WithEnvoyProxyOutput(name string, description string) *Env { // en
 }
 
 // Create or update a binding of type EnvoyRouteConfig in the environment
-func (r *Env) WithEnvoyRouteConfigInput(name string, value *EnvoyRouteConfig, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:218:6)
+func (r *Env) WithEnvoyRouteConfigInput(name string, value *EnvoyRouteConfig, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:219:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withEnvoyRouteConfigInput")
 	q = q.Arg("name", name)
@@ -308,7 +317,7 @@ func (r *Env) WithEnvoyRouteConfigInput(name string, value *EnvoyRouteConfig, de
 }
 
 // Declare a desired EnvoyRouteConfig output to be assigned in the environment
-func (r *Env) WithEnvoyRouteConfigOutput(name string, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:218:6)
+func (r *Env) WithEnvoyRouteConfigOutput(name string, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:219:6)
 	q := r.query.Select("withEnvoyRouteConfigOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -319,7 +328,7 @@ func (r *Env) WithEnvoyRouteConfigOutput(name string, description string) *Env {
 }
 
 // Create or update a binding of type EnvoyRoute in the environment
-func (r *Env) WithEnvoyRouteInput(name string, value *EnvoyRoute, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:169:6)
+func (r *Env) WithEnvoyRouteInput(name string, value *EnvoyRoute, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:170:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withEnvoyRouteInput")
 	q = q.Arg("name", name)
@@ -332,7 +341,7 @@ func (r *Env) WithEnvoyRouteInput(name string, value *EnvoyRoute, description st
 }
 
 // Declare a desired EnvoyRoute output to be assigned in the environment
-func (r *Env) WithEnvoyRouteOutput(name string, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:169:6)
+func (r *Env) WithEnvoyRouteOutput(name string, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:170:6)
 	q := r.query.Select("withEnvoyRouteOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -367,7 +376,7 @@ func (r *Env) WithEnvoyServerSecurityOutput(name string, description string) *En
 }
 
 // Create or update a binding of type EnvoyTcpProxy in the environment
-func (r *Env) WithEnvoyTCPProxyInput(name string, value *EnvoyTCPProxy, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:463:6)
+func (r *Env) WithEnvoyTCPProxyInput(name string, value *EnvoyTCPProxy, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:464:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withEnvoyTcpProxyInput")
 	q = q.Arg("name", name)
@@ -380,7 +389,7 @@ func (r *Env) WithEnvoyTCPProxyInput(name string, value *EnvoyTCPProxy, descript
 }
 
 // Declare a desired EnvoyTcpProxy output to be assigned in the environment
-func (r *Env) WithEnvoyTCPProxyOutput(name string, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:463:6)
+func (r *Env) WithEnvoyTCPProxyOutput(name string, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:464:6)
 	q := r.query.Select("withEnvoyTcpProxyOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -415,7 +424,7 @@ func (r *Env) WithEnvoyUpstreamSecurityOutput(name string, description string) *
 }
 
 // Create or update a binding of type EnvoyVirtualHost in the environment
-func (r *Env) WithEnvoyVirtualHostInput(name string, value *EnvoyVirtualHost, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:188:6)
+func (r *Env) WithEnvoyVirtualHostInput(name string, value *EnvoyVirtualHost, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:189:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withEnvoyVirtualHostInput")
 	q = q.Arg("name", name)
@@ -428,8 +437,32 @@ func (r *Env) WithEnvoyVirtualHostInput(name string, value *EnvoyVirtualHost, de
 }
 
 // Declare a desired EnvoyVirtualHost output to be assigned in the environment
-func (r *Env) WithEnvoyVirtualHostOutput(name string, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:188:6)
+func (r *Env) WithEnvoyVirtualHostOutput(name string, description string) *Env { // envoy (../../../../../daggerverse/envoy/main.go:189:6)
 	q := r.query.Select("withEnvoyVirtualHostOutput")
+	q = q.Arg("name", name)
+	q = q.Arg("description", description)
+
+	return &Env{
+		query: q,
+	}
+}
+
+// Create or update a binding of type EnvoyXdsResources in the environment
+func (r *Env) WithEnvoyXdsResourcesInput(name string, value *EnvoyXdsResources, description string) *Env { // envoy (../../../../../daggerverse/envoy/xds.go:124:6)
+	assertNotNil("value", value)
+	q := r.query.Select("withEnvoyXdsResourcesInput")
+	q = q.Arg("name", name)
+	q = q.Arg("value", value)
+	q = q.Arg("description", description)
+
+	return &Env{
+		query: q,
+	}
+}
+
+// Declare a desired EnvoyXdsResources output to be assigned in the environment
+func (r *Env) WithEnvoyXdsResourcesOutput(name string, description string) *Env { // envoy (../../../../../daggerverse/envoy/xds.go:124:6)
+	q := r.query.Select("withEnvoyXdsResourcesOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
 
@@ -440,7 +473,7 @@ func (r *Env) WithEnvoyVirtualHostOutput(name string, description string) *Env {
 
 // Envoy is the top-level builder type. All component factories hang
 // off of it.
-type Envoy struct { // envoy (../../../../../daggerverse/envoy/main.go:36:6)
+type Envoy struct { // envoy (../../../../../daggerverse/envoy/main.go:37:6)
 	query *querybuilder.Selection
 
 	id *ID
@@ -456,16 +489,16 @@ func (r *Envoy) WithGraphQLQuery(q *querybuilder.Selection) *Envoy {
 type EnvoyClusterOpts struct {
 
 	// Default: "STRICT_DNS"
-	ClusterType string // envoy (../../../../../daggerverse/envoy/main.go:123:2)
+	ClusterType string // envoy (../../../../../daggerverse/envoy/main.go:124:2)
 
-	Upstream *EnvoyUpstreamSecurity // envoy (../../../../../daggerverse/envoy/main.go:125:2)
+	Upstream *EnvoyUpstreamSecurity // envoy (../../../../../daggerverse/envoy/main.go:126:2)
 }
 
 // Cluster builds a Cluster optionally configured with upstream
 // TLS / mTLS via an UpstreamSecurity profile. clusterType defaults
 // to "STRICT_DNS"; unknown values return a non-nil error. A nil or
 // plaintext upstream produces the same plaintext cluster as before.
-func (r *Envoy) Cluster(name string, opts ...EnvoyClusterOpts) *EnvoyCluster { // envoy (../../../../../daggerverse/envoy/main.go:119:1)
+func (r *Envoy) Cluster(name string, opts ...EnvoyClusterOpts) *EnvoyCluster { // envoy (../../../../../daggerverse/envoy/main.go:120:1)
 	q := r.query.Select("cluster")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `clusterType` optional argument
@@ -487,7 +520,7 @@ func (r *Envoy) Cluster(name string, opts ...EnvoyClusterOpts) *EnvoyCluster { /
 // CustomHttpFilter builds an HTTP filter whose typed_config body is
 // the caller-supplied YAML, spliced verbatim. yamlBody is validated
 // via yaml.Unmarshal at construction time.
-func (r *Envoy) CustomHTTPFilter(name string, yamlBody string) *EnvoyHTTPFilter { // envoy (../../../../../daggerverse/envoy/main.go:266:1)
+func (r *Envoy) CustomHTTPFilter(name string, yamlBody string) *EnvoyHTTPFilter { // envoy (../../../../../daggerverse/envoy/main.go:267:1)
 	q := r.query.Select("customHttpFilter")
 	q = q.Arg("name", name)
 	q = q.Arg("yamlBody", yamlBody)
@@ -501,7 +534,7 @@ func (r *Envoy) CustomHTTPFilter(name string, yamlBody string) *EnvoyHTTPFilter 
 // YAML, spliced verbatim under static_resources.listeners with `name`
 // keyed in by the builder. The yamlBody must NOT include a top-level
 // `name:` key (the builder splices that from the argument).
-func (r *Envoy) CustomListener(name string, yamlBody string) *EnvoyListener { // envoy (../../../../../daggerverse/envoy/main.go:610:1)
+func (r *Envoy) CustomListener(name string, yamlBody string) *EnvoyListener { // envoy (../../../../../daggerverse/envoy/main.go:611:1)
 	q := r.query.Select("customListener")
 	q = q.Arg("name", name)
 	q = q.Arg("yamlBody", yamlBody)
@@ -513,7 +546,7 @@ func (r *Envoy) CustomListener(name string, yamlBody string) *EnvoyListener { //
 
 // Endpoint builds an Endpoint, validating host (non-empty) and port
 // (1..65535).
-func (r *Envoy) Endpoint(host string, port int) *EnvoyEndpoint { // envoy (../../../../../daggerverse/envoy/main.go:82:1)
+func (r *Envoy) Endpoint(host string, port int) *EnvoyEndpoint { // envoy (../../../../../daggerverse/envoy/main.go:83:1)
 	q := r.query.Select("endpoint")
 	q = q.Arg("host", host)
 	q = q.Arg("port", port)
@@ -524,7 +557,7 @@ func (r *Envoy) Endpoint(host string, port int) *EnvoyEndpoint { // envoy (../..
 }
 
 // HttpConnectionManager builds an HCM bound to routeConfig.
-func (r *Envoy) HTTPConnectionManager(statPrefix string, routeConfig *EnvoyRouteConfig) *EnvoyHTTPConnectionManager { // envoy (../../../../../daggerverse/envoy/main.go:290:1)
+func (r *Envoy) HTTPConnectionManager(statPrefix string, routeConfig *EnvoyRouteConfig) *EnvoyHTTPConnectionManager { // envoy (../../../../../daggerverse/envoy/main.go:291:1)
 	assertNotNil("routeConfig", routeConfig)
 	q := r.query.Select("httpConnectionManager")
 	q = q.Arg("statPrefix", statPrefix)
@@ -539,9 +572,9 @@ func (r *Envoy) HTTPConnectionManager(statPrefix string, routeConfig *EnvoyRoute
 type EnvoyHTTPListenerOpts struct {
 
 	// Default: "0.0.0.0"
-	Address string // envoy (../../../../../daggerverse/envoy/main.go:319:2)
+	Address string // envoy (../../../../../daggerverse/envoy/main.go:320:2)
 
-	Security *EnvoyServerSecurity // envoy (../../../../../daggerverse/envoy/main.go:323:2)
+	Security *EnvoyServerSecurity // envoy (../../../../../daggerverse/envoy/main.go:324:2)
 }
 
 // HttpListener builds an L7 listener bound at address:port whose
@@ -550,7 +583,7 @@ type EnvoyHTTPListenerOpts struct {
 // per-listener server leaf certificate from the supplied CA at
 // factory time and embeds the transport_socket block in the filter
 // chain.
-func (r *Envoy) HTTPListener(name string, port int, hcm *EnvoyHTTPConnectionManager, opts ...EnvoyHTTPListenerOpts) *EnvoyListener { // envoy (../../../../../daggerverse/envoy/main.go:315:1)
+func (r *Envoy) HTTPListener(name string, port int, hcm *EnvoyHTTPConnectionManager, opts ...EnvoyHTTPListenerOpts) *EnvoyListener { // envoy (../../../../../daggerverse/envoy/main.go:316:1)
 	assertNotNil("hcm", hcm)
 	q := r.query.Select("httpListener")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -685,15 +718,15 @@ func (r *Envoy) PlaintextUpstreamSecurity() *EnvoyUpstreamSecurity { // envoy (.
 type EnvoyProxyOpts struct {
 
 	// Default: "docker.io"
-	Registry string // envoy (../../../../../daggerverse/envoy/main.go:645:2)
+	Registry string // envoy (../../../../../daggerverse/envoy/main.go:653:2)
 
 	// Default: "v1.32.1"
-	Tag string // envoy (../../../../../daggerverse/envoy/main.go:647:2)
+	Tag string // envoy (../../../../../daggerverse/envoy/main.go:655:2)
 
 	// Default: 9901
-	AdminPort int // envoy (../../../../../daggerverse/envoy/main.go:649:2)
+	AdminPort int // envoy (../../../../../daggerverse/envoy/main.go:657:2)
 
-	ConfigFile *File // envoy (../../../../../daggerverse/envoy/main.go:651:2)
+	ConfigFile *File // envoy (../../../../../daggerverse/envoy/main.go:659:2)
 }
 
 // Proxy returns a Proxy backed by the envoyproxy/envoy image at
@@ -702,7 +735,7 @@ type EnvoyProxyOpts struct {
 // ignored when an override is set, and listeners added via WithListener
 // are ignored for rendering but still drive container port exposure so
 // callers can expose ports from an override config.
-func (r *Envoy) Proxy(opts ...EnvoyProxyOpts) *EnvoyProxy { // envoy (../../../../../daggerverse/envoy/main.go:643:1)
+func (r *Envoy) Proxy(opts ...EnvoyProxyOpts) *EnvoyProxy { // envoy (../../../../../daggerverse/envoy/main.go:651:1)
 	q := r.query.Select("proxy")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `registry` optional argument
@@ -729,7 +762,7 @@ func (r *Envoy) Proxy(opts ...EnvoyProxyOpts) *EnvoyProxy { // envoy (../../../.
 }
 
 // RouteConfig builds an empty RouteConfig.
-func (r *Envoy) RouteConfig(name string) *EnvoyRouteConfig { // envoy (../../../../../daggerverse/envoy/main.go:224:1)
+func (r *Envoy) RouteConfig(name string) *EnvoyRouteConfig { // envoy (../../../../../daggerverse/envoy/main.go:225:1)
 	q := r.query.Select("routeConfig")
 	q = q.Arg("name", name)
 
@@ -740,7 +773,7 @@ func (r *Envoy) RouteConfig(name string) *EnvoyRouteConfig { // envoy (../../../
 
 // RoutePrefix builds a route matching paths with the given prefix and
 // forwarding to cluster.
-func (r *Envoy) RoutePrefix(prefix string, cluster string) *EnvoyRoute { // envoy (../../../../../daggerverse/envoy/main.go:176:1)
+func (r *Envoy) RoutePrefix(prefix string, cluster string) *EnvoyRoute { // envoy (../../../../../daggerverse/envoy/main.go:177:1)
 	q := r.query.Select("routePrefix")
 	q = q.Arg("prefix", prefix)
 	q = q.Arg("cluster", cluster)
@@ -754,7 +787,7 @@ func (r *Envoy) RoutePrefix(prefix string, cluster string) *EnvoyRoute { // envo
 // filter. Per the Envoy contract this must be the last filter in the
 // http_filters chain; the builder does NOT enforce ordering — Envoy
 // rejects the bootstrap at startup if violated.
-func (r *Envoy) RouterHTTPFilter() *EnvoyHTTPFilter { // envoy (../../../../../daggerverse/envoy/main.go:259:1)
+func (r *Envoy) RouterHTTPFilter() *EnvoyHTTPFilter { // envoy (../../../../../daggerverse/envoy/main.go:260:1)
 	q := r.query.Select("routerHttpFilter")
 
 	return &EnvoyHTTPFilter{
@@ -766,9 +799,9 @@ func (r *Envoy) RouterHTTPFilter() *EnvoyHTTPFilter { // envoy (../../../../../d
 type EnvoyTCPListenerOpts struct {
 
 	// Default: "0.0.0.0"
-	Address string // envoy (../../../../../daggerverse/envoy/main.go:490:2)
+	Address string // envoy (../../../../../daggerverse/envoy/main.go:491:2)
 
-	Security *EnvoyServerSecurity // envoy (../../../../../daggerverse/envoy/main.go:494:2)
+	Security *EnvoyServerSecurity // envoy (../../../../../daggerverse/envoy/main.go:495:2)
 }
 
 // TcpListener builds an L4 listener bound at address:port whose
@@ -776,7 +809,7 @@ type EnvoyTCPListenerOpts struct {
 // union as HttpListener — TLS / mTLS terminates on the listener and
 // the resulting transport_socket lives on the filter chain alongside
 // the tcp_proxy filter.
-func (r *Envoy) TCPListener(name string, port int, proxy *EnvoyTCPProxy, opts ...EnvoyTCPListenerOpts) *EnvoyListener { // envoy (../../../../../daggerverse/envoy/main.go:486:1)
+func (r *Envoy) TCPListener(name string, port int, proxy *EnvoyTCPProxy, opts ...EnvoyTCPListenerOpts) *EnvoyListener { // envoy (../../../../../daggerverse/envoy/main.go:487:1)
 	assertNotNil("proxy", proxy)
 	q := r.query.Select("tcpListener")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -799,7 +832,7 @@ func (r *Envoy) TCPListener(name string, port int, proxy *EnvoyTCPProxy, opts ..
 }
 
 // TcpProxy builds a TcpProxy network filter targeting cluster.
-func (r *Envoy) TCPProxy(statPrefix string, cluster string) *EnvoyTCPProxy { // envoy (../../../../../daggerverse/envoy/main.go:469:1)
+func (r *Envoy) TCPProxy(statPrefix string, cluster string) *EnvoyTCPProxy { // envoy (../../../../../daggerverse/envoy/main.go:470:1)
 	q := r.query.Select("tcpProxy")
 	q = q.Arg("statPrefix", statPrefix)
 	q = q.Arg("cluster", cluster)
@@ -840,12 +873,23 @@ func (r *Envoy) TLSUpstreamSecurity(trustStore *File, trustStorePassword *Secret
 }
 
 // VirtualHost builds an empty VirtualHost.
-func (r *Envoy) VirtualHost(name string, domains []string) *EnvoyVirtualHost { // envoy (../../../../../daggerverse/envoy/main.go:195:1)
+func (r *Envoy) VirtualHost(name string, domains []string) *EnvoyVirtualHost { // envoy (../../../../../daggerverse/envoy/main.go:196:1)
 	q := r.query.Select("virtualHost")
 	q = q.Arg("name", name)
 	q = q.Arg("domains", domains)
 
 	return &EnvoyVirtualHost{
+		query: q,
+	}
+}
+
+// XdsResources returns an empty discovery-resource set. Feed it
+// listeners and clusters, then hand Directory() to
+// (*Proxy).WithDynamicResources.
+func (r *Envoy) XdsResources() *EnvoyXdsResources { // envoy (../../../../../daggerverse/envoy/xds.go:132:1)
+	q := r.query.Select("xdsResources")
+
+	return &EnvoyXdsResources{
 		query: q,
 	}
 }
@@ -860,7 +904,7 @@ func (r *Envoy) AsNode() Node {
 
 // Cluster is a named upstream cluster of Endpoints, optionally
 // configured with TLS / mTLS to the upstream side.
-type EnvoyCluster struct { // envoy (../../../../../daggerverse/envoy/main.go:94:6)
+type EnvoyCluster struct { // envoy (../../../../../daggerverse/envoy/main.go:95:6)
 	query *querybuilder.Selection
 
 	id   *ID
@@ -882,7 +926,7 @@ func (r *EnvoyCluster) WithGraphQLQuery(q *querybuilder.Selection) *EnvoyCluster
 	}
 }
 
-func (r *EnvoyCluster) Endpoints(ctx context.Context) ([]EnvoyEndpoint, error) { // envoy (../../../../../daggerverse/envoy/main.go:97:2)
+func (r *EnvoyCluster) Endpoints(ctx context.Context) ([]EnvoyEndpoint, error) { // envoy (../../../../../daggerverse/envoy/main.go:98:2)
 	q := r.query.Select("endpoints")
 
 	q = q.Select("id")
@@ -963,7 +1007,7 @@ func (r *EnvoyCluster) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
-func (r *EnvoyCluster) Kind(ctx context.Context) (string, error) { // envoy (../../../../../daggerverse/envoy/main.go:96:2)
+func (r *EnvoyCluster) Kind(ctx context.Context) (string, error) { // envoy (../../../../../daggerverse/envoy/main.go:97:2)
 	if r.kind != nil {
 		return *r.kind, nil
 	}
@@ -975,7 +1019,7 @@ func (r *EnvoyCluster) Kind(ctx context.Context) (string, error) { // envoy (../
 	return response, q.Execute(ctx)
 }
 
-func (r *EnvoyCluster) Name(ctx context.Context) (string, error) { // envoy (../../../../../daggerverse/envoy/main.go:95:2)
+func (r *EnvoyCluster) Name(ctx context.Context) (string, error) { // envoy (../../../../../daggerverse/envoy/main.go:96:2)
 	if r.name != nil {
 		return *r.name, nil
 	}
@@ -989,7 +1033,7 @@ func (r *EnvoyCluster) Name(ctx context.Context) (string, error) { // envoy (../
 
 // WithEndpoint appends an Endpoint to the cluster and returns a new
 // cluster value.
-func (r *EnvoyCluster) WithEndpoint(ep *EnvoyEndpoint) *EnvoyCluster { // envoy (../../../../../daggerverse/envoy/main.go:162:1)
+func (r *EnvoyCluster) WithEndpoint(ep *EnvoyEndpoint) *EnvoyCluster { // envoy (../../../../../daggerverse/envoy/main.go:163:1)
 	assertNotNil("ep", ep)
 	q := r.query.Select("withEndpoint")
 	q = q.Arg("ep", ep)
@@ -1009,7 +1053,7 @@ func (r *EnvoyCluster) AsNode() Node {
 
 // Endpoint is a single upstream address (host + port) that a Cluster
 // resolves to.
-type EnvoyEndpoint struct { // envoy (../../../../../daggerverse/envoy/main.go:75:6)
+type EnvoyEndpoint struct { // envoy (../../../../../daggerverse/envoy/main.go:76:6)
 	query *querybuilder.Selection
 
 	host *string
@@ -1023,7 +1067,7 @@ func (r *EnvoyEndpoint) WithGraphQLQuery(q *querybuilder.Selection) *EnvoyEndpoi
 	}
 }
 
-func (r *EnvoyEndpoint) Host(ctx context.Context) (string, error) { // envoy (../../../../../daggerverse/envoy/main.go:76:2)
+func (r *EnvoyEndpoint) Host(ctx context.Context) (string, error) { // envoy (../../../../../daggerverse/envoy/main.go:77:2)
 	if r.host != nil {
 		return *r.host, nil
 	}
@@ -1084,7 +1128,7 @@ func (r *EnvoyEndpoint) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
-func (r *EnvoyEndpoint) Port(ctx context.Context) (int, error) { // envoy (../../../../../daggerverse/envoy/main.go:77:2)
+func (r *EnvoyEndpoint) Port(ctx context.Context) (int, error) { // envoy (../../../../../daggerverse/envoy/main.go:78:2)
 	if r.port != nil {
 		return *r.port, nil
 	}
@@ -1107,7 +1151,7 @@ func (r *EnvoyEndpoint) AsNode() Node {
 // HttpConnectionManager is the L7 network filter that decodes HTTP
 // frames, applies an ordered filter chain, and dispatches to a
 // route_config.
-type EnvoyHTTPConnectionManager struct { // envoy (../../../../../daggerverse/envoy/main.go:283:6)
+type EnvoyHTTPConnectionManager struct { // envoy (../../../../../daggerverse/envoy/main.go:284:6)
 	query *querybuilder.Selection
 
 	id         *ID
@@ -1128,7 +1172,7 @@ func (r *EnvoyHTTPConnectionManager) WithGraphQLQuery(q *querybuilder.Selection)
 	}
 }
 
-func (r *EnvoyHTTPConnectionManager) HTTPFilters(ctx context.Context) ([]EnvoyHTTPFilter, error) { // envoy (../../../../../daggerverse/envoy/main.go:286:2)
+func (r *EnvoyHTTPConnectionManager) HTTPFilters(ctx context.Context) ([]EnvoyHTTPFilter, error) { // envoy (../../../../../daggerverse/envoy/main.go:287:2)
 	q := r.query.Select("httpFilters")
 
 	q = q.Select("id")
@@ -1209,7 +1253,7 @@ func (r *EnvoyHTTPConnectionManager) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
-func (r *EnvoyHTTPConnectionManager) RouteConfig() *EnvoyRouteConfig { // envoy (../../../../../daggerverse/envoy/main.go:285:2)
+func (r *EnvoyHTTPConnectionManager) RouteConfig() *EnvoyRouteConfig { // envoy (../../../../../daggerverse/envoy/main.go:286:2)
 	q := r.query.Select("routeConfig")
 
 	return &EnvoyRouteConfig{
@@ -1217,7 +1261,7 @@ func (r *EnvoyHTTPConnectionManager) RouteConfig() *EnvoyRouteConfig { // envoy 
 	}
 }
 
-func (r *EnvoyHTTPConnectionManager) StatPrefix(ctx context.Context) (string, error) { // envoy (../../../../../daggerverse/envoy/main.go:284:2)
+func (r *EnvoyHTTPConnectionManager) StatPrefix(ctx context.Context) (string, error) { // envoy (../../../../../daggerverse/envoy/main.go:285:2)
 	if r.statPrefix != nil {
 		return *r.statPrefix, nil
 	}
@@ -1230,7 +1274,7 @@ func (r *EnvoyHTTPConnectionManager) StatPrefix(ctx context.Context) (string, er
 }
 
 // WithHttpFilter appends an HTTP filter to the HCM.
-func (r *EnvoyHTTPConnectionManager) WithHTTPFilter(f *EnvoyHTTPFilter) *EnvoyHTTPConnectionManager { // envoy (../../../../../daggerverse/envoy/main.go:301:1)
+func (r *EnvoyHTTPConnectionManager) WithHTTPFilter(f *EnvoyHTTPFilter) *EnvoyHTTPConnectionManager { // envoy (../../../../../daggerverse/envoy/main.go:302:1)
 	assertNotNil("f", f)
 	q := r.query.Select("withHttpFilter")
 	q = q.Arg("f", f)
@@ -1253,7 +1297,7 @@ func (r *EnvoyHTTPConnectionManager) AsNode() Node {
 // filter's `typed_config` map; for the terminal router filter Body
 // is empty (the typed_config has a fixed shape and is filled in at
 // render time).
-type EnvoyHTTPFilter struct { // envoy (../../../../../daggerverse/envoy/main.go:243:6)
+type EnvoyHTTPFilter struct { // envoy (../../../../../daggerverse/envoy/main.go:244:6)
 	query *querybuilder.Selection
 
 	body *string
@@ -1267,7 +1311,7 @@ func (r *EnvoyHTTPFilter) WithGraphQLQuery(q *querybuilder.Selection) *EnvoyHTTP
 	}
 }
 
-func (r *EnvoyHTTPFilter) Body(ctx context.Context) (string, error) { // envoy (../../../../../daggerverse/envoy/main.go:245:2)
+func (r *EnvoyHTTPFilter) Body(ctx context.Context) (string, error) { // envoy (../../../../../daggerverse/envoy/main.go:246:2)
 	if r.body != nil {
 		return *r.body, nil
 	}
@@ -1328,7 +1372,7 @@ func (r *EnvoyHTTPFilter) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
-func (r *EnvoyHTTPFilter) Name(ctx context.Context) (string, error) { // envoy (../../../../../daggerverse/envoy/main.go:244:2)
+func (r *EnvoyHTTPFilter) Name(ctx context.Context) (string, error) { // envoy (../../../../../daggerverse/envoy/main.go:245:2)
 	if r.name != nil {
 		return *r.name, nil
 	}
@@ -1356,7 +1400,7 @@ func (r *EnvoyHTTPFilter) AsNode() Node {
 // (*Proxy).ConfigFile() can validate references against the
 // registered cluster set; it is empty for CustomListener whose body
 // is opaque.
-type EnvoyListener struct { // envoy (../../../../../daggerverse/envoy/main.go:556:6)
+type EnvoyListener struct { // envoy (../../../../../daggerverse/envoy/main.go:557:6)
 	query *querybuilder.Selection
 
 	body *string
@@ -1370,7 +1414,7 @@ func (r *EnvoyListener) WithGraphQLQuery(q *querybuilder.Selection) *EnvoyListen
 	}
 }
 
-func (r *EnvoyListener) Body(ctx context.Context) (string, error) { // envoy (../../../../../daggerverse/envoy/main.go:558:2)
+func (r *EnvoyListener) Body(ctx context.Context) (string, error) { // envoy (../../../../../daggerverse/envoy/main.go:559:2)
 	if r.body != nil {
 		return *r.body, nil
 	}
@@ -1382,7 +1426,7 @@ func (r *EnvoyListener) Body(ctx context.Context) (string, error) { // envoy (..
 	return response, q.Execute(ctx)
 }
 
-func (r *EnvoyListener) ClusterRefs(ctx context.Context) ([]string, error) { // envoy (../../../../../daggerverse/envoy/main.go:559:2)
+func (r *EnvoyListener) ClusterRefs(ctx context.Context) ([]string, error) { // envoy (../../../../../daggerverse/envoy/main.go:560:2)
 	q := r.query.Select("clusterRefs")
 
 	var response []string
@@ -1440,7 +1484,7 @@ func (r *EnvoyListener) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
-func (r *EnvoyListener) Name(ctx context.Context) (string, error) { // envoy (../../../../../daggerverse/envoy/main.go:557:2)
+func (r *EnvoyListener) Name(ctx context.Context) (string, error) { // envoy (../../../../../daggerverse/envoy/main.go:558:2)
 	if r.name != nil {
 		return *r.name, nil
 	}
@@ -1461,8 +1505,10 @@ func (r *EnvoyListener) AsNode() Node {
 }
 
 // Proxy is a running Envoy instance with a composed (or
-// caller-supplied) static-resources bootstrap.
-type EnvoyProxy struct { // envoy (../../../../../daggerverse/envoy/main.go:626:6)
+// caller-supplied) static-resources bootstrap, or — when
+// DynamicResources is set — a file-based xDS bootstrap that
+// discovers its listeners and clusters from a mounted directory.
+type EnvoyProxy struct { // envoy (../../../../../daggerverse/envoy/main.go:629:6)
 	query *querybuilder.Selection
 
 	adminEndpoint    *string
@@ -1488,7 +1534,7 @@ func (r *EnvoyProxy) WithGraphQLQuery(q *querybuilder.Selection) *EnvoyProxy {
 }
 
 // AdminEndpoint returns host:adminPort for the running proxy.
-func (r *EnvoyProxy) AdminEndpoint(ctx context.Context) (string, error) { // envoy (../../../../../daggerverse/envoy/main.go:794:1)
+func (r *EnvoyProxy) AdminEndpoint(ctx context.Context) (string, error) { // envoy (../../../../../daggerverse/envoy/main.go:831:1)
 	if r.adminEndpoint != nil {
 		return *r.adminEndpoint, nil
 	}
@@ -1500,7 +1546,7 @@ func (r *EnvoyProxy) AdminEndpoint(ctx context.Context) (string, error) { // env
 	return response, q.Execute(ctx)
 }
 
-func (r *EnvoyProxy) AdminPort(ctx context.Context) (int, error) { // envoy (../../../../../daggerverse/envoy/main.go:629:2)
+func (r *EnvoyProxy) AdminPort(ctx context.Context) (int, error) { // envoy (../../../../../daggerverse/envoy/main.go:632:2)
 	if r.adminPort != nil {
 		return *r.adminPort, nil
 	}
@@ -1512,7 +1558,7 @@ func (r *EnvoyProxy) AdminPort(ctx context.Context) (int, error) { // envoy (../
 	return response, q.Execute(ctx)
 }
 
-func (r *EnvoyProxy) BindingHosts(ctx context.Context) ([]string, error) { // envoy (../../../../../daggerverse/envoy/main.go:633:2)
+func (r *EnvoyProxy) BindingHosts(ctx context.Context) ([]string, error) { // envoy (../../../../../daggerverse/envoy/main.go:636:2)
 	q := r.query.Select("bindingHosts")
 
 	var response []string
@@ -1521,7 +1567,7 @@ func (r *EnvoyProxy) BindingHosts(ctx context.Context) ([]string, error) { // en
 	return response, q.Execute(ctx)
 }
 
-func (r *EnvoyProxy) BindingSvcs(ctx context.Context) ([]Service, error) { // envoy (../../../../../daggerverse/envoy/main.go:634:2)
+func (r *EnvoyProxy) BindingSvcs(ctx context.Context) ([]Service, error) { // envoy (../../../../../daggerverse/envoy/main.go:637:2)
 	q := r.query.Select("bindingSvcs")
 
 	q = q.Select("id")
@@ -1553,7 +1599,7 @@ func (r *EnvoyProxy) BindingSvcs(ctx context.Context) ([]Service, error) { // en
 	return convert(response), nil
 }
 
-func (r *EnvoyProxy) Clusters(ctx context.Context) ([]EnvoyCluster, error) { // envoy (../../../../../daggerverse/envoy/main.go:632:2)
+func (r *EnvoyProxy) Clusters(ctx context.Context) ([]EnvoyCluster, error) { // envoy (../../../../../daggerverse/envoy/main.go:635:2)
 	q := r.query.Select("clusters")
 
 	q = q.Select("id")
@@ -1586,13 +1632,27 @@ func (r *EnvoyProxy) Clusters(ctx context.Context) ([]EnvoyCluster, error) { // 
 }
 
 // ConfigFile returns the file that will be mounted as Envoy's -c
-// argument: either the caller-supplied override or the rendered
-// bootstrap. Returns a non-nil error if any listener references an
-// unregistered cluster, or if two listeners share a name.
-func (r *EnvoyProxy) ConfigFile() *File { // envoy (../../../../../daggerverse/envoy/main.go:695:1)
+// argument: the caller-supplied override, the rendered
+// static_resources bootstrap, or — when WithDynamicResources was
+// called — the file-based xDS bootstrap. Returns a non-nil error if
+// any listener references an unregistered cluster, if two listeners
+// share a name, or if WithDynamicResources was mixed with any of
+// WithListener / WithCluster / WithConfigFile.
+func (r *EnvoyProxy) ConfigFile() *File { // envoy (../../../../../daggerverse/envoy/main.go:706:1)
 	q := r.query.Select("configFile")
 
 	return &File{
+		query: q,
+	}
+}
+
+// DynamicResources is the file-based xDS discovery-resource
+// directory set via WithDynamicResources. Exclusive with
+// Override / Listeners / Clusters.
+func (r *EnvoyProxy) DynamicResources() *Directory { // envoy (../../../../../daggerverse/envoy/main.go:642:2)
+	q := r.query.Select("dynamicResources")
+
+	return &Directory{
 		query: q,
 	}
 }
@@ -1647,9 +1707,11 @@ func (r *EnvoyProxy) UnmarshalJSON(bs []byte) error {
 }
 
 // ListenerEndpoint returns host:port for the named listener on the
-// running proxy. Returns a non-nil error if no listener matches name
-// or if the listener's body has no recognizable socket_address.port_value.
-func (r *EnvoyProxy) ListenerEndpoint(ctx context.Context, name string) (string, error) { // envoy (../../../../../daggerverse/envoy/main.go:831:1)
+// running proxy — resolved against the registered Listeners, or
+// against the mounted lds.yaml when the proxy runs in file-based xDS
+// mode. Returns a non-nil error if no listener matches name or if the
+// listener has no recognizable socket_address.port_value.
+func (r *EnvoyProxy) ListenerEndpoint(ctx context.Context, name string) (string, error) { // envoy (../../../../../daggerverse/envoy/main.go:870:1)
 	if r.listenerEndpoint != nil {
 		return *r.listenerEndpoint, nil
 	}
@@ -1662,7 +1724,7 @@ func (r *EnvoyProxy) ListenerEndpoint(ctx context.Context, name string) (string,
 	return response, q.Execute(ctx)
 }
 
-func (r *EnvoyProxy) Listeners(ctx context.Context) ([]EnvoyListener, error) { // envoy (../../../../../daggerverse/envoy/main.go:631:2)
+func (r *EnvoyProxy) Listeners(ctx context.Context) ([]EnvoyListener, error) { // envoy (../../../../../daggerverse/envoy/main.go:634:2)
 	q := r.query.Select("listeners")
 
 	q = q.Select("id")
@@ -1694,7 +1756,7 @@ func (r *EnvoyProxy) Listeners(ctx context.Context) ([]EnvoyListener, error) { /
 	return convert(response), nil
 }
 
-func (r *EnvoyProxy) Override() *File { // envoy (../../../../../daggerverse/envoy/main.go:630:2)
+func (r *EnvoyProxy) Override() *File { // envoy (../../../../../daggerverse/envoy/main.go:633:2)
 	q := r.query.Select("override")
 
 	return &File{
@@ -1702,7 +1764,7 @@ func (r *EnvoyProxy) Override() *File { // envoy (../../../../../daggerverse/env
 	}
 }
 
-func (r *EnvoyProxy) Registry(ctx context.Context) (string, error) { // envoy (../../../../../daggerverse/envoy/main.go:627:2)
+func (r *EnvoyProxy) Registry(ctx context.Context) (string, error) { // envoy (../../../../../daggerverse/envoy/main.go:630:2)
 	if r.registry != nil {
 		return *r.registry, nil
 	}
@@ -1715,11 +1777,13 @@ func (r *EnvoyProxy) Registry(ctx context.Context) (string, error) { // envoy (.
 }
 
 // Service returns the running Envoy container. Listens on
-// AdminPort (admin) plus each registered listener's port. When no
-// override and no listeners/clusters are registered, launches with
-// no `-c` flag so the envoy binary exits non-zero — exposed verbatim
-// so callers can detect the misconfig via service-binding probes.
-func (r *EnvoyProxy) Service() *Service { // envoy (../../../../../daggerverse/envoy/main.go:721:1)
+// AdminPort (admin) plus each registered listener's port — read from
+// the mounted lds.yaml when the proxy runs in file-based xDS mode.
+// When no override and no listeners/clusters are registered, launches
+// with no `-c` flag so the envoy binary exits non-zero — exposed
+// verbatim so callers can detect the misconfig via service-binding
+// probes.
+func (r *EnvoyProxy) Service() *Service { // envoy (../../../../../daggerverse/envoy/main.go:748:1)
 	q := r.query.Select("service")
 
 	return &Service{
@@ -1727,7 +1791,7 @@ func (r *EnvoyProxy) Service() *Service { // envoy (../../../../../daggerverse/e
 	}
 }
 
-func (r *EnvoyProxy) Tag(ctx context.Context) (string, error) { // envoy (../../../../../daggerverse/envoy/main.go:628:2)
+func (r *EnvoyProxy) Tag(ctx context.Context) (string, error) { // envoy (../../../../../daggerverse/envoy/main.go:631:2)
 	if r.tag != nil {
 		return *r.tag, nil
 	}
@@ -1740,7 +1804,7 @@ func (r *EnvoyProxy) Tag(ctx context.Context) (string, error) { // envoy (../../
 }
 
 // WithCluster appends a cluster to the proxy.
-func (r *EnvoyProxy) WithCluster(c *EnvoyCluster) *EnvoyProxy { // envoy (../../../../../daggerverse/envoy/main.go:678:1)
+func (r *EnvoyProxy) WithCluster(c *EnvoyCluster) *EnvoyProxy { // envoy (../../../../../daggerverse/envoy/main.go:686:1)
 	assertNotNil("c", c)
 	q := r.query.Select("withCluster")
 	q = q.Arg("c", c)
@@ -1751,7 +1815,7 @@ func (r *EnvoyProxy) WithCluster(c *EnvoyCluster) *EnvoyProxy { // envoy (../../
 }
 
 // WithConfigFile fully replaces the rendered bootstrap.
-func (r *EnvoyProxy) WithConfigFile(f *File) *EnvoyProxy { // envoy (../../../../../daggerverse/envoy/main.go:685:1)
+func (r *EnvoyProxy) WithConfigFile(f *File) *EnvoyProxy { // envoy (../../../../../daggerverse/envoy/main.go:693:1)
 	assertNotNil("f", f)
 	q := r.query.Select("withConfigFile")
 	q = q.Arg("f", f)
@@ -1761,8 +1825,38 @@ func (r *EnvoyProxy) WithConfigFile(f *File) *EnvoyProxy { // envoy (../../../..
 	}
 }
 
+// WithDynamicResources switches the proxy from a rendered
+// static_resources bootstrap to file-based xDS: the bootstrap's
+// dynamic_resources block points lds_config at
+// /etc/envoy/xds/lds.yaml and cds_config at /etc/envoy/xds/cds.yaml,
+// and dir is mounted at /etc/envoy/xds. dir must contain at minimum
+// lds.yaml and cds.yaml, each a v3 discovery response; rds.yaml is
+// loaded only when a listener's HttpConnectionManager references it
+// via an `rds` config source (the bootstrap does not wire RDS
+// itself).
+//
+// This mode is exclusive with WithListener / WithCluster /
+// WithConfigFile: calling both makes ConfigFile() (and therefore
+// Service()) return a non-nil error.
+//
+// Hot reload is NOT exercised. Dagger's WithMountedDirectory is
+// content-addressed and immutable at mount time, so the mounted
+// resource files never change for the lifetime of the container —
+// only Envoy's initial discovery path runs. Callers wanting to test
+// reload semantics need to launch a fresh Proxy per resource
+// snapshot.
+func (r *EnvoyProxy) WithDynamicResources(dir *Directory) *EnvoyProxy { // envoy (../../../../../daggerverse/envoy/xds.go:60:1)
+	assertNotNil("dir", dir)
+	q := r.query.Select("withDynamicResources")
+	q = q.Arg("dir", dir)
+
+	return &EnvoyProxy{
+		query: q,
+	}
+}
+
 // WithListener appends a listener to the proxy.
-func (r *EnvoyProxy) WithListener(l *EnvoyListener) *EnvoyProxy { // envoy (../../../../../daggerverse/envoy/main.go:671:1)
+func (r *EnvoyProxy) WithListener(l *EnvoyListener) *EnvoyProxy { // envoy (../../../../../daggerverse/envoy/main.go:679:1)
 	assertNotNil("l", l)
 	q := r.query.Select("withListener")
 	q = q.Arg("l", l)
@@ -1774,7 +1868,7 @@ func (r *EnvoyProxy) WithListener(l *EnvoyListener) *EnvoyProxy { // envoy (../.
 
 // WithServiceBinding binds an upstream service into Envoy's network
 // so cluster endpoints can reach it by hostname.
-func (r *EnvoyProxy) WithServiceBinding(host string, svc *Service) *EnvoyProxy { // envoy (../../../../../daggerverse/envoy/main.go:663:1)
+func (r *EnvoyProxy) WithServiceBinding(host string, svc *Service) *EnvoyProxy { // envoy (../../../../../daggerverse/envoy/main.go:671:1)
 	assertNotNil("svc", svc)
 	q := r.query.Select("withServiceBinding")
 	q = q.Arg("host", host)
@@ -1794,7 +1888,7 @@ func (r *EnvoyProxy) AsNode() Node {
 }
 
 // Route is a single HTTP route (prefix match → cluster).
-type EnvoyRoute struct { // envoy (../../../../../daggerverse/envoy/main.go:169:6)
+type EnvoyRoute struct { // envoy (../../../../../daggerverse/envoy/main.go:170:6)
 	query *querybuilder.Selection
 
 	cluster *string
@@ -1808,7 +1902,7 @@ func (r *EnvoyRoute) WithGraphQLQuery(q *querybuilder.Selection) *EnvoyRoute {
 	}
 }
 
-func (r *EnvoyRoute) Cluster(ctx context.Context) (string, error) { // envoy (../../../../../daggerverse/envoy/main.go:171:2)
+func (r *EnvoyRoute) Cluster(ctx context.Context) (string, error) { // envoy (../../../../../daggerverse/envoy/main.go:172:2)
 	if r.cluster != nil {
 		return *r.cluster, nil
 	}
@@ -1869,7 +1963,7 @@ func (r *EnvoyRoute) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
-func (r *EnvoyRoute) Prefix(ctx context.Context) (string, error) { // envoy (../../../../../daggerverse/envoy/main.go:170:2)
+func (r *EnvoyRoute) Prefix(ctx context.Context) (string, error) { // envoy (../../../../../daggerverse/envoy/main.go:171:2)
 	if r.prefix != nil {
 		return *r.prefix, nil
 	}
@@ -1890,7 +1984,7 @@ func (r *EnvoyRoute) AsNode() Node {
 }
 
 // RouteConfig is a named route configuration (a set of virtual hosts).
-type EnvoyRouteConfig struct { // envoy (../../../../../daggerverse/envoy/main.go:218:6)
+type EnvoyRouteConfig struct { // envoy (../../../../../daggerverse/envoy/main.go:219:6)
 	query *querybuilder.Selection
 
 	id   *ID
@@ -1960,7 +2054,7 @@ func (r *EnvoyRouteConfig) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
-func (r *EnvoyRouteConfig) Name(ctx context.Context) (string, error) { // envoy (../../../../../daggerverse/envoy/main.go:219:2)
+func (r *EnvoyRouteConfig) Name(ctx context.Context) (string, error) { // envoy (../../../../../daggerverse/envoy/main.go:220:2)
 	if r.name != nil {
 		return *r.name, nil
 	}
@@ -1972,7 +2066,7 @@ func (r *EnvoyRouteConfig) Name(ctx context.Context) (string, error) { // envoy 
 	return response, q.Execute(ctx)
 }
 
-func (r *EnvoyRouteConfig) VirtualHosts(ctx context.Context) ([]EnvoyVirtualHost, error) { // envoy (../../../../../daggerverse/envoy/main.go:220:2)
+func (r *EnvoyRouteConfig) VirtualHosts(ctx context.Context) ([]EnvoyVirtualHost, error) { // envoy (../../../../../daggerverse/envoy/main.go:221:2)
 	q := r.query.Select("virtualHosts")
 
 	q = q.Select("id")
@@ -2005,7 +2099,7 @@ func (r *EnvoyRouteConfig) VirtualHosts(ctx context.Context) ([]EnvoyVirtualHost
 }
 
 // WithVirtualHost appends a VirtualHost to the route config.
-func (r *EnvoyRouteConfig) WithVirtualHost(v *EnvoyVirtualHost) *EnvoyRouteConfig { // envoy (../../../../../daggerverse/envoy/main.go:232:1)
+func (r *EnvoyRouteConfig) WithVirtualHost(v *EnvoyVirtualHost) *EnvoyRouteConfig { // envoy (../../../../../daggerverse/envoy/main.go:233:1)
 	assertNotNil("v", v)
 	q := r.query.Select("withVirtualHost")
 	q = q.Arg("v", v)
@@ -2098,7 +2192,7 @@ func (r *EnvoyServerSecurity) AsNode() Node {
 
 // TcpProxy is the network-level filter that forwards bytes from a
 // TcpListener to a single cluster.
-type EnvoyTCPProxy struct { // envoy (../../../../../daggerverse/envoy/main.go:463:6)
+type EnvoyTCPProxy struct { // envoy (../../../../../daggerverse/envoy/main.go:464:6)
 	query *querybuilder.Selection
 
 	cluster    *string
@@ -2112,7 +2206,7 @@ func (r *EnvoyTCPProxy) WithGraphQLQuery(q *querybuilder.Selection) *EnvoyTCPPro
 	}
 }
 
-func (r *EnvoyTCPProxy) Cluster(ctx context.Context) (string, error) { // envoy (../../../../../daggerverse/envoy/main.go:465:2)
+func (r *EnvoyTCPProxy) Cluster(ctx context.Context) (string, error) { // envoy (../../../../../daggerverse/envoy/main.go:466:2)
 	if r.cluster != nil {
 		return *r.cluster, nil
 	}
@@ -2173,7 +2267,7 @@ func (r *EnvoyTCPProxy) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
-func (r *EnvoyTCPProxy) StatPrefix(ctx context.Context) (string, error) { // envoy (../../../../../daggerverse/envoy/main.go:464:2)
+func (r *EnvoyTCPProxy) StatPrefix(ctx context.Context) (string, error) { // envoy (../../../../../daggerverse/envoy/main.go:465:2)
 	if r.statPrefix != nil {
 		return *r.statPrefix, nil
 	}
@@ -2268,7 +2362,7 @@ func (r *EnvoyUpstreamSecurity) AsNode() Node {
 
 // VirtualHost is a named virtual host with a domain list and an
 // ordered set of routes.
-type EnvoyVirtualHost struct { // envoy (../../../../../daggerverse/envoy/main.go:188:6)
+type EnvoyVirtualHost struct { // envoy (../../../../../daggerverse/envoy/main.go:189:6)
 	query *querybuilder.Selection
 
 	id   *ID
@@ -2289,7 +2383,7 @@ func (r *EnvoyVirtualHost) WithGraphQLQuery(q *querybuilder.Selection) *EnvoyVir
 	}
 }
 
-func (r *EnvoyVirtualHost) Domains(ctx context.Context) ([]string, error) { // envoy (../../../../../daggerverse/envoy/main.go:190:2)
+func (r *EnvoyVirtualHost) Domains(ctx context.Context) ([]string, error) { // envoy (../../../../../daggerverse/envoy/main.go:191:2)
 	q := r.query.Select("domains")
 
 	var response []string
@@ -2347,7 +2441,7 @@ func (r *EnvoyVirtualHost) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
-func (r *EnvoyVirtualHost) Name(ctx context.Context) (string, error) { // envoy (../../../../../daggerverse/envoy/main.go:189:2)
+func (r *EnvoyVirtualHost) Name(ctx context.Context) (string, error) { // envoy (../../../../../daggerverse/envoy/main.go:190:2)
 	if r.name != nil {
 		return *r.name, nil
 	}
@@ -2359,7 +2453,7 @@ func (r *EnvoyVirtualHost) Name(ctx context.Context) (string, error) { // envoy 
 	return response, q.Execute(ctx)
 }
 
-func (r *EnvoyVirtualHost) Routes(ctx context.Context) ([]EnvoyRoute, error) { // envoy (../../../../../daggerverse/envoy/main.go:191:2)
+func (r *EnvoyVirtualHost) Routes(ctx context.Context) ([]EnvoyRoute, error) { // envoy (../../../../../daggerverse/envoy/main.go:192:2)
 	q := r.query.Select("routes")
 
 	q = q.Select("id")
@@ -2392,7 +2486,7 @@ func (r *EnvoyVirtualHost) Routes(ctx context.Context) ([]EnvoyRoute, error) { /
 }
 
 // WithRoute appends a route to the virtual host.
-func (r *EnvoyVirtualHost) WithRoute(route *EnvoyRoute) *EnvoyVirtualHost { // envoy (../../../../../daggerverse/envoy/main.go:211:1)
+func (r *EnvoyVirtualHost) WithRoute(route *EnvoyRoute) *EnvoyVirtualHost { // envoy (../../../../../daggerverse/envoy/main.go:212:1)
 	assertNotNil("route", route)
 	q := r.query.Select("withRoute")
 	q = q.Arg("route", route)
@@ -2410,9 +2504,203 @@ func (r *EnvoyVirtualHost) AsNode() Node {
 	}
 }
 
+// XdsResources composes the same v1 component types the static
+// builders take (Listener, Cluster) into the discovery-resource files
+// a file-based xDS Proxy consumes. Composition mirrors Proxy: WithX
+// methods return shallow copies.
+type EnvoyXdsResources struct { // envoy (../../../../../daggerverse/envoy/xds.go:124:6)
+	query *querybuilder.Selection
+
+	id *ID
+}
+type WithEnvoyXdsResourcesFunc func(r *EnvoyXdsResources) *EnvoyXdsResources
+
+// With calls the provided function with current EnvoyXdsResources.
+//
+// This is useful for reusability and readability by not breaking the calling chain.
+func (r *EnvoyXdsResources) With(f WithEnvoyXdsResourcesFunc) *EnvoyXdsResources {
+	return f(r)
+}
+
+func (r *EnvoyXdsResources) WithGraphQLQuery(q *querybuilder.Selection) *EnvoyXdsResources {
+	return &EnvoyXdsResources{
+		query: q,
+	}
+}
+
+func (r *EnvoyXdsResources) Clusters(ctx context.Context) ([]EnvoyCluster, error) { // envoy (../../../../../daggerverse/envoy/xds.go:126:2)
+	q := r.query.Select("clusters")
+
+	q = q.Select("id")
+
+	type clusters struct {
+		Id ID
+	}
+
+	convert := func(fields []clusters) []EnvoyCluster {
+		out := []EnvoyCluster{}
+
+		for i := range fields {
+			val := EnvoyCluster{id: &fields[i].Id}
+			val.query = selectNode(q.Root(), fields[i].Id, "EnvoyCluster")
+			out = append(out, val)
+		}
+
+		return out
+	}
+	var response []clusters
+
+	q = q.Bind(&response)
+
+	err := q.Execute(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return convert(response), nil
+}
+
+// Directory renders lds.yaml and cds.yaml — v3 discovery responses
+// carrying the registered listeners and clusters — into a directory
+// suitable for (*Proxy).WithDynamicResources. Each resource is
+// structurally identical to the static_resources entry the same
+// component produces in static mode, plus the `@type` discriminator
+// the discovery response requires.
+//
+// Route configurations stay inline in each listener's
+// HttpConnectionManager, so no rds.yaml is emitted: the v1 builders
+// have no way to express an RDS config source. Callers who need RDS
+// bring their own directory containing rds.yaml plus listeners that
+// reference it.
+//
+// Returns a non-nil error under the same conditions as
+// (*Proxy).ConfigFile() — a listener referencing a cluster that isn't
+// registered here, or two listeners sharing a name — and also when
+// any component carries TLS / mTLS security, whose key material only
+// (*Proxy).Service() can mount and which the Proxy cannot see through
+// an opaque resource directory.
+func (r *EnvoyXdsResources) Directory() *Directory { // envoy (../../../../../daggerverse/envoy/xds.go:169:1)
+	q := r.query.Select("directory")
+
+	return &Directory{
+		query: q,
+	}
+}
+
+// A unique identifier for this EnvoyXdsResources.
+func (r *EnvoyXdsResources) ID(ctx context.Context) (ID, error) {
+	if r.id != nil {
+		return *r.id, nil
+	}
+	q := r.query.Select("id")
+
+	var response ID
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// XXX_GraphQLType is an internal function. It returns the native GraphQL type name
+func (r *EnvoyXdsResources) XXX_GraphQLType() string {
+	return "EnvoyXdsResources"
+}
+
+// XXX_GraphQLIDType is an internal function. It returns the native GraphQL type name for the ID of this object
+func (r *EnvoyXdsResources) XXX_GraphQLIDType() string {
+	return "ID"
+}
+
+// XXX_GraphQLID is an internal function. It returns the underlying type ID
+func (r *EnvoyXdsResources) XXX_GraphQLID(ctx context.Context) (string, error) {
+	id, err := r.ID(ctx)
+	if err != nil {
+		return "", err
+	}
+	return string(id), nil
+}
+
+func (r *EnvoyXdsResources) MarshalJSON() ([]byte, error) {
+	id, err := r.ID(marshalCtx)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(id)
+}
+func (r *EnvoyXdsResources) UnmarshalJSON(bs []byte) error {
+	var id string
+	err := json.Unmarshal(bs, &id)
+	if err != nil {
+		return err
+	}
+	*r = EnvoyXdsResources{query: selectNode(dag.query, id, "EnvoyXdsResources")}
+	return nil
+}
+
+func (r *EnvoyXdsResources) Listeners(ctx context.Context) ([]EnvoyListener, error) { // envoy (../../../../../daggerverse/envoy/xds.go:125:2)
+	q := r.query.Select("listeners")
+
+	q = q.Select("id")
+
+	type listeners struct {
+		Id ID
+	}
+
+	convert := func(fields []listeners) []EnvoyListener {
+		out := []EnvoyListener{}
+
+		for i := range fields {
+			val := EnvoyListener{id: &fields[i].Id}
+			val.query = selectNode(q.Root(), fields[i].Id, "EnvoyListener")
+			out = append(out, val)
+		}
+
+		return out
+	}
+	var response []listeners
+
+	q = q.Bind(&response)
+
+	err := q.Execute(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return convert(response), nil
+}
+
+// WithCluster appends a cluster to the CDS resource set.
+func (r *EnvoyXdsResources) WithCluster(c *EnvoyCluster) *EnvoyXdsResources { // envoy (../../../../../daggerverse/envoy/xds.go:144:1)
+	assertNotNil("c", c)
+	q := r.query.Select("withCluster")
+	q = q.Arg("c", c)
+
+	return &EnvoyXdsResources{
+		query: q,
+	}
+}
+
+// WithListener appends a listener to the LDS resource set.
+func (r *EnvoyXdsResources) WithListener(l *EnvoyListener) *EnvoyXdsResources { // envoy (../../../../../daggerverse/envoy/xds.go:137:1)
+	assertNotNil("l", l)
+	q := r.query.Select("withListener")
+	q = q.Arg("l", l)
+
+	return &EnvoyXdsResources{
+		query: q,
+	}
+}
+
+// AsNode returns this EnvoyXdsResources as a Node.
+// This is a local type conversion — no GraphQL call.
+func (r *EnvoyXdsResources) AsNode() Node {
+	return &NodeClient{
+		query: r.query,
+	}
+}
+
 // Envoy is the top-level builder type. All component factories hang
 // off of it.
-func (r *Query) Envoy() *Envoy { // envoy (../../../../../daggerverse/envoy/main.go:36:6)
+func (r *Query) Envoy() *Envoy { // envoy (../../../../../daggerverse/envoy/main.go:37:6)
 	q := r.query.Select("envoy")
 
 	return &Envoy{

--- a/daggerverse/envoy/tests/internal/dagger/envoy.gen.go
+++ b/daggerverse/envoy/tests/internal/dagger/envoy.gen.go
@@ -127,7 +127,7 @@ func (r *Binding) AsEnvoyVirtualHost() *EnvoyVirtualHost { // envoy (../../../..
 }
 
 // Retrieve the binding value, as type EnvoyXdsResources
-func (r *Binding) AsEnvoyXdsResources() *EnvoyXdsResources { // envoy (../../../../../daggerverse/envoy/xds.go:124:6)
+func (r *Binding) AsEnvoyXdsResources() *EnvoyXdsResources { // envoy (../../../../../daggerverse/envoy/xds.go:128:6)
 	q := r.query.Select("asEnvoyXdsResources")
 
 	return &EnvoyXdsResources{
@@ -448,7 +448,7 @@ func (r *Env) WithEnvoyVirtualHostOutput(name string, description string) *Env {
 }
 
 // Create or update a binding of type EnvoyXdsResources in the environment
-func (r *Env) WithEnvoyXdsResourcesInput(name string, value *EnvoyXdsResources, description string) *Env { // envoy (../../../../../daggerverse/envoy/xds.go:124:6)
+func (r *Env) WithEnvoyXdsResourcesInput(name string, value *EnvoyXdsResources, description string) *Env { // envoy (../../../../../daggerverse/envoy/xds.go:128:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withEnvoyXdsResourcesInput")
 	q = q.Arg("name", name)
@@ -461,7 +461,7 @@ func (r *Env) WithEnvoyXdsResourcesInput(name string, value *EnvoyXdsResources, 
 }
 
 // Declare a desired EnvoyXdsResources output to be assigned in the environment
-func (r *Env) WithEnvoyXdsResourcesOutput(name string, description string) *Env { // envoy (../../../../../daggerverse/envoy/xds.go:124:6)
+func (r *Env) WithEnvoyXdsResourcesOutput(name string, description string) *Env { // envoy (../../../../../daggerverse/envoy/xds.go:128:6)
 	q := r.query.Select("withEnvoyXdsResourcesOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -886,7 +886,7 @@ func (r *Envoy) VirtualHost(name string, domains []string) *EnvoyVirtualHost { /
 // XdsResources returns an empty discovery-resource set. Feed it
 // listeners and clusters, then hand Directory() to
 // (*Proxy).WithDynamicResources.
-func (r *Envoy) XdsResources() *EnvoyXdsResources { // envoy (../../../../../daggerverse/envoy/xds.go:132:1)
+func (r *Envoy) XdsResources() *EnvoyXdsResources { // envoy (../../../../../daggerverse/envoy/xds.go:136:1)
 	q := r.query.Select("xdsResources")
 
 	return &EnvoyXdsResources{
@@ -1845,7 +1845,7 @@ func (r *EnvoyProxy) WithConfigFile(f *File) *EnvoyProxy { // envoy (../../../..
 // only Envoy's initial discovery path runs. Callers wanting to test
 // reload semantics need to launch a fresh Proxy per resource
 // snapshot.
-func (r *EnvoyProxy) WithDynamicResources(dir *Directory) *EnvoyProxy { // envoy (../../../../../daggerverse/envoy/xds.go:60:1)
+func (r *EnvoyProxy) WithDynamicResources(dir *Directory) *EnvoyProxy { // envoy (../../../../../daggerverse/envoy/xds.go:64:1)
 	assertNotNil("dir", dir)
 	q := r.query.Select("withDynamicResources")
 	q = q.Arg("dir", dir)
@@ -2508,7 +2508,7 @@ func (r *EnvoyVirtualHost) AsNode() Node {
 // builders take (Listener, Cluster) into the discovery-resource files
 // a file-based xDS Proxy consumes. Composition mirrors Proxy: WithX
 // methods return shallow copies.
-type EnvoyXdsResources struct { // envoy (../../../../../daggerverse/envoy/xds.go:124:6)
+type EnvoyXdsResources struct { // envoy (../../../../../daggerverse/envoy/xds.go:128:6)
 	query *querybuilder.Selection
 
 	id *ID
@@ -2528,7 +2528,7 @@ func (r *EnvoyXdsResources) WithGraphQLQuery(q *querybuilder.Selection) *EnvoyXd
 	}
 }
 
-func (r *EnvoyXdsResources) Clusters(ctx context.Context) ([]EnvoyCluster, error) { // envoy (../../../../../daggerverse/envoy/xds.go:126:2)
+func (r *EnvoyXdsResources) Clusters(ctx context.Context) ([]EnvoyCluster, error) { // envoy (../../../../../daggerverse/envoy/xds.go:130:2)
 	q := r.query.Select("clusters")
 
 	q = q.Select("id")
@@ -2579,7 +2579,7 @@ func (r *EnvoyXdsResources) Clusters(ctx context.Context) ([]EnvoyCluster, error
 // any component carries TLS / mTLS security, whose key material only
 // (*Proxy).Service() can mount and which the Proxy cannot see through
 // an opaque resource directory.
-func (r *EnvoyXdsResources) Directory() *Directory { // envoy (../../../../../daggerverse/envoy/xds.go:169:1)
+func (r *EnvoyXdsResources) Directory() *Directory { // envoy (../../../../../daggerverse/envoy/xds.go:173:1)
 	q := r.query.Select("directory")
 
 	return &Directory{
@@ -2636,7 +2636,7 @@ func (r *EnvoyXdsResources) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
-func (r *EnvoyXdsResources) Listeners(ctx context.Context) ([]EnvoyListener, error) { // envoy (../../../../../daggerverse/envoy/xds.go:125:2)
+func (r *EnvoyXdsResources) Listeners(ctx context.Context) ([]EnvoyListener, error) { // envoy (../../../../../daggerverse/envoy/xds.go:129:2)
 	q := r.query.Select("listeners")
 
 	q = q.Select("id")
@@ -2669,7 +2669,7 @@ func (r *EnvoyXdsResources) Listeners(ctx context.Context) ([]EnvoyListener, err
 }
 
 // WithCluster appends a cluster to the CDS resource set.
-func (r *EnvoyXdsResources) WithCluster(c *EnvoyCluster) *EnvoyXdsResources { // envoy (../../../../../daggerverse/envoy/xds.go:144:1)
+func (r *EnvoyXdsResources) WithCluster(c *EnvoyCluster) *EnvoyXdsResources { // envoy (../../../../../daggerverse/envoy/xds.go:148:1)
 	assertNotNil("c", c)
 	q := r.query.Select("withCluster")
 	q = q.Arg("c", c)
@@ -2680,7 +2680,7 @@ func (r *EnvoyXdsResources) WithCluster(c *EnvoyCluster) *EnvoyXdsResources { //
 }
 
 // WithListener appends a listener to the LDS resource set.
-func (r *EnvoyXdsResources) WithListener(l *EnvoyListener) *EnvoyXdsResources { // envoy (../../../../../daggerverse/envoy/xds.go:137:1)
+func (r *EnvoyXdsResources) WithListener(l *EnvoyListener) *EnvoyXdsResources { // envoy (../../../../../daggerverse/envoy/xds.go:141:1)
 	assertNotNil("l", l)
 	q := r.query.Select("withListener")
 	q = q.Arg("l", l)

--- a/daggerverse/envoy/tests/main.go
+++ b/daggerverse/envoy/tests/main.go
@@ -77,6 +77,12 @@ func (t *Tests) Validation(
 	jobs = jobs.WithJob("TlsUpstreamSecurityRendersUpstreamTlsContext", t.TlsUpstreamSecurityRendersUpstreamTlsContext)
 	jobs = jobs.WithJob("MtlsUpstreamSecurityIncludesClientLeaf", t.MtlsUpstreamSecurityIncludesClientLeaf)
 	jobs = jobs.WithJob("PlaintextUpstreamSecurityRendersNoTransportSocket", t.PlaintextUpstreamSecurityRendersNoTransportSocket)
+	jobs = jobs.WithJob("DynamicResourcesRendersDynamicBootstrap", t.DynamicResourcesRendersDynamicBootstrap)
+	jobs = jobs.WithJob("DynamicResourcesConflictsWithStatic", t.DynamicResourcesConflictsWithStatic)
+	jobs = jobs.WithJob("DynamicResourcesRequiresLdsAndCds", t.DynamicResourcesRequiresLdsAndCds)
+	jobs = jobs.WithJob("XdsResourcesMatchStaticResources", t.XdsResourcesMatchStaticResources)
+	jobs = jobs.WithJob("XdsResourcesRejectsInvalidResourceSet", t.XdsResourcesRejectsInvalidResourceSet)
+	jobs = jobs.WithJob("XdsResourcesRejectsSecureComponents", t.XdsResourcesRejectsSecureComponents)
 	return jobs.Run(ctx)
 }
 
@@ -150,6 +156,12 @@ func (t *Tests) RoundTrips(
 	})
 	jobs = jobs.WithJob("L4TcpTlsRoundTrip", func(ctx context.Context) error {
 		return t.L4TcpTlsRoundTrip(ctx, envoyTag)
+	})
+	jobs = jobs.WithJob("L7HttpXdsRoundTrip", func(ctx context.Context) error {
+		return t.L7HttpXdsRoundTrip(ctx, envoyTag)
+	})
+	jobs = jobs.WithJob("L4TcpXdsRoundTrip", func(ctx context.Context) error {
+		return t.L4TcpXdsRoundTrip(ctx, envoyTag)
 	})
 	return jobs.Run(ctx)
 }

--- a/daggerverse/envoy/tests/xds.go
+++ b/daggerverse/envoy/tests/xds.go
@@ -1,0 +1,411 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"dagger/tests/internal/dagger"
+
+	"gopkg.in/yaml.v3"
+)
+
+// DynamicResourcesRendersDynamicBootstrap asserts WithDynamicResources
+// renders a bootstrap whose dynamic_resources block points lds/cds at
+// the mounted xds directory and which carries no static_resources.
+func (t *Tests) DynamicResourcesRendersDynamicBootstrap(ctx context.Context) error {
+	xds := dag.Directory().
+		WithNewFile("lds.yaml", "resources: []\n").
+		WithNewFile("cds.yaml", "resources: []\n")
+	contents, err := dag.Envoy().Proxy().
+		WithDynamicResources(xds).
+		ConfigFile().
+		Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("ConfigFile().Contents: %w", err)
+	}
+	var cfg struct {
+		StaticResources map[string]any `yaml:"static_resources"`
+		Admin           struct {
+			Address struct {
+				SocketAddress struct {
+					PortValue int `yaml:"port_value"`
+				} `yaml:"socket_address"`
+			} `yaml:"address"`
+		} `yaml:"admin"`
+		DynamicResources struct {
+			LdsConfig struct {
+				PathConfigSource struct {
+					Path string `yaml:"path"`
+				} `yaml:"path_config_source"`
+				ResourceAPIVersion string `yaml:"resource_api_version"`
+			} `yaml:"lds_config"`
+			CdsConfig struct {
+				PathConfigSource struct {
+					Path string `yaml:"path"`
+				} `yaml:"path_config_source"`
+				ResourceAPIVersion string `yaml:"resource_api_version"`
+			} `yaml:"cds_config"`
+		} `yaml:"dynamic_resources"`
+	}
+	if err := yaml.Unmarshal([]byte(contents), &cfg); err != nil {
+		return fmt.Errorf("parse bootstrap yaml: %w\n---\n%s", err, contents)
+	}
+	if cfg.StaticResources != nil {
+		return fmt.Errorf("expected no static_resources in dynamic bootstrap, got %v\n---\n%s", cfg.StaticResources, contents)
+	}
+	if got := cfg.Admin.Address.SocketAddress.PortValue; got != defaultAdmin {
+		return fmt.Errorf("expected admin port %d, got %d\n---\n%s", defaultAdmin, got, contents)
+	}
+	dyn := cfg.DynamicResources
+	if got := dyn.LdsConfig.PathConfigSource.Path; got != "/etc/envoy/xds/lds.yaml" {
+		return fmt.Errorf("expected lds_config path /etc/envoy/xds/lds.yaml, got %q\n---\n%s", got, contents)
+	}
+	if got := dyn.CdsConfig.PathConfigSource.Path; got != "/etc/envoy/xds/cds.yaml" {
+		return fmt.Errorf("expected cds_config path /etc/envoy/xds/cds.yaml, got %q\n---\n%s", got, contents)
+	}
+	for name, got := range map[string]string{
+		"lds_config": dyn.LdsConfig.ResourceAPIVersion,
+		"cds_config": dyn.CdsConfig.ResourceAPIVersion,
+	} {
+		if got != "V3" {
+			return fmt.Errorf("expected %s.resource_api_version == V3, got %q\n---\n%s", name, got, contents)
+		}
+	}
+	return nil
+}
+
+// L7HttpXdsRoundTrip stands up an HTTP upstream behind an Envoy
+// proxy whose listeners and clusters arrive over file-based xDS
+// rather than static_resources, and asserts a request through Envoy
+// returns a fresh random marker served by the upstream.
+func (t *Tests) L7HttpXdsRoundTrip(
+	ctx context.Context,
+	// +default="v1.32.1"
+	envoyTag string,
+) error {
+	mark, err := marker(ctx)
+	if err != nil {
+		return err
+	}
+	upstream := pythonHttpUpstream(mark, 5678)
+
+	e := dag.Envoy()
+	rc := e.RouteConfig("rc").WithVirtualHost(
+		e.VirtualHost("vh", []string{"*"}).WithRoute(e.RoutePrefix("/", "upstream")),
+	)
+	hcm := e.HTTPConnectionManager("ingress", rc).WithHTTPFilter(e.RouterHTTPFilter())
+	resources := e.XdsResources().
+		WithListener(e.HTTPListener("http", 18080, hcm)).
+		WithCluster(e.Cluster("upstream").WithEndpoint(e.Endpoint("upstream", 5678)))
+
+	svc := e.Proxy(proxyOpts(envoyTag)).
+		WithServiceBinding("upstream", upstream).
+		WithDynamicResources(resources.Directory()).
+		Service()
+
+	_, err = dag.Container().From(curlImage).
+		WithServiceBinding("envoy", svc).
+		WithEnvVariable("MARKER", mark).
+		WithExec([]string{"sh", "-c", `
+set -eu
+for i in $(seq 1 60); do
+  BODY=$(curl -sS http://envoy:18080/ || true)
+  case "${BODY}" in *"${MARKER}"*) echo "marker observed after ${i}s"; exit 0 ;; esac
+  sleep 1
+done
+echo "marker ${MARKER} never appeared in envoy response" >&2
+echo "last body: ${BODY}" >&2
+exit 1
+`}).
+		Sync(ctx)
+	if err != nil {
+		return fmt.Errorf("L7 xDS round-trip: %w", err)
+	}
+	return nil
+}
+
+// L4TcpXdsRoundTrip stands up an alpine `nc` echo upstream behind an
+// Envoy TcpListener delivered over file-based xDS and asserts bytes
+// sent through Envoy come back on the same TCP connection. Also
+// asserts ListenerEndpoint resolves the listener's port out of the
+// mounted lds.yaml, since no Listener is registered on the Proxy in
+// this mode.
+func (t *Tests) L4TcpXdsRoundTrip(
+	ctx context.Context,
+	// +default="v1.32.1"
+	envoyTag string,
+) error {
+	mark, err := marker(ctx)
+	if err != nil {
+		return err
+	}
+	upstream := dag.Container().From(probeImage).
+		WithExec([]string{"apk", "add", "--no-cache", "busybox-extras"}).
+		WithExposedPort(5000).
+		AsService(dagger.ContainerAsServiceOpts{
+			Args: []string{"sh", "-c", "while true; do nc -l -p 5000 -e /bin/cat; done"},
+		})
+
+	e := dag.Envoy()
+	resources := e.XdsResources().
+		WithListener(e.TCPListener("ingress", 14000, e.TCPProxy("tcp", "upstream"))).
+		WithCluster(e.Cluster("upstream").WithEndpoint(e.Endpoint("upstream", 5000)))
+
+	proxy := e.Proxy(proxyOpts(envoyTag)).
+		WithServiceBinding("upstream", upstream).
+		WithDynamicResources(resources.Directory())
+
+	endpoint, err := proxy.ListenerEndpoint(ctx, "ingress")
+	if err != nil {
+		return fmt.Errorf("ListenerEndpoint(ingress): %w", err)
+	}
+	if !strings.HasSuffix(endpoint, ":14000") {
+		return fmt.Errorf("expected ListenerEndpoint(ingress) to end in :14000, got %q", endpoint)
+	}
+
+	_, err = dag.Container().From(probeImage).
+		WithExec([]string{"apk", "add", "--no-cache", "busybox-extras"}).
+		WithServiceBinding("envoy", proxy.Service()).
+		WithEnvVariable("MARKER", mark).
+		WithExec([]string{"sh", "-c", `
+set -eu
+for i in $(seq 1 60); do
+  OUT=$(printf "%s" "${MARKER}" | nc -w 3 envoy 14000 || true)
+  case "${OUT}" in *"${MARKER}"*) echo "marker echoed after ${i}s"; exit 0 ;; esac
+  sleep 1
+done
+echo "marker ${MARKER} never echoed back" >&2
+echo "last out: ${OUT}" >&2
+exit 1
+`}).
+		Sync(ctx)
+	if err != nil {
+		return fmt.Errorf("L4 xDS round-trip: %w", err)
+	}
+	return nil
+}
+
+// XdsResourcesMatchStaticResources asserts that the lds.yaml /
+// cds.yaml discovery responses rendered by XdsResources.Directory()
+// are structurally equivalent to the static_resources block the same
+// components produce in static mode — identical apart from the
+// per-resource `@type` discriminator that only the xDS shape needs.
+func (t *Tests) XdsResourcesMatchStaticResources(ctx context.Context) error {
+	e := dag.Envoy()
+	rc := e.RouteConfig("rc").WithVirtualHost(
+		e.VirtualHost("vh", []string{"*"}).WithRoute(e.RoutePrefix("/", "upstream")),
+	)
+	hcm := e.HTTPConnectionManager("ingress", rc).WithHTTPFilter(e.RouterHTTPFilter())
+	listener := e.HTTPListener("http", 18080, hcm)
+	cluster := e.Cluster("upstream").WithEndpoint(e.Endpoint("upstream", 5678))
+
+	static, err := e.Proxy().
+		WithListener(listener).
+		WithCluster(cluster).
+		ConfigFile().
+		Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("static ConfigFile().Contents: %w", err)
+	}
+	var staticCfg struct {
+		StaticResources struct {
+			Listeners []map[string]any `yaml:"listeners"`
+			Clusters  []map[string]any `yaml:"clusters"`
+		} `yaml:"static_resources"`
+	}
+	if err := yaml.Unmarshal([]byte(static), &staticCfg); err != nil {
+		return fmt.Errorf("parse static bootstrap: %w\n---\n%s", err, static)
+	}
+
+	dir := e.XdsResources().
+		WithListener(listener).
+		WithCluster(cluster).
+		Directory()
+
+	for _, tc := range []struct {
+		file    string
+		typeURL string
+		want    []map[string]any
+	}{
+		{"lds.yaml", "type.googleapis.com/envoy.config.listener.v3.Listener", staticCfg.StaticResources.Listeners},
+		{"cds.yaml", "type.googleapis.com/envoy.config.cluster.v3.Cluster", staticCfg.StaticResources.Clusters},
+	} {
+		contents, err := dir.File(tc.file).Contents(ctx)
+		if err != nil {
+			return fmt.Errorf("%s contents: %w", tc.file, err)
+		}
+		var resp struct {
+			Resources []map[string]any `yaml:"resources"`
+		}
+		if err := yaml.Unmarshal([]byte(contents), &resp); err != nil {
+			return fmt.Errorf("parse %s: %w\n---\n%s", tc.file, err, contents)
+		}
+		if len(resp.Resources) != len(tc.want) {
+			return fmt.Errorf("%s: expected %d resources, got %d\n---\n%s", tc.file, len(tc.want), len(resp.Resources), contents)
+		}
+		for i, got := range resp.Resources {
+			if got["@type"] != tc.typeURL {
+				return fmt.Errorf("%s: resources[%d].@type == %v, want %q", tc.file, i, got["@type"], tc.typeURL)
+			}
+			stripped := make(map[string]any, len(got))
+			for k, v := range got {
+				if k != "@type" {
+					stripped[k] = v
+				}
+			}
+			gotYAML, err := yaml.Marshal(stripped)
+			if err != nil {
+				return fmt.Errorf("%s: re-marshal resources[%d]: %w", tc.file, i, err)
+			}
+			wantYAML, err := yaml.Marshal(tc.want[i])
+			if err != nil {
+				return fmt.Errorf("%s: re-marshal static[%d]: %w", tc.file, i, err)
+			}
+			if string(gotYAML) != string(wantYAML) {
+				return fmt.Errorf("%s: resources[%d] differs from static equivalent:\n--- xds ---\n%s\n--- static ---\n%s", tc.file, i, gotYAML, wantYAML)
+			}
+		}
+	}
+	return nil
+}
+
+// XdsResourcesRejectsInvalidResourceSet asserts Directory() surfaces
+// the same two errors (*Proxy).ConfigFile() does: two listeners
+// sharing a name, and a listener whose filter chain references a
+// cluster that isn't in the resource set.
+func (t *Tests) XdsResourcesRejectsInvalidResourceSet(ctx context.Context) error {
+	e := dag.Envoy()
+
+	dup := e.CustomListener("dup", "address: { socket_address: { address: 0.0.0.0, port_value: 18080 } }\nfilter_chains: []\n")
+	if _, err := e.XdsResources().
+		WithListener(dup).
+		WithListener(dup).
+		Directory().
+		ID(ctx); err == nil {
+		return fmt.Errorf("duplicate listener name: expected Directory() error, got nil")
+	}
+
+	dangling := e.TCPListener("ingress", 14000, e.TCPProxy("tcp", "missing"))
+	if _, err := e.XdsResources().
+		WithListener(dangling).
+		Directory().
+		ID(ctx); err == nil {
+		return fmt.Errorf("unknown cluster reference: expected Directory() error, got nil")
+	}
+
+	// Same listener with its cluster registered must render cleanly.
+	if _, err := e.XdsResources().
+		WithListener(e.TCPListener("ingress", 14000, e.TCPProxy("tcp", "upstream"))).
+		WithCluster(e.Cluster("upstream")).
+		Directory().
+		ID(ctx); err != nil {
+		return fmt.Errorf("valid resource set: expected nil, got %w", err)
+	}
+	return nil
+}
+
+// XdsResourcesRejectsSecureComponents asserts Directory() refuses
+// TLS / mTLS listeners and clusters: their rendered resources point
+// at key material under /etc/envoy/secrets that only the static
+// Service() path mounts, so a proxy fed them through an opaque
+// resource directory would boot and then fail every handshake.
+func (t *Tests) XdsResourcesRejectsSecureComponents(ctx context.Context) error {
+	e := dag.Envoy()
+
+	ca, caPwd, err := testCa(ctx, "xds-tls")
+	if err != nil {
+		return err
+	}
+	tlsListener := minimalHttpListener("https", 18443, e.TLSServerSecurity(ca.KeyStore().Pkcs12(), caPwd))
+	if _, err := e.XdsResources().
+		WithListener(tlsListener).
+		WithCluster(e.Cluster("upstream")).
+		Directory().
+		ID(ctx); err == nil {
+		return fmt.Errorf("TLS listener: expected Directory() error, got nil")
+	}
+
+	upstreamCa, upstreamPwd, err := testCa(ctx, "xds-upstream-tls")
+	if err != nil {
+		return err
+	}
+	tlsCluster := e.Cluster("upstream", dagger.EnvoyClusterOpts{
+		Upstream: e.TLSUpstreamSecurity(upstreamCa.TrustStore().Pkcs12(), upstreamPwd),
+	})
+	if _, err := e.XdsResources().
+		WithCluster(tlsCluster).
+		Directory().
+		ID(ctx); err == nil {
+		return fmt.Errorf("TLS cluster: expected Directory() error, got nil")
+	}
+	return nil
+}
+
+// DynamicResourcesRequiresLdsAndCds asserts Service() rejects a
+// resource directory missing either of the two files the bootstrap's
+// dynamic_resources block points at, rather than booting an Envoy
+// that silently discovers nothing.
+func (t *Tests) DynamicResourcesRequiresLdsAndCds(ctx context.Context) error {
+	for _, tc := range []struct {
+		name string
+		dir  *dagger.Directory
+	}{
+		{"missing cds.yaml", dag.Directory().WithNewFile("lds.yaml", "resources: []\n")},
+		{"missing lds.yaml", dag.Directory().WithNewFile("cds.yaml", "resources: []\n")},
+		{"empty", dag.Directory()},
+	} {
+		if _, err := dag.Envoy().Proxy().
+			WithDynamicResources(tc.dir).
+			Service().
+			ID(ctx); err == nil {
+			return fmt.Errorf("%s: expected Service() error, got nil", tc.name)
+		}
+	}
+	return nil
+}
+
+// DynamicResourcesConflictsWithStatic asserts that mixing
+// WithDynamicResources with any of WithListener / WithCluster /
+// WithConfigFile on the same Proxy makes ConfigFile() return a
+// non-nil error — the two configuration modes are exclusive.
+func (t *Tests) DynamicResourcesConflictsWithStatic(ctx context.Context) error {
+	e := dag.Envoy()
+	xds := dag.Directory().
+		WithNewFile("lds.yaml", "resources: []\n").
+		WithNewFile("cds.yaml", "resources: []\n")
+
+	listener := e.CustomListener("manual", "address: { socket_address: { address: 0.0.0.0, port_value: 18080 } }\nfilter_chains: []\n")
+	if _, err := e.Proxy().
+		WithDynamicResources(xds).
+		WithListener(listener).
+		ConfigFile().
+		Contents(ctx); err == nil {
+		return fmt.Errorf("WithDynamicResources + WithListener: expected ConfigFile() error, got nil")
+	}
+
+	if _, err := e.Proxy().
+		WithDynamicResources(xds).
+		WithCluster(e.Cluster("upstream")).
+		ConfigFile().
+		Contents(ctx); err == nil {
+		return fmt.Errorf("WithDynamicResources + WithCluster: expected ConfigFile() error, got nil")
+	}
+
+	override := dag.Directory().
+		WithNewFile("override.yaml", "admin: {}\n").
+		File("override.yaml")
+	if _, err := e.Proxy().
+		WithDynamicResources(xds).
+		WithConfigFile(override).
+		ConfigFile().
+		Contents(ctx); err == nil {
+		return fmt.Errorf("WithDynamicResources + WithConfigFile: expected ConfigFile() error, got nil")
+	}
+
+	// The same directory on its own must still render cleanly.
+	if _, err := e.Proxy().WithDynamicResources(xds).ConfigFile().Contents(ctx); err != nil {
+		return fmt.Errorf("WithDynamicResources alone: expected nil, got %w", err)
+	}
+	return nil
+}

--- a/daggerverse/envoy/xds.go
+++ b/daggerverse/envoy/xds.go
@@ -1,0 +1,340 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"dagger/envoy/internal/dagger"
+
+	"gopkg.in/yaml.v3"
+)
+
+// xdsMountPath is where a Proxy's dynamic-resource directory is
+// mounted inside the running envoy container. The bootstrap's
+// dynamic_resources block points its lds/cds config sources at files
+// under this directory, so the paths are part of the module's
+// contract with callers who bring their own discovery-resource
+// directory.
+const xdsMountPath = "/etc/envoy/xds"
+
+// The two discovery-response files the bootstrap's dynamic_resources
+// block subscribes to. An rds.yaml alongside them is loaded by Envoy
+// only if a listener resource names it in an `rds` config source; the
+// bootstrap never points at it directly, and the v1 builders — whose
+// HttpConnectionManagers always carry an inline route_config — never
+// emit one.
+const (
+	xdsLdsFile = "lds.yaml"
+	xdsCdsFile = "cds.yaml"
+)
+
+// Discovery-response resource type URLs. Each resource in a
+// file-based xDS discovery response carries its own `@type` so Envoy
+// can decode the google.protobuf.Any.
+const (
+	listenerTypeURL = "type.googleapis.com/envoy.config.listener.v3.Listener"
+	clusterTypeURL  = "type.googleapis.com/envoy.config.cluster.v3.Cluster"
+)
+
+func xdsPath(name string) string {
+	return filepath.Join(xdsMountPath, name)
+}
+
+// WithDynamicResources switches the proxy from a rendered
+// static_resources bootstrap to file-based xDS: the bootstrap's
+// dynamic_resources block points lds_config at
+// /etc/envoy/xds/lds.yaml and cds_config at /etc/envoy/xds/cds.yaml,
+// and dir is mounted at /etc/envoy/xds. dir must contain at minimum
+// lds.yaml and cds.yaml, each a v3 discovery response; rds.yaml is
+// loaded only when a listener's HttpConnectionManager references it
+// via an `rds` config source (the bootstrap does not wire RDS
+// itself).
+//
+// This mode is exclusive with WithListener / WithCluster /
+// WithConfigFile: calling both makes ConfigFile() (and therefore
+// Service()) return a non-nil error.
+//
+// Hot reload is NOT exercised. Dagger's WithMountedDirectory is
+// content-addressed and immutable at mount time, so the mounted
+// resource files never change for the lifetime of the container —
+// only Envoy's initial discovery path runs. Callers wanting to test
+// reload semantics need to launch a fresh Proxy per resource
+// snapshot.
+func (p *Proxy) WithDynamicResources(dir *dagger.Directory) *Proxy {
+	out := *p
+	out.DynamicResources = dir
+	return &out
+}
+
+// validateDynamicProxy enforces that file-based xDS and the static
+// builders are never mixed on the same Proxy. Silently preferring one
+// over the other would hand callers a proxy that ignores half of what
+// they configured.
+func validateDynamicProxy(p *Proxy) error {
+	if p.Override != nil {
+		return fmt.Errorf("proxy: WithDynamicResources and WithConfigFile are exclusive")
+	}
+	if len(p.Listeners) > 0 {
+		return fmt.Errorf("proxy: WithDynamicResources and WithListener are exclusive (supply listeners via the mounted %s directory)", xdsLdsFile)
+	}
+	if len(p.Clusters) > 0 {
+		return fmt.Errorf("proxy: WithDynamicResources and WithCluster are exclusive (supply clusters via the mounted %s directory)", xdsCdsFile)
+	}
+	return nil
+}
+
+// xdsNodeID and xdsNodeCluster identify this Envoy to a management
+// server. Envoy refuses to initialize a dynamic_resources config
+// without them ("node 'id' and 'cluster' are required"), even for a
+// filesystem subscription that has no management server to identify
+// itself to. Fixed values keep the rendered bootstrap deterministic;
+// nothing in file-based xDS keys off them.
+const (
+	xdsNodeID      = "envoy"
+	xdsNodeCluster = "envoy"
+)
+
+// renderDynamicBootstrap composes the file-based xDS bootstrap: a
+// node identity, an admin listener, and a dynamic_resources block
+// whose lds/cds config sources are filesystem paths under the mounted
+// xds directory.
+func renderDynamicBootstrap(adminPort int) ([]byte, error) {
+	root := map[string]any{
+		"node": map[string]any{
+			"id":      xdsNodeID,
+			"cluster": xdsNodeCluster,
+		},
+		"admin": map[string]any{
+			"address": map[string]any{
+				"socket_address": map[string]any{
+					"address":    "0.0.0.0",
+					"port_value": adminPort,
+				},
+			},
+		},
+		"dynamic_resources": map[string]any{
+			"lds_config": pathConfigSource(xdsPath(xdsLdsFile)),
+			"cds_config": pathConfigSource(xdsPath(xdsCdsFile)),
+		},
+	}
+	return yaml.Marshal(root)
+}
+
+// XdsResources composes the same v1 component types the static
+// builders take (Listener, Cluster) into the discovery-resource files
+// a file-based xDS Proxy consumes. Composition mirrors Proxy: WithX
+// methods return shallow copies.
+type XdsResources struct {
+	Listeners []*Listener
+	Clusters  []*Cluster
+}
+
+// XdsResources returns an empty discovery-resource set. Feed it
+// listeners and clusters, then hand Directory() to
+// (*Proxy).WithDynamicResources.
+func (e *Envoy) XdsResources() *XdsResources {
+	return &XdsResources{}
+}
+
+// WithListener appends a listener to the LDS resource set.
+func (x *XdsResources) WithListener(l *Listener) *XdsResources {
+	out := *x
+	out.Listeners = append(append([]*Listener{}, x.Listeners...), l)
+	return &out
+}
+
+// WithCluster appends a cluster to the CDS resource set.
+func (x *XdsResources) WithCluster(c *Cluster) *XdsResources {
+	out := *x
+	out.Clusters = append(append([]*Cluster{}, x.Clusters...), c)
+	return &out
+}
+
+// Directory renders lds.yaml and cds.yaml — v3 discovery responses
+// carrying the registered listeners and clusters — into a directory
+// suitable for (*Proxy).WithDynamicResources. Each resource is
+// structurally identical to the static_resources entry the same
+// component produces in static mode, plus the `@type` discriminator
+// the discovery response requires.
+//
+// Route configurations stay inline in each listener's
+// HttpConnectionManager, so no rds.yaml is emitted: the v1 builders
+// have no way to express an RDS config source. Callers who need RDS
+// bring their own directory containing rds.yaml plus listeners that
+// reference it.
+//
+// Returns a non-nil error under the same conditions as
+// (*Proxy).ConfigFile() — a listener referencing a cluster that isn't
+// registered here, or two listeners sharing a name — and also when
+// any component carries TLS / mTLS security, whose key material only
+// (*Proxy).Service() can mount and which the Proxy cannot see through
+// an opaque resource directory.
+func (x *XdsResources) Directory() (*dagger.Directory, error) {
+	if err := validateResources(x.Listeners, x.Clusters, "resource set", "WithCluster"); err != nil {
+		return nil, err
+	}
+	if err := validateXdsPlaintext(x); err != nil {
+		return nil, err
+	}
+	lds, err := renderDiscoveryResponse(listenerTypeURL, func() ([]map[string]any, error) {
+		out := make([]map[string]any, 0, len(x.Listeners))
+		for _, l := range x.Listeners {
+			res, err := renderListener(l)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, res)
+		}
+		return out, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	cds, err := renderDiscoveryResponse(clusterTypeURL, func() ([]map[string]any, error) {
+		out := make([]map[string]any, 0, len(x.Clusters))
+		for _, c := range x.Clusters {
+			out = append(out, renderCluster(c))
+		}
+		return out, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return dag.Directory().
+		WithNewFile(xdsLdsFile, string(lds)).
+		WithNewFile(xdsCdsFile, string(cds)), nil
+}
+
+// validateXdsPlaintext rejects TLS / mTLS components. A rendered
+// resource for a secured listener or cluster points at certificate
+// and key files under /etc/envoy/secrets, but only the static path
+// mounts them: WithDynamicResources hands the Proxy an opaque
+// directory it cannot introspect for the material to mount. Failing
+// here beats a proxy that boots and then fails every handshake on a
+// missing file.
+func validateXdsPlaintext(x *XdsResources) error {
+	for _, l := range x.Listeners {
+		if l.SecurityMode == "TLS" || l.SecurityMode == "MTLS" {
+			return fmt.Errorf("listener %q: %s listeners are not supported in file-based xDS mode (the mounted resource directory carries no key material)", l.Name, l.SecurityMode)
+		}
+	}
+	for _, c := range x.Clusters {
+		if c.UpstreamMode == "TLS" || c.UpstreamMode == "MTLS" {
+			return fmt.Errorf("cluster %q: %s upstreams are not supported in file-based xDS mode (the mounted resource directory carries no key material)", c.Name, c.UpstreamMode)
+		}
+	}
+	return nil
+}
+
+// renderDiscoveryResponse marshals resources into the DiscoveryResponse
+// shape Envoy's filesystem subscription expects, stamping each entry
+// with typeURL.
+func renderDiscoveryResponse(typeURL string, resources func() ([]map[string]any, error)) ([]byte, error) {
+	items, err := resources()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]any, 0, len(items))
+	for _, item := range items {
+		entry := map[string]any{"@type": typeURL}
+		for k, v := range item {
+			entry[k] = v
+		}
+		out = append(out, entry)
+	}
+	return yaml.Marshal(map[string]any{
+		"version_info": "1",
+		"resources":    out,
+	})
+}
+
+// pathConfigSource builds the non-deprecated filesystem ConfigSource
+// shape. The bare `path` field Envoy accepted historically is
+// deprecated in favour of path_config_source.
+func pathConfigSource(path string) map[string]any {
+	return map[string]any{
+		"path_config_source": map[string]any{
+			"path": path,
+		},
+		"resource_api_version": "V3",
+	}
+}
+
+// xdsListenerPorts reads the ports Envoy will bind from the LDS
+// discovery response in dir. In static mode the ports to expose come
+// from the registered Listener values; in dynamic mode the resource
+// directory is the only place they exist, so Service() has to read it
+// to know which container ports to open. Also doubles as the
+// arrival check for the two files the bootstrap points at.
+func xdsListenerPorts(ctx context.Context, dir *dagger.Directory) ([]int, error) {
+	entries, err := dir.Entries(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("dynamic resources: read directory: %w", err)
+	}
+	present := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		present[e] = true
+	}
+	for _, required := range []string{xdsLdsFile, xdsCdsFile} {
+		if !present[required] {
+			return nil, fmt.Errorf("dynamic resources: directory must contain %s (got %v)", required, entries)
+		}
+	}
+	contents, err := dir.File(xdsLdsFile).Contents(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("dynamic resources: read %s: %w", xdsLdsFile, err)
+	}
+	var resp struct {
+		Resources []map[string]any `yaml:"resources"`
+	}
+	if err := yaml.Unmarshal([]byte(contents), &resp); err != nil {
+		return nil, fmt.Errorf("dynamic resources: parse %s: %w", xdsLdsFile, err)
+	}
+	seen := map[int]bool{}
+	var ports []int
+	for _, res := range resp.Resources {
+		body, err := yaml.Marshal(res)
+		if err != nil {
+			return nil, fmt.Errorf("dynamic resources: re-marshal %s resource: %w", xdsLdsFile, err)
+		}
+		port, ok := extractListenerPort(string(body))
+		if !ok || seen[port] {
+			continue
+		}
+		seen[port] = true
+		ports = append(ports, port)
+	}
+	return ports, nil
+}
+
+// xdsListenerPort resolves a single named listener's port from the
+// LDS discovery response in dir, so ListenerEndpoint works the same
+// way in dynamic mode as it does against registered Listeners.
+func xdsListenerPort(ctx context.Context, dir *dagger.Directory, name string) (int, error) {
+	contents, err := dir.File(xdsLdsFile).Contents(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("dynamic resources: read %s: %w", xdsLdsFile, err)
+	}
+	var resp struct {
+		Resources []map[string]any `yaml:"resources"`
+	}
+	if err := yaml.Unmarshal([]byte(contents), &resp); err != nil {
+		return 0, fmt.Errorf("dynamic resources: parse %s: %w", xdsLdsFile, err)
+	}
+	for _, res := range resp.Resources {
+		if res["name"] != name {
+			continue
+		}
+		body, err := yaml.Marshal(res)
+		if err != nil {
+			return 0, fmt.Errorf("dynamic resources: re-marshal %s resource: %w", xdsLdsFile, err)
+		}
+		port, ok := extractListenerPort(string(body))
+		if !ok {
+			return 0, fmt.Errorf("listener %q: cannot extract socket_address.port_value from %s", name, xdsLdsFile)
+		}
+		return port, nil
+	}
+	return 0, fmt.Errorf("listener %q: not present in %s", name, xdsLdsFile)
+}


### PR DESCRIPTION
Closes #46.

Adds file-based xDS dynamic configuration to the `envoy` daggerverse
module. gRPC-based xDS (ADS, SDS over streaming RPCs) remains out of
scope.

## Bootstrap path

`(*Proxy).WithDynamicResources(dir)` swaps the rendered
`static_resources` bootstrap for a `dynamic_resources` block whose
`lds_config` / `cds_config` point at `/etc/envoy/xds/lds.yaml` and
`/etc/envoy/xds/cds.yaml`, and mounts `dir` there. The mode is
exclusive with `WithListener` / `WithCluster` / `WithConfigFile` —
`ConfigFile()` (and therefore `Service()`) returns a non-nil error
when they are mixed.

`Service()` reads the mounted `lds.yaml` for the ports to expose,
since in this mode that file is the only place they exist;
`ListenerEndpoint` resolves names against it too rather than failing
with "not registered on proxy".

## Render-from-builders path

`Envoy.XdsResources()` composes the same v1 `Listener` / `Cluster`
values the static builders take and renders them as v3 discovery
responses via `Directory()`. Each resource is byte-identical to its
`static_resources` counterpart apart from the `@type` discriminator
(asserted by re-marshaling both sides), and `Directory()` surfaces the
same duplicate-listener-name and dangling-cluster-reference errors
`ConfigFile()` does.

```go
resources := dag.Envoy().XdsResources().
    WithListener(httpListener).
    WithCluster(upstreamCluster)

proxy := dag.Envoy().Proxy().
    WithServiceBinding("backend", backendSvc).
    WithDynamicResources(resources.Directory())
```

## Tests

8 new tests wired into the existing `+check` aggregators — 6 under
`Validation`, 2 under `RoundTrips` (L7 HTTP and L4 TCP end-to-end
through file-based xDS). Full suite green locally.

## Judgment calls worth a look

1. **No `rds.yaml`.** The issue lists it as a `Directory()` output, but
   AC #2 requires lds/cds to be structurally equivalent to
   `static_resources` — splitting route configs out would force each
   HCM to use an `rds` config source instead of the inline
   `route_config` static mode produces. The v1 builders cannot express
   an RDS config source at all, so route configs stay inline and
   callers needing RDS bring their own directory. Adding a builder
   knob for RDS is a reasonable follow-up.

2. **TLS / mTLS rejected in xDS mode** (not in the issue). A secured
   listener's rendered resource references key material under
   `/etc/envoy/secrets`, which only the static `Service()` path mounts
   — through an opaque directory the Proxy cannot see it.
   `Directory()` errors instead of producing a proxy that boots and
   then fails every handshake.

3. **`node: {id, cluster}` in the dynamic bootstrap.** Envoy refuses
   to initialize any `dynamic_resources` config without it
   (`node 'id' and 'cluster' are required`), even for a filesystem
   subscription with no management server. Fixed values keep the
   render deterministic.

## Hot-reload caveat

`WithMountedDirectory` is content-addressed and immutable at mount
time, so only Envoy's *initial discovery* path is exercised — there is
no in-place reload. Callers wanting reload semantics launch a fresh
`Proxy` per resource snapshot. The doc comment on
`WithDynamicResources` says so explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
