### PR TITLE
story(issue-200): add valkey-server configuration passthrough

### DIFF
--- a/ci/internal/dagger/valkey-tests.gen.go
+++ b/ci/internal/dagger/valkey-tests.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type ValkeyTests
-func (r *Binding) AsValkeyTests() *ValkeyTests { // valkey-tests (../../../daggerverse/valkey/tests/main.go:26:6)
+func (r *Binding) AsValkeyTests() *ValkeyTests { // valkey-tests (../../../daggerverse/valkey/tests/main.go:28:6)
 	q := r.query.Select("asValkeyTests")
 
 	return &ValkeyTests{
@@ -19,7 +19,7 @@ func (r *Binding) AsValkeyTests() *ValkeyTests { // valkey-tests (../../../dagge
 }
 
 // Create or update a binding of type ValkeyTests in the environment
-func (r *Env) WithValkeyTestsInput(name string, value *ValkeyTests, description string) *Env { // valkey-tests (../../../daggerverse/valkey/tests/main.go:26:6)
+func (r *Env) WithValkeyTestsInput(name string, value *ValkeyTests, description string) *Env { // valkey-tests (../../../daggerverse/valkey/tests/main.go:28:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withValkeyTestsInput")
 	q = q.Arg("name", name)
@@ -32,7 +32,7 @@ func (r *Env) WithValkeyTestsInput(name string, value *ValkeyTests, description 
 }
 
 // Declare a desired ValkeyTests output to be assigned in the environment
-func (r *Env) WithValkeyTestsOutput(name string, description string) *Env { // valkey-tests (../../../daggerverse/valkey/tests/main.go:26:6)
+func (r *Env) WithValkeyTestsOutput(name string, description string) *Env { // valkey-tests (../../../daggerverse/valkey/tests/main.go:28:6)
 	q := r.query.Select("withValkeyTestsOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -48,9 +48,11 @@ func (r *Env) WithValkeyTestsOutput(name string, description string) *Env { // v
 // `dagger call all`.
 //
 // Every password, server name, and key prefix is minted at runtime via
-// dag.Random().Sha256. The ACL user deliberately uses the valkey
-// module's default ("default"), which a few tests assert against.
-func (r *Query) ValkeyTests() *ValkeyTests { // valkey-tests (../../../daggerverse/valkey/tests/main.go:26:6)
+// dag.Random().Sha256. Clients authenticate as the valkey module's
+// default ACL user ("default"), which a few tests assert against; the
+// configuration-passthrough tests are the exception, since an ACL file is
+// how a caller gets any other user at all.
+func (r *Query) ValkeyTests() *ValkeyTests { // valkey-tests (../../../daggerverse/valkey/tests/main.go:28:6)
 	q := r.query.Select("valkeyTests")
 
 	return &ValkeyTests{
@@ -58,63 +60,74 @@ func (r *Query) ValkeyTests() *ValkeyTests { // valkey-tests (../../../daggerver
 	}
 }
 
-type ValkeyTests struct { // valkey-tests (../../../daggerverse/valkey/tests/main.go:26:6)
+type ValkeyTests struct { // valkey-tests (../../../daggerverse/valkey/tests/main.go:28:6)
 	query *querybuilder.Selection
 
-	all                                   *Void
-	applyFileReportsFailingCommand        *Void
-	applyFileSeedsData                    *Void
-	bindServerReachableFromAlpine         *Void
-	bindServerReachableUnderTls           *Void
-	client                                *Void
-	clientPingWrongPasswordFails          *Void
-	cluster                               *Void
-	clusterAdvertisesPinnedHostnames      *Void
-	clusterBindNodesReachableFromConsumer *Void
-	clusterDelSpansMultipleSlots          *Void
-	clusterKeysScansEveryShard            *Void
-	clusterRejectsTlsSecurity             *Void
-	clusterRejectsTooFewShards            *Void
-	clusterReportsFormedState             *Void
-	clusterRoundTripsKeysAcrossSlots      *Void
-	clusterStopTerminatesEveryNode        *Void
-	dbSelectsLogicalDatabase              *Void
-	defaultsProduceHealthyServer          *Void
-	delRemovesKeys                        *Void
-	doReturnsJsonReplies                  *Void
-	endpointShouldNotBeCached             *Void
-	flushAllClearsKeys                    *Void
-	getMissingKeyFails                    *Void
-	getShouldNotBeCached                  *Void
-	id                                    *ID
-	infoReportsRole                       *Void
-	keysScansPattern                      *Void
-	mtlsNodeDemandsClientCertAtWire       *Void
-	mtlsServerRejectsTlsOnlyClient        *Void
-	passwordReusableViaClient             *Void
-	plaintextDialAgainstTlsNodeFails      *Void
-	replication                           *Void
-	replicationLinkAuthenticates          *Void
-	replicationNodesHaveDistinctHostnames *Void
-	replicationPropagatesWritesToReplica  *Void
-	replicationRejectsTlsSecurity         *Void
-	replicationRejectsTooFewReplicas      *Void
-	replicationReplicaRejectsWrites       *Void
-	replicationReportsRoles               *Void
-	replicationStopTerminatesEveryNode    *Void
-	sameNameServerSharesState             *Void
-	security                              *Void
-	server                                *Void
-	serverMtlsRoundTripFromClient         *Void
-	serverRejectsNilPassword              *Void
-	serverRejectsNilSecurity              *Void
-	serverTlsRoundTripFromClient          *Void
-	setGetRoundTrip                       *Void
-	setWithTtlExpires                     *Void
-	stopTerminatesServer                  *Void
-	tlsServerRejectsEmptyName             *Void
-	tlsServerRejectsPlaintextClient       *Void
-	validation                            *Void
+	aclFileProvisionsUser                  *Void
+	all                                    *Void
+	appendOnlyEnablesAof                   *Void
+	applyFileReportsFailingCommand         *Void
+	applyFileSeedsData                     *Void
+	bindServerReachableFromAlpine          *Void
+	bindServerReachableUnderTls            *Void
+	client                                 *Void
+	clientPingWrongPasswordFails           *Void
+	cluster                                *Void
+	clusterAdvertisesPinnedHostnames       *Void
+	clusterBindNodesReachableFromConsumer  *Void
+	clusterDelSpansMultipleSlots           *Void
+	clusterKeysScansEveryShard             *Void
+	clusterRejectsTlsSecurity              *Void
+	clusterRejectsTooFewShards             *Void
+	clusterReportsFormedState              *Void
+	clusterRoundTripsKeysAcrossSlots       *Void
+	clusterStopTerminatesEveryNode         *Void
+	config                                 *Void
+	configFileDirectivesApply              *Void
+	dbSelectsLogicalDatabase               *Void
+	defaultsProduceHealthyServer           *Void
+	delRemovesKeys                         *Void
+	doReturnsJsonReplies                   *Void
+	endpointShouldNotBeCached              *Void
+	extraArgsReachServerLast               *Void
+	flagArgumentBeatsConfigFile            *Void
+	flushAllClearsKeys                     *Void
+	getMissingKeyFails                     *Void
+	getShouldNotBeCached                   *Void
+	id                                     *ID
+	infoReportsRole                        *Void
+	keysScansPattern                       *Void
+	maxMemoryEvictsOverLimit               *Void
+	mtlsNodeDemandsClientCertAtWire        *Void
+	mtlsServerRejectsTlsOnlyClient         *Void
+	omittedConfigLeavesValkeyDefaults      *Void
+	passwordReusableViaClient              *Void
+	plaintextDialAgainstTlsNodeFails       *Void
+	replication                            *Void
+	replicationLinkAuthenticates           *Void
+	replicationNodesHaveDistinctHostnames  *Void
+	replicationPropagatesWritesToReplica   *Void
+	replicationRejectsTlsSecurity          *Void
+	replicationRejectsTooFewReplicas       *Void
+	replicationReplicaRejectsWrites        *Void
+	replicationReportsRoles                *Void
+	replicationStopTerminatesEveryNode     *Void
+	sameNameServerSharesState              *Void
+	security                               *Void
+	server                                 *Void
+	serverMtlsRoundTripFromClient          *Void
+	serverRejectsAclFileWithoutDefaultUser *Void
+	serverRejectsInvalidMaxMemory          *Void
+	serverRejectsInvalidMaxMemoryPolicy    *Void
+	serverRejectsNilPassword               *Void
+	serverRejectsNilSecurity               *Void
+	serverTlsRoundTripFromClient           *Void
+	setGetRoundTrip                        *Void
+	setWithTtlExpires                      *Void
+	stopTerminatesServer                   *Void
+	tlsServerRejectsEmptyName              *Void
+	tlsServerRejectsPlaintextClient        *Void
+	validation                             *Void
 }
 
 func (r *ValkeyTests) WithGraphQLQuery(q *querybuilder.Selection) *ValkeyTests {
@@ -123,9 +136,29 @@ func (r *ValkeyTests) WithGraphQLQuery(q *querybuilder.Selection) *ValkeyTests {
 	}
 }
 
+// AclFileProvisionsUser verifies an ACL file rides in as a secret and
+// provisions a user the module never knew about.
+//
+// The file is the only place that user's password exists in plaintext,
+// and it reaches the node as a mounted secret rather than an argument —
+// so the test also pins the leak paths shut: Valkey stores the password
+// as a SHA-256 digest, and neither ACL LIST nor ACL GETUSER may echo the
+// plaintext back. CONFIG GET aclfile reporting the mount path is the
+// other half of that: it proves the users arrived through the mounted
+// file rather than through `user ...` directives on the command line,
+// where they would be visible in the Dagger graph.
+func (r *ValkeyTests) ACLFileProvisionsUser(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3042:1)
+	if r.aclFileProvisionsUser != nil {
+		return nil
+	}
+	q := r.query.Select("aclFileProvisionsUser")
+
+	return q.Execute(ctx)
+}
+
 // ValkeyTestsAllOpts contains options for ValkeyTests.All
 type ValkeyTestsAllOpts struct {
-	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:38:2)
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:40:2)
 }
 
 // All runs every valkey test as a convenience for local `dagger call
@@ -133,7 +166,7 @@ type ValkeyTestsAllOpts struct {
 // below is registered as its own check, so GH Actions schedules each
 // onto its own runner in parallel — running All on top would
 // double-bill the same work.
-func (r *ValkeyTests) All(ctx context.Context, opts ...ValkeyTestsAllOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:35:1)
+func (r *ValkeyTests) All(ctx context.Context, opts ...ValkeyTestsAllOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:37:1)
 	if r.all != nil {
 		return nil
 	}
@@ -148,9 +181,26 @@ func (r *ValkeyTests) All(ctx context.Context, opts ...ValkeyTestsAllOpts) error
 	return q.Execute(ctx)
 }
 
+// AppendOnlyEnablesAof verifies `appendOnly: true` reaches the node as a
+// real persistence change: INFO persistence reports aof_enabled:1 and
+// CONFIG GET agrees.
+//
+// A control node with the parameter omitted is asserted to report
+// aof_enabled:0 in the same test. Without it, an image that shipped with
+// the AOF already on would make the positive assertion pass while the
+// parameter did nothing at all — the classic vacuous config test.
+func (r *ValkeyTests) AppendOnlyEnablesAof(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2862:1)
+	if r.appendOnlyEnablesAof != nil {
+		return nil
+	}
+	q := r.query.Select("appendOnlyEnablesAof")
+
+	return q.Execute(ctx)
+}
+
 // ApplyFileReportsFailingCommand verifies a mid-file failure is not
 // swallowed and that the error names the offending line.
-func (r *ValkeyTests) ApplyFileReportsFailingCommand(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1130:1)
+func (r *ValkeyTests) ApplyFileReportsFailingCommand(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1262:1)
 	if r.applyFileReportsFailingCommand != nil {
 		return nil
 	}
@@ -162,7 +212,7 @@ func (r *ValkeyTests) ApplyFileReportsFailingCommand(ctx context.Context) error 
 // ApplyFileSeedsData verifies a command file lands as data on one
 // connection, and that its quoting and line splitting survive: values
 // with spaces, embedded quotes, blank lines, and `#` comments.
-func (r *ValkeyTests) ApplyFileSeedsData(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1075:1)
+func (r *ValkeyTests) ApplyFileSeedsData(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1207:1)
 	if r.applyFileSeedsData != nil {
 		return nil
 	}
@@ -175,7 +225,7 @@ func (r *ValkeyTests) ApplyFileSeedsData(ctx context.Context) error { // valkey-
 // a consumer container under the hostname Endpoint reports, and that the
 // consumer gets a real PONG back. A port probe would be a false
 // positive: it proves something is listening, not that Valkey answers.
-func (r *ValkeyTests) BindServerReachableFromAlpine(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:613:1)
+func (r *ValkeyTests) BindServerReachableFromAlpine(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:745:1)
 	if r.bindServerReachableFromAlpine != nil {
 		return nil
 	}
@@ -189,7 +239,7 @@ func (r *ValkeyTests) BindServerReachableFromAlpine(ctx context.Context) error {
 // the right CA gets a PONG, proving BindServer stays reachable under TLS
 // from a consumer container. The password rides in as a secret env var so
 // it never enters the exec's argv.
-func (r *ValkeyTests) BindServerReachableUnderTLS(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2153:1)
+func (r *ValkeyTests) BindServerReachableUnderTLS(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2285:1)
 	if r.bindServerReachableUnderTls != nil {
 		return nil
 	}
@@ -200,13 +250,13 @@ func (r *ValkeyTests) BindServerReachableUnderTLS(ctx context.Context) error { /
 
 // ValkeyTestsClientOpts contains options for ValkeyTests.Client
 type ValkeyTestsClientOpts struct {
-	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:188:2)
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:196:2)
 }
 
 // Client runs the command round-trip tests. Each test boots its own node
 // via bootServer, so the keyspaces stay disjoint and the group fans out
 // safely.
-func (r *ValkeyTests) Client(ctx context.Context, opts ...ValkeyTestsClientOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:185:1)
+func (r *ValkeyTests) Client(ctx context.Context, opts ...ValkeyTestsClientOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:193:1)
 	if r.client != nil {
 		return nil
 	}
@@ -224,7 +274,7 @@ func (r *ValkeyTests) Client(ctx context.Context, opts ...ValkeyTestsClientOpts)
 // ClientPingWrongPasswordFails proves requirepass is genuinely applied
 // and the node is not wide open: a client holding a different password
 // cannot authenticate.
-func (r *ValkeyTests) ClientPingWrongPasswordFails(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1222:1)
+func (r *ValkeyTests) ClientPingWrongPasswordFails(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1354:1)
 	if r.clientPingWrongPasswordFails != nil {
 		return nil
 	}
@@ -235,7 +285,7 @@ func (r *ValkeyTests) ClientPingWrongPasswordFails(ctx context.Context) error { 
 
 // ValkeyTestsClusterOpts contains options for ValkeyTests.Cluster
 type ValkeyTestsClusterOpts struct {
-	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:134:2)
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:142:2)
 }
 
 // Cluster runs the slot-sharded Valkey Cluster tests. Each test boots its
@@ -247,7 +297,7 @@ type ValkeyTestsClusterOpts struct {
 // cluster is three nodes, and every one of them has to boot before the
 // bootstrap can even start — so they get their own aggregator rather than
 // riding along with the single-node groups.
-func (r *ValkeyTests) Cluster(ctx context.Context, opts ...ValkeyTestsClusterOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:131:1)
+func (r *ValkeyTests) Cluster(ctx context.Context, opts ...ValkeyTestsClusterOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:139:1)
 	if r.cluster != nil {
 		return nil
 	}
@@ -271,7 +321,7 @@ func (r *ValkeyTests) Cluster(ctx context.Context, opts ...ValkeyTestsClusterOpt
 // "another" node, dials itself. The cluster never forms, or forms and
 // then answers for the wrong shard, and CLUSTER INFO alone would not say
 // why. Asserting the announced identity is what pins the fix.
-func (r *ValkeyTests) ClusterAdvertisesPinnedHostnames(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2275:1)
+func (r *ValkeyTests) ClusterAdvertisesPinnedHostnames(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2407:1)
 	if r.clusterAdvertisesPinnedHostnames != nil {
 		return nil
 	}
@@ -297,7 +347,7 @@ func (r *ValkeyTests) ClusterAdvertisesPinnedHostnames(ctx context.Context) erro
 //
 // The whole probe runs in one exec so a partial failure names the node it
 // failed on rather than surfacing as an opaque non-zero exit.
-func (r *ValkeyTests) ClusterBindNodesReachableFromConsumer(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2525:1)
+func (r *ValkeyTests) ClusterBindNodesReachableFromConsumer(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2657:1)
 	if r.clusterBindNodesReachableFromConsumer != nil {
 		return nil
 	}
@@ -315,7 +365,7 @@ func (r *ValkeyTests) ClusterBindNodesReachableFromConsumer(ctx context.Context)
 // One key in the list never existed, so a Del that reported the number of
 // keys it was asked about rather than the number it removed is caught
 // too.
-func (r *ValkeyTests) ClusterDelSpansMultipleSlots(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2467:1)
+func (r *ValkeyTests) ClusterDelSpansMultipleSlots(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2599:1)
 	if r.clusterDelSpansMultipleSlots != nil {
 		return nil
 	}
@@ -335,7 +385,7 @@ func (r *ValkeyTests) ClusterDelSpansMultipleSlots(ctx context.Context) error { 
 // really were split across more than one primary, so the first assertion
 // can't pass vacuously on a cluster that happened to pile everything into
 // one shard.
-func (r *ValkeyTests) ClusterKeysScansEveryShard(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2384:1)
+func (r *ValkeyTests) ClusterKeysScansEveryShard(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2516:1)
 	if r.clusterKeysScansEveryShard != nil {
 		return nil
 	}
@@ -350,7 +400,7 @@ func (r *ValkeyTests) ClusterKeysScansEveryShard(ctx context.Context) error { //
 // would also have to run over TLS, and neither the peers nor the
 // valkey-cli that bootstraps them get the trust material they'd need from
 // a client-listener ServerSecurity.
-func (r *ValkeyTests) ClusterRejectsTLSSecurity(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:477:1)
+func (r *ValkeyTests) ClusterRejectsTLSSecurity(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:609:1)
 	if r.clusterRejectsTlsSecurity != nil {
 		return nil
 	}
@@ -369,7 +419,7 @@ func (r *ValkeyTests) ClusterRejectsTLSSecurity(ctx context.Context) error { // 
 //
 // The guard is checked before anything starts, so this test costs no
 // containers.
-func (r *ValkeyTests) ClusterRejectsTooFewShards(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:440:1)
+func (r *ValkeyTests) ClusterRejectsTooFewShards(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:572:1)
 	if r.clusterRejectsTooFewShards != nil {
 		return nil
 	}
@@ -386,7 +436,7 @@ func (r *ValkeyTests) ClusterRejectsTooFewShards(ctx context.Context) error { //
 // didn't finish: a node whose gossip never reached the others still
 // reports state:ok for the slots it can see, and only cluster_known_nodes
 // gives it away.
-func (r *ValkeyTests) ClusterReportsFormedState(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2243:1)
+func (r *ValkeyTests) ClusterReportsFormedState(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2375:1)
 	if r.clusterReportsFormedState != nil {
 		return nil
 	}
@@ -406,7 +456,7 @@ func (r *ValkeyTests) ClusterReportsFormedState(ctx context.Context) error { // 
 // A client that silently talked to one node would fail the write, not the
 // read: a key that hashes elsewhere is refused with MOVED, never stored
 // locally.
-func (r *ValkeyTests) ClusterRoundTripsKeysAcrossSlots(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2316:1)
+func (r *ValkeyTests) ClusterRoundTripsKeysAcrossSlots(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2448:1)
 	if r.clusterRoundTripsKeysAcrossSlots != nil {
 		return nil
 	}
@@ -424,7 +474,7 @@ func (r *ValkeyTests) ClusterRoundTripsKeysAcrossSlots(ctx context.Context) erro
 // Cluster members have no service bindings between them, so unlike the
 // replication topology there is no dependency teardown to hide behind:
 // every node that is still up after Stop is a node Stop failed to kill.
-func (r *ValkeyTests) ClusterStopTerminatesEveryNode(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2590:1)
+func (r *ValkeyTests) ClusterStopTerminatesEveryNode(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2722:1)
 	if r.clusterStopTerminatesEveryNode != nil {
 		return nil
 	}
@@ -433,10 +483,55 @@ func (r *ValkeyTests) ClusterStopTerminatesEveryNode(ctx context.Context) error 
 	return q.Execute(ctx)
 }
 
+// ValkeyTestsConfigOpts contains options for ValkeyTests.Config
+type ValkeyTestsConfigOpts struct {
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:259:2)
+}
+
+// Config runs the `valkey-server` configuration passthrough tests: the
+// config file, the ACL file, the append-only log, the memory ceiling, and
+// the extraArgs escape hatch. Each test boots its own node under a
+// runtime-random name, so the group fans out safely.
+func (r *ValkeyTests) Config(ctx context.Context, opts ...ValkeyTestsConfigOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:256:1)
+	if r.config != nil {
+		return nil
+	}
+	q := r.query.Select("config")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `parallel` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Parallel) {
+			q = q.Arg("parallel", opts[i].Parallel)
+		}
+	}
+
+	return q.Execute(ctx)
+}
+
+// ConfigFileDirectivesApply verifies a mounted valkey.conf is genuinely
+// loaded, and — the harder half — that it still governs settings this
+// module has parameters of its own for.
+//
+// The file deliberately sets `appendonly` and `maxmemory-policy`, the two
+// settings whose module parameters carry defaults that match Valkey's.
+// An implementation that rendered those parameters unconditionally would
+// emit `--appendonly no --maxmemory-policy noeviction` after the config
+// file and quietly win, so this is the test that pins the "a parameter
+// left at its default emits no flag" rule. `hash-max-listpack-entries` is
+// along for the ride as a directive the module has no opinion about at
+// all.
+func (r *ValkeyTests) ConfigFileDirectivesApply(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3250:1)
+	if r.configFileDirectivesApply != nil {
+		return nil
+	}
+	q := r.query.Select("configFileDirectivesApply")
+
+	return q.Execute(ctx)
+}
+
 // DbSelectsLogicalDatabase verifies db is honoured end to end: a write
 // on db 0 is invisible to a client on db 1, and each database keeps its
 // own DbSize.
-func (r *ValkeyTests) DbSelectsLogicalDatabase(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1257:1)
+func (r *ValkeyTests) DbSelectsLogicalDatabase(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1389:1)
 	if r.dbSelectsLogicalDatabase != nil {
 		return nil
 	}
@@ -448,7 +543,7 @@ func (r *ValkeyTests) DbSelectsLogicalDatabase(ctx context.Context) error { // v
 // DefaultsProduceHealthyServer boots a default node and proves it is a
 // healthy Valkey by answering PING and self-reporting 9.1 in INFO
 // server. Catches image-path drift and a silently moved default tag.
-func (r *ValkeyTests) DefaultsProduceHealthyServer(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:519:1)
+func (r *ValkeyTests) DefaultsProduceHealthyServer(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:651:1)
 	if r.defaultsProduceHealthyServer != nil {
 		return nil
 	}
@@ -459,7 +554,7 @@ func (r *ValkeyTests) DefaultsProduceHealthyServer(ctx context.Context) error { 
 
 // DelRemovesKeys verifies Del reports how many keys it actually removed
 // and that DbSize agrees with the survivors.
-func (r *ValkeyTests) DelRemovesKeys(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:924:1)
+func (r *ValkeyTests) DelRemovesKeys(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1056:1)
 	if r.delRemovesKeys != nil {
 		return nil
 	}
@@ -471,7 +566,7 @@ func (r *ValkeyTests) DelRemovesKeys(ctx context.Context) error { // valkey-test
 // DoReturnsJsonReplies verifies each RESP type survives the JSON
 // encoding distinctly. The dangerous pair is nil versus empty string: a
 // naive encoder collapses both to "".
-func (r *ValkeyTests) DoReturnsJSONReplies(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1015:1)
+func (r *ValkeyTests) DoReturnsJSONReplies(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1147:1)
 	if r.doReturnsJsonReplies != nil {
 		return nil
 	}
@@ -483,7 +578,7 @@ func (r *ValkeyTests) DoReturnsJSONReplies(ctx context.Context) error { // valke
 // EndpointShouldNotBeCached verifies Endpoint re-executes against the
 // receiver it was called on rather than freezing on the first result.
 // Valkey.Server isaddress.
-func (r *ValkeyTests) EndpointShouldNotBeCached(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:545:1)
+func (r *ValkeyTests) EndpointShouldNotBeCached(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:677:1)
 	if r.endpointShouldNotBeCached != nil {
 		return nil
 	}
@@ -492,9 +587,45 @@ func (r *ValkeyTests) EndpointShouldNotBeCached(ctx context.Context) error { // 
 	return q.Execute(ctx)
 }
 
+// ExtraArgsReachServerLast verifies the escape hatch does both of the
+// things it promises: the arguments reach valkey-server verbatim, and
+// they land last on the command line.
+//
+// `databases` is a setting with no module parameter at all, so it can
+// only have arrived through extraArgs. `maxmemory-policy` is passed
+// BOTH ways, with different values, so the reply says which one Valkey
+// saw last — and therefore whether extraArgs really is appended after
+// the module's own flags rather than merely somewhere among them.
+func (r *ValkeyTests) ExtraArgsReachServerLast(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3338:1)
+	if r.extraArgsReachServerLast != nil {
+		return nil
+	}
+	q := r.query.Select("extraArgsReachServerLast")
+
+	return q.Execute(ctx)
+}
+
+// FlagArgumentBeatsConfigFile verifies the precedence contract in the
+// direction that matters: when the same setting appears in `configFile`
+// and as a parameter, the parameter wins.
+//
+// Both settings are given deliberately conflicting values in the file, so
+// a passing result cannot be an accident of agreement. This is the
+// mirror of ConfigFileDirectivesApply — together they say the file is
+// loaded first and the flags are applied on top, which is the whole
+// ordering guarantee.
+func (r *ValkeyTests) FlagArgumentBeatsConfigFile(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3298:1)
+	if r.flagArgumentBeatsConfigFile != nil {
+		return nil
+	}
+	q := r.query.Select("flagArgumentBeatsConfigFile")
+
+	return q.Execute(ctx)
+}
+
 // FlushAllClearsKeys verifies FlushAll empties the keyspace and DbSize
 // returns to 0.
-func (r *ValkeyTests) FlushAllClearsKeys(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1183:1)
+func (r *ValkeyTests) FlushAllClearsKeys(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1315:1)
 	if r.flushAllClearsKeys != nil {
 		return nil
 	}
@@ -506,7 +637,7 @@ func (r *ValkeyTests) FlushAllClearsKeys(ctx context.Context) error { // valkey-
 // GetMissingKeyFails verifies absence stays distinguishable from an
 // empty value: an unset key errors, while a key holding "" reads back as
 // "".
-func (r *ValkeyTests) GetMissingKeyFails(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:811:1)
+func (r *ValkeyTests) GetMissingKeyFails(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:943:1)
 	if r.getMissingKeyFails != nil {
 		return nil
 	}
@@ -518,7 +649,7 @@ func (r *ValkeyTests) GetMissingKeyFails(ctx context.Context) error { // valkey-
 // GetShouldNotBeCached verifies Get re-executes on every call: write v1,
 // read it, overwrite with v2, read again. A cached Get would still
 // report v1 — the canonical stale-read bug a missingproduces.
-func (r *ValkeyTests) GetShouldNotBeCached(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:765:1)
+func (r *ValkeyTests) GetShouldNotBeCached(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:897:1)
 	if r.getShouldNotBeCached != nil {
 		return nil
 	}
@@ -579,7 +710,7 @@ func (r *ValkeyTests) UnmarshalJSON(bs []byte) error {
 // InfoReportsRole verifies INFO replication reports a standalone node as
 // the primary. ReplicationReportsRoles is the multi-node counterpart,
 // where a replica reports role:slave instead.
-func (r *ValkeyTests) InfoReportsRole(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1164:1)
+func (r *ValkeyTests) InfoReportsRole(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1296:1)
 	if r.infoReportsRole != nil {
 		return nil
 	}
@@ -592,11 +723,32 @@ func (r *ValkeyTests) InfoReportsRole(ctx context.Context) error { // valkey-tes
 // checks the full match set comes back. One SCAN page holds far fewer
 // than that, so an implementation that returned the first page — or that
 // stopped before the cursor wrapped to 0 — comes up short here.
-func (r *ValkeyTests) KeysScansPattern(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:964:1)
+func (r *ValkeyTests) KeysScansPattern(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1096:1)
 	if r.keysScansPattern != nil {
 		return nil
 	}
 	q := r.query.Select("keysScansPattern")
+
+	return q.Execute(ctx)
+}
+
+// MaxMemoryEvictsOverLimit verifies the memory ceiling is a real limit
+// and that the eviction policy alongside it decides what happens when a
+// write crosses it.
+//
+// Two nodes, same ceiling, opposite policies, because either half alone
+// proves little. Under `allkeys-lru` the over-limit writes must all be
+// ACCEPTED and paid for by evicting older keys — so the keyspace ends up
+// smaller than what was written and evicted_keys is non-zero. Under the
+// default `noeviction` the same writes must be REFUSED with OOM. A
+// maxMemory that never reached valkey-server would leave both nodes
+// happily holding the whole keyspace, and a maxMemoryPolicy that never
+// reached it would make the two nodes behave identically.
+func (r *ValkeyTests) MaxMemoryEvictsOverLimit(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2945:1)
+	if r.maxMemoryEvictsOverLimit != nil {
+		return nil
+	}
+	q := r.query.Select("maxMemoryEvictsOverLimit")
 
 	return q.Execute(ctx)
 }
@@ -610,7 +762,7 @@ func (r *ValkeyTests) KeysScansPattern(ctx context.Context) error { // valkey-te
 // default `yes`. A regression that passed `--tls-auth-clients no` for
 // MTLS too would let this certless client through and go undetected by
 // the round-trip tests.
-func (r *ValkeyTests) MtlsNodeDemandsClientCertAtWire(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2006:1)
+func (r *ValkeyTests) MtlsNodeDemandsClientCertAtWire(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2138:1)
 	if r.mtlsNodeDemandsClientCertAtWire != nil {
 		return nil
 	}
@@ -623,7 +775,7 @@ func (r *ValkeyTests) MtlsNodeDemandsClientCertAtWire(ctx context.Context) error
 // mTLS side: asking an mTLS node for a TLS-only client returns an error
 // naming both modes, before any wire activity. The SAN value on the cert
 // is irrelevant here — the guard fires in requireMode, ahead of any dial.
-func (r *ValkeyTests) MtlsServerRejectsTLSOnlyClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1961:1)
+func (r *ValkeyTests) MtlsServerRejectsTLSOnlyClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2093:1)
 	if r.mtlsServerRejectsTlsOnlyClient != nil {
 		return nil
 	}
@@ -632,10 +784,31 @@ func (r *ValkeyTests) MtlsServerRejectsTLSOnlyClient(ctx context.Context) error 
 	return q.Execute(ctx)
 }
 
+// OmittedConfigLeavesValkeyDefaults verifies the passthrough is genuinely
+// opt-in: a node built without any of the new parameters reports Valkey's
+// own defaults for every one of them.
+//
+// This is the test that pins the "a parameter left at its default emits
+// no flag" rule, and it is not merely a restatement of the defaults. An
+// implementation that rendered `--appendonly no` or `--maxmemory-policy
+// noeviction` unconditionally would pass every assertion below and still
+// be wrong — because those flags sit after the config file on the command
+// line and would silently override a `configFile` that set them. The
+// configFile tests further down are what catch that, and this one is what
+// makes their failure legible.
+func (r *ValkeyTests) OmittedConfigLeavesValkeyDefaults(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2826:1)
+	if r.omittedConfigLeavesValkeyDefaults != nil {
+		return nil
+	}
+	q := r.query.Select("omittedConfigLeavesValkeyDefaults")
+
+	return q.Execute(ctx)
+}
+
 // PasswordReusableViaClient verifies the credentials a Server hands back
 // authenticate through the standalone constructor: Endpointare enough to build a working client, which is what makes the same
 // Client usable against a remote Valkey.
-func (r *ValkeyTests) PasswordReusableViaClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:652:1)
+func (r *ValkeyTests) PasswordReusableViaClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:784:1)
 	if r.passwordReusableViaClient != nil {
 		return nil
 	}
@@ -650,7 +823,7 @@ func (r *ValkeyTests) PasswordReusableViaClient(ctx context.Context) error { // 
 // wire protocol to the encrypted listener and fails. If `--port 0` were
 // missing, a plaintext listener would still be up on 6379 and this dial
 // would succeed.
-func (r *ValkeyTests) PlaintextDialAgainstTLSNodeFails(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2074:1)
+func (r *ValkeyTests) PlaintextDialAgainstTLSNodeFails(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2206:1)
 	if r.plaintextDialAgainstTlsNodeFails != nil {
 		return nil
 	}
@@ -661,14 +834,14 @@ func (r *ValkeyTests) PlaintextDialAgainstTLSNodeFails(ctx context.Context) erro
 
 // ValkeyTestsReplicationOpts contains options for ValkeyTests.Replication
 type ValkeyTestsReplicationOpts struct {
-	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:102:2)
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:110:2)
 }
 
 // Replication runs the primary/replica topology tests. Each test boots
 // its own topology via bootReplication, whose runtime-random name folds
 // into Valkey.Replication's session-cache key and into every node's
 // hostname, so concurrent tests get independent topologies.
-func (r *ValkeyTests) Replication(ctx context.Context, opts ...ValkeyTestsReplicationOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:99:1)
+func (r *ValkeyTests) Replication(ctx context.Context, opts ...ValkeyTestsReplicationOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:107:1)
 	if r.replication != nil {
 		return nil
 	}
@@ -689,7 +862,7 @@ func (r *ValkeyTests) Replication(ctx context.Context, opts ...ValkeyTestsReplic
 // wrong never reaches — it stays `down`, retrying on NOAUTH, while every
 // other assertion in this file would still pass against its (empty but
 // readable) local keyspace.
-func (r *ValkeyTests) ReplicationLinkAuthenticates(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1526:1)
+func (r *ValkeyTests) ReplicationLinkAuthenticates(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1658:1)
 	if r.replicationLinkAuthenticates != nil {
 		return nil
 	}
@@ -706,7 +879,7 @@ func (r *ValkeyTests) ReplicationLinkAuthenticates(ctx context.Context) error { 
 //
 // Endpoint is a pure accessor, so this asserts the addressing scheme
 // without booting anything.
-func (r *ValkeyTests) ReplicationNodesHaveDistinctHostnames(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1566:1)
+func (r *ValkeyTests) ReplicationNodesHaveDistinctHostnames(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1698:1)
 	if r.replicationNodesHaveDistinctHostnames != nil {
 		return nil
 	}
@@ -719,7 +892,7 @@ func (r *ValkeyTests) ReplicationNodesHaveDistinctHostnames(ctx context.Context)
 // path: a key written to the primary becomes readable from the replica.
 // The read polls, because the link is asynchronous and a single read
 // would race the initial sync.
-func (r *ValkeyTests) ReplicationPropagatesWritesToReplica(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1391:1)
+func (r *ValkeyTests) ReplicationPropagatesWritesToReplica(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1523:1)
 	if r.replicationPropagatesWritesToReplica != nil {
 		return nil
 	}
@@ -733,7 +906,7 @@ func (r *ValkeyTests) ReplicationPropagatesWritesToReplica(ctx context.Context) 
 // forever on a failed handshake: a TLS node runs with `--port 0`, so the
 // replication link would also have to run over TLS, and a client-listener
 // ServerSecurity carries none of the trust material that link needs.
-func (r *ValkeyTests) ReplicationRejectsTLSSecurity(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:395:1)
+func (r *ValkeyTests) ReplicationRejectsTLSSecurity(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:527:1)
 	if r.replicationRejectsTlsSecurity != nil {
 		return nil
 	}
@@ -752,7 +925,7 @@ func (r *ValkeyTests) ReplicationRejectsTLSSecurity(ctx context.Context) error {
 // any optional argument holding its zero value, so `Replicas: 0` never
 // reaches the module and resolves to the `the CLI does reach the guard, which is why the guard is `< 1` and not
 // `< 0`.
-func (r *ValkeyTests) ReplicationRejectsTooFewReplicas(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:362:1)
+func (r *ValkeyTests) ReplicationRejectsTooFewReplicas(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:494:1)
 	if r.replicationRejectsTooFewReplicas != nil {
 		return nil
 	}
@@ -765,7 +938,7 @@ func (r *ValkeyTests) ReplicationRejectsTooFewReplicas(ctx context.Context) erro
 // holds: a write against a replica is refused with READONLY, so a test
 // that writes to the wrong node fails loudly instead of silently losing
 // the write on the next sync.
-func (r *ValkeyTests) ReplicationReplicaRejectsWrites(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1486:1)
+func (r *ValkeyTests) ReplicationReplicaRejectsWrites(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1618:1)
 	if r.replicationReplicaRejectsWrites != nil {
 		return nil
 	}
@@ -779,7 +952,7 @@ func (r *ValkeyTests) ReplicationReplicaRejectsWrites(ctx context.Context) error
 // connected_slaves as there are replicas, and every replica reports the
 // replica role. Two replicas rather than one, so a count that reported
 // "some replica connected" instead of all of them fails here.
-func (r *ValkeyTests) ReplicationReportsRoles(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1433:1)
+func (r *ValkeyTests) ReplicationReportsRoles(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1565:1)
 	if r.replicationReportsRoles != nil {
 		return nil
 	}
@@ -802,7 +975,7 @@ func (r *ValkeyTests) ReplicationReportsRoles(ctx context.Context) error { // va
 // every other node depends on". Replication.Stop still walks every node
 // explicitly rather than leaning on that dependency teardown, which is
 // not a documented guarantee.
-func (r *ValkeyTests) ReplicationStopTerminatesEveryNode(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1629:1)
+func (r *ValkeyTests) ReplicationStopTerminatesEveryNode(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1761:1)
 	if r.replicationStopTerminatesEveryNode != nil {
 		return nil
 	}
@@ -815,7 +988,7 @@ func (r *ValkeyTests) ReplicationStopTerminatesEveryNode(ctx context.Context) er
 // resolve to one backing node: a key written through the first is
 // readable through the second. Catches session cache-key drift, which
 // would silently split a multi-step test across two empty keyspaces.
-func (r *ValkeyTests) SameNameServerSharesState(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:574:1)
+func (r *ValkeyTests) SameNameServerSharesState(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:706:1)
 	if r.sameNameServerSharesState != nil {
 		return nil
 	}
@@ -826,14 +999,14 @@ func (r *ValkeyTests) SameNameServerSharesState(ctx context.Context) error { // 
 
 // ValkeyTestsSecurityOpts contains options for ValkeyTests.Security
 type ValkeyTestsSecurityOpts struct {
-	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:222:2)
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:230:2)
 }
 
 // Security runs the TLS / mTLS listener + client tests. Each test mints
 // its own CA, leaf certs, password, and server name at runtime (no
 // literal credentials or PEM blobs), and folds a unique name into the
 // node's session-cache key, so the tests fan out without sharing state.
-func (r *ValkeyTests) Security(ctx context.Context, opts ...ValkeyTestsSecurityOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:219:1)
+func (r *ValkeyTests) Security(ctx context.Context, opts ...ValkeyTestsSecurityOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:227:1)
 	if r.security != nil {
 		return nil
 	}
@@ -850,14 +1023,14 @@ func (r *ValkeyTests) Security(ctx context.Context, opts ...ValkeyTestsSecurityO
 
 // ValkeyTestsServerOpts contains options for ValkeyTests.Server
 type ValkeyTestsServerOpts struct {
-	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:162:2)
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:170:2)
 }
 
 // Server runs the topology, default, and caching tests. Each test boots
 // its own node via bootServer, whose runtime-random name folds into
 // Valkey.Server's session-cache key so concurrent tests boot independent
 // backing services and never share a keyspace.
-func (r *ValkeyTests) Server(ctx context.Context, opts ...ValkeyTestsServerOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:159:1)
+func (r *ValkeyTests) Server(ctx context.Context, opts ...ValkeyTestsServerOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:167:1)
 	if r.server != nil {
 		return nil
 	}
@@ -875,7 +1048,7 @@ func (r *ValkeyTests) Server(ctx context.Context, opts ...ValkeyTestsServerOpts)
 // ServerMtlsRoundTripFromClient boots a mutual-TLS node and proves a
 // matching mTLS client (presenting a client cert signed by the trusted
 // CA) can round-trip Set
-func (r *ValkeyTests) ServerMtlsRoundTripFromClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1866:1)
+func (r *ValkeyTests) ServerMtlsRoundTripFromClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1998:1)
 	if r.serverMtlsRoundTripFromClient != nil {
 		return nil
 	}
@@ -884,8 +1057,67 @@ func (r *ValkeyTests) ServerMtlsRoundTripFromClient(ctx context.Context) error {
 	return q.Execute(ctx)
 }
 
+// ServerRejectsAclFileWithoutDefaultUser verifies the module refuses an
+// ACL file that never mentions the `default` user.
+//
+// This is the module's password guarantee holding under the new
+// parameter. Valkey loads the ACL file after `requirepass` and recreates
+// any user the file omits in its factory `on nopass` state — so an ACL
+// file listing only the caller's own users silently drops the password
+// from `default` and leaves the node reachable by anything that can route
+// to it. Valkey.Server rejects a nil password for exactly that reason,
+// and an ACL file must not be a back door around it.
+//
+// The accepting cases prove the guard is a mention and not an
+// interpretation: naming `default` at all — even to turn it off — is a
+// decision the caller is entitled to make.
+func (r *ValkeyTests) ServerRejectsACLFileWithoutDefaultUser(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3189:1)
+	if r.serverRejectsAclFileWithoutDefaultUser != nil {
+		return nil
+	}
+	q := r.query.Select("serverRejectsAclFileWithoutDefaultUser")
+
+	return q.Execute(ctx)
+}
+
+// ServerRejectsInvalidMaxMemory verifies a malformed memory ceiling is
+// caught in-process rather than at boot. valkey-server parses `maxmemory`
+// with memtoll, which accepts an integer plus an optional unit suffix and
+// nothing else — a fractional value or an invented unit makes it refuse
+// to start, and the caller would meet that as a readiness timeout with
+// the parse error stranded in a service log nobody reads.
+//
+// The accepted cases run too, so the guard can't pass by rejecting
+// everything: `k`/`m`/`g` (powers of 1000) and `kb`/`mb`/`gb` (powers of
+// 1024) are both legal, as is a bare byte count.
+func (r *ValkeyTests) ServerRejectsInvalidMaxMemory(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:409:1)
+	if r.serverRejectsInvalidMaxMemory != nil {
+		return nil
+	}
+	q := r.query.Select("serverRejectsInvalidMaxMemory")
+
+	return q.Execute(ctx)
+}
+
+// ServerRejectsInvalidMaxMemoryPolicy verifies an unknown eviction policy
+// is caught in-process, for the same reason as the memory ceiling: a
+// mistyped policy is a config-parse error at boot, which surfaces as a
+// node that simply never becomes ready.
+//
+// Every policy Valkey accepts is exercised on the accept side, so a guard
+// that only knew the common ones would fail here rather than in a
+// caller's pipeline.
+func (r *ValkeyTests) ServerRejectsInvalidMaxMemoryPolicy(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:448:1)
+	if r.serverRejectsInvalidMaxMemoryPolicy != nil {
+		return nil
+	}
+	q := r.query.Select("serverRejectsInvalidMaxMemoryPolicy")
+
+	return q.Execute(ctx)
+}
+
 // ServerRejectsNilPassword verifies a passwordless node must not boot.
-func (r *ValkeyTests) ServerRejectsNilPassword(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:307:1)
+func (r *ValkeyTests) ServerRejectsNilPassword(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:355:1)
 	if r.serverRejectsNilPassword != nil {
 		return nil
 	}
@@ -897,7 +1129,7 @@ func (r *ValkeyTests) ServerRejectsNilPassword(ctx context.Context) error { // v
 // ServerRejectsNilSecurity verifies plaintext must be a deliberate
 // choice, so the TLS follow-up stays an explicit upgrade rather than a
 // silent default.
-func (r *ValkeyTests) ServerRejectsNilSecurity(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:328:1)
+func (r *ValkeyTests) ServerRejectsNilSecurity(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:376:1)
 	if r.serverRejectsNilSecurity != nil {
 		return nil
 	}
@@ -910,7 +1142,7 @@ func (r *ValkeyTests) ServerRejectsNilSecurity(ctx context.Context) error { // v
 // matching TLS client — presenting NO client certificate — can Setagainst it over the encrypted listener. That the certless client is
 // accepted is the `--tls-auth-clients no` acceptance criterion: without
 // that flag Valkey would demand a client cert and reject this dial.
-func (r *ValkeyTests) ServerTLSRoundTripFromClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1816:1)
+func (r *ValkeyTests) ServerTLSRoundTripFromClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1948:1)
 	if r.serverTlsRoundTripFromClient != nil {
 		return nil
 	}
@@ -921,7 +1153,7 @@ func (r *ValkeyTests) ServerTLSRoundTripFromClient(ctx context.Context) error { 
 
 // SetGetRoundTrip is the core smoke path: a value written through Set
 // comes back through Get unchanged.
-func (r *ValkeyTests) SetGetRoundTrip(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:732:1)
+func (r *ValkeyTests) SetGetRoundTrip(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:864:1)
 	if r.setGetRoundTrip != nil {
 		return nil
 	}
@@ -940,7 +1172,7 @@ func (r *ValkeyTests) SetGetRoundTrip(ctx context.Context) error { // valkey-tes
 // an expiry check, because every step here is a round trip through a
 // re-probed service — a lower bound on the *remaining* TTL would be a
 // stopwatch race under a loaded parallel suite.
-func (r *ValkeyTests) SetWithTTLExpires(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:855:1)
+func (r *ValkeyTests) SetWithTTLExpires(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:987:1)
 	if r.setWithTtlExpires != nil {
 		return nil
 	}
@@ -953,7 +1185,7 @@ func (r *ValkeyTests) SetWithTTLExpires(ctx context.Context) error { // valkey-t
 // The post-Stop probe goes through the standalone constructor on
 // purpose: Server.Client would re-Start the service it is asked to dial
 // and the test would pass no matter what Stop did.
-func (r *ValkeyTests) StopTerminatesServer(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:692:1)
+func (r *ValkeyTests) StopTerminatesServer(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:824:1)
 	if r.stopTerminatesServer != nil {
 		return nil
 	}
@@ -968,7 +1200,7 @@ func (r *ValkeyTests) StopTerminatesServer(ctx context.Context) error { // valke
 // TLS/mTLS node onto the same sha256("") host and invite cert/SAN reuse.
 // The guard fires in the constructor, before any service starts, so a
 // placeholder SAN on the cert is fine here.
-func (r *ValkeyTests) TLSServerRejectsEmptyName(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2118:1)
+func (r *ValkeyTests) TLSServerRejectsEmptyName(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2250:1)
 	if r.tlsServerRejectsEmptyName != nil {
 		return nil
 	}
@@ -980,7 +1212,7 @@ func (r *ValkeyTests) TLSServerRejectsEmptyName(ctx context.Context) error { // 
 // TlsServerRejectsPlaintextClient verifies the mode-coupling check:
 // asking a TLS node for a plaintext client returns an error naming both
 // modes, before any wire activity.
-func (r *ValkeyTests) TLSServerRejectsPlaintextClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1922:1)
+func (r *ValkeyTests) TLSServerRejectsPlaintextClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2054:1)
 	if r.tlsServerRejectsPlaintextClient != nil {
 		return nil
 	}
@@ -991,12 +1223,12 @@ func (r *ValkeyTests) TLSServerRejectsPlaintextClient(ctx context.Context) error
 
 // ValkeyTestsValidationOpts contains options for ValkeyTests.Validation
 type ValkeyTestsValidationOpts struct {
-	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:75:2)
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:80:2)
 }
 
 // Validation runs the input-rejection tests. These boot no service, so
 // they're safe to fan out unbounded.
-func (r *ValkeyTests) Validation(ctx context.Context, opts ...ValkeyTestsValidationOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:72:1)
+func (r *ValkeyTests) Validation(ctx context.Context, opts ...ValkeyTestsValidationOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:77:1)
 	if r.validation != nil {
 		return nil
 	}

--- a/daggerverse/valkey/README.md
+++ b/daggerverse/valkey/README.md
@@ -92,6 +92,12 @@ Valkey.Server(
     registry="docker.io", tag="9.1",
     password *dagger.Secret,
     clientListenerSecurity *ServerSecurity,
+    configFile *dagger.File = nil,          // a valkey.conf, loaded before every flag
+    aclFile *dagger.Secret = nil,           // an ACL file, mounted as a secret
+    appendOnly bool = false,                // --appendonly yes
+    maxMemory string = "",                  // --maxmemory 512mb
+    maxMemoryPolicy string = "noeviction",  // --maxmemory-policy allkeys-lru
+    extraArgs []string = nil,               // unsupported escape hatch, appended last
 ) (*Server, error)
 
 Server.Endpoint() string              // host:6379 (pure accessor; BindServer makes it reachable)
@@ -104,8 +110,10 @@ Server.Stop(ctx) error
 
 Rejected inputs (each a descriptive error rather than a half-broken or
 wide-open boot): `password == nil`, `clientListenerSecurity == nil`, an
-incomplete TLS/mTLS profile (missing cert, key, or client CA), and an
-empty `name` for a TLS/mTLS node.
+incomplete TLS/mTLS profile (missing cert, key, or client CA), an empty
+`name` for a TLS/mTLS node, a malformed `maxMemory` or unknown
+`maxMemoryPolicy`, and an `aclFile` that never mentions the `default`
+user.
 
 The password reaches `valkey-server` through a secret environment
 variable expanded by a shell wrapper, not through a literal `argv` entry
@@ -121,6 +129,50 @@ it when minting a server certificate whose SAN must match the dialed
 host. Every method
 on `*Server` / `*Client` is `+cache="never"` so any data-returning call
 re-executes per invocation.
+
+### Configuration passthrough
+
+`configFile`, `aclFile`, `appendOnly`, `maxMemory`, `maxMemoryPolicy`,
+and `extraArgs` are all optional, and a call that omits every one of them
+produces exactly the node it produced before they existed. They are
+constructor parameters rather than post-boot modifiers because
+`valkey-server` reads each of them only while starting up. They are
+`Server`-only: `Replication` and `Cluster` own their members' boot flags.
+
+Precedence runs left to right along the command line, which Valkey
+resolves last-one-wins:
+
+```
+<configFile>  <listener flags>  <passthrough flags>  <extraArgs>
+```
+
+So a flag argument always beats the same directive in `configFile`, and
+`extraArgs` beats everything — including this module's own choices. A
+passthrough parameter left at its default emits **no flag at all**, which
+is what lets `configFile` govern the settings you did not name: were
+`--appendonly no` rendered unconditionally, a config file that turned the
+AOF on would be silently overridden and you would have no way to express
+"leave it to the file".
+
+`aclFile` is a `*dagger.Secret`, not a `*dagger.File` — an ACL file
+carries per-user password material, so it is mounted as a secret and
+never lands in an image layer or the Dagger graph. It must contain a
+`user default ...` rule. Valkey loads the ACL file *after* `requirepass`
+and recreates any user the file omits in its factory `on nopass` state,
+so a file listing only your own users would silently drop the password
+from `default` and leave the node open — `Server` rejects that outright,
+the same way it rejects a nil password. Restate the credential (`user
+default on >$password ~* &* +@all`) or disable the user deliberately
+(`user default off`). A `configFile` carrying its own `user ...`
+directives cannot be combined with an `aclFile` at all: `valkey-server`
+refuses to start when both are present, and this module does not read the
+config file, so that one surfaces as a node that never becomes ready.
+
+`extraArgs` is the deliberate escape hatch: appended verbatim, last, and
+completely unvalidated. It is **unsupported surface** — anything
+reachable only through it may break without notice. Each element becomes
+one shell word in the node's boot command, so quote values containing
+whitespace yourself.
 
 `Endpoint()` is a pure accessor and does **not** start the service.
 Reachability from a consumer container comes from `BindServer`, which
@@ -365,7 +417,6 @@ failing command aborts the run and reports its line number.
 TLS/mTLS for the replication link (`--tls-replication yes` plus the trust
 material a replica needs to verify and authenticate to its primary) and
 for the cluster bus (`--tls-cluster yes`, plus `--tls`/`--cacert` for the
-bootstrapping `valkey-cli`); `valkey-server` config passthrough (config
-file, ACL file, append-only, max-memory, extra args); the
-`valkey/valkey-bundle` image with module verification; keyspace
-export/import via SCAN + DUMP/RESTORE.
+bootstrapping `valkey-cli`); configuration passthrough for `Replication`
+and `Cluster` members; the `valkey/valkey-bundle` image with module
+verification; keyspace export/import via SCAN + DUMP/RESTORE.

--- a/daggerverse/valkey/cluster.go
+++ b/daggerverse/valkey/cluster.go
@@ -165,6 +165,9 @@ func (v *Valkey) Cluster(
 			image,
 			password,
 			clientListenerSecurity,
+			// The configuration passthrough is Valkey.Server's alone: a
+			// cluster member's boot flags are this module's to own.
+			nil,
 			clusterArgs(serverHostname(nodeName)),
 			// Deliberately no bindings between peers — see startAll.
 			nil,

--- a/daggerverse/valkey/config.go
+++ b/daggerverse/valkey/config.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"dagger/valkey/internal/dagger"
+)
+
+// Fixed in-container paths for the caller-supplied configuration
+// passthrough. The config file is an ordinary world-readable file; the
+// ACL file rides in as a mounted secret because it carries per-user
+// password hashes (and, for a caller who writes one carelessly,
+// plaintext). Both are owned by the valkey user the entrypoint drops to,
+// so valkey-server can still read them after `gosu valkey`.
+const (
+	serverConfigPath  = "/etc/valkey/valkey.conf"
+	serverAclFilePath = "/etc/valkey/users.acl"
+)
+
+// defaultMaxMemoryPolicy is both Valkey's own default eviction policy and
+// this module's `+default` for maxMemoryPolicy. Because the two agree, a
+// caller who never touches the parameter gets no `--maxmemory-policy`
+// flag at all — see applyServerConfig for why that matters.
+const defaultMaxMemoryPolicy = "noeviction"
+
+// serverConfig carries the `valkey-server` configuration a caller wants
+// applied at boot. Every field is optional; the zero value renders no
+// mounts and no arguments, so a node built from it is byte-identical to
+// one built before this passthrough existed.
+//
+// These are boot-time settings rather than post-boot modifiers because
+// several of them (an ACL file, an append-only log, a config file) are
+// only read while valkey-server starts up.
+type serverConfig struct {
+	File            *dagger.File   // A valkey.conf loaded ahead of every flag argument.
+	AclFile         *dagger.Secret // An ACL file mounted as a secret and loaded via --aclfile.
+	AppendOnly      bool           // Turn the AOF on (`--appendonly yes`).
+	MaxMemory       string         // Memory ceiling in Valkey's own notation ("512mb", "1gb", "104857600").
+	MaxMemoryPolicy string         // Eviction policy applied once MaxMemory is reached.
+	ExtraArgs       []string       // Unvalidated escape hatch, appended after everything else.
+}
+
+// maxMemoryPolicies is the set of eviction policies Valkey accepts. A
+// typo here (`allkeys-lfu` mistyped as `allkeys-flu`, say) makes
+// valkey-server refuse to start with a config-parse error buried in the
+// service's logs, long after the Dagger call that caused it — so the set
+// is checked in-process instead.
+var maxMemoryPolicies = []string{
+	"noeviction",
+	"allkeys-lru",
+	"allkeys-lfu",
+	"allkeys-random",
+	"volatile-lru",
+	"volatile-lfu",
+	"volatile-random",
+	"volatile-ttl",
+}
+
+// maxMemoryPattern matches what Valkey's own memtoll parser accepts: an
+// integer optionally followed by a unit suffix, case-insensitively. The
+// suffixes are deliberately NOT interchangeable — `k`/`m`/`g` are powers
+// of 1000 and `kb`/`mb`/`gb` powers of 1024 — so the value is passed
+// through verbatim rather than normalised. A fractional value ("1.5gb")
+// is rejected because memtoll stops at the `.` and fails on the
+// remainder.
+var maxMemoryPattern = regexp.MustCompile(`^[0-9]+([bB]|[kK][bB]?|[mM][bB]?|[gG][bB]?)?$`)
+
+// validateServerConfig rejects a passthrough that would make
+// valkey-server die during startup. Both checks catch a class of failure
+// that is otherwise near-invisible: the node's service simply never
+// becomes ready, and the caller sees a readiness timeout rather than the
+// typo that caused it.
+//
+// The config file, the ACL file, and ExtraArgs are deliberately NOT
+// validated — the first two are opaque to this module and the third is
+// documented as unsupported surface.
+func validateServerConfig(cfg *serverConfig) error {
+	if cfg.MaxMemory != "" && !maxMemoryPattern.MatchString(cfg.MaxMemory) {
+		return fmt.Errorf(
+			"maxMemory %q is not a valid Valkey memory value: expected an integer with an optional unit suffix (b, k, kb, m, mb, g, gb), e.g. %q or %q",
+			cfg.MaxMemory, "512mb", "104857600",
+		)
+	}
+	if cfg.MaxMemoryPolicy != "" && !isMaxMemoryPolicy(cfg.MaxMemoryPolicy) {
+		return fmt.Errorf(
+			"maxMemoryPolicy %q is not a valid Valkey eviction policy: expected one of %s",
+			cfg.MaxMemoryPolicy, strings.Join(maxMemoryPolicies, ", "),
+		)
+	}
+	return nil
+}
+
+// validateAclFile rejects an ACL file that never mentions the `default`
+// user.
+//
+// This is not pedantry, it is the module's password guarantee. Valkey
+// applies `requirepass` while parsing the config and loads the ACL file
+// afterwards, and an ACL file that omits `default` does not leave that
+// user alone — it recreates it in its factory state, which is `on
+// nopass ~* +@all`. So an ACL file listing only the caller's own users
+// silently un-does `requirepass` and leaves the node reachable by
+// anything that can route to it. Valkey.Server rejects `password == nil`
+// for exactly that reason; letting `aclFile` reintroduce it through the
+// back door would make the guarantee a lie.
+//
+// The check is deliberately a mention, not an interpretation: `user
+// default off` and `user default on >… ~… +…` are both fine, because a
+// caller who named `default` has made a decision about it. Only silence
+// is refused.
+//
+// Reading the secret here costs nothing extra in exposure — the same
+// bytes are mounted into the node a moment later — and nothing is logged.
+func validateAclFile(ctx context.Context, aclFile *dagger.Secret) error {
+	contents, err := aclFile.Plaintext(ctx)
+	if err != nil {
+		return fmt.Errorf("read aclFile: %w", err)
+	}
+	for _, line := range strings.Split(contents, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 || strings.HasPrefix(fields[0], "#") {
+			continue
+		}
+		if strings.EqualFold(fields[0], "user") && fields[1] == defaultUser {
+			return nil
+		}
+	}
+	return fmt.Errorf(
+		"aclFile must contain a `user %s ...` rule: Valkey loads the ACL file after requirepass and recreates any user the file omits in its factory state (`on nopass`), so an ACL file that lists only your own users would silently drop the password from the %s user and leave the node open; add `user %s on >$password ~* &* +@all` to keep the requirepass credentials, or `user %s off` to disable it deliberately",
+		defaultUser, defaultUser, defaultUser, defaultUser,
+	)
+}
+
+// isMaxMemoryPolicy reports whether policy is one Valkey accepts.
+func isMaxMemoryPolicy(policy string) bool {
+	for _, known := range maxMemoryPolicies {
+		if policy == known {
+			return true
+		}
+	}
+	return false
+}
+
+// applyServerConfig renders the container mutations and the
+// `valkey-server` arguments that realise a configuration passthrough. It
+// returns the (possibly mutated) container plus TWO argument slices,
+// because they belong at opposite ends of the command line:
+//
+//   - leading — the config file path, which valkey-server only honours as
+//     its FIRST positional argument. Everything after it is a flag
+//     override.
+//   - flags — the individual settings, which must therefore follow every
+//     directive the file supplied in order to win over it.
+//
+// The rule the flags follow: a parameter left at its default emits NO
+// flag. That is what keeps `configFile` meaningful. A flag beats the
+// file, so unconditionally emitting `--appendonly no` (Valkey's default,
+// and this module's) would silently override a config file that turned
+// the AOF on, and the caller would have no way to express "leave it to
+// the file". Emitting nothing until the caller actually asks for
+// something means the file's directive survives untouched.
+//
+// ExtraArgs is not rendered here: buildServer appends it after the
+// topology arguments so it is genuinely last on the command line.
+func applyServerConfig(ctr *dagger.Container, cfg *serverConfig) (*dagger.Container, []string, []string) {
+	var leading, flags []string
+
+	if cfg.File != nil {
+		ctr = ctr.WithFile(serverConfigPath, cfg.File, dagger.ContainerWithFileOpts{
+			Permissions: 0o644,
+			Owner:       "valkey:valkey",
+		})
+		leading = append(leading, serverConfigPath)
+	}
+
+	if cfg.AclFile != nil {
+		ctr = ctr.WithMountedSecret(serverAclFilePath, cfg.AclFile, dagger.ContainerWithMountedSecretOpts{
+			Mode:  0o600,
+			Owner: "valkey:valkey",
+		})
+		flags = append(flags, "--aclfile", serverAclFilePath)
+	}
+
+	if cfg.AppendOnly {
+		flags = append(flags, "--appendonly", "yes")
+	}
+	if cfg.MaxMemory != "" {
+		flags = append(flags, "--maxmemory", cfg.MaxMemory)
+	}
+	if cfg.MaxMemoryPolicy != "" && cfg.MaxMemoryPolicy != defaultMaxMemoryPolicy {
+		flags = append(flags, "--maxmemory-policy", cfg.MaxMemoryPolicy)
+	}
+
+	return ctr, leading, flags
+}

--- a/daggerverse/valkey/dagger.gen.go
+++ b/daggerverse/valkey/dagger.gen.go
@@ -933,7 +933,49 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg clientListenerSecurity", err))
 				}
 			}
-			return (*Valkey).Server(&parent, ctx, name, registry, tag, password, clientListenerSecurity)
+			var configFile *dagger.File
+			if inputArgs["configFile"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["configFile"]), &configFile)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg configFile", err))
+				}
+			}
+			var aclFile *dagger.Secret
+			if inputArgs["aclFile"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["aclFile"]), &aclFile)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg aclFile", err))
+				}
+			}
+			var appendOnly bool
+			if inputArgs["appendOnly"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["appendOnly"]), &appendOnly)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg appendOnly", err))
+				}
+			}
+			var maxMemory string
+			if inputArgs["maxMemory"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["maxMemory"]), &maxMemory)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg maxMemory", err))
+				}
+			}
+			var maxMemoryPolicy string
+			if inputArgs["maxMemoryPolicy"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["maxMemoryPolicy"]), &maxMemoryPolicy)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg maxMemoryPolicy", err))
+				}
+			}
+			var extraArgs []string
+			if inputArgs["extraArgs"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["extraArgs"]), &extraArgs)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg extraArgs", err))
+				}
+			}
+			return (*Valkey).Server(&parent, ctx, name, registry, tag, password, clientListenerSecurity, configFile, aclFile, appendOnly, maxMemory, maxMemoryPolicy, extraArgs)
 		case "TlsClientSecurity":
 			var parent Valkey
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/valkey/main.go
+++ b/daggerverse/valkey/main.go
@@ -24,6 +24,10 @@
 //   - server.go      — *Server + Valkey.Server, input validation, the
 //     shared node builder (buildServer), and the Endpoint / User /
 //     Password / BindServer / Client / Stop methods.
+//   - config.go      — the `valkey-server` configuration passthrough a
+//     caller hands Valkey.Server (config file, ACL file, append-only,
+//     max-memory, extra args), its validation, and its rendering into
+//     mounts and boot arguments.
 //   - replication.go — *Replication + Valkey.Replication, the
 //     primary/replica topology builder, and the Primary / Replicas /
 //     Stop methods.

--- a/daggerverse/valkey/replication.go
+++ b/daggerverse/valkey/replication.go
@@ -90,7 +90,7 @@ func (v *Valkey) Replication(
 
 	image := valkeyImage(registry, tag)
 
-	primary := buildServer(replicationNodeName(name, 0), image, password, clientListenerSecurity, nil, nil, nil)
+	primary := buildServer(replicationNodeName(name, 0), image, password, clientListenerSecurity, nil, nil, nil, nil)
 
 	nodes := make([]*Server, 0, replicas+1)
 	nodes = append(nodes, primary)
@@ -100,6 +100,9 @@ func (v *Valkey) Replication(
 			image,
 			password,
 			clientListenerSecurity,
+			// The configuration passthrough is Valkey.Server's alone: a
+			// replica's boot flags are this module's to own.
+			nil,
 			replicaArgs(primary.Host),
 			[]serviceBinding{{host: primary.Host, svc: primary.Svc}},
 			nil,

--- a/daggerverse/valkey/server.go
+++ b/daggerverse/valkey/server.go
@@ -56,6 +56,49 @@ type Server struct {
 //   - `name == ""` for a TLS / MTLS node — the hostname (and therefore
 //     the SAN the server cert must carry) derives from `name`, so each
 //     encrypted node needs a unique discriminator.
+//   - a malformed `maxMemory` or an unknown `maxMemoryPolicy` — either
+//     makes valkey-server refuse to start, which would otherwise reach
+//     the caller as an opaque readiness timeout.
+//   - an `aclFile` that never mentions the `default` user — Valkey would
+//     recreate that user `nopass` and the node would boot without the
+//     password this function insists on. See validateAclFile.
+//
+// # Configuration passthrough
+//
+// `configFile`, `aclFile`, `appendOnly`, `maxMemory`, `maxMemoryPolicy`,
+// and `extraArgs` are all optional, and omitting every one of them
+// produces exactly the node this function produced before they existed.
+// They are constructor parameters rather than post-boot modifiers
+// because valkey-server reads each of them only while starting up.
+//
+// Precedence runs left to right along the command line, which Valkey
+// resolves last-one-wins:
+//
+//	<configFile>  <listener flags>  <passthrough flags>  <extraArgs>
+//
+// So a flag argument always beats the same directive in `configFile`,
+// and `extraArgs` beats everything — including this module's own
+// choices. A passthrough parameter left at its default emits no flag at
+// all, which is what lets `configFile` govern the settings the caller
+// did not name.
+//
+// `aclFile` is a `*dagger.Secret`, not a `*dagger.File`: an ACL file
+// carries per-user password material, so it is mounted as a secret and
+// never lands in an image layer or the Dagger graph. Valkey loads it
+// AFTER `requirepass` and recreates any user the file omits in its
+// factory `on nopass` state, so the file must say something about
+// `default` — that is the one thing about it this function validates.
+//
+// A `configFile` carrying its own `user ...` directives cannot be
+// combined with an `aclFile`: valkey-server refuses to start when both
+// are present. This module does not read the config file, so that one
+// surfaces as a node that never becomes ready.
+//
+// `extraArgs` is the deliberate escape hatch. It is appended verbatim,
+// last, and completely unvalidated; it is UNSUPPORTED surface, and
+// anything reachable through it may break without notice. Each element
+// becomes one shell word in the node's boot command, so a caller passing
+// a value containing whitespace must quote it themselves.
 //
 // Session-cached so that repeated chained method calls on the returned
 // server (e.g. Client.Set → Client.Get across two Server.Client() calls
@@ -84,6 +127,31 @@ func (v *Valkey) Server(
 	tag string,
 	password *dagger.Secret,
 	clientListenerSecurity *ServerSecurity,
+	// A valkey.conf loaded before every flag argument; conflicting flags win.
+	//
+	// +optional
+	configFile *dagger.File,
+	// An ACL file loaded via --aclfile. A secret, not a file: it carries
+	// per-user password material.
+	//
+	// +optional
+	aclFile *dagger.Secret,
+	// Turn the append-only file on. Defaults to false, matching Valkey.
+	//
+	// +default=false
+	appendOnly bool,
+	// Memory ceiling in Valkey's notation ("512mb", "1gb", "104857600").
+	//
+	// +optional
+	maxMemory string,
+	// Eviction policy applied once maxMemory is reached.
+	//
+	// +default="noeviction"
+	maxMemoryPolicy string,
+	// Unvalidated, unsupported valkey-server arguments, appended last.
+	//
+	// +optional
+	extraArgs []string,
 ) (*Server, error) {
 	if password == nil {
 		return nil, fmt.Errorf("password must not be nil; pass a *dagger.Secret with the requirepass value")
@@ -108,7 +176,24 @@ func (v *Valkey) Server(
 		)
 	}
 
-	return buildServer(name, valkeyImage(registry, tag), password, clientListenerSecurity, nil, nil, nil), nil
+	cfg := &serverConfig{
+		File:            configFile,
+		AclFile:         aclFile,
+		AppendOnly:      appendOnly,
+		MaxMemory:       maxMemory,
+		MaxMemoryPolicy: maxMemoryPolicy,
+		ExtraArgs:       extraArgs,
+	}
+	if err := validateServerConfig(cfg); err != nil {
+		return nil, err
+	}
+	if aclFile != nil {
+		if err := validateAclFile(ctx, aclFile); err != nil {
+			return nil, err
+		}
+	}
+
+	return buildServer(name, valkeyImage(registry, tag), password, clientListenerSecurity, cfg, nil, nil, nil), nil
 }
 
 // valkeyImage renders the image reference a node boots from. The
@@ -139,21 +224,27 @@ type serviceBinding struct {
 }
 
 // buildServer assembles a single valkey-server node: the container, the
-// security-derived listener flags, any extra `valkey-server` arguments
-// (replication or cluster flags, say), the service bindings the node
-// needs in order to dial its peers, and any ports beyond the client
-// listener the node must expose (the cluster bus, say). Inputs are
-// assumed already validated — Valkey.Server, Valkey.Replication, and
-// Valkey.Cluster each validate before calling.
+// security-derived listener flags, the caller's configuration
+// passthrough, any topology `valkey-server` arguments (replication or
+// cluster flags, say), the service bindings the node needs in order to
+// dial its peers, and any ports beyond the client listener the node must
+// expose (the cluster bus, say). Inputs are assumed already validated —
+// Valkey.Server, Valkey.Replication, and Valkey.Cluster each validate
+// before calling. A nil cfg means no passthrough, which is what the
+// topology constructors pass.
 func buildServer(
 	name string,
 	image string,
 	password *dagger.Secret,
 	security *ServerSecurity,
-	extraArgs []string,
+	cfg *serverConfig,
+	topologyArgs []string,
 	bindings []serviceBinding,
 	extraPorts []int,
 ) *Server {
+	if cfg == nil {
+		cfg = &serverConfig{}
+	}
 	host := serverHostname(name)
 
 	// The password reaches valkey-server through a secret environment
@@ -176,8 +267,31 @@ func buildServer(
 		ctr = ctr.WithServiceBinding(b.host, b.svc)
 	}
 
-	ctr, args := applyServerSecurity(ctr, security)
-	args = append(args, extraArgs...)
+	ctr, configPath, configFlags := applyServerConfig(ctr, cfg)
+	ctr, securityArgs := applyServerSecurity(ctr, security)
+
+	// The command line IS the precedence contract, so the order here is
+	// load-bearing rather than incidental:
+	//
+	//  1. the config file path — valkey-server reads it only as the first
+	//     positional argument, and every flag after it is an override;
+	//  2. the listener flags (port + requirepass), which the module owns
+	//     outright and so always win over the file;
+	//  3. the caller's passthrough flags, which win over the file for the
+	//     settings the caller actually named;
+	//  4. the topology flags (--replicaof, --cluster-enabled), which the
+	//     module owns for the same reason as (2);
+	//  5. extraArgs — deliberately last, so the escape hatch can override
+	//     anything above it, including this module's own choices.
+	//
+	// Valkey resolves duplicate settings last-one-wins, so "later" and
+	// "higher precedence" are the same statement.
+	args := make([]string, 0, len(configPath)+len(securityArgs)+len(configFlags)+len(topologyArgs)+len(cfg.ExtraArgs))
+	args = append(args, configPath...)
+	args = append(args, securityArgs...)
+	args = append(args, configFlags...)
+	args = append(args, topologyArgs...)
+	args = append(args, cfg.ExtraArgs...)
 
 	// A shell wrapper is what makes "$VALKEY_PASSWORD" expand at boot;
 	// AsService args are exec'd directly, with no shell to expand them.

--- a/daggerverse/valkey/tests/dagger.gen.go
+++ b/daggerverse/valkey/tests/dagger.gen.go
@@ -192,6 +192,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 	switch parentName {
 	case "Tests":
 		switch fnName {
+		case "AclFileProvisionsUser":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).AclFileProvisionsUser(&parent, ctx)
 		case "All":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -206,6 +213,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Tests).All(&parent, ctx, parallel)
+		case "AppendOnlyEnablesAof":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).AppendOnlyEnablesAof(&parent, ctx)
 		case "ApplyFileReportsFailingCommand":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -332,6 +346,27 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).ClusterStopTerminatesEveryNode(&parent, ctx)
+		case "Config":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var parallel int
+			if inputArgs["parallel"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["parallel"]), &parallel)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg parallel", err))
+				}
+			}
+			return nil, (*Tests).Config(&parent, ctx, parallel)
+		case "ConfigFileDirectivesApply":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ConfigFileDirectivesApply(&parent, ctx)
 		case "DbSelectsLogicalDatabase":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -367,6 +402,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).EndpointShouldNotBeCached(&parent, ctx)
+		case "ExtraArgsReachServerLast":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ExtraArgsReachServerLast(&parent, ctx)
+		case "FlagArgumentBeatsConfigFile":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).FlagArgumentBeatsConfigFile(&parent, ctx)
 		case "FlushAllClearsKeys":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -402,6 +451,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).KeysScansPattern(&parent, ctx)
+		case "MaxMemoryEvictsOverLimit":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).MaxMemoryEvictsOverLimit(&parent, ctx)
 		case "MtlsNodeDemandsClientCertAtWire":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -416,6 +472,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).MtlsServerRejectsTlsOnlyClient(&parent, ctx)
+		case "OmittedConfigLeavesValkeyDefaults":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).OmittedConfigLeavesValkeyDefaults(&parent, ctx)
 		case "PasswordReusableViaClient":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -542,6 +605,27 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).ServerMtlsRoundTripFromClient(&parent, ctx)
+		case "ServerRejectsAclFileWithoutDefaultUser":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ServerRejectsAclFileWithoutDefaultUser(&parent, ctx)
+		case "ServerRejectsInvalidMaxMemory":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ServerRejectsInvalidMaxMemory(&parent, ctx)
+		case "ServerRejectsInvalidMaxMemoryPolicy":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ServerRejectsInvalidMaxMemoryPolicy(&parent, ctx)
 		case "ServerRejectsNilPassword":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/valkey/tests/internal/dagger/valkey.gen.go
+++ b/daggerverse/valkey/tests/internal/dagger/valkey.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type Valkey
-func (r *Binding) AsValkey() *Valkey { // valkey (../../../../../daggerverse/valkey/main.go:43:6)
+func (r *Binding) AsValkey() *Valkey { // valkey (../../../../../daggerverse/valkey/main.go:47:6)
 	q := r.query.Select("asValkey")
 
 	return &Valkey{
@@ -145,7 +145,7 @@ func (r *Env) WithValkeyClusterOutput(name string, description string) *Env { //
 }
 
 // Create or update a binding of type Valkey in the environment
-func (r *Env) WithValkeyInput(name string, value *Valkey, description string) *Env { // valkey (../../../../../daggerverse/valkey/main.go:43:6)
+func (r *Env) WithValkeyInput(name string, value *Valkey, description string) *Env { // valkey (../../../../../daggerverse/valkey/main.go:47:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withValkeyInput")
 	q = q.Arg("name", name)
@@ -158,7 +158,7 @@ func (r *Env) WithValkeyInput(name string, value *Valkey, description string) *E
 }
 
 // Declare a desired Valkey output to be assigned in the environment
-func (r *Env) WithValkeyOutput(name string, description string) *Env { // valkey (../../../../../daggerverse/valkey/main.go:43:6)
+func (r *Env) WithValkeyOutput(name string, description string) *Env { // valkey (../../../../../daggerverse/valkey/main.go:47:6)
 	q := r.query.Select("withValkeyOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -244,7 +244,7 @@ func (r *Env) WithValkeyServerSecurityOutput(name string, description string) *E
 // module. The server constructor, security helpers, and the
 // remote-client factory all hang off *Valkey so the generated Dagger SDK
 // surfaces them under `dag.Valkey().<Func>(...)`.
-func (r *Query) Valkey() *Valkey { // valkey (../../../../../daggerverse/valkey/main.go:43:6)
+func (r *Query) Valkey() *Valkey { // valkey (../../../../../daggerverse/valkey/main.go:47:6)
 	q := r.query.Select("valkey")
 
 	return &Valkey{
@@ -256,7 +256,7 @@ func (r *Query) Valkey() *Valkey { // valkey (../../../../../daggerverse/valkey/
 // module. The server constructor, security helpers, and the
 // remote-client factory all hang off *Valkey so the generated Dagger SDK
 // surfaces them under `dag.Valkey().<Func>(...)`.
-type Valkey struct { // valkey (../../../../../daggerverse/valkey/main.go:43:6)
+type Valkey struct { // valkey (../../../../../daggerverse/valkey/main.go:47:6)
 	query *querybuilder.Selection
 
 	id *ID
@@ -596,13 +596,40 @@ func (r *Valkey) Replication(password *Secret, clientListenerSecurity *ValkeySer
 
 // ValkeyServerOpts contains options for Valkey.Server
 type ValkeyServerOpts struct {
-	Name string // valkey (../../../../../daggerverse/valkey/server.go:80:2)
+	Name string // valkey (../../../../../daggerverse/valkey/server.go:123:2)
 
 	// Default: "docker.io"
-	Registry string // valkey (../../../../../daggerverse/valkey/server.go:82:2)
+	Registry string // valkey (../../../../../daggerverse/valkey/server.go:125:2)
 
 	// Default: "9.1"
-	Tag string // valkey (../../../../../daggerverse/valkey/server.go:84:2)
+	Tag string // valkey (../../../../../daggerverse/valkey/server.go:127:2)
+	//
+	// A valkey.conf loaded before every flag argument; conflicting flags win.
+	//
+	ConfigFile *File // valkey (../../../../../daggerverse/valkey/server.go:133:2)
+	//
+	// An ACL file loaded via --aclfile. A secret, not a file: it carries
+	// per-user password material.
+	//
+	ACLFile *Secret // valkey (../../../../../daggerverse/valkey/server.go:138:2)
+	//
+	// Turn the append-only file on. Defaults to false, matching Valkey.
+	//
+	AppendOnly bool // valkey (../../../../../daggerverse/valkey/server.go:142:2)
+	//
+	// Memory ceiling in Valkey's notation ("512mb", "1gb", "104857600").
+	//
+	MaxMemory string // valkey (../../../../../daggerverse/valkey/server.go:146:2)
+	//
+	// Eviction policy applied once maxMemory is reached.
+	//
+	//
+	// Default: "noeviction"
+	MaxMemoryPolicy string // valkey (../../../../../daggerverse/valkey/server.go:150:2)
+	//
+	// Unvalidated, unsupported valkey-server arguments, appended last.
+	//
+	ExtraArgs []string // valkey (../../../../../daggerverse/valkey/server.go:154:2)
 }
 
 // Server spins up a single-node Valkey server listening on 6379 with
@@ -627,6 +654,49 @@ type ValkeyServerOpts struct {
 //   - `name == ""` for a TLS / MTLS node — the hostname (and therefore
 //     the SAN the server cert must carry) derives from `name`, so each
 //     encrypted node needs a unique discriminator.
+//   - a malformed `maxMemory` or an unknown `maxMemoryPolicy` — either
+//     makes valkey-server refuse to start, which would otherwise reach
+//     the caller as an opaque readiness timeout.
+//   - an `aclFile` that never mentions the `default` user — Valkey would
+//     recreate that user `nopass` and the node would boot without the
+//     password this function insists on. See validateAclFile.
+//
+// # Configuration passthrough
+//
+// `configFile`, `aclFile`, `appendOnly`, `maxMemory`, `maxMemoryPolicy`,
+// and `extraArgs` are all optional, and omitting every one of them
+// produces exactly the node this function produced before they existed.
+// They are constructor parameters rather than post-boot modifiers
+// because valkey-server reads each of them only while starting up.
+//
+// Precedence runs left to right along the command line, which Valkey
+// resolves last-one-wins:
+//
+//	<configFile>  <listener flags>  <passthrough flags>  <extraArgs>
+//
+// So a flag argument always beats the same directive in `configFile`,
+// and `extraArgs` beats everything — including this module's own
+// choices. A passthrough parameter left at its default emits no flag at
+// all, which is what lets `configFile` govern the settings the caller
+// did not name.
+//
+// `aclFile` is a `*dagger.Secret`, not a `*dagger.File`: an ACL file
+// carries per-user password material, so it is mounted as a secret and
+// never lands in an image layer or the Dagger graph. Valkey loads it
+// AFTER `requirepass` and recreates any user the file omits in its
+// factory `on nopass` state, so the file must say something about
+// `default` — that is the one thing about it this function validates.
+//
+// A `configFile` carrying its own `user ...` directives cannot be
+// combined with an `aclFile`: valkey-server refuses to start when both
+// are present. This module does not read the config file, so that one
+// surfaces as a node that never becomes ready.
+//
+// `extraArgs` is the deliberate escape hatch. It is appended verbatim,
+// last, and completely unvalidated; it is UNSUPPORTED surface, and
+// anything reachable through it may break without notice. Each element
+// becomes one shell word in the node's boot command, so a caller passing
+// a value containing whitespace must quote it themselves.
 //
 // Session-cached so that repeated chained method calls on the returned
 // server (e.g. Client.Set → Client.Get across two Server.Client() calls
@@ -643,7 +713,7 @@ type ValkeyServerOpts struct {
 // what a single test's chained Client calls need. Leaving the default
 // empty is fine for ad-hoc `dagger call` use where only one node is in
 // play.
-func (r *Valkey) Server(password *Secret, clientListenerSecurity *ValkeyServerSecurity, opts ...ValkeyServerOpts) *ValkeyServer { // valkey (../../../../../daggerverse/valkey/server.go:77:1)
+func (r *Valkey) Server(password *Secret, clientListenerSecurity *ValkeyServerSecurity, opts ...ValkeyServerOpts) *ValkeyServer { // valkey (../../../../../daggerverse/valkey/server.go:120:1)
 	assertNotNil("password", password)
 	assertNotNil("clientListenerSecurity", clientListenerSecurity)
 	q := r.query.Select("server")
@@ -659,6 +729,30 @@ func (r *Valkey) Server(password *Secret, clientListenerSecurity *ValkeyServerSe
 		// `tag` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Tag) {
 			q = q.Arg("tag", opts[i].Tag)
+		}
+		// `configFile` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ConfigFile) {
+			q = q.Arg("configFile", opts[i].ConfigFile)
+		}
+		// `aclFile` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ACLFile) {
+			q = q.Arg("aclFile", opts[i].ACLFile)
+		}
+		// `appendOnly` optional argument
+		if !querybuilder.IsZeroValue(opts[i].AppendOnly) {
+			q = q.Arg("appendOnly", opts[i].AppendOnly)
+		}
+		// `maxMemory` optional argument
+		if !querybuilder.IsZeroValue(opts[i].MaxMemory) {
+			q = q.Arg("maxMemory", opts[i].MaxMemory)
+		}
+		// `maxMemoryPolicy` optional argument
+		if !querybuilder.IsZeroValue(opts[i].MaxMemoryPolicy) {
+			q = q.Arg("maxMemoryPolicy", opts[i].MaxMemoryPolicy)
+		}
+		// `extraArgs` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ExtraArgs) {
+			q = q.Arg("extraArgs", opts[i].ExtraArgs)
 		}
 	}
 	q = q.Arg("password", password)
@@ -1087,7 +1181,7 @@ func (r *ValkeyCluster) WithGraphQLQuery(q *querybuilder.Selection) *ValkeyClust
 // bootstrap a build-time dependency of whatever the consumer runs next,
 // so the container's first command meets a cluster whose slots are
 // already assigned rather than one answering CLUSTERDOWN.
-func (r *ValkeyCluster) BindNodes(ctr *Container) *Container { // valkey (../../../../../daggerverse/valkey/cluster.go:406:1)
+func (r *ValkeyCluster) BindNodes(ctr *Container) *Container { // valkey (../../../../../daggerverse/valkey/cluster.go:409:1)
 	assertNotNil("ctr", ctr)
 	q := r.query.Select("bindNodes")
 	q = q.Arg("ctr", ctr)
@@ -1115,7 +1209,7 @@ func (r *ValkeyCluster) BindNodes(ctr *Container) *Container { // valkey (../../
 // makes BindNodes unusable on the same cluster afterwards — see
 // Valkey.Cluster — so a consumer container should bind a cluster this
 // module has not already dialled.
-func (r *ValkeyCluster) Client(security *ValkeyClientSecurity) *ValkeyClient { // valkey (../../../../../daggerverse/valkey/cluster.go:434:1)
+func (r *ValkeyCluster) Client(security *ValkeyClientSecurity) *ValkeyClient { // valkey (../../../../../daggerverse/valkey/cluster.go:437:1)
 	assertNotNil("security", security)
 	q := r.query.Select("client")
 	q = q.Arg("security", security)
@@ -1132,7 +1226,7 @@ func (r *ValkeyCluster) Client(security *ValkeyClientSecurity) *ValkeyClient { /
 //
 // Session-cached rather than never-cached: Dagger v0.21 detaches module
 // objects returned from a `module reads their fields lazily, and `tests/` is such a consumer.
-func (r *ValkeyCluster) Endpoints(ctx context.Context) ([]string, error) { // valkey (../../../../../daggerverse/valkey/cluster.go:384:1)
+func (r *ValkeyCluster) Endpoints(ctx context.Context) ([]string, error) { // valkey (../../../../../daggerverse/valkey/cluster.go:387:1)
 	q := r.query.Select("endpoints")
 
 	var response []string
@@ -1194,7 +1288,7 @@ func (r *ValkeyCluster) UnmarshalJSON(bs []byte) error {
 // earlier one fails, and the failures are joined — a partial teardown
 // that reported only the first error would leave services running with
 // nothing naming them.
-func (r *ValkeyCluster) Stop(ctx context.Context) error { // valkey (../../../../../daggerverse/valkey/cluster.go:461:1)
+func (r *ValkeyCluster) Stop(ctx context.Context) error { // valkey (../../../../../daggerverse/valkey/cluster.go:464:1)
 	if r.stop != nil {
 		return nil
 	}
@@ -1287,7 +1381,7 @@ func (r *ValkeyReplication) UnmarshalJSON(bs []byte) error {
 // objects returned from a `module reads their fields lazily, and `tests/` is such a consumer. The
 // methods on the returned *Server are individually never-cached, so no
 // data-returning call is served stale.
-func (r *ValkeyReplication) Primary() *ValkeyServer { // valkey (../../../../../daggerverse/valkey/replication.go:162:1)
+func (r *ValkeyReplication) Primary() *ValkeyServer { // valkey (../../../../../daggerverse/valkey/replication.go:165:1)
 	q := r.query.Select("primary")
 
 	return &ValkeyServer{
@@ -1297,7 +1391,7 @@ func (r *ValkeyReplication) Primary() *ValkeyServer { // valkey (../../../../../
 
 // Replicas returns the topology's read replicas, in creation order.
 // Session-cached for the same reason Primary is.
-func (r *ValkeyReplication) Replicas(ctx context.Context) ([]ValkeyServer, error) { // valkey (../../../../../daggerverse/valkey/replication.go:173:1)
+func (r *ValkeyReplication) Replicas(ctx context.Context) ([]ValkeyServer, error) { // valkey (../../../../../daggerverse/valkey/replication.go:176:1)
 	q := r.query.Select("replicas")
 
 	q = q.Select("id")
@@ -1334,7 +1428,7 @@ func (r *ValkeyReplication) Replicas(ctx context.Context) ([]ValkeyServer, error
 // node is attempted even if an earlier one fails, and the failures are
 // joined — a partial teardown that reported only the first error would
 // leave services running with nothing naming them.
-func (r *ValkeyReplication) Stop(ctx context.Context) error { // valkey (../../../../../daggerverse/valkey/replication.go:187:1)
+func (r *ValkeyReplication) Stop(ctx context.Context) error { // valkey (../../../../../daggerverse/valkey/replication.go:190:1)
 	if r.stop != nil {
 		return nil
 	}
@@ -1373,7 +1467,7 @@ func (r *ValkeyServer) WithGraphQLQuery(q *querybuilder.Selection) *ValkeyServer
 // BindServer attaches the Valkey service to the given container under
 // the same hostname Endpoint reports, so the container can dial the node
 // at `Endpoint()` (e.g. `valkey-cli -h <host> -a <pw> PING`).
-func (r *ValkeyServer) BindServer(ctr *Container) *Container { // valkey (../../../../../daggerverse/valkey/server.go:245:1)
+func (r *ValkeyServer) BindServer(ctr *Container) *Container { // valkey (../../../../../daggerverse/valkey/server.go:359:1)
 	assertNotNil("ctr", ctr)
 	q := r.query.Select("bindServer")
 	q = q.Arg("ctr", ctr)
@@ -1391,7 +1485,7 @@ func (r *ValkeyServer) BindServer(ctr *Container) *Container { // valkey (../../
 // rather than failing opaquely at the wire. Readiness is then probed
 // with the client itself, so a TLS / mTLS listener would be polled over
 // TLS using the caller's own cert material.
-func (r *ValkeyServer) Client(security *ValkeyClientSecurity) *ValkeyClient { // valkey (../../../../../daggerverse/valkey/server.go:259:1)
+func (r *ValkeyServer) Client(security *ValkeyClientSecurity) *ValkeyClient { // valkey (../../../../../daggerverse/valkey/server.go:373:1)
 	assertNotNil("security", security)
 	q := r.query.Select("client")
 	q = q.Arg("security", security)
@@ -1412,7 +1506,7 @@ func (r *ValkeyServer) Client(security *ValkeyClientSecurity) *ValkeyClient { //
 // would register the service in the module's DNS domain, which the
 // binding's host-file lookup can't resolve from a session-domain
 // consumer — so the start must be driven by the binding, not here.
-func (r *ValkeyServer) Endpoint(ctx context.Context) (string, error) { // valkey (../../../../../daggerverse/valkey/server.go:218:1)
+func (r *ValkeyServer) Endpoint(ctx context.Context) (string, error) { // valkey (../../../../../daggerverse/valkey/server.go:332:1)
 	if r.endpoint != nil {
 		return *r.endpoint, nil
 	}
@@ -1476,7 +1570,7 @@ func (r *ValkeyServer) UnmarshalJSON(bs []byte) error {
 // Password returns the `requirepass` secret the node was provisioned
 // with, so callers can re-use it via Valkey.Client against the same
 // endpoint.
-func (r *ValkeyServer) Password() *Secret { // valkey (../../../../../daggerverse/valkey/server.go:236:1)
+func (r *ValkeyServer) Password() *Secret { // valkey (../../../../../daggerverse/valkey/server.go:350:1)
 	q := r.query.Select("password")
 
 	return &Secret{
@@ -1488,7 +1582,7 @@ func (r *ValkeyServer) Password() *Secret { // valkey (../../../../../daggervers
 // call this in a defer so the service span closes when the test returns.
 // SIGKILL skips graceful shutdown — Valkey's save-on-shutdown path is
 // wasted work for a torn-down test node.
-func (r *ValkeyServer) Stop(ctx context.Context) error { // valkey (../../../../../daggerverse/valkey/server.go:295:1)
+func (r *ValkeyServer) Stop(ctx context.Context) error { // valkey (../../../../../daggerverse/valkey/server.go:409:1)
 	if r.stop != nil {
 		return nil
 	}
@@ -1500,7 +1594,7 @@ func (r *ValkeyServer) Stop(ctx context.Context) error { // valkey (../../../../
 // User returns the ACL user clients authenticate as. `requirepass` sets
 // the password of the built-in `default` user, so this is always
 // "default" in this story; an ACL-file follow-up is what makes it vary.
-func (r *ValkeyServer) User(ctx context.Context) (string, error) { // valkey (../../../../../daggerverse/valkey/server.go:227:1)
+func (r *ValkeyServer) User(ctx context.Context) (string, error) { // valkey (../../../../../daggerverse/valkey/server.go:341:1)
 	if r.user != nil {
 		return *r.user, nil
 	}

--- a/daggerverse/valkey/tests/main.go
+++ b/daggerverse/valkey/tests/main.go
@@ -4,8 +4,10 @@
 // `dagger call all`.
 //
 // Every password, server name, and key prefix is minted at runtime via
-// dag.Random().Sha256. The ACL user deliberately uses the valkey
-// module's default ("default"), which a few tests assert against.
+// dag.Random().Sha256. Clients authenticate as the valkey module's
+// default ACL user ("default"), which a few tests assert against; the
+// configuration-passthrough tests are the exception, since an ACL file is
+// how a caller gets any other user at all.
 package main
 
 import (
@@ -55,6 +57,9 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("Security", func(ctx context.Context) error {
 		return t.Security(ctx, parallel)
 	})
+	jobs = jobs.WithJob("Config", func(ctx context.Context) error {
+		return t.Config(ctx, parallel)
+	})
 	jobs = jobs.WithJob("Replication", func(ctx context.Context) error {
 		return t.Replication(ctx, parallel)
 	})
@@ -82,6 +87,9 @@ func (t *Tests) Validation(
 	}
 	jobs = jobs.WithJob("server-rejects-nil-password", t.ServerRejectsNilPassword)
 	jobs = jobs.WithJob("server-rejects-nil-security", t.ServerRejectsNilSecurity)
+	jobs = jobs.WithJob("server-rejects-invalid-max-memory", t.ServerRejectsInvalidMaxMemory)
+	jobs = jobs.WithJob("server-rejects-invalid-max-memory-policy", t.ServerRejectsInvalidMaxMemoryPolicy)
+	jobs = jobs.WithJob("server-rejects-acl-file-without-default-user", t.ServerRejectsAclFileWithoutDefaultUser)
 	jobs = jobs.WithJob("replication-rejects-too-few-replicas", t.ReplicationRejectsTooFewReplicas)
 	jobs = jobs.WithJob("replication-rejects-tls-security", t.ReplicationRejectsTlsSecurity)
 	jobs = jobs.WithJob("cluster-rejects-too-few-shards", t.ClusterRejectsTooFewShards)
@@ -238,6 +246,34 @@ func (t *Tests) Security(
 	return jobs.Run(ctx)
 }
 
+// Config runs the `valkey-server` configuration passthrough tests: the
+// config file, the ACL file, the append-only log, the memory ceiling, and
+// the extraArgs escape hatch. Each test boots its own node under a
+// runtime-random name, so the group fans out safely.
+//
+// +check
+// +cache="session"
+func (t *Tests) Config(
+	ctx context.Context,
+	// +default=0
+	parallel int,
+) error {
+	jobs := par.New().
+		WithRollupLogs(true).
+		WithRollupSpans(true)
+	if parallel > 0 {
+		jobs = jobs.WithLimit(parallel)
+	}
+	jobs = jobs.WithJob("omitted-config-leaves-valkey-defaults", t.OmittedConfigLeavesValkeyDefaults)
+	jobs = jobs.WithJob("append-only-enables-aof", t.AppendOnlyEnablesAof)
+	jobs = jobs.WithJob("max-memory-evicts-over-limit", t.MaxMemoryEvictsOverLimit)
+	jobs = jobs.WithJob("acl-file-provisions-user", t.AclFileProvisionsUser)
+	jobs = jobs.WithJob("config-file-directives-apply", t.ConfigFileDirectivesApply)
+	jobs = jobs.WithJob("flag-argument-beats-config-file", t.FlagArgumentBeatsConfigFile)
+	jobs = jobs.WithJob("extra-args-reach-server-last", t.ExtraArgsReachServerLast)
+	return jobs.Run(ctx)
+}
+
 // -----------------------------------------------------------------------------
 // Helpers — all identifiers minted at runtime, no literals.
 // -----------------------------------------------------------------------------
@@ -260,6 +296,18 @@ func randSecret(ctx context.Context) (*dagger.Secret, error) {
 		return nil, err
 	}
 	return dag.SetSecret("valkey-pw-"+full[:12], full), nil
+}
+
+// randSecretPair mints a random password and returns both the wrapped
+// *dagger.Secret and its plaintext. The plaintext is what a test needs
+// when it has to write the same credential into a fixture the server will
+// read back — an ACL file, say.
+func randSecretPair(ctx context.Context) (*dagger.Secret, string, error) {
+	full, err := dag.Random().Sha256(ctx, dagger.RandomSha256Opts{N: 32})
+	if err != nil {
+		return nil, "", err
+	}
+	return dag.SetSecret("valkey-pw-"+full[:12], full), full, nil
 }
 
 // bootServer mints a fresh single-node Valkey server and returns it
@@ -343,6 +391,90 @@ func (t *Tests) ServerRejectsNilSecurity(ctx context.Context) (returnErr error) 
 	}
 	server := dag.Valkey().Server(pass, nil)
 	_, _ = server.Endpoint(ctx)
+	return nil
+}
+
+// ServerRejectsInvalidMaxMemory verifies a malformed memory ceiling is
+// caught in-process rather than at boot. valkey-server parses `maxmemory`
+// with memtoll, which accepts an integer plus an optional unit suffix and
+// nothing else — a fractional value or an invented unit makes it refuse
+// to start, and the caller would meet that as a readiness timeout with
+// the parse error stranded in a service log nobody reads.
+//
+// The accepted cases run too, so the guard can't pass by rejecting
+// everything: `k`/`m`/`g` (powers of 1000) and `kb`/`mb`/`gb` (powers of
+// 1024) are both legal, as is a bare byte count.
+//
+// +cache="never"
+func (t *Tests) ServerRejectsInvalidMaxMemory(ctx context.Context) error {
+	pass, err := randSecret(ctx)
+	if err != nil {
+		return err
+	}
+	build := func(maxMemory string) *dagger.ValkeyServer {
+		return dag.Valkey().Server(
+			pass,
+			dag.Valkey().PlaintextServerSecurity(),
+			dagger.ValkeyServerOpts{MaxMemory: maxMemory},
+		)
+	}
+	for _, bad := range []string{"1.5gb", "512 mb", "lots", "512tb", "-1", "mb"} {
+		_, err := build(bad).Endpoint(ctx)
+		if err == nil {
+			return fmt.Errorf("expected maxMemory=%q to be rejected, but it built a server", bad)
+		}
+		if !strings.Contains(err.Error(), "maxMemory") {
+			return fmt.Errorf("expected the maxMemory=%q rejection to name the argument, got: %v", bad, err)
+		}
+	}
+	for _, good := range []string{"104857600", "512b", "64k", "64kb", "512m", "512mb", "1g", "1GB"} {
+		if _, err := build(good).Endpoint(ctx); err != nil {
+			return fmt.Errorf("expected maxMemory=%q to be accepted: %w", good, err)
+		}
+	}
+	return nil
+}
+
+// ServerRejectsInvalidMaxMemoryPolicy verifies an unknown eviction policy
+// is caught in-process, for the same reason as the memory ceiling: a
+// mistyped policy is a config-parse error at boot, which surfaces as a
+// node that simply never becomes ready.
+//
+// Every policy Valkey accepts is exercised on the accept side, so a guard
+// that only knew the common ones would fail here rather than in a
+// caller's pipeline.
+//
+// +cache="never"
+func (t *Tests) ServerRejectsInvalidMaxMemoryPolicy(ctx context.Context) error {
+	pass, err := randSecret(ctx)
+	if err != nil {
+		return err
+	}
+	build := func(policy string) *dagger.ValkeyServer {
+		return dag.Valkey().Server(
+			pass,
+			dag.Valkey().PlaintextServerSecurity(),
+			dagger.ValkeyServerOpts{MaxMemoryPolicy: policy},
+		)
+	}
+	for _, bad := range []string{"allkeys-flu", "lru", "evict-everything", "ALLKEYS-LRU"} {
+		_, err := build(bad).Endpoint(ctx)
+		if err == nil {
+			return fmt.Errorf("expected maxMemoryPolicy=%q to be rejected, but it built a server", bad)
+		}
+		if !strings.Contains(err.Error(), "maxMemoryPolicy") {
+			return fmt.Errorf("expected the maxMemoryPolicy=%q rejection to name the argument, got: %v", bad, err)
+		}
+	}
+	for _, good := range []string{
+		"noeviction",
+		"allkeys-lru", "allkeys-lfu", "allkeys-random",
+		"volatile-lru", "volatile-lfu", "volatile-random", "volatile-ttl",
+	} {
+		if _, err := build(good).Endpoint(ctx); err != nil {
+			return fmt.Errorf("expected maxMemoryPolicy=%q to be accepted: %w", good, err)
+		}
+	}
 	return nil
 }
 
@@ -2616,6 +2748,625 @@ func (t *Tests) ClusterStopTerminatesEveryNode(ctx context.Context) error {
 		if err := node.Ping(ctx); err == nil {
 			return fmt.Errorf("expected node %d to be down after Stop, but it still answered", i)
 		}
+	}
+	return nil
+}
+
+// -----------------------------------------------------------------------------
+// Config tests — `valkey-server` configuration passthrough.
+//
+// Every setting here is applied at boot, so each test boots its own node
+// and reads the result back through CONFIG GET / INFO rather than
+// asserting on rendered arguments: what matters is what valkey-server
+// ended up believing, not what this module thinks it asked for.
+// -----------------------------------------------------------------------------
+
+// configGet reads one configuration parameter back off a running node.
+//
+// CONFIG GET answers with a map under RESP3 and a flat array under RESP2,
+// so both shapes are decoded — the module pins neither, and a protocol
+// change should not read as a config failure.
+func configGet(ctx context.Context, client *dagger.ValkeyClient, param string) (string, error) {
+	reply, err := client.Do(ctx, []string{"CONFIG", "GET", param})
+	if err != nil {
+		return "", fmt.Errorf("config get %s: %w", param, err)
+	}
+	var asMap map[string]string
+	if err := json.Unmarshal([]byte(reply), &asMap); err == nil {
+		value, ok := asMap[param]
+		if !ok {
+			return "", fmt.Errorf("expected CONFIG GET %s to report the parameter, got %s", param, reply)
+		}
+		return value, nil
+	}
+	var asPairs []string
+	if err := json.Unmarshal([]byte(reply), &asPairs); err != nil {
+		return "", fmt.Errorf("expected CONFIG GET %s to decode as a map or an array, got %s", param, reply)
+	}
+	for i := 0; i+1 < len(asPairs); i += 2 {
+		if asPairs[i] == param {
+			return asPairs[i+1], nil
+		}
+	}
+	return "", fmt.Errorf("expected CONFIG GET %s to report the parameter, got %s", param, reply)
+}
+
+// bootConfiguredServer mints a node with a configuration passthrough
+// applied, under a runtime-random name so it does not share a session
+// cache key — or a keyspace — with any other test. The password is
+// returned so a caller can build a standalone client against the same
+// node.
+func bootConfiguredServer(ctx context.Context, opts dagger.ValkeyServerOpts) (*dagger.ValkeyServer, *dagger.Secret, error) {
+	name, err := randHex(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	pass, err := randSecret(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	opts.Name = name
+	return dag.Valkey().Server(pass, dag.Valkey().PlaintextServerSecurity(), opts), pass, nil
+}
+
+// OmittedConfigLeavesValkeyDefaults verifies the passthrough is genuinely
+// opt-in: a node built without any of the new parameters reports Valkey's
+// own defaults for every one of them.
+//
+// This is the test that pins the "a parameter left at its default emits
+// no flag" rule, and it is not merely a restatement of the defaults. An
+// implementation that rendered `--appendonly no` or `--maxmemory-policy
+// noeviction` unconditionally would pass every assertion below and still
+// be wrong — because those flags sit after the config file on the command
+// line and would silently override a `configFile` that set them. The
+// configFile tests further down are what catch that, and this one is what
+// makes their failure legible.
+//
+// +cache="never"
+func (t *Tests) OmittedConfigLeavesValkeyDefaults(ctx context.Context) error {
+	server, _, err := bootServer(ctx)
+	if err != nil {
+		return err
+	}
+	client := plaintextClient(server)
+	if err := client.Ping(ctx); err != nil {
+		return fmt.Errorf("ping: %w", err)
+	}
+	for param, want := range map[string]string{
+		"appendonly":       "no",
+		"maxmemory":        "0",
+		"maxmemory-policy": "noeviction",
+		"aclfile":          "",
+	} {
+		got, err := configGet(ctx, client, param)
+		if err != nil {
+			return err
+		}
+		if got != want {
+			return fmt.Errorf("expected %s to stay at Valkey's default %q with no passthrough, got %q", param, want, got)
+		}
+	}
+	return nil
+}
+
+// AppendOnlyEnablesAof verifies `appendOnly: true` reaches the node as a
+// real persistence change: INFO persistence reports aof_enabled:1 and
+// CONFIG GET agrees.
+//
+// A control node with the parameter omitted is asserted to report
+// aof_enabled:0 in the same test. Without it, an image that shipped with
+// the AOF already on would make the positive assertion pass while the
+// parameter did nothing at all — the classic vacuous config test.
+//
+// +cache="never"
+func (t *Tests) AppendOnlyEnablesAof(ctx context.Context) error {
+	on, _, err := bootConfiguredServer(ctx, dagger.ValkeyServerOpts{AppendOnly: true})
+	if err != nil {
+		return err
+	}
+	onClient := plaintextClient(on)
+	info, err := onClient.Info(ctx, dagger.ValkeyClientInfoOpts{Section: "persistence"})
+	if err != nil {
+		return fmt.Errorf("info persistence with appendOnly: %w", err)
+	}
+	if !strings.Contains(info, "aof_enabled:1") {
+		return fmt.Errorf("expected aof_enabled:1 with appendOnly=true, got:\n%s", info)
+	}
+	if got, err := configGet(ctx, onClient, "appendonly"); err != nil {
+		return err
+	} else if got != "yes" {
+		return fmt.Errorf("expected CONFIG GET appendonly to report yes, got %q", got)
+	}
+
+	off, _, err := bootServer(ctx)
+	if err != nil {
+		return err
+	}
+	offInfo, err := plaintextClient(off).Info(ctx, dagger.ValkeyClientInfoOpts{Section: "persistence"})
+	if err != nil {
+		return fmt.Errorf("info persistence without appendOnly: %w", err)
+	}
+	if !strings.Contains(offInfo, "aof_enabled:0") {
+		return fmt.Errorf("expected aof_enabled:0 without appendOnly (the positive case would pass vacuously), got:\n%s", offInfo)
+	}
+	return nil
+}
+
+// infoValue pulls one `field:value` entry out of an INFO reply.
+func infoValue(info, field string) (string, error) {
+	for _, line := range strings.Split(info, "\n") {
+		name, value, ok := strings.Cut(strings.TrimSpace(line), ":")
+		if ok && name == field {
+			return value, nil
+		}
+	}
+	return "", fmt.Errorf("expected INFO to report %s, got:\n%s", field, info)
+}
+
+// infoInt pulls one numeric `field:value` entry out of an INFO reply.
+func infoInt(info, field string) (int, error) {
+	raw, err := infoValue(info, field)
+	if err != nil {
+		return 0, err
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, fmt.Errorf("expected INFO %s to be numeric, got %q: %w", field, raw, err)
+	}
+	return n, nil
+}
+
+// bigKeySeed renders a command file that grows `count` keys to ~4KiB
+// each. SETRANGE is what keeps the file small: a ~30-byte line produces
+// 4KiB of server-side value, so filling a multi-megabyte keyspace costs
+// kilobytes of fixture rather than megabytes.
+func bigKeySeed(prefix string, count int) string {
+	var seed strings.Builder
+	for i := 0; i < count; i++ {
+		fmt.Fprintf(&seed, "SETRANGE %s:%05d 4095 x\n", prefix, i)
+	}
+	return seed.String()
+}
+
+// MaxMemoryEvictsOverLimit verifies the memory ceiling is a real limit
+// and that the eviction policy alongside it decides what happens when a
+// write crosses it.
+//
+// Two nodes, same ceiling, opposite policies, because either half alone
+// proves little. Under `allkeys-lru` the over-limit writes must all be
+// ACCEPTED and paid for by evicting older keys — so the keyspace ends up
+// smaller than what was written and evicted_keys is non-zero. Under the
+// default `noeviction` the same writes must be REFUSED with OOM. A
+// maxMemory that never reached valkey-server would leave both nodes
+// happily holding the whole keyspace, and a maxMemoryPolicy that never
+// reached it would make the two nodes behave identically.
+//
+// +cache="never"
+func (t *Tests) MaxMemoryEvictsOverLimit(ctx context.Context) error {
+	// ~4KiB per key, so the seed is several times the ceiling. The ceiling
+	// itself sits well clear of an empty node's own ~1MiB overhead, so the
+	// evictions below are the seeded keys being reclaimed and not Valkey
+	// failing to fit its own bookkeeping.
+	const (
+		maxMemory      = "16mb"
+		maxMemoryBytes = 16 * 1024 * 1024
+		keys           = 8000
+	)
+
+	evicting, _, err := bootConfiguredServer(ctx, dagger.ValkeyServerOpts{
+		MaxMemory:       maxMemory,
+		MaxMemoryPolicy: "allkeys-lru",
+	})
+	if err != nil {
+		return err
+	}
+	client := plaintextClient(evicting)
+
+	if got, err := configGet(ctx, client, "maxmemory"); err != nil {
+		return err
+	} else if got != strconv.Itoa(maxMemoryBytes) {
+		return fmt.Errorf("expected CONFIG GET maxmemory to report %d bytes for %q, got %q", maxMemoryBytes, maxMemory, got)
+	}
+	if got, err := configGet(ctx, client, "maxmemory-policy"); err != nil {
+		return err
+	} else if got != "allkeys-lru" {
+		return fmt.Errorf("expected CONFIG GET maxmemory-policy to report allkeys-lru, got %q", got)
+	}
+
+	prefix, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+	if err := client.ApplyFile(ctx, commandFile(bigKeySeed(prefix, keys))); err != nil {
+		return fmt.Errorf("expected an evicting node to accept every over-limit write: %w", err)
+	}
+
+	stats, err := client.Info(ctx, dagger.ValkeyClientInfoOpts{Section: "stats"})
+	if err != nil {
+		return fmt.Errorf("info stats: %w", err)
+	}
+	evicted, err := infoInt(stats, "evicted_keys")
+	if err != nil {
+		return err
+	}
+	if evicted == 0 {
+		return fmt.Errorf("expected the over-limit writes to evict keys, evicted_keys is 0 (maxmemory likely never reached valkey-server)")
+	}
+	size, err := client.DbSize(ctx)
+	if err != nil {
+		return fmt.Errorf("dbsize: %w", err)
+	}
+	if size >= keys {
+		return fmt.Errorf("expected the keyspace to be capped below the %d keys written, DbSize reports %d", keys, size)
+	}
+	memory, err := client.Info(ctx, dagger.ValkeyClientInfoOpts{Section: "memory"})
+	if err != nil {
+		return fmt.Errorf("info memory: %w", err)
+	}
+	used, err := infoInt(memory, "used_memory")
+	if err != nil {
+		return err
+	}
+	if used > maxMemoryBytes {
+		return fmt.Errorf("expected used_memory to stay within the %d byte ceiling, got %d", maxMemoryBytes, used)
+	}
+
+	// Same ceiling, default policy: the writes must be refused instead.
+	refusing, _, err := bootConfiguredServer(ctx, dagger.ValkeyServerOpts{MaxMemory: maxMemory})
+	if err != nil {
+		return err
+	}
+	err = plaintextClient(refusing).ApplyFile(ctx, commandFile(bigKeySeed(prefix, keys)))
+	if err == nil {
+		return fmt.Errorf("expected a noeviction node to refuse the over-limit writes, but it accepted all %d", keys)
+	}
+	if !strings.Contains(err.Error(), "OOM") {
+		return fmt.Errorf("expected an OOM rejection under the default noeviction policy, got: %v", err)
+	}
+	return nil
+}
+
+// AclFileProvisionsUser verifies an ACL file rides in as a secret and
+// provisions a user the module never knew about.
+//
+// The file is the only place that user's password exists in plaintext,
+// and it reaches the node as a mounted secret rather than an argument —
+// so the test also pins the leak paths shut: Valkey stores the password
+// as a SHA-256 digest, and neither ACL LIST nor ACL GETUSER may echo the
+// plaintext back. CONFIG GET aclfile reporting the mount path is the
+// other half of that: it proves the users arrived through the mounted
+// file rather than through `user ...` directives on the command line,
+// where they would be visible in the Dagger graph.
+//
+// +cache="never"
+func (t *Tests) AclFileProvisionsUser(ctx context.Context) error {
+	suffix, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+	userPlaintext, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+	name, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+	pass, passPlaintext, err := randSecretPair(ctx)
+	if err != nil {
+		return err
+	}
+	user := "app-" + suffix
+	// `>password` is the realistic form — a plaintext the file carries and
+	// Valkey hashes on load — and is exactly why aclFile is a *dagger.Secret.
+	//
+	// The `default` rule restates the module's own requirepass credential.
+	// It is not optional: Valkey recreates any user the ACL file omits in
+	// its factory `on nopass` state, so a file listing only `app-…` would
+	// leave the node open — which is what the rejection test next door
+	// pins.
+	aclFile := dag.SetSecret(
+		"valkey-acl-"+suffix,
+		fmt.Sprintf("user default on >%s ~* &* +@all\nuser %s on >%s ~* &* +@all\n",
+			passPlaintext, user, userPlaintext),
+	)
+	server := dag.Valkey().Server(
+		pass,
+		dag.Valkey().PlaintextServerSecurity(),
+		dagger.ValkeyServerOpts{Name: name, ACLFile: aclFile},
+	)
+	if err := plaintextClient(server).Ping(ctx); err != nil {
+		return fmt.Errorf("ping as the module's own user: %w", err)
+	}
+	if got, err := configGet(ctx, plaintextClient(server), "aclfile"); err != nil {
+		return err
+	} else if got == "" {
+		return fmt.Errorf("expected CONFIG GET aclfile to report the mounted path, got an empty value")
+	}
+
+	endpoint, err := server.Endpoint(ctx)
+	if err != nil {
+		return fmt.Errorf("endpoint: %w", err)
+	}
+	host, _, _ := strings.Cut(endpoint, ":")
+	asUser := dag.Valkey().Client(
+		host,
+		dag.SetSecret("valkey-acl-pw-"+suffix, userPlaintext),
+		dag.Valkey().PlaintextClientSecurity(),
+		dagger.ValkeyClientOpts{User: user},
+	)
+	key, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+	want, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+	if err := asUser.Set(ctx, key, want); err != nil {
+		return fmt.Errorf("set as the ACL-provisioned user %s: %w", user, err)
+	}
+	got, err := asUser.Get(ctx, key)
+	if err != nil {
+		return fmt.Errorf("get as the ACL-provisioned user %s: %w", user, err)
+	}
+	if got != want {
+		return fmt.Errorf("expected %q back as %s, got %q", want, user, got)
+	}
+
+	// A wrong password for the same user must still be refused — otherwise
+	// the round trip above would prove only that the node is open.
+	wrong, err := randSecret(ctx)
+	if err != nil {
+		return err
+	}
+	err = dag.Valkey().Client(
+		host,
+		wrong,
+		dag.Valkey().PlaintextClientSecurity(),
+		dagger.ValkeyClientOpts{User: user},
+	).Ping(ctx)
+	if err == nil {
+		return fmt.Errorf("expected a wrong password for %s to be refused, but the node accepted it", user)
+	}
+	if !strings.Contains(err.Error(), "WRONGPASS") {
+		return fmt.Errorf("expected a WRONGPASS rejection for %s, got: %v", user, err)
+	}
+
+	// Valkey keeps a SHA-256 digest, never the plaintext, so nothing the
+	// server will hand back may contain it. ACL GETUSER names the user only
+	// in the request, so the listing is what proves the rules were read from
+	// the file at all.
+	listing, err := asUser.Do(ctx, []string{"ACL", "LIST"})
+	if err != nil {
+		return fmt.Errorf("acl list: %w", err)
+	}
+	if !strings.Contains(listing, user) {
+		return fmt.Errorf("expected ACL LIST to know about %s, got: %s", user, listing)
+	}
+	rules, err := asUser.Do(ctx, []string{"ACL", "GETUSER", user})
+	if err != nil {
+		return fmt.Errorf("acl getuser: %w", err)
+	}
+	if !strings.Contains(rules, "passwords") {
+		return fmt.Errorf("expected ACL GETUSER %s to describe the user, got: %s", user, rules)
+	}
+	for what, reply := range map[string]string{"ACL LIST": listing, "ACL GETUSER": rules} {
+		if strings.Contains(reply, userPlaintext) {
+			return fmt.Errorf("expected %s to expose only a password digest, but it echoed the plaintext", what)
+		}
+	}
+
+	// The ACL file is loaded after `requirepass`, so it is entitled to
+	// redefine `default` — this asserts it did NOT silently do so by
+	// omission, which would leave the node reachable without a password.
+	err = dag.Valkey().Client(host, wrong, dag.Valkey().PlaintextClientSecurity()).Ping(ctx)
+	if err == nil {
+		return fmt.Errorf("expected requirepass to still guard the default user, but a wrong password was accepted")
+	}
+	if !strings.Contains(err.Error(), "WRONGPASS") {
+		return fmt.Errorf("expected a WRONGPASS rejection for the default user, got: %v", err)
+	}
+	return nil
+}
+
+// ServerRejectsAclFileWithoutDefaultUser verifies the module refuses an
+// ACL file that never mentions the `default` user.
+//
+// This is the module's password guarantee holding under the new
+// parameter. Valkey loads the ACL file after `requirepass` and recreates
+// any user the file omits in its factory `on nopass` state — so an ACL
+// file listing only the caller's own users silently drops the password
+// from `default` and leaves the node reachable by anything that can route
+// to it. Valkey.Server rejects a nil password for exactly that reason,
+// and an ACL file must not be a back door around it.
+//
+// The accepting cases prove the guard is a mention and not an
+// interpretation: naming `default` at all — even to turn it off — is a
+// decision the caller is entitled to make.
+//
+// +cache="never"
+func (t *Tests) ServerRejectsAclFileWithoutDefaultUser(ctx context.Context) error {
+	suffix, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+	pass, passPlaintext, err := randSecretPair(ctx)
+	if err != nil {
+		return err
+	}
+	build := func(label, contents string) *dagger.ValkeyServer {
+		return dag.Valkey().Server(
+			pass,
+			dag.Valkey().PlaintextServerSecurity(),
+			dagger.ValkeyServerOpts{
+				Name:    suffix + label,
+				ACLFile: dag.SetSecret("valkey-acl-"+suffix+label, contents),
+			},
+		)
+	}
+	rejected := map[string]string{
+		"only-own-user": fmt.Sprintf("user app-%s on >%s ~* &* +@all\n", suffix, passPlaintext),
+		"empty":         "",
+		// `default` appears, but only as prose — a comment is not a rule.
+		"commented-out": fmt.Sprintf("# user default on >%s ~* +@all\nuser app-%s on >%s ~* +@all\n",
+			passPlaintext, suffix, passPlaintext),
+	}
+	for label, contents := range rejected {
+		_, err := build(label, contents).Endpoint(ctx)
+		if err == nil {
+			return fmt.Errorf("expected the %s ACL file to be rejected, but it built a server", label)
+		}
+		if !strings.Contains(err.Error(), "aclFile") || !strings.Contains(err.Error(), "default") {
+			return fmt.Errorf("expected the %s rejection to name aclFile and the default user, got: %v", label, err)
+		}
+	}
+	accepted := map[string]string{
+		"default-with-password": fmt.Sprintf("user default on >%s ~* &* +@all\n", passPlaintext),
+		"default-disabled":      "user default off\n",
+	}
+	for label, contents := range accepted {
+		if _, err := build(label, contents).Endpoint(ctx); err != nil {
+			return fmt.Errorf("expected the %s ACL file to be accepted: %w", label, err)
+		}
+	}
+	return nil
+}
+
+// ConfigFileDirectivesApply verifies a mounted valkey.conf is genuinely
+// loaded, and — the harder half — that it still governs settings this
+// module has parameters of its own for.
+//
+// The file deliberately sets `appendonly` and `maxmemory-policy`, the two
+// settings whose module parameters carry defaults that match Valkey's.
+// An implementation that rendered those parameters unconditionally would
+// emit `--appendonly no --maxmemory-policy noeviction` after the config
+// file and quietly win, so this is the test that pins the "a parameter
+// left at its default emits no flag" rule. `hash-max-listpack-entries` is
+// along for the ride as a directive the module has no opinion about at
+// all.
+//
+// +cache="never"
+func (t *Tests) ConfigFileDirectivesApply(ctx context.Context) error {
+	directives := map[string]string{
+		"appendonly":                "yes",
+		"maxmemory-policy":          "allkeys-lfu",
+		"hash-max-listpack-entries": "42",
+	}
+	var conf strings.Builder
+	for param, value := range directives {
+		fmt.Fprintf(&conf, "%s %s\n", param, value)
+	}
+
+	server, _, err := bootConfiguredServer(ctx, dagger.ValkeyServerOpts{
+		ConfigFile: commandFile(conf.String()),
+	})
+	if err != nil {
+		return err
+	}
+	client := plaintextClient(server)
+	if err := client.Ping(ctx); err != nil {
+		return fmt.Errorf("ping a node booted from a config file: %w", err)
+	}
+	for param, want := range directives {
+		got, err := configGet(ctx, client, param)
+		if err != nil {
+			return err
+		}
+		if got != want {
+			return fmt.Errorf("expected the config file's %s %s to survive, CONFIG GET reports %q", param, want, got)
+		}
+	}
+
+	// The listener flags are the module's own and DO override the file —
+	// the node still answers on 6379 with the password it was given, which
+	// the ping above already proved.
+	return nil
+}
+
+// FlagArgumentBeatsConfigFile verifies the precedence contract in the
+// direction that matters: when the same setting appears in `configFile`
+// and as a parameter, the parameter wins.
+//
+// Both settings are given deliberately conflicting values in the file, so
+// a passing result cannot be an accident of agreement. This is the
+// mirror of ConfigFileDirectivesApply — together they say the file is
+// loaded first and the flags are applied on top, which is the whole
+// ordering guarantee.
+//
+// +cache="never"
+func (t *Tests) FlagArgumentBeatsConfigFile(ctx context.Context) error {
+	conf := "maxmemory 100mb\nmaxmemory-policy allkeys-lfu\n"
+	server, _, err := bootConfiguredServer(ctx, dagger.ValkeyServerOpts{
+		ConfigFile:      commandFile(conf),
+		MaxMemory:       "50mb",
+		MaxMemoryPolicy: "allkeys-random",
+	})
+	if err != nil {
+		return err
+	}
+	client := plaintextClient(server)
+	if err := client.Ping(ctx); err != nil {
+		return fmt.Errorf("ping: %w", err)
+	}
+	for param, want := range map[string]string{
+		"maxmemory":        strconv.Itoa(50 * 1024 * 1024),
+		"maxmemory-policy": "allkeys-random",
+	} {
+		got, err := configGet(ctx, client, param)
+		if err != nil {
+			return err
+		}
+		if got != want {
+			return fmt.Errorf("expected the %s flag argument to beat the config file's value, CONFIG GET reports %q (wanted %q)", param, got, want)
+		}
+	}
+	return nil
+}
+
+// ExtraArgsReachServerLast verifies the escape hatch does both of the
+// things it promises: the arguments reach valkey-server verbatim, and
+// they land last on the command line.
+//
+// `databases` is a setting with no module parameter at all, so it can
+// only have arrived through extraArgs. `maxmemory-policy` is passed
+// BOTH ways, with different values, so the reply says which one Valkey
+// saw last — and therefore whether extraArgs really is appended after
+// the module's own flags rather than merely somewhere among them.
+//
+// +cache="never"
+func (t *Tests) ExtraArgsReachServerLast(ctx context.Context) error {
+	server, _, err := bootConfiguredServer(ctx, dagger.ValkeyServerOpts{
+		MaxMemory:       "64mb",
+		MaxMemoryPolicy: "allkeys-lru",
+		ExtraArgs: []string{
+			"--databases", "24",
+			"--maxmemory-policy", "volatile-ttl",
+		},
+	})
+	if err != nil {
+		return err
+	}
+	client := plaintextClient(server)
+	if err := client.Ping(ctx); err != nil {
+		return fmt.Errorf("ping a node booted with extraArgs: %w", err)
+	}
+	if got, err := configGet(ctx, client, "databases"); err != nil {
+		return err
+	} else if got != "24" {
+		return fmt.Errorf("expected --databases 24 to reach valkey-server verbatim, CONFIG GET reports %q", got)
+	}
+	if got, err := configGet(ctx, client, "maxmemory-policy"); err != nil {
+		return err
+	} else if got != "volatile-ttl" {
+		return fmt.Errorf("expected extraArgs to be appended after the maxMemoryPolicy parameter, CONFIG GET reports %q (wanted volatile-ttl)", got)
+	}
+	// The parameter it did not shadow is untouched, so "last wins" is a
+	// property of the ordering and not of extraArgs clobbering everything.
+	if got, err := configGet(ctx, client, "maxmemory"); err != nil {
+		return err
+	} else if want := strconv.Itoa(64 * 1024 * 1024); got != want {
+		return fmt.Errorf("expected maxMemory to survive alongside extraArgs, CONFIG GET reports %q (wanted %q)", got, want)
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #200.

Adds `configFile`, `aclFile`, `appendOnly`, `maxMemory`, `maxMemoryPolicy`, and `extraArgs` to `Valkey.Server`. All optional; a call omitting every one of them produces exactly the node it produced before. They are constructor parameters rather than post-boot modifiers because `valkey-server` reads each of them only while starting up.

## Precedence

Precedence runs left to right along the command line, which Valkey resolves last-one-wins:

```
<configFile>  <listener flags>  <passthrough flags>  <extraArgs>
```

The rule that makes `configFile` meaningful: **a parameter left at its default emits no flag at all**. Were `--appendonly no` rendered unconditionally it would sit after the file and silently override a config that turned the AOF on, with no way for the caller to express "leave it to the file".

## One guard beyond the acceptance criteria

The ACL-file test surfaced something worth calling out. Valkey loads the ACL file **after** `requirepass` and recreates any user the file omits in its factory `on nopass` state — so an ACL file listing only the caller's own users silently drops the password from `default` and leaves the node wide open. This was confirmed empirically: a deliberately wrong password was accepted.

`Valkey.Server` rejects `password == nil` precisely to prevent an unauthenticated node, so `aclFile` must not be a back door around it. `validateAclFile` requires the file to *mention* `default` — `user default on >…` and `user default off` both pass, only silence is refused.

`aclFile` is a `*dagger.Secret` mounted with `WithMountedSecret`, so per-user password material never enters argv or the Dagger graph.

## Other validation

`maxMemory` is checked against Valkey's own `memtoll` grammar (integer plus optional `b`/`k`/`kb`/`m`/`mb`/`g`/`gb`) and `maxMemoryPolicy` against its eviction-policy set. Either would otherwise be a config-parse failure at boot, reaching the caller as an opaque readiness timeout rather than as the typo that caused it.

`extraArgs` is the deliberate escape hatch: appended verbatim, last, unvalidated, and documented as unsupported surface.

`Replication` and `Cluster` pass no passthrough — their members' boot flags stay the module's.

## Tests

New `Config` check (registered via `+check`, wired into `All`):

- `omitted-config-leaves-valkey-defaults`
- `append-only-enables-aof` — with a control node, so an image shipping the AOF on couldn't make it pass vacuously
- `max-memory-evicts-over-limit` — two nodes at the same 16MB ceiling with opposite policies: `allkeys-lru` must accept the over-limit writes and pay with `evicted_keys`, default `noeviction` must refuse them with OOM
- `acl-file-provisions-user` — the ACL user round-trips, a wrong password is refused, `ACL LIST`/`ACL GETUSER` expose only the digest, and `requirepass` still guards `default`
- `config-file-directives-apply` / `flag-argument-beats-config-file` — the two halves of the ordering guarantee
- `extra-args-reach-server-last` — `--databases` proves verbatim delivery, a conflicting `--maxmemory-policy` proves the position

Plus three additions to `Validation` for the new rejections.

## Verification

- `dagger -m daggerverse/valkey/tests call all --parallel=6` — green (1m44s)
- `dagger develop` re-run in the module, `tests/`, and the repo root; `dagger -m . call generated` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
