### PR TITLE
story(issue-198): add primary/replica replication to valkey

### DIFF
--- a/ci/internal/dagger/valkey-tests.gen.go
+++ b/ci/internal/dagger/valkey-tests.gen.go
@@ -61,41 +61,50 @@ func (r *Query) ValkeyTests() *ValkeyTests { // valkey-tests (../../../daggerver
 type ValkeyTests struct { // valkey-tests (../../../daggerverse/valkey/tests/main.go:26:6)
 	query *querybuilder.Selection
 
-	all                              *Void
-	applyFileReportsFailingCommand   *Void
-	applyFileSeedsData               *Void
-	bindServerReachableFromAlpine    *Void
-	bindServerReachableUnderTls      *Void
-	client                           *Void
-	clientPingWrongPasswordFails     *Void
-	dbSelectsLogicalDatabase         *Void
-	defaultsProduceHealthyServer     *Void
-	delRemovesKeys                   *Void
-	doReturnsJsonReplies             *Void
-	endpointShouldNotBeCached        *Void
-	flushAllClearsKeys               *Void
-	getMissingKeyFails               *Void
-	getShouldNotBeCached             *Void
-	id                               *ID
-	infoReportsRole                  *Void
-	keysScansPattern                 *Void
-	mtlsNodeDemandsClientCertAtWire  *Void
-	mtlsServerRejectsTlsOnlyClient   *Void
-	passwordReusableViaClient        *Void
-	plaintextDialAgainstTlsNodeFails *Void
-	sameNameServerSharesState        *Void
-	security                         *Void
-	server                           *Void
-	serverMtlsRoundTripFromClient    *Void
-	serverRejectsNilPassword         *Void
-	serverRejectsNilSecurity         *Void
-	serverTlsRoundTripFromClient     *Void
-	setGetRoundTrip                  *Void
-	setWithTtlExpires                *Void
-	stopTerminatesServer             *Void
-	tlsServerRejectsEmptyName        *Void
-	tlsServerRejectsPlaintextClient  *Void
-	validation                       *Void
+	all                                   *Void
+	applyFileReportsFailingCommand        *Void
+	applyFileSeedsData                    *Void
+	bindServerReachableFromAlpine         *Void
+	bindServerReachableUnderTls           *Void
+	client                                *Void
+	clientPingWrongPasswordFails          *Void
+	dbSelectsLogicalDatabase              *Void
+	defaultsProduceHealthyServer          *Void
+	delRemovesKeys                        *Void
+	doReturnsJsonReplies                  *Void
+	endpointShouldNotBeCached             *Void
+	flushAllClearsKeys                    *Void
+	getMissingKeyFails                    *Void
+	getShouldNotBeCached                  *Void
+	id                                    *ID
+	infoReportsRole                       *Void
+	keysScansPattern                      *Void
+	mtlsNodeDemandsClientCertAtWire       *Void
+	mtlsServerRejectsTlsOnlyClient        *Void
+	passwordReusableViaClient             *Void
+	plaintextDialAgainstTlsNodeFails      *Void
+	replication                           *Void
+	replicationLinkAuthenticates          *Void
+	replicationNodesHaveDistinctHostnames *Void
+	replicationPropagatesWritesToReplica  *Void
+	replicationRejectsTlsSecurity         *Void
+	replicationRejectsTooFewReplicas      *Void
+	replicationReplicaRejectsWrites       *Void
+	replicationReportsRoles               *Void
+	replicationStopTerminatesEveryNode    *Void
+	sameNameServerSharesState             *Void
+	security                              *Void
+	server                                *Void
+	serverMtlsRoundTripFromClient         *Void
+	serverRejectsNilPassword              *Void
+	serverRejectsNilSecurity              *Void
+	serverTlsRoundTripFromClient          *Void
+	setGetRoundTrip                       *Void
+	setWithTtlExpires                     *Void
+	stopTerminatesServer                  *Void
+	tlsServerRejectsEmptyName             *Void
+	tlsServerRejectsPlaintextClient       *Void
+	validation                            *Void
 }
 
 func (r *ValkeyTests) WithGraphQLQuery(q *querybuilder.Selection) *ValkeyTests {
@@ -131,7 +140,7 @@ func (r *ValkeyTests) All(ctx context.Context, opts ...ValkeyTestsAllOpts) error
 
 // ApplyFileReportsFailingCommand verifies a mid-file failure is not
 // swallowed and that the error names the offending line.
-func (r *ValkeyTests) ApplyFileReportsFailingCommand(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:899:1)
+func (r *ValkeyTests) ApplyFileReportsFailingCommand(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1010:1)
 	if r.applyFileReportsFailingCommand != nil {
 		return nil
 	}
@@ -143,7 +152,7 @@ func (r *ValkeyTests) ApplyFileReportsFailingCommand(ctx context.Context) error 
 // ApplyFileSeedsData verifies a command file lands as data on one
 // connection, and that its quoting and line splitting survive: values
 // with spaces, embedded quotes, blank lines, and `#` comments.
-func (r *ValkeyTests) ApplyFileSeedsData(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:844:1)
+func (r *ValkeyTests) ApplyFileSeedsData(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:955:1)
 	if r.applyFileSeedsData != nil {
 		return nil
 	}
@@ -156,7 +165,7 @@ func (r *ValkeyTests) ApplyFileSeedsData(ctx context.Context) error { // valkey-
 // a consumer container under the hostname Endpoint reports, and that the
 // consumer gets a real PONG back. A port probe would be a false
 // positive: it proves something is listening, not that Valkey answers.
-func (r *ValkeyTests) BindServerReachableFromAlpine(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:382:1)
+func (r *ValkeyTests) BindServerReachableFromAlpine(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:493:1)
 	if r.bindServerReachableFromAlpine != nil {
 		return nil
 	}
@@ -170,7 +179,7 @@ func (r *ValkeyTests) BindServerReachableFromAlpine(ctx context.Context) error {
 // the right CA gets a PONG, proving BindServer stays reachable under TLS
 // from a consumer container. The password rides in as a secret env var so
 // it never enters the exec's argv.
-func (r *ValkeyTests) BindServerReachableUnderTLS(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1551:1)
+func (r *ValkeyTests) BindServerReachableUnderTLS(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2033:1)
 	if r.bindServerReachableUnderTls != nil {
 		return nil
 	}
@@ -181,13 +190,13 @@ func (r *ValkeyTests) BindServerReachableUnderTLS(ctx context.Context) error { /
 
 // ValkeyTestsClientOpts contains options for ValkeyTests.Client
 type ValkeyTestsClientOpts struct {
-	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:118:2)
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:150:2)
 }
 
 // Client runs the command round-trip tests. Each test boots its own node
 // via bootServer, so the keyspaces stay disjoint and the group fans out
 // safely.
-func (r *ValkeyTests) Client(ctx context.Context, opts ...ValkeyTestsClientOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:115:1)
+func (r *ValkeyTests) Client(ctx context.Context, opts ...ValkeyTestsClientOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:147:1)
 	if r.client != nil {
 		return nil
 	}
@@ -205,7 +214,7 @@ func (r *ValkeyTests) Client(ctx context.Context, opts ...ValkeyTestsClientOpts)
 // ClientPingWrongPasswordFails proves requirepass is genuinely applied
 // and the node is not wide open: a client holding a different password
 // cannot authenticate.
-func (r *ValkeyTests) ClientPingWrongPasswordFails(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:991:1)
+func (r *ValkeyTests) ClientPingWrongPasswordFails(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1102:1)
 	if r.clientPingWrongPasswordFails != nil {
 		return nil
 	}
@@ -217,7 +226,7 @@ func (r *ValkeyTests) ClientPingWrongPasswordFails(ctx context.Context) error { 
 // DbSelectsLogicalDatabase verifies db is honoured end to end: a write
 // on db 0 is invisible to a client on db 1, and each database keeps its
 // own DbSize.
-func (r *ValkeyTests) DbSelectsLogicalDatabase(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1026:1)
+func (r *ValkeyTests) DbSelectsLogicalDatabase(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1137:1)
 	if r.dbSelectsLogicalDatabase != nil {
 		return nil
 	}
@@ -229,7 +238,7 @@ func (r *ValkeyTests) DbSelectsLogicalDatabase(ctx context.Context) error { // v
 // DefaultsProduceHealthyServer boots a default node and proves it is a
 // healthy Valkey by answering PING and self-reporting 9.1 in INFO
 // server. Catches image-path drift and a silently moved default tag.
-func (r *ValkeyTests) DefaultsProduceHealthyServer(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:288:1)
+func (r *ValkeyTests) DefaultsProduceHealthyServer(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:399:1)
 	if r.defaultsProduceHealthyServer != nil {
 		return nil
 	}
@@ -240,7 +249,7 @@ func (r *ValkeyTests) DefaultsProduceHealthyServer(ctx context.Context) error { 
 
 // DelRemovesKeys verifies Del reports how many keys it actually removed
 // and that DbSize agrees with the survivors.
-func (r *ValkeyTests) DelRemovesKeys(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:693:1)
+func (r *ValkeyTests) DelRemovesKeys(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:804:1)
 	if r.delRemovesKeys != nil {
 		return nil
 	}
@@ -252,7 +261,7 @@ func (r *ValkeyTests) DelRemovesKeys(ctx context.Context) error { // valkey-test
 // DoReturnsJsonReplies verifies each RESP type survives the JSON
 // encoding distinctly. The dangerous pair is nil versus empty string: a
 // naive encoder collapses both to "".
-func (r *ValkeyTests) DoReturnsJSONReplies(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:784:1)
+func (r *ValkeyTests) DoReturnsJSONReplies(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:895:1)
 	if r.doReturnsJsonReplies != nil {
 		return nil
 	}
@@ -264,7 +273,7 @@ func (r *ValkeyTests) DoReturnsJSONReplies(ctx context.Context) error { // valke
 // EndpointShouldNotBeCached verifies Endpoint re-executes against the
 // receiver it was called on rather than freezing on the first result.
 // Valkey.Server isaddress.
-func (r *ValkeyTests) EndpointShouldNotBeCached(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:314:1)
+func (r *ValkeyTests) EndpointShouldNotBeCached(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:425:1)
 	if r.endpointShouldNotBeCached != nil {
 		return nil
 	}
@@ -275,7 +284,7 @@ func (r *ValkeyTests) EndpointShouldNotBeCached(ctx context.Context) error { // 
 
 // FlushAllClearsKeys verifies FlushAll empties the keyspace and DbSize
 // returns to 0.
-func (r *ValkeyTests) FlushAllClearsKeys(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:952:1)
+func (r *ValkeyTests) FlushAllClearsKeys(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1063:1)
 	if r.flushAllClearsKeys != nil {
 		return nil
 	}
@@ -287,7 +296,7 @@ func (r *ValkeyTests) FlushAllClearsKeys(ctx context.Context) error { // valkey-
 // GetMissingKeyFails verifies absence stays distinguishable from an
 // empty value: an unset key errors, while a key holding "" reads back as
 // "".
-func (r *ValkeyTests) GetMissingKeyFails(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:580:1)
+func (r *ValkeyTests) GetMissingKeyFails(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:691:1)
 	if r.getMissingKeyFails != nil {
 		return nil
 	}
@@ -299,7 +308,7 @@ func (r *ValkeyTests) GetMissingKeyFails(ctx context.Context) error { // valkey-
 // GetShouldNotBeCached verifies Get re-executes on every call: write v1,
 // read it, overwrite with v2, read again. A cached Get would still
 // report v1 — the canonical stale-read bug a missingproduces.
-func (r *ValkeyTests) GetShouldNotBeCached(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:534:1)
+func (r *ValkeyTests) GetShouldNotBeCached(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:645:1)
 	if r.getShouldNotBeCached != nil {
 		return nil
 	}
@@ -358,9 +367,9 @@ func (r *ValkeyTests) UnmarshalJSON(bs []byte) error {
 }
 
 // InfoReportsRole verifies INFO replication reports a standalone node as
-// the primary. This is the assertion the replication follow-up builds
-// on: a replica reports role:slave.
-func (r *ValkeyTests) InfoReportsRole(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:933:1)
+// the primary. ReplicationReportsRoles is the multi-node counterpart,
+// where a replica reports role:slave instead.
+func (r *ValkeyTests) InfoReportsRole(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1044:1)
 	if r.infoReportsRole != nil {
 		return nil
 	}
@@ -373,7 +382,7 @@ func (r *ValkeyTests) InfoReportsRole(ctx context.Context) error { // valkey-tes
 // checks the full match set comes back. One SCAN page holds far fewer
 // than that, so an implementation that returned the first page — or that
 // stopped before the cursor wrapped to 0 — comes up short here.
-func (r *ValkeyTests) KeysScansPattern(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:733:1)
+func (r *ValkeyTests) KeysScansPattern(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:844:1)
 	if r.keysScansPattern != nil {
 		return nil
 	}
@@ -391,7 +400,7 @@ func (r *ValkeyTests) KeysScansPattern(ctx context.Context) error { // valkey-te
 // default `yes`. A regression that passed `--tls-auth-clients no` for
 // MTLS too would let this certless client through and go undetected by
 // the round-trip tests.
-func (r *ValkeyTests) MtlsNodeDemandsClientCertAtWire(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1404:1)
+func (r *ValkeyTests) MtlsNodeDemandsClientCertAtWire(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1886:1)
 	if r.mtlsNodeDemandsClientCertAtWire != nil {
 		return nil
 	}
@@ -404,7 +413,7 @@ func (r *ValkeyTests) MtlsNodeDemandsClientCertAtWire(ctx context.Context) error
 // mTLS side: asking an mTLS node for a TLS-only client returns an error
 // naming both modes, before any wire activity. The SAN value on the cert
 // is irrelevant here — the guard fires in requireMode, ahead of any dial.
-func (r *ValkeyTests) MtlsServerRejectsTLSOnlyClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1359:1)
+func (r *ValkeyTests) MtlsServerRejectsTLSOnlyClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1841:1)
 	if r.mtlsServerRejectsTlsOnlyClient != nil {
 		return nil
 	}
@@ -416,7 +425,7 @@ func (r *ValkeyTests) MtlsServerRejectsTLSOnlyClient(ctx context.Context) error 
 // PasswordReusableViaClient verifies the credentials a Server hands back
 // authenticate through the standalone constructor: Endpointare enough to build a working client, which is what makes the same
 // Client usable against a remote Valkey.
-func (r *ValkeyTests) PasswordReusableViaClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:421:1)
+func (r *ValkeyTests) PasswordReusableViaClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:532:1)
 	if r.passwordReusableViaClient != nil {
 		return nil
 	}
@@ -431,7 +440,7 @@ func (r *ValkeyTests) PasswordReusableViaClient(ctx context.Context) error { // 
 // wire protocol to the encrypted listener and fails. If `--port 0` were
 // missing, a plaintext listener would still be up on 6379 and this dial
 // would succeed.
-func (r *ValkeyTests) PlaintextDialAgainstTLSNodeFails(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1472:1)
+func (r *ValkeyTests) PlaintextDialAgainstTLSNodeFails(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1954:1)
 	if r.plaintextDialAgainstTlsNodeFails != nil {
 		return nil
 	}
@@ -440,11 +449,163 @@ func (r *ValkeyTests) PlaintextDialAgainstTLSNodeFails(ctx context.Context) erro
 	return q.Execute(ctx)
 }
 
+// ValkeyTestsReplicationOpts contains options for ValkeyTests.Replication
+type ValkeyTestsReplicationOpts struct {
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:97:2)
+}
+
+// Replication runs the primary/replica topology tests. Each test boots
+// its own topology via bootReplication, whose runtime-random name folds
+// into Valkey.Replication's session-cache key and into every node's
+// hostname, so concurrent tests get independent topologies.
+func (r *ValkeyTests) Replication(ctx context.Context, opts ...ValkeyTestsReplicationOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:94:1)
+	if r.replication != nil {
+		return nil
+	}
+	q := r.query.Select("replication")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `parallel` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Parallel) {
+			q = q.Arg("parallel", opts[i].Parallel)
+		}
+	}
+
+	return q.Execute(ctx)
+}
+
+// ReplicationLinkAuthenticates verifies the replica actually authenticates
+// to the password-protected primary: it polls for
+// `master_link_status:up`, which a replica whose masterauth was missing or
+// wrong never reaches — it stays `down`, retrying on NOAUTH, while every
+// other assertion in this file would still pass against its (empty but
+// readable) local keyspace.
+func (r *ValkeyTests) ReplicationLinkAuthenticates(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1406:1)
+	if r.replicationLinkAuthenticates != nil {
+		return nil
+	}
+	q := r.query.Select("replicationLinkAuthenticates")
+
+	return q.Execute(ctx)
+}
+
+// ReplicationNodesHaveDistinctHostnames verifies every node gets its own
+// pinned hostname and that two topologies built under different names do
+// not collide. A shared hostname would silently fold two nodes onto one
+// service: the replicas of one topology would answer for the other's, and
+// a parallel suite would trade reads across tests.
+//
+// Endpoint is a pure accessor, so this asserts the addressing scheme
+// without booting anything.
+func (r *ValkeyTests) ReplicationNodesHaveDistinctHostnames(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1446:1)
+	if r.replicationNodesHaveDistinctHostnames != nil {
+		return nil
+	}
+	q := r.query.Select("replicationNodesHaveDistinctHostnames")
+
+	return q.Execute(ctx)
+}
+
+// ReplicationPropagatesWritesToReplica is the core replication smoke
+// path: a key written to the primary becomes readable from the replica.
+// The read polls, because the link is asynchronous and a single read
+// would race the initial sync.
+func (r *ValkeyTests) ReplicationPropagatesWritesToReplica(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1271:1)
+	if r.replicationPropagatesWritesToReplica != nil {
+		return nil
+	}
+	q := r.query.Select("replicationPropagatesWritesToReplica")
+
+	return q.Execute(ctx)
+}
+
+// ReplicationRejectsTlsSecurity verifies a TLS listener profile is
+// refused with an explanation rather than booting replicas that spin
+// forever on a failed handshake: a TLS node runs with `--port 0`, so the
+// replication link would also have to run over TLS, and a client-listener
+// ServerSecurity carries none of the trust material that link needs.
+func (r *ValkeyTests) ReplicationRejectsTLSSecurity(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:357:1)
+	if r.replicationRejectsTlsSecurity != nil {
+		return nil
+	}
+	q := r.query.Select("replicationRejectsTlsSecurity")
+
+	return q.Execute(ctx)
+}
+
+// ReplicationRejectsTooFewReplicas verifies a replica-less "replication"
+// topology is refused rather than silently degrading to a single node —
+// Valkey.Server is what builds that, and a caller who asked for
+// replication and got none would find out only when their read-replica
+// assertions started passing against the primary.
+//
+// The cases are negative rather than 0: the generated Go binding drops
+// any optional argument holding its zero value, so `Replicas: 0` never
+// reaches the module and resolves to the `the CLI does reach the guard, which is why the guard is `< 1` and not
+// `< 0`.
+func (r *ValkeyTests) ReplicationRejectsTooFewReplicas(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:324:1)
+	if r.replicationRejectsTooFewReplicas != nil {
+		return nil
+	}
+	q := r.query.Select("replicationRejectsTooFewReplicas")
+
+	return q.Execute(ctx)
+}
+
+// ReplicationReplicaRejectsWrites verifies `--replica-read-only yes`
+// holds: a write against a replica is refused with READONLY, so a test
+// that writes to the wrong node fails loudly instead of silently losing
+// the write on the next sync.
+func (r *ValkeyTests) ReplicationReplicaRejectsWrites(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1366:1)
+	if r.replicationReplicaRejectsWrites != nil {
+		return nil
+	}
+	q := r.query.Select("replicationReplicaRejectsWrites")
+
+	return q.Execute(ctx)
+}
+
+// ReplicationReportsRoles verifies INFO replication describes the
+// topology from both ends: the primary is role:master with as many
+// connected_slaves as there are replicas, and every replica reports the
+// replica role. Two replicas rather than one, so a count that reported
+// "some replica connected" instead of all of them fails here.
+func (r *ValkeyTests) ReplicationReportsRoles(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1313:1)
+	if r.replicationReportsRoles != nil {
+		return nil
+	}
+	q := r.query.Select("replicationReportsRoles")
+
+	return q.Execute(ctx)
+}
+
+// ReplicationStopTerminatesEveryNode verifies no node in the topology
+// answers once Stop returns. The post-Stop probes go through the
+// standalone constructor on purpose: Server.Client would re-Start the
+// service it is asked to dial and the test would pass no matter what Stop
+// did.
+//
+// What this pins and what it cannot: a Stop that did nothing, that
+// errored, or that stopped only the replicas is caught here. A Stop that
+// stopped only the primary is NOT — measured against this engine, tearing
+// down the primary also takes down the replicas bound to it, so
+// reachability cannot separate "stopped every node" from "stopped the one
+// every other node depends on". Replication.Stop still walks every node
+// explicitly rather than leaning on that dependency teardown, which is
+// not a documented guarantee.
+func (r *ValkeyTests) ReplicationStopTerminatesEveryNode(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1509:1)
+	if r.replicationStopTerminatesEveryNode != nil {
+		return nil
+	}
+	q := r.query.Select("replicationStopTerminatesEveryNode")
+
+	return q.Execute(ctx)
+}
+
 // SameNameServerSharesState verifies two Server calls with the same name
 // resolve to one backing node: a key written through the first is
 // readable through the second. Catches session cache-key drift, which
 // would silently split a multi-step test across two empty keyspaces.
-func (r *ValkeyTests) SameNameServerSharesState(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:343:1)
+func (r *ValkeyTests) SameNameServerSharesState(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:454:1)
 	if r.sameNameServerSharesState != nil {
 		return nil
 	}
@@ -455,14 +616,14 @@ func (r *ValkeyTests) SameNameServerSharesState(ctx context.Context) error { // 
 
 // ValkeyTestsSecurityOpts contains options for ValkeyTests.Security
 type ValkeyTestsSecurityOpts struct {
-	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:152:2)
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:184:2)
 }
 
 // Security runs the TLS / mTLS listener + client tests. Each test mints
 // its own CA, leaf certs, password, and server name at runtime (no
 // literal credentials or PEM blobs), and folds a unique name into the
 // node's session-cache key, so the tests fan out without sharing state.
-func (r *ValkeyTests) Security(ctx context.Context, opts ...ValkeyTestsSecurityOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:149:1)
+func (r *ValkeyTests) Security(ctx context.Context, opts ...ValkeyTestsSecurityOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:181:1)
 	if r.security != nil {
 		return nil
 	}
@@ -479,14 +640,14 @@ func (r *ValkeyTests) Security(ctx context.Context, opts ...ValkeyTestsSecurityO
 
 // ValkeyTestsServerOpts contains options for ValkeyTests.Server
 type ValkeyTestsServerOpts struct {
-	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:92:2)
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:124:2)
 }
 
 // Server runs the topology, default, and caching tests. Each test boots
 // its own node via bootServer, whose runtime-random name folds into
 // Valkey.Server's session-cache key so concurrent tests boot independent
 // backing services and never share a keyspace.
-func (r *ValkeyTests) Server(ctx context.Context, opts ...ValkeyTestsServerOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:89:1)
+func (r *ValkeyTests) Server(ctx context.Context, opts ...ValkeyTestsServerOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:121:1)
 	if r.server != nil {
 		return nil
 	}
@@ -504,7 +665,7 @@ func (r *ValkeyTests) Server(ctx context.Context, opts ...ValkeyTestsServerOpts)
 // ServerMtlsRoundTripFromClient boots a mutual-TLS node and proves a
 // matching mTLS client (presenting a client cert signed by the trusted
 // CA) can round-trip Set
-func (r *ValkeyTests) ServerMtlsRoundTripFromClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1264:1)
+func (r *ValkeyTests) ServerMtlsRoundTripFromClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1746:1)
 	if r.serverMtlsRoundTripFromClient != nil {
 		return nil
 	}
@@ -514,7 +675,7 @@ func (r *ValkeyTests) ServerMtlsRoundTripFromClient(ctx context.Context) error {
 }
 
 // ServerRejectsNilPassword verifies a passwordless node must not boot.
-func (r *ValkeyTests) ServerRejectsNilPassword(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:237:1)
+func (r *ValkeyTests) ServerRejectsNilPassword(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:269:1)
 	if r.serverRejectsNilPassword != nil {
 		return nil
 	}
@@ -526,7 +687,7 @@ func (r *ValkeyTests) ServerRejectsNilPassword(ctx context.Context) error { // v
 // ServerRejectsNilSecurity verifies plaintext must be a deliberate
 // choice, so the TLS follow-up stays an explicit upgrade rather than a
 // silent default.
-func (r *ValkeyTests) ServerRejectsNilSecurity(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:258:1)
+func (r *ValkeyTests) ServerRejectsNilSecurity(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:290:1)
 	if r.serverRejectsNilSecurity != nil {
 		return nil
 	}
@@ -539,7 +700,7 @@ func (r *ValkeyTests) ServerRejectsNilSecurity(ctx context.Context) error { // v
 // matching TLS client — presenting NO client certificate — can Setagainst it over the encrypted listener. That the certless client is
 // accepted is the `--tls-auth-clients no` acceptance criterion: without
 // that flag Valkey would demand a client cert and reject this dial.
-func (r *ValkeyTests) ServerTLSRoundTripFromClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1214:1)
+func (r *ValkeyTests) ServerTLSRoundTripFromClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1696:1)
 	if r.serverTlsRoundTripFromClient != nil {
 		return nil
 	}
@@ -550,7 +711,7 @@ func (r *ValkeyTests) ServerTLSRoundTripFromClient(ctx context.Context) error { 
 
 // SetGetRoundTrip is the core smoke path: a value written through Set
 // comes back through Get unchanged.
-func (r *ValkeyTests) SetGetRoundTrip(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:501:1)
+func (r *ValkeyTests) SetGetRoundTrip(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:612:1)
 	if r.setGetRoundTrip != nil {
 		return nil
 	}
@@ -569,7 +730,7 @@ func (r *ValkeyTests) SetGetRoundTrip(ctx context.Context) error { // valkey-tes
 // an expiry check, because every step here is a round trip through a
 // re-probed service — a lower bound on the *remaining* TTL would be a
 // stopwatch race under a loaded parallel suite.
-func (r *ValkeyTests) SetWithTTLExpires(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:624:1)
+func (r *ValkeyTests) SetWithTTLExpires(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:735:1)
 	if r.setWithTtlExpires != nil {
 		return nil
 	}
@@ -582,7 +743,7 @@ func (r *ValkeyTests) SetWithTTLExpires(ctx context.Context) error { // valkey-t
 // The post-Stop probe goes through the standalone constructor on
 // purpose: Server.Client would re-Start the service it is asked to dial
 // and the test would pass no matter what Stop did.
-func (r *ValkeyTests) StopTerminatesServer(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:461:1)
+func (r *ValkeyTests) StopTerminatesServer(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:572:1)
 	if r.stopTerminatesServer != nil {
 		return nil
 	}
@@ -597,7 +758,7 @@ func (r *ValkeyTests) StopTerminatesServer(ctx context.Context) error { // valke
 // TLS/mTLS node onto the same sha256("") host and invite cert/SAN reuse.
 // The guard fires in the constructor, before any service starts, so a
 // placeholder SAN on the cert is fine here.
-func (r *ValkeyTests) TLSServerRejectsEmptyName(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1516:1)
+func (r *ValkeyTests) TLSServerRejectsEmptyName(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1998:1)
 	if r.tlsServerRejectsEmptyName != nil {
 		return nil
 	}
@@ -609,7 +770,7 @@ func (r *ValkeyTests) TLSServerRejectsEmptyName(ctx context.Context) error { // 
 // TlsServerRejectsPlaintextClient verifies the mode-coupling check:
 // asking a TLS node for a plaintext client returns an error naming both
 // modes, before any wire activity.
-func (r *ValkeyTests) TLSServerRejectsPlaintextClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1320:1)
+func (r *ValkeyTests) TLSServerRejectsPlaintextClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1802:1)
 	if r.tlsServerRejectsPlaintextClient != nil {
 		return nil
 	}
@@ -620,12 +781,12 @@ func (r *ValkeyTests) TLSServerRejectsPlaintextClient(ctx context.Context) error
 
 // ValkeyTestsValidationOpts contains options for ValkeyTests.Validation
 type ValkeyTestsValidationOpts struct {
-	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:69:2)
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:72:2)
 }
 
 // Validation runs the input-rejection tests. These boot no service, so
 // they're safe to fan out unbounded.
-func (r *ValkeyTests) Validation(ctx context.Context, opts ...ValkeyTestsValidationOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:66:1)
+func (r *ValkeyTests) Validation(ctx context.Context, opts ...ValkeyTestsValidationOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:69:1)
 	if r.validation != nil {
 		return nil
 	}

--- a/daggerverse/valkey/README.md
+++ b/daggerverse/valkey/README.md
@@ -1,10 +1,10 @@
 # valkey
 
-Daggerverse module that spins up a single-node [Valkey](https://valkey.io)
-server (from the upstream `valkey/valkey` image) and exposes a pure-Go
-client (built on
+Daggerverse module that spins up [Valkey](https://valkey.io) topologies
+(from the upstream `valkey/valkey` image) — a single node, or a primary
+with N read replicas — and exposes a pure-Go client (built on
 [`github.com/valkey-io/valkey-go`](https://github.com/valkey-io/valkey-go))
-that can target either the local node or a remote Valkey (e.g.
+that can target either a local node or a remote Valkey (e.g.
 ElastiCache Serverless, MemoryDB, a self-hosted node).
 
 It is the daggerverse's first key-value store, and it targets Valkey
@@ -12,9 +12,9 @@ It is the daggerverse's first key-value store, and it targets Valkey
 
 It supports three client-facing listener modes — plaintext (`requirepass`
 auth over an unencrypted TCP listener), one-way TLS, and mutual TLS.
-Primary/replica replication, Valkey Cluster, `valkey-server` config
-passthrough, the `valkey-bundle` image, and keyspace export/import all
-land in follow-ups.
+Valkey Cluster, `valkey-server` config passthrough, the `valkey-bundle`
+image, TLS for the replication link, and keyspace export/import all land
+in follow-ups.
 
 ## Why `Server` and not `Cluster`
 
@@ -129,6 +129,72 @@ register the service in the module's DNS domain, which a session-domain
 consumer's host-file lookup can't resolve.) For module-runtime access,
 use `Server.Client`, which starts the service itself.
 
+## Replication
+
+Primary/replica topology: one primary plus `replicas` asynchronous read
+replicas, all from the same image. A replica is asymmetric — it dials a
+primary that is already up — so the whole topology is an ordinary service
+binding, with none of the symmetric-peer startup problems Valkey Cluster
+will bring.
+
+```go
+Valkey.Replication(
+    ctx,
+    name="",
+    registry="docker.io", tag="9.1",
+    replicas=1,
+    password *dagger.Secret,
+    clientListenerSecurity *ServerSecurity,
+) (*Replication, error)
+
+Replication.Primary() *Server    // the only node that accepts writes
+Replication.Replicas() []*Server // read replicas, in creation order
+Replication.Stop(ctx) error      // tears down every node
+```
+
+Each replica boots with `--replicaof <primary-host> 6379`, the primary's
+password, and `--replica-read-only yes`. The password is a single secret
+shared by the whole topology: it is each node's own `requirepass` *and*
+the replicas' `masterauth`, and it reaches every node through the same
+secret environment variable, so it never enters any node's `argv` in the
+Dagger graph.
+
+**`masterauth`, not `primaryauth`.** Valkey 9.1 accepts both spellings
+(verified against the pinned image), but `primaryauth` only exists from
+Valkey 8.0 onwards and `tag` is caller-overridable, so the older spelling
+is the one that works across every tag a caller could plausibly pass.
+
+**Plaintext only, for now.** A TLS node runs with `--port 0`, so the
+replication link would have to run over TLS too (`--tls-replication
+yes`), and that link needs trust material a client-listener
+`*ServerSecurity` does not carry: the replica must verify the primary
+against a CA, and under mTLS present a client certificate the primary's
+CA accepts. A TLS or mTLS profile is therefore rejected in the
+constructor rather than booting replicas that spin on a failed handshake.
+
+**Hostnames.** Every node's hostname is `valkey-<sha12(...)>` derived from
+`name` plus the node's role and index, so each node in a topology gets its
+own pinned hostname, two topologies with different `name`s never collide,
+and a topology's nodes never collide with a `Valkey.Server` booted under
+the same `name`.
+
+**Replication is asynchronous.** A read-your-write assertion against a
+replica must poll to a deadline rather than reading once — the write is
+acknowledged by the primary before it reaches any replica.
+
+`Primary()` and `Replicas()` are `+cache="session"` rather than
+`"never"`: Dagger v0.21 detaches module objects returned from a
+`+cache="never"` function when a consumer module reads their fields
+lazily, and `tests/` is such a consumer. The `*Server` methods themselves
+stay `"never"`, so no data-returning call is served stale.
+
+Rejected inputs: `password == nil`, `clientListenerSecurity == nil`, an
+incomplete or non-plaintext security profile, and `replicas < 1` (a
+zero-replica topology is a single node with extra steps — use
+`Valkey.Server`). Note that the generated Go binding drops an optional
+argument holding its zero value, so `Replicas: 0` from Go resolves to the
+`+default=1`; `--replicas=0` on the CLI reaches the guard.
+
 ## Client
 
 Pure-Go valkey-go based client. No container image. Works against the
@@ -190,7 +256,9 @@ failing command aborts the run and reports its line number.
 
 ## Follow-ups
 
-Primary/replica replication; Valkey Cluster / slot sharding;
-`valkey-server` config passthrough (config file, ACL file, append-only,
-max-memory, extra args); the `valkey/valkey-bundle` image with module
-verification; keyspace export/import via SCAN + DUMP/RESTORE.
+TLS/mTLS for the replication link (`--tls-replication yes` plus the trust
+material a replica needs to verify and authenticate to its primary);
+Valkey Cluster / slot sharding; `valkey-server` config passthrough
+(config file, ACL file, append-only, max-memory, extra args); the
+`valkey/valkey-bundle` image with module verification; keyspace
+export/import via SCAN + DUMP/RESTORE.

--- a/daggerverse/valkey/dagger.gen.go
+++ b/daggerverse/valkey/dagger.gen.go
@@ -189,6 +189,26 @@ func (r *ServerSecurity) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
+func (r Replication) MarshalJSON() ([]byte, error) {
+	var concrete struct {
+		Nodes []*Server
+	}
+	concrete.Nodes = r.Nodes
+	return json.Marshal(&concrete)
+}
+
+func (r *Replication) UnmarshalJSON(bs []byte) error {
+	var concrete struct {
+		Nodes []*Server
+	}
+	err := json.Unmarshal(bs, &concrete)
+	if err != nil {
+		return err
+	}
+	r.Nodes = concrete.Nodes
+	return nil
+}
+
 func (r Server) MarshalJSON() ([]byte, error) {
 	var concrete struct {
 		Svc                *dagger.Service
@@ -480,6 +500,32 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 		default:
 			return nil, fmt.Errorf("unknown function %s", fnName)
 		}
+	case "Replication":
+		switch fnName {
+		case "Primary":
+			var parent Replication
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Replication).Primary(&parent), nil
+		case "Replicas":
+			var parent Replication
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Replication).Replicas(&parent), nil
+		case "Stop":
+			var parent Replication
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Replication).Stop(&parent, ctx)
+		default:
+			return nil, fmt.Errorf("unknown function %s", fnName)
+		}
 	case "Server":
 		switch fnName {
 		case "BindServer":
@@ -662,6 +708,55 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return (*Valkey).PlaintextServerSecurity(&parent), nil
+		case "Replication":
+			var parent Valkey
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var name string
+			if inputArgs["name"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["name"]), &name)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg name", err))
+				}
+			}
+			var registry string
+			if inputArgs["registry"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["registry"]), &registry)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg registry", err))
+				}
+			}
+			var tag string
+			if inputArgs["tag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["tag"]), &tag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg tag", err))
+				}
+			}
+			var replicas int
+			if inputArgs["replicas"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["replicas"]), &replicas)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg replicas", err))
+				}
+			}
+			var password *dagger.Secret
+			if inputArgs["password"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["password"]), &password)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg password", err))
+				}
+			}
+			var clientListenerSecurity *ServerSecurity
+			if inputArgs["clientListenerSecurity"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["clientListenerSecurity"]), &clientListenerSecurity)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg clientListenerSecurity", err))
+				}
+			}
+			return (*Valkey).Replication(&parent, ctx, name, registry, tag, replicas, password, clientListenerSecurity)
 		case "Server":
 			var parent Valkey
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/valkey/main.go
+++ b/daggerverse/valkey/main.go
@@ -1,16 +1,16 @@
-// Valkey provides Dagger functions for spinning up a single-node Valkey
-// server (from the upstream `valkey/valkey` image) and a pure-Go
-// valkey-go based client that can target either the local node or any
-// reachable remote Valkey (e.g. ElastiCache Serverless, MemoryDB, a
-// self-hosted node).
+// Valkey provides Dagger functions for spinning up Valkey topologies
+// (from the upstream `valkey/valkey` image) — a single node, or a
+// primary with N read replicas — plus a pure-Go valkey-go based client
+// that can target either a local node or any reachable remote Valkey
+// (e.g. ElastiCache Serverless, MemoryDB, a self-hosted node).
 //
 // Three client-facing listener modes are supported: PLAINTEXT
 // (`requirepass` auth over an unencrypted TCP listener), TLS (one-way:
 // the node presents a server certificate on a `--tls-port` listener and
 // clients still authenticate with the password), and MTLS (mutual: the
 // client must additionally present a certificate signed by the node's
-// trusted CA). Primary/replica replication and Valkey Cluster land in
-// follow-ups.
+// trusted CA). Replication is plaintext-only for now — see
+// Valkey.Replication. Valkey Cluster lands in a follow-up.
 //
 // The single-node type is `Server`, not `Cluster`: in Valkey "cluster"
 // means slot-sharded Valkey Cluster, so that name is reserved for the
@@ -18,13 +18,16 @@
 //
 // File map (all `package main`, surfaced as one Dagger module):
 //
-//   - security.go — *ServerSecurity / *ClientSecurity, the Plaintext /
+//   - security.go    — *ServerSecurity / *ClientSecurity, the Plaintext /
 //     Tls / Mtls constructors, and the listener-mode rendering
 //     (validateServerSecurity / applyServerSecurity).
-//   - server.go   — *Server + Valkey.Server, input validation, the
-//     single-node topology builder, and the Endpoint / User / Password /
-//     BindServer / Client / Stop methods.
-//   - client.go   — *Client + Valkey.Client, valkey-go wiring, and the
+//   - server.go      — *Server + Valkey.Server, input validation, the
+//     shared node builder (buildServer), and the Endpoint / User /
+//     Password / BindServer / Client / Stop methods.
+//   - replication.go — *Replication + Valkey.Replication, the
+//     primary/replica topology builder, and the Primary / Replicas /
+//     Stop methods.
+//   - client.go      — *Client + Valkey.Client, valkey-go wiring, and the
 //     Ping / Do / Get / Set / Del / Keys / ApplyFile / Info / DbSize /
 //     FlushAll method set.
 package main

--- a/daggerverse/valkey/replication.go
+++ b/daggerverse/valkey/replication.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"dagger/valkey/internal/dagger"
+)
+
+// Replication is a primary/replica Valkey topology: one primary plus N
+// asynchronous read replicas. Nodes[0] is always the primary and the
+// remainder are its replicas, in the order they were created.
+//
+// A replica is asymmetric — it dials a primary that is already up — so
+// the whole topology is expressible with an ordinary service binding and
+// none of the symmetric-peer startup problems of Valkey Cluster apply.
+type Replication struct {
+	// +private
+	Nodes []*Server
+}
+
+// Replication boots a primary/replica topology: one primary node plus
+// `replicas` read replicas, each booted with `--replicaof <primary-host>
+// 6379`, the primary's password, and `--replica-read-only yes`.
+//
+// Image: `<registry>/valkey/valkey:<tag>` for every node — the topology
+// is deliberately homogeneous.
+//
+// Rejected inputs (each a descriptive error rather than a half-broken
+// topology):
+//
+//   - `password == nil` — the same secret is both the nodes'
+//     `requirepass` and the replicas' `masterauth`, so it is mandatory.
+//   - `clientListenerSecurity == nil` — plaintext must be a deliberate
+//     caller choice, exactly as for a single Server.
+//   - a TLS or MTLS profile — see the note below.
+//   - `replicas < 1` — a zero-replica "replication" topology is a
+//     single node with extra steps, and Valkey.Server already builds
+//     that.
+//
+// TLS/mTLS is not supported for this topology yet. A TLS node runs with
+// `--port 0`, so the replication link would have to run over TLS too
+// (`--tls-replication yes`), and that link needs trust material this
+// profile does not carry: the replica must verify the primary against a
+// CA, and under mTLS it must additionally present a client certificate
+// the primary's CA accepts. `*ServerSecurity` describes the
+// *client-facing* listener only, so a TLS/mTLS profile is rejected here
+// rather than silently booting replicas that spin on a failed handshake.
+//
+// Session-cached for the same reason Valkey.Server is: repeated chained
+// calls on the returned topology within one test must observe the SAME
+// backing services, and therefore the same keyspace. `name` folds into
+// that cache key and into every node's hostname, so parallel test suites
+// should pass a unique value per test.
+//
+// +cache="session"
+func (v *Valkey) Replication(
+	ctx context.Context,
+	// +default=""
+	name string,
+	// +default="docker.io"
+	registry string,
+	// +default="9.1"
+	tag string,
+	// +default=1
+	replicas int,
+	password *dagger.Secret,
+	clientListenerSecurity *ServerSecurity,
+) (*Replication, error) {
+	if password == nil {
+		return nil, fmt.Errorf("password must not be nil; pass a *dagger.Secret with the requirepass value")
+	}
+	if clientListenerSecurity == nil {
+		return nil, fmt.Errorf("clientListenerSecurity must not be nil; pass PlaintextServerSecurity() explicitly")
+	}
+	if err := validateServerSecurity(clientListenerSecurity); err != nil {
+		return nil, err
+	}
+	if clientListenerSecurity.Mode != "PLAINTEXT" {
+		return nil, fmt.Errorf(
+			"replication does not support %s listeners yet: the replication link would also have to run over TLS, and the replica needs trust material (a CA to verify the primary, plus a client certificate under mTLS) that a client-listener ServerSecurity profile does not carry; pass PlaintextServerSecurity()",
+			securityModeLabel(clientListenerSecurity.Mode),
+		)
+	}
+	if replicas < 1 {
+		return nil, fmt.Errorf("replicas must be at least 1, got %d; use Valkey.Server for a single node", replicas)
+	}
+
+	image := valkeyImage(registry, tag)
+
+	primary := buildServer(replicationNodeName(name, 0), image, password, clientListenerSecurity, nil, nil)
+
+	nodes := make([]*Server, 0, replicas+1)
+	nodes = append(nodes, primary)
+	for i := 1; i <= replicas; i++ {
+		nodes = append(nodes, buildServer(
+			replicationNodeName(name, i),
+			image,
+			password,
+			clientListenerSecurity,
+			replicaArgs(primary.Host),
+			[]serviceBinding{{host: primary.Host, svc: primary.Svc}},
+		))
+	}
+
+	return &Replication{Nodes: nodes}, nil
+}
+
+// replicationNodeName derives the per-node `name` each node's hostname is
+// hashed from: index 0 is the primary, the rest are replicas. Folding the
+// role and index into the name is what gives every node in a topology a
+// distinct pinned hostname, keeps two Replication calls with different
+// `name`s from colliding, and keeps a node from colliding with a
+// Valkey.Server booted under the same `name`.
+func replicationNodeName(name string, index int) string {
+	if index == 0 {
+		return name + "/replication/primary"
+	}
+	return name + "/replication/replica-" + strconv.Itoa(index)
+}
+
+// replicaArgs renders the `valkey-server` flags that turn a node into a
+// read replica of primaryHost.
+//
+// `masterauth` rather than `primaryauth`: Valkey 9.1 accepts both
+// spellings (verified against the pinned image), but `primaryauth` only
+// exists from Valkey 8.0 onwards, and `tag` is caller-overridable — so
+// the older spelling is the one that works across every tag a caller
+// could plausibly pass.
+//
+// `"$VALKEY_PASSWORD"` is expanded by the shell wrapper buildServer wraps
+// these args in, from the secret environment variable, so the primary's
+// password never enters the replica's argv in the Dagger graph. It is the
+// same secret as the node's own `requirepass`: every node in the topology
+// shares one password.
+//
+// `--replica-read-only yes` is Valkey's default, but it is passed
+// explicitly so a write against a replica failing with READONLY is a
+// property of this topology rather than of an upstream default that could
+// move.
+func replicaArgs(primaryHost string) []string {
+	return []string{
+		"--replicaof", primaryHost, strconv.Itoa(valkeyPort),
+		"--masterauth", `"$VALKEY_PASSWORD"`,
+		"--replica-read-only", "yes",
+	}
+}
+
+// Primary returns the topology's primary node — the only node that
+// accepts writes.
+//
+// Session-cached rather than never-cached: Dagger v0.21 detaches module
+// objects returned from a `+cache="never"` function when a consumer
+// module reads their fields lazily, and `tests/` is such a consumer. The
+// methods on the returned *Server are individually never-cached, so no
+// data-returning call is served stale.
+//
+// +cache="session"
+func (rep *Replication) Primary() *Server {
+	if len(rep.Nodes) == 0 {
+		return nil
+	}
+	return rep.Nodes[0]
+}
+
+// Replicas returns the topology's read replicas, in creation order.
+// Session-cached for the same reason Primary is.
+//
+// +cache="session"
+func (rep *Replication) Replicas() []*Server {
+	if len(rep.Nodes) == 0 {
+		return nil
+	}
+	return rep.Nodes[1:]
+}
+
+// Stop tears down every node in the topology, replicas first so the
+// primary does not spend its last moments logging dropped links. Every
+// node is attempted even if an earlier one fails, and the failures are
+// joined — a partial teardown that reported only the first error would
+// leave services running with nothing naming them.
+//
+// +cache="never"
+func (rep *Replication) Stop(ctx context.Context) error {
+	var errs []error
+	for i := len(rep.Nodes) - 1; i >= 0; i-- {
+		if err := rep.Nodes[i].Stop(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("node %d: %w", i, err))
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/daggerverse/valkey/server.go
+++ b/daggerverse/valkey/server.go
@@ -108,15 +108,50 @@ func (v *Valkey) Server(
 		)
 	}
 
-	image := fmt.Sprintf("%s/valkey/valkey:%s", registry, tag)
+	return buildServer(name, valkeyImage(registry, tag), password, clientListenerSecurity, nil, nil), nil
+}
 
-	// Stable hostname is scoped per-server so parallel invocations don't
-	// collide on a single `valkey` alias. It is derived from `name` alone
-	// so a caller minting a TLS server certificate in the follow-up can
-	// predict the hostname and embed it as the cert's SAN — the same
-	// derivation postgres and kafka use.
+// valkeyImage renders the image reference a node boots from. The
+// `valkey/valkey` portion is fixed; only the registry and tag are
+// caller-overridable.
+func valkeyImage(registry, tag string) string {
+	return fmt.Sprintf("%s/valkey/valkey:%s", registry, tag)
+}
+
+// serverHostname derives a node's stable hostname from its name. The
+// hostname is scoped per-node so parallel invocations don't collide on a
+// single `valkey` alias, and it is derived from `name` alone so a caller
+// minting a TLS server certificate can predict the hostname and embed it
+// as the cert's SAN — the same derivation postgres and kafka use.
+func serverHostname(name string) string {
 	keyBytes := sha256.Sum256([]byte(name))
-	host := "valkey-" + hex.EncodeToString(keyBytes[:6]) // 12 hex chars = 48 bits
+	return "valkey-" + hex.EncodeToString(keyBytes[:6]) // 12 hex chars = 48 bits
+}
+
+// serviceBinding is a service a node must be able to dial by hostname
+// before it starts — a replica's primary, for instance. It is a slice
+// element rather than a map entry so the resulting container's args and
+// mounts stay in a deterministic order and the LLB digest is stable
+// across invocations.
+type serviceBinding struct {
+	host string
+	svc  *dagger.Service
+}
+
+// buildServer assembles a single valkey-server node: the container, the
+// security-derived listener flags, any extra `valkey-server` arguments
+// (replication flags, say), and the service bindings the node needs in
+// order to dial its peers. Inputs are assumed already validated —
+// Valkey.Server and Valkey.Replication each validate before calling.
+func buildServer(
+	name string,
+	image string,
+	password *dagger.Secret,
+	security *ServerSecurity,
+	extraArgs []string,
+	bindings []serviceBinding,
+) *Server {
+	host := serverHostname(name)
 
 	// The password reaches valkey-server through a secret environment
 	// variable rather than a literal argv entry: a plaintext
@@ -127,7 +162,15 @@ func (v *Valkey) Server(
 		WithSecretVariable("VALKEY_PASSWORD", password).
 		WithExposedPort(valkeyPort)
 
-	ctr, args := applyServerSecurity(ctr, clientListenerSecurity)
+	// Bindings go on before AsService so the node resolves its peers from
+	// /etc/hosts at boot, and so Dagger starts those peers as dependencies
+	// of this node rather than leaving it to retry against a dead name.
+	for _, b := range bindings {
+		ctr = ctr.WithServiceBinding(b.host, b.svc)
+	}
+
+	ctr, args := applyServerSecurity(ctr, security)
+	args = append(args, extraArgs...)
 
 	// A shell wrapper is what makes "$VALKEY_PASSWORD" expand at boot;
 	// AsService args are exec'd directly, with no shell to expand them.
@@ -148,8 +191,8 @@ func (v *Valkey) Server(
 		Host:               host,
 		UserName:           defaultUser,
 		Pass:               password,
-		ClientListenerMode: clientListenerSecurity.Mode,
-	}, nil
+		ClientListenerMode: security.Mode,
+	}
 }
 
 // Endpoint returns the node's `host:6379` address. It does NOT start the

--- a/daggerverse/valkey/tests/dagger.gen.go
+++ b/daggerverse/valkey/tests/dagger.gen.go
@@ -353,6 +353,76 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).PlaintextDialAgainstTlsNodeFails(&parent, ctx)
+		case "Replication":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var parallel int
+			if inputArgs["parallel"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["parallel"]), &parallel)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg parallel", err))
+				}
+			}
+			return nil, (*Tests).Replication(&parent, ctx, parallel)
+		case "ReplicationLinkAuthenticates":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ReplicationLinkAuthenticates(&parent, ctx)
+		case "ReplicationNodesHaveDistinctHostnames":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ReplicationNodesHaveDistinctHostnames(&parent, ctx)
+		case "ReplicationPropagatesWritesToReplica":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ReplicationPropagatesWritesToReplica(&parent, ctx)
+		case "ReplicationRejectsTlsSecurity":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ReplicationRejectsTlsSecurity(&parent, ctx)
+		case "ReplicationRejectsTooFewReplicas":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ReplicationRejectsTooFewReplicas(&parent, ctx)
+		case "ReplicationReplicaRejectsWrites":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ReplicationReplicaRejectsWrites(&parent, ctx)
+		case "ReplicationReportsRoles":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ReplicationReportsRoles(&parent, ctx)
+		case "ReplicationStopTerminatesEveryNode":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ReplicationStopTerminatesEveryNode(&parent, ctx)
 		case "SameNameServerSharesState":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/valkey/tests/internal/dagger/dagger.gen.go
+++ b/daggerverse/valkey/tests/internal/dagger/dagger.gen.go
@@ -379,6 +379,9 @@ type ValkeyClientSecurityID string
 type ValkeyID string
 
 // A unique identifier for an object.
+type ValkeyReplicationID string
+
+// A unique identifier for an object.
 type ValkeyServerID string
 
 // A unique identifier for an object.
@@ -13549,6 +13552,16 @@ func (r *Query) LoadValkeyFromID(id ValkeyID) *Valkey {
 	q = q.Arg("id", id)
 
 	return &Valkey{
+		query: q,
+	}
+}
+
+// Load a ValkeyReplication from its ID.
+func (r *Query) LoadValkeyReplicationFromID(id ValkeyReplicationID) *ValkeyReplication {
+	q := r.query.Select("loadValkeyReplicationFromID")
+	q = q.Arg("id", id)
+
+	return &ValkeyReplication{
 		query: q,
 	}
 }

--- a/daggerverse/valkey/tests/internal/dagger/valkey.gen.go
+++ b/daggerverse/valkey/tests/internal/dagger/valkey.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type Valkey
-func (r *Binding) AsValkey() *Valkey { // valkey (../../../../../daggerverse/valkey/main.go:36:6)
+func (r *Binding) AsValkey() *Valkey { // valkey (../../../../../daggerverse/valkey/main.go:39:6)
 	q := r.query.Select("asValkey")
 
 	return &Valkey{
@@ -32,6 +32,15 @@ func (r *Binding) AsValkeyClientSecurity() *ValkeyClientSecurity { // valkey (..
 	q := r.query.Select("asValkeyClientSecurity")
 
 	return &ValkeyClientSecurity{
+		query: q,
+	}
+}
+
+// Retrieve the binding value, as type ValkeyReplication
+func (r *Binding) AsValkeyReplication() *ValkeyReplication { // valkey (../../../../../daggerverse/valkey/replication.go:19:6)
+	q := r.query.Select("asValkeyReplication")
+
+	return &ValkeyReplication{
 		query: q,
 	}
 }
@@ -103,7 +112,7 @@ func (r *Env) WithValkeyClientSecurityOutput(name string, description string) *E
 }
 
 // Create or update a binding of type Valkey in the environment
-func (r *Env) WithValkeyInput(name string, value *Valkey, description string) *Env { // valkey (../../../../../daggerverse/valkey/main.go:36:6)
+func (r *Env) WithValkeyInput(name string, value *Valkey, description string) *Env { // valkey (../../../../../daggerverse/valkey/main.go:39:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withValkeyInput")
 	q = q.Arg("name", name)
@@ -116,8 +125,32 @@ func (r *Env) WithValkeyInput(name string, value *Valkey, description string) *E
 }
 
 // Declare a desired Valkey output to be assigned in the environment
-func (r *Env) WithValkeyOutput(name string, description string) *Env { // valkey (../../../../../daggerverse/valkey/main.go:36:6)
+func (r *Env) WithValkeyOutput(name string, description string) *Env { // valkey (../../../../../daggerverse/valkey/main.go:39:6)
 	q := r.query.Select("withValkeyOutput")
+	q = q.Arg("name", name)
+	q = q.Arg("description", description)
+
+	return &Env{
+		query: q,
+	}
+}
+
+// Create or update a binding of type ValkeyReplication in the environment
+func (r *Env) WithValkeyReplicationInput(name string, value *ValkeyReplication, description string) *Env { // valkey (../../../../../daggerverse/valkey/replication.go:19:6)
+	assertNotNil("value", value)
+	q := r.query.Select("withValkeyReplicationInput")
+	q = q.Arg("name", name)
+	q = q.Arg("value", value)
+	q = q.Arg("description", description)
+
+	return &Env{
+		query: q,
+	}
+}
+
+// Declare a desired ValkeyReplication output to be assigned in the environment
+func (r *Env) WithValkeyReplicationOutput(name string, description string) *Env { // valkey (../../../../../daggerverse/valkey/replication.go:19:6)
+	q := r.query.Select("withValkeyReplicationOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
 
@@ -178,7 +211,7 @@ func (r *Env) WithValkeyServerSecurityOutput(name string, description string) *E
 // module. The server constructor, security helpers, and the
 // remote-client factory all hang off *Valkey so the generated Dagger SDK
 // surfaces them under `dag.Valkey().<Func>(...)`.
-func (r *Query) Valkey() *Valkey { // valkey (../../../../../daggerverse/valkey/main.go:36:6)
+func (r *Query) Valkey() *Valkey { // valkey (../../../../../daggerverse/valkey/main.go:39:6)
 	q := r.query.Select("valkey")
 
 	return &Valkey{
@@ -190,7 +223,7 @@ func (r *Query) Valkey() *Valkey { // valkey (../../../../../daggerverse/valkey/
 // module. The server constructor, security helpers, and the
 // remote-client factory all hang off *Valkey so the generated Dagger SDK
 // surfaces them under `dag.Valkey().<Func>(...)`.
-type Valkey struct { // valkey (../../../../../daggerverse/valkey/main.go:36:6)
+type Valkey struct { // valkey (../../../../../daggerverse/valkey/main.go:39:6)
 	query *querybuilder.Selection
 
 	id *ID
@@ -349,6 +382,83 @@ func (r *Valkey) PlaintextServerSecurity() *ValkeyServerSecurity { // valkey (..
 	q := r.query.Select("plaintextServerSecurity")
 
 	return &ValkeyServerSecurity{
+		query: q,
+	}
+}
+
+// ValkeyReplicationOpts contains options for Valkey.Replication
+type ValkeyReplicationOpts struct {
+	Name string // valkey (../../../../../daggerverse/valkey/replication.go:62:2)
+
+	// Default: "docker.io"
+	Registry string // valkey (../../../../../daggerverse/valkey/replication.go:64:2)
+
+	// Default: "9.1"
+	Tag string // valkey (../../../../../daggerverse/valkey/replication.go:66:2)
+
+	// Default: 1
+	Replicas int // valkey (../../../../../daggerverse/valkey/replication.go:68:2)
+}
+
+// Replication boots a primary/replica topology: one primary node plus
+// `replicas` read replicas, each booted with `--replicaof <primary-host>
+// 6379`, the primary's password, and `--replica-read-only yes`.
+//
+// Image: `<registry>/valkey/valkey:<tag>` for every node — the topology
+// is deliberately homogeneous.
+//
+// Rejected inputs (each a descriptive error rather than a half-broken
+// topology):
+//
+//   - `password == nil` — the same secret is both the nodes'
+//     `requirepass` and the replicas' `masterauth`, so it is mandatory.
+//   - `clientListenerSecurity == nil` — plaintext must be a deliberate
+//     caller choice, exactly as for a single Server.
+//   - a TLS or MTLS profile — see the note below.
+//   - `replicas < 1` — a zero-replica "replication" topology is a
+//     single node with extra steps, and Valkey.Server already builds
+//     that.
+//
+// TLS/mTLS is not supported for this topology yet. A TLS node runs with
+// `--port 0`, so the replication link would have to run over TLS too
+// (`--tls-replication yes`), and that link needs trust material this
+// profile does not carry: the replica must verify the primary against a
+// CA, and under mTLS it must additionally present a client certificate
+// the primary's CA accepts. `*ServerSecurity` describes the
+// *client-facing* listener only, so a TLS/mTLS profile is rejected here
+// rather than silently booting replicas that spin on a failed handshake.
+//
+// Session-cached for the same reason Valkey.Server is: repeated chained
+// calls on the returned topology within one test must observe the SAME
+// backing services, and therefore the same keyspace. `name` folds into
+// that cache key and into every node's hostname, so parallel test suites
+// should pass a unique value per test.
+func (r *Valkey) Replication(password *Secret, clientListenerSecurity *ValkeyServerSecurity, opts ...ValkeyReplicationOpts) *ValkeyReplication { // valkey (../../../../../daggerverse/valkey/replication.go:59:1)
+	assertNotNil("password", password)
+	assertNotNil("clientListenerSecurity", clientListenerSecurity)
+	q := r.query.Select("replication")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `name` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Name) {
+			q = q.Arg("name", opts[i].Name)
+		}
+		// `registry` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Registry) {
+			q = q.Arg("registry", opts[i].Registry)
+		}
+		// `tag` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Tag) {
+			q = q.Arg("tag", opts[i].Tag)
+		}
+		// `replicas` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Replicas) {
+			q = q.Arg("replicas", opts[i].Replicas)
+		}
+	}
+	q = q.Arg("password", password)
+	q = q.Arg("clientListenerSecurity", clientListenerSecurity)
+
+	return &ValkeyReplication{
 		query: q,
 	}
 }
@@ -796,6 +906,146 @@ func (r *ValkeyClientSecurity) AsNode() Node {
 	}
 }
 
+// Replication is a primary/replica Valkey topology: one primary plus N
+// asynchronous read replicas. Nodes[0] is always the primary and the
+// remainder are its replicas, in the order they were created.
+//
+// A replica is asymmetric — it dials a primary that is already up — so
+// the whole topology is expressible with an ordinary service binding and
+// none of the symmetric-peer startup problems of Valkey Cluster apply.
+type ValkeyReplication struct { // valkey (../../../../../daggerverse/valkey/replication.go:19:6)
+	query *querybuilder.Selection
+
+	id   *ID
+	stop *Void
+}
+
+func (r *ValkeyReplication) WithGraphQLQuery(q *querybuilder.Selection) *ValkeyReplication {
+	return &ValkeyReplication{
+		query: q,
+	}
+}
+
+// A unique identifier for this ValkeyReplication.
+func (r *ValkeyReplication) ID(ctx context.Context) (ID, error) {
+	if r.id != nil {
+		return *r.id, nil
+	}
+	q := r.query.Select("id")
+
+	var response ID
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// XXX_GraphQLType is an internal function. It returns the native GraphQL type name
+func (r *ValkeyReplication) XXX_GraphQLType() string {
+	return "ValkeyReplication"
+}
+
+// XXX_GraphQLIDType is an internal function. It returns the native GraphQL type name for the ID of this object
+func (r *ValkeyReplication) XXX_GraphQLIDType() string {
+	return "ID"
+}
+
+// XXX_GraphQLID is an internal function. It returns the underlying type ID
+func (r *ValkeyReplication) XXX_GraphQLID(ctx context.Context) (string, error) {
+	id, err := r.ID(ctx)
+	if err != nil {
+		return "", err
+	}
+	return string(id), nil
+}
+
+func (r *ValkeyReplication) MarshalJSON() ([]byte, error) {
+	id, err := r.ID(marshalCtx)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(id)
+}
+func (r *ValkeyReplication) UnmarshalJSON(bs []byte) error {
+	var id string
+	err := json.Unmarshal(bs, &id)
+	if err != nil {
+		return err
+	}
+	*r = ValkeyReplication{query: selectNode(dag.query, id, "ValkeyReplication")}
+	return nil
+}
+
+// Primary returns the topology's primary node — the only node that
+// accepts writes.
+//
+// Session-cached rather than never-cached: Dagger v0.21 detaches module
+// objects returned from a `module reads their fields lazily, and `tests/` is such a consumer. The
+// methods on the returned *Server are individually never-cached, so no
+// data-returning call is served stale.
+func (r *ValkeyReplication) Primary() *ValkeyServer { // valkey (../../../../../daggerverse/valkey/replication.go:161:1)
+	q := r.query.Select("primary")
+
+	return &ValkeyServer{
+		query: q,
+	}
+}
+
+// Replicas returns the topology's read replicas, in creation order.
+// Session-cached for the same reason Primary is.
+func (r *ValkeyReplication) Replicas(ctx context.Context) ([]ValkeyServer, error) { // valkey (../../../../../daggerverse/valkey/replication.go:172:1)
+	q := r.query.Select("replicas")
+
+	q = q.Select("id")
+
+	type replicas struct {
+		Id ID
+	}
+
+	convert := func(fields []replicas) []ValkeyServer {
+		out := []ValkeyServer{}
+
+		for i := range fields {
+			val := ValkeyServer{id: &fields[i].Id}
+			val.query = selectNode(q.Root(), fields[i].Id, "ValkeyServer")
+			out = append(out, val)
+		}
+
+		return out
+	}
+	var response []replicas
+
+	q = q.Bind(&response)
+
+	err := q.Execute(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return convert(response), nil
+}
+
+// Stop tears down every node in the topology, replicas first so the
+// primary does not spend its last moments logging dropped links. Every
+// node is attempted even if an earlier one fails, and the failures are
+// joined — a partial teardown that reported only the first error would
+// leave services running with nothing naming them.
+func (r *ValkeyReplication) Stop(ctx context.Context) error { // valkey (../../../../../daggerverse/valkey/replication.go:186:1)
+	if r.stop != nil {
+		return nil
+	}
+	q := r.query.Select("stop")
+
+	return q.Execute(ctx)
+}
+
+// AsNode returns this ValkeyReplication as a Node.
+// This is a local type conversion — no GraphQL call.
+func (r *ValkeyReplication) AsNode() Node {
+	return &NodeClient{
+		query: r.query,
+	}
+}
+
 // Server represents a running single-node Valkey server plus the
 // connection metadata callers need to reach it. Holds a reference to the
 // backing service so callers can bind it into their own containers or
@@ -818,7 +1068,7 @@ func (r *ValkeyServer) WithGraphQLQuery(q *querybuilder.Selection) *ValkeyServer
 // BindServer attaches the Valkey service to the given container under
 // the same hostname Endpoint reports, so the container can dial the node
 // at `Endpoint()` (e.g. `valkey-cli -h <host> -a <pw> PING`).
-func (r *ValkeyServer) BindServer(ctr *Container) *Container { // valkey (../../../../../daggerverse/valkey/server.go:195:1)
+func (r *ValkeyServer) BindServer(ctr *Container) *Container { // valkey (../../../../../daggerverse/valkey/server.go:238:1)
 	assertNotNil("ctr", ctr)
 	q := r.query.Select("bindServer")
 	q = q.Arg("ctr", ctr)
@@ -836,7 +1086,7 @@ func (r *ValkeyServer) BindServer(ctr *Container) *Container { // valkey (../../
 // rather than failing opaquely at the wire. Readiness is then probed
 // with the client itself, so a TLS / mTLS listener would be polled over
 // TLS using the caller's own cert material.
-func (r *ValkeyServer) Client(security *ValkeyClientSecurity) *ValkeyClient { // valkey (../../../../../daggerverse/valkey/server.go:209:1)
+func (r *ValkeyServer) Client(security *ValkeyClientSecurity) *ValkeyClient { // valkey (../../../../../daggerverse/valkey/server.go:252:1)
 	assertNotNil("security", security)
 	q := r.query.Select("client")
 	q = q.Arg("security", security)
@@ -857,7 +1107,7 @@ func (r *ValkeyServer) Client(security *ValkeyClientSecurity) *ValkeyClient { //
 // would register the service in the module's DNS domain, which the
 // binding's host-file lookup can't resolve from a session-domain
 // consumer — so the start must be driven by the binding, not here.
-func (r *ValkeyServer) Endpoint(ctx context.Context) (string, error) { // valkey (../../../../../daggerverse/valkey/server.go:168:1)
+func (r *ValkeyServer) Endpoint(ctx context.Context) (string, error) { // valkey (../../../../../daggerverse/valkey/server.go:211:1)
 	if r.endpoint != nil {
 		return *r.endpoint, nil
 	}
@@ -921,7 +1171,7 @@ func (r *ValkeyServer) UnmarshalJSON(bs []byte) error {
 // Password returns the `requirepass` secret the node was provisioned
 // with, so callers can re-use it via Valkey.Client against the same
 // endpoint.
-func (r *ValkeyServer) Password() *Secret { // valkey (../../../../../daggerverse/valkey/server.go:186:1)
+func (r *ValkeyServer) Password() *Secret { // valkey (../../../../../daggerverse/valkey/server.go:229:1)
 	q := r.query.Select("password")
 
 	return &Secret{
@@ -933,7 +1183,7 @@ func (r *ValkeyServer) Password() *Secret { // valkey (../../../../../daggervers
 // call this in a defer so the service span closes when the test returns.
 // SIGKILL skips graceful shutdown — Valkey's save-on-shutdown path is
 // wasted work for a torn-down test node.
-func (r *ValkeyServer) Stop(ctx context.Context) error { // valkey (../../../../../daggerverse/valkey/server.go:245:1)
+func (r *ValkeyServer) Stop(ctx context.Context) error { // valkey (../../../../../daggerverse/valkey/server.go:288:1)
 	if r.stop != nil {
 		return nil
 	}
@@ -945,7 +1195,7 @@ func (r *ValkeyServer) Stop(ctx context.Context) error { // valkey (../../../../
 // User returns the ACL user clients authenticate as. `requirepass` sets
 // the password of the built-in `default` user, so this is always
 // "default" in this story; an ACL-file follow-up is what makes it vary.
-func (r *ValkeyServer) User(ctx context.Context) (string, error) { // valkey (../../../../../daggerverse/valkey/server.go:177:1)
+func (r *ValkeyServer) User(ctx context.Context) (string, error) { // valkey (../../../../../daggerverse/valkey/server.go:220:1)
 	if r.user != nil {
 		return *r.user, nil
 	}

--- a/daggerverse/valkey/tests/main.go
+++ b/daggerverse/valkey/tests/main.go
@@ -55,6 +55,9 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("Security", func(ctx context.Context) error {
 		return t.Security(ctx, parallel)
 	})
+	jobs = jobs.WithJob("Replication", func(ctx context.Context) error {
+		return t.Replication(ctx, parallel)
+	})
 	return jobs.Run(ctx)
 }
 
@@ -76,6 +79,35 @@ func (t *Tests) Validation(
 	}
 	jobs = jobs.WithJob("server-rejects-nil-password", t.ServerRejectsNilPassword)
 	jobs = jobs.WithJob("server-rejects-nil-security", t.ServerRejectsNilSecurity)
+	jobs = jobs.WithJob("replication-rejects-too-few-replicas", t.ReplicationRejectsTooFewReplicas)
+	jobs = jobs.WithJob("replication-rejects-tls-security", t.ReplicationRejectsTlsSecurity)
+	return jobs.Run(ctx)
+}
+
+// Replication runs the primary/replica topology tests. Each test boots
+// its own topology via bootReplication, whose runtime-random name folds
+// into Valkey.Replication's session-cache key and into every node's
+// hostname, so concurrent tests get independent topologies.
+//
+// +check
+// +cache="session"
+func (t *Tests) Replication(
+	ctx context.Context,
+	// +default=0
+	parallel int,
+) error {
+	jobs := par.New().
+		WithRollupLogs(true).
+		WithRollupSpans(true)
+	if parallel > 0 {
+		jobs = jobs.WithLimit(parallel)
+	}
+	jobs = jobs.WithJob("replication-propagates-writes-to-replica", t.ReplicationPropagatesWritesToReplica)
+	jobs = jobs.WithJob("replication-reports-roles", t.ReplicationReportsRoles)
+	jobs = jobs.WithJob("replication-replica-rejects-writes", t.ReplicationReplicaRejectsWrites)
+	jobs = jobs.WithJob("replication-link-authenticates", t.ReplicationLinkAuthenticates)
+	jobs = jobs.WithJob("replication-nodes-have-distinct-hostnames", t.ReplicationNodesHaveDistinctHostnames)
+	jobs = jobs.WithJob("replication-stop-terminates-every-node", t.ReplicationStopTerminatesEveryNode)
 	return jobs.Run(ctx)
 }
 
@@ -273,6 +305,85 @@ func (t *Tests) ServerRejectsNilSecurity(ctx context.Context) (returnErr error) 
 	}
 	server := dag.Valkey().Server(pass, nil)
 	_, _ = server.Endpoint(ctx)
+	return nil
+}
+
+// ReplicationRejectsTooFewReplicas verifies a replica-less "replication"
+// topology is refused rather than silently degrading to a single node —
+// Valkey.Server is what builds that, and a caller who asked for
+// replication and got none would find out only when their read-replica
+// assertions started passing against the primary.
+//
+// The cases are negative rather than 0: the generated Go binding drops
+// any optional argument holding its zero value, so `Replicas: 0` never
+// reaches the module and resolves to the `+default=1`. `--replicas=0` on
+// the CLI does reach the guard, which is why the guard is `< 1` and not
+// `< 0`.
+//
+// +cache="never"
+func (t *Tests) ReplicationRejectsTooFewReplicas(ctx context.Context) error {
+	name, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+	pass, err := randSecret(ctx)
+	if err != nil {
+		return err
+	}
+	for _, replicas := range []int{-1, -2} {
+		rep := dag.Valkey().Replication(
+			pass,
+			dag.Valkey().PlaintextServerSecurity(),
+			dagger.ValkeyReplicationOpts{Name: name, Replicas: replicas},
+		)
+		_, err := rep.Primary().Endpoint(ctx)
+		if err == nil {
+			return fmt.Errorf("expected Replication(replicas=%d) to be rejected, but it built a topology", replicas)
+		}
+		if !strings.Contains(err.Error(), "replicas") {
+			return fmt.Errorf("expected the replicas=%d rejection to name the replicas argument, got: %v", replicas, err)
+		}
+	}
+	return nil
+}
+
+// ReplicationRejectsTlsSecurity verifies a TLS listener profile is
+// refused with an explanation rather than booting replicas that spin
+// forever on a failed handshake: a TLS node runs with `--port 0`, so the
+// replication link would also have to run over TLS, and a client-listener
+// ServerSecurity carries none of the trust material that link needs.
+//
+// +cache="never"
+func (t *Tests) ReplicationRejectsTlsSecurity(ctx context.Context) error {
+	name, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+	pass, err := randSecret(ctx)
+	if err != nil {
+		return err
+	}
+	ca, err := freshCa(ctx, "vk-rep-tls")
+	if err != nil {
+		return err
+	}
+	// SAN value is irrelevant: the guard rejects before any node boots.
+	cert, key, err := issueServerCert(ctx, ca, "valkey-placeholder", "vk-rep-tls-server")
+	if err != nil {
+		return err
+	}
+	rep := dag.Valkey().Replication(
+		pass,
+		dag.Valkey().TLSServerSecurity(cert, key),
+		dagger.ValkeyReplicationOpts{Name: name},
+	)
+	_, err = rep.Primary().Endpoint(ctx)
+	if err == nil {
+		return fmt.Errorf("expected a TLS Replication topology to be rejected")
+	}
+	if !strings.Contains(err.Error(), "TLS") {
+		return fmt.Errorf("expected the rejection to name TLS, got: %v", err)
+	}
 	return nil
 }
 
@@ -926,8 +1037,8 @@ func (t *Tests) ApplyFileReportsFailingCommand(ctx context.Context) error {
 }
 
 // InfoReportsRole verifies INFO replication reports a standalone node as
-// the primary. This is the assertion the replication follow-up builds
-// on: a replica reports role:slave.
+// the primary. ReplicationReportsRoles is the multi-node counterpart,
+// where a replica reports role:slave instead.
 //
 // +cache="never"
 func (t *Tests) InfoReportsRole(ctx context.Context) error {
@@ -1069,6 +1180,377 @@ func (t *Tests) DbSelectsLogicalDatabase(ctx context.Context) error {
 	}
 	if got != value {
 		return fmt.Errorf("expected %q back on db 0, got %q", value, got)
+	}
+	return nil
+}
+
+// -----------------------------------------------------------------------------
+// Replication tests — primary/replica topology.
+//
+// Replication is asynchronous, so every assertion about state that has to
+// travel the link (a propagated write, the primary's replica count, the
+// link status itself) polls to a deadline rather than reading once. A
+// single read would be a stopwatch race against the initial full sync
+// under a loaded parallel suite.
+// -----------------------------------------------------------------------------
+
+// replicationTimeout bounds every poll below. A full sync of an
+// essentially empty keyspace takes well under a second once both nodes
+// are up; the headroom is for image pulls and a contended engine.
+const replicationTimeout = 90 * time.Second
+
+// eventually polls check until it succeeds or the deadline passes,
+// reporting the last failure so a timeout says what was still wrong
+// rather than merely that time ran out.
+func eventually(ctx context.Context, what string, check func(context.Context) error) error {
+	deadline := time.Now().Add(replicationTimeout)
+	for {
+		err := check(ctx)
+		if err == nil {
+			return nil
+		}
+		if !time.Now().Before(deadline) {
+			return fmt.Errorf("%s within %s: %w", what, replicationTimeout, err)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+}
+
+// bootReplication mints a fresh primary/replica topology and returns it
+// with the password secret every node shares. The topology name is a
+// runtime-random value that folds into Valkey.Replication's
+// +cache="session" key and into each node's hostname, so concurrent tests
+// get independent topologies.
+func bootReplication(ctx context.Context, replicas int) (*dagger.ValkeyReplication, *dagger.Secret, error) {
+	name, err := randHex(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	pass, err := randSecret(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	rep := dag.Valkey().Replication(
+		pass,
+		dag.Valkey().PlaintextServerSecurity(),
+		dagger.ValkeyReplicationOpts{Name: name, Replicas: replicas},
+	)
+	return rep, pass, nil
+}
+
+// replicaClients readies every replica and returns a plaintext client per
+// replica. Pinging each one is what starts its backing service (and, as
+// its dependency, the primary), so the caller's later assertions run
+// against a topology that is actually up.
+func replicaClients(ctx context.Context, rep *dagger.ValkeyReplication) ([]*dagger.ValkeyClient, error) {
+	replicas, err := rep.Replicas(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("replicas: %w", err)
+	}
+	clients := make([]*dagger.ValkeyClient, 0, len(replicas))
+	for i := range replicas {
+		client := plaintextClient(&replicas[i])
+		if err := client.Ping(ctx); err != nil {
+			return nil, fmt.Errorf("ping replica %d: %w", i, err)
+		}
+		clients = append(clients, client)
+	}
+	return clients, nil
+}
+
+// ReplicationPropagatesWritesToReplica is the core replication smoke
+// path: a key written to the primary becomes readable from the replica.
+// The read polls, because the link is asynchronous and a single read
+// would race the initial sync.
+//
+// +cache="never"
+func (t *Tests) ReplicationPropagatesWritesToReplica(ctx context.Context) error {
+	rep, _, err := bootReplication(ctx, 1)
+	if err != nil {
+		return err
+	}
+	key, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+	want, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+	replicas, err := replicaClients(ctx, rep)
+	if err != nil {
+		return err
+	}
+	if len(replicas) != 1 {
+		return fmt.Errorf("expected 1 replica, got %d", len(replicas))
+	}
+	if err := plaintextClient(rep.Primary()).Set(ctx, key, want); err != nil {
+		return fmt.Errorf("set on primary: %w", err)
+	}
+	return eventually(ctx, "the primary's write to reach the replica", func(ctx context.Context) error {
+		got, err := replicas[0].Get(ctx, key)
+		if err != nil {
+			return err
+		}
+		if got != want {
+			return fmt.Errorf("expected %q on the replica, got %q", want, got)
+		}
+		return nil
+	})
+}
+
+// ReplicationReportsRoles verifies INFO replication describes the
+// topology from both ends: the primary is role:master with as many
+// connected_slaves as there are replicas, and every replica reports the
+// replica role. Two replicas rather than one, so a count that reported
+// "some replica connected" instead of all of them fails here.
+//
+// +cache="never"
+func (t *Tests) ReplicationReportsRoles(ctx context.Context) error {
+	const wantReplicas = 2
+	rep, _, err := bootReplication(ctx, wantReplicas)
+	if err != nil {
+		return err
+	}
+	replicas, err := replicaClients(ctx, rep)
+	if err != nil {
+		return err
+	}
+	if len(replicas) != wantReplicas {
+		return fmt.Errorf("expected %d replicas, got %d", wantReplicas, len(replicas))
+	}
+
+	primary := plaintextClient(rep.Primary())
+	err = eventually(ctx, "the primary to report both replicas", func(ctx context.Context) error {
+		info, err := primary.Info(ctx, dagger.ValkeyClientInfoOpts{Section: "replication"})
+		if err != nil {
+			return err
+		}
+		if !strings.Contains(info, "role:master") {
+			return fmt.Errorf("expected role:master on the primary, got:\n%s", info)
+		}
+		if want := fmt.Sprintf("connected_slaves:%d", wantReplicas); !strings.Contains(info, want) {
+			return fmt.Errorf("expected %s on the primary, got:\n%s", want, info)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	for i, replica := range replicas {
+		info, err := replica.Info(ctx, dagger.ValkeyClientInfoOpts{Section: "replication"})
+		if err != nil {
+			return fmt.Errorf("info replication on replica %d: %w", i, err)
+		}
+		// Valkey 9.1 still spells the replica role `slave` in INFO for
+		// wire compatibility, so that — not `role:replica` — is what a
+		// replica reports.
+		if !strings.Contains(info, "role:slave") {
+			return fmt.Errorf("expected the replica role on replica %d, got:\n%s", i, info)
+		}
+	}
+	return nil
+}
+
+// ReplicationReplicaRejectsWrites verifies `--replica-read-only yes`
+// holds: a write against a replica is refused with READONLY, so a test
+// that writes to the wrong node fails loudly instead of silently losing
+// the write on the next sync.
+//
+// +cache="never"
+func (t *Tests) ReplicationReplicaRejectsWrites(ctx context.Context) error {
+	rep, _, err := bootReplication(ctx, 1)
+	if err != nil {
+		return err
+	}
+	replicas, err := replicaClients(ctx, rep)
+	if err != nil {
+		return err
+	}
+	key, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+	value, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+	err = replicas[0].Set(ctx, key, value)
+	if err == nil {
+		return fmt.Errorf("expected a write against a read-only replica to be refused, but it succeeded")
+	}
+	if !strings.Contains(err.Error(), "READONLY") {
+		return fmt.Errorf("expected a READONLY rejection, got: %v", err)
+	}
+	// The primary still takes the same write — proving the rejection is
+	// the replica's read-only stance and not a broken topology.
+	if err := plaintextClient(rep.Primary()).Set(ctx, key, value); err != nil {
+		return fmt.Errorf("expected the primary to accept the same write: %w", err)
+	}
+	return nil
+}
+
+// ReplicationLinkAuthenticates verifies the replica actually authenticates
+// to the password-protected primary: it polls for
+// `master_link_status:up`, which a replica whose masterauth was missing or
+// wrong never reaches — it stays `down`, retrying on NOAUTH, while every
+// other assertion in this file would still pass against its (empty but
+// readable) local keyspace.
+//
+// +cache="never"
+func (t *Tests) ReplicationLinkAuthenticates(ctx context.Context) error {
+	rep, _, err := bootReplication(ctx, 1)
+	if err != nil {
+		return err
+	}
+	replicas, err := replicaClients(ctx, rep)
+	if err != nil {
+		return err
+	}
+	primaryEndpoint, err := rep.Primary().Endpoint(ctx)
+	if err != nil {
+		return fmt.Errorf("primary endpoint: %w", err)
+	}
+	primaryHost, _, _ := strings.Cut(primaryEndpoint, ":")
+
+	return eventually(ctx, "the replication link to come up", func(ctx context.Context) error {
+		info, err := replicas[0].Info(ctx, dagger.ValkeyClientInfoOpts{Section: "replication"})
+		if err != nil {
+			return err
+		}
+		if want := "master_host:" + primaryHost; !strings.Contains(info, want) {
+			return fmt.Errorf("expected the replica to follow %s, got:\n%s", want, info)
+		}
+		if !strings.Contains(info, "master_link_status:up") {
+			return fmt.Errorf("expected master_link_status:up (a wrong or missing masterauth leaves it down), got:\n%s", info)
+		}
+		return nil
+	})
+}
+
+// ReplicationNodesHaveDistinctHostnames verifies every node gets its own
+// pinned hostname and that two topologies built under different names do
+// not collide. A shared hostname would silently fold two nodes onto one
+// service: the replicas of one topology would answer for the other's, and
+// a parallel suite would trade reads across tests.
+//
+// Endpoint is a pure accessor, so this asserts the addressing scheme
+// without booting anything.
+//
+// +cache="never"
+func (t *Tests) ReplicationNodesHaveDistinctHostnames(ctx context.Context) error {
+	const replicas = 2
+	first, _, err := bootReplication(ctx, replicas)
+	if err != nil {
+		return err
+	}
+	second, _, err := bootReplication(ctx, replicas)
+	if err != nil {
+		return err
+	}
+
+	seen := make(map[string]string)
+	for _, topology := range []struct {
+		label string
+		rep   *dagger.ValkeyReplication
+	}{{"first", first}, {"second", second}} {
+		nodes, err := topology.rep.Replicas(ctx)
+		if err != nil {
+			return fmt.Errorf("%s replicas: %w", topology.label, err)
+		}
+		if len(nodes) != replicas {
+			return fmt.Errorf("expected %d replicas in the %s topology, got %d", replicas, topology.label, len(nodes))
+		}
+		endpoints := make([]string, 0, replicas+1)
+		primary, err := topology.rep.Primary().Endpoint(ctx)
+		if err != nil {
+			return fmt.Errorf("%s primary endpoint: %w", topology.label, err)
+		}
+		endpoints = append(endpoints, primary)
+		for i := range nodes {
+			endpoint, err := nodes[i].Endpoint(ctx)
+			if err != nil {
+				return fmt.Errorf("%s replica %d endpoint: %w", topology.label, i, err)
+			}
+			endpoints = append(endpoints, endpoint)
+		}
+		for i, endpoint := range endpoints {
+			where := fmt.Sprintf("%s topology node %d", topology.label, i)
+			if prior, ok := seen[endpoint]; ok {
+				return fmt.Errorf("expected every node to get its own hostname, but %s and %s both answer at %s", prior, where, endpoint)
+			}
+			seen[endpoint] = where
+		}
+	}
+	return nil
+}
+
+// ReplicationStopTerminatesEveryNode verifies no node in the topology
+// answers once Stop returns. The post-Stop probes go through the
+// standalone constructor on purpose: Server.Client would re-Start the
+// service it is asked to dial and the test would pass no matter what Stop
+// did.
+//
+// What this pins and what it cannot: a Stop that did nothing, that
+// errored, or that stopped only the replicas is caught here. A Stop that
+// stopped only the primary is NOT — measured against this engine, tearing
+// down the primary also takes down the replicas bound to it, so
+// reachability cannot separate "stopped every node" from "stopped the one
+// every other node depends on". Replication.Stop still walks every node
+// explicitly rather than leaning on that dependency teardown, which is
+// not a documented guarantee.
+//
+// +cache="never"
+func (t *Tests) ReplicationStopTerminatesEveryNode(ctx context.Context) error {
+	rep, pass, err := bootReplication(ctx, 2)
+	if err != nil {
+		return err
+	}
+	// Ready every node, so a failed probe after Stop means Stop killed it
+	// and not that it had never come up.
+	if _, err := replicaClients(ctx, rep); err != nil {
+		return err
+	}
+	if err := plaintextClient(rep.Primary()).Ping(ctx); err != nil {
+		return fmt.Errorf("ping primary: %w", err)
+	}
+
+	replicas, err := rep.Replicas(ctx)
+	if err != nil {
+		return fmt.Errorf("replicas: %w", err)
+	}
+	nodes := make([]*dagger.ValkeyServer, 0, len(replicas)+1)
+	nodes = append(nodes, rep.Primary())
+	for i := range replicas {
+		nodes = append(nodes, &replicas[i])
+	}
+
+	standalone := make([]*dagger.ValkeyClient, 0, len(nodes))
+	for i, node := range nodes {
+		endpoint, err := node.Endpoint(ctx)
+		if err != nil {
+			return fmt.Errorf("node %d endpoint: %w", i, err)
+		}
+		host, _, _ := strings.Cut(endpoint, ":")
+		client := dag.Valkey().Client(host, pass, dag.Valkey().PlaintextClientSecurity())
+		if err := client.Ping(ctx); err != nil {
+			return fmt.Errorf("standalone ping of node %d before stop: %w", i, err)
+		}
+		standalone = append(standalone, client)
+	}
+
+	if err := rep.Stop(ctx); err != nil {
+		return fmt.Errorf("stop: %w", err)
+	}
+	for i, client := range standalone {
+		if err := client.Ping(ctx); err == nil {
+			return fmt.Errorf("expected node %d to be down after Stop, but it still answered", i)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #198.

Adds `Valkey.Replication`: one primary plus N asynchronous read replicas, each booted with `--replicaof <primary-host> 6379`, the primary's password, and `--replica-read-only yes`. A replica is asymmetric — it dials a primary that is already up — so the topology is an ordinary service binding, with none of the symmetric-peer startup problems Valkey Cluster will bring.

```go
Valkey.Replication(ctx, name="", registry="docker.io", tag="9.1", replicas=1,
                   password *dagger.Secret, clientListenerSecurity *ServerSecurity) (*Replication, error)
Replication.Primary() *Server     // +cache="session"
Replication.Replicas() []*Server  // +cache="session"
Replication.Stop(ctx) error       // +cache="never"
```

`server.go` grows a shared node builder (`buildServer`) that `Server` and `Replication` both use; it takes extra `valkey-server` args and the service bindings a node needs to dial its peers.

## Verified against the pinned image, not assumed

Probed `valkey/valkey:9.1` (9.1.1) directly before writing the implementation:

- Both `masterauth` and `primaryauth` are accepted. The module uses **`masterauth`**: `primaryauth` only exists from Valkey 8.0 onwards and `tag` is caller-overridable, so the older spelling is the one that works across every tag a caller could plausibly pass.
- A replica reports `role:slave` in `INFO replication`, not `role:replica`; the primary reports `role:master` / `connected_slaves:<n>`.

## TLS/mTLS is rejected, not implemented

A TLS node runs with `--port 0`, so the replication link would also have to run over TLS (`--tls-replication yes`), and that link needs trust material a client-listener `*ServerSecurity` does not carry: a CA for the replica to verify the primary, plus — under mTLS — a client certificate the primary's CA accepts, which a server leaf's EKU won't satisfy. The constructor returns an explanatory error rather than booting replicas that spin on a failed handshake. Moved to the module's follow-ups.

The issue's acceptance criteria don't require TLS, but `clientListenerSecurity` is in the signature, so this is a deliberate narrowing worth a look.

## Two limits the tests document rather than paper over

- **`replicas < 1` is only reachable from the CLI.** The generated Go binding drops an optional argument holding its zero value, so `Replicas: 0` resolves to the `+default=1`. The guard is `< 1`; the test exercises it with `-1`/`-2`.
- **`Stop`'s "every node, not just the primary" claim is only partly testable.** Measured on this engine, tearing down the primary also takes down the replicas bound to it, so reachability cannot separate "stopped every node" from "stopped the one every other node depends on". The test still catches a no-op `Stop`, an erroring `Stop`, and a replicas-only `Stop`, and `Stop` walks every node explicitly rather than leaning on that undocumented cascade.

## Tests

New `+check` group `valkey-tests:replication` (propagation, roles, READONLY, link auth, distinct hostnames, teardown) plus two validation tests. Replication is asynchronous, so every assertion about state that travels the link polls to a deadline rather than reading once.

Negative controls run during development: removing `--masterauth` fails both the link-status and the write-propagation tests, confirming neither is vacuous.

`dagger -m daggerverse/valkey/tests call all` passes. `dagger develop` re-run in the module, `tests/`, and the root `ci` module (whose `valkey-tests` toolchain bindings were stale); `ci:generated` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)