### PR TITLE
story(issue-199): add Valkey Cluster mode with slot sharding

### DIFF
--- a/ci/internal/dagger/valkey-tests.gen.go
+++ b/ci/internal/dagger/valkey-tests.gen.go
@@ -68,6 +68,16 @@ type ValkeyTests struct { // valkey-tests (../../../daggerverse/valkey/tests/mai
 	bindServerReachableUnderTls           *Void
 	client                                *Void
 	clientPingWrongPasswordFails          *Void
+	cluster                               *Void
+	clusterAdvertisesPinnedHostnames      *Void
+	clusterBindNodesReachableFromConsumer *Void
+	clusterDelSpansMultipleSlots          *Void
+	clusterKeysScansEveryShard            *Void
+	clusterRejectsTlsSecurity             *Void
+	clusterRejectsTooFewShards            *Void
+	clusterReportsFormedState             *Void
+	clusterRoundTripsKeysAcrossSlots      *Void
+	clusterStopTerminatesEveryNode        *Void
 	dbSelectsLogicalDatabase              *Void
 	defaultsProduceHealthyServer          *Void
 	delRemovesKeys                        *Void
@@ -140,7 +150,7 @@ func (r *ValkeyTests) All(ctx context.Context, opts ...ValkeyTestsAllOpts) error
 
 // ApplyFileReportsFailingCommand verifies a mid-file failure is not
 // swallowed and that the error names the offending line.
-func (r *ValkeyTests) ApplyFileReportsFailingCommand(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1010:1)
+func (r *ValkeyTests) ApplyFileReportsFailingCommand(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1130:1)
 	if r.applyFileReportsFailingCommand != nil {
 		return nil
 	}
@@ -152,7 +162,7 @@ func (r *ValkeyTests) ApplyFileReportsFailingCommand(ctx context.Context) error 
 // ApplyFileSeedsData verifies a command file lands as data on one
 // connection, and that its quoting and line splitting survive: values
 // with spaces, embedded quotes, blank lines, and `#` comments.
-func (r *ValkeyTests) ApplyFileSeedsData(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:955:1)
+func (r *ValkeyTests) ApplyFileSeedsData(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1075:1)
 	if r.applyFileSeedsData != nil {
 		return nil
 	}
@@ -165,7 +175,7 @@ func (r *ValkeyTests) ApplyFileSeedsData(ctx context.Context) error { // valkey-
 // a consumer container under the hostname Endpoint reports, and that the
 // consumer gets a real PONG back. A port probe would be a false
 // positive: it proves something is listening, not that Valkey answers.
-func (r *ValkeyTests) BindServerReachableFromAlpine(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:493:1)
+func (r *ValkeyTests) BindServerReachableFromAlpine(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:613:1)
 	if r.bindServerReachableFromAlpine != nil {
 		return nil
 	}
@@ -179,7 +189,7 @@ func (r *ValkeyTests) BindServerReachableFromAlpine(ctx context.Context) error {
 // the right CA gets a PONG, proving BindServer stays reachable under TLS
 // from a consumer container. The password rides in as a secret env var so
 // it never enters the exec's argv.
-func (r *ValkeyTests) BindServerReachableUnderTLS(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2033:1)
+func (r *ValkeyTests) BindServerReachableUnderTLS(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2153:1)
 	if r.bindServerReachableUnderTls != nil {
 		return nil
 	}
@@ -190,13 +200,13 @@ func (r *ValkeyTests) BindServerReachableUnderTLS(ctx context.Context) error { /
 
 // ValkeyTestsClientOpts contains options for ValkeyTests.Client
 type ValkeyTestsClientOpts struct {
-	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:150:2)
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:188:2)
 }
 
 // Client runs the command round-trip tests. Each test boots its own node
 // via bootServer, so the keyspaces stay disjoint and the group fans out
 // safely.
-func (r *ValkeyTests) Client(ctx context.Context, opts ...ValkeyTestsClientOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:147:1)
+func (r *ValkeyTests) Client(ctx context.Context, opts ...ValkeyTestsClientOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:185:1)
 	if r.client != nil {
 		return nil
 	}
@@ -214,7 +224,7 @@ func (r *ValkeyTests) Client(ctx context.Context, opts ...ValkeyTestsClientOpts)
 // ClientPingWrongPasswordFails proves requirepass is genuinely applied
 // and the node is not wide open: a client holding a different password
 // cannot authenticate.
-func (r *ValkeyTests) ClientPingWrongPasswordFails(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1102:1)
+func (r *ValkeyTests) ClientPingWrongPasswordFails(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1222:1)
 	if r.clientPingWrongPasswordFails != nil {
 		return nil
 	}
@@ -223,10 +233,210 @@ func (r *ValkeyTests) ClientPingWrongPasswordFails(ctx context.Context) error { 
 	return q.Execute(ctx)
 }
 
+// ValkeyTestsClusterOpts contains options for ValkeyTests.Cluster
+type ValkeyTestsClusterOpts struct {
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:134:2)
+}
+
+// Cluster runs the slot-sharded Valkey Cluster tests. Each test boots its
+// own cluster via bootCluster, whose runtime-random name folds into
+// Valkey.Cluster's session-cache key and into every node's hostname, so
+// concurrent tests get independent clusters.
+//
+// These are the most expensive tests in the suite — the smallest legal
+// cluster is three nodes, and every one of them has to boot before the
+// bootstrap can even start — so they get their own aggregator rather than
+// riding along with the single-node groups.
+func (r *ValkeyTests) Cluster(ctx context.Context, opts ...ValkeyTestsClusterOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:131:1)
+	if r.cluster != nil {
+		return nil
+	}
+	q := r.query.Select("cluster")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `parallel` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Parallel) {
+			q = q.Arg("parallel", opts[i].Parallel)
+		}
+	}
+
+	return q.Execute(ctx)
+}
+
+// ClusterAdvertisesPinnedHostnames verifies every node self-identifies
+// with its own pinned hostname rather than falling back to localhost.
+//
+// This is the failure that looks like success. A node that cannot work
+// out a routable identity announces the loopback address, and every peer
+// dutifully records it — so each peer, following a MOVED redirect to
+// "another" node, dials itself. The cluster never forms, or forms and
+// then answers for the wrong shard, and CLUSTER INFO alone would not say
+// why. Asserting the announced identity is what pins the fix.
+func (r *ValkeyTests) ClusterAdvertisesPinnedHostnames(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2275:1)
+	if r.clusterAdvertisesPinnedHostnames != nil {
+		return nil
+	}
+	q := r.query.Select("clusterAdvertisesPinnedHostnames")
+
+	return q.Execute(ctx)
+}
+
+// ClusterBindNodesReachableFromConsumer verifies BindNodes wires EVERY
+// member into a consumer container, not just a seed. A cluster client is
+// redirected to a node's advertised hostname, so a container that could
+// only resolve one of them would work right up until the first key that
+// hashes elsewhere. The probe therefore pings every endpoint in turn from
+// inside the container, using valkey-cli rather than the module's own
+// client so the reachability being tested is the container's.
+//
+// It then writes and reads a set of keys through `valkey-cli -c`, which
+// follows MOVED redirects the way any cluster client would. That covers
+// the second half of BindNodes' contract: the container meets a cluster
+// whose slots are already assigned. Against an unbootstrapped cluster
+// every one of those writes would come back CLUSTERDOWN, no matter how
+// reachable the nodes were.
+//
+// The whole probe runs in one exec so a partial failure names the node it
+// failed on rather than surfacing as an opaque non-zero exit.
+func (r *ValkeyTests) ClusterBindNodesReachableFromConsumer(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2525:1)
+	if r.clusterBindNodesReachableFromConsumer != nil {
+		return nil
+	}
+	q := r.query.Select("clusterBindNodesReachableFromConsumer")
+
+	return q.Execute(ctx)
+}
+
+// ClusterDelSpansMultipleSlots verifies Del handles keys that hash to
+// different slots. A single DEL naming two slots is refused outright with
+// CROSSSLOT — the slots may live on different primaries and Valkey will
+// not split a command across them — so an implementation that passed the
+// whole list through fails here rather than deleting a partial set.
+//
+// One key in the list never existed, so a Del that reported the number of
+// keys it was asked about rather than the number it removed is caught
+// too.
+func (r *ValkeyTests) ClusterDelSpansMultipleSlots(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2467:1)
+	if r.clusterDelSpansMultipleSlots != nil {
+		return nil
+	}
+	q := r.query.Select("clusterDelSpansMultipleSlots")
+
+	return q.Execute(ctx)
+}
+
+// ClusterKeysScansEveryShard verifies Keys reports the whole match set
+// across the sharded keyspace, not just the shard its seed node owns.
+//
+// SCAN names no key, so a cluster client has no slot to route it by and
+// the command is answered by whichever node it lands on — an
+// implementation that scanned one node would return roughly 1/shards of
+// the keys and look plausible. The test therefore asserts twice: that
+// every seeded key comes back, and (via per-node DbSize) that the keys
+// really were split across more than one primary, so the first assertion
+// can't pass vacuously on a cluster that happened to pile everything into
+// one shard.
+func (r *ValkeyTests) ClusterKeysScansEveryShard(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2384:1)
+	if r.clusterKeysScansEveryShard != nil {
+		return nil
+	}
+	q := r.query.Select("clusterKeysScansEveryShard")
+
+	return q.Execute(ctx)
+}
+
+// ClusterRejectsTlsSecurity verifies a TLS listener profile is refused
+// with an explanation rather than booting peers that spin forever on a
+// failed handshake: a TLS node runs with `--port 0`, so the cluster bus
+// would also have to run over TLS, and neither the peers nor the
+// valkey-cli that bootstraps them get the trust material they'd need from
+// a client-listener ServerSecurity.
+func (r *ValkeyTests) ClusterRejectsTLSSecurity(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:477:1)
+	if r.clusterRejectsTlsSecurity != nil {
+		return nil
+	}
+	q := r.query.Select("clusterRejectsTlsSecurity")
+
+	return q.Execute(ctx)
+}
+
+// ClusterRejectsTooFewShards verifies a sub-quorum cluster is refused
+// with an explanation rather than booting. Valkey Cluster agrees slot
+// ownership by a majority vote of the primaries, so two primaries can
+// never form a quorum once one is unreachable and one primary is a
+// standalone node wearing a cluster hat — either would boot into a
+// topology that looks healthy right up until it has to agree on
+// something.
+//
+// The guard is checked before anything starts, so this test costs no
+// containers.
+func (r *ValkeyTests) ClusterRejectsTooFewShards(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:440:1)
+	if r.clusterRejectsTooFewShards != nil {
+		return nil
+	}
+	q := r.query.Select("clusterRejectsTooFewShards")
+
+	return q.Execute(ctx)
+}
+
+// ClusterReportsFormedState verifies the bootstrap actually happened: the
+// cluster reports cluster_state:ok (every one of the 16384 slots is owned
+// by some primary) and knows exactly as many nodes as were booted.
+//
+// The node count is the half that catches a cluster which formed but
+// didn't finish: a node whose gossip never reached the others still
+// reports state:ok for the slots it can see, and only cluster_known_nodes
+// gives it away.
+func (r *ValkeyTests) ClusterReportsFormedState(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2243:1)
+	if r.clusterReportsFormedState != nil {
+		return nil
+	}
+	q := r.query.Select("clusterReportsFormedState")
+
+	return q.Execute(ctx)
+}
+
+// ClusterRoundTripsKeysAcrossSlots verifies one Client addresses the
+// whole sharded keyspace. The keys are chosen to land on different slots
+// (distinct random names, no `{...}` hashtag to pin them together), so
+// writing and reading them all back through a single client means the
+// client followed MOVED redirects to whichever primary owns each slot —
+// and that every one of those primaries was reachable at the hostname it
+// advertised.
+//
+// A client that silently talked to one node would fail the write, not the
+// read: a key that hashes elsewhere is refused with MOVED, never stored
+// locally.
+func (r *ValkeyTests) ClusterRoundTripsKeysAcrossSlots(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2316:1)
+	if r.clusterRoundTripsKeysAcrossSlots != nil {
+		return nil
+	}
+	q := r.query.Select("clusterRoundTripsKeysAcrossSlots")
+
+	return q.Execute(ctx)
+}
+
+// ClusterStopTerminatesEveryNode verifies no member answers once Stop
+// returns. The post-Stop probes go through the standalone constructor on
+// purpose: a cluster client would be free to route its command to
+// whichever node it liked, so a Stop that missed one node could still
+// look dead — or, worse, look alive.
+//
+// Cluster members have no service bindings between them, so unlike the
+// replication topology there is no dependency teardown to hide behind:
+// every node that is still up after Stop is a node Stop failed to kill.
+func (r *ValkeyTests) ClusterStopTerminatesEveryNode(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2590:1)
+	if r.clusterStopTerminatesEveryNode != nil {
+		return nil
+	}
+	q := r.query.Select("clusterStopTerminatesEveryNode")
+
+	return q.Execute(ctx)
+}
+
 // DbSelectsLogicalDatabase verifies db is honoured end to end: a write
 // on db 0 is invisible to a client on db 1, and each database keeps its
 // own DbSize.
-func (r *ValkeyTests) DbSelectsLogicalDatabase(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1137:1)
+func (r *ValkeyTests) DbSelectsLogicalDatabase(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1257:1)
 	if r.dbSelectsLogicalDatabase != nil {
 		return nil
 	}
@@ -238,7 +448,7 @@ func (r *ValkeyTests) DbSelectsLogicalDatabase(ctx context.Context) error { // v
 // DefaultsProduceHealthyServer boots a default node and proves it is a
 // healthy Valkey by answering PING and self-reporting 9.1 in INFO
 // server. Catches image-path drift and a silently moved default tag.
-func (r *ValkeyTests) DefaultsProduceHealthyServer(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:399:1)
+func (r *ValkeyTests) DefaultsProduceHealthyServer(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:519:1)
 	if r.defaultsProduceHealthyServer != nil {
 		return nil
 	}
@@ -249,7 +459,7 @@ func (r *ValkeyTests) DefaultsProduceHealthyServer(ctx context.Context) error { 
 
 // DelRemovesKeys verifies Del reports how many keys it actually removed
 // and that DbSize agrees with the survivors.
-func (r *ValkeyTests) DelRemovesKeys(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:804:1)
+func (r *ValkeyTests) DelRemovesKeys(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:924:1)
 	if r.delRemovesKeys != nil {
 		return nil
 	}
@@ -261,7 +471,7 @@ func (r *ValkeyTests) DelRemovesKeys(ctx context.Context) error { // valkey-test
 // DoReturnsJsonReplies verifies each RESP type survives the JSON
 // encoding distinctly. The dangerous pair is nil versus empty string: a
 // naive encoder collapses both to "".
-func (r *ValkeyTests) DoReturnsJSONReplies(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:895:1)
+func (r *ValkeyTests) DoReturnsJSONReplies(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1015:1)
 	if r.doReturnsJsonReplies != nil {
 		return nil
 	}
@@ -273,7 +483,7 @@ func (r *ValkeyTests) DoReturnsJSONReplies(ctx context.Context) error { // valke
 // EndpointShouldNotBeCached verifies Endpoint re-executes against the
 // receiver it was called on rather than freezing on the first result.
 // Valkey.Server isaddress.
-func (r *ValkeyTests) EndpointShouldNotBeCached(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:425:1)
+func (r *ValkeyTests) EndpointShouldNotBeCached(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:545:1)
 	if r.endpointShouldNotBeCached != nil {
 		return nil
 	}
@@ -284,7 +494,7 @@ func (r *ValkeyTests) EndpointShouldNotBeCached(ctx context.Context) error { // 
 
 // FlushAllClearsKeys verifies FlushAll empties the keyspace and DbSize
 // returns to 0.
-func (r *ValkeyTests) FlushAllClearsKeys(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1063:1)
+func (r *ValkeyTests) FlushAllClearsKeys(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1183:1)
 	if r.flushAllClearsKeys != nil {
 		return nil
 	}
@@ -296,7 +506,7 @@ func (r *ValkeyTests) FlushAllClearsKeys(ctx context.Context) error { // valkey-
 // GetMissingKeyFails verifies absence stays distinguishable from an
 // empty value: an unset key errors, while a key holding "" reads back as
 // "".
-func (r *ValkeyTests) GetMissingKeyFails(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:691:1)
+func (r *ValkeyTests) GetMissingKeyFails(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:811:1)
 	if r.getMissingKeyFails != nil {
 		return nil
 	}
@@ -308,7 +518,7 @@ func (r *ValkeyTests) GetMissingKeyFails(ctx context.Context) error { // valkey-
 // GetShouldNotBeCached verifies Get re-executes on every call: write v1,
 // read it, overwrite with v2, read again. A cached Get would still
 // report v1 — the canonical stale-read bug a missingproduces.
-func (r *ValkeyTests) GetShouldNotBeCached(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:645:1)
+func (r *ValkeyTests) GetShouldNotBeCached(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:765:1)
 	if r.getShouldNotBeCached != nil {
 		return nil
 	}
@@ -369,7 +579,7 @@ func (r *ValkeyTests) UnmarshalJSON(bs []byte) error {
 // InfoReportsRole verifies INFO replication reports a standalone node as
 // the primary. ReplicationReportsRoles is the multi-node counterpart,
 // where a replica reports role:slave instead.
-func (r *ValkeyTests) InfoReportsRole(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1044:1)
+func (r *ValkeyTests) InfoReportsRole(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1164:1)
 	if r.infoReportsRole != nil {
 		return nil
 	}
@@ -382,7 +592,7 @@ func (r *ValkeyTests) InfoReportsRole(ctx context.Context) error { // valkey-tes
 // checks the full match set comes back. One SCAN page holds far fewer
 // than that, so an implementation that returned the first page — or that
 // stopped before the cursor wrapped to 0 — comes up short here.
-func (r *ValkeyTests) KeysScansPattern(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:844:1)
+func (r *ValkeyTests) KeysScansPattern(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:964:1)
 	if r.keysScansPattern != nil {
 		return nil
 	}
@@ -400,7 +610,7 @@ func (r *ValkeyTests) KeysScansPattern(ctx context.Context) error { // valkey-te
 // default `yes`. A regression that passed `--tls-auth-clients no` for
 // MTLS too would let this certless client through and go undetected by
 // the round-trip tests.
-func (r *ValkeyTests) MtlsNodeDemandsClientCertAtWire(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1886:1)
+func (r *ValkeyTests) MtlsNodeDemandsClientCertAtWire(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2006:1)
 	if r.mtlsNodeDemandsClientCertAtWire != nil {
 		return nil
 	}
@@ -413,7 +623,7 @@ func (r *ValkeyTests) MtlsNodeDemandsClientCertAtWire(ctx context.Context) error
 // mTLS side: asking an mTLS node for a TLS-only client returns an error
 // naming both modes, before any wire activity. The SAN value on the cert
 // is irrelevant here — the guard fires in requireMode, ahead of any dial.
-func (r *ValkeyTests) MtlsServerRejectsTLSOnlyClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1841:1)
+func (r *ValkeyTests) MtlsServerRejectsTLSOnlyClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1961:1)
 	if r.mtlsServerRejectsTlsOnlyClient != nil {
 		return nil
 	}
@@ -425,7 +635,7 @@ func (r *ValkeyTests) MtlsServerRejectsTLSOnlyClient(ctx context.Context) error 
 // PasswordReusableViaClient verifies the credentials a Server hands back
 // authenticate through the standalone constructor: Endpointare enough to build a working client, which is what makes the same
 // Client usable against a remote Valkey.
-func (r *ValkeyTests) PasswordReusableViaClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:532:1)
+func (r *ValkeyTests) PasswordReusableViaClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:652:1)
 	if r.passwordReusableViaClient != nil {
 		return nil
 	}
@@ -440,7 +650,7 @@ func (r *ValkeyTests) PasswordReusableViaClient(ctx context.Context) error { // 
 // wire protocol to the encrypted listener and fails. If `--port 0` were
 // missing, a plaintext listener would still be up on 6379 and this dial
 // would succeed.
-func (r *ValkeyTests) PlaintextDialAgainstTLSNodeFails(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1954:1)
+func (r *ValkeyTests) PlaintextDialAgainstTLSNodeFails(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2074:1)
 	if r.plaintextDialAgainstTlsNodeFails != nil {
 		return nil
 	}
@@ -451,14 +661,14 @@ func (r *ValkeyTests) PlaintextDialAgainstTLSNodeFails(ctx context.Context) erro
 
 // ValkeyTestsReplicationOpts contains options for ValkeyTests.Replication
 type ValkeyTestsReplicationOpts struct {
-	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:97:2)
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:102:2)
 }
 
 // Replication runs the primary/replica topology tests. Each test boots
 // its own topology via bootReplication, whose runtime-random name folds
 // into Valkey.Replication's session-cache key and into every node's
 // hostname, so concurrent tests get independent topologies.
-func (r *ValkeyTests) Replication(ctx context.Context, opts ...ValkeyTestsReplicationOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:94:1)
+func (r *ValkeyTests) Replication(ctx context.Context, opts ...ValkeyTestsReplicationOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:99:1)
 	if r.replication != nil {
 		return nil
 	}
@@ -479,7 +689,7 @@ func (r *ValkeyTests) Replication(ctx context.Context, opts ...ValkeyTestsReplic
 // wrong never reaches — it stays `down`, retrying on NOAUTH, while every
 // other assertion in this file would still pass against its (empty but
 // readable) local keyspace.
-func (r *ValkeyTests) ReplicationLinkAuthenticates(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1406:1)
+func (r *ValkeyTests) ReplicationLinkAuthenticates(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1526:1)
 	if r.replicationLinkAuthenticates != nil {
 		return nil
 	}
@@ -496,7 +706,7 @@ func (r *ValkeyTests) ReplicationLinkAuthenticates(ctx context.Context) error { 
 //
 // Endpoint is a pure accessor, so this asserts the addressing scheme
 // without booting anything.
-func (r *ValkeyTests) ReplicationNodesHaveDistinctHostnames(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1446:1)
+func (r *ValkeyTests) ReplicationNodesHaveDistinctHostnames(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1566:1)
 	if r.replicationNodesHaveDistinctHostnames != nil {
 		return nil
 	}
@@ -509,7 +719,7 @@ func (r *ValkeyTests) ReplicationNodesHaveDistinctHostnames(ctx context.Context)
 // path: a key written to the primary becomes readable from the replica.
 // The read polls, because the link is asynchronous and a single read
 // would race the initial sync.
-func (r *ValkeyTests) ReplicationPropagatesWritesToReplica(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1271:1)
+func (r *ValkeyTests) ReplicationPropagatesWritesToReplica(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1391:1)
 	if r.replicationPropagatesWritesToReplica != nil {
 		return nil
 	}
@@ -523,7 +733,7 @@ func (r *ValkeyTests) ReplicationPropagatesWritesToReplica(ctx context.Context) 
 // forever on a failed handshake: a TLS node runs with `--port 0`, so the
 // replication link would also have to run over TLS, and a client-listener
 // ServerSecurity carries none of the trust material that link needs.
-func (r *ValkeyTests) ReplicationRejectsTLSSecurity(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:357:1)
+func (r *ValkeyTests) ReplicationRejectsTLSSecurity(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:395:1)
 	if r.replicationRejectsTlsSecurity != nil {
 		return nil
 	}
@@ -542,7 +752,7 @@ func (r *ValkeyTests) ReplicationRejectsTLSSecurity(ctx context.Context) error {
 // any optional argument holding its zero value, so `Replicas: 0` never
 // reaches the module and resolves to the `the CLI does reach the guard, which is why the guard is `< 1` and not
 // `< 0`.
-func (r *ValkeyTests) ReplicationRejectsTooFewReplicas(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:324:1)
+func (r *ValkeyTests) ReplicationRejectsTooFewReplicas(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:362:1)
 	if r.replicationRejectsTooFewReplicas != nil {
 		return nil
 	}
@@ -555,7 +765,7 @@ func (r *ValkeyTests) ReplicationRejectsTooFewReplicas(ctx context.Context) erro
 // holds: a write against a replica is refused with READONLY, so a test
 // that writes to the wrong node fails loudly instead of silently losing
 // the write on the next sync.
-func (r *ValkeyTests) ReplicationReplicaRejectsWrites(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1366:1)
+func (r *ValkeyTests) ReplicationReplicaRejectsWrites(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1486:1)
 	if r.replicationReplicaRejectsWrites != nil {
 		return nil
 	}
@@ -569,7 +779,7 @@ func (r *ValkeyTests) ReplicationReplicaRejectsWrites(ctx context.Context) error
 // connected_slaves as there are replicas, and every replica reports the
 // replica role. Two replicas rather than one, so a count that reported
 // "some replica connected" instead of all of them fails here.
-func (r *ValkeyTests) ReplicationReportsRoles(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1313:1)
+func (r *ValkeyTests) ReplicationReportsRoles(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1433:1)
 	if r.replicationReportsRoles != nil {
 		return nil
 	}
@@ -592,7 +802,7 @@ func (r *ValkeyTests) ReplicationReportsRoles(ctx context.Context) error { // va
 // every other node depends on". Replication.Stop still walks every node
 // explicitly rather than leaning on that dependency teardown, which is
 // not a documented guarantee.
-func (r *ValkeyTests) ReplicationStopTerminatesEveryNode(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1509:1)
+func (r *ValkeyTests) ReplicationStopTerminatesEveryNode(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1629:1)
 	if r.replicationStopTerminatesEveryNode != nil {
 		return nil
 	}
@@ -605,7 +815,7 @@ func (r *ValkeyTests) ReplicationStopTerminatesEveryNode(ctx context.Context) er
 // resolve to one backing node: a key written through the first is
 // readable through the second. Catches session cache-key drift, which
 // would silently split a multi-step test across two empty keyspaces.
-func (r *ValkeyTests) SameNameServerSharesState(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:454:1)
+func (r *ValkeyTests) SameNameServerSharesState(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:574:1)
 	if r.sameNameServerSharesState != nil {
 		return nil
 	}
@@ -616,14 +826,14 @@ func (r *ValkeyTests) SameNameServerSharesState(ctx context.Context) error { // 
 
 // ValkeyTestsSecurityOpts contains options for ValkeyTests.Security
 type ValkeyTestsSecurityOpts struct {
-	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:184:2)
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:222:2)
 }
 
 // Security runs the TLS / mTLS listener + client tests. Each test mints
 // its own CA, leaf certs, password, and server name at runtime (no
 // literal credentials or PEM blobs), and folds a unique name into the
 // node's session-cache key, so the tests fan out without sharing state.
-func (r *ValkeyTests) Security(ctx context.Context, opts ...ValkeyTestsSecurityOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:181:1)
+func (r *ValkeyTests) Security(ctx context.Context, opts ...ValkeyTestsSecurityOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:219:1)
 	if r.security != nil {
 		return nil
 	}
@@ -640,14 +850,14 @@ func (r *ValkeyTests) Security(ctx context.Context, opts ...ValkeyTestsSecurityO
 
 // ValkeyTestsServerOpts contains options for ValkeyTests.Server
 type ValkeyTestsServerOpts struct {
-	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:124:2)
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:162:2)
 }
 
 // Server runs the topology, default, and caching tests. Each test boots
 // its own node via bootServer, whose runtime-random name folds into
 // Valkey.Server's session-cache key so concurrent tests boot independent
 // backing services and never share a keyspace.
-func (r *ValkeyTests) Server(ctx context.Context, opts ...ValkeyTestsServerOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:121:1)
+func (r *ValkeyTests) Server(ctx context.Context, opts ...ValkeyTestsServerOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:159:1)
 	if r.server != nil {
 		return nil
 	}
@@ -665,7 +875,7 @@ func (r *ValkeyTests) Server(ctx context.Context, opts ...ValkeyTestsServerOpts)
 // ServerMtlsRoundTripFromClient boots a mutual-TLS node and proves a
 // matching mTLS client (presenting a client cert signed by the trusted
 // CA) can round-trip Set
-func (r *ValkeyTests) ServerMtlsRoundTripFromClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1746:1)
+func (r *ValkeyTests) ServerMtlsRoundTripFromClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1866:1)
 	if r.serverMtlsRoundTripFromClient != nil {
 		return nil
 	}
@@ -675,7 +885,7 @@ func (r *ValkeyTests) ServerMtlsRoundTripFromClient(ctx context.Context) error {
 }
 
 // ServerRejectsNilPassword verifies a passwordless node must not boot.
-func (r *ValkeyTests) ServerRejectsNilPassword(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:269:1)
+func (r *ValkeyTests) ServerRejectsNilPassword(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:307:1)
 	if r.serverRejectsNilPassword != nil {
 		return nil
 	}
@@ -687,7 +897,7 @@ func (r *ValkeyTests) ServerRejectsNilPassword(ctx context.Context) error { // v
 // ServerRejectsNilSecurity verifies plaintext must be a deliberate
 // choice, so the TLS follow-up stays an explicit upgrade rather than a
 // silent default.
-func (r *ValkeyTests) ServerRejectsNilSecurity(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:290:1)
+func (r *ValkeyTests) ServerRejectsNilSecurity(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:328:1)
 	if r.serverRejectsNilSecurity != nil {
 		return nil
 	}
@@ -700,7 +910,7 @@ func (r *ValkeyTests) ServerRejectsNilSecurity(ctx context.Context) error { // v
 // matching TLS client — presenting NO client certificate — can Setagainst it over the encrypted listener. That the certless client is
 // accepted is the `--tls-auth-clients no` acceptance criterion: without
 // that flag Valkey would demand a client cert and reject this dial.
-func (r *ValkeyTests) ServerTLSRoundTripFromClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1696:1)
+func (r *ValkeyTests) ServerTLSRoundTripFromClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1816:1)
 	if r.serverTlsRoundTripFromClient != nil {
 		return nil
 	}
@@ -711,7 +921,7 @@ func (r *ValkeyTests) ServerTLSRoundTripFromClient(ctx context.Context) error { 
 
 // SetGetRoundTrip is the core smoke path: a value written through Set
 // comes back through Get unchanged.
-func (r *ValkeyTests) SetGetRoundTrip(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:612:1)
+func (r *ValkeyTests) SetGetRoundTrip(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:732:1)
 	if r.setGetRoundTrip != nil {
 		return nil
 	}
@@ -730,7 +940,7 @@ func (r *ValkeyTests) SetGetRoundTrip(ctx context.Context) error { // valkey-tes
 // an expiry check, because every step here is a round trip through a
 // re-probed service — a lower bound on the *remaining* TTL would be a
 // stopwatch race under a loaded parallel suite.
-func (r *ValkeyTests) SetWithTTLExpires(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:735:1)
+func (r *ValkeyTests) SetWithTTLExpires(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:855:1)
 	if r.setWithTtlExpires != nil {
 		return nil
 	}
@@ -743,7 +953,7 @@ func (r *ValkeyTests) SetWithTTLExpires(ctx context.Context) error { // valkey-t
 // The post-Stop probe goes through the standalone constructor on
 // purpose: Server.Client would re-Start the service it is asked to dial
 // and the test would pass no matter what Stop did.
-func (r *ValkeyTests) StopTerminatesServer(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:572:1)
+func (r *ValkeyTests) StopTerminatesServer(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:692:1)
 	if r.stopTerminatesServer != nil {
 		return nil
 	}
@@ -758,7 +968,7 @@ func (r *ValkeyTests) StopTerminatesServer(ctx context.Context) error { // valke
 // TLS/mTLS node onto the same sha256("") host and invite cert/SAN reuse.
 // The guard fires in the constructor, before any service starts, so a
 // placeholder SAN on the cert is fine here.
-func (r *ValkeyTests) TLSServerRejectsEmptyName(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1998:1)
+func (r *ValkeyTests) TLSServerRejectsEmptyName(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2118:1)
 	if r.tlsServerRejectsEmptyName != nil {
 		return nil
 	}
@@ -770,7 +980,7 @@ func (r *ValkeyTests) TLSServerRejectsEmptyName(ctx context.Context) error { // 
 // TlsServerRejectsPlaintextClient verifies the mode-coupling check:
 // asking a TLS node for a plaintext client returns an error naming both
 // modes, before any wire activity.
-func (r *ValkeyTests) TLSServerRejectsPlaintextClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1802:1)
+func (r *ValkeyTests) TLSServerRejectsPlaintextClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1922:1)
 	if r.tlsServerRejectsPlaintextClient != nil {
 		return nil
 	}
@@ -781,12 +991,12 @@ func (r *ValkeyTests) TLSServerRejectsPlaintextClient(ctx context.Context) error
 
 // ValkeyTestsValidationOpts contains options for ValkeyTests.Validation
 type ValkeyTestsValidationOpts struct {
-	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:72:2)
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:75:2)
 }
 
 // Validation runs the input-rejection tests. These boot no service, so
 // they're safe to fan out unbounded.
-func (r *ValkeyTests) Validation(ctx context.Context, opts ...ValkeyTestsValidationOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:69:1)
+func (r *ValkeyTests) Validation(ctx context.Context, opts ...ValkeyTestsValidationOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:72:1)
 	if r.validation != nil {
 		return nil
 	}

--- a/daggerverse/valkey/README.md
+++ b/daggerverse/valkey/README.md
@@ -1,10 +1,11 @@
 # valkey
 
 Daggerverse module that spins up [Valkey](https://valkey.io) topologies
-(from the upstream `valkey/valkey` image) — a single node, or a primary
-with N read replicas — and exposes a pure-Go client (built on
+(from the upstream `valkey/valkey` image) — a single node, a primary with
+N read replicas, or a slot-sharded Valkey Cluster — and exposes a pure-Go
+client (built on
 [`github.com/valkey-io/valkey-go`](https://github.com/valkey-io/valkey-go))
-that can target either a local node or a remote Valkey (e.g.
+that can target either a local topology or a remote Valkey (e.g.
 ElastiCache Serverless, MemoryDB, a self-hosted node).
 
 It is the daggerverse's first key-value store, and it targets Valkey
@@ -12,16 +13,16 @@ It is the daggerverse's first key-value store, and it targets Valkey
 
 It supports three client-facing listener modes — plaintext (`requirepass`
 auth over an unencrypted TCP listener), one-way TLS, and mutual TLS.
-Valkey Cluster, `valkey-server` config passthrough, the `valkey-bundle`
-image, TLS for the replication link, and keyspace export/import all land
-in follow-ups.
+`valkey-server` config passthrough, the `valkey-bundle` image, TLS for
+the replication link and the cluster bus, and keyspace export/import all
+land in follow-ups.
 
 ## Why `Server` and not `Cluster`
 
 Postgres calls its single node a `Cluster` because that is PostgreSQL's
 own word for an instance. In Valkey, "cluster" means slot-sharded Valkey
-Cluster, so the single-node type here is `Server` and `Cluster` stays
-reserved for the follow-up that adds sharding.
+Cluster, so the single-node type here is `Server` and `Cluster` is the
+sharded topology.
 
 ## Security profiles
 
@@ -135,7 +136,7 @@ Primary/replica topology: one primary plus `replicas` asynchronous read
 replicas, all from the same image. A replica is asymmetric — it dials a
 primary that is already up — so the whole topology is an ordinary service
 binding, with none of the symmetric-peer startup problems Valkey Cluster
-will bring.
+brings.
 
 ```go
 Valkey.Replication(
@@ -195,10 +196,103 @@ zero-replica topology is a single node with extra steps — use
 argument holding its zero value, so `Replicas: 0` from Go resolves to the
 `+default=1`; `--replicas=0` on the CLI reaches the guard.
 
+## Cluster
+
+Slot-sharded Valkey Cluster: `shards` primaries splitting the 16384 hash
+slots between them, each with `replicasPerShard` replicas, all from the
+same image.
+
+```go
+Valkey.Cluster(
+    ctx,
+    name="",
+    registry="docker.io", tag="9.1",
+    shards=3,
+    replicasPerShard=0,
+    password *dagger.Secret,
+    clientListenerSecurity *ServerSecurity,
+) (*Cluster, error)
+
+Cluster.Endpoints() []string                       // host:6379 per member, primaries first
+Cluster.BindNodes(*dagger.Container) *dagger.Container
+Cluster.Client(ctx, security *ClientSecurity) (*Client, error)
+Cluster.Stop(ctx) error                            // tears down every member
+```
+
+**Symmetric peers, so no bindings between them.** Cluster members gossip
+with each other over a bus port (client port + 10000) and none of them is
+"already up" when its neighbours boot. A node-to-node
+`WithServiceBinding` would therefore deadlock: binding A to B makes
+Dagger fully ready B before it even boots A, while B's readiness depends
+on the cluster that needs A. The nodes carry no bindings at all and are
+started *concurrently* instead (`startAll`), discovering each other by
+hostname over session-wide DNS — the same shape the Redpanda multi-broker
+topology uses.
+
+**Every node advertises its own pinned hostname.** Each member boots with
+`--cluster-announce-ip <its WithHostname alias>`,
+`--cluster-announce-port 6379`, and `--cluster-announce-bus-port 16379`.
+A node that cannot self-identify falls back to announcing localhost, at
+which point every peer dials itself and the cluster never forms. The
+announce address is the hostname rather than an IP on purpose: the
+container IP is unknown until the service starts and changes between
+sessions, whereas the alias is stable and resolvable from every peer,
+from the module runtime, and — via `BindNodes` — from a consumer
+container.
+
+**Bootstrap is a lazy container, not constructor work.** `Valkey.Cluster`
+validates, builds the nodes, and composes (but does not run) a
+`valkey-cli --cluster create --cluster-yes --cluster-replicas N` exec
+that waits for every node to answer, assigns the slots, and then waits
+for every node to report `cluster_state:ok` *and* the full
+`cluster_known_nodes`. Whoever forces that exec — `Cluster.Client` from
+the module runtime, or a consumer container's exec through `BindNodes` —
+brings the node services up as dependencies of their own request. The
+laziness is what makes `BindNodes` usable at all: a Dagger service is
+only reachable from the client that started it, so bootstrapping eagerly
+here would pin every node to the valkey module's DNS domain and a
+consumer module binding them could not resolve them. `BindNodes` grafts
+the bootstrap's completion marker into the consumer container, so the
+container's first command meets a cluster whose slots are assigned rather
+than one answering `CLUSTERDOWN`.
+
+The flip side: `Cluster.Client` *does* start the services explicitly
+(concurrently, from the module runtime) because valkey-go dials them from
+there and needs the hostnames in session DNS. A cluster this module has
+already dialled cannot then be bound by a consumer container — the
+binding fails with `lookup valkey-<host> for hosts file: … no such host`
+— so bind a fresh one. That cross-module resolution failure is a known
+Dagger limitation and has been reported upstream; if it is fixed, the
+lazy bootstrap can collapse back into the constructor.
+
+**`shards < 3` is rejected.** Valkey Cluster agrees slot ownership by a
+majority vote of the primaries, so two primaries can never form a quorum
+once one is unreachable, and one primary is a standalone node wearing a
+cluster hat. The other rejected inputs: `password == nil`,
+`clientListenerSecurity == nil`, a non-plaintext profile, and
+`replicasPerShard < 0`.
+
+**Plaintext only, for now.** A TLS node runs with `--port 0`, so the
+cluster bus would have to run over TLS too (`--tls-cluster yes`) and each
+peer would need trust material a client-listener `*ServerSecurity` does
+not carry — and the `valkey-cli` that bootstraps them would need its own
+`--tls` / `--cacert` material on top of that.
+
+**Hostnames.** Every member's hostname is `valkey-<sha12(...)>` derived
+from `name` plus the node's index, so each member gets its own pinned
+hostname, two clusters with different `name`s never collide, and a
+member never collides with a `Valkey.Server` or `Valkey.Replication` node
+booted under the same `name`.
+
+`Endpoints()` is `+cache="session"` rather than `"never"` for the same
+reason `Replication.Primary()` is: Dagger v0.21 detaches module objects
+returned from a `+cache="never"` function when a consumer module reads
+their fields lazily.
+
 ## Client
 
 Pure-Go valkey-go based client. No container image. Works against the
-local node or any reachable remote Valkey.
+local topology or any reachable remote Valkey.
 
 ```go
 Valkey.Client(
@@ -248,6 +342,18 @@ legitimate stored value and must stay distinguishable from absence.
 for the whole sweep) and walks the cursor to exhaustion, so the result is
 the complete match set and not just SCAN's first page.
 
+**Cluster-aware `Keys` and `Del`.** A client from `Cluster.Client` seeds
+from every member, lets valkey-go keep a slot map, and follows MOVED/ASK
+redirects — but two methods need more than that. `Keys` scans *every*
+node rather than the one it seeded from: SCAN names no key, so a cluster
+client has no slot to route it by and it is answered by whichever node it
+lands on, reporting that shard as if it were the whole keyspace.
+(Replicas answer SCAN locally too, so the union is de-duplicated.) `Del`
+groups its keys by hash slot and issues one pipelined DEL per group: a
+single DEL naming two slots is refused outright with `CROSSSLOT`, because
+the slots may live on different primaries. Against a standalone node both
+methods behave exactly as before.
+
 `ApplyFile` is the fixture-seeding path: one command per line in
 valkey-cli syntax, run in order on a single connection. Blank lines and
 `#` comments are skipped; arguments split on whitespace with single- and
@@ -257,8 +363,9 @@ failing command aborts the run and reports its line number.
 ## Follow-ups
 
 TLS/mTLS for the replication link (`--tls-replication yes` plus the trust
-material a replica needs to verify and authenticate to its primary);
-Valkey Cluster / slot sharding; `valkey-server` config passthrough
-(config file, ACL file, append-only, max-memory, extra args); the
+material a replica needs to verify and authenticate to its primary) and
+for the cluster bus (`--tls-cluster yes`, plus `--tls`/`--cacert` for the
+bootstrapping `valkey-cli`); `valkey-server` config passthrough (config
+file, ACL file, append-only, max-memory, extra args); the
 `valkey/valkey-bundle` image with module verification; keyspace
 export/import via SCAN + DUMP/RESTORE.

--- a/daggerverse/valkey/client.go
+++ b/daggerverse/valkey/client.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -44,6 +45,10 @@ type Client struct {
 	Db int
 	// +private
 	SecurityMode string
+	// +private
+	Addrs []string // Cluster only: every seed address; empty means dial Host:Port.
+	// +private
+	ClusterMode bool // Cluster only: let valkey-go keep a slot map and follow MOVED/ASK.
 	// +private
 	ServerCa *dagger.File // TLS + MTLS: PEM root used to verify the server.
 	// +private
@@ -98,11 +103,13 @@ func clientFrom(host string, port int, user string, password *dagger.Secret, db 
 // LOADING) surfaces here rather than on first command.
 //
 // ForceSingleClient skips the CLUSTER SLOTS probe valkey-go would
-// otherwise run to auto-detect a cluster; this story only ever targets a
-// standalone node. DisableCache turns off client-side caching, which
-// would otherwise let a second read of the same key answer from a local
-// tracking cache — exactly the stale read `+cache="never"` exists to
-// prevent.
+// otherwise run to auto-detect a cluster, so a standalone client stays
+// pinned to the one node it was pointed at. A cluster client (ClusterMode,
+// set by Cluster.Client) needs the opposite: it seeds from every member,
+// lets valkey-go build a slot map, and follows MOVED/ASK redirects.
+// DisableCache turns off client-side caching, which would otherwise let a
+// second read of the same key answer from a local tracking cache —
+// exactly the stale read `+cache="never"` exists to prevent.
 func (c *Client) dial(ctx context.Context) (valkey.Client, func(), error) {
 	if c.Pass == nil {
 		return nil, nil, fmt.Errorf("client has no password configured")
@@ -115,18 +122,21 @@ func (c *Client) dial(ctx context.Context) (valkey.Client, func(), error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	addr := net.JoinHostPort(c.Host, strconv.Itoa(c.Port))
+	addrs := c.Addrs
+	if len(addrs) == 0 {
+		addrs = []string{net.JoinHostPort(c.Host, strconv.Itoa(c.Port))}
+	}
 	client, err := valkey.NewClient(valkey.ClientOption{
-		InitAddress:       []string{addr},
+		InitAddress:       addrs,
 		Username:          c.UserName,
 		Password:          password,
 		SelectDB:          c.Db,
 		TLSConfig:         tlsCfg,
 		DisableCache:      true,
-		ForceSingleClient: true,
+		ForceSingleClient: !c.ClusterMode,
 	})
 	if err != nil {
-		return nil, nil, fmt.Errorf("connect %s: %w", addr, err)
+		return nil, nil, fmt.Errorf("connect %s: %w", strings.Join(addrs, ","), err)
 	}
 	return client, client.Close, nil
 }
@@ -319,6 +329,13 @@ func (c *Client) Set(
 
 // Del removes the given keys and returns how many actually existed.
 //
+// Against a cluster the keys are grouped by hash slot and one DEL is
+// issued per group: a single DEL naming keys from two slots is refused
+// outright with CROSSSLOT, because the slots may live on different
+// primaries and Valkey will not split a command across them. The groups
+// are pipelined with DoMulti, so a multi-slot delete still costs one
+// round trip per node rather than one per key.
+//
 // +cache="never"
 func (c *Client) Del(ctx context.Context, keys []string) (int, error) {
 	if len(keys) == 0 {
@@ -331,11 +348,55 @@ func (c *Client) Del(ctx context.Context, keys []string) (int, error) {
 	}
 	defer cleanup()
 
-	n, err := client.Do(ctx, client.B().Del().Key(keys...).Build()).ToInt64()
-	if err != nil {
-		return 0, err
+	if !c.ClusterMode {
+		n, err := client.Do(ctx, client.B().Del().Key(keys...).Build()).ToInt64()
+		if err != nil {
+			return 0, err
+		}
+		return int(n), nil
 	}
-	return int(n), nil
+
+	cmds := make([]valkey.Completed, 0, len(keys))
+	for _, group := range groupKeysBySlot(client, keys) {
+		cmds = append(cmds, client.B().Del().Key(group...).Build())
+	}
+	total := int64(0)
+	for _, res := range client.DoMulti(ctx, cmds...) {
+		n, err := res.ToInt64()
+		if err != nil {
+			return 0, err
+		}
+		total += n
+	}
+	return int(total), nil
+}
+
+// groupKeysBySlot buckets keys by the hash slot Valkey would route them
+// to, preserving the caller's key order within each bucket and returning
+// the buckets in first-appearance order so the resulting commands are
+// deterministic.
+//
+// valkey-go computes the slot (CRC16 of the key, or of its `{...}`
+// hashtag) while building a command but does not export the function, so
+// the slot is read back off a throwaway single-key command. The throwaway
+// is never sent; it only costs a pooled command slice that goes back to
+// the garbage collector instead of to valkey-go's pool.
+func groupKeysBySlot(client valkey.Client, keys []string) [][]string {
+	order := make([]uint16, 0, len(keys))
+	bySlot := make(map[uint16][]string, len(keys))
+	for _, key := range keys {
+		cmd := client.B().Del().Key(key).Build()
+		slot := cmd.Slot()
+		if _, ok := bySlot[slot]; !ok {
+			order = append(order, slot)
+		}
+		bySlot[slot] = append(bySlot[slot], key)
+	}
+	groups := make([][]string, 0, len(order))
+	for _, slot := range order {
+		groups = append(groups, bySlot[slot])
+	}
+	return groups
 }
 
 // Keys returns every key matching a glob pattern (`"*"` for all).
@@ -343,6 +404,14 @@ func (c *Client) Del(ctx context.Context, keys []string) (int, error) {
 // It is SCAN-backed rather than KEYS-backed — KEYS blocks the server for
 // the whole sweep — and walks the cursor to exhaustion, so the result is
 // the complete match set and not just SCAN's first page.
+//
+// Against a cluster it scans EVERY node rather than the one the client
+// happens to be seeded from. SCAN names no key, so a cluster client has
+// no slot to route it by and it is answered from whichever node it lands
+// on — reporting that node's shard of the keyspace as if it were the
+// whole thing. Replicas are scanned too (they answer SCAN locally rather
+// than redirecting) and the union is de-duplicated, so a replica lagging
+// its primary can only ever contribute keys the primary also reports.
 //
 // +cache="never"
 func (c *Client) Keys(ctx context.Context, pattern string) ([]string, error) {
@@ -352,19 +421,58 @@ func (c *Client) Keys(ctx context.Context, pattern string) ([]string, error) {
 	}
 	defer cleanup()
 
+	targets := []valkey.Client{client}
+	if c.ClusterMode {
+		// Nodes() is a map, so its iteration order varies per call; walking
+		// the addresses in sorted order keeps the returned key order stable
+		// between two Keys calls against the same cluster.
+		nodes := client.Nodes()
+		addrs := make([]string, 0, len(nodes))
+		for addr := range nodes {
+			addrs = append(addrs, addr)
+		}
+		sort.Strings(addrs)
+
+		targets = targets[:0]
+		for _, addr := range addrs {
+			targets = append(targets, nodes[addr])
+		}
+	}
+
 	out := make([]string, 0)
+	seen := make(map[string]struct{})
+	for _, target := range targets {
+		if err := scanNode(ctx, target, pattern, func(key string) {
+			if _, dup := seen[key]; dup {
+				return
+			}
+			seen[key] = struct{}{}
+			out = append(out, key)
+		}); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+// scanNode walks one node's SCAN cursor to exhaustion, handing every
+// matched key to emit. SCAN may return the same key on more than one
+// page, so callers de-duplicate.
+func scanNode(ctx context.Context, client valkey.Client, pattern string, emit func(string)) error {
 	var cursor uint64
 	for {
 		entry, err := client.Do(ctx,
 			client.B().Scan().Cursor(cursor).Match(pattern).Count(scanCount).Build(),
 		).AsScanEntry()
 		if err != nil {
-			return nil, err
+			return err
 		}
-		out = append(out, entry.Elements...)
+		for _, key := range entry.Elements {
+			emit(key)
+		}
 		cursor = entry.Cursor
 		if cursor == 0 {
-			return out, nil
+			return nil
 		}
 	}
 }

--- a/daggerverse/valkey/cluster.go
+++ b/daggerverse/valkey/cluster.go
@@ -1,0 +1,469 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+
+	"dagger/valkey/internal/dagger"
+)
+
+// clusterBusPort is the port cluster members gossip over. Valkey derives
+// it from the client port by adding 10000 and there is no reason to move
+// it in a throwaway topology, so — like valkeyPort — it is fixed rather
+// than caller-overridable.
+const clusterBusPort = valkeyPort + 10000
+
+// minClusterShards is the smallest shard count Valkey Cluster can run
+// with. Slot ownership changes are agreed by a majority vote of the
+// primaries, so two primaries can never form a majority once one of them
+// is unreachable, and a single primary is a standalone node wearing a
+// cluster hat.
+const minClusterShards = 3
+
+// clusterBootstrapAttempts is how many one-second attempts the bootstrap
+// script gives each wait. Node startup and slot assignment are both
+// near-instant; the headroom is for image pulls and for gossip to
+// converge on a contended engine.
+const clusterBootstrapAttempts = 180
+
+// clusterBootstrapMarker is the file the bootstrap script writes once
+// every node agrees the cluster is up. BindNodes grafts it into the
+// consumer container purely so the consumer's evaluation cannot start
+// before the bootstrap has finished.
+const clusterBootstrapMarker = "/bootstrap.done"
+
+// clusterBoundMarker is where BindNodes lands that marker in the consumer
+// container. Its contents are uninteresting; its presence is the receipt
+// that the cluster was formed before the consumer's first command ran.
+const clusterBoundMarker = "/etc/valkey-cluster/bootstrap.done"
+
+// Cluster is a slot-sharded Valkey Cluster: `shards` primaries splitting
+// the 16384-slot keyspace between them, each with `replicasPerShard`
+// replicas. Nodes holds every member — the first `shards` entries are the
+// primaries, the remainder their replicas — in the order valkey-cli is
+// handed them at bootstrap.
+//
+// Unlike Replication, the members are symmetric peers: each one gossips
+// with every other over the cluster bus, and none of them is "already up"
+// when its neighbours boot. That is what rules out node-to-node service
+// bindings here — see startAll.
+type Cluster struct {
+	// +private
+	Nodes []*Server
+	// +private
+	Bootstrap *dagger.Container // The exec that assigns the slots; see clusterBootstrapScript.
+}
+
+// Cluster describes a Valkey Cluster: `shards` primaries sharing the
+// 16384 hash slots, each with `replicasPerShard` replicas.
+//
+// Image: `<registry>/valkey/valkey:<tag>` for every node — the topology
+// is deliberately homogeneous.
+//
+// Rejected inputs (each a descriptive error rather than a half-formed
+// cluster):
+//
+//   - `password == nil` — the same secret is every node's `requirepass`
+//     and every replica's `masterauth`, so it is mandatory.
+//   - `clientListenerSecurity == nil` — plaintext must be a deliberate
+//     caller choice, exactly as for a single Server.
+//   - a TLS or MTLS profile — see the note below.
+//   - `shards < 3` — see minClusterShards.
+//   - `replicasPerShard < 0` — nonsense rather than a topology.
+//
+// TLS/mTLS is not supported for this topology yet, for the reason
+// Replication does not support it and one more besides: a TLS node runs
+// with `--port 0`, so the cluster bus would have to run over TLS too
+// (`--tls-cluster yes`), and each peer would need trust material a
+// client-facing `*ServerSecurity` profile does not carry. On top of that
+// the bootstrap runs through `valkey-cli --cluster create`, which would
+// need its own `--tls` / `--cacert` material to reach the nodes at all. A
+// TLS/mTLS profile is therefore rejected here rather than booting a
+// cluster whose members spin on a failed handshake.
+//
+// Like Valkey.Server, this constructor starts nothing: it validates,
+// builds every node, and composes the bootstrap exec, all lazily. Both
+// entry points into a running cluster — Cluster.Client and
+// Cluster.BindNodes — drive that bootstrap themselves, because a Dagger
+// service is only reachable from whichever client started it. Starting
+// the nodes here (from the valkey module's runtime) would register them
+// in the valkey module's DNS domain, and a consumer container binding
+// them from ANOTHER module then cannot resolve them at all:
+//
+//	lookup valkey-<host> for hosts file: ... no such host
+//
+// — the same trap Server.Endpoint documents, and a known Dagger
+// limitation reported upstream. Until it is addressed, BindNodes has to
+// be able to bring the cluster up itself.
+//
+// Session-cached for the same reason Valkey.Server and
+// Valkey.Replication are: repeated chained calls on the returned cluster
+// within one test must observe the SAME backing services — and the same
+// bootstrap exec — and therefore the same keyspace. `name` folds into
+// that cache key and into every node's hostname, so parallel test suites
+// should pass a unique value per test.
+//
+// +cache="session"
+func (v *Valkey) Cluster(
+	ctx context.Context,
+	// +default=""
+	name string,
+	// +default="docker.io"
+	registry string,
+	// +default="9.1"
+	tag string,
+	// +default=3
+	shards int,
+	// +default=0
+	replicasPerShard int,
+	password *dagger.Secret,
+	clientListenerSecurity *ServerSecurity,
+) (*Cluster, error) {
+	if password == nil {
+		return nil, fmt.Errorf("password must not be nil; pass a *dagger.Secret with the requirepass value")
+	}
+	if clientListenerSecurity == nil {
+		return nil, fmt.Errorf("clientListenerSecurity must not be nil; pass PlaintextServerSecurity() explicitly")
+	}
+	if err := validateServerSecurity(clientListenerSecurity); err != nil {
+		return nil, err
+	}
+	if clientListenerSecurity.Mode != "PLAINTEXT" {
+		return nil, fmt.Errorf(
+			"cluster does not support %s listeners yet: the cluster bus between peers would also have to run over TLS (--tls-cluster yes), and both the peers and the valkey-cli that bootstraps them need trust material that a client-listener ServerSecurity profile does not carry; pass PlaintextServerSecurity()",
+			securityModeLabel(clientListenerSecurity.Mode),
+		)
+	}
+	if shards < minClusterShards {
+		return nil, fmt.Errorf(
+			"shards must be at least %d, got %d: Valkey Cluster agrees slot ownership by a majority vote of the primaries, so fewer than %d can never form a quorum; use Valkey.Replication or Valkey.Server for a smaller topology",
+			minClusterShards, shards, minClusterShards,
+		)
+	}
+	if replicasPerShard < 0 {
+		return nil, fmt.Errorf("replicasPerShard must not be negative, got %d", replicasPerShard)
+	}
+
+	image := valkeyImage(registry, tag)
+
+	// Primaries first, then replicas: `valkey-cli --cluster create` takes
+	// the first len(nodes)/(replicasPerShard+1) addresses as primaries and
+	// distributes the remainder as their replicas, so this ordering is
+	// what makes Nodes[:shards] the primaries.
+	total := shards * (1 + replicasPerShard)
+	nodes := make([]*Server, 0, total)
+	for i := 0; i < total; i++ {
+		nodeName := clusterNodeName(name, i)
+		nodes = append(nodes, buildServer(
+			nodeName,
+			image,
+			password,
+			clientListenerSecurity,
+			clusterArgs(serverHostname(nodeName)),
+			// Deliberately no bindings between peers — see startAll.
+			nil,
+			[]int{clusterBusPort},
+		))
+	}
+
+	cluster := &Cluster{Nodes: nodes}
+	bootstrap, err := cluster.bootstrapContainer(image, password, replicasPerShard)
+	if err != nil {
+		return nil, err
+	}
+	cluster.Bootstrap = bootstrap
+	return cluster, nil
+}
+
+// clusterNodeName derives the per-node `name` each node's hostname is
+// hashed from. Folding the topology role and index into the name is what
+// gives every member its own pinned hostname, keeps two Cluster calls
+// with different `name`s from colliding, and keeps a member from
+// colliding with a Valkey.Server or Valkey.Replication node booted under
+// the same `name`.
+func clusterNodeName(name string, index int) string {
+	return name + "/cluster/node-" + strconv.Itoa(index)
+}
+
+// clusterArgs renders the `valkey-server` flags that turn a node into a
+// cluster member advertising itself at host.
+//
+// Every node must advertise a routable identity of its own. Left to
+// itself a node announces the address it believes it has, and inside a
+// Dagger service that is not an address its peers (or a client following
+// a MOVED redirect) can dial — so the three `--cluster-announce-*` flags
+// pin it to the node's own WithHostname alias, its client port, and the
+// bus port. A node that cannot self-identify ends up advertising
+// localhost, at which point every peer dials itself and the cluster never
+// forms.
+//
+// `--cluster-announce-ip` takes the hostname rather than an IP on
+// purpose: the container IP is not known until the service starts (and
+// changes between sessions), whereas the WithHostname alias is stable and
+// resolvable from every peer, from the module runtime, and — via
+// BindNodes — from a consumer container.
+//
+// `--masterauth` is what lets a replica authenticate to the primary it is
+// assigned at bootstrap. It is the same secret as the node's own
+// `requirepass`, expanded by the shell wrapper buildServer wraps these
+// args in, so it never enters the node's argv in the Dagger graph. See
+// replicaArgs for why `masterauth` and not `primaryauth`.
+func clusterArgs(host string) []string {
+	return []string{
+		"--cluster-enabled", "yes",
+		"--cluster-config-file", "nodes.conf",
+		"--cluster-node-timeout", "5000",
+		"--cluster-announce-ip", host,
+		"--cluster-announce-port", strconv.Itoa(valkeyPort),
+		"--cluster-announce-bus-port", strconv.Itoa(clusterBusPort),
+		"--masterauth", `"$VALKEY_PASSWORD"`,
+	}
+}
+
+// startAll boots every node service concurrently, so the module runtime
+// can resolve them by hostname.
+//
+// Concurrency is not an optimisation here, it is a correctness
+// requirement. Cluster members are symmetric peers: they gossip over the
+// bus port and none of them is "already up" when its neighbours boot, so
+// there is deliberately NO node-to-node WithServiceBinding. A binding
+// would force Dagger to fully ready node B before it even boots node A,
+// while B's own readiness depends on the cluster it needs A to help form
+// — the same readiness deadlock the Redpanda multi-broker topology hit.
+// Starting the nodes together instead lets them discover each other by
+// hostname over session-wide DNS.
+func startAll(ctx context.Context, nodes []*Server) error {
+	var wg sync.WaitGroup
+	errs := make([]error, len(nodes))
+	for i, node := range nodes {
+		if node == nil || node.Svc == nil {
+			continue
+		}
+		wg.Add(1)
+		go func(i int, node *Server) {
+			defer wg.Done()
+			if _, err := node.Svc.Start(ctx); err != nil {
+				errs[i] = fmt.Errorf("start cluster node %d (%s): %w", i, node.Host, err)
+			}
+		}(i, node)
+	}
+	wg.Wait()
+	return errors.Join(errs...)
+}
+
+// bootstrapContainer composes (but does not run) the exec that assigns
+// the 16384 hash slots across the primaries, wires each replica to one of
+// them, and waits for every node to agree the cluster is up.
+//
+// `valkey-cli --cluster create` does the assignment rather than a Go
+// reimplementation of CLUSTER MEET + ADDSLOTS + REPLICATE, because the
+// slot split and the replica placement are exactly what it exists to get
+// right. Its container binds every node — a fan-out from one consumer to
+// N services, not the peer-to-peer cycle the nodes themselves must avoid.
+//
+// It is left lazy on purpose. Whoever forces it — Cluster.Client from the
+// module runtime, or a consumer container's exec through BindNodes —
+// drives the node services up as dependencies of their own request, in
+// their own DNS domain. Bootstrapping eagerly in the constructor would
+// pin the services to the valkey module's domain and make BindNodes
+// unusable from any other module.
+//
+// The nonce env var is a cache buster. Nothing else in this exec's inputs
+// changes between engine sessions (the image, the args, and the node
+// hostnames are all derived from `name`), so a second session with the
+// same `name` would replay the first session's cached exec and hand back
+// a cluster that was never actually bootstrapped. Cluster is
+// session-cached, so the nonce is minted once per session — the exec
+// re-runs per session, not per call.
+func (c *Cluster) bootstrapContainer(image string, password *dagger.Secret, replicasPerShard int) (*dagger.Container, error) {
+	nonce := make([]byte, 16)
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, fmt.Errorf("generate bootstrap nonce: %w", err)
+	}
+
+	ctr := dag.Container().
+		From(image).
+		WithSecretVariable("VALKEY_PASSWORD", password).
+		WithEnvVariable("VALKEY_CLUSTER_BOOTSTRAP_NONCE", hex.EncodeToString(nonce))
+	for _, node := range c.Nodes {
+		ctr = ctr.WithServiceBinding(node.Host, node.Svc)
+	}
+	script := clusterBootstrapScript(c.Endpoints(), len(c.Nodes), replicasPerShard)
+	return ctr.WithExec([]string{"sh", "-c", script}), nil
+}
+
+// clusterBootstrapScript renders the shell program that brings a cluster
+// up: wait for every node to answer, create the cluster, then wait for
+// every node to agree it is formed.
+//
+// It waits in the container rather than in Go so that BindNodes — which
+// returns a *dagger.Container and so has neither a context nor an error
+// to report through — gets the same guarantee Cluster.Client does.
+//
+// Both waits matter. `valkey-cli --cluster create` aborts on the first
+// node it cannot reach, and valkey-server opens its client port only once
+// it has finished loading, so the pre-create wait is what stops the
+// bootstrap racing a node that is still starting. The post-create wait
+// covers the other end: slot ownership reaches the rest of the cluster by
+// gossip, and a client seeded with a node that has not caught up yet gets
+// a stale slot map and MOVED-loops. Every node is polled, not just the
+// one valkey-cli was pointed at, and `cluster_known_nodes` is checked
+// alongside `cluster_state:ok` — a node whose gossip never reached the
+// others still reports state:ok for the slots it can see, and only the
+// node count gives it away.
+func clusterBootstrapScript(endpoints []string, nodeCount, replicasPerShard int) string {
+	return fmt.Sprintf(`set -eu
+
+NODES=%q
+ATTEMPTS=%d
+
+# probe HOST PORT COMMAND... — one command against one specific node.
+probe() {
+  h=$1; p=$2; shift 2
+  valkey-cli --no-auth-warning -h "$h" -p "$p" -a "$VALKEY_PASSWORD" "$@" 2>/dev/null
+}
+
+# await NEEDLE WHAT ENDPOINT COMMAND... — poll one node until its reply
+# contains NEEDLE, then fail loudly (with the last reply) if it never does.
+await() {
+  needle=$1; what=$2; ep=$3; shift 3
+  h=${ep%%%%:*}; p=${ep##*:}
+  i=0
+  while [ "$i" -lt "$ATTEMPTS" ]; do
+    if probe "$h" "$p" "$@" | grep -q "$needle"; then
+      return 0
+    fi
+    i=$((i + 1))
+    sleep 1
+  done
+  echo "timed out after ${ATTEMPTS}s waiting for $what on $ep; last reply:" >&2
+  probe "$h" "$p" "$@" >&2 || true
+  exit 1
+}
+
+for ep in $NODES; do
+  await PONG "the node to accept authenticated commands" "$ep" PING
+done
+
+valkey-cli --no-auth-warning -a "$VALKEY_PASSWORD" \
+  --cluster create $NODES \
+  --cluster-replicas %d \
+  --cluster-yes
+
+for ep in $NODES; do
+  await cluster_state:ok "every hash slot to be owned" "$ep" CLUSTER INFO
+  await cluster_known_nodes:%d "every node to be known to this one" "$ep" CLUSTER INFO
+done
+
+echo ok > %s
+`,
+		strings.Join(endpoints, " "),
+		clusterBootstrapAttempts,
+		replicasPerShard,
+		nodeCount,
+		clusterBootstrapMarker,
+	)
+}
+
+// Endpoints returns every member's `host:6379` address, primaries first.
+// These are the addresses a cluster-aware client seeds from, and the
+// hostnames BindNodes makes reachable. Like Server.Endpoint it is a pure
+// accessor and starts nothing.
+//
+// Session-cached rather than never-cached: Dagger v0.21 detaches module
+// objects returned from a `+cache="never"` function when a consumer
+// module reads their fields lazily, and `tests/` is such a consumer.
+//
+// +cache="session"
+func (c *Cluster) Endpoints() []string {
+	out := make([]string, 0, len(c.Nodes))
+	for _, node := range c.Nodes {
+		out = append(out, node.Endpoint())
+	}
+	return out
+}
+
+// BindNodes attaches every member service to the given container under
+// the hostname it advertises, so the container can dial any of them at
+// the addresses Endpoints reports — and, just as importantly, can follow
+// a MOVED redirect to any other member, since a cluster client is told to
+// go to a node's *advertised* hostname rather than the one it dialed.
+// Binding only the seed node would leave every redirect unresolvable.
+//
+// The returned container also carries the bootstrap script's completion
+// marker. That file is never read; grafting it is what makes the
+// bootstrap a build-time dependency of whatever the consumer runs next,
+// so the container's first command meets a cluster whose slots are
+// already assigned rather than one answering CLUSTERDOWN.
+//
+// +cache="never"
+func (c *Cluster) BindNodes(ctr *dagger.Container) *dagger.Container {
+	ctr = ctr.WithFile(clusterBoundMarker, c.Bootstrap.File(clusterBootstrapMarker))
+	for _, node := range c.Nodes {
+		ctr = ctr.WithServiceBinding(node.Host, node.Svc)
+	}
+	return ctr
+}
+
+// Client brings the cluster up and returns a cluster-aware valkey-go
+// Client seeded with every member's endpoint. valkey-go detects cluster
+// mode from the seed addresses (CLUSTER SLOTS), keeps its own slot map,
+// and follows MOVED/ASK redirects itself, so callers address the cluster
+// as one keyspace.
+//
+// The supplied ClientSecurity mode must match the cluster's listener
+// mode, which is PLAINTEXT for now; a mismatch returns an error naming
+// both modes rather than failing opaquely at the wire.
+//
+// The nodes are started explicitly (and concurrently — see startAll)
+// rather than left to the bootstrap exec's service bindings, because a
+// binding only wires the service into that one container's hosts file:
+// the returned valkey-go client dials from the module runtime, which
+// needs the hostnames in session DNS. Starting them here is also what
+// makes BindNodes unusable on the same cluster afterwards — see
+// Valkey.Cluster — so a consumer container should bind a cluster this
+// module has not already dialled.
+//
+// +cache="never"
+func (c *Cluster) Client(ctx context.Context, security *ClientSecurity) (*Client, error) {
+	if len(c.Nodes) == 0 {
+		return nil, fmt.Errorf("cluster has no nodes")
+	}
+	if err := c.Nodes[0].requireMode(security); err != nil {
+		return nil, err
+	}
+	if err := startAll(ctx, c.Nodes); err != nil {
+		return nil, err
+	}
+	if _, err := c.Bootstrap.Sync(ctx); err != nil {
+		return nil, fmt.Errorf("bootstrap valkey cluster: %w", err)
+	}
+
+	seed := c.Nodes[0]
+	client := clientFrom(seed.Host, valkeyPort, seed.UserName, seed.Pass, 0, security)
+	client.Addrs = c.Endpoints()
+	client.ClusterMode = true
+	return client, nil
+}
+
+// Stop tears down every member. Every node is attempted even if an
+// earlier one fails, and the failures are joined — a partial teardown
+// that reported only the first error would leave services running with
+// nothing naming them.
+//
+// +cache="never"
+func (c *Cluster) Stop(ctx context.Context) error {
+	var errs []error
+	for i := len(c.Nodes) - 1; i >= 0; i-- {
+		if err := c.Nodes[i].Stop(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("node %d: %w", i, err))
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/daggerverse/valkey/dagger.gen.go
+++ b/daggerverse/valkey/dagger.gen.go
@@ -81,6 +81,8 @@ func (r Client) MarshalJSON() ([]byte, error) {
 		Pass         *dagger.Secret
 		Db           int
 		SecurityMode string
+		Addrs        []string
+		ClusterMode  bool
 		ServerCa     *dagger.File
 		ClientCert   *dagger.File
 		ClientKey    *dagger.Secret
@@ -91,6 +93,8 @@ func (r Client) MarshalJSON() ([]byte, error) {
 	concrete.Pass = r.Pass
 	concrete.Db = r.Db
 	concrete.SecurityMode = r.SecurityMode
+	concrete.Addrs = r.Addrs
+	concrete.ClusterMode = r.ClusterMode
 	concrete.ServerCa = r.ServerCa
 	concrete.ClientCert = r.ClientCert
 	concrete.ClientKey = r.ClientKey
@@ -105,6 +109,8 @@ func (r *Client) UnmarshalJSON(bs []byte) error {
 		Pass         *dagger.Secret
 		Db           int
 		SecurityMode string
+		Addrs        []string
+		ClusterMode  bool
 		ServerCa     *dagger.File
 		ClientCert   *dagger.File
 		ClientKey    *dagger.Secret
@@ -119,6 +125,8 @@ func (r *Client) UnmarshalJSON(bs []byte) error {
 	r.Pass = concrete.Pass
 	r.Db = concrete.Db
 	r.SecurityMode = concrete.SecurityMode
+	r.Addrs = concrete.Addrs
+	r.ClusterMode = concrete.ClusterMode
 	r.ServerCa = concrete.ServerCa
 	r.ClientCert = concrete.ClientCert
 	r.ClientKey = concrete.ClientKey
@@ -154,6 +162,30 @@ func (r *ClientSecurity) UnmarshalJSON(bs []byte) error {
 	r.ServerCa = concrete.ServerCa
 	r.ClientCert = concrete.ClientCert
 	r.ClientKey = concrete.ClientKey
+	return nil
+}
+
+func (r Cluster) MarshalJSON() ([]byte, error) {
+	var concrete struct {
+		Nodes     []*Server
+		Bootstrap *dagger.Container
+	}
+	concrete.Nodes = r.Nodes
+	concrete.Bootstrap = r.Bootstrap
+	return json.Marshal(&concrete)
+}
+
+func (r *Cluster) UnmarshalJSON(bs []byte) error {
+	var concrete struct {
+		Nodes     []*Server
+		Bootstrap *dagger.Container
+	}
+	err := json.Unmarshal(bs, &concrete)
+	if err != nil {
+		return err
+	}
+	r.Nodes = concrete.Nodes
+	r.Bootstrap = concrete.Bootstrap
 	return nil
 }
 
@@ -500,6 +532,53 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 		default:
 			return nil, fmt.Errorf("unknown function %s", fnName)
 		}
+	case "Cluster":
+		switch fnName {
+		case "BindNodes":
+			var parent Cluster
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var ctr *dagger.Container
+			if inputArgs["ctr"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["ctr"]), &ctr)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg ctr", err))
+				}
+			}
+			return (*Cluster).BindNodes(&parent, ctr), nil
+		case "Client":
+			var parent Cluster
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var security *ClientSecurity
+			if inputArgs["security"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["security"]), &security)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg security", err))
+				}
+			}
+			return (*Cluster).Client(&parent, ctx, security)
+		case "Endpoints":
+			var parent Cluster
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Cluster).Endpoints(&parent), nil
+		case "Stop":
+			var parent Cluster
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Cluster).Stop(&parent, ctx)
+		default:
+			return nil, fmt.Errorf("unknown function %s", fnName)
+		}
 	case "Replication":
 		switch fnName {
 		case "Primary":
@@ -638,6 +717,62 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Valkey).Client(&parent, host, port, user, password, db, security), nil
+		case "Cluster":
+			var parent Valkey
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var name string
+			if inputArgs["name"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["name"]), &name)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg name", err))
+				}
+			}
+			var registry string
+			if inputArgs["registry"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["registry"]), &registry)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg registry", err))
+				}
+			}
+			var tag string
+			if inputArgs["tag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["tag"]), &tag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg tag", err))
+				}
+			}
+			var shards int
+			if inputArgs["shards"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["shards"]), &shards)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg shards", err))
+				}
+			}
+			var replicasPerShard int
+			if inputArgs["replicasPerShard"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["replicasPerShard"]), &replicasPerShard)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg replicasPerShard", err))
+				}
+			}
+			var password *dagger.Secret
+			if inputArgs["password"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["password"]), &password)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg password", err))
+				}
+			}
+			var clientListenerSecurity *ServerSecurity
+			if inputArgs["clientListenerSecurity"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["clientListenerSecurity"]), &clientListenerSecurity)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg clientListenerSecurity", err))
+				}
+			}
+			return (*Valkey).Cluster(&parent, ctx, name, registry, tag, shards, replicasPerShard, password, clientListenerSecurity)
 		case "MtlsClientSecurity":
 			var parent Valkey
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/valkey/main.go
+++ b/daggerverse/valkey/main.go
@@ -1,20 +1,20 @@
 // Valkey provides Dagger functions for spinning up Valkey topologies
-// (from the upstream `valkey/valkey` image) — a single node, or a
-// primary with N read replicas — plus a pure-Go valkey-go based client
-// that can target either a local node or any reachable remote Valkey
-// (e.g. ElastiCache Serverless, MemoryDB, a self-hosted node).
+// (from the upstream `valkey/valkey` image) — a single node, a primary
+// with N read replicas, or a slot-sharded Valkey Cluster — plus a pure-Go
+// valkey-go based client that can target either a local topology or any
+// reachable remote Valkey (e.g. ElastiCache Serverless, MemoryDB, a
+// self-hosted node).
 //
 // Three client-facing listener modes are supported: PLAINTEXT
 // (`requirepass` auth over an unencrypted TCP listener), TLS (one-way:
 // the node presents a server certificate on a `--tls-port` listener and
 // clients still authenticate with the password), and MTLS (mutual: the
 // client must additionally present a certificate signed by the node's
-// trusted CA). Replication is plaintext-only for now — see
-// Valkey.Replication. Valkey Cluster lands in a follow-up.
+// trusted CA). Replication and Cluster are plaintext-only for now — see
+// Valkey.Replication and Valkey.Cluster.
 //
 // The single-node type is `Server`, not `Cluster`: in Valkey "cluster"
-// means slot-sharded Valkey Cluster, so that name is reserved for the
-// follow-up that adds it.
+// means slot-sharded Valkey Cluster, and that is what `Cluster` is.
 //
 // File map (all `package main`, surfaced as one Dagger module):
 //
@@ -27,9 +27,13 @@
 //   - replication.go — *Replication + Valkey.Replication, the
 //     primary/replica topology builder, and the Primary / Replicas /
 //     Stop methods.
+//   - cluster.go     — *Cluster + Valkey.Cluster, the symmetric-peer node
+//     builder, the concurrent start (startAll) and the containerised
+//     slot-assignment bootstrap, and the Endpoints / BindNodes / Client /
+//     Stop methods.
 //   - client.go      — *Client + Valkey.Client, valkey-go wiring, and the
 //     Ping / Do / Get / Set / Del / Keys / ApplyFile / Info / DbSize /
-//     FlushAll method set.
+//     FlushAll method set — the last of which are cluster-aware.
 package main
 
 // Valkey is the root namespace for every exported function in this

--- a/daggerverse/valkey/replication.go
+++ b/daggerverse/valkey/replication.go
@@ -90,7 +90,7 @@ func (v *Valkey) Replication(
 
 	image := valkeyImage(registry, tag)
 
-	primary := buildServer(replicationNodeName(name, 0), image, password, clientListenerSecurity, nil, nil)
+	primary := buildServer(replicationNodeName(name, 0), image, password, clientListenerSecurity, nil, nil, nil)
 
 	nodes := make([]*Server, 0, replicas+1)
 	nodes = append(nodes, primary)
@@ -102,6 +102,7 @@ func (v *Valkey) Replication(
 			clientListenerSecurity,
 			replicaArgs(primary.Host),
 			[]serviceBinding{{host: primary.Host, svc: primary.Svc}},
+			nil,
 		))
 	}
 

--- a/daggerverse/valkey/server.go
+++ b/daggerverse/valkey/server.go
@@ -108,7 +108,7 @@ func (v *Valkey) Server(
 		)
 	}
 
-	return buildServer(name, valkeyImage(registry, tag), password, clientListenerSecurity, nil, nil), nil
+	return buildServer(name, valkeyImage(registry, tag), password, clientListenerSecurity, nil, nil, nil), nil
 }
 
 // valkeyImage renders the image reference a node boots from. The
@@ -140,9 +140,11 @@ type serviceBinding struct {
 
 // buildServer assembles a single valkey-server node: the container, the
 // security-derived listener flags, any extra `valkey-server` arguments
-// (replication flags, say), and the service bindings the node needs in
-// order to dial its peers. Inputs are assumed already validated —
-// Valkey.Server and Valkey.Replication each validate before calling.
+// (replication or cluster flags, say), the service bindings the node
+// needs in order to dial its peers, and any ports beyond the client
+// listener the node must expose (the cluster bus, say). Inputs are
+// assumed already validated — Valkey.Server, Valkey.Replication, and
+// Valkey.Cluster each validate before calling.
 func buildServer(
 	name string,
 	image string,
@@ -150,6 +152,7 @@ func buildServer(
 	security *ServerSecurity,
 	extraArgs []string,
 	bindings []serviceBinding,
+	extraPorts []int,
 ) *Server {
 	host := serverHostname(name)
 
@@ -161,6 +164,10 @@ func buildServer(
 		From(image).
 		WithSecretVariable("VALKEY_PASSWORD", password).
 		WithExposedPort(valkeyPort)
+
+	for _, port := range extraPorts {
+		ctr = ctr.WithExposedPort(port)
+	}
 
 	// Bindings go on before AsService so the node resolves its peers from
 	// /etc/hosts at boot, and so Dagger starts those peers as dependencies

--- a/daggerverse/valkey/tests/dagger.gen.go
+++ b/daggerverse/valkey/tests/dagger.gen.go
@@ -255,6 +255,83 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).ClientPingWrongPasswordFails(&parent, ctx)
+		case "Cluster":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var parallel int
+			if inputArgs["parallel"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["parallel"]), &parallel)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg parallel", err))
+				}
+			}
+			return nil, (*Tests).Cluster(&parent, ctx, parallel)
+		case "ClusterAdvertisesPinnedHostnames":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ClusterAdvertisesPinnedHostnames(&parent, ctx)
+		case "ClusterBindNodesReachableFromConsumer":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ClusterBindNodesReachableFromConsumer(&parent, ctx)
+		case "ClusterDelSpansMultipleSlots":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ClusterDelSpansMultipleSlots(&parent, ctx)
+		case "ClusterKeysScansEveryShard":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ClusterKeysScansEveryShard(&parent, ctx)
+		case "ClusterRejectsTlsSecurity":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ClusterRejectsTlsSecurity(&parent, ctx)
+		case "ClusterRejectsTooFewShards":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ClusterRejectsTooFewShards(&parent, ctx)
+		case "ClusterReportsFormedState":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ClusterReportsFormedState(&parent, ctx)
+		case "ClusterRoundTripsKeysAcrossSlots":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ClusterRoundTripsKeysAcrossSlots(&parent, ctx)
+		case "ClusterStopTerminatesEveryNode":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ClusterStopTerminatesEveryNode(&parent, ctx)
 		case "DbSelectsLogicalDatabase":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/valkey/tests/internal/dagger/dagger.gen.go
+++ b/daggerverse/valkey/tests/internal/dagger/dagger.gen.go
@@ -376,6 +376,9 @@ type ValkeyClientID string
 type ValkeyClientSecurityID string
 
 // A unique identifier for an object.
+type ValkeyClusterID string
+
+// A unique identifier for an object.
 type ValkeyID string
 
 // A unique identifier for an object.
@@ -13542,6 +13545,16 @@ func (r *Query) LoadValkeyClientSecurityFromID(id ValkeyClientSecurityID) *Valke
 	q = q.Arg("id", id)
 
 	return &ValkeyClientSecurity{
+		query: q,
+	}
+}
+
+// Load a ValkeyCluster from its ID.
+func (r *Query) LoadValkeyClusterFromID(id ValkeyClusterID) *ValkeyCluster {
+	q := r.query.Select("loadValkeyClusterFromID")
+	q = q.Arg("id", id)
+
+	return &ValkeyCluster{
 		query: q,
 	}
 }

--- a/daggerverse/valkey/tests/internal/dagger/valkey.gen.go
+++ b/daggerverse/valkey/tests/internal/dagger/valkey.gen.go
@@ -315,18 +315,18 @@ func (r *Valkey) Client(host string, password *Secret, security *ValkeyClientSec
 
 // ValkeyClusterOpts contains options for Valkey.Cluster
 type ValkeyClusterOpts struct {
-	Name string // valkey (../../../../../daggerverse/valkey/cluster.go:112:2)
+	Name string // valkey (../../../../../daggerverse/valkey/cluster.go:116:2)
 
 	// Default: "docker.io"
-	Registry string // valkey (../../../../../daggerverse/valkey/cluster.go:114:2)
+	Registry string // valkey (../../../../../daggerverse/valkey/cluster.go:118:2)
 
 	// Default: "9.1"
-	Tag string // valkey (../../../../../daggerverse/valkey/cluster.go:116:2)
+	Tag string // valkey (../../../../../daggerverse/valkey/cluster.go:120:2)
 
 	// Default: 3
-	Shards int // valkey (../../../../../daggerverse/valkey/cluster.go:118:2)
+	Shards int // valkey (../../../../../daggerverse/valkey/cluster.go:122:2)
 
-	ReplicasPerShard int // valkey (../../../../../daggerverse/valkey/cluster.go:120:2)
+	ReplicasPerShard int // valkey (../../../../../daggerverse/valkey/cluster.go:124:2)
 }
 
 // Cluster describes a Valkey Cluster: `shards` primaries sharing the
@@ -356,16 +356,20 @@ type ValkeyClusterOpts struct {
 // TLS/mTLS profile is therefore rejected here rather than booting a
 // cluster whose members spin on a failed handshake.
 //
-// Like Valkey.Server and unlike its own doc-level description, this
-// constructor starts nothing: it validates, builds every node, and
-// composes the bootstrap exec, all lazily. Both entry points into a
-// running cluster — Cluster.Client and Cluster.BindNodes — drive that
-// bootstrap themselves, because a Dagger service is only reachable from
-// whichever client started it. Starting the nodes here (from the valkey
-// module's runtime) would register them in the valkey module's DNS
-// domain, and a consumer container binding them from ANOTHER module then
-// cannot resolve them at all — the same trap Server.Endpoint documents,
-// which is why BindNodes has to be able to bring the cluster up itself.
+// Like Valkey.Server, this constructor starts nothing: it validates,
+// builds every node, and composes the bootstrap exec, all lazily. Both
+// entry points into a running cluster — Cluster.Client and
+// Cluster.BindNodes — drive that bootstrap themselves, because a Dagger
+// service is only reachable from whichever client started it. Starting
+// the nodes here (from the valkey module's runtime) would register them
+// in the valkey module's DNS domain, and a consumer container binding
+// them from ANOTHER module then cannot resolve them at all:
+//
+//	lookup valkey-<host> for hosts file: ... no such host
+//
+// — the same trap Server.Endpoint documents, and a known Dagger
+// limitation reported upstream. Until it is addressed, BindNodes has to
+// be able to bring the cluster up itself.
 //
 // Session-cached for the same reason Valkey.Server and
 // Valkey.Replication are: repeated chained calls on the returned cluster
@@ -373,7 +377,7 @@ type ValkeyClusterOpts struct {
 // bootstrap exec — and therefore the same keyspace. `name` folds into
 // that cache key and into every node's hostname, so parallel test suites
 // should pass a unique value per test.
-func (r *Valkey) Cluster(password *Secret, clientListenerSecurity *ValkeyServerSecurity, opts ...ValkeyClusterOpts) *ValkeyCluster { // valkey (../../../../../daggerverse/valkey/cluster.go:109:1)
+func (r *Valkey) Cluster(password *Secret, clientListenerSecurity *ValkeyServerSecurity, opts ...ValkeyClusterOpts) *ValkeyCluster { // valkey (../../../../../daggerverse/valkey/cluster.go:113:1)
 	assertNotNil("password", password)
 	assertNotNil("clientListenerSecurity", clientListenerSecurity)
 	q := r.query.Select("cluster")
@@ -1083,7 +1087,7 @@ func (r *ValkeyCluster) WithGraphQLQuery(q *querybuilder.Selection) *ValkeyClust
 // bootstrap a build-time dependency of whatever the consumer runs next,
 // so the container's first command meets a cluster whose slots are
 // already assigned rather than one answering CLUSTERDOWN.
-func (r *ValkeyCluster) BindNodes(ctr *Container) *Container { // valkey (../../../../../daggerverse/valkey/cluster.go:402:1)
+func (r *ValkeyCluster) BindNodes(ctr *Container) *Container { // valkey (../../../../../daggerverse/valkey/cluster.go:406:1)
 	assertNotNil("ctr", ctr)
 	q := r.query.Select("bindNodes")
 	q = q.Arg("ctr", ctr)
@@ -1111,7 +1115,7 @@ func (r *ValkeyCluster) BindNodes(ctr *Container) *Container { // valkey (../../
 // makes BindNodes unusable on the same cluster afterwards — see
 // Valkey.Cluster — so a consumer container should bind a cluster this
 // module has not already dialled.
-func (r *ValkeyCluster) Client(security *ValkeyClientSecurity) *ValkeyClient { // valkey (../../../../../daggerverse/valkey/cluster.go:430:1)
+func (r *ValkeyCluster) Client(security *ValkeyClientSecurity) *ValkeyClient { // valkey (../../../../../daggerverse/valkey/cluster.go:434:1)
 	assertNotNil("security", security)
 	q := r.query.Select("client")
 	q = q.Arg("security", security)
@@ -1128,7 +1132,7 @@ func (r *ValkeyCluster) Client(security *ValkeyClientSecurity) *ValkeyClient { /
 //
 // Session-cached rather than never-cached: Dagger v0.21 detaches module
 // objects returned from a `module reads their fields lazily, and `tests/` is such a consumer.
-func (r *ValkeyCluster) Endpoints(ctx context.Context) ([]string, error) { // valkey (../../../../../daggerverse/valkey/cluster.go:380:1)
+func (r *ValkeyCluster) Endpoints(ctx context.Context) ([]string, error) { // valkey (../../../../../daggerverse/valkey/cluster.go:384:1)
 	q := r.query.Select("endpoints")
 
 	var response []string
@@ -1190,7 +1194,7 @@ func (r *ValkeyCluster) UnmarshalJSON(bs []byte) error {
 // earlier one fails, and the failures are joined — a partial teardown
 // that reported only the first error would leave services running with
 // nothing naming them.
-func (r *ValkeyCluster) Stop(ctx context.Context) error { // valkey (../../../../../daggerverse/valkey/cluster.go:457:1)
+func (r *ValkeyCluster) Stop(ctx context.Context) error { // valkey (../../../../../daggerverse/valkey/cluster.go:461:1)
 	if r.stop != nil {
 		return nil
 	}

--- a/daggerverse/valkey/tests/internal/dagger/valkey.gen.go
+++ b/daggerverse/valkey/tests/internal/dagger/valkey.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type Valkey
-func (r *Binding) AsValkey() *Valkey { // valkey (../../../../../daggerverse/valkey/main.go:39:6)
+func (r *Binding) AsValkey() *Valkey { // valkey (../../../../../daggerverse/valkey/main.go:43:6)
 	q := r.query.Select("asValkey")
 
 	return &Valkey{
@@ -19,7 +19,7 @@ func (r *Binding) AsValkey() *Valkey { // valkey (../../../../../daggerverse/val
 }
 
 // Retrieve the binding value, as type ValkeyClient
-func (r *Binding) AsValkeyClient() *ValkeyClient { // valkey (../../../../../daggerverse/valkey/client.go:34:6)
+func (r *Binding) AsValkeyClient() *ValkeyClient { // valkey (../../../../../daggerverse/valkey/client.go:35:6)
 	q := r.query.Select("asValkeyClient")
 
 	return &ValkeyClient{
@@ -32,6 +32,15 @@ func (r *Binding) AsValkeyClientSecurity() *ValkeyClientSecurity { // valkey (..
 	q := r.query.Select("asValkeyClientSecurity")
 
 	return &ValkeyClientSecurity{
+		query: q,
+	}
+}
+
+// Retrieve the binding value, as type ValkeyCluster
+func (r *Binding) AsValkeyCluster() *ValkeyCluster { // valkey (../../../../../daggerverse/valkey/cluster.go:56:6)
+	q := r.query.Select("asValkeyCluster")
+
+	return &ValkeyCluster{
 		query: q,
 	}
 }
@@ -64,7 +73,7 @@ func (r *Binding) AsValkeyServerSecurity() *ValkeyServerSecurity { // valkey (..
 }
 
 // Create or update a binding of type ValkeyClient in the environment
-func (r *Env) WithValkeyClientInput(name string, value *ValkeyClient, description string) *Env { // valkey (../../../../../daggerverse/valkey/client.go:34:6)
+func (r *Env) WithValkeyClientInput(name string, value *ValkeyClient, description string) *Env { // valkey (../../../../../daggerverse/valkey/client.go:35:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withValkeyClientInput")
 	q = q.Arg("name", name)
@@ -77,7 +86,7 @@ func (r *Env) WithValkeyClientInput(name string, value *ValkeyClient, descriptio
 }
 
 // Declare a desired ValkeyClient output to be assigned in the environment
-func (r *Env) WithValkeyClientOutput(name string, description string) *Env { // valkey (../../../../../daggerverse/valkey/client.go:34:6)
+func (r *Env) WithValkeyClientOutput(name string, description string) *Env { // valkey (../../../../../daggerverse/valkey/client.go:35:6)
 	q := r.query.Select("withValkeyClientOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -111,8 +120,32 @@ func (r *Env) WithValkeyClientSecurityOutput(name string, description string) *E
 	}
 }
 
+// Create or update a binding of type ValkeyCluster in the environment
+func (r *Env) WithValkeyClusterInput(name string, value *ValkeyCluster, description string) *Env { // valkey (../../../../../daggerverse/valkey/cluster.go:56:6)
+	assertNotNil("value", value)
+	q := r.query.Select("withValkeyClusterInput")
+	q = q.Arg("name", name)
+	q = q.Arg("value", value)
+	q = q.Arg("description", description)
+
+	return &Env{
+		query: q,
+	}
+}
+
+// Declare a desired ValkeyCluster output to be assigned in the environment
+func (r *Env) WithValkeyClusterOutput(name string, description string) *Env { // valkey (../../../../../daggerverse/valkey/cluster.go:56:6)
+	q := r.query.Select("withValkeyClusterOutput")
+	q = q.Arg("name", name)
+	q = q.Arg("description", description)
+
+	return &Env{
+		query: q,
+	}
+}
+
 // Create or update a binding of type Valkey in the environment
-func (r *Env) WithValkeyInput(name string, value *Valkey, description string) *Env { // valkey (../../../../../daggerverse/valkey/main.go:39:6)
+func (r *Env) WithValkeyInput(name string, value *Valkey, description string) *Env { // valkey (../../../../../daggerverse/valkey/main.go:43:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withValkeyInput")
 	q = q.Arg("name", name)
@@ -125,7 +158,7 @@ func (r *Env) WithValkeyInput(name string, value *Valkey, description string) *E
 }
 
 // Declare a desired Valkey output to be assigned in the environment
-func (r *Env) WithValkeyOutput(name string, description string) *Env { // valkey (../../../../../daggerverse/valkey/main.go:39:6)
+func (r *Env) WithValkeyOutput(name string, description string) *Env { // valkey (../../../../../daggerverse/valkey/main.go:43:6)
 	q := r.query.Select("withValkeyOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -211,7 +244,7 @@ func (r *Env) WithValkeyServerSecurityOutput(name string, description string) *E
 // module. The server constructor, security helpers, and the
 // remote-client factory all hang off *Valkey so the generated Dagger SDK
 // surfaces them under `dag.Valkey().<Func>(...)`.
-func (r *Query) Valkey() *Valkey { // valkey (../../../../../daggerverse/valkey/main.go:39:6)
+func (r *Query) Valkey() *Valkey { // valkey (../../../../../daggerverse/valkey/main.go:43:6)
 	q := r.query.Select("valkey")
 
 	return &Valkey{
@@ -223,7 +256,7 @@ func (r *Query) Valkey() *Valkey { // valkey (../../../../../daggerverse/valkey/
 // module. The server constructor, security helpers, and the
 // remote-client factory all hang off *Valkey so the generated Dagger SDK
 // surfaces them under `dag.Valkey().<Func>(...)`.
-type Valkey struct { // valkey (../../../../../daggerverse/valkey/main.go:39:6)
+type Valkey struct { // valkey (../../../../../daggerverse/valkey/main.go:43:6)
 	query *querybuilder.Selection
 
 	id *ID
@@ -239,12 +272,12 @@ func (r *Valkey) WithGraphQLQuery(q *querybuilder.Selection) *Valkey {
 type ValkeyClientOpts struct {
 
 	// Default: 6379
-	Port int // valkey (../../../../../daggerverse/valkey/client.go:66:2)
+	Port int // valkey (../../../../../daggerverse/valkey/client.go:71:2)
 
 	// Default: "default"
-	User string // valkey (../../../../../daggerverse/valkey/client.go:68:2)
+	User string // valkey (../../../../../daggerverse/valkey/client.go:73:2)
 
-	Db int // valkey (../../../../../daggerverse/valkey/client.go:71:2)
+	Db int // valkey (../../../../../daggerverse/valkey/client.go:76:2)
 }
 
 // Client constructs a valkey-go backed client targeting host:port with
@@ -253,7 +286,7 @@ type ValkeyClientOpts struct {
 // reachable remote Valkey — ElastiCache Serverless, MemoryDB, an
 // existing self-hosted node, anything that speaks the Valkey/Redis wire
 // protocol with password auth.
-func (r *Valkey) Client(host string, password *Secret, security *ValkeyClientSecurity, opts ...ValkeyClientOpts) *ValkeyClient { // valkey (../../../../../daggerverse/valkey/client.go:63:1)
+func (r *Valkey) Client(host string, password *Secret, security *ValkeyClientSecurity, opts ...ValkeyClientOpts) *ValkeyClient { // valkey (../../../../../daggerverse/valkey/client.go:68:1)
 	assertNotNil("password", password)
 	assertNotNil("security", security)
 	q := r.query.Select("client")
@@ -276,6 +309,100 @@ func (r *Valkey) Client(host string, password *Secret, security *ValkeyClientSec
 	q = q.Arg("security", security)
 
 	return &ValkeyClient{
+		query: q,
+	}
+}
+
+// ValkeyClusterOpts contains options for Valkey.Cluster
+type ValkeyClusterOpts struct {
+	Name string // valkey (../../../../../daggerverse/valkey/cluster.go:112:2)
+
+	// Default: "docker.io"
+	Registry string // valkey (../../../../../daggerverse/valkey/cluster.go:114:2)
+
+	// Default: "9.1"
+	Tag string // valkey (../../../../../daggerverse/valkey/cluster.go:116:2)
+
+	// Default: 3
+	Shards int // valkey (../../../../../daggerverse/valkey/cluster.go:118:2)
+
+	ReplicasPerShard int // valkey (../../../../../daggerverse/valkey/cluster.go:120:2)
+}
+
+// Cluster describes a Valkey Cluster: `shards` primaries sharing the
+// 16384 hash slots, each with `replicasPerShard` replicas.
+//
+// Image: `<registry>/valkey/valkey:<tag>` for every node — the topology
+// is deliberately homogeneous.
+//
+// Rejected inputs (each a descriptive error rather than a half-formed
+// cluster):
+//
+//   - `password == nil` — the same secret is every node's `requirepass`
+//     and every replica's `masterauth`, so it is mandatory.
+//   - `clientListenerSecurity == nil` — plaintext must be a deliberate
+//     caller choice, exactly as for a single Server.
+//   - a TLS or MTLS profile — see the note below.
+//   - `shards < 3` — see minClusterShards.
+//   - `replicasPerShard < 0` — nonsense rather than a topology.
+//
+// TLS/mTLS is not supported for this topology yet, for the reason
+// Replication does not support it and one more besides: a TLS node runs
+// with `--port 0`, so the cluster bus would have to run over TLS too
+// (`--tls-cluster yes`), and each peer would need trust material a
+// client-facing `*ServerSecurity` profile does not carry. On top of that
+// the bootstrap runs through `valkey-cli --cluster create`, which would
+// need its own `--tls` / `--cacert` material to reach the nodes at all. A
+// TLS/mTLS profile is therefore rejected here rather than booting a
+// cluster whose members spin on a failed handshake.
+//
+// Like Valkey.Server and unlike its own doc-level description, this
+// constructor starts nothing: it validates, builds every node, and
+// composes the bootstrap exec, all lazily. Both entry points into a
+// running cluster — Cluster.Client and Cluster.BindNodes — drive that
+// bootstrap themselves, because a Dagger service is only reachable from
+// whichever client started it. Starting the nodes here (from the valkey
+// module's runtime) would register them in the valkey module's DNS
+// domain, and a consumer container binding them from ANOTHER module then
+// cannot resolve them at all — the same trap Server.Endpoint documents,
+// which is why BindNodes has to be able to bring the cluster up itself.
+//
+// Session-cached for the same reason Valkey.Server and
+// Valkey.Replication are: repeated chained calls on the returned cluster
+// within one test must observe the SAME backing services — and the same
+// bootstrap exec — and therefore the same keyspace. `name` folds into
+// that cache key and into every node's hostname, so parallel test suites
+// should pass a unique value per test.
+func (r *Valkey) Cluster(password *Secret, clientListenerSecurity *ValkeyServerSecurity, opts ...ValkeyClusterOpts) *ValkeyCluster { // valkey (../../../../../daggerverse/valkey/cluster.go:109:1)
+	assertNotNil("password", password)
+	assertNotNil("clientListenerSecurity", clientListenerSecurity)
+	q := r.query.Select("cluster")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `name` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Name) {
+			q = q.Arg("name", opts[i].Name)
+		}
+		// `registry` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Registry) {
+			q = q.Arg("registry", opts[i].Registry)
+		}
+		// `tag` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Tag) {
+			q = q.Arg("tag", opts[i].Tag)
+		}
+		// `shards` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Shards) {
+			q = q.Arg("shards", opts[i].Shards)
+		}
+		// `replicasPerShard` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ReplicasPerShard) {
+			q = q.Arg("replicasPerShard", opts[i].ReplicasPerShard)
+		}
+	}
+	q = q.Arg("password", password)
+	q = q.Arg("clientListenerSecurity", clientListenerSecurity)
+
+	return &ValkeyCluster{
 		query: q,
 	}
 }
@@ -582,7 +709,7 @@ func (r *Valkey) AsNode() Node {
 // connection so the function call is stateless from Dagger's
 // perspective; ApplyFile is the exception — it runs every command on one
 // connection.
-type ValkeyClient struct { // valkey (../../../../../daggerverse/valkey/client.go:34:6)
+type ValkeyClient struct { // valkey (../../../../../daggerverse/valkey/client.go:35:6)
 	query *querybuilder.Selection
 
 	applyFile *Void
@@ -611,7 +738,7 @@ func (r *ValkeyClient) WithGraphQLQuery(q *querybuilder.Selection) *ValkeyClient
 // whitespace, with single- and double-quoted runs kept intact so values
 // containing spaces survive; `\` escapes inside double quotes. A command
 // that fails aborts the run and reports the offending line number.
-func (r *ValkeyClient) ApplyFile(ctx context.Context, file *File) error { // valkey (../../../../../daggerverse/valkey/client.go:382:1)
+func (r *ValkeyClient) ApplyFile(ctx context.Context, file *File) error { // valkey (../../../../../daggerverse/valkey/client.go:490:1)
 	assertNotNil("file", file)
 	if r.applyFile != nil {
 		return nil
@@ -623,7 +750,7 @@ func (r *ValkeyClient) ApplyFile(ctx context.Context, file *File) error { // val
 }
 
 // DbSize returns the number of keys in the client's logical database.
-func (r *ValkeyClient) DbSize(ctx context.Context) (int, error) { // valkey (../../../../../daggerverse/valkey/client.go:507:1)
+func (r *ValkeyClient) DbSize(ctx context.Context) (int, error) { // valkey (../../../../../daggerverse/valkey/client.go:615:1)
 	if r.dbSize != nil {
 		return *r.dbSize, nil
 	}
@@ -636,7 +763,14 @@ func (r *ValkeyClient) DbSize(ctx context.Context) (int, error) { // valkey (../
 }
 
 // Del removes the given keys and returns how many actually existed.
-func (r *ValkeyClient) Del(ctx context.Context, keys []string) (int, error) { // valkey (../../../../../daggerverse/valkey/client.go:323:1)
+//
+// Against a cluster the keys are grouped by hash slot and one DEL is
+// issued per group: a single DEL naming keys from two slots is refused
+// outright with CROSSSLOT, because the slots may live on different
+// primaries and Valkey will not split a command across them. The groups
+// are pipelined with DoMulti, so a multi-slot delete still costs one
+// round trip per node rather than one per key.
+func (r *ValkeyClient) Del(ctx context.Context, keys []string) (int, error) { // valkey (../../../../../daggerverse/valkey/client.go:340:1)
 	if r.del != nil {
 		return *r.del, nil
 	}
@@ -659,7 +793,7 @@ func (r *ValkeyClient) Del(ctx context.Context, keys []string) (int, error) { //
 // through it. The reply comes back as a string rather than a
 // *dagger.File because a single command reply is small and a core scalar
 // keeps `dagger call do --args=GET,foo` readable.
-func (r *ValkeyClient) Do(ctx context.Context, args []string) (string, error) { // valkey (../../../../../daggerverse/valkey/client.go:207:1)
+func (r *ValkeyClient) Do(ctx context.Context, args []string) (string, error) { // valkey (../../../../../daggerverse/valkey/client.go:217:1)
 	if r.do != nil {
 		return *r.do, nil
 	}
@@ -673,7 +807,7 @@ func (r *ValkeyClient) Do(ctx context.Context, args []string) (string, error) { 
 }
 
 // FlushAll removes every key from every logical database on the node.
-func (r *ValkeyClient) FlushAll(ctx context.Context) error { // valkey (../../../../../daggerverse/valkey/client.go:524:1)
+func (r *ValkeyClient) FlushAll(ctx context.Context) error { // valkey (../../../../../daggerverse/valkey/client.go:632:1)
 	if r.flushAll != nil {
 		return nil
 	}
@@ -685,7 +819,7 @@ func (r *ValkeyClient) FlushAll(ctx context.Context) error { // valkey (../../..
 // Get returns the string value stored at key. A missing key is an error,
 // not an empty string — an empty string is itself a legitimate stored
 // value and must stay distinguishable from absence.
-func (r *ValkeyClient) Get(ctx context.Context, key string) (string, error) { // valkey (../../../../../daggerverse/valkey/client.go:265:1)
+func (r *ValkeyClient) Get(ctx context.Context, key string) (string, error) { // valkey (../../../../../daggerverse/valkey/client.go:275:1)
 	if r.get != nil {
 		return *r.get, nil
 	}
@@ -749,13 +883,13 @@ func (r *ValkeyClient) UnmarshalJSON(bs []byte) error {
 
 // ValkeyClientInfoOpts contains options for ValkeyClient.Info
 type ValkeyClientInfoOpts struct {
-	Section string // valkey (../../../../../daggerverse/valkey/client.go:489:2)
+	Section string // valkey (../../../../../daggerverse/valkey/client.go:597:2)
 }
 
 // Info returns the server's INFO output. An empty section returns the
 // default set; pass a section name (`"server"`, `"replication"`,
 // `"keyspace"`, …) to narrow it.
-func (r *ValkeyClient) Info(ctx context.Context, opts ...ValkeyClientInfoOpts) (string, error) { // valkey (../../../../../daggerverse/valkey/client.go:486:1)
+func (r *ValkeyClient) Info(ctx context.Context, opts ...ValkeyClientInfoOpts) (string, error) { // valkey (../../../../../daggerverse/valkey/client.go:594:1)
 	if r.info != nil {
 		return *r.info, nil
 	}
@@ -778,7 +912,15 @@ func (r *ValkeyClient) Info(ctx context.Context, opts ...ValkeyClientInfoOpts) (
 // It is SCAN-backed rather than KEYS-backed — KEYS blocks the server for
 // the whole sweep — and walks the cursor to exhaustion, so the result is
 // the complete match set and not just SCAN's first page.
-func (r *ValkeyClient) Keys(ctx context.Context, pattern string) ([]string, error) { // valkey (../../../../../daggerverse/valkey/client.go:348:1)
+//
+// Against a cluster it scans EVERY node rather than the one the client
+// happens to be seeded from. SCAN names no key, so a cluster client has
+// no slot to route it by and it is answered from whichever node it lands
+// on — reporting that node's shard of the keyspace as if it were the
+// whole thing. Replicas are scanned too (they answer SCAN locally rather
+// than redirecting) and the union is de-duplicated, so a replica lagging
+// its primary can only ever contribute keys the primary also reports.
+func (r *ValkeyClient) Keys(ctx context.Context, pattern string) ([]string, error) { // valkey (../../../../../daggerverse/valkey/client.go:417:1)
 	q := r.query.Select("keys")
 	q = q.Arg("pattern", pattern)
 
@@ -790,7 +932,7 @@ func (r *ValkeyClient) Keys(ctx context.Context, pattern string) ([]string, erro
 
 // Ping opens a connection and verifies the node is reachable and
 // accepting authenticated commands.
-func (r *ValkeyClient) Ping(ctx context.Context) error { // valkey (../../../../../daggerverse/valkey/client.go:186:1)
+func (r *ValkeyClient) Ping(ctx context.Context) error { // valkey (../../../../../daggerverse/valkey/client.go:196:1)
 	if r.ping != nil {
 		return nil
 	}
@@ -801,12 +943,12 @@ func (r *ValkeyClient) Ping(ctx context.Context) error { // valkey (../../../../
 
 // ValkeyClientSetOpts contains options for ValkeyClient.Set
 type ValkeyClientSetOpts struct {
-	TTL string // valkey (../../../../../daggerverse/valkey/client.go:291:2)
+	TTL string // valkey (../../../../../daggerverse/valkey/client.go:301:2)
 }
 
 // Set stores value at key. ttl is a Go duration string (`"250ms"`,
 // `"30s"`, `"5m"`); empty means no expiry.
-func (r *ValkeyClient) Set(ctx context.Context, key string, value string, opts ...ValkeyClientSetOpts) error { // valkey (../../../../../daggerverse/valkey/client.go:286:1)
+func (r *ValkeyClient) Set(ctx context.Context, key string, value string, opts ...ValkeyClientSetOpts) error { // valkey (../../../../../daggerverse/valkey/client.go:296:1)
 	if r.set != nil {
 		return nil
 	}
@@ -906,6 +1048,165 @@ func (r *ValkeyClientSecurity) AsNode() Node {
 	}
 }
 
+// Cluster is a slot-sharded Valkey Cluster: `shards` primaries splitting
+// the 16384-slot keyspace between them, each with `replicasPerShard`
+// replicas. Nodes holds every member — the first `shards` entries are the
+// primaries, the remainder their replicas — in the order valkey-cli is
+// handed them at bootstrap.
+//
+// Unlike Replication, the members are symmetric peers: each one gossips
+// with every other over the cluster bus, and none of them is "already up"
+// when its neighbours boot. That is what rules out node-to-node service
+// bindings here — see startAll.
+type ValkeyCluster struct { // valkey (../../../../../daggerverse/valkey/cluster.go:56:6)
+	query *querybuilder.Selection
+
+	id   *ID
+	stop *Void
+}
+
+func (r *ValkeyCluster) WithGraphQLQuery(q *querybuilder.Selection) *ValkeyCluster {
+	return &ValkeyCluster{
+		query: q,
+	}
+}
+
+// BindNodes attaches every member service to the given container under
+// the hostname it advertises, so the container can dial any of them at
+// the addresses Endpoints reports — and, just as importantly, can follow
+// a MOVED redirect to any other member, since a cluster client is told to
+// go to a node's *advertised* hostname rather than the one it dialed.
+// Binding only the seed node would leave every redirect unresolvable.
+//
+// The returned container also carries the bootstrap script's completion
+// marker. That file is never read; grafting it is what makes the
+// bootstrap a build-time dependency of whatever the consumer runs next,
+// so the container's first command meets a cluster whose slots are
+// already assigned rather than one answering CLUSTERDOWN.
+func (r *ValkeyCluster) BindNodes(ctr *Container) *Container { // valkey (../../../../../daggerverse/valkey/cluster.go:402:1)
+	assertNotNil("ctr", ctr)
+	q := r.query.Select("bindNodes")
+	q = q.Arg("ctr", ctr)
+
+	return &Container{
+		query: q,
+	}
+}
+
+// Client brings the cluster up and returns a cluster-aware valkey-go
+// Client seeded with every member's endpoint. valkey-go detects cluster
+// mode from the seed addresses (CLUSTER SLOTS), keeps its own slot map,
+// and follows MOVED/ASK redirects itself, so callers address the cluster
+// as one keyspace.
+//
+// The supplied ClientSecurity mode must match the cluster's listener
+// mode, which is PLAINTEXT for now; a mismatch returns an error naming
+// both modes rather than failing opaquely at the wire.
+//
+// The nodes are started explicitly (and concurrently — see startAll)
+// rather than left to the bootstrap exec's service bindings, because a
+// binding only wires the service into that one container's hosts file:
+// the returned valkey-go client dials from the module runtime, which
+// needs the hostnames in session DNS. Starting them here is also what
+// makes BindNodes unusable on the same cluster afterwards — see
+// Valkey.Cluster — so a consumer container should bind a cluster this
+// module has not already dialled.
+func (r *ValkeyCluster) Client(security *ValkeyClientSecurity) *ValkeyClient { // valkey (../../../../../daggerverse/valkey/cluster.go:430:1)
+	assertNotNil("security", security)
+	q := r.query.Select("client")
+	q = q.Arg("security", security)
+
+	return &ValkeyClient{
+		query: q,
+	}
+}
+
+// Endpoints returns every member's `host:6379` address, primaries first.
+// These are the addresses a cluster-aware client seeds from, and the
+// hostnames BindNodes makes reachable. Like Server.Endpoint it is a pure
+// accessor and starts nothing.
+//
+// Session-cached rather than never-cached: Dagger v0.21 detaches module
+// objects returned from a `module reads their fields lazily, and `tests/` is such a consumer.
+func (r *ValkeyCluster) Endpoints(ctx context.Context) ([]string, error) { // valkey (../../../../../daggerverse/valkey/cluster.go:380:1)
+	q := r.query.Select("endpoints")
+
+	var response []string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// A unique identifier for this ValkeyCluster.
+func (r *ValkeyCluster) ID(ctx context.Context) (ID, error) {
+	if r.id != nil {
+		return *r.id, nil
+	}
+	q := r.query.Select("id")
+
+	var response ID
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// XXX_GraphQLType is an internal function. It returns the native GraphQL type name
+func (r *ValkeyCluster) XXX_GraphQLType() string {
+	return "ValkeyCluster"
+}
+
+// XXX_GraphQLIDType is an internal function. It returns the native GraphQL type name for the ID of this object
+func (r *ValkeyCluster) XXX_GraphQLIDType() string {
+	return "ID"
+}
+
+// XXX_GraphQLID is an internal function. It returns the underlying type ID
+func (r *ValkeyCluster) XXX_GraphQLID(ctx context.Context) (string, error) {
+	id, err := r.ID(ctx)
+	if err != nil {
+		return "", err
+	}
+	return string(id), nil
+}
+
+func (r *ValkeyCluster) MarshalJSON() ([]byte, error) {
+	id, err := r.ID(marshalCtx)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(id)
+}
+func (r *ValkeyCluster) UnmarshalJSON(bs []byte) error {
+	var id string
+	err := json.Unmarshal(bs, &id)
+	if err != nil {
+		return err
+	}
+	*r = ValkeyCluster{query: selectNode(dag.query, id, "ValkeyCluster")}
+	return nil
+}
+
+// Stop tears down every member. Every node is attempted even if an
+// earlier one fails, and the failures are joined — a partial teardown
+// that reported only the first error would leave services running with
+// nothing naming them.
+func (r *ValkeyCluster) Stop(ctx context.Context) error { // valkey (../../../../../daggerverse/valkey/cluster.go:457:1)
+	if r.stop != nil {
+		return nil
+	}
+	q := r.query.Select("stop")
+
+	return q.Execute(ctx)
+}
+
+// AsNode returns this ValkeyCluster as a Node.
+// This is a local type conversion — no GraphQL call.
+func (r *ValkeyCluster) AsNode() Node {
+	return &NodeClient{
+		query: r.query,
+	}
+}
+
 // Replication is a primary/replica Valkey topology: one primary plus N
 // asynchronous read replicas. Nodes[0] is always the primary and the
 // remainder are its replicas, in the order they were created.
@@ -982,7 +1283,7 @@ func (r *ValkeyReplication) UnmarshalJSON(bs []byte) error {
 // objects returned from a `module reads their fields lazily, and `tests/` is such a consumer. The
 // methods on the returned *Server are individually never-cached, so no
 // data-returning call is served stale.
-func (r *ValkeyReplication) Primary() *ValkeyServer { // valkey (../../../../../daggerverse/valkey/replication.go:161:1)
+func (r *ValkeyReplication) Primary() *ValkeyServer { // valkey (../../../../../daggerverse/valkey/replication.go:162:1)
 	q := r.query.Select("primary")
 
 	return &ValkeyServer{
@@ -992,7 +1293,7 @@ func (r *ValkeyReplication) Primary() *ValkeyServer { // valkey (../../../../../
 
 // Replicas returns the topology's read replicas, in creation order.
 // Session-cached for the same reason Primary is.
-func (r *ValkeyReplication) Replicas(ctx context.Context) ([]ValkeyServer, error) { // valkey (../../../../../daggerverse/valkey/replication.go:172:1)
+func (r *ValkeyReplication) Replicas(ctx context.Context) ([]ValkeyServer, error) { // valkey (../../../../../daggerverse/valkey/replication.go:173:1)
 	q := r.query.Select("replicas")
 
 	q = q.Select("id")
@@ -1029,7 +1330,7 @@ func (r *ValkeyReplication) Replicas(ctx context.Context) ([]ValkeyServer, error
 // node is attempted even if an earlier one fails, and the failures are
 // joined — a partial teardown that reported only the first error would
 // leave services running with nothing naming them.
-func (r *ValkeyReplication) Stop(ctx context.Context) error { // valkey (../../../../../daggerverse/valkey/replication.go:186:1)
+func (r *ValkeyReplication) Stop(ctx context.Context) error { // valkey (../../../../../daggerverse/valkey/replication.go:187:1)
 	if r.stop != nil {
 		return nil
 	}
@@ -1068,7 +1369,7 @@ func (r *ValkeyServer) WithGraphQLQuery(q *querybuilder.Selection) *ValkeyServer
 // BindServer attaches the Valkey service to the given container under
 // the same hostname Endpoint reports, so the container can dial the node
 // at `Endpoint()` (e.g. `valkey-cli -h <host> -a <pw> PING`).
-func (r *ValkeyServer) BindServer(ctr *Container) *Container { // valkey (../../../../../daggerverse/valkey/server.go:238:1)
+func (r *ValkeyServer) BindServer(ctr *Container) *Container { // valkey (../../../../../daggerverse/valkey/server.go:245:1)
 	assertNotNil("ctr", ctr)
 	q := r.query.Select("bindServer")
 	q = q.Arg("ctr", ctr)
@@ -1086,7 +1387,7 @@ func (r *ValkeyServer) BindServer(ctr *Container) *Container { // valkey (../../
 // rather than failing opaquely at the wire. Readiness is then probed
 // with the client itself, so a TLS / mTLS listener would be polled over
 // TLS using the caller's own cert material.
-func (r *ValkeyServer) Client(security *ValkeyClientSecurity) *ValkeyClient { // valkey (../../../../../daggerverse/valkey/server.go:252:1)
+func (r *ValkeyServer) Client(security *ValkeyClientSecurity) *ValkeyClient { // valkey (../../../../../daggerverse/valkey/server.go:259:1)
 	assertNotNil("security", security)
 	q := r.query.Select("client")
 	q = q.Arg("security", security)
@@ -1107,7 +1408,7 @@ func (r *ValkeyServer) Client(security *ValkeyClientSecurity) *ValkeyClient { //
 // would register the service in the module's DNS domain, which the
 // binding's host-file lookup can't resolve from a session-domain
 // consumer — so the start must be driven by the binding, not here.
-func (r *ValkeyServer) Endpoint(ctx context.Context) (string, error) { // valkey (../../../../../daggerverse/valkey/server.go:211:1)
+func (r *ValkeyServer) Endpoint(ctx context.Context) (string, error) { // valkey (../../../../../daggerverse/valkey/server.go:218:1)
 	if r.endpoint != nil {
 		return *r.endpoint, nil
 	}
@@ -1171,7 +1472,7 @@ func (r *ValkeyServer) UnmarshalJSON(bs []byte) error {
 // Password returns the `requirepass` secret the node was provisioned
 // with, so callers can re-use it via Valkey.Client against the same
 // endpoint.
-func (r *ValkeyServer) Password() *Secret { // valkey (../../../../../daggerverse/valkey/server.go:229:1)
+func (r *ValkeyServer) Password() *Secret { // valkey (../../../../../daggerverse/valkey/server.go:236:1)
 	q := r.query.Select("password")
 
 	return &Secret{
@@ -1183,7 +1484,7 @@ func (r *ValkeyServer) Password() *Secret { // valkey (../../../../../daggervers
 // call this in a defer so the service span closes when the test returns.
 // SIGKILL skips graceful shutdown — Valkey's save-on-shutdown path is
 // wasted work for a torn-down test node.
-func (r *ValkeyServer) Stop(ctx context.Context) error { // valkey (../../../../../daggerverse/valkey/server.go:288:1)
+func (r *ValkeyServer) Stop(ctx context.Context) error { // valkey (../../../../../daggerverse/valkey/server.go:295:1)
 	if r.stop != nil {
 		return nil
 	}
@@ -1195,7 +1496,7 @@ func (r *ValkeyServer) Stop(ctx context.Context) error { // valkey (../../../../
 // User returns the ACL user clients authenticate as. `requirepass` sets
 // the password of the built-in `default` user, so this is always
 // "default" in this story; an ACL-file follow-up is what makes it vary.
-func (r *ValkeyServer) User(ctx context.Context) (string, error) { // valkey (../../../../../daggerverse/valkey/server.go:220:1)
+func (r *ValkeyServer) User(ctx context.Context) (string, error) { // valkey (../../../../../daggerverse/valkey/server.go:227:1)
 	if r.user != nil {
 		return *r.user, nil
 	}

--- a/daggerverse/valkey/tests/main.go
+++ b/daggerverse/valkey/tests/main.go
@@ -58,6 +58,9 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("Replication", func(ctx context.Context) error {
 		return t.Replication(ctx, parallel)
 	})
+	jobs = jobs.WithJob("Cluster", func(ctx context.Context) error {
+		return t.Cluster(ctx, parallel)
+	})
 	return jobs.Run(ctx)
 }
 
@@ -81,6 +84,8 @@ func (t *Tests) Validation(
 	jobs = jobs.WithJob("server-rejects-nil-security", t.ServerRejectsNilSecurity)
 	jobs = jobs.WithJob("replication-rejects-too-few-replicas", t.ReplicationRejectsTooFewReplicas)
 	jobs = jobs.WithJob("replication-rejects-tls-security", t.ReplicationRejectsTlsSecurity)
+	jobs = jobs.WithJob("cluster-rejects-too-few-shards", t.ClusterRejectsTooFewShards)
+	jobs = jobs.WithJob("cluster-rejects-tls-security", t.ClusterRejectsTlsSecurity)
 	return jobs.Run(ctx)
 }
 
@@ -108,6 +113,39 @@ func (t *Tests) Replication(
 	jobs = jobs.WithJob("replication-link-authenticates", t.ReplicationLinkAuthenticates)
 	jobs = jobs.WithJob("replication-nodes-have-distinct-hostnames", t.ReplicationNodesHaveDistinctHostnames)
 	jobs = jobs.WithJob("replication-stop-terminates-every-node", t.ReplicationStopTerminatesEveryNode)
+	return jobs.Run(ctx)
+}
+
+// Cluster runs the slot-sharded Valkey Cluster tests. Each test boots its
+// own cluster via bootCluster, whose runtime-random name folds into
+// Valkey.Cluster's session-cache key and into every node's hostname, so
+// concurrent tests get independent clusters.
+//
+// These are the most expensive tests in the suite — the smallest legal
+// cluster is three nodes, and every one of them has to boot before the
+// bootstrap can even start — so they get their own aggregator rather than
+// riding along with the single-node groups.
+//
+// +check
+// +cache="session"
+func (t *Tests) Cluster(
+	ctx context.Context,
+	// +default=0
+	parallel int,
+) error {
+	jobs := par.New().
+		WithRollupLogs(true).
+		WithRollupSpans(true)
+	if parallel > 0 {
+		jobs = jobs.WithLimit(parallel)
+	}
+	jobs = jobs.WithJob("cluster-reports-formed-state", t.ClusterReportsFormedState)
+	jobs = jobs.WithJob("cluster-advertises-pinned-hostnames", t.ClusterAdvertisesPinnedHostnames)
+	jobs = jobs.WithJob("cluster-round-trips-keys-across-slots", t.ClusterRoundTripsKeysAcrossSlots)
+	jobs = jobs.WithJob("cluster-keys-scans-every-shard", t.ClusterKeysScansEveryShard)
+	jobs = jobs.WithJob("cluster-del-spans-multiple-slots", t.ClusterDelSpansMultipleSlots)
+	jobs = jobs.WithJob("cluster-bind-nodes-reachable-from-consumer", t.ClusterBindNodesReachableFromConsumer)
+	jobs = jobs.WithJob("cluster-stop-terminates-every-node", t.ClusterStopTerminatesEveryNode)
 	return jobs.Run(ctx)
 }
 
@@ -380,6 +418,88 @@ func (t *Tests) ReplicationRejectsTlsSecurity(ctx context.Context) error {
 	_, err = rep.Primary().Endpoint(ctx)
 	if err == nil {
 		return fmt.Errorf("expected a TLS Replication topology to be rejected")
+	}
+	if !strings.Contains(err.Error(), "TLS") {
+		return fmt.Errorf("expected the rejection to name TLS, got: %v", err)
+	}
+	return nil
+}
+
+// ClusterRejectsTooFewShards verifies a sub-quorum cluster is refused
+// with an explanation rather than booting. Valkey Cluster agrees slot
+// ownership by a majority vote of the primaries, so two primaries can
+// never form a quorum once one is unreachable and one primary is a
+// standalone node wearing a cluster hat — either would boot into a
+// topology that looks healthy right up until it has to agree on
+// something.
+//
+// The guard is checked before anything starts, so this test costs no
+// containers.
+//
+// +cache="never"
+func (t *Tests) ClusterRejectsTooFewShards(ctx context.Context) error {
+	name, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+	pass, err := randSecret(ctx)
+	if err != nil {
+		return err
+	}
+	for _, shards := range []int{1, 2} {
+		cluster := dag.Valkey().Cluster(
+			pass,
+			dag.Valkey().PlaintextServerSecurity(),
+			dagger.ValkeyClusterOpts{Name: name, Shards: shards},
+		)
+		_, err := cluster.Endpoints(ctx)
+		if err == nil {
+			return fmt.Errorf("expected Cluster(shards=%d) to be rejected, but it built a topology", shards)
+		}
+		if !strings.Contains(err.Error(), "shards") {
+			return fmt.Errorf("expected the shards=%d rejection to name the shards argument, got: %v", shards, err)
+		}
+		if !strings.Contains(err.Error(), "quorum") {
+			return fmt.Errorf("expected the shards=%d rejection to explain the quorum requirement, got: %v", shards, err)
+		}
+	}
+	return nil
+}
+
+// ClusterRejectsTlsSecurity verifies a TLS listener profile is refused
+// with an explanation rather than booting peers that spin forever on a
+// failed handshake: a TLS node runs with `--port 0`, so the cluster bus
+// would also have to run over TLS, and neither the peers nor the
+// valkey-cli that bootstraps them get the trust material they'd need from
+// a client-listener ServerSecurity.
+//
+// +cache="never"
+func (t *Tests) ClusterRejectsTlsSecurity(ctx context.Context) error {
+	name, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+	pass, err := randSecret(ctx)
+	if err != nil {
+		return err
+	}
+	ca, err := freshCa(ctx, "vk-cluster-tls")
+	if err != nil {
+		return err
+	}
+	// SAN value is irrelevant: the guard rejects before any node boots.
+	cert, key, err := issueServerCert(ctx, ca, "valkey-placeholder", "vk-cluster-tls-server")
+	if err != nil {
+		return err
+	}
+	cluster := dag.Valkey().Cluster(
+		pass,
+		dag.Valkey().TLSServerSecurity(cert, key),
+		dagger.ValkeyClusterOpts{Name: name},
+	)
+	_, err = cluster.Endpoints(ctx)
+	if err == nil {
+		return fmt.Errorf("expected a TLS Cluster topology to be rejected")
 	}
 	if !strings.Contains(err.Error(), "TLS") {
 		return fmt.Errorf("expected the rejection to name TLS, got: %v", err)
@@ -2073,6 +2193,429 @@ func (t *Tests) BindServerReachableUnderTls(ctx context.Context) error {
 	}
 	if !strings.Contains(out, "PONG") {
 		return fmt.Errorf("expected PONG over TLS from %s, got %q", host, out)
+	}
+	return nil
+}
+
+// -----------------------------------------------------------------------------
+// Cluster tests — slot-sharded Valkey Cluster.
+//
+// Valkey.Cluster boots every node and bootstraps the slot assignment
+// before it returns, so unlike the other topologies there is nothing to
+// ready here: by the time a test can call a method on the cluster, the
+// cluster is formed. What these tests pin is that the formation is real
+// (every node agrees, every node advertises a routable identity of its
+// own) and that the client addresses the whole sharded keyspace rather
+// than the one shard it happened to seed from.
+// -----------------------------------------------------------------------------
+
+// bootCluster mints a fresh Valkey Cluster and returns it with the
+// password secret every node shares. The cluster name is a runtime-random
+// value that folds into Valkey.Cluster's +cache="session" key and into
+// each node's hostname, so concurrent tests get independent clusters.
+func bootCluster(ctx context.Context, shards, replicasPerShard int) (*dagger.ValkeyCluster, *dagger.Secret, error) {
+	name, err := randHex(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	pass, err := randSecret(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	cluster := dag.Valkey().Cluster(
+		pass,
+		dag.Valkey().PlaintextServerSecurity(),
+		dagger.ValkeyClusterOpts{Name: name, Shards: shards, ReplicasPerShard: replicasPerShard},
+	)
+	return cluster, pass, nil
+}
+
+// ClusterReportsFormedState verifies the bootstrap actually happened: the
+// cluster reports cluster_state:ok (every one of the 16384 slots is owned
+// by some primary) and knows exactly as many nodes as were booted.
+//
+// The node count is the half that catches a cluster which formed but
+// didn't finish: a node whose gossip never reached the others still
+// reports state:ok for the slots it can see, and only cluster_known_nodes
+// gives it away.
+//
+// +cache="never"
+func (t *Tests) ClusterReportsFormedState(ctx context.Context) error {
+	const shards, replicasPerShard = 3, 1
+	cluster, _, err := bootCluster(ctx, shards, replicasPerShard)
+	if err != nil {
+		return err
+	}
+	info, err := cluster.Client(dag.Valkey().PlaintextClientSecurity()).
+		Do(ctx, []string{"CLUSTER", "INFO"})
+	if err != nil {
+		return fmt.Errorf("cluster info: %w", err)
+	}
+	if !strings.Contains(info, "cluster_state:ok") {
+		return fmt.Errorf("expected cluster_state:ok, got:\n%s", info)
+	}
+	wantNodes := fmt.Sprintf("cluster_known_nodes:%d", shards*(1+replicasPerShard))
+	if !strings.Contains(info, wantNodes) {
+		return fmt.Errorf("expected %s, got:\n%s", wantNodes, info)
+	}
+	return nil
+}
+
+// ClusterAdvertisesPinnedHostnames verifies every node self-identifies
+// with its own pinned hostname rather than falling back to localhost.
+//
+// This is the failure that looks like success. A node that cannot work
+// out a routable identity announces the loopback address, and every peer
+// dutifully records it — so each peer, following a MOVED redirect to
+// "another" node, dials itself. The cluster never forms, or forms and
+// then answers for the wrong shard, and CLUSTER INFO alone would not say
+// why. Asserting the announced identity is what pins the fix.
+//
+// +cache="never"
+func (t *Tests) ClusterAdvertisesPinnedHostnames(ctx context.Context) error {
+	cluster, _, err := bootCluster(ctx, 3, 1)
+	if err != nil {
+		return err
+	}
+	endpoints, err := cluster.Endpoints(ctx)
+	if err != nil {
+		return fmt.Errorf("endpoints: %w", err)
+	}
+	nodes, err := cluster.Client(dag.Valkey().PlaintextClientSecurity()).
+		Do(ctx, []string{"CLUSTER", "NODES"})
+	if err != nil {
+		return fmt.Errorf("cluster nodes: %w", err)
+	}
+	for _, endpoint := range endpoints {
+		host, _, _ := strings.Cut(endpoint, ":")
+		if !strings.Contains(nodes, host) {
+			return fmt.Errorf("expected %s to appear in CLUSTER NODES, got:\n%s", host, nodes)
+		}
+	}
+	for _, loopback := range []string{"localhost", "127.0.0.1"} {
+		if strings.Contains(nodes, loopback) {
+			return fmt.Errorf("expected no node to advertise %s, got:\n%s", loopback, nodes)
+		}
+	}
+	return nil
+}
+
+// ClusterRoundTripsKeysAcrossSlots verifies one Client addresses the
+// whole sharded keyspace. The keys are chosen to land on different slots
+// (distinct random names, no `{...}` hashtag to pin them together), so
+// writing and reading them all back through a single client means the
+// client followed MOVED redirects to whichever primary owns each slot —
+// and that every one of those primaries was reachable at the hostname it
+// advertised.
+//
+// A client that silently talked to one node would fail the write, not the
+// read: a key that hashes elsewhere is refused with MOVED, never stored
+// locally.
+//
+// +cache="never"
+func (t *Tests) ClusterRoundTripsKeysAcrossSlots(ctx context.Context) error {
+	cluster, _, err := bootCluster(ctx, 3, 0)
+	if err != nil {
+		return err
+	}
+	client := cluster.Client(dag.Valkey().PlaintextClientSecurity())
+
+	// Enough keys that the odds of all of them hashing into slots owned by
+	// a single primary are negligible; ClusterKeysScansEveryShard is what
+	// actually proves the spread happened.
+	const keyCount = 24
+	values := make(map[string]string, keyCount)
+	for i := 0; i < keyCount; i++ {
+		key, err := randHex(ctx)
+		if err != nil {
+			return err
+		}
+		value, err := randHex(ctx)
+		if err != nil {
+			return err
+		}
+		values[key] = value
+		if err := client.Set(ctx, key, value); err != nil {
+			return fmt.Errorf("set %s: %w", key, err)
+		}
+	}
+	for key, want := range values {
+		got, err := client.Get(ctx, key)
+		if err != nil {
+			return fmt.Errorf("get %s: %w", key, err)
+		}
+		if got != want {
+			return fmt.Errorf("expected %q at %s, got %q", want, key, got)
+		}
+	}
+	return nil
+}
+
+// clusterNodeClients returns a standalone (non-cluster) client per node,
+// each pinned to the one node it names. Cluster-wide assertions can't see
+// the shard split — a cluster client deliberately hides it — so anything
+// that needs to know which node actually holds what goes through these.
+func clusterNodeClients(ctx context.Context, cluster *dagger.ValkeyCluster, pass *dagger.Secret) ([]*dagger.ValkeyClient, error) {
+	endpoints, err := cluster.Endpoints(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("endpoints: %w", err)
+	}
+	clients := make([]*dagger.ValkeyClient, 0, len(endpoints))
+	for _, endpoint := range endpoints {
+		host, _, _ := strings.Cut(endpoint, ":")
+		clients = append(clients, dag.Valkey().Client(host, pass, dag.Valkey().PlaintextClientSecurity()))
+	}
+	return clients, nil
+}
+
+// ClusterKeysScansEveryShard verifies Keys reports the whole match set
+// across the sharded keyspace, not just the shard its seed node owns.
+//
+// SCAN names no key, so a cluster client has no slot to route it by and
+// the command is answered by whichever node it lands on — an
+// implementation that scanned one node would return roughly 1/shards of
+// the keys and look plausible. The test therefore asserts twice: that
+// every seeded key comes back, and (via per-node DbSize) that the keys
+// really were split across more than one primary, so the first assertion
+// can't pass vacuously on a cluster that happened to pile everything into
+// one shard.
+//
+// +cache="never"
+func (t *Tests) ClusterKeysScansEveryShard(ctx context.Context) error {
+	const shards = 3
+	cluster, pass, err := bootCluster(ctx, shards, 0)
+	if err != nil {
+		return err
+	}
+	prefix, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+	decoy, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+
+	// No `{...}` hashtag anywhere, so each key hashes on its own and the
+	// set spreads over the slot space — and therefore over the primaries.
+	const n = 300
+	var seed strings.Builder
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&seed, "SET %s:%04d %d\n", prefix, i, i)
+	}
+	for i := 0; i < 10; i++ {
+		fmt.Fprintf(&seed, "SET %s:%04d %d\n", decoy, i, i)
+	}
+
+	client := cluster.Client(dag.Valkey().PlaintextClientSecurity())
+	if err := client.ApplyFile(ctx, commandFile(seed.String())); err != nil {
+		return fmt.Errorf("seed keys: %w", err)
+	}
+
+	nodes, err := clusterNodeClients(ctx, cluster, pass)
+	if err != nil {
+		return err
+	}
+	holding := 0
+	for i, node := range nodes {
+		size, err := node.DbSize(ctx)
+		if err != nil {
+			return fmt.Errorf("dbsize on node %d: %w", i, err)
+		}
+		if size > 0 {
+			holding++
+		}
+		if size == n+10 {
+			return fmt.Errorf("expected the keyspace to be sharded, but node %d holds all %d keys", i, size)
+		}
+	}
+	if holding < 2 {
+		return fmt.Errorf("expected the seeded keys to span more than one primary, only %d node(s) hold any", holding)
+	}
+
+	keys, err := client.Keys(ctx, prefix+":*")
+	if err != nil {
+		return fmt.Errorf("keys: %w", err)
+	}
+	if len(keys) != n {
+		return fmt.Errorf("expected %d keys across every shard, got %d", n, len(keys))
+	}
+	seen := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		if !strings.HasPrefix(k, prefix+":") {
+			return fmt.Errorf("expected only %s:* keys, got %q", prefix, k)
+		}
+		seen[k] = struct{}{}
+	}
+	if len(seen) != n {
+		return fmt.Errorf("expected %d distinct keys, got %d (shard results likely overlap)", n, len(seen))
+	}
+	return nil
+}
+
+// ClusterDelSpansMultipleSlots verifies Del handles keys that hash to
+// different slots. A single DEL naming two slots is refused outright with
+// CROSSSLOT — the slots may live on different primaries and Valkey will
+// not split a command across them — so an implementation that passed the
+// whole list through fails here rather than deleting a partial set.
+//
+// One key in the list never existed, so a Del that reported the number of
+// keys it was asked about rather than the number it removed is caught
+// too.
+//
+// +cache="never"
+func (t *Tests) ClusterDelSpansMultipleSlots(ctx context.Context) error {
+	cluster, _, err := bootCluster(ctx, 3, 0)
+	if err != nil {
+		return err
+	}
+	prefix, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+	client := cluster.Client(dag.Valkey().PlaintextClientSecurity())
+
+	const seeded = 12
+	keys := make([]string, 0, seeded+1)
+	for i := 0; i < seeded; i++ {
+		key := fmt.Sprintf("%s:%02d", prefix, i)
+		if err := client.Set(ctx, key, key); err != nil {
+			return fmt.Errorf("seed %s: %w", key, err)
+		}
+		keys = append(keys, key)
+	}
+	keys = append(keys, prefix+":never-existed")
+
+	deleted, err := client.Del(ctx, keys)
+	if err != nil {
+		return fmt.Errorf("del across slots: %w", err)
+	}
+	if deleted != seeded {
+		return fmt.Errorf("expected Del to report %d removed keys, got %d", seeded, deleted)
+	}
+	survivors, err := client.Keys(ctx, prefix+":*")
+	if err != nil {
+		return fmt.Errorf("keys: %w", err)
+	}
+	if len(survivors) != 0 {
+		return fmt.Errorf("expected no surviving keys, got %v", survivors)
+	}
+	return nil
+}
+
+// ClusterBindNodesReachableFromConsumer verifies BindNodes wires EVERY
+// member into a consumer container, not just a seed. A cluster client is
+// redirected to a node's advertised hostname, so a container that could
+// only resolve one of them would work right up until the first key that
+// hashes elsewhere. The probe therefore pings every endpoint in turn from
+// inside the container, using valkey-cli rather than the module's own
+// client so the reachability being tested is the container's.
+//
+// It then writes and reads a set of keys through `valkey-cli -c`, which
+// follows MOVED redirects the way any cluster client would. That covers
+// the second half of BindNodes' contract: the container meets a cluster
+// whose slots are already assigned. Against an unbootstrapped cluster
+// every one of those writes would come back CLUSTERDOWN, no matter how
+// reachable the nodes were.
+//
+// The whole probe runs in one exec so a partial failure names the node it
+// failed on rather than surfacing as an opaque non-zero exit.
+//
+// +cache="never"
+func (t *Tests) ClusterBindNodesReachableFromConsumer(ctx context.Context) error {
+	cluster, pass, err := bootCluster(ctx, 3, 0)
+	if err != nil {
+		return err
+	}
+	endpoints, err := cluster.Endpoints(ctx)
+	if err != nil {
+		return fmt.Errorf("endpoints: %w", err)
+	}
+	prefix, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+	ctr := cluster.BindNodes(
+		dag.Container().
+			From("docker.io/valkey/valkey:9.1-alpine").
+			WithSecretVariable("VALKEY_PW", pass),
+	)
+	probe := fmt.Sprintf(`set -u
+seed=""
+for ep in %s; do
+  host=${ep%%%%:*}; port=${ep#*:}
+  out=$(valkey-cli --no-auth-warning -h "$host" -p "$port" -a "$VALKEY_PW" PING 2>&1)
+  case "$out" in
+    *PONG*) echo "$host PONG";;
+    *) echo "$host UNREACHABLE: $out"; exit 1;;
+  esac
+  [ -n "$seed" ] || seed="$host $port"
+done
+set -- $seed
+for i in 0 1 2 3 4 5 6 7 8 9; do
+  key="%s:$i"
+  valkey-cli -c --no-auth-warning -h "$1" -p "$2" -a "$VALKEY_PW" SET "$key" "$i" >/dev/null
+  got=$(valkey-cli -c --no-auth-warning -h "$1" -p "$2" -a "$VALKEY_PW" GET "$key" 2>&1)
+  [ "$got" = "$i" ] || { echo "expected $i at $key, got: $got"; exit 1; }
+done
+echo "CLUSTER ROUND TRIP OK"
+`, strings.Join(endpoints, " "), prefix)
+	out, err := ctr.WithExec([]string{"sh", "-c", probe}).Stdout(ctx)
+	if err != nil {
+		return fmt.Errorf("valkey-cli probe of every bound node: %w", err)
+	}
+	for _, endpoint := range endpoints {
+		host, _, _ := strings.Cut(endpoint, ":")
+		if !strings.Contains(out, host+" PONG") {
+			return fmt.Errorf("expected PONG from %s, got:\n%s", host, out)
+		}
+	}
+	if !strings.Contains(out, "CLUSTER ROUND TRIP OK") {
+		return fmt.Errorf("expected a cluster-mode round trip from the bound container, got:\n%s", out)
+	}
+	return nil
+}
+
+// ClusterStopTerminatesEveryNode verifies no member answers once Stop
+// returns. The post-Stop probes go through the standalone constructor on
+// purpose: a cluster client would be free to route its command to
+// whichever node it liked, so a Stop that missed one node could still
+// look dead — or, worse, look alive.
+//
+// Cluster members have no service bindings between them, so unlike the
+// replication topology there is no dependency teardown to hide behind:
+// every node that is still up after Stop is a node Stop failed to kill.
+//
+// +cache="never"
+func (t *Tests) ClusterStopTerminatesEveryNode(ctx context.Context) error {
+	cluster, pass, err := bootCluster(ctx, 3, 0)
+	if err != nil {
+		return err
+	}
+	// Bring the cluster up first: Valkey.Cluster starts nothing, so until
+	// something drives the bootstrap there is no service for a standalone
+	// client to even resolve.
+	if err := cluster.Client(dag.Valkey().PlaintextClientSecurity()).Ping(ctx); err != nil {
+		return fmt.Errorf("ping cluster: %w", err)
+	}
+	nodes, err := clusterNodeClients(ctx, cluster, pass)
+	if err != nil {
+		return err
+	}
+	// Ready every node, so a failed probe after Stop means Stop killed it
+	// and not that it had never come up.
+	for i, node := range nodes {
+		if err := node.Ping(ctx); err != nil {
+			return fmt.Errorf("ping node %d before stop: %w", i, err)
+		}
+	}
+	if err := cluster.Stop(ctx); err != nil {
+		return fmt.Errorf("stop: %w", err)
+	}
+	for i, node := range nodes {
+		if err := node.Ping(ctx); err == nil {
+			return fmt.Errorf("expected node %d to be down after Stop, but it still answered", i)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #199.

Adds `Valkey.Cluster`: `shards` primaries splitting the 16384 hash slots between them, each with `replicasPerShard` replicas, bootstrapped with `valkey-cli --cluster create --cluster-yes --cluster-replicas N`.

```go
Valkey.Cluster(ctx, name="", registry="docker.io", tag="9.1", shards=3, replicasPerShard=0,
               password *dagger.Secret, clientListenerSecurity *ServerSecurity) (*Cluster, error)
Cluster.Endpoints() []string                            // +cache="session"
Cluster.BindNodes(*dagger.Container) *dagger.Container  // +cache="never"
Cluster.Client(ctx, security *ClientSecurity) (*Client, error)
Cluster.Stop(ctx) error
```

`buildServer` grows an `extraPorts` parameter so a member can expose the cluster bus (6379 + 10000) alongside its client listener.

## The two failure modes the issue called out

**Symmetric peers, so no bindings between them.** Members gossip over the bus port and none is "already up" when its neighbours boot, so a node-to-node `WithServiceBinding` deadlocks. The nodes carry no bindings at all; `startAll` boots them concurrently and they find each other by hostname over session DNS — the same shape as `daggerverse/kafka`'s Redpanda cluster (#166).

**Every node advertises a routable identity.** Each member boots with `--cluster-announce-ip <its WithHostname alias>`, `--cluster-announce-port 6379`, `--cluster-announce-bus-port 16379`, plus `--masterauth` so a replica can sync from the primary it is assigned at bootstrap. The announce address is the hostname rather than an IP on purpose: the container IP is unknown until the service starts and changes between sessions, whereas the alias is stable and resolvable from every peer, from the module runtime, and — via `BindNodes` — from a consumer container. `cluster-advertises-pinned-hostnames` asserts every hostname appears in `CLUSTER NODES` and that neither `localhost` nor `127.0.0.1` does.

## Bootstrap is lazy, and that is a deliberate deviation from the issue's sketch

The issue has `Valkey.Cluster` boot and bootstrap eagerly in the constructor. That was built first, and it broke the `BindNodes` acceptance criterion outright:

```
lookup valkey-e6f0110a2bb3 for hosts file: lookup valkey-e6f0110a2bb3 on 10.87.0.1:53: no such host
```

A Dagger service is only resolvable from the client that started it. Bootstrapping in the constructor pins every node to the *valkey module's* DNS domain, and a consumer container in `tests/` then cannot resolve them when binding — the same trap `Server.Endpoint`'s comment already documents for the single-node case. This is a known Dagger limitation that has been reported upstream; if it is fixed, the lazy bootstrap can collapse back into the constructor.

So `Valkey.Cluster` validates, builds every node, and *composes but does not run* the bootstrap exec. Whoever forces it drives the node services up as dependencies of their own request, in their own DNS domain:

- `Cluster.Client` starts the nodes explicitly (concurrently, via `startAll`) because valkey-go dials from the module runtime and needs the hostnames in session DNS, then `Sync`s the bootstrap exec.
- `BindNodes` grafts the bootstrap's completion marker file into the consumer container. The file is never read; grafting it is what makes the bootstrap a build-time dependency, so the container's first command meets a cluster whose slots are already assigned rather than one answering `CLUSTERDOWN`.

The bootstrap script therefore waits in the container rather than in Go — `BindNodes` returns a `*dagger.Container` and has neither a context nor an error to report through. It waits for every node to answer `PING` before `--cluster create` (the CLI aborts on the first node it cannot reach), then polls **every** node for `cluster_state:ok` *and* the full `cluster_known_nodes` afterwards, since slot ownership propagates by gossip and a node whose gossip never landed still reports `state:ok` for the slots it can see.

The exec carries a per-session nonce env var. Nothing else in its inputs changes between engine sessions — image, args, and hostnames all derive from `name` — so without it a second session with the same `name` would replay the first session's cached exec and hand back a cluster that was never actually bootstrapped.

**Known consequence, documented in code and README:** a cluster this module has already dialled via `Client` cannot then be bound by a consumer container. Bind a fresh one. `daggerverse/kafka`'s `RedpandaCluster` has the same constraint.

## Client-side rework

`Cluster.Client` returns a client seeded with every member (`ForceSingleClient` off), so valkey-go keeps its own slot map and follows MOVED/ASK. Two existing methods needed more than that:

- **`Keys`** scans *every* node rather than its seed. SCAN names no key, so a cluster client has no slot to route it by and it is answered by whichever node it lands on — reporting one shard as if it were the whole keyspace. Replicas are scanned too (they answer SCAN locally rather than redirecting) and the union is de-duplicated, so a lagging replica can only ever contribute keys its primary also reports. Nodes are walked in sorted address order so the result is stable between calls.
- **`Del`** groups keys by hash slot and pipelines one DEL per group via `DoMulti`. A single DEL naming two slots is refused with `CROSSSLOT`. valkey-go computes the slot while building a command but does not export the function, so the slot is read off a throwaway single-key command.

Both keep the standalone path byte-identical.

## Rejected inputs

`shards < 3` is refused with the quorum reasoning (slot ownership is agreed by a majority vote of the primaries, so two can never form a majority once one is unreachable, and one primary is a standalone node wearing a cluster hat). TLS/mTLS is refused for the reason `Replication` refuses it plus one more: the bus would need `--tls-cluster yes` and per-peer trust material a client-listener `*ServerSecurity` does not carry, and the bootstrapping `valkey-cli` would need its own `--tls`/`--cacert` on top. Moved to the module's follow-ups. Also refused: `password == nil`, `clientListenerSecurity == nil`, `replicasPerShard < 0`.

## Tests

New `+check` group `valkey-tests:cluster` — formed state (`cluster_state:ok` + `cluster_known_nodes`), pinned-hostname advertisement, cross-slot round trip through one client, `Keys` across every shard, `Del` spanning slots, `BindNodes` reachability, teardown — plus two validation tests in the existing group.

Two of them are deliberately non-vacuous:

- `cluster-keys-scans-every-shard` asserts via per-node `DbSize` that the 300 seeded keys really did land on more than one primary (and on no single one) *before* asserting `Keys` returns all of them, so it cannot pass against a cluster that happened to pile everything into one shard.
- `cluster-bind-nodes-reachable-from-consumer` pings every endpoint *and* does a `valkey-cli -c` SET/GET round trip, which returns `CLUSTERDOWN` against an unbootstrapped cluster — that half is what covers the marker-file dependency, not just reachability.

`dagger -m daggerverse/valkey/tests call all` passes. `dagger develop` re-run in the module, `tests/`, and the root `ci` module; `ci:generated` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
