### PR TITLE
story(issue-191): cover opentofu remote backend state end-to-end

### DIFF
--- a/ci/internal/dagger/opentofu-tests.gen.go
+++ b/ci/internal/dagger/opentofu-tests.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type OpentofuTests
-func (r *Binding) AsOpentofuTests() *OpentofuTests { // opentofu-tests (../../../daggerverse/opentofu/tests/main.go:23:6)
+func (r *Binding) AsOpentofuTests() *OpentofuTests { // opentofu-tests (../../../daggerverse/opentofu/tests/main.go:27:6)
 	q := r.query.Select("asOpentofuTests")
 
 	return &OpentofuTests{
@@ -19,7 +19,7 @@ func (r *Binding) AsOpentofuTests() *OpentofuTests { // opentofu-tests (../../..
 }
 
 // Create or update a binding of type OpentofuTests in the environment
-func (r *Env) WithOpentofuTestsInput(name string, value *OpentofuTests, description string) *Env { // opentofu-tests (../../../daggerverse/opentofu/tests/main.go:23:6)
+func (r *Env) WithOpentofuTestsInput(name string, value *OpentofuTests, description string) *Env { // opentofu-tests (../../../daggerverse/opentofu/tests/main.go:27:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withOpentofuTestsInput")
 	q = q.Arg("name", name)
@@ -32,7 +32,7 @@ func (r *Env) WithOpentofuTestsInput(name string, value *OpentofuTests, descript
 }
 
 // Declare a desired OpentofuTests output to be assigned in the environment
-func (r *Env) WithOpentofuTestsOutput(name string, description string) *Env { // opentofu-tests (../../../daggerverse/opentofu/tests/main.go:23:6)
+func (r *Env) WithOpentofuTestsOutput(name string, description string) *Env { // opentofu-tests (../../../daggerverse/opentofu/tests/main.go:27:6)
 	q := r.query.Select("withOpentofuTestsOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -42,7 +42,7 @@ func (r *Env) WithOpentofuTestsOutput(name string, description string) *Env { //
 	}
 }
 
-type OpentofuTests struct { // opentofu-tests (../../../daggerverse/opentofu/tests/main.go:23:6)
+type OpentofuTests struct { // opentofu-tests (../../../daggerverse/opentofu/tests/main.go:27:6)
 	query *querybuilder.Selection
 
 	all                                     *Void
@@ -51,6 +51,7 @@ type OpentofuTests struct { // opentofu-tests (../../../daggerverse/opentofu/tes
 	applyProducesStateAndOutputs            *Void
 	applyRejectsTargetsWithSavedPlan        *Void
 	applyShouldNotBeCached                  *Void
+	backendConfigFileMatchesBackendConfig   *Void
 	ciCheckAggregatesStageFailures          *Void
 	ciCheckPassesOnCleanConfiguration       *Void
 	ciCheckReportsInvalidConfiguration      *Void
@@ -62,6 +63,7 @@ type OpentofuTests struct { // opentofu-tests (../../../daggerverse/opentofu/tes
 	ciCheckWithoutValidateSkipsIt           *Void
 	ciRunFailsOnFailedCheck                 *Void
 	ciRunProducesPlanArtifacts              *Void
+	concurrentAppliesDoNotCorruptState      *Void
 	containerHasGitAndCaCertificates        *Void
 	containerHasTofu                        *Void
 	destroyEmptiesState                     *Void
@@ -76,6 +78,8 @@ type OpentofuTests struct { // opentofu-tests (../../../daggerverse/opentofu/tes
 	planReportsChanges                      *Void
 	planShouldNotBeCached                   *Void
 	planTargetsLimitScope                   *Void
+	remoteBackendRoundTripsState            *Void
+	remoteWorkspacesIsolateState            *Void
 	secretVarReachesTofuWithoutLeaking      *Void
 	secretVariableBindsEnvironmentSecret    *Void
 	showRendersState                        *Void
@@ -102,7 +106,7 @@ func (r *OpentofuTests) WithGraphQLQuery(q *querybuilder.Selection) *OpentofuTes
 
 // OpentofuTestsAllOpts contains options for OpentofuTests.All
 type OpentofuTestsAllOpts struct {
-	Parallel int // opentofu-tests (../../../daggerverse/opentofu/tests/main.go:37:2)
+	Parallel int // opentofu-tests (../../../daggerverse/opentofu/tests/main.go:41:2)
 }
 
 // All runs every opentofu-module test in parallel.
@@ -111,7 +115,7 @@ type OpentofuTestsAllOpts struct {
 // 0 (unbounded fan-out) — each `dagger check` job runs on its own GH Actions
 // runner, so in-runner parallelism is bounded by the VM's CPU/memory, not by
 // the scheduler. Pass any positive integer to opt into a specific cap.
-func (r *OpentofuTests) All(ctx context.Context, opts ...OpentofuTestsAllOpts) error { // opentofu-tests (../../../daggerverse/opentofu/tests/main.go:34:1)
+func (r *OpentofuTests) All(ctx context.Context, opts ...OpentofuTestsAllOpts) error { // opentofu-tests (../../../daggerverse/opentofu/tests/main.go:38:1)
 	if r.all != nil {
 		return nil
 	}
@@ -181,6 +185,22 @@ func (r *OpentofuTests) ApplyShouldNotBeCached(ctx context.Context) error { // o
 		return nil
 	}
 	q := r.query.Select("applyShouldNotBeCached")
+
+	return q.Execute(ctx)
+}
+
+// BackendConfigFileMatchesBackendConfig asserts the file form of the backend
+// settings selects the same backend as the individual calls: state written
+// through one is found by the other.
+//
+// A Plan reporting no changes is the assertion, because the only way this
+// Config can know there is nothing to do is by having read the state the
+// flag-configured apply left behind.
+func (r *OpentofuTests) BackendConfigFileMatchesBackendConfig(ctx context.Context) error { // opentofu-tests (../../../daggerverse/opentofu/tests/backend.go:109:1)
+	if r.backendConfigFileMatchesBackendConfig != nil {
+		return nil
+	}
+	q := r.query.Select("backendConfigFileMatchesBackendConfig")
 
 	return q.Execute(ctx)
 }
@@ -327,10 +347,34 @@ func (r *OpentofuTests) CiRunProducesPlanArtifacts(ctx context.Context) error { 
 	return q.Execute(ctx)
 }
 
+// ConcurrentAppliesDoNotCorruptState asserts two applies racing for the same
+// remote state either serialise or fail on the lock — never both go through as
+// if the other had not happened.
+//
+// The two accepted outcomes are asserted separately because which one occurs
+// is a matter of timing, not of correctness:
+//
+//   - one apply fails with tofu's state-lock diagnostic, or
+//   - both succeed, and exactly one of them created the resources while the
+//     other found them already there.
+//
+// The second half is what makes this more than a smoke test. A backend without
+// working locking also lets both applies succeed — but then both start from an
+// empty state, both report resources added, and the loser's work is silently
+// dropped when the winner writes its state.
+func (r *OpentofuTests) ConcurrentAppliesDoNotCorruptState(ctx context.Context) error { // opentofu-tests (../../../daggerverse/opentofu/tests/backend.go:220:1)
+	if r.concurrentAppliesDoNotCorruptState != nil {
+		return nil
+	}
+	q := r.query.Select("concurrentAppliesDoNotCorruptState")
+
+	return q.Execute(ctx)
+}
+
 // ContainerHasGitAndCaCertificates asserts the two things the -minimal image
 // omits and every non-trivial configuration needs: git, for module sources,
 // and a CA bundle, for the provider registry.
-func (r *OpentofuTests) ContainerHasGitAndCaCertificates(ctx context.Context) error { // opentofu-tests (../../../daggerverse/opentofu/tests/main.go:124:1)
+func (r *OpentofuTests) ContainerHasGitAndCaCertificates(ctx context.Context) error { // opentofu-tests (../../../daggerverse/opentofu/tests/main.go:133:1)
 	if r.containerHasGitAndCaCertificates != nil {
 		return nil
 	}
@@ -341,7 +385,7 @@ func (r *OpentofuTests) ContainerHasGitAndCaCertificates(ctx context.Context) er
 
 // ContainerHasTofu asserts the assembled container exposes the tofu binary on
 // PATH, so the escape hatch documented on Container() actually works.
-func (r *OpentofuTests) ContainerHasTofu(ctx context.Context) error { // opentofu-tests (../../../daggerverse/opentofu/tests/main.go:108:1)
+func (r *OpentofuTests) ContainerHasTofu(ctx context.Context) error { // opentofu-tests (../../../daggerverse/opentofu/tests/main.go:117:1)
 	if r.containerHasTofu != nil {
 		return nil
 	}
@@ -541,6 +585,39 @@ func (r *OpentofuTests) PlanTargetsLimitScope(ctx context.Context) error { // op
 	return q.Execute(ctx)
 }
 
+// RemoteBackendRoundTripsState asserts the backend path end to end: an apply
+// against a real S3 backend hands back no terraform.tfstate, the backend holds
+// the state instead, a second Config reads it back with nothing but the
+// backend settings to go on, and a destroy empties it.
+//
+// The file-carried tests can only prove that WithBackendConfig reaches
+// `tofu init`; this one proves the state actually goes somewhere else.
+func (r *OpentofuTests) RemoteBackendRoundTripsState(ctx context.Context) error { // opentofu-tests (../../../daggerverse/opentofu/tests/backend.go:22:1)
+	if r.remoteBackendRoundTripsState != nil {
+		return nil
+	}
+	q := r.query.Select("remoteBackendRoundTripsState")
+
+	return q.Execute(ctx)
+}
+
+// RemoteWorkspacesIsolateState asserts WithWorkspace partitions a remote
+// backend: an apply in one workspace is invisible to a plan in another, and
+// the two states are distinct objects in the bucket.
+//
+// The local backend makes this awkward to see — each workspace's state comes
+// back as the same terraform.tfstate file in a different directory — which is
+// why the isolation is pinned here rather than alongside the file-carried
+// workspace test.
+func (r *OpentofuTests) RemoteWorkspacesIsolateState(ctx context.Context) error { // opentofu-tests (../../../daggerverse/opentofu/tests/backend.go:145:1)
+	if r.remoteWorkspacesIsolateState != nil {
+		return nil
+	}
+	q := r.query.Select("remoteWorkspacesIsolateState")
+
+	return q.Execute(ctx)
+}
+
 // SecretVarReachesTofuWithoutLeaking asserts WithSecretVar delivers the value
 // to tofu and that the plaintext appears in none of the artifacts the module
 // hands back.
@@ -642,7 +719,7 @@ func (r *OpentofuTests) ValidateWorksWithoutBackendCredentials(ctx context.Conte
 // VersionAcceptsMinimalSuffix asserts a caller who spells out the -minimal
 // suffix lands on the same image as one who does not — the suffix is appended
 // only when absent.
-func (r *OpentofuTests) VersionAcceptsMinimalSuffix(ctx context.Context) error { // opentofu-tests (../../../daggerverse/opentofu/tests/main.go:150:1)
+func (r *OpentofuTests) VersionAcceptsMinimalSuffix(ctx context.Context) error { // opentofu-tests (../../../daggerverse/opentofu/tests/main.go:159:1)
 	if r.versionAcceptsMinimalSuffix != nil {
 		return nil
 	}
@@ -652,7 +729,7 @@ func (r *OpentofuTests) VersionAcceptsMinimalSuffix(ctx context.Context) error {
 }
 
 // VersionReportsRelease asserts Version reports the release New was asked for.
-func (r *OpentofuTests) VersionReportsRelease(ctx context.Context) error { // opentofu-tests (../../../daggerverse/opentofu/tests/main.go:136:1)
+func (r *OpentofuTests) VersionReportsRelease(ctx context.Context) error { // opentofu-tests (../../../daggerverse/opentofu/tests/main.go:145:1)
 	if r.versionReportsRelease != nil {
 		return nil
 	}
@@ -750,7 +827,11 @@ func (r *OpentofuTests) AsNode() Node {
 // provider's resources exist purely in state, which is what makes the
 // state round-trip assertions meaningful — there is no out-of-band object to
 // drift away underneath them.
-func (r *Query) OpentofuTests() *OpentofuTests { // opentofu-tests (../../../daggerverse/opentofu/tests/main.go:23:6)
+//
+// The remote-state fixtures declare an s3 backend, and it too is hermetic: the
+// S3 they write to is a MinIO service the suite stands up per test, with a
+// root credential minted at runtime. See backend.go.
+func (r *Query) OpentofuTests() *OpentofuTests { // opentofu-tests (../../../daggerverse/opentofu/tests/main.go:27:6)
 	q := r.query.Select("opentofuTests")
 
 	return &OpentofuTests{

--- a/daggerverse/opentofu/README.md
+++ b/daggerverse/opentofu/README.md
@@ -74,6 +74,13 @@ variables. State never leaves the backend, and no state file is emitted.
 Calling `WithState` alongside `WithBackendConfig*` is rejected with an error
 naming both modes rather than silently picking a winner.
 
+A backend standing up inside the same pipeline — a state server, an
+S3-compatible service — is unreachable until it is bound:
+`WithServiceBinding(alias, service)` puts it on the tofu container's network
+under `alias`. That is the seam the suite's own MinIO fixture uses, and it
+works for anything else tofu has to dial (a provider's API, a git server
+hosting module sources).
+
 `Destroy` with neither state nor a backend is rejected too: `tofu` would
 happily report "0 destroyed" and exit 0, which reads as a successful teardown
 while the real infrastructure — whose state was never supplied — stays up.
@@ -120,6 +127,7 @@ lock file refreshed with `tofu providers lock`.
 | `Config.WithVarFile(file)` | `-var-file`, staged outside the root module. |
 | `Config.WithEnvVariable(name, value)` | A plain environment variable on every exec. |
 | `Config.WithSecretVariable(name, secret)` | A secret environment variable — how provider credentials arrive. |
+| `Config.WithServiceBinding(alias, service)` | Make a Dagger service reachable from every tofu exec under `alias`. |
 | `Config.WithBackendConfig(name, value)` | `-backend-config=name=value`. |
 | `Config.WithBackendConfigFile(file)` | `-backend-config=<file>`. |
 | `Config.WithWorkspace(name)` | `tofu workspace select -or-create`. |
@@ -242,3 +250,19 @@ Fixtures under `tests/fixtures/` use `hashicorp/random` and `hashicorp/local`
 only, so nothing needs a cloud credential. The random provider's resources
 exist purely in state, which is what makes the state round-trip assertions
 meaningful — there is no out-of-band object to drift away underneath them.
+
+The remote-backend half of the suite is hermetic too. `tests/backend.go`
+stands up a MinIO service per test, mints its root credential with
+`dag.Random().Sha256()` and crosses it as a `*Secret`, and points the `s3`
+backend at it through `WithServiceBinding`. Against that it proves state lives
+in the bucket and not in the returned directory, that `WithBackendConfigFile`
+selects the same backend as the individual `WithBackendConfig` calls, that
+`WithWorkspace` keeps two workspaces' states apart, and that two applies racing
+for one state either serialise or fail on the lock — with the losing apply's
+work never silently overwritten.
+
+One endpoint detail that fixture has to work around: the `s3` backend's
+endpoint override lives under a nested `endpoints` attribute, which
+`-backend-config=name=value` cannot express. The fixture sets
+`AWS_ENDPOINT_URL_S3` instead, which is also what makes the flag form and the
+file form carry an identical list of settings.

--- a/daggerverse/opentofu/config.go
+++ b/daggerverse/opentofu/config.go
@@ -101,6 +101,11 @@ type Config struct {
 	SecretEnvValues []*dagger.Secret
 
 	// +private
+	ServiceAliases []string
+	// +private
+	Services []*dagger.Service
+
+	// +private
 	BackendNames []string
 	// +private
 	BackendValues []string
@@ -169,6 +174,24 @@ func (c *Config) WithSecretVariable(name string, value *dagger.Secret) *Config {
 	out := c.clone()
 	out.SecretEnvNames = append(out.SecretEnvNames, name)
 	out.SecretEnvValues = append(out.SecretEnvValues, value)
+	return out
+}
+
+// WithServiceBinding makes a Dagger service reachable from every tofu exec
+// under the given hostname, the way `docker run --link` used to work.
+//
+// Without it a backend standing up inside the same pipeline is unreachable:
+// tofu runs in its own container, and nothing else in this module opens a
+// route out of it. That is the case for a state server, a LocalStack-style
+// API the providers talk to, or a git server hosting module sources.
+func (c *Config) WithServiceBinding(
+	// Hostname the service answers to from inside the tofu container.
+	alias string,
+	service *dagger.Service,
+) *Config {
+	out := c.clone()
+	out.ServiceAliases = append(out.ServiceAliases, alias)
+	out.Services = append(out.Services, service)
 	return out
 }
 
@@ -493,6 +516,8 @@ func (c *Config) clone() *Config {
 	out.EnvValues = append([]string(nil), c.EnvValues...)
 	out.SecretEnvNames = append([]string(nil), c.SecretEnvNames...)
 	out.SecretEnvValues = append([]*dagger.Secret(nil), c.SecretEnvValues...)
+	out.ServiceAliases = append([]string(nil), c.ServiceAliases...)
+	out.Services = append([]*dagger.Service(nil), c.Services...)
 	out.BackendNames = append([]string(nil), c.BackendNames...)
 	out.BackendValues = append([]string(nil), c.BackendValues...)
 	out.BackendFiles = append([]*dagger.File(nil), c.BackendFiles...)
@@ -534,6 +559,11 @@ func (c *Config) validate() error {
 			return fmt.Errorf("WithSecretVariable: variable name is required")
 		}
 	}
+	for _, alias := range c.ServiceAliases {
+		if strings.TrimSpace(alias) == "" {
+			return fmt.Errorf("WithServiceBinding: hostname alias is required")
+		}
+	}
 	return nil
 }
 
@@ -564,6 +594,9 @@ func (c *Config) container() *dagger.Container {
 	}
 	for i, f := range c.BackendFiles {
 		ctr = ctr.WithMountedFile(backendFilePath(i), f)
+	}
+	for i, alias := range c.ServiceAliases {
+		ctr = ctr.WithServiceBinding(alias, c.Services[i])
 	}
 	for i, name := range c.EnvNames {
 		ctr = ctr.WithEnvVariable(name, c.EnvValues[i])

--- a/daggerverse/opentofu/dagger.gen.go
+++ b/daggerverse/opentofu/dagger.gen.go
@@ -100,6 +100,8 @@ func (r Config) MarshalJSON() ([]byte, error) {
 		EnvValues       []string
 		SecretEnvNames  []string
 		SecretEnvValues []*dagger.Secret
+		ServiceAliases  []string
+		Services        []*dagger.Service
 		BackendNames    []string
 		BackendValues   []string
 		BackendFiles    []*dagger.File
@@ -118,6 +120,8 @@ func (r Config) MarshalJSON() ([]byte, error) {
 	concrete.EnvValues = r.EnvValues
 	concrete.SecretEnvNames = r.SecretEnvNames
 	concrete.SecretEnvValues = r.SecretEnvValues
+	concrete.ServiceAliases = r.ServiceAliases
+	concrete.Services = r.Services
 	concrete.BackendNames = r.BackendNames
 	concrete.BackendValues = r.BackendValues
 	concrete.BackendFiles = r.BackendFiles
@@ -140,6 +144,8 @@ func (r *Config) UnmarshalJSON(bs []byte) error {
 		EnvValues       []string
 		SecretEnvNames  []string
 		SecretEnvValues []*dagger.Secret
+		ServiceAliases  []string
+		Services        []*dagger.Service
 		BackendNames    []string
 		BackendValues   []string
 		BackendFiles    []*dagger.File
@@ -162,6 +168,8 @@ func (r *Config) UnmarshalJSON(bs []byte) error {
 	r.EnvValues = concrete.EnvValues
 	r.SecretEnvNames = concrete.SecretEnvNames
 	r.SecretEnvValues = concrete.SecretEnvValues
+	r.ServiceAliases = concrete.ServiceAliases
+	r.Services = concrete.Services
 	r.BackendNames = concrete.BackendNames
 	r.BackendValues = concrete.BackendValues
 	r.BackendFiles = concrete.BackendFiles
@@ -569,6 +577,27 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Config).WithSecretVariable(&parent, name, value), nil
+		case "WithServiceBinding":
+			var parent Config
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var alias string
+			if inputArgs["alias"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["alias"]), &alias)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg alias", err))
+				}
+			}
+			var service *dagger.Service
+			if inputArgs["service"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["service"]), &service)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg service", err))
+				}
+			}
+			return (*Config).WithServiceBinding(&parent, alias, service), nil
 		case "WithState":
 			var parent Config
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/opentofu/tests/backend.go
+++ b/daggerverse/opentofu/tests/backend.go
@@ -1,0 +1,597 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+
+	"dagger/tests/internal/dagger"
+)
+
+// ----------------------------------------------------------- remote backend
+
+// RemoteBackendRoundTripsState asserts the backend path end to end: an apply
+// against a real S3 backend hands back no terraform.tfstate, the backend holds
+// the state instead, a second Config reads it back with nothing but the
+// backend settings to go on, and a destroy empties it.
+//
+// The file-carried tests can only prove that WithBackendConfig reaches
+// `tofu init`; this one proves the state actually goes somewhere else.
+func (t *Tests) RemoteBackendRoundTripsState(ctx context.Context) error {
+	b, err := newBackend(ctx, "round-trip")
+	if err != nil {
+		return err
+	}
+	defer b.stop(ctx)
+
+	applied, err := pin(ctx, b.withFlags(b.config("remote-state")).Apply())
+	if err != nil {
+		return fmt.Errorf("Apply against the remote backend: %w", err)
+	}
+	entries, err := applied.Entries(ctx)
+	if err != nil {
+		return fmt.Errorf("read the apply directory: %w", err)
+	}
+	if slices.Contains(entries, stateFileName) {
+		return fmt.Errorf("expected no %s from a backend-backed apply, got %v", stateFileName, entries)
+	}
+	for _, want := range []string{outputsName, applyLogName} {
+		if !slices.Contains(entries, want) {
+			return fmt.Errorf("expected %s in the apply directory, got %v", want, entries)
+		}
+	}
+
+	objects, err := b.objects(ctx)
+	if err != nil {
+		return err
+	}
+	if !slices.Contains(objects, stateKey) {
+		return fmt.Errorf("expected the backend to hold %s, got %v", stateKey, objects)
+	}
+	state, err := b.state(ctx, stateKey)
+	if err != nil {
+		return err
+	}
+	want := []string{"random_integer.port", "random_pet.name"}
+	if got := state.addresses(); !slices.Equal(got, want) {
+		return fmt.Errorf("expected the backend's state to track %v, got %v", want, got)
+	}
+
+	// Nothing but the backend settings travels into this Config — no state
+	// file, no artifact from the apply above. Reading the applied outputs back
+	// out of it is what proves the backend, not the container, is carrying the
+	// state between runs.
+	raw, err := b.withFlags(b.config("remote-state")).Outputs(ctx)
+	if err != nil {
+		return fmt.Errorf("Outputs from the remote backend: %w", err)
+	}
+	var outputs map[string]outputValue
+	if err := json.Unmarshal([]byte(raw), &outputs); err != nil {
+		return fmt.Errorf("parse the outputs as JSON (%q): %w", raw, err)
+	}
+	for _, name := range []string{"name", "port"} {
+		if _, ok := outputs[name]; !ok {
+			return fmt.Errorf("expected a %s output read back from the backend, got %v", name, outputs)
+		}
+	}
+
+	destroyed, err := pin(ctx, b.withFlags(b.config("remote-state")).Destroy())
+	if err != nil {
+		return fmt.Errorf("Destroy against the remote backend: %w", err)
+	}
+	entries, err = destroyed.Entries(ctx)
+	if err != nil {
+		return fmt.Errorf("read the destroy directory: %w", err)
+	}
+	if slices.Contains(entries, stateFileName) {
+		return fmt.Errorf("expected no %s from a backend-backed destroy, got %v", stateFileName, entries)
+	}
+
+	state, err = b.state(ctx, stateKey)
+	if err != nil {
+		return err
+	}
+	if got := state.addresses(); len(got) != 0 {
+		return fmt.Errorf("expected the backend's state to be emptied, still tracking %v", got)
+	}
+	return nil
+}
+
+// BackendConfigFileMatchesBackendConfig asserts the file form of the backend
+// settings selects the same backend as the individual calls: state written
+// through one is found by the other.
+//
+// A Plan reporting no changes is the assertion, because the only way this
+// Config can know there is nothing to do is by having read the state the
+// flag-configured apply left behind.
+func (t *Tests) BackendConfigFileMatchesBackendConfig(ctx context.Context) error {
+	b, err := newBackend(ctx, "config-file")
+	if err != nil {
+		return err
+	}
+	defer b.stop(ctx)
+
+	if _, err := pin(ctx, b.withFlags(b.config("remote-state")).Apply()); err != nil {
+		return fmt.Errorf("Apply with individual backend settings: %w", err)
+	}
+
+	plan, err := pin(ctx, b.withFile(b.config("remote-state")).Plan())
+	if err != nil {
+		return fmt.Errorf("Plan with a backend settings file: %w", err)
+	}
+	changes, err := plan.File(changesName).Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", changesName, err)
+	}
+	if changes != "none" {
+		text, _ := plan.File(planTextName).Contents(ctx)
+		return fmt.Errorf(
+			"expected the settings file to select the same backend as the individual settings, got changes=%q:\n%s",
+			changes, text)
+	}
+	return nil
+}
+
+// RemoteWorkspacesIsolateState asserts WithWorkspace partitions a remote
+// backend: an apply in one workspace is invisible to a plan in another, and
+// the two states are distinct objects in the bucket.
+//
+// The local backend makes this awkward to see — each workspace's state comes
+// back as the same terraform.tfstate file in a different directory — which is
+// why the isolation is pinned here rather than alongside the file-carried
+// workspace test.
+func (t *Tests) RemoteWorkspacesIsolateState(ctx context.Context) error {
+	b, err := newBackend(ctx, "workspaces")
+	if err != nil {
+		return err
+	}
+	defer b.stop(ctx)
+
+	const (
+		staging    = "staging"
+		production = "production"
+	)
+
+	if _, err := pin(ctx, b.withFlags(b.config("remote-state")).WithWorkspace(staging).Apply()); err != nil {
+		return fmt.Errorf("Apply on workspace %q: %w", staging, err)
+	}
+
+	stagingChanges, err := b.planChanges(ctx, staging)
+	if err != nil {
+		return err
+	}
+	if stagingChanges != "none" {
+		return fmt.Errorf("expected workspace %q to see its own apply, got changes=%q", staging, stagingChanges)
+	}
+
+	productionChanges, err := b.planChanges(ctx, production)
+	if err != nil {
+		return err
+	}
+	if productionChanges != "changes" {
+		return fmt.Errorf(
+			"expected workspace %q to start from an empty state, got changes=%q — the workspaces share state",
+			production, productionChanges)
+	}
+
+	// The plan verdicts above are read through tofu, which would agree with
+	// itself even if both workspaces resolved to one object. The bucket is the
+	// independent witness.
+	objects, err := b.objects(ctx)
+	if err != nil {
+		return err
+	}
+	want := workspaceStateKey(staging)
+	if !slices.Contains(objects, want) {
+		return fmt.Errorf("expected the backend to hold %s for workspace %q, got %v", want, staging, objects)
+	}
+	if slices.Contains(objects, stateKey) {
+		return fmt.Errorf("expected no default-workspace state at %s, got %v", stateKey, objects)
+	}
+
+	state, err := b.state(ctx, want)
+	if err != nil {
+		return err
+	}
+	wantAddresses := []string{"random_integer.port", "random_pet.name"}
+	if got := state.addresses(); !slices.Equal(got, wantAddresses) {
+		return fmt.Errorf("expected workspace %q to track %v, got %v", staging, wantAddresses, got)
+	}
+	return nil
+}
+
+// ConcurrentAppliesDoNotCorruptState asserts two applies racing for the same
+// remote state either serialise or fail on the lock — never both go through as
+// if the other had not happened.
+//
+// The two accepted outcomes are asserted separately because which one occurs
+// is a matter of timing, not of correctness:
+//
+//   - one apply fails with tofu's state-lock diagnostic, or
+//   - both succeed, and exactly one of them created the resources while the
+//     other found them already there.
+//
+// The second half is what makes this more than a smoke test. A backend without
+// working locking also lets both applies succeed — but then both start from an
+// empty state, both report resources added, and the loser's work is silently
+// dropped when the winner writes its state.
+func (t *Tests) ConcurrentAppliesDoNotCorruptState(ctx context.Context) error {
+	b, err := newBackend(ctx, "locking")
+	if err != nil {
+		return err
+	}
+	defer b.stop(ctx)
+
+	type outcome struct {
+		added int
+		err   error
+	}
+	results := make(chan outcome, 2)
+	for _, attempt := range []string{"a", "b"} {
+		go func() {
+			added, err := b.raceApply(ctx, attempt)
+			results <- outcome{added: added, err: err}
+		}()
+	}
+	first, second := <-results, <-results
+
+	switch {
+	case first.err != nil && second.err != nil:
+		return fmt.Errorf("expected at most one apply to fail, both did:\n%v\n%v", first.err, second.err)
+	case first.err != nil:
+		return expectLockError(first.err)
+	case second.err != nil:
+		return expectLockError(second.err)
+	}
+
+	// Both got through, so they were serialised: the second one to hold the
+	// lock must have read the first one's state and found its work already
+	// done.
+	created := 0
+	for _, o := range []outcome{first, second} {
+		if o.added > 0 {
+			created++
+		}
+	}
+	if created != 1 {
+		return fmt.Errorf(
+			"expected exactly one of two serialised applies to create the resources, got %d added and %d added — "+
+				"both started from an empty state, so one apply's work was overwritten by the other",
+			first.added, second.added)
+	}
+
+	state, err := b.state(ctx, stateKey)
+	if err != nil {
+		return err
+	}
+	want := []string{"random_pet.name", "terraform_data.delay"}
+	if got := state.addresses(); !slices.Equal(got, want) {
+		return fmt.Errorf("expected the surviving state to track %v, got %v", want, got)
+	}
+	return nil
+}
+
+// ------------------------------------------------------------------ fixture
+
+const (
+	// minioImage is the S3-compatible server the backend tests write to. It is
+	// the last community MinIO release, pinned so a suite that passes today
+	// passes tomorrow.
+	minioImage = "minio/minio:RELEASE.2025-09-07T16-13-09Z"
+
+	// mcImage is MinIO's own client. It creates the bucket, and it reads the
+	// bucket back from outside tofu — the only way to assert the state landed
+	// in the backend rather than merely that tofu did not complain.
+	mcImage = "minio/mc:RELEASE.2025-08-13T08-35-41Z"
+
+	minioPort = 9000
+
+	// backendRegion is arbitrary. MinIO ignores it and the s3 backend insists
+	// on having one.
+	backendRegion = "us-east-1"
+
+	// stateKey is where the remote-state fixtures keep the default workspace's
+	// state inside the bucket.
+	stateKey = "state/terraform.tfstate"
+
+	// workspaceKeyPrefix is the s3 backend's default prefix for every
+	// non-default workspace: its state lands at <prefix>/<workspace>/<key>.
+	workspaceKeyPrefix = "env:"
+)
+
+// backend is a throwaway S3 backend: a MinIO service, a bucket inside it, and
+// the credentials tofu needs to reach both.
+//
+// Everything a second fixture could collide on — the binding alias, the
+// bucket, the credential — is derived from fresh randomness, so the backend
+// tests run in parallel with each other under `all`.
+type backend struct {
+	Svc *dagger.Service
+	// Host is the alias the service is bound under, not a hostname the
+	// service itself claims; see the note in newBackend.
+	Host      string
+	Bucket    string
+	AccessKey *dagger.Secret
+	SecretKey *dagger.Secret
+}
+
+// newBackend starts a MinIO service with a randomly generated root credential
+// and creates the bucket the fixtures write their state into.
+func newBackend(ctx context.Context, label string) (*backend, error) {
+	id, err := dag.Random().Sha256(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("name the %s backend fixture: %w", label, err)
+	}
+	suffix := id[:12]
+
+	// The root credential is minted the same way every other secret in this
+	// suite is, and travels the same way: as a *dagger.Secret, never as a
+	// literal. A throwaway MinIO is no reason to put a password in git.
+	_, accessKey, err := testSecret(ctx, label+"-access-key")
+	if err != nil {
+		return nil, err
+	}
+	_, secretKey, err := testSecret(ctx, label+"-secret-key")
+	if err != nil {
+		return nil, err
+	}
+
+	b := &backend{
+		Host:      "minio-" + suffix,
+		Bucket:    "tofu-state-" + suffix,
+		AccessKey: accessKey,
+		SecretKey: secretKey,
+	}
+	b.Svc = dag.Container().
+		From(minioImage).
+		WithSecretVariable("MINIO_ROOT_USER", accessKey).
+		WithSecretVariable("MINIO_ROOT_PASSWORD", secretKey).
+		WithExposedPort(minioPort).
+		// A server never exits, so it belongs in AsService's args rather than
+		// a WithExec, which would wait for it forever.
+		AsService(dagger.ContainerAsServiceOpts{
+			Args: []string{"minio", "server", "/data", "--address", fmt.Sprintf(":%d", minioPort)},
+		})
+	// Deliberately no WithHostname: a custom hostname is registered in the DNS
+	// domain of the client that starts the service, and the container that has
+	// to reach this one is assembled inside the opentofu module — a different
+	// client, which cannot resolve it. The generated hostname is
+	// session-visible, and Host is only ever the alias a binding maps onto it.
+
+	// Started here rather than left to the first WithServiceBinding: a binding
+	// holds the service only for the exec that declares it, and this MinIO
+	// keeps its data in a scratch container filesystem. A restart between the
+	// apply and the plan that is supposed to observe it would take the state
+	// with it.
+	if _, err := b.Svc.Start(ctx); err != nil {
+		return nil, fmt.Errorf("start the MinIO backend: %w", err)
+	}
+	if _, err := b.mc(ctx, "mb", "--ignore-existing", "local/"+b.Bucket); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// stop tears the service down. Under `all` several backends are alive at once,
+// and each is useless the moment its test returns.
+func (b *backend) stop(ctx context.Context) {
+	_, _ = b.Svc.Stop(ctx)
+}
+
+func (b *backend) endpoint() string {
+	return fmt.Sprintf("http://%s:%d", b.Host, minioPort)
+}
+
+// config binds a fixture to the toolchain with everything the backend needs
+// except the backend settings themselves, which withFlags and withFile supply
+// in their two different ways.
+func (b *backend) config(name string) *dagger.OpentofuConfig {
+	return opentofu().
+		Config(fixture(name)).
+		// Without this the backend is simply unreachable: tofu runs in its own
+		// container, and MinIO is a service in the session, not on the
+		// internet.
+		WithServiceBinding(b.Host, b.Svc).
+		WithSecretVariable("AWS_ACCESS_KEY_ID", b.AccessKey).
+		WithSecretVariable("AWS_SECRET_ACCESS_KEY", b.SecretKey).
+		// The endpoint override is the one setting that cannot travel as a
+		// `-backend-config=name=value` scalar — it lives under the s3 backend's
+		// nested `endpoints` attribute. Routing it through the AWS SDK's own
+		// environment override instead is what lets the flag form and the file
+		// form below carry an identical list of settings.
+		WithEnvVariable("AWS_ENDPOINT_URL_S3", b.endpoint()).
+		WithEnvVariable("AWS_REGION", backendRegion)
+}
+
+// settings is the backend configuration both forms render, so the equivalence
+// test compares two spellings of one list rather than two lists.
+func (b *backend) settings() [][2]string {
+	return [][2]string{
+		{"bucket", b.Bucket},
+		{"key", stateKey},
+		{"region", backendRegion},
+		// MinIO serves one host, not a bucket-per-subdomain wildcard.
+		{"use_path_style", "true"},
+		// Locking through a conditional-write lock object in the bucket
+		// itself. The alternative, a DynamoDB table, has no counterpart here.
+		{"use_lockfile", "true"},
+		// The credential is a MinIO root user: there is no STS to validate it
+		// against, no account ID to request, and no instance metadata service
+		// behind the endpoint.
+		{"skip_credentials_validation", "true"},
+		{"skip_requesting_account_id", "true"},
+		{"skip_metadata_api_check", "true"},
+		{"skip_region_validation", "true"},
+	}
+}
+
+// withFlags renders the settings as individual WithBackendConfig calls.
+func (b *backend) withFlags(cfg *dagger.OpentofuConfig) *dagger.OpentofuConfig {
+	for _, setting := range b.settings() {
+		cfg = cfg.WithBackendConfig(setting[0], setting[1])
+	}
+	return cfg
+}
+
+// withFile renders the same settings as a single backend settings file.
+func (b *backend) withFile(cfg *dagger.OpentofuConfig) *dagger.OpentofuConfig {
+	var hcl strings.Builder
+	for _, setting := range b.settings() {
+		fmt.Fprintf(&hcl, "%s = %q\n", setting[0], setting[1])
+	}
+	return cfg.WithBackendConfigFile(newFile("backend.hcl", hcl.String()))
+}
+
+// planChanges plans the remote-state fixture on the named workspace and
+// returns the one-word verdict.
+func (b *backend) planChanges(ctx context.Context, workspace string) (string, error) {
+	plan, err := pin(ctx, b.withFlags(b.config("remote-state")).WithWorkspace(workspace).Plan())
+	if err != nil {
+		return "", fmt.Errorf("Plan on workspace %q: %w", workspace, err)
+	}
+	changes, err := plan.File(changesName).Contents(ctx)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", changesName, err)
+	}
+	return changes, nil
+}
+
+// raceApply is one of the two concurrent applies. It returns how many
+// resources the apply reported creating.
+//
+// The plugin cache is off on purpose: it is shared with LOCKED sharing, which
+// would serialise the two inits before either reached the backend and leave
+// the lock untested.
+//
+// attempt only distinguishes the two calls from each other. Two byte-identical
+// concurrent calls would be one call as far as the engine is concerned, and
+// the race would have a single participant.
+func (b *backend) raceApply(ctx context.Context, attempt string) (int, error) {
+	result, err := pin(ctx, b.withFlags(b.config("remote-state-slow")).
+		WithoutPluginCache().
+		WithEnvVariable("TOFU_TEST_ATTEMPT", attempt).
+		Apply())
+	if err != nil {
+		return 0, err
+	}
+	log, err := result.File(applyLogName).Contents(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("read %s: %w", applyLogName, err)
+	}
+	return addedResources(log)
+}
+
+// ------------------------------------------------------------- mc helpers
+
+// mc runs a MinIO client command against the fixture and returns its stdout.
+//
+// The alias is assembled from secret environment variables inside the
+// container rather than passed to `mc alias set`, so the credential never
+// enters argv. The run carries a nonce because two identical mc invocations
+// would otherwise be one content-addressed exec, and a listing taken before an
+// apply would be handed back as the listing after it.
+func (b *backend) mc(ctx context.Context, args ...string) (string, error) {
+	nonce, err := dag.Random().UUIDV4(ctx)
+	if err != nil {
+		return "", fmt.Errorf("name an mc run: %w", err)
+	}
+	script := `set -e
+export MC_HOST_local="http://$MC_ACCESS_KEY:$MC_SECRET_KEY@$MC_ADDR"
+ready=
+for _ in $(seq 1 90); do
+  if mc --config-dir /tmp/mc ls local >/dev/null 2>&1; then ready=1; break; fi
+  sleep 1
+done
+[ -n "$ready" ] || { echo "MinIO at $MC_ADDR never became ready" >&2; exit 1; }
+exec mc --config-dir /tmp/mc "$@"`
+
+	out, err := dag.Container().
+		From(mcImage).
+		WithServiceBinding(b.Host, b.Svc).
+		WithSecretVariable("MC_ACCESS_KEY", b.AccessKey).
+		WithSecretVariable("MC_SECRET_KEY", b.SecretKey).
+		WithEnvVariable("MC_ADDR", fmt.Sprintf("%s:%d", b.Host, minioPort)).
+		WithEnvVariable("MC_RUN_NONCE", nonce).
+		WithExec(append([]string{"sh", "-c", script, "mc"}, args...)).
+		Stdout(ctx)
+	if err != nil {
+		return "", fmt.Errorf("mc %s: %w", strings.Join(args, " "), err)
+	}
+	return out, nil
+}
+
+// objects lists everything in the bucket, sorted, so an assertion does not
+// depend on the order MinIO happens to return.
+func (b *backend) objects(ctx context.Context) ([]string, error) {
+	out, err := b.mc(ctx, "ls", "--recursive", "--json", "local/"+b.Bucket)
+	if err != nil {
+		return nil, err
+	}
+	var keys []string
+	for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var entry struct {
+			Key string `json:"key"`
+		}
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			return nil, fmt.Errorf("parse an mc listing entry (%q): %w", line, err)
+		}
+		if entry.Key != "" {
+			keys = append(keys, entry.Key)
+		}
+	}
+	slices.Sort(keys)
+	return keys, nil
+}
+
+// state reads one state object out of the bucket and decodes it.
+func (b *backend) state(ctx context.Context, key string) (stateDocument, error) {
+	raw, err := b.mc(ctx, "cat", "local/"+b.Bucket+"/"+key)
+	if err != nil {
+		return stateDocument{}, err
+	}
+	return parseState(raw)
+}
+
+// ------------------------------------------------------------------ helpers
+
+// workspaceStateKey is where the s3 backend keeps a named workspace's state,
+// given this suite never overrides workspace_key_prefix.
+func workspaceStateKey(workspace string) string {
+	return workspaceKeyPrefix + "/" + workspace + "/" + stateKey
+}
+
+// addedResources reads the resource count out of an apply log's closing line,
+// which reads `Apply complete! Resources: 2 added, 0 changed, 0 destroyed.`
+func addedResources(log string) (int, error) {
+	for line := range strings.SplitSeq(log, "\n") {
+		_, after, found := strings.Cut(line, "Resources:")
+		if !found {
+			continue
+		}
+		count, rest, ok := strings.Cut(strings.TrimSpace(after), " added")
+		if !ok || rest == "" {
+			continue
+		}
+		var added int
+		if _, err := fmt.Sscanf(count, "%d", &added); err != nil {
+			return 0, fmt.Errorf("parse the resource count from %q: %w", line, err)
+		}
+		return added, nil
+	}
+	return 0, fmt.Errorf("expected an apply log ending in a resource summary, got:\n%s", log)
+}
+
+// expectLockError asserts a failed apply failed for the one reason this test
+// accepts: it could not take the state lock. Any other failure — a broken
+// backend, a provider error — is a genuine failure of the test.
+func expectLockError(err error) error {
+	if strings.Contains(err.Error(), "state lock") || strings.Contains(err.Error(), "Lock Info") {
+		return nil
+	}
+	return fmt.Errorf("expected the losing apply to fail on the state lock, got: %v", err)
+}

--- a/daggerverse/opentofu/tests/dagger.gen.go
+++ b/daggerverse/opentofu/tests/dagger.gen.go
@@ -241,6 +241,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).ApplyShouldNotBeCached(&parent, ctx)
+		case "BackendConfigFileMatchesBackendConfig":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).BackendConfigFileMatchesBackendConfig(&parent, ctx)
 		case "CiCheckAggregatesStageFailures":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -318,6 +325,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).CiRunProducesPlanArtifacts(&parent, ctx)
+		case "ConcurrentAppliesDoNotCorruptState":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ConcurrentAppliesDoNotCorruptState(&parent, ctx)
 		case "ContainerHasGitAndCaCertificates":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -409,6 +423,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).PlanTargetsLimitScope(&parent, ctx)
+		case "RemoteBackendRoundTripsState":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).RemoteBackendRoundTripsState(&parent, ctx)
+		case "RemoteWorkspacesIsolateState":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).RemoteWorkspacesIsolateState(&parent, ctx)
 		case "SecretVarReachesTofuWithoutLeaking":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/opentofu/tests/fixtures/remote-state-slow/main.tf
+++ b/daggerverse/opentofu/tests/fixtures/remote-state-slow/main.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+
+  backend "s3" {}
+}
+
+variable "delay_seconds" {
+  type        = number
+  default     = 12
+  description = "How long an apply holds the state lock open."
+}
+
+# Holds the apply — and with it the state lock — open long enough for a second,
+# concurrent apply to reach the backend while this one still owns it.
+# terraform_data is built into tofu, so the delay costs no extra provider
+# download, and with no triggers_replace it is created once and never again:
+# an apply that observed the first one's state adds nothing.
+resource "terraform_data" "delay" {
+  provisioner "local-exec" {
+    command = "sleep ${var.delay_seconds}"
+  }
+}
+
+resource "random_pet" "name" {
+  length    = 2
+  separator = "-"
+}
+
+output "name" {
+  value = random_pet.name.id
+}

--- a/daggerverse/opentofu/tests/fixtures/remote-state/main.tf
+++ b/daggerverse/opentofu/tests/fixtures/remote-state/main.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+
+  # A partial configuration: the block names the backend and nothing else, so
+  # every setting arrives at init time and one root module can be pointed at
+  # whichever bucket the caller stood up.
+  backend "s3" {}
+}
+
+# Same shape as the basic fixture, and for the same reason: the random
+# provider's resources exist only in state, so what the backend holds after an
+# apply is the whole truth about them.
+resource "random_pet" "name" {
+  length    = 2
+  separator = "-"
+}
+
+resource "random_integer" "port" {
+  min = 30000
+  max = 32767
+}
+
+output "name" {
+  value = random_pet.name.id
+}
+
+output "port" {
+  value = random_integer.port.result
+}

--- a/daggerverse/opentofu/tests/internal/dagger/opentofu.gen.go
+++ b/daggerverse/opentofu/tests/internal/dagger/opentofu.gen.go
@@ -439,12 +439,12 @@ type OpentofuConfigApplyOpts struct {
 	//
 	// A saved plan from Plan. Without it, Apply plans and applies in one run.
 	//
-	Plan *File // opentofu (../../../../../daggerverse/opentofu/config.go:398:2)
+	Plan *File // opentofu (../../../../../daggerverse/opentofu/config.go:421:2)
 	//
 	// Limit the apply to these resource addresses (`-target`). Rejected
 	// alongside a saved plan, which already fixes what it changes.
 	//
-	Targets []string // opentofu (../../../../../daggerverse/opentofu/config.go:402:2)
+	Targets []string // opentofu (../../../../../daggerverse/opentofu/config.go:425:2)
 }
 
 // Apply realises the configuration and returns terraform.tfstate (in
@@ -459,7 +459,7 @@ type OpentofuConfigApplyOpts struct {
 // produced in file-carried mode. That is deliberate: the alternative, always
 // returning the directory with an exit code inside it, turns a failed apply
 // into a silent green whenever a caller forgets to look.
-func (r *OpentofuConfig) Apply(opts ...OpentofuConfigApplyOpts) *Directory { // opentofu (../../../../../daggerverse/opentofu/config.go:394:1)
+func (r *OpentofuConfig) Apply(opts ...OpentofuConfigApplyOpts) *Directory { // opentofu (../../../../../daggerverse/opentofu/config.go:417:1)
 	q := r.query.Select("apply")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `plan` optional argument
@@ -493,7 +493,7 @@ type OpentofuConfigDestroyOpts struct {
 	//
 	// Limit the destroy to these resource addresses (`-target`).
 	//
-	Targets []string // opentofu (../../../../../daggerverse/opentofu/config.go:437:2)
+	Targets []string // opentofu (../../../../../daggerverse/opentofu/config.go:460:2)
 }
 
 // Destroy tears down everything the state tracks and returns the post-destroy
@@ -503,7 +503,7 @@ type OpentofuConfigDestroyOpts struct {
 // backend to read it from: tofu would happily report "0 destroyed" against an
 // empty state, which reads as success while leaving the real infrastructure
 // untouched.
-func (r *OpentofuConfig) Destroy(opts ...OpentofuConfigDestroyOpts) *Directory { // opentofu (../../../../../daggerverse/opentofu/config.go:433:1)
+func (r *OpentofuConfig) Destroy(opts ...OpentofuConfigDestroyOpts) *Directory { // opentofu (../../../../../daggerverse/opentofu/config.go:456:1)
 	q := r.query.Select("destroy")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `targets` optional argument
@@ -523,7 +523,7 @@ func (r *OpentofuConfig) Destroy(opts ...OpentofuConfigDestroyOpts) *Directory {
 //
 // A failing run carries the diff in the error rather than the return value:
 // Dagger drops a function's value whenever its error is non-nil.
-func (r *OpentofuConfig) Fmt(ctx context.Context) (string, error) { // opentofu (../../../../../daggerverse/opentofu/config.go:242:1)
+func (r *OpentofuConfig) Fmt(ctx context.Context) (string, error) { // opentofu (../../../../../daggerverse/opentofu/config.go:265:1)
 	if r.fmt != nil {
 		return *r.fmt, nil
 	}
@@ -592,7 +592,7 @@ func (r *OpentofuConfig) UnmarshalJSON(bs []byte) error {
 // exist outside this container, so carrying them out would hand the caller
 // dangling links. The lock file is the portable artifact of an init, and it
 // is what a repo commits.
-func (r *OpentofuConfig) Init() *Directory { // opentofu (../../../../../daggerverse/opentofu/config.go:300:1)
+func (r *OpentofuConfig) Init() *Directory { // opentofu (../../../../../daggerverse/opentofu/config.go:323:1)
 	q := r.query.Select("init")
 
 	return &Directory{
@@ -602,7 +602,7 @@ func (r *OpentofuConfig) Init() *Directory { // opentofu (../../../../../daggerv
 
 // Outputs returns the root module's output values as JSON
 // (`tofu output -json`).
-func (r *OpentofuConfig) Outputs(ctx context.Context) (string, error) { // opentofu (../../../../../daggerverse/opentofu/config.go:471:1)
+func (r *OpentofuConfig) Outputs(ctx context.Context) (string, error) { // opentofu (../../../../../daggerverse/opentofu/config.go:494:1)
 	if r.outputs != nil {
 		return *r.outputs, nil
 	}
@@ -619,11 +619,11 @@ type OpentofuConfigPlanOpts struct {
 	//
 	// Plan the destruction of all remote objects (`-destroy`).
 	//
-	Destroy bool // opentofu (../../../../../daggerverse/opentofu/config.go:323:2)
+	Destroy bool // opentofu (../../../../../daggerverse/opentofu/config.go:346:2)
 	//
 	// Limit the plan to these resource addresses (`-target`).
 	//
-	Targets []string // opentofu (../../../../../daggerverse/opentofu/config.go:326:2)
+	Targets []string // opentofu (../../../../../daggerverse/opentofu/config.go:349:2)
 }
 
 // Plan produces a saved plan and everything needed to read it, in a single
@@ -634,7 +634,7 @@ type OpentofuConfigPlanOpts struct {
 // One run, not two: underobtain the JSON form could legitimately disagree with the first. The JSON
 // and text renderings are derived from the saved plan file, so they describe
 // exactly the plan that was made.
-func (r *OpentofuConfig) Plan(opts ...OpentofuConfigPlanOpts) *Directory { // opentofu (../../../../../daggerverse/opentofu/config.go:319:1)
+func (r *OpentofuConfig) Plan(opts ...OpentofuConfigPlanOpts) *Directory { // opentofu (../../../../../daggerverse/opentofu/config.go:342:1)
 	q := r.query.Select("plan")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `destroy` optional argument
@@ -654,7 +654,7 @@ func (r *OpentofuConfig) Plan(opts ...OpentofuConfigPlanOpts) *Directory { // op
 
 // Show returns the human-readable rendering of the current state
 // (`tofu show`).
-func (r *OpentofuConfig) Show(ctx context.Context) (string, error) { // opentofu (../../../../../daggerverse/opentofu/config.go:479:1)
+func (r *OpentofuConfig) Show(ctx context.Context) (string, error) { // opentofu (../../../../../daggerverse/opentofu/config.go:502:1)
 	if r.show != nil {
 		return *r.show, nil
 	}
@@ -673,7 +673,7 @@ func (r *OpentofuConfig) Show(ctx context.Context) (string, error) { // opentofu
 // remote backend validates without any credentials and without touching the
 // backend at all. Providers are still installed, because validation needs
 // their schemas.
-func (r *OpentofuConfig) Validate(ctx context.Context) error { // opentofu (../../../../../daggerverse/opentofu/config.go:270:1)
+func (r *OpentofuConfig) Validate(ctx context.Context) error { // opentofu (../../../../../daggerverse/opentofu/config.go:293:1)
 	if r.validate != nil {
 		return nil
 	}
@@ -688,7 +688,7 @@ func (r *OpentofuConfig) Validate(ctx context.Context) error { // opentofu (../.
 // Selecting a remote backend is mutually exclusive with WithState: they are
 // two different answers to where state lives, and combining them is rejected
 // rather than silently resolved.
-func (r *OpentofuConfig) WithBackendConfig(name string, value string) *OpentofuConfig { // opentofu (../../../../../daggerverse/opentofu/config.go:181:1)
+func (r *OpentofuConfig) WithBackendConfig(name string, value string) *OpentofuConfig { // opentofu (../../../../../daggerverse/opentofu/config.go:204:1)
 	q := r.query.Select("withBackendConfig")
 	q = q.Arg("name", name)
 	q = q.Arg("value", value)
@@ -701,7 +701,7 @@ func (r *OpentofuConfig) WithBackendConfig(name string, value string) *OpentofuC
 // WithBackendConfigFile adds a backend settings file
 // (`-backend-config=<file>`). Like WithBackendConfig, it is mutually
 // exclusive with WithState.
-func (r *OpentofuConfig) WithBackendConfigFile(file *File) *OpentofuConfig { // opentofu (../../../../../daggerverse/opentofu/config.go:191:1)
+func (r *OpentofuConfig) WithBackendConfigFile(file *File) *OpentofuConfig { // opentofu (../../../../../daggerverse/opentofu/config.go:214:1)
 	assertNotNil("file", file)
 	q := r.query.Select("withBackendConfigFile")
 	q = q.Arg("file", file)
@@ -715,7 +715,7 @@ func (r *OpentofuConfig) WithBackendConfigFile(file *File) *OpentofuConfig { // 
 // escape hatch for the non-sensitive knobs tofu reads from the environment
 // (TF_LOG, TF_CLI_ARGS_*, provider region settings, ...). Credentials belong
 // in WithSecretVariable.
-func (r *OpentofuConfig) WithEnvVariable(name string, value string) *OpentofuConfig { // opentofu (../../../../../daggerverse/opentofu/config.go:157:1)
+func (r *OpentofuConfig) WithEnvVariable(name string, value string) *OpentofuConfig { // opentofu (../../../../../daggerverse/opentofu/config.go:162:1)
 	q := r.query.Select("withEnvVariable")
 	q = q.Arg("name", name)
 	q = q.Arg("value", value)
@@ -732,7 +732,7 @@ func (r *OpentofuConfig) WithEnvVariable(name string, value string) *OpentofuCon
 // argv, the CLI log, or a saved plan's command line. tofu still marks the
 // variable's own value in the plan unless the variable is declared
 // `sensitive = true`, which a configuration handling secrets should do.
-func (r *OpentofuConfig) WithSecretVar(name string, value *Secret) *OpentofuConfig { // opentofu (../../../../../daggerverse/opentofu/config.go:137:1)
+func (r *OpentofuConfig) WithSecretVar(name string, value *Secret) *OpentofuConfig { // opentofu (../../../../../daggerverse/opentofu/config.go:142:1)
 	assertNotNil("value", value)
 	q := r.query.Select("withSecretVar")
 	q = q.Arg("name", name)
@@ -747,11 +747,29 @@ func (r *OpentofuConfig) WithSecretVar(name string, value *Secret) *OpentofuConf
 // exec. This is how provider credentials reach tofu — AWS_ACCESS_KEY_ID,
 // AWS_SECRET_ACCESS_KEY, TF_TOKEN_app_terraform_io and friends — as
 // *dagger.Secret, never as a string.
-func (r *OpentofuConfig) WithSecretVariable(name string, value *Secret) *OpentofuConfig { // opentofu (../../../../../daggerverse/opentofu/config.go:168:1)
+func (r *OpentofuConfig) WithSecretVariable(name string, value *Secret) *OpentofuConfig { // opentofu (../../../../../daggerverse/opentofu/config.go:173:1)
 	assertNotNil("value", value)
 	q := r.query.Select("withSecretVariable")
 	q = q.Arg("name", name)
 	q = q.Arg("value", value)
+
+	return &OpentofuConfig{
+		query: q,
+	}
+}
+
+// WithServiceBinding makes a Dagger service reachable from every tofu exec
+// under the given hostname, the way `docker run --link` used to work.
+//
+// Without it a backend standing up inside the same pipeline is unreachable:
+// tofu runs in its own container, and nothing else in this module opens a
+// route out of it. That is the case for a state server, a LocalStack-style
+// API the providers talk to, or a git server hosting module sources.
+func (r *OpentofuConfig) WithServiceBinding(alias string, service *Service) *OpentofuConfig { // opentofu (../../../../../daggerverse/opentofu/config.go:187:1)
+	assertNotNil("service", service)
+	q := r.query.Select("withServiceBinding")
+	q = q.Arg("alias", alias)
+	q = q.Arg("service", service)
 
 	return &OpentofuConfig{
 		query: q,
@@ -764,7 +782,7 @@ func (r *OpentofuConfig) WithSecretVariable(name string, value *Secret) *Opentof
 // backend required, and the caller owns persistence.
 //
 // Omit it entirely for a first apply against an empty state.
-func (r *OpentofuConfig) WithState(state *File) *OpentofuConfig { // opentofu (../../../../../daggerverse/opentofu/config.go:226:1)
+func (r *OpentofuConfig) WithState(state *File) *OpentofuConfig { // opentofu (../../../../../daggerverse/opentofu/config.go:249:1)
 	assertNotNil("state", state)
 	q := r.query.Select("withState")
 	q = q.Arg("state", state)
@@ -779,7 +797,7 @@ func (r *OpentofuConfig) WithState(state *File) *OpentofuConfig { // opentofu (.
 // It takes a name and a value rather than a map because Dagger functions
 // cannot accept map parameters. Use WithSecretVar for anything sensitive:
 // a value passed here lands in argv and in the plan.
-func (r *OpentofuConfig) WithVar(name string, value string) *OpentofuConfig { // opentofu (../../../../../daggerverse/opentofu/config.go:123:1)
+func (r *OpentofuConfig) WithVar(name string, value string) *OpentofuConfig { // opentofu (../../../../../daggerverse/opentofu/config.go:128:1)
 	q := r.query.Select("withVar")
 	q = q.Arg("name", name)
 	q = q.Arg("value", value)
@@ -792,7 +810,7 @@ func (r *OpentofuConfig) WithVar(name string, value string) *OpentofuConfig { //
 // WithVarFile adds a variable definitions file (`-var-file`). The file is
 // staged outside the root module so it cannot collide with a file the
 // configuration owns; tofu is pointed at the staged path.
-func (r *OpentofuConfig) WithVarFile(file *File) *OpentofuConfig { // opentofu (../../../../../daggerverse/opentofu/config.go:147:1)
+func (r *OpentofuConfig) WithVarFile(file *File) *OpentofuConfig { // opentofu (../../../../../daggerverse/opentofu/config.go:152:1)
 	assertNotNil("file", file)
 	q := r.query.Select("withVarFile")
 	q = q.Arg("file", file)
@@ -806,7 +824,7 @@ func (r *OpentofuConfig) WithVarFile(file *File) *OpentofuConfig { // opentofu (
 // (`tofu workspace select -or-create`). With the local backend this moves the
 // state to terraform.tfstate.d/<name>/terraform.tfstate, which is where
 // WithState writes and where Apply reads the emitted state from.
-func (r *OpentofuConfig) WithWorkspace(name string) *OpentofuConfig { // opentofu (../../../../../daggerverse/opentofu/config.go:201:1)
+func (r *OpentofuConfig) WithWorkspace(name string) *OpentofuConfig { // opentofu (../../../../../daggerverse/opentofu/config.go:224:1)
 	q := r.query.Select("withWorkspace")
 	q = q.Arg("name", name)
 
@@ -821,7 +839,7 @@ func (r *OpentofuConfig) WithWorkspace(name string) *OpentofuConfig { // opentof
 // This is a Without* modifier rather than a `pluginCache bool` parameter
 // defaulting to true, because a `false from the Go SDK: the zero value is dropped before it reaches the
 // engine.
-func (r *OpentofuConfig) WithoutPluginCache() *OpentofuConfig { // opentofu (../../../../../daggerverse/opentofu/config.go:214:1)
+func (r *OpentofuConfig) WithoutPluginCache() *OpentofuConfig { // opentofu (../../../../../daggerverse/opentofu/config.go:237:1)
 	q := r.query.Select("withoutPluginCache")
 
 	return &OpentofuConfig{

--- a/daggerverse/opentofu/tests/lifecycle.go
+++ b/daggerverse/opentofu/tests/lifecycle.go
@@ -413,11 +413,17 @@ func decodePlan(ctx context.Context, plan *dagger.Directory) (planDocument, erro
 }
 
 func decodeState(ctx context.Context, state *dagger.File) (stateDocument, error) {
-	var doc stateDocument
 	raw, err := state.Contents(ctx)
 	if err != nil {
-		return doc, fmt.Errorf("read %s: %w", stateFileName, err)
+		return stateDocument{}, fmt.Errorf("read %s: %w", stateFileName, err)
 	}
+	return parseState(raw)
+}
+
+// parseState decodes a state document that was read as text — from a file
+// here, from an object in a remote backend in the backend tests.
+func parseState(raw string) (stateDocument, error) {
+	var doc stateDocument
 	if err := json.Unmarshal([]byte(raw), &doc); err != nil {
 		return doc, fmt.Errorf("parse %s: %w", stateFileName, err)
 	}

--- a/daggerverse/opentofu/tests/main.go
+++ b/daggerverse/opentofu/tests/main.go
@@ -8,6 +8,10 @@
 // provider's resources exist purely in state, which is what makes the
 // state round-trip assertions meaningful — there is no out-of-band object to
 // drift away underneath them.
+//
+// The remote-state fixtures declare an s3 backend, and it too is hermetic: the
+// S3 they write to is a MinIO service the suite stands up per test, with a
+// root credential minted at runtime. See backend.go.
 package main
 
 import (
@@ -82,6 +86,11 @@ func (t *Tests) All(
 
 	jobs = jobs.WithJob("WithWorkspaceIsolatesState", t.WithWorkspaceIsolatesState)
 	jobs = jobs.WithJob("WithoutPluginCacheStillApplies", t.WithoutPluginCacheStillApplies)
+
+	jobs = jobs.WithJob("RemoteBackendRoundTripsState", t.RemoteBackendRoundTripsState)
+	jobs = jobs.WithJob("BackendConfigFileMatchesBackendConfig", t.BackendConfigFileMatchesBackendConfig)
+	jobs = jobs.WithJob("RemoteWorkspacesIsolateState", t.RemoteWorkspacesIsolateState)
+	jobs = jobs.WithJob("ConcurrentAppliesDoNotCorruptState", t.ConcurrentAppliesDoNotCorruptState)
 
 	jobs = jobs.WithJob("CiCheckPassesOnCleanConfiguration", t.CiCheckPassesOnCleanConfiguration)
 	jobs = jobs.WithJob("CiCheckReportsUnformattedConfiguration", t.CiCheckReportsUnformattedConfiguration)


### PR DESCRIPTION
Closes #191.

The suite exercised the file-carried state path exhaustively but only proved that `WithBackendConfig` values reached `tofu init` — no test ever ran a real remote backend, because doing so needs a state server stood up as a Dagger service. This closes that gap, and with it the `WithWorkspace` coverage that local-state workspaces make awkward.

## Module change

`Config.WithServiceBinding(alias, service)` in `daggerverse/opentofu/config.go`. Without it the story is not implementable: the tofu container is assembled inside the module, so nothing a caller can reach puts a backend living in the same pipeline on its network. Bindings are applied in `container()` alongside the env/secret wiring, and an empty alias is rejected in `validate()` with the other deferred builder checks. It is equally the seam for anything else tofu has to dial — a provider's API, a git server hosting module sources.

## Fixture

`tests/backend.go` stands up a MinIO service per test — root credential from `dag.Random().Sha256(ctx)`, crossed as a `*dagger.Secret`, no literal in git — creates the bucket with `mc`, and uses `mc` again as the independent witness that reads the bucket from outside tofu. `tests/fixtures/remote-state/` is a partial `backend "s3" {}` over the usual random-provider resources; `remote-state-slow/` adds a `terraform_data` with a `local-exec` sleep to hold the state lock open.

## Tests

- **`RemoteBackendRoundTripsState`** — apply emits no `terraform.tfstate`, the bucket holds it, a fresh `Config` with nothing but the backend settings reads the outputs back, and destroy empties it.
- **`BackendConfigFileMatchesBackendConfig`** — the file-configured plan finds the flag-configured apply's state, which it can only do by having selected the same backend.
- **`RemoteWorkspacesIsolateState`** — an apply in `staging` is invisible to a plan in `production`; the bucket independently shows `env:/staging/...` and no default-workspace object, because the plan verdicts alone would agree with themselves even if both workspaces resolved to one key.
- **`ConcurrentAppliesDoNotCorruptState`** — two racing applies either fail on the lock or serialise with exactly one of them creating the resources.

Three points worth a reviewer's eye:

- **The race test has verified teeth.** Run as a negative control with `use_lockfile=false`, the two applies overlap, both report `2 added`, and it fails with "one apply's work was overwritten by the other". Asserting only that both succeeded would have passed there — a backend without working locking also lets both through, it just drops the loser's work. The plugin cache is off in that test on purpose: `LOCKED` sharing would serialise the two inits before either reached the backend.
- **The service must not use `WithHostname`.** A custom hostname registers in the DNS domain of the client that starts the service; the consuming container is assembled inside the *opentofu* module — a different client — and the binding's lookup fails with `no such host`. The generated hostname is session-visible, so the alias-only form is what works. Noted in the fixture so the next author does not re-derive it.
- **The endpoint override cannot be a `-backend-config` scalar.** It lives under the `s3` backend's nested `endpoints` attribute. The fixture sets `AWS_ENDPOINT_URL_S3` instead, which is also what lets the flag form and the file form carry a byte-identical settings list — so the equivalence test compares two spellings of one list rather than two lists.

`dagger develop` re-run in the module, `tests/` and the root `ci` module; generated code committed. All four tests pass individually, `dagger -m daggerverse/opentofu/tests call all` and `dagger call generated` are green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
