### PR TITLE
story(issue-193): wrap opentofu state manipulation subcommands

### DIFF
--- a/ci/internal/dagger/opentofu-tests.gen.go
+++ b/ci/internal/dagger/opentofu-tests.gen.go
@@ -74,7 +74,10 @@ type OpentofuTests struct { // opentofu-tests (../../../daggerverse/opentofu/tes
 	formatLeavesFormattedConfigurationUnchanged *Void
 	formatLeavesInputDirectoryUntouched         *Void
 	formatRewritesUnformattedConfiguration      *Void
+	graphRendersDependencyGraph                 *Void
 	id                                          *ID
+	importBringsResourceUnderManagement         *Void
+	importRejectsAddressAbsentFromConfiguration *Void
 	initProducesLockFile                        *Void
 	lockCoversRequestedPlatforms                *Void
 	lockRejectsUnavailablePlatform              *Void
@@ -85,6 +88,7 @@ type OpentofuTests struct { // opentofu-tests (../../../daggerverse/opentofu/tes
 	planReportsChanges                          *Void
 	planShouldNotBeCached                       *Void
 	planTargetsLimitScope                       *Void
+	refreshUpdatesStateWithoutChanges           *Void
 	remoteBackendRoundTripsState                *Void
 	remoteWorkspacesIsolateState                *Void
 	secretVarReachesTofuWithoutLeaking          *Void
@@ -92,6 +96,16 @@ type OpentofuTests struct { // opentofu-tests (../../../daggerverse/opentofu/tes
 	showRendersState                            *Void
 	stateAndBackendConfigAreRejected            *Void
 	stateAndBackendConfigFileAreRejected        *Void
+	stateListOnEmptyStateIsEmpty                *Void
+	stateListReportsAppliedAddresses            *Void
+	stateMvRejectsUnknownAddress                *Void
+	stateMvRenamesAddress                       *Void
+	stateRmDropsAddressFromState                *Void
+	stateRmRejectsUnknownAddress                *Void
+	stateShowRejectsUnknownAddress              *Void
+	stateShowReturnsResourceJson                *Void
+	taintProposesReplacement                    *Void
+	untaintClearsReplacement                    *Void
 	validateAcceptsValidConfiguration           *Void
 	validateRejectsInvalidConfiguration         *Void
 	validateWorksWithoutBackendCredentials      *Void
@@ -381,7 +395,7 @@ func (r *OpentofuTests) ConcurrentAppliesDoNotCorruptState(ctx context.Context) 
 // ContainerHasGitAndCaCertificates asserts the two things the -minimal image
 // omits and every non-trivial configuration needs: git, for module sources,
 // and a CA bundle, for the provider registry.
-func (r *OpentofuTests) ContainerHasGitAndCaCertificates(ctx context.Context) error { // opentofu-tests (../../../daggerverse/opentofu/tests/main.go:140:1)
+func (r *OpentofuTests) ContainerHasGitAndCaCertificates(ctx context.Context) error { // opentofu-tests (../../../daggerverse/opentofu/tests/main.go:155:1)
 	if r.containerHasGitAndCaCertificates != nil {
 		return nil
 	}
@@ -392,7 +406,7 @@ func (r *OpentofuTests) ContainerHasGitAndCaCertificates(ctx context.Context) er
 
 // ContainerHasTofu asserts the assembled container exposes the tofu binary on
 // PATH, so the escape hatch documented on Container() actually works.
-func (r *OpentofuTests) ContainerHasTofu(ctx context.Context) error { // opentofu-tests (../../../daggerverse/opentofu/tests/main.go:124:1)
+func (r *OpentofuTests) ContainerHasTofu(ctx context.Context) error { // opentofu-tests (../../../daggerverse/opentofu/tests/main.go:139:1)
 	if r.containerHasTofu != nil {
 		return nil
 	}
@@ -497,6 +511,18 @@ func (r *OpentofuTests) FormatRewritesUnformattedConfiguration(ctx context.Conte
 	return q.Execute(ctx)
 }
 
+// GraphRendersDependencyGraph asserts Graph returns DOT a reader could parse —
+// one balanced `digraph` — naming both resources the configuration declares
+// and the variable one of them depends on.
+func (r *OpentofuTests) GraphRendersDependencyGraph(ctx context.Context) error { // opentofu-tests (../../../daggerverse/opentofu/tests/state.go:395:1)
+	if r.graphRendersDependencyGraph != nil {
+		return nil
+	}
+	q := r.query.Select("graphRendersDependencyGraph")
+
+	return q.Execute(ctx)
+}
+
 // A unique identifier for this OpentofuTests.
 func (r *OpentofuTests) ID(ctx context.Context) (ID, error) {
 	if r.id != nil {
@@ -544,6 +570,30 @@ func (r *OpentofuTests) UnmarshalJSON(bs []byte) error {
 	}
 	*r = OpentofuTests{query: selectNode(dag.query, id, "OpentofuTests")}
 	return nil
+}
+
+// ImportBringsResourceUnderManagement asserts an object named by id lands in
+// state under the declared address, and that a plan afterwards is empty —
+// which it is only if the import recorded the object rather than something
+// approximating it.
+func (r *OpentofuTests) ImportBringsResourceUnderManagement(ctx context.Context) error { // opentofu-tests (../../../daggerverse/opentofu/tests/state.go:224:1)
+	if r.importBringsResourceUnderManagement != nil {
+		return nil
+	}
+	q := r.query.Select("importBringsResourceUnderManagement")
+
+	return q.Execute(ctx)
+}
+
+// ImportRejectsAddressAbsentFromConfiguration asserts import writes state and
+// not HCL: an address the configuration never declares fails, naming it.
+func (r *OpentofuTests) ImportRejectsAddressAbsentFromConfiguration(ctx context.Context) error { // opentofu-tests (../../../daggerverse/opentofu/tests/state.go:260:1)
+	if r.importRejectsAddressAbsentFromConfiguration != nil {
+		return nil
+	}
+	q := r.query.Select("importRejectsAddressAbsentFromConfiguration")
+
+	return q.Execute(ctx)
 }
 
 // InitProducesLockFile asserts Init emits the dependency lock file — the
@@ -686,6 +736,19 @@ func (r *OpentofuTests) PlanTargetsLimitScope(ctx context.Context) error { // op
 	return q.Execute(ctx)
 }
 
+// RefreshUpdatesStateWithoutChanges asserts a refresh-only apply hands back
+// state that still tracks everything it was given and still matches the
+// configuration. With hermetic fixtures there is no reality to drift, so what
+// is proved is that the refresh round-trips state rather than rewriting it.
+func (r *OpentofuTests) RefreshUpdatesStateWithoutChanges(ctx context.Context) error { // opentofu-tests (../../../daggerverse/opentofu/tests/state.go:274:1)
+	if r.refreshUpdatesStateWithoutChanges != nil {
+		return nil
+	}
+	q := r.query.Select("refreshUpdatesStateWithoutChanges")
+
+	return q.Execute(ctx)
+}
+
 // RemoteBackendRoundTripsState asserts the backend path end to end: an apply
 // against a real S3 backend hands back no terraform.tfstate, the backend holds
 // the state instead, a second Config reads it back with nothing but the
@@ -783,6 +846,124 @@ func (r *OpentofuTests) StateAndBackendConfigFileAreRejected(ctx context.Context
 	return q.Execute(ctx)
 }
 
+// StateListOnEmptyStateIsEmpty asserts a configuration with no state yet lists
+// nothing rather than failing. tofu refuses a wholly absent state file; the
+// module answers the question that was actually asked, which has an empty
+// answer.
+func (r *OpentofuTests) StateListOnEmptyStateIsEmpty(ctx context.Context) error { // opentofu-tests (../../../daggerverse/opentofu/tests/state.go:44:1)
+	if r.stateListOnEmptyStateIsEmpty != nil {
+		return nil
+	}
+	q := r.query.Select("stateListOnEmptyStateIsEmpty")
+
+	return q.Execute(ctx)
+}
+
+// StateListReportsAppliedAddresses asserts StateList names what an Apply put
+// under management, one address per line.
+func (r *OpentofuTests) StateListReportsAppliedAddresses(ctx context.Context) error { // opentofu-tests (../../../daggerverse/opentofu/tests/state.go:24:1)
+	if r.stateListReportsAppliedAddresses != nil {
+		return nil
+	}
+	q := r.query.Select("stateListReportsAppliedAddresses")
+
+	return q.Execute(ctx)
+}
+
+// StateMvRejectsUnknownAddress asserts a source address absent from state
+// fails, naming it.
+func (r *OpentofuTests) StateMvRejectsUnknownAddress(ctx context.Context) error { // opentofu-tests (../../../daggerverse/opentofu/tests/state.go:205:1)
+	if r.stateMvRejectsUnknownAddress != nil {
+		return nil
+	}
+	q := r.query.Select("stateMvRejectsUnknownAddress")
+
+	return q.Execute(ctx)
+}
+
+// StateMvRenamesAddress asserts a resource renamed in state stays the same
+// resource: a plan against the configuration that renamed it to match reports
+// no changes, where without the move tofu would destroy and recreate.
+func (r *OpentofuTests) StateMvRenamesAddress(ctx context.Context) error { // opentofu-tests (../../../daggerverse/opentofu/tests/state.go:164:1)
+	if r.stateMvRenamesAddress != nil {
+		return nil
+	}
+	q := r.query.Select("stateMvRenamesAddress")
+
+	return q.Execute(ctx)
+}
+
+// StateRmDropsAddressFromState asserts StateRm removes the address from state
+// and nothing else: the resulting state omits it, still tracks its neighbour,
+// and a plan afterwards proposes creating it again — which is exactly the
+// hazard of dropping something whose object is still out there.
+func (r *OpentofuTests) StateRmDropsAddressFromState(ctx context.Context) error { // opentofu-tests (../../../daggerverse/opentofu/tests/state.go:106:1)
+	if r.stateRmDropsAddressFromState != nil {
+		return nil
+	}
+	q := r.query.Select("stateRmDropsAddressFromState")
+
+	return q.Execute(ctx)
+}
+
+// StateRmRejectsUnknownAddress asserts an address absent from state fails,
+// naming it.
+func (r *OpentofuTests) StateRmRejectsUnknownAddress(ctx context.Context) error { // opentofu-tests (../../../daggerverse/opentofu/tests/state.go:146:1)
+	if r.stateRmRejectsUnknownAddress != nil {
+		return nil
+	}
+	q := r.query.Select("stateRmRejectsUnknownAddress")
+
+	return q.Execute(ctx)
+}
+
+// StateShowRejectsUnknownAddress asserts an address absent from state is an
+// error naming it, rather than an empty document a caller could mistake for a
+// resource with no attributes.
+func (r *OpentofuTests) StateShowRejectsUnknownAddress(ctx context.Context) error { // opentofu-tests (../../../daggerverse/opentofu/tests/state.go:91:1)
+	if r.stateShowRejectsUnknownAddress != nil {
+		return nil
+	}
+	q := r.query.Select("stateShowRejectsUnknownAddress")
+
+	return q.Execute(ctx)
+}
+
+// StateShowReturnsResourceJson asserts StateShow returns one parseable JSON
+// document describing the requested resource — not the JSON *stream* tofu
+// writes, whose first line is a UI message about the version it ran.
+func (r *OpentofuTests) StateShowReturnsResourceJSON(ctx context.Context) error { // opentofu-tests (../../../daggerverse/opentofu/tests/state.go:60:1)
+	if r.stateShowReturnsResourceJson != nil {
+		return nil
+	}
+	q := r.query.Select("stateShowReturnsResourceJson")
+
+	return q.Execute(ctx)
+}
+
+// TaintProposesReplacement asserts a tainted resource is planned for
+// replacement — destroyed and created again — while its neighbour is left
+// alone.
+func (r *OpentofuTests) TaintProposesReplacement(ctx context.Context) error { // opentofu-tests (../../../daggerverse/opentofu/tests/state.go:322:1)
+	if r.taintProposesReplacement != nil {
+		return nil
+	}
+	q := r.query.Select("taintProposesReplacement")
+
+	return q.Execute(ctx)
+}
+
+// UntaintClearsReplacement asserts Untaint reverses Taint: the same state,
+// taken through both, plans no changes at all.
+func (r *OpentofuTests) UntaintClearsReplacement(ctx context.Context) error { // opentofu-tests (../../../daggerverse/opentofu/tests/state.go:353:1)
+	if r.untaintClearsReplacement != nil {
+		return nil
+	}
+	q := r.query.Select("untaintClearsReplacement")
+
+	return q.Execute(ctx)
+}
+
 // ValidateAcceptsValidConfiguration asserts a well-formed root module
 // validates.
 func (r *OpentofuTests) ValidateAcceptsValidConfiguration(ctx context.Context) error { // opentofu-tests (../../../daggerverse/opentofu/tests/validation.go:191:1)
@@ -820,7 +1001,7 @@ func (r *OpentofuTests) ValidateWorksWithoutBackendCredentials(ctx context.Conte
 // VersionAcceptsMinimalSuffix asserts a caller who spells out the -minimal
 // suffix lands on the same image as one who does not — the suffix is appended
 // only when absent.
-func (r *OpentofuTests) VersionAcceptsMinimalSuffix(ctx context.Context) error { // opentofu-tests (../../../daggerverse/opentofu/tests/main.go:166:1)
+func (r *OpentofuTests) VersionAcceptsMinimalSuffix(ctx context.Context) error { // opentofu-tests (../../../daggerverse/opentofu/tests/main.go:181:1)
 	if r.versionAcceptsMinimalSuffix != nil {
 		return nil
 	}
@@ -830,7 +1011,7 @@ func (r *OpentofuTests) VersionAcceptsMinimalSuffix(ctx context.Context) error {
 }
 
 // VersionReportsRelease asserts Version reports the release New was asked for.
-func (r *OpentofuTests) VersionReportsRelease(ctx context.Context) error { // opentofu-tests (../../../daggerverse/opentofu/tests/main.go:152:1)
+func (r *OpentofuTests) VersionReportsRelease(ctx context.Context) error { // opentofu-tests (../../../daggerverse/opentofu/tests/main.go:167:1)
 	if r.versionReportsRelease != nil {
 		return nil
 	}

--- a/daggerverse/opentofu/README.md
+++ b/daggerverse/opentofu/README.md
@@ -85,6 +85,51 @@ hosting module sources).
 happily report "0 destroyed" and exit 0, which reads as a successful teardown
 while the real infrastructure — whose state was never supplied — stays up.
 
+## State manipulation
+
+The lifecycle functions are what a pipeline runs unattended. Once state and
+reality have diverged, an operator reaches for a different set — and reaching
+for them through `Container()` means assembling argv, mounting the source and
+threading credentials by hand, which is the work this module exists to remove.
+So they are wrapped too.
+
+```sh
+# What is under management?
+dagger -m github.com/z5labs/devex/daggerverse/opentofu call \
+  config --source=. with-state --state=terraform.tfstate state-list
+
+# Rename a resource in state to match one renamed in the configuration.
+dagger -m github.com/z5labs/devex/daggerverse/opentofu call \
+  config --source=. with-state --state=terraform.tfstate \
+  state-mv --from=random_pet.old --to=random_pet.new \
+  file --path=terraform.tfstate export --path=terraform.tfstate
+```
+
+Every one of them writes state, so every one returns a `*Directory` carrying
+the resulting `terraform.tfstate` exactly the way `Apply` does: emitted in
+file-carried mode, absent under a remote backend, and forfeited entirely on a
+non-zero exit.
+
+That last part is the sharp edge. `StateMv`, `StateRm` and `Import` are
+destructive against state in ways a failed run cannot undo, and a run that
+fails hands back nothing — so hold your own copy of the input state before
+starting, the same discipline as `terraform state pull` before a manual edit.
+
+`StateList` answers with an empty listing when there is no state yet. `tofu`
+itself refuses a wholly absent state file, but "no state" and "an emptied
+state" hold the same answer to what is under management, and a listing that
+distinguished them would only make the caller handle a case with no content.
+
+`StateShow` returns one JSON document, not the JSON *stream* `tofu state show
+-json` writes — that stream opens with a UI message naming the version it ran,
+which no caller asked for. Note that `-json` prints sensitive values in full
+regardless of how the variable behind one was declared, so treat the result as
+sensitive whenever the resource is.
+
+`Graph` is the one read-only member, and the one derived from the
+configuration rather than from live state, so it is the one that caches per
+session rather than never.
+
 ## Secrets
 
 `WithSecretVar(name, secret)` binds `TF_VAR_<name>` as a container environment
@@ -144,6 +189,15 @@ reason.
 | `Config.Destroy(targets)` | A directory of `terraform.tfstate`, `outputs.json`, `destroy.log`. |
 | `Config.Outputs()` | `tofu output -json`. |
 | `Config.Show()` | `tofu show`. |
+| `Config.StateList()` | `tofu state list`; the addresses under management, one per line. |
+| `Config.StateShow(address)` | `tofu state show -json`; one resource's state as a JSON document. |
+| `Config.StateMv(from, to)` | `tofu state mv`; the resulting state directory. |
+| `Config.StateRm(addresses)` | `tofu state rm`; the resulting state directory. |
+| `Config.Import(address, id)` | `tofu import`; the resulting state directory. |
+| `Config.Refresh()` | `tofu apply -refresh-only -auto-approve`; the resulting state directory. |
+| `Config.Taint(address)` | `tofu taint`; the resulting state directory. |
+| `Config.Untaint(address)` | `tofu untaint`; the resulting state directory. |
+| `Config.Graph()` | `tofu graph`; the dependency graph in DOT. |
 | `Config.Ci()` | A chained CI pipeline builder over this configuration. |
 | `Ci.WithFmt()` | Enable the `fmt` stage. |
 | `Ci.WithValidate()` | Enable the `validate` stage. |
@@ -251,10 +305,11 @@ enable the stage, that single plan run is both the check and the artifact.
 
 ## Failure is an error, not a file
 
-`Apply` and `Destroy` fail hard on a non-zero `tofu` exit, and the error text
-carries `tofu`'s own diagnostics. Because Dagger drops a function's value when
-its error is non-nil, a partially failed apply forfeits the state it produced
-in file-carried mode; the remote-backend path is unaffected, since the backend
+Every function that writes state — `Apply`, `Destroy`, and the state-surgery
+set above — fails hard on a non-zero `tofu` exit, and the error text carries
+`tofu`'s own diagnostics. Because Dagger drops a function's value when its
+error is non-nil, a partially failed apply forfeits the state it produced in
+file-carried mode; the remote-backend path is unaffected, since the backend
 already holds the state.
 
 This is a deliberate trade. The alternative — always returning the directory
@@ -268,9 +323,11 @@ the directive repeats on each of them individually rather than being assumed to
 propagate from `Config`.
 
 That directive governs the *function* result; the `WithExec` layers underneath
-are still content-addressed, so `Plan`, `Apply`, `Destroy`, `Outputs` and
-`Show` each stamp a per-call random nonce onto the run that must genuinely
-re-execute.
+are still content-addressed, so each of those functions stamps a per-call
+random nonce onto the run that must genuinely re-execute. The two that read
+configuration rather than infrastructure — `Fmt`/`Format` and `Graph` — carry
+`+cache="session"` and no nonce, so they are free to come back from the layer
+cache.
 
 The same fact bites callers: two selections off one `+cache="never"` call are
 two invocations. Reading `plan.json` and `changes` off a single `Plan()` would

--- a/daggerverse/opentofu/config.go
+++ b/daggerverse/opentofu/config.go
@@ -560,7 +560,7 @@ func (c *Config) Apply(
 		args = append(args, c.varArgs()...)
 		args = append(args, targetArgs(targets)...)
 	}
-	return c.runMutation(ctx, ctr, args, "tofu apply")
+	return c.runMutation(ctx, ctr, args, "tofu apply", "apply.log")
 }
 
 // Destroy tears down everything the state tracks and returns the post-destroy
@@ -603,7 +603,7 @@ func (c *Config) Destroy(
 	args := []string{"tofu", "destroy", "-input=false", "-no-color", "-auto-approve"}
 	args = append(args, c.varArgs()...)
 	args = append(args, targetArgs(targets)...)
-	return c.runMutation(ctx, ctr, args, "tofu destroy")
+	return c.runMutation(ctx, ctr, args, "tofu destroy", "destroy.log")
 }
 
 // Outputs returns the root module's output values as JSON
@@ -611,7 +611,7 @@ func (c *Config) Destroy(
 //
 // +cache="never"
 func (c *Config) Outputs(ctx context.Context) (string, error) {
-	return c.read(ctx, []string{"tofu", "output", "-json", "-no-color"}, "tofu output -json")
+	return c.read(ctx, []string{"tofu", "output", "-json", "-no-color"}, "tofu output -json", true)
 }
 
 // Show returns the human-readable rendering of the current state
@@ -619,7 +619,7 @@ func (c *Config) Outputs(ctx context.Context) (string, error) {
 //
 // +cache="never"
 func (c *Config) Show(ctx context.Context) (string, error) {
-	return c.read(ctx, []string{"tofu", "show", "-no-color"}, "tofu show")
+	return c.read(ctx, []string{"tofu", "show", "-no-color"}, "tofu show", true)
 }
 
 // ------------------------------------------------------------------- internals
@@ -758,15 +758,19 @@ func (c *Config) initialized(ctx context.Context) (*dagger.Container, error) {
 	return ws, nil
 }
 
-// runMutation executes an apply or destroy and packages its results:
+// runMutation executes a command that writes state and packages its results:
 // terraform.tfstate when the state is file-carried, the output values, and
 // the run's own log.
-func (c *Config) runMutation(ctx context.Context, ctr *dagger.Container, args []string, label string) (*dagger.Directory, error) {
+//
+// label names the run in an error message and carries whatever identifies it
+// — the addresses a state move names, say — while logName is fixed per
+// function, so the returned directory's contents do not vary with the
+// arguments.
+func (c *Config) runMutation(ctx context.Context, ctr *dagger.Container, args []string, label string, logName string) (*dagger.Directory, error) {
 	nonce, err := randHex()
 	if err != nil {
 		return nil, err
 	}
-	logName := strings.TrimPrefix(label, "tofu ") + ".log"
 
 	exec := ctr.
 		WithEnvVariable("TOFU_RUN_NONCE", nonce).
@@ -803,18 +807,16 @@ func (c *Config) runMutation(ctx context.Context, ctr *dagger.Container, args []
 
 // read runs a read-only tofu subcommand against the initialised root module
 // and returns its stdout.
-func (c *Config) read(ctx context.Context, args []string, label string) (string, error) {
-	ctr, err := c.initialized(ctx)
+//
+// fresh stamps a per-call nonce onto the exec, which is what a +cache="never"
+// reading needs to genuinely re-run: the directive governs the function
+// result, while the WithExec layer underneath stays content-addressed. A
+// +cache="session" reading passes false and may be served from that layer.
+func (c *Config) read(ctx context.Context, args []string, label string, fresh bool) (string, error) {
+	exec, err := c.readExec(ctx, args, fresh)
 	if err != nil {
 		return "", err
 	}
-	nonce, err := randHex()
-	if err != nil {
-		return "", err
-	}
-	exec := ctr.
-		WithEnvVariable("TOFU_RUN_NONCE", nonce).
-		WithExec(args, dagger.ContainerWithExecOpts{Expect: dagger.ReturnTypeAny})
 	code, err := exec.ExitCode(ctx)
 	if err != nil {
 		return "", err
@@ -827,6 +829,23 @@ func (c *Config) read(ctx context.Context, args []string, label string) (string,
 		return "", fmt.Errorf("%s: %s", label, errText(err))
 	}
 	return out, nil
+}
+
+// readExec builds the exec read runs, for the callers that have to inspect a
+// non-zero exit themselves rather than take it as a failure.
+func (c *Config) readExec(ctx context.Context, args []string, fresh bool) (*dagger.Container, error) {
+	ctr, err := c.initialized(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if fresh {
+		nonce, err := randHex()
+		if err != nil {
+			return nil, err
+		}
+		ctr = ctr.WithEnvVariable("TOFU_RUN_NONCE", nonce)
+	}
+	return ctr.WithExec(args, dagger.ContainerWithExecOpts{Expect: dagger.ReturnTypeAny}), nil
 }
 
 // initArgs renders `tofu init`. backend=false is how Validate reaches a
@@ -975,6 +994,20 @@ func checkPairName(fn string, what string, name string) error {
 	}
 	if strings.Contains(name, "=") {
 		return fmt.Errorf("%s: %s %q must not contain %q", fn, what, name, "=")
+	}
+	return nil
+}
+
+// checkPositional rejects a positional argument that would not survive the
+// trip through argv: an empty one, which tofu reads as a missing argument, or
+// one opening with a dash, which it reads as a flag. Both turn a call on a
+// specific resource into a call on something else entirely.
+func checkPositional(fn string, what string, value string) error {
+	if strings.TrimSpace(value) == "" {
+		return fmt.Errorf("%s: %s is required", fn, what)
+	}
+	if strings.HasPrefix(value, "-") {
+		return fmt.Errorf("%s: %s %q must not begin with %q — tofu would read it as a flag", fn, what, value, "-")
 	}
 	return nil
 }

--- a/daggerverse/opentofu/dagger.gen.go
+++ b/daggerverse/opentofu/dagger.gen.go
@@ -437,6 +437,34 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return (*Config).Format(&parent, ctx)
+		case "Graph":
+			var parent Config
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Config).Graph(&parent, ctx)
+		case "Import":
+			var parent Config
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var address string
+			if inputArgs["address"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["address"]), &address)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg address", err))
+				}
+			}
+			var id string
+			if inputArgs["id"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["id"]), &id)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg id", err))
+				}
+			}
+			return (*Config).Import(&parent, ctx, address, id)
 		case "Init":
 			var parent Config
 			err = json.Unmarshal(parentJSON, &parent)
@@ -486,6 +514,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Config).Plan(&parent, ctx, destroy, targets)
+		case "Refresh":
+			var parent Config
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Config).Refresh(&parent, ctx)
 		case "Show":
 			var parent Config
 			err = json.Unmarshal(parentJSON, &parent)
@@ -493,6 +528,90 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return (*Config).Show(&parent, ctx)
+		case "StateList":
+			var parent Config
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Config).StateList(&parent, ctx)
+		case "StateMv":
+			var parent Config
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var from string
+			if inputArgs["from"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["from"]), &from)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg from", err))
+				}
+			}
+			var to string
+			if inputArgs["to"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["to"]), &to)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg to", err))
+				}
+			}
+			return (*Config).StateMv(&parent, ctx, from, to)
+		case "StateRm":
+			var parent Config
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var addresses []string
+			if inputArgs["addresses"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["addresses"]), &addresses)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg addresses", err))
+				}
+			}
+			return (*Config).StateRm(&parent, ctx, addresses)
+		case "StateShow":
+			var parent Config
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var address string
+			if inputArgs["address"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["address"]), &address)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg address", err))
+				}
+			}
+			return (*Config).StateShow(&parent, ctx, address)
+		case "Taint":
+			var parent Config
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var address string
+			if inputArgs["address"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["address"]), &address)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg address", err))
+				}
+			}
+			return (*Config).Taint(&parent, ctx, address)
+		case "Untaint":
+			var parent Config
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var address string
+			if inputArgs["address"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["address"]), &address)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg address", err))
+				}
+			}
+			return (*Config).Untaint(&parent, ctx, address)
 		case "Validate":
 			var parent Config
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/opentofu/state.go
+++ b/daggerverse/opentofu/state.go
@@ -1,0 +1,294 @@
+package main
+
+// The state-manipulation half of the tofu CLI: what an operator reaches for
+// once state and reality have diverged. The lifecycle functions in config.go
+// are what a pipeline runs unattended; these are what someone runs on purpose.
+//
+// Every one of them writes state, so every one hands the resulting
+// terraform.tfstate back the way Apply and Destroy do — through runMutation,
+// which emits it only in file-carried mode and forfeits it on a non-zero exit.
+// Graph is the exception: it reads the configuration and returns text.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"dagger/opentofu/internal/dagger"
+)
+
+const (
+	// noStateMarker is how tofu announces that the state commands found no
+	// state file at all. An emptied state file is not this case: tofu lists it
+	// as zero resources and exits 0. Only a wholly absent one is refused, and
+	// StateList answers that with the same empty listing rather than an error.
+	noStateMarker = "No state file was found"
+
+	// uiLevelKey marks a line of tofu's -json output as a UI message rather
+	// than the document being asked for. Every -json subcommand prefixes its
+	// payload with at least a version message, so the stream has to be sifted.
+	uiLevelKey = "@level"
+)
+
+// ---------------------------------------------------------------- inspection
+
+// StateList returns the resource addresses in state, one per line
+// (`tofu state list`).
+//
+// A configuration with no state yet lists nothing rather than failing: tofu
+// itself refuses a wholly absent state file, but "no state" and "an emptied
+// state" hold the same answer to what is under management, and a listing that
+// distinguishes them only makes the caller handle a case with no content.
+//
+// +cache="never"
+func (c *Config) StateList(ctx context.Context) (string, error) {
+	args := []string{"tofu", "state", "list", "-no-color"}
+	args = append(args, c.varArgs()...)
+
+	exec, err := c.readExec(ctx, args, true)
+	if err != nil {
+		return "", err
+	}
+	code, err := exec.ExitCode(ctx)
+	if err != nil {
+		return "", err
+	}
+	if code != 0 {
+		out := combinedOutput(ctx, exec)
+		if strings.Contains(out, noStateMarker) {
+			return "", nil
+		}
+		return "", fmt.Errorf("tofu state list failed (exit %d):\n%s", code, out)
+	}
+	out, err := exec.Stdout(ctx)
+	if err != nil {
+		return "", fmt.Errorf("tofu state list: %s", errText(err))
+	}
+	return out, nil
+}
+
+// StateShow returns the state of one resource as JSON
+// (`tofu state show -json <address>`).
+//
+// An address that matches nothing in state is an error naming it, rather than
+// an empty document a caller could mistake for a resource with no attributes.
+//
+// Note what the JSON form does not do: `-json` prints sensitive values in
+// full, whether or not the variable behind one was declared
+// `sensitive = true`. Treat the result as sensitive whenever the resource is.
+//
+// +cache="never"
+func (c *Config) StateShow(
+	ctx context.Context,
+	// Address of the resource instance to show, e.g. `random_pet.name`.
+	address string,
+) (string, error) {
+	if err := checkPositional("StateShow", "resource address", address); err != nil {
+		return "", err
+	}
+	args := []string{"tofu", "state", "show", "-json"}
+	args = append(args, c.varArgs()...)
+	args = append(args, address)
+
+	stream, err := c.read(ctx, args, "tofu state show "+address, true)
+	if err != nil {
+		return "", err
+	}
+	return jsonDocument(stream, "tofu state show -json "+address)
+}
+
+// Graph returns the DOT rendering of the configuration's dependency graph
+// (`tofu graph`), for GraphViz or anything else that reads the format.
+//
+// It is the one member of this file that is read-only, and it is derived from
+// the configuration rather than from live state — so unlike the rest it caches
+// for the session.
+//
+// +cache="session"
+func (c *Config) Graph(ctx context.Context) (string, error) {
+	args := []string{"tofu", "graph", "-no-color"}
+	args = append(args, c.varArgs()...)
+	return c.read(ctx, args, "tofu graph", false)
+}
+
+// ------------------------------------------------------------------ surgery
+
+// StateMv renames a resource in state (`tofu state mv <from> <to>`) and
+// returns the resulting state directory.
+//
+// This is how a resource survives being renamed in the configuration: without
+// it, tofu reads the new name as a new resource and the old one as gone, and
+// plans to destroy and recreate.
+//
+// +cache="never"
+func (c *Config) StateMv(
+	ctx context.Context,
+	// Address the resource is recorded under now.
+	from string,
+	// Address to record it under instead.
+	to string,
+) (*dagger.Directory, error) {
+	if err := checkPositional("StateMv", "source address", from); err != nil {
+		return nil, err
+	}
+	if err := checkPositional("StateMv", "destination address", to); err != nil {
+		return nil, err
+	}
+	ctr, err := c.initialized(ctx)
+	if err != nil {
+		return nil, err
+	}
+	args := []string{"tofu", "state", "mv", "-no-color"}
+	args = append(args, c.varArgs()...)
+	args = append(args, from, to)
+	return c.runMutation(ctx, ctr, args, fmt.Sprintf("tofu state mv %s %s", from, to), "state-mv.log")
+}
+
+// StateRm drops resources from state (`tofu state rm <address>...`) and
+// returns the resulting state directory.
+//
+// The objects themselves are left alone: this is how a resource is handed over
+// to another configuration, or abandoned to be managed by hand. A plan run
+// afterwards sees them as absent and proposes creating them again, which is
+// the hazard — the objects are still out there.
+//
+// +cache="never"
+func (c *Config) StateRm(
+	ctx context.Context,
+	// Addresses to drop from state.
+	addresses []string,
+) (*dagger.Directory, error) {
+	if len(addresses) == 0 {
+		return nil, fmt.Errorf("StateRm: at least one resource address is required")
+	}
+	for _, address := range addresses {
+		if err := checkPositional("StateRm", "resource address", address); err != nil {
+			return nil, err
+		}
+	}
+	ctr, err := c.initialized(ctx)
+	if err != nil {
+		return nil, err
+	}
+	args := []string{"tofu", "state", "rm", "-no-color"}
+	args = append(args, c.varArgs()...)
+	args = append(args, addresses...)
+	return c.runMutation(ctx, ctr, args, "tofu state rm "+strings.Join(addresses, " "), "state-rm.log")
+}
+
+// Import brings an existing object under management
+// (`tofu import <address> <id>`) and returns the resulting state directory.
+//
+// The address has to already be declared in the configuration — import writes
+// state, it does not write HCL — and the id is whatever the resource's own
+// provider accepts, which varies per resource type.
+//
+// +cache="never"
+func (c *Config) Import(
+	ctx context.Context,
+	// Address the object is to be recorded under, as declared in the
+	// configuration.
+	address string,
+	// Provider-specific id of the existing object.
+	id string,
+) (*dagger.Directory, error) {
+	if err := checkPositional("Import", "resource address", address); err != nil {
+		return nil, err
+	}
+	if err := checkPositional("Import", "resource id", id); err != nil {
+		return nil, err
+	}
+	ctr, err := c.initialized(ctx)
+	if err != nil {
+		return nil, err
+	}
+	args := []string{"tofu", "import", "-input=false", "-no-color"}
+	args = append(args, c.varArgs()...)
+	args = append(args, address, id)
+	return c.runMutation(ctx, ctr, args, "tofu import "+address, "import.log")
+}
+
+// Refresh updates state to match what the providers report
+// (`tofu apply -refresh-only -auto-approve`) and returns the resulting state
+// directory.
+//
+// It is the refresh-only apply rather than the deprecated `tofu refresh`:
+// both write state, but only this one is still supported.
+//
+// +cache="never"
+func (c *Config) Refresh(ctx context.Context) (*dagger.Directory, error) {
+	ctr, err := c.initialized(ctx)
+	if err != nil {
+		return nil, err
+	}
+	args := []string{"tofu", "apply", "-refresh-only", "-auto-approve", "-input=false", "-no-color"}
+	args = append(args, c.varArgs()...)
+	return c.runMutation(ctx, ctr, args, "tofu apply -refresh-only", "refresh.log")
+}
+
+// Taint marks a resource for replacement (`tofu taint <address>`) and returns
+// the resulting state directory. The next plan proposes destroying and
+// recreating it.
+//
+// +cache="never"
+func (c *Config) Taint(
+	ctx context.Context,
+	// Address of the resource instance to mark.
+	address string,
+) (*dagger.Directory, error) {
+	return c.mark(ctx, "Taint", "taint", address)
+}
+
+// Untaint clears the mark Taint set (`tofu untaint <address>`) and returns the
+// resulting state directory.
+//
+// +cache="never"
+func (c *Config) Untaint(
+	ctx context.Context,
+	// Address of the resource instance to clear.
+	address string,
+) (*dagger.Directory, error) {
+	return c.mark(ctx, "Untaint", "untaint", address)
+}
+
+// ---------------------------------------------------------------- internals
+
+// mark runs taint or untaint, which differ only in the subcommand name.
+func (c *Config) mark(ctx context.Context, fn string, subcommand string, address string) (*dagger.Directory, error) {
+	if err := checkPositional(fn, "resource address", address); err != nil {
+		return nil, err
+	}
+	ctr, err := c.initialized(ctx)
+	if err != nil {
+		return nil, err
+	}
+	args := []string{"tofu", subcommand, "-no-color"}
+	args = append(args, c.varArgs()...)
+	args = append(args, address)
+	return c.runMutation(ctx, ctr, args, "tofu "+subcommand+" "+address, subcommand+".log")
+}
+
+// jsonDocument pulls the payload out of a tofu `-json` output.
+//
+// That output is a JSON *stream*, not a document: tofu prefixes the payload
+// with UI messages of its own, starting with the version it ran. The UI lines
+// carry an `@level` key and the payload does not, which is what separates
+// them.
+func jsonDocument(stream string, label string) (string, error) {
+	for line := range strings.SplitSeq(stream, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(line), &fields); err != nil {
+			continue
+		}
+		if _, ui := fields[uiLevelKey]; ui {
+			continue
+		}
+		return line, nil
+	}
+	return "", fmt.Errorf("%s emitted no JSON document:\n%s", label, stream)
+}

--- a/daggerverse/opentofu/tests/dagger.gen.go
+++ b/daggerverse/opentofu/tests/dagger.gen.go
@@ -402,6 +402,27 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).FormatRewritesUnformattedConfiguration(&parent, ctx)
+		case "GraphRendersDependencyGraph":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).GraphRendersDependencyGraph(&parent, ctx)
+		case "ImportBringsResourceUnderManagement":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ImportBringsResourceUnderManagement(&parent, ctx)
+		case "ImportRejectsAddressAbsentFromConfiguration":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ImportRejectsAddressAbsentFromConfiguration(&parent, ctx)
 		case "InitProducesLockFile":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -472,6 +493,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).PlanTargetsLimitScope(&parent, ctx)
+		case "RefreshUpdatesStateWithoutChanges":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).RefreshUpdatesStateWithoutChanges(&parent, ctx)
 		case "RemoteBackendRoundTripsState":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -521,6 +549,76 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).StateAndBackendConfigFileAreRejected(&parent, ctx)
+		case "StateListOnEmptyStateIsEmpty":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).StateListOnEmptyStateIsEmpty(&parent, ctx)
+		case "StateListReportsAppliedAddresses":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).StateListReportsAppliedAddresses(&parent, ctx)
+		case "StateMvRejectsUnknownAddress":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).StateMvRejectsUnknownAddress(&parent, ctx)
+		case "StateMvRenamesAddress":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).StateMvRenamesAddress(&parent, ctx)
+		case "StateRmDropsAddressFromState":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).StateRmDropsAddressFromState(&parent, ctx)
+		case "StateRmRejectsUnknownAddress":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).StateRmRejectsUnknownAddress(&parent, ctx)
+		case "StateShowRejectsUnknownAddress":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).StateShowRejectsUnknownAddress(&parent, ctx)
+		case "StateShowReturnsResourceJson":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).StateShowReturnsResourceJson(&parent, ctx)
+		case "TaintProposesReplacement":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).TaintProposesReplacement(&parent, ctx)
+		case "UntaintClearsReplacement":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).UntaintClearsReplacement(&parent, ctx)
 		case "ValidateAcceptsValidConfiguration":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/opentofu/tests/fixtures/importable/main.tf
+++ b/daggerverse/opentofu/tests/fixtures/importable/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}
+
+# random_integer is the one hermetic resource that supports import: its id is
+# `result,min,max`, so an object to adopt can be named outright instead of
+# having to exist somewhere first. Which is what makes the import assertion
+# meaningful — the result is fixed, so a plan afterwards is empty only if the
+# import genuinely recorded it.
+resource "random_integer" "adopted" {
+  min = 1
+  max = 100
+}
+
+output "adopted" {
+  value = random_integer.adopted.result
+}

--- a/daggerverse/opentofu/tests/fixtures/renamed/main.tf
+++ b/daggerverse/opentofu/tests/fixtures/renamed/main.tf
@@ -1,0 +1,37 @@
+terraform {
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}
+
+variable "prefix" {
+  type        = string
+  default     = "devex"
+  description = "Prefix given to the generated pet name."
+}
+
+# The basic fixture with one resource renamed, and nothing else changed. It is
+# the other half of a StateMv: moving the address in state has to leave a plan
+# against this configuration empty, which it only does if the two fixtures
+# agree on everything but the name.
+resource "random_pet" "renamed" {
+  prefix    = var.prefix
+  length    = 2
+  separator = "-"
+}
+
+resource "random_integer" "port" {
+  min = 30000
+  max = 32767
+}
+
+output "name" {
+  value = random_pet.renamed.id
+}
+
+output "port" {
+  value = random_integer.port.result
+}

--- a/daggerverse/opentofu/tests/internal/dagger/opentofu.gen.go
+++ b/daggerverse/opentofu/tests/internal/dagger/opentofu.gen.go
@@ -413,11 +413,14 @@ func (r *OpentofuCi) AsNode() Node {
 type OpentofuConfig struct { // opentofu (../../../../../daggerverse/opentofu/config.go:95:6)
 	query *querybuilder.Selection
 
-	fmt      *string
-	id       *ID
-	outputs  *string
-	show     *string
-	validate *Void
+	fmt       *string
+	graph     *string
+	id        *ID
+	outputs   *string
+	show      *string
+	stateList *string
+	stateShow *string
+	validate  *Void
 }
 type WithOpentofuConfigFunc func(r *OpentofuConfig) *OpentofuConfig
 
@@ -549,6 +552,24 @@ func (r *OpentofuConfig) Format() *Directory { // opentofu (../../../../../dagge
 	}
 }
 
+// Graph returns the DOT rendering of the configuration's dependency graph
+// (`tofu graph`), for GraphViz or anything else that reads the format.
+//
+// It is the one member of this file that is read-only, and it is derived from
+// the configuration rather than from live state — so unlike the rest it caches
+// for the session.
+func (r *OpentofuConfig) Graph(ctx context.Context) (string, error) { // opentofu (../../../../../daggerverse/opentofu/state.go:109:1)
+	if r.graph != nil {
+		return *r.graph, nil
+	}
+	q := r.query.Select("graph")
+
+	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
 // A unique identifier for this OpentofuConfig.
 func (r *OpentofuConfig) ID(ctx context.Context) (ID, error) {
 	if r.id != nil {
@@ -596,6 +617,22 @@ func (r *OpentofuConfig) UnmarshalJSON(bs []byte) error {
 	}
 	*r = OpentofuConfig{query: selectNode(dag.query, id, "OpentofuConfig")}
 	return nil
+}
+
+// Import brings an existing object under management
+// (`tofu import <address> <id>`) and returns the resulting state directory.
+//
+// The address has to already be declared in the configuration — import writes
+// state, it does not write HCL — and the id is whatever the resource's own
+// provider accepts, which varies per resource type.
+func (r *OpentofuConfig) Import(address string, id string) *Directory { // opentofu (../../../../../daggerverse/opentofu/state.go:188:1)
+	q := r.query.Select("import")
+	q = q.Arg("address", address)
+	q = q.Arg("id", id)
+
+	return &Directory{
+		query: q,
+	}
 }
 
 // Init runs a full `tofu init` — backend included — and returns the root
@@ -704,6 +741,20 @@ func (r *OpentofuConfig) Plan(opts ...OpentofuConfigPlanOpts) *Directory { // op
 	}
 }
 
+// Refresh updates state to match what the providers report
+// (`tofu apply -refresh-only -auto-approve`) and returns the resulting state
+// directory.
+//
+// It is the refresh-only apply rather than the deprecated `tofu refresh`:
+// both write state, but only this one is still supported.
+func (r *OpentofuConfig) Refresh() *Directory { // opentofu (../../../../../daggerverse/opentofu/state.go:220:1)
+	q := r.query.Select("refresh")
+
+	return &Directory{
+		query: q,
+	}
+}
+
 // Show returns the human-readable rendering of the current state
 // (`tofu show`).
 func (r *OpentofuConfig) Show(ctx context.Context) (string, error) { // opentofu (../../../../../daggerverse/opentofu/config.go:621:1)
@@ -716,6 +767,102 @@ func (r *OpentofuConfig) Show(ctx context.Context) (string, error) { // opentofu
 
 	q = q.Bind(&response)
 	return response, q.Execute(ctx)
+}
+
+// StateList returns the resource addresses in state, one per line
+// (`tofu state list`).
+//
+// A configuration with no state yet lists nothing rather than failing: tofu
+// itself refuses a wholly absent state file, but "no state" and "an emptied
+// state" hold the same answer to what is under management, and a listing that
+// distinguishes them only makes the caller handle a case with no content.
+func (r *OpentofuConfig) StateList(ctx context.Context) (string, error) { // opentofu (../../../../../daggerverse/opentofu/state.go:45:1)
+	if r.stateList != nil {
+		return *r.stateList, nil
+	}
+	q := r.query.Select("stateList")
+
+	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// StateMv renames a resource in state (`tofu state mv <from> <to>`) and
+// returns the resulting state directory.
+//
+// This is how a resource survives being renamed in the configuration: without
+// it, tofu reads the new name as a new resource and the old one as gone, and
+// plans to destroy and recreate.
+func (r *OpentofuConfig) StateMv(from string, to string) *Directory { // opentofu (../../../../../daggerverse/opentofu/state.go:125:1)
+	q := r.query.Select("stateMv")
+	q = q.Arg("from", from)
+	q = q.Arg("to", to)
+
+	return &Directory{
+		query: q,
+	}
+}
+
+// StateRm drops resources from state (`tofu state rm <address>...`) and
+// returns the resulting state directory.
+//
+// The objects themselves are left alone: this is how a resource is handed over
+// to another configuration, or abandoned to be managed by hand. A plan run
+// afterwards sees them as absent and proposes creating them again, which is
+// the hazard — the objects are still out there.
+func (r *OpentofuConfig) StateRm(addresses []string) *Directory { // opentofu (../../../../../daggerverse/opentofu/state.go:157:1)
+	q := r.query.Select("stateRm")
+	q = q.Arg("addresses", addresses)
+
+	return &Directory{
+		query: q,
+	}
+}
+
+// StateShow returns the state of one resource as JSON
+// (`tofu state show -json <address>`).
+//
+// An address that matches nothing in state is an error naming it, rather than
+// an empty document a caller could mistake for a resource with no attributes.
+//
+// Note what the JSON form does not do: `-json` prints sensitive values in
+// full, whether or not the variable behind one was declared
+// `sensitive = true`. Treat the result as sensitive whenever the resource is.
+func (r *OpentofuConfig) StateShow(ctx context.Context, address string) (string, error) { // opentofu (../../../../../daggerverse/opentofu/state.go:82:1)
+	if r.stateShow != nil {
+		return *r.stateShow, nil
+	}
+	q := r.query.Select("stateShow")
+	q = q.Arg("address", address)
+
+	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// Taint marks a resource for replacement (`tofu taint <address>`) and returns
+// the resulting state directory. The next plan proposes destroying and
+// recreating it.
+func (r *OpentofuConfig) Taint(address string) *Directory { // opentofu (../../../../../daggerverse/opentofu/state.go:235:1)
+	q := r.query.Select("taint")
+	q = q.Arg("address", address)
+
+	return &Directory{
+		query: q,
+	}
+}
+
+// Untaint clears the mark Taint set (`tofu untaint <address>`) and returns the
+// resulting state directory.
+func (r *OpentofuConfig) Untaint(address string) *Directory { // opentofu (../../../../../daggerverse/opentofu/state.go:247:1)
+	q := r.query.Select("untaint")
+	q = q.Arg("address", address)
+
+	return &Directory{
+		query: q,
+	}
 }
 
 // Validate checks the configuration for internal consistency with

--- a/daggerverse/opentofu/tests/lifecycle.go
+++ b/daggerverse/opentofu/tests/lifecycle.go
@@ -464,6 +464,19 @@ type planDocument struct {
 	} `json:"resource_changes"`
 }
 
+// actions maps each address the plan covers to what it proposes doing to it.
+//
+// Every resource in the configuration appears, including the ones the plan
+// leaves alone — those carry `no-op` — so an assertion about one resource has
+// to name the rest rather than expect them to be absent.
+func (p planDocument) actions() map[string][]string {
+	out := make(map[string][]string, len(p.ResourceChanges))
+	for _, rc := range p.ResourceChanges {
+		out[rc.Address] = rc.Change.Actions
+	}
+	return out
+}
+
 // addresses returns the planned resource addresses, sorted so assertions do
 // not depend on tofu's ordering.
 func (p planDocument) addresses() []string {

--- a/daggerverse/opentofu/tests/main.go
+++ b/daggerverse/opentofu/tests/main.go
@@ -91,6 +91,21 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("SecretVarReachesTofuWithoutLeaking", t.SecretVarReachesTofuWithoutLeaking)
 	jobs = jobs.WithJob("SecretVariableBindsEnvironmentSecret", t.SecretVariableBindsEnvironmentSecret)
 
+	jobs = jobs.WithJob("StateListReportsAppliedAddresses", t.StateListReportsAppliedAddresses)
+	jobs = jobs.WithJob("StateListOnEmptyStateIsEmpty", t.StateListOnEmptyStateIsEmpty)
+	jobs = jobs.WithJob("StateShowReturnsResourceJson", t.StateShowReturnsResourceJson)
+	jobs = jobs.WithJob("StateShowRejectsUnknownAddress", t.StateShowRejectsUnknownAddress)
+	jobs = jobs.WithJob("StateRmDropsAddressFromState", t.StateRmDropsAddressFromState)
+	jobs = jobs.WithJob("StateRmRejectsUnknownAddress", t.StateRmRejectsUnknownAddress)
+	jobs = jobs.WithJob("StateMvRenamesAddress", t.StateMvRenamesAddress)
+	jobs = jobs.WithJob("StateMvRejectsUnknownAddress", t.StateMvRejectsUnknownAddress)
+	jobs = jobs.WithJob("ImportBringsResourceUnderManagement", t.ImportBringsResourceUnderManagement)
+	jobs = jobs.WithJob("ImportRejectsAddressAbsentFromConfiguration", t.ImportRejectsAddressAbsentFromConfiguration)
+	jobs = jobs.WithJob("RefreshUpdatesStateWithoutChanges", t.RefreshUpdatesStateWithoutChanges)
+	jobs = jobs.WithJob("TaintProposesReplacement", t.TaintProposesReplacement)
+	jobs = jobs.WithJob("UntaintClearsReplacement", t.UntaintClearsReplacement)
+	jobs = jobs.WithJob("GraphRendersDependencyGraph", t.GraphRendersDependencyGraph)
+
 	jobs = jobs.WithJob("WithWorkspaceIsolatesState", t.WithWorkspaceIsolatesState)
 	jobs = jobs.WithJob("WithoutPluginCacheStillApplies", t.WithoutPluginCacheStillApplies)
 

--- a/daggerverse/opentofu/tests/state.go
+++ b/daggerverse/opentofu/tests/state.go
@@ -1,0 +1,497 @@
+package main
+
+// Tests for the state-manipulation surface: the subcommands an operator
+// reaches for once state and reality have diverged.
+//
+// The fixtures stay hermetic, which shapes what these can assert. The random
+// provider's resources exist only in state, so "the resource survived being
+// dropped from state" has no out-of-band object to check — what is checked
+// instead is the state itself and the plan tofu makes from it, which is the
+// same evidence an operator acts on.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// -------------------------------------------------------------- state list
+
+// StateListReportsAppliedAddresses asserts StateList names what an Apply put
+// under management, one address per line.
+func (t *Tests) StateListReportsAppliedAddresses(ctx context.Context) error {
+	state, err := applyBasic(ctx)
+	if err != nil {
+		return err
+	}
+	out, err := opentofu().Config(fixture("basic")).WithState(state).StateList(ctx)
+	if err != nil {
+		return fmt.Errorf("StateList: %w", err)
+	}
+	want := []string{"random_integer.port", "random_pet.name"}
+	if got := listedAddresses(out); !slices.Equal(got, want) {
+		return fmt.Errorf("expected StateList to report %v, got %v", want, got)
+	}
+	return nil
+}
+
+// StateListOnEmptyStateIsEmpty asserts a configuration with no state yet lists
+// nothing rather than failing. tofu refuses a wholly absent state file; the
+// module answers the question that was actually asked, which has an empty
+// answer.
+func (t *Tests) StateListOnEmptyStateIsEmpty(ctx context.Context) error {
+	out, err := opentofu().Config(fixture("basic")).StateList(ctx)
+	if err != nil {
+		return fmt.Errorf("StateList against no state: %w", err)
+	}
+	if got := listedAddresses(out); len(got) != 0 {
+		return fmt.Errorf("expected an empty listing, got %v", got)
+	}
+	return nil
+}
+
+// -------------------------------------------------------------- state show
+
+// StateShowReturnsResourceJson asserts StateShow returns one parseable JSON
+// document describing the requested resource — not the JSON *stream* tofu
+// writes, whose first line is a UI message about the version it ran.
+func (t *Tests) StateShowReturnsResourceJson(ctx context.Context) error {
+	state, err := applyBasic(ctx)
+	if err != nil {
+		return err
+	}
+	raw, err := opentofu().Config(fixture("basic")).WithState(state).StateShow(ctx, "random_pet.name")
+	if err != nil {
+		return fmt.Errorf("StateShow: %w", err)
+	}
+
+	var doc showDocument
+	if err := json.Unmarshal([]byte(raw), &doc); err != nil {
+		return fmt.Errorf("parse the shown resource as JSON (%q): %w", raw, err)
+	}
+	resources := doc.Values.RootModule.Resources
+	if len(resources) != 1 {
+		return fmt.Errorf("expected exactly one resource in the document, got %d: %s", len(resources), raw)
+	}
+	if resources[0].Address != "random_pet.name" {
+		return fmt.Errorf("expected random_pet.name, got %q", resources[0].Address)
+	}
+	id, _ := resources[0].Values["id"].(string)
+	if !strings.HasPrefix(id, "devex-") {
+		return fmt.Errorf("expected the shown resource to carry the applied pet name, got id %q", id)
+	}
+	return nil
+}
+
+// StateShowRejectsUnknownAddress asserts an address absent from state is an
+// error naming it, rather than an empty document a caller could mistake for a
+// resource with no attributes.
+func (t *Tests) StateShowRejectsUnknownAddress(ctx context.Context) error {
+	state, err := applyBasic(ctx)
+	if err != nil {
+		return err
+	}
+	_, err = opentofu().Config(fixture("basic")).WithState(state).StateShow(ctx, "random_pet.missing")
+	return expectErrorContains(err, "tofu state show", "random_pet.missing")
+}
+
+// ---------------------------------------------------------------- state rm
+
+// StateRmDropsAddressFromState asserts StateRm removes the address from state
+// and nothing else: the resulting state omits it, still tracks its neighbour,
+// and a plan afterwards proposes creating it again — which is exactly the
+// hazard of dropping something whose object is still out there.
+func (t *Tests) StateRmDropsAddressFromState(ctx context.Context) error {
+	state, err := applyBasic(ctx)
+	if err != nil {
+		return err
+	}
+	result, err := pin(ctx, opentofu().
+		Config(fixture("basic")).
+		WithState(state).
+		StateRm([]string{"random_pet.name"}))
+	if err != nil {
+		return fmt.Errorf("StateRm: %w", err)
+	}
+	after, err := decodeState(ctx, result.File(stateFileName))
+	if err != nil {
+		return err
+	}
+	want := []string{"random_integer.port"}
+	if got := after.addresses(); !slices.Equal(got, want) {
+		return fmt.Errorf("expected the remaining state to track %v, got %v", want, got)
+	}
+
+	plan, err := pin(ctx, opentofu().
+		Config(fixture("basic")).
+		WithState(result.File(stateFileName)).
+		Plan())
+	if err != nil {
+		return fmt.Errorf("Plan after StateRm: %w", err)
+	}
+	decoded, err := decodePlan(ctx, plan)
+	if err != nil {
+		return err
+	}
+	return expectActions(decoded, map[string][]string{
+		"random_pet.name":     {"create"},
+		"random_integer.port": {"no-op"},
+	})
+}
+
+// StateRmRejectsUnknownAddress asserts an address absent from state fails,
+// naming it.
+func (t *Tests) StateRmRejectsUnknownAddress(ctx context.Context) error {
+	state, err := applyBasic(ctx)
+	if err != nil {
+		return err
+	}
+	_, err = opentofu().
+		Config(fixture("basic")).
+		WithState(state).
+		StateRm([]string{"random_pet.missing"}).
+		Sync(ctx)
+	return expectErrorContains(err, "tofu state rm", "random_pet.missing")
+}
+
+// ---------------------------------------------------------------- state mv
+
+// StateMvRenamesAddress asserts a resource renamed in state stays the same
+// resource: a plan against the configuration that renamed it to match reports
+// no changes, where without the move tofu would destroy and recreate.
+func (t *Tests) StateMvRenamesAddress(ctx context.Context) error {
+	state, err := applyBasic(ctx)
+	if err != nil {
+		return err
+	}
+	result, err := pin(ctx, opentofu().
+		Config(fixture("basic")).
+		WithState(state).
+		StateMv("random_pet.name", "random_pet.renamed"))
+	if err != nil {
+		return fmt.Errorf("StateMv: %w", err)
+	}
+	moved, err := decodeState(ctx, result.File(stateFileName))
+	if err != nil {
+		return err
+	}
+	want := []string{"random_integer.port", "random_pet.renamed"}
+	if got := moved.addresses(); !slices.Equal(got, want) {
+		return fmt.Errorf("expected the moved state to track %v, got %v", want, got)
+	}
+
+	plan, err := pin(ctx, opentofu().
+		Config(fixture("renamed")).
+		WithState(result.File(stateFileName)).
+		Plan())
+	if err != nil {
+		return fmt.Errorf("Plan against the renamed configuration: %w", err)
+	}
+	changes, err := plan.File(changesName).Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", changesName, err)
+	}
+	if changes != "none" {
+		text, _ := plan.File(planTextName).Contents(ctx)
+		return fmt.Errorf("expected changes=%q after the move, got %q:\n%s", "none", changes, text)
+	}
+	return nil
+}
+
+// StateMvRejectsUnknownAddress asserts a source address absent from state
+// fails, naming it.
+func (t *Tests) StateMvRejectsUnknownAddress(ctx context.Context) error {
+	state, err := applyBasic(ctx)
+	if err != nil {
+		return err
+	}
+	_, err = opentofu().
+		Config(fixture("basic")).
+		WithState(state).
+		StateMv("random_pet.missing", "random_pet.renamed").
+		Sync(ctx)
+	return expectErrorContains(err, "tofu state mv", "random_pet.missing")
+}
+
+// ------------------------------------------------------------------ import
+
+// ImportBringsResourceUnderManagement asserts an object named by id lands in
+// state under the declared address, and that a plan afterwards is empty —
+// which it is only if the import recorded the object rather than something
+// approximating it.
+func (t *Tests) ImportBringsResourceUnderManagement(ctx context.Context) error {
+	result, err := pin(ctx, opentofu().
+		Config(fixture("importable")).
+		Import("random_integer.adopted", importedInteger))
+	if err != nil {
+		return fmt.Errorf("Import: %w", err)
+	}
+	imported, err := decodeState(ctx, result.File(stateFileName))
+	if err != nil {
+		return err
+	}
+	want := []string{"random_integer.adopted"}
+	if got := imported.addresses(); !slices.Equal(got, want) {
+		return fmt.Errorf("expected the imported state to track %v, got %v", want, got)
+	}
+
+	plan, err := pin(ctx, opentofu().
+		Config(fixture("importable")).
+		WithState(result.File(stateFileName)).
+		Plan())
+	if err != nil {
+		return fmt.Errorf("Plan after Import: %w", err)
+	}
+	changes, err := plan.File(changesName).Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", changesName, err)
+	}
+	if changes != "none" {
+		text, _ := plan.File(planTextName).Contents(ctx)
+		return fmt.Errorf("expected changes=%q after the import, got %q:\n%s", "none", changes, text)
+	}
+	return nil
+}
+
+// ImportRejectsAddressAbsentFromConfiguration asserts import writes state and
+// not HCL: an address the configuration never declares fails, naming it.
+func (t *Tests) ImportRejectsAddressAbsentFromConfiguration(ctx context.Context) error {
+	_, err := opentofu().
+		Config(fixture("importable")).
+		Import("random_integer.missing", importedInteger).
+		Sync(ctx)
+	return expectErrorContains(err, "tofu import", "random_integer.missing")
+}
+
+// ----------------------------------------------------------------- refresh
+
+// RefreshUpdatesStateWithoutChanges asserts a refresh-only apply hands back
+// state that still tracks everything it was given and still matches the
+// configuration. With hermetic fixtures there is no reality to drift, so what
+// is proved is that the refresh round-trips state rather than rewriting it.
+func (t *Tests) RefreshUpdatesStateWithoutChanges(ctx context.Context) error {
+	state, err := applyBasic(ctx)
+	if err != nil {
+		return err
+	}
+	result, err := pin(ctx, opentofu().Config(fixture("basic")).WithState(state).Refresh())
+	if err != nil {
+		return fmt.Errorf("Refresh: %w", err)
+	}
+	refreshed, err := decodeState(ctx, result.File(stateFileName))
+	if err != nil {
+		return err
+	}
+	want := []string{"random_integer.port", "random_pet.name"}
+	if got := refreshed.addresses(); !slices.Equal(got, want) {
+		return fmt.Errorf("expected the refreshed state to track %v, got %v", want, got)
+	}
+	log, err := result.File("refresh.log").Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("read refresh.log: %w", err)
+	}
+	if !strings.Contains(log, "Apply complete!") {
+		return fmt.Errorf("expected the refresh log to record completion, got:\n%s", log)
+	}
+
+	plan, err := pin(ctx, opentofu().
+		Config(fixture("basic")).
+		WithState(result.File(stateFileName)).
+		Plan())
+	if err != nil {
+		return fmt.Errorf("Plan after Refresh: %w", err)
+	}
+	changes, err := plan.File(changesName).Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", changesName, err)
+	}
+	if changes != "none" {
+		text, _ := plan.File(planTextName).Contents(ctx)
+		return fmt.Errorf("expected changes=%q after a refresh, got %q:\n%s", "none", changes, text)
+	}
+	return nil
+}
+
+// ------------------------------------------------------------ taint/untaint
+
+// TaintProposesReplacement asserts a tainted resource is planned for
+// replacement — destroyed and created again — while its neighbour is left
+// alone.
+func (t *Tests) TaintProposesReplacement(ctx context.Context) error {
+	state, err := applyBasic(ctx)
+	if err != nil {
+		return err
+	}
+	tainted, err := pin(ctx, opentofu().
+		Config(fixture("basic")).
+		WithState(state).
+		Taint("random_pet.name"))
+	if err != nil {
+		return fmt.Errorf("Taint: %w", err)
+	}
+	plan, err := pin(ctx, opentofu().
+		Config(fixture("basic")).
+		WithState(tainted.File(stateFileName)).
+		Plan())
+	if err != nil {
+		return fmt.Errorf("Plan after Taint: %w", err)
+	}
+	decoded, err := decodePlan(ctx, plan)
+	if err != nil {
+		return err
+	}
+	return expectActions(decoded, map[string][]string{
+		"random_pet.name":     {"delete", "create"},
+		"random_integer.port": {"no-op"},
+	})
+}
+
+// UntaintClearsReplacement asserts Untaint reverses Taint: the same state,
+// taken through both, plans no changes at all.
+func (t *Tests) UntaintClearsReplacement(ctx context.Context) error {
+	state, err := applyBasic(ctx)
+	if err != nil {
+		return err
+	}
+	tainted, err := pin(ctx, opentofu().
+		Config(fixture("basic")).
+		WithState(state).
+		Taint("random_pet.name"))
+	if err != nil {
+		return fmt.Errorf("Taint: %w", err)
+	}
+	cleared, err := pin(ctx, opentofu().
+		Config(fixture("basic")).
+		WithState(tainted.File(stateFileName)).
+		Untaint("random_pet.name"))
+	if err != nil {
+		return fmt.Errorf("Untaint: %w", err)
+	}
+	plan, err := pin(ctx, opentofu().
+		Config(fixture("basic")).
+		WithState(cleared.File(stateFileName)).
+		Plan())
+	if err != nil {
+		return fmt.Errorf("Plan after Untaint: %w", err)
+	}
+	changes, err := plan.File(changesName).Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", changesName, err)
+	}
+	if changes != "none" {
+		text, _ := plan.File(planTextName).Contents(ctx)
+		return fmt.Errorf("expected changes=%q after Untaint, got %q:\n%s", "none", changes, text)
+	}
+	return nil
+}
+
+// ------------------------------------------------------------------- graph
+
+// GraphRendersDependencyGraph asserts Graph returns DOT a reader could parse —
+// one balanced `digraph` — naming both resources the configuration declares
+// and the variable one of them depends on.
+func (t *Tests) GraphRendersDependencyGraph(ctx context.Context) error {
+	dot, err := opentofu().Config(fixture("basic")).Graph(ctx)
+	if err != nil {
+		return fmt.Errorf("Graph: %w", err)
+	}
+	if !strings.HasPrefix(strings.TrimSpace(dot), "digraph") {
+		return fmt.Errorf("expected a digraph, got:\n%s", dot)
+	}
+	if err := checkBalancedBraces(dot); err != nil {
+		return fmt.Errorf("%w:\n%s", err, dot)
+	}
+	for _, want := range []string{"random_pet.name", "random_integer.port", "var.prefix"} {
+		if !strings.Contains(dot, want) {
+			return fmt.Errorf("expected the graph to name %s, got:\n%s", want, dot)
+		}
+	}
+	return nil
+}
+
+// ------------------------------------------------------------------ helpers
+
+// importedInteger is the id ImportBringsResourceUnderManagement adopts:
+// random_integer's id is `result,min,max`, and these bounds are the ones the
+// importable fixture declares. A mismatch would show up as a plan proposing to
+// replace what was just imported.
+const importedInteger = "42,1,100"
+
+// expectActions asserts a plan proposes exactly the given action per address —
+// `no-op` for the resources it leaves alone included, since those appear in
+// the plan too.
+func expectActions(plan planDocument, want map[string][]string) error {
+	got := plan.actions()
+	if len(got) != len(want) {
+		return fmt.Errorf("expected a plan covering %v, got %v", want, got)
+	}
+	for address, actions := range want {
+		if !slices.Equal(got[address], actions) {
+			return fmt.Errorf("expected %s to be %v, got %v", address, actions, got[address])
+		}
+	}
+	return nil
+}
+
+// listedAddresses splits `tofu state list` output into addresses, sorted so
+// assertions do not depend on tofu's ordering.
+func listedAddresses(out string) []string {
+	var addresses []string
+	for line := range strings.SplitSeq(out, "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			addresses = append(addresses, line)
+		}
+	}
+	slices.Sort(addresses)
+	return addresses
+}
+
+// showDocument is the slice of `tofu state show -json` the assertions read.
+type showDocument struct {
+	FormatVersion string `json:"format_version"`
+	Values        struct {
+		RootModule struct {
+			Resources []struct {
+				Address string         `json:"address"`
+				Values  map[string]any `json:"values"`
+			} `json:"resources"`
+		} `json:"root_module"`
+	} `json:"values"`
+}
+
+// checkBalancedBraces is the parseability check GraphRendersDependencyGraph
+// applies to the DOT: every block opened is closed, and none is closed that
+// was never opened. Braces inside quoted labels are skipped — DOT escapes a
+// quote with a backslash, which the graph's own provider labels use.
+func checkBalancedBraces(dot string) error {
+	depth := 0
+	quoted := false
+	escaped := false
+	for _, r := range dot {
+		switch {
+		case escaped:
+			escaped = false
+		case r == '\\':
+			escaped = true
+		case r == '"':
+			quoted = !quoted
+		case quoted:
+		case r == '{':
+			depth++
+		case r == '}':
+			depth--
+			if depth < 0 {
+				return fmt.Errorf("expected balanced DOT, found a stray %q", "}")
+			}
+		}
+	}
+	if quoted {
+		return fmt.Errorf("expected balanced DOT, found an unterminated quoted string")
+	}
+	if depth != 0 {
+		return fmt.Errorf("expected balanced DOT, found %d unclosed %q", depth, "{")
+	}
+	return nil
+}


### PR DESCRIPTION
Closes #193.

Wraps the long tail of `tofu` state manipulation, so the subcommands an
operator reaches for once state and reality have diverged stop requiring the
`Container()` escape hatch — which means assembling argv, mounting the source
and threading credentials by hand.

| Function | Command |
|---|---|
| `StateList()` | `tofu state list` |
| `StateShow(address)` | `tofu state show -json <address>` |
| `StateMv(from, to)` | `tofu state mv` |
| `StateRm(addresses)` | `tofu state rm` |
| `Import(address, id)` | `tofu import` |
| `Refresh()` | `tofu apply -refresh-only -auto-approve` |
| `Taint(address)` / `Untaint(address)` | `tofu taint` / `tofu untaint` |
| `Graph()` | `tofu graph` |

Every mutating member goes through `runMutation`, so it inherits the state
boundary #189 established: `terraform.tfstate` in file-carried mode, nothing
under a remote backend, `+cache="never"` individually, and the directory
forfeited outright on a non-zero exit. `Graph` is the one read-only member and
is derived from configuration rather than live state, so it carries
`+cache="session"`.

### Two behaviours that are the module's, not tofu's

- **`StateList` on no state returns an empty listing.** `tofu` refuses a wholly
  absent state file with `No state file was found`, but "no state" and "an
  emptied state" hold the same answer to what is under management, and a
  listing that distinguished them would only make the caller handle a case with
  no content.
- **`StateShow` returns one JSON document.** `tofu state show -json` writes a
  JSON *stream* whose first line is a UI message naming the version it ran; the
  payload is sifted out by its lack of an `@level` key. Documented alongside it:
  `-json` prints sensitive values in full regardless of how the variable behind
  one was declared.

### Incidental refactors

- `runMutation` takes the log name explicitly. Deriving it from the label would
  have put resource addresses in the returned directory's file names, while the
  label still carries them for the error text.
- `read()` grew a `fresh` flag, so `Graph` can skip the cache-busting nonce that
  the `+cache="never"` readings need.

### Tests

14 new tests in `tests/state.go`, plus two fixtures — `renamed` (the other half
of a `StateMv`) and `importable` (a `random_integer`, the one hermetic resource
that supports import, whose id is `result,min,max`). All hermetic:
`hashicorp/random` only.

Each passes individually and the suite passes via `all`:

```
dagger -m daggerverse/opentofu/tests call all   # ✔ 2m50s
dagger call generated                           # ✔
```

`dagger develop` re-run in the module, in `tests/`, and at the repo root;
generated code committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)