### PR TITLE
story(issue-201): support the valkey-bundle image modules

### DIFF
--- a/ci/internal/dagger/valkey-tests.gen.go
+++ b/ci/internal/dagger/valkey-tests.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type ValkeyTests
-func (r *Binding) AsValkeyTests() *ValkeyTests { // valkey-tests (../../../daggerverse/valkey/tests/main.go:28:6)
+func (r *Binding) AsValkeyTests() *ValkeyTests { // valkey-tests (../../../daggerverse/valkey/tests/main.go:29:6)
 	q := r.query.Select("asValkeyTests")
 
 	return &ValkeyTests{
@@ -19,7 +19,7 @@ func (r *Binding) AsValkeyTests() *ValkeyTests { // valkey-tests (../../../dagge
 }
 
 // Create or update a binding of type ValkeyTests in the environment
-func (r *Env) WithValkeyTestsInput(name string, value *ValkeyTests, description string) *Env { // valkey-tests (../../../daggerverse/valkey/tests/main.go:28:6)
+func (r *Env) WithValkeyTestsInput(name string, value *ValkeyTests, description string) *Env { // valkey-tests (../../../daggerverse/valkey/tests/main.go:29:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withValkeyTestsInput")
 	q = q.Arg("name", name)
@@ -32,7 +32,7 @@ func (r *Env) WithValkeyTestsInput(name string, value *ValkeyTests, description 
 }
 
 // Declare a desired ValkeyTests output to be assigned in the environment
-func (r *Env) WithValkeyTestsOutput(name string, description string) *Env { // valkey-tests (../../../daggerverse/valkey/tests/main.go:28:6)
+func (r *Env) WithValkeyTestsOutput(name string, description string) *Env { // valkey-tests (../../../daggerverse/valkey/tests/main.go:29:6)
 	q := r.query.Select("withValkeyTestsOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -52,7 +52,7 @@ func (r *Env) WithValkeyTestsOutput(name string, description string) *Env { // v
 // default ACL user ("default"), which a few tests assert against; the
 // configuration-passthrough tests are the exception, since an ACL file is
 // how a caller gets any other user at all.
-func (r *Query) ValkeyTests() *ValkeyTests { // valkey-tests (../../../daggerverse/valkey/tests/main.go:28:6)
+func (r *Query) ValkeyTests() *ValkeyTests { // valkey-tests (../../../daggerverse/valkey/tests/main.go:29:6)
 	q := r.query.Select("valkeyTests")
 
 	return &ValkeyTests{
@@ -60,7 +60,7 @@ func (r *Query) ValkeyTests() *ValkeyTests { // valkey-tests (../../../daggerver
 	}
 }
 
-type ValkeyTests struct { // valkey-tests (../../../daggerverse/valkey/tests/main.go:28:6)
+type ValkeyTests struct { // valkey-tests (../../../daggerverse/valkey/tests/main.go:29:6)
 	query *querybuilder.Selection
 
 	aclFileProvisionsUser                  *Void
@@ -70,6 +70,12 @@ type ValkeyTests struct { // valkey-tests (../../../daggerverse/valkey/tests/mai
 	applyFileSeedsData                     *Void
 	bindServerReachableFromAlpine          *Void
 	bindServerReachableUnderTls            *Void
+	bundle                                 *Void
+	bundleBindServerReachableFromConsumer  *Void
+	bundleBloomRoundTrip                   *Void
+	bundleJsonRoundTrip                    *Void
+	bundleServerLoadsModules               *Void
+	bundleServerMethodsMatchStock          *Void
 	client                                 *Void
 	clientPingWrongPasswordFails           *Void
 	cluster                                *Void
@@ -124,6 +130,7 @@ type ValkeyTests struct { // valkey-tests (../../../daggerverse/valkey/tests/mai
 	serverTlsRoundTripFromClient           *Void
 	setGetRoundTrip                        *Void
 	setWithTtlExpires                      *Void
+	stockServerLacksBundleModules          *Void
 	stopTerminatesServer                   *Void
 	tlsServerRejectsEmptyName              *Void
 	tlsServerRejectsPlaintextClient        *Void
@@ -147,7 +154,7 @@ func (r *ValkeyTests) WithGraphQLQuery(q *querybuilder.Selection) *ValkeyTests {
 // other half of that: it proves the users arrived through the mounted
 // file rather than through `user ...` directives on the command line,
 // where they would be visible in the Dagger graph.
-func (r *ValkeyTests) ACLFileProvisionsUser(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3042:1)
+func (r *ValkeyTests) ACLFileProvisionsUser(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3074:1)
 	if r.aclFileProvisionsUser != nil {
 		return nil
 	}
@@ -158,7 +165,7 @@ func (r *ValkeyTests) ACLFileProvisionsUser(ctx context.Context) error { // valk
 
 // ValkeyTestsAllOpts contains options for ValkeyTests.All
 type ValkeyTestsAllOpts struct {
-	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:40:2)
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:41:2)
 }
 
 // All runs every valkey test as a convenience for local `dagger call
@@ -166,7 +173,7 @@ type ValkeyTestsAllOpts struct {
 // below is registered as its own check, so GH Actions schedules each
 // onto its own runner in parallel — running All on top would
 // double-bill the same work.
-func (r *ValkeyTests) All(ctx context.Context, opts ...ValkeyTestsAllOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:37:1)
+func (r *ValkeyTests) All(ctx context.Context, opts ...ValkeyTestsAllOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:38:1)
 	if r.all != nil {
 		return nil
 	}
@@ -189,7 +196,7 @@ func (r *ValkeyTests) All(ctx context.Context, opts ...ValkeyTestsAllOpts) error
 // aof_enabled:0 in the same test. Without it, an image that shipped with
 // the AOF already on would make the positive assertion pass while the
 // parameter did nothing at all — the classic vacuous config test.
-func (r *ValkeyTests) AppendOnlyEnablesAof(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2862:1)
+func (r *ValkeyTests) AppendOnlyEnablesAof(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2894:1)
 	if r.appendOnlyEnablesAof != nil {
 		return nil
 	}
@@ -200,7 +207,7 @@ func (r *ValkeyTests) AppendOnlyEnablesAof(ctx context.Context) error { // valke
 
 // ApplyFileReportsFailingCommand verifies a mid-file failure is not
 // swallowed and that the error names the offending line.
-func (r *ValkeyTests) ApplyFileReportsFailingCommand(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1262:1)
+func (r *ValkeyTests) ApplyFileReportsFailingCommand(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1294:1)
 	if r.applyFileReportsFailingCommand != nil {
 		return nil
 	}
@@ -212,7 +219,7 @@ func (r *ValkeyTests) ApplyFileReportsFailingCommand(ctx context.Context) error 
 // ApplyFileSeedsData verifies a command file lands as data on one
 // connection, and that its quoting and line splitting survive: values
 // with spaces, embedded quotes, blank lines, and `#` comments.
-func (r *ValkeyTests) ApplyFileSeedsData(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1207:1)
+func (r *ValkeyTests) ApplyFileSeedsData(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1239:1)
 	if r.applyFileSeedsData != nil {
 		return nil
 	}
@@ -225,7 +232,7 @@ func (r *ValkeyTests) ApplyFileSeedsData(ctx context.Context) error { // valkey-
 // a consumer container under the hostname Endpoint reports, and that the
 // consumer gets a real PONG back. A port probe would be a false
 // positive: it proves something is listening, not that Valkey answers.
-func (r *ValkeyTests) BindServerReachableFromAlpine(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:745:1)
+func (r *ValkeyTests) BindServerReachableFromAlpine(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:777:1)
 	if r.bindServerReachableFromAlpine != nil {
 		return nil
 	}
@@ -239,7 +246,7 @@ func (r *ValkeyTests) BindServerReachableFromAlpine(ctx context.Context) error {
 // the right CA gets a PONG, proving BindServer stays reachable under TLS
 // from a consumer container. The password rides in as a secret env var so
 // it never enters the exec's argv.
-func (r *ValkeyTests) BindServerReachableUnderTLS(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2285:1)
+func (r *ValkeyTests) BindServerReachableUnderTLS(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2317:1)
 	if r.bindServerReachableUnderTls != nil {
 		return nil
 	}
@@ -248,15 +255,120 @@ func (r *ValkeyTests) BindServerReachableUnderTLS(ctx context.Context) error { /
 	return q.Execute(ctx)
 }
 
+// ValkeyTestsBundleOpts contains options for ValkeyTests.Bundle
+type ValkeyTestsBundleOpts struct {
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:292:2)
+}
+
+// Bundle runs the `valkey/valkey-bundle` image tests: that the module
+// ecosystem it ships actually loads, that JSON and Bloom commands round
+// trip through Do, and that every *Server method behaves the same
+// against a bundle node as against a stock one. Each test boots its own
+// node under a runtime-random name, so the group fans out safely.
+func (r *ValkeyTests) Bundle(ctx context.Context, opts ...ValkeyTestsBundleOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:289:1)
+	if r.bundle != nil {
+		return nil
+	}
+	q := r.query.Select("bundle")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `parallel` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Parallel) {
+			q = q.Arg("parallel", opts[i].Parallel)
+		}
+	}
+
+	return q.Execute(ctx)
+}
+
+// BundleBindServerReachableFromConsumer verifies BindServer wires a
+// bundle node into a consumer container exactly as it does a stock one,
+// and that the consumer gets a real PONG back rather than merely finding
+// something listening.
+//
+// The node is deliberately untouched before the binding: starting a
+// service from the valkey module's runtime registers it in that module's
+// DNS domain, which a consumer in the session domain then cannot resolve
+// ("lookup valkey-<host> ... no such host"). That is the trap
+// Server.Endpoint documents, and it is why this cannot ride along inside
+// BundleServerMethodsMatchStock.
+func (r *ValkeyTests) BundleBindServerReachableFromConsumer(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3726:1)
+	if r.bundleBindServerReachableFromConsumer != nil {
+		return nil
+	}
+	q := r.query.Select("bundleBindServerReachableFromConsumer")
+
+	return q.Execute(ctx)
+}
+
+// BundleBloomRoundTrip verifies the Bloom module answers through Do. A
+// Bloom filter admits false positives but never false negatives, so the
+// load-bearing assertions are that an added item is reported present and
+// that a second BF.ADD of it reports "already there"; the absent-item
+// check rides along on a filter holding exactly one item, where a false
+// positive is vanishingly unlikely.
+func (r *ValkeyTests) BundleBloomRoundTrip(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3588:1)
+	if r.bundleBloomRoundTrip != nil {
+		return nil
+	}
+	q := r.query.Select("bundleBloomRoundTrip")
+
+	return q.Execute(ctx)
+}
+
+// BundleJsonRoundTrip verifies the JSON module answers through Do: a
+// document written with JSON.SET reads back through a JSONPath JSON.GET.
+// The reply is a bulk string holding the JSONPath result array, so it
+// arrives double-encoded — a JSON string whose contents are themselves
+// JSON — and both layers are decoded here rather than string-matched.
+func (r *ValkeyTests) BundleJSONRoundTrip(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3525:1)
+	if r.bundleJsonRoundTrip != nil {
+		return nil
+	}
+	q := r.query.Select("bundleJsonRoundTrip")
+
+	return q.Execute(ctx)
+}
+
+// BundleServerLoadsModules verifies a bundle node boots with the JSON,
+// Bloom, and Search modules actually loaded. The bundle image only loads
+// them when its own `bundle-docker-entrypoint.sh` composes the
+// `--loadmodule` flags, so a node built through the stock
+// `docker-entrypoint.sh` comes up healthy with an empty module list —
+// which is exactly the silent failure this asserts against.
+func (r *ValkeyTests) BundleServerLoadsModules(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3419:1)
+	if r.bundleServerLoadsModules != nil {
+		return nil
+	}
+	q := r.query.Select("bundleServerLoadsModules")
+
+	return q.Execute(ctx)
+}
+
+// BundleServerMethodsMatchStock verifies the *Server contract is
+// unchanged by the image swap: the same endpoint shape, the same
+// requirepass user, credentials that still build a working standalone
+// client, a working Set/Get/DbSize round trip, an INFO that reports the
+// pinned Valkey version, and a Stop that really terminates the node.
+// BindServer is the one method missing here — it must run against a node
+// nothing has started yet, so it gets its own test below.
+func (r *ValkeyTests) BundleServerMethodsMatchStock(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3638:1)
+	if r.bundleServerMethodsMatchStock != nil {
+		return nil
+	}
+	q := r.query.Select("bundleServerMethodsMatchStock")
+
+	return q.Execute(ctx)
+}
+
 // ValkeyTestsClientOpts contains options for ValkeyTests.Client
 type ValkeyTestsClientOpts struct {
-	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:196:2)
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:200:2)
 }
 
 // Client runs the command round-trip tests. Each test boots its own node
 // via bootServer, so the keyspaces stay disjoint and the group fans out
 // safely.
-func (r *ValkeyTests) Client(ctx context.Context, opts ...ValkeyTestsClientOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:193:1)
+func (r *ValkeyTests) Client(ctx context.Context, opts ...ValkeyTestsClientOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:197:1)
 	if r.client != nil {
 		return nil
 	}
@@ -274,7 +386,7 @@ func (r *ValkeyTests) Client(ctx context.Context, opts ...ValkeyTestsClientOpts)
 // ClientPingWrongPasswordFails proves requirepass is genuinely applied
 // and the node is not wide open: a client holding a different password
 // cannot authenticate.
-func (r *ValkeyTests) ClientPingWrongPasswordFails(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1354:1)
+func (r *ValkeyTests) ClientPingWrongPasswordFails(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1386:1)
 	if r.clientPingWrongPasswordFails != nil {
 		return nil
 	}
@@ -285,7 +397,7 @@ func (r *ValkeyTests) ClientPingWrongPasswordFails(ctx context.Context) error { 
 
 // ValkeyTestsClusterOpts contains options for ValkeyTests.Cluster
 type ValkeyTestsClusterOpts struct {
-	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:142:2)
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:146:2)
 }
 
 // Cluster runs the slot-sharded Valkey Cluster tests. Each test boots its
@@ -297,7 +409,7 @@ type ValkeyTestsClusterOpts struct {
 // cluster is three nodes, and every one of them has to boot before the
 // bootstrap can even start — so they get their own aggregator rather than
 // riding along with the single-node groups.
-func (r *ValkeyTests) Cluster(ctx context.Context, opts ...ValkeyTestsClusterOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:139:1)
+func (r *ValkeyTests) Cluster(ctx context.Context, opts ...ValkeyTestsClusterOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:143:1)
 	if r.cluster != nil {
 		return nil
 	}
@@ -321,7 +433,7 @@ func (r *ValkeyTests) Cluster(ctx context.Context, opts ...ValkeyTestsClusterOpt
 // "another" node, dials itself. The cluster never forms, or forms and
 // then answers for the wrong shard, and CLUSTER INFO alone would not say
 // why. Asserting the announced identity is what pins the fix.
-func (r *ValkeyTests) ClusterAdvertisesPinnedHostnames(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2407:1)
+func (r *ValkeyTests) ClusterAdvertisesPinnedHostnames(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2439:1)
 	if r.clusterAdvertisesPinnedHostnames != nil {
 		return nil
 	}
@@ -347,7 +459,7 @@ func (r *ValkeyTests) ClusterAdvertisesPinnedHostnames(ctx context.Context) erro
 //
 // The whole probe runs in one exec so a partial failure names the node it
 // failed on rather than surfacing as an opaque non-zero exit.
-func (r *ValkeyTests) ClusterBindNodesReachableFromConsumer(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2657:1)
+func (r *ValkeyTests) ClusterBindNodesReachableFromConsumer(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2689:1)
 	if r.clusterBindNodesReachableFromConsumer != nil {
 		return nil
 	}
@@ -365,7 +477,7 @@ func (r *ValkeyTests) ClusterBindNodesReachableFromConsumer(ctx context.Context)
 // One key in the list never existed, so a Del that reported the number of
 // keys it was asked about rather than the number it removed is caught
 // too.
-func (r *ValkeyTests) ClusterDelSpansMultipleSlots(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2599:1)
+func (r *ValkeyTests) ClusterDelSpansMultipleSlots(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2631:1)
 	if r.clusterDelSpansMultipleSlots != nil {
 		return nil
 	}
@@ -385,7 +497,7 @@ func (r *ValkeyTests) ClusterDelSpansMultipleSlots(ctx context.Context) error { 
 // really were split across more than one primary, so the first assertion
 // can't pass vacuously on a cluster that happened to pile everything into
 // one shard.
-func (r *ValkeyTests) ClusterKeysScansEveryShard(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2516:1)
+func (r *ValkeyTests) ClusterKeysScansEveryShard(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2548:1)
 	if r.clusterKeysScansEveryShard != nil {
 		return nil
 	}
@@ -400,7 +512,7 @@ func (r *ValkeyTests) ClusterKeysScansEveryShard(ctx context.Context) error { //
 // would also have to run over TLS, and neither the peers nor the
 // valkey-cli that bootstraps them get the trust material they'd need from
 // a client-listener ServerSecurity.
-func (r *ValkeyTests) ClusterRejectsTLSSecurity(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:609:1)
+func (r *ValkeyTests) ClusterRejectsTLSSecurity(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:641:1)
 	if r.clusterRejectsTlsSecurity != nil {
 		return nil
 	}
@@ -419,7 +531,7 @@ func (r *ValkeyTests) ClusterRejectsTLSSecurity(ctx context.Context) error { // 
 //
 // The guard is checked before anything starts, so this test costs no
 // containers.
-func (r *ValkeyTests) ClusterRejectsTooFewShards(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:572:1)
+func (r *ValkeyTests) ClusterRejectsTooFewShards(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:604:1)
 	if r.clusterRejectsTooFewShards != nil {
 		return nil
 	}
@@ -436,7 +548,7 @@ func (r *ValkeyTests) ClusterRejectsTooFewShards(ctx context.Context) error { //
 // didn't finish: a node whose gossip never reached the others still
 // reports state:ok for the slots it can see, and only cluster_known_nodes
 // gives it away.
-func (r *ValkeyTests) ClusterReportsFormedState(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2375:1)
+func (r *ValkeyTests) ClusterReportsFormedState(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2407:1)
 	if r.clusterReportsFormedState != nil {
 		return nil
 	}
@@ -456,7 +568,7 @@ func (r *ValkeyTests) ClusterReportsFormedState(ctx context.Context) error { // 
 // A client that silently talked to one node would fail the write, not the
 // read: a key that hashes elsewhere is refused with MOVED, never stored
 // locally.
-func (r *ValkeyTests) ClusterRoundTripsKeysAcrossSlots(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2448:1)
+func (r *ValkeyTests) ClusterRoundTripsKeysAcrossSlots(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2480:1)
 	if r.clusterRoundTripsKeysAcrossSlots != nil {
 		return nil
 	}
@@ -474,7 +586,7 @@ func (r *ValkeyTests) ClusterRoundTripsKeysAcrossSlots(ctx context.Context) erro
 // Cluster members have no service bindings between them, so unlike the
 // replication topology there is no dependency teardown to hide behind:
 // every node that is still up after Stop is a node Stop failed to kill.
-func (r *ValkeyTests) ClusterStopTerminatesEveryNode(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2722:1)
+func (r *ValkeyTests) ClusterStopTerminatesEveryNode(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2754:1)
 	if r.clusterStopTerminatesEveryNode != nil {
 		return nil
 	}
@@ -485,14 +597,14 @@ func (r *ValkeyTests) ClusterStopTerminatesEveryNode(ctx context.Context) error 
 
 // ValkeyTestsConfigOpts contains options for ValkeyTests.Config
 type ValkeyTestsConfigOpts struct {
-	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:259:2)
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:263:2)
 }
 
 // Config runs the `valkey-server` configuration passthrough tests: the
 // config file, the ACL file, the append-only log, the memory ceiling, and
 // the extraArgs escape hatch. Each test boots its own node under a
 // runtime-random name, so the group fans out safely.
-func (r *ValkeyTests) Config(ctx context.Context, opts ...ValkeyTestsConfigOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:256:1)
+func (r *ValkeyTests) Config(ctx context.Context, opts ...ValkeyTestsConfigOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:260:1)
 	if r.config != nil {
 		return nil
 	}
@@ -519,7 +631,7 @@ func (r *ValkeyTests) Config(ctx context.Context, opts ...ValkeyTestsConfigOpts)
 // left at its default emits no flag" rule. `hash-max-listpack-entries` is
 // along for the ride as a directive the module has no opinion about at
 // all.
-func (r *ValkeyTests) ConfigFileDirectivesApply(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3250:1)
+func (r *ValkeyTests) ConfigFileDirectivesApply(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3282:1)
 	if r.configFileDirectivesApply != nil {
 		return nil
 	}
@@ -531,7 +643,7 @@ func (r *ValkeyTests) ConfigFileDirectivesApply(ctx context.Context) error { // 
 // DbSelectsLogicalDatabase verifies db is honoured end to end: a write
 // on db 0 is invisible to a client on db 1, and each database keeps its
 // own DbSize.
-func (r *ValkeyTests) DbSelectsLogicalDatabase(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1389:1)
+func (r *ValkeyTests) DbSelectsLogicalDatabase(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1421:1)
 	if r.dbSelectsLogicalDatabase != nil {
 		return nil
 	}
@@ -543,7 +655,7 @@ func (r *ValkeyTests) DbSelectsLogicalDatabase(ctx context.Context) error { // v
 // DefaultsProduceHealthyServer boots a default node and proves it is a
 // healthy Valkey by answering PING and self-reporting 9.1 in INFO
 // server. Catches image-path drift and a silently moved default tag.
-func (r *ValkeyTests) DefaultsProduceHealthyServer(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:651:1)
+func (r *ValkeyTests) DefaultsProduceHealthyServer(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:683:1)
 	if r.defaultsProduceHealthyServer != nil {
 		return nil
 	}
@@ -554,7 +666,7 @@ func (r *ValkeyTests) DefaultsProduceHealthyServer(ctx context.Context) error { 
 
 // DelRemovesKeys verifies Del reports how many keys it actually removed
 // and that DbSize agrees with the survivors.
-func (r *ValkeyTests) DelRemovesKeys(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1056:1)
+func (r *ValkeyTests) DelRemovesKeys(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1088:1)
 	if r.delRemovesKeys != nil {
 		return nil
 	}
@@ -566,7 +678,7 @@ func (r *ValkeyTests) DelRemovesKeys(ctx context.Context) error { // valkey-test
 // DoReturnsJsonReplies verifies each RESP type survives the JSON
 // encoding distinctly. The dangerous pair is nil versus empty string: a
 // naive encoder collapses both to "".
-func (r *ValkeyTests) DoReturnsJSONReplies(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1147:1)
+func (r *ValkeyTests) DoReturnsJSONReplies(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1179:1)
 	if r.doReturnsJsonReplies != nil {
 		return nil
 	}
@@ -578,7 +690,7 @@ func (r *ValkeyTests) DoReturnsJSONReplies(ctx context.Context) error { // valke
 // EndpointShouldNotBeCached verifies Endpoint re-executes against the
 // receiver it was called on rather than freezing on the first result.
 // Valkey.Server isaddress.
-func (r *ValkeyTests) EndpointShouldNotBeCached(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:677:1)
+func (r *ValkeyTests) EndpointShouldNotBeCached(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:709:1)
 	if r.endpointShouldNotBeCached != nil {
 		return nil
 	}
@@ -596,7 +708,7 @@ func (r *ValkeyTests) EndpointShouldNotBeCached(ctx context.Context) error { // 
 // BOTH ways, with different values, so the reply says which one Valkey
 // saw last — and therefore whether extraArgs really is appended after
 // the module's own flags rather than merely somewhere among them.
-func (r *ValkeyTests) ExtraArgsReachServerLast(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3338:1)
+func (r *ValkeyTests) ExtraArgsReachServerLast(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3370:1)
 	if r.extraArgsReachServerLast != nil {
 		return nil
 	}
@@ -614,7 +726,7 @@ func (r *ValkeyTests) ExtraArgsReachServerLast(ctx context.Context) error { // v
 // mirror of ConfigFileDirectivesApply — together they say the file is
 // loaded first and the flags are applied on top, which is the whole
 // ordering guarantee.
-func (r *ValkeyTests) FlagArgumentBeatsConfigFile(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3298:1)
+func (r *ValkeyTests) FlagArgumentBeatsConfigFile(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3330:1)
 	if r.flagArgumentBeatsConfigFile != nil {
 		return nil
 	}
@@ -625,7 +737,7 @@ func (r *ValkeyTests) FlagArgumentBeatsConfigFile(ctx context.Context) error { /
 
 // FlushAllClearsKeys verifies FlushAll empties the keyspace and DbSize
 // returns to 0.
-func (r *ValkeyTests) FlushAllClearsKeys(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1315:1)
+func (r *ValkeyTests) FlushAllClearsKeys(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1347:1)
 	if r.flushAllClearsKeys != nil {
 		return nil
 	}
@@ -637,7 +749,7 @@ func (r *ValkeyTests) FlushAllClearsKeys(ctx context.Context) error { // valkey-
 // GetMissingKeyFails verifies absence stays distinguishable from an
 // empty value: an unset key errors, while a key holding "" reads back as
 // "".
-func (r *ValkeyTests) GetMissingKeyFails(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:943:1)
+func (r *ValkeyTests) GetMissingKeyFails(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:975:1)
 	if r.getMissingKeyFails != nil {
 		return nil
 	}
@@ -649,7 +761,7 @@ func (r *ValkeyTests) GetMissingKeyFails(ctx context.Context) error { // valkey-
 // GetShouldNotBeCached verifies Get re-executes on every call: write v1,
 // read it, overwrite with v2, read again. A cached Get would still
 // report v1 — the canonical stale-read bug a missingproduces.
-func (r *ValkeyTests) GetShouldNotBeCached(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:897:1)
+func (r *ValkeyTests) GetShouldNotBeCached(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:929:1)
 	if r.getShouldNotBeCached != nil {
 		return nil
 	}
@@ -710,7 +822,7 @@ func (r *ValkeyTests) UnmarshalJSON(bs []byte) error {
 // InfoReportsRole verifies INFO replication reports a standalone node as
 // the primary. ReplicationReportsRoles is the multi-node counterpart,
 // where a replica reports role:slave instead.
-func (r *ValkeyTests) InfoReportsRole(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1296:1)
+func (r *ValkeyTests) InfoReportsRole(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1328:1)
 	if r.infoReportsRole != nil {
 		return nil
 	}
@@ -723,7 +835,7 @@ func (r *ValkeyTests) InfoReportsRole(ctx context.Context) error { // valkey-tes
 // checks the full match set comes back. One SCAN page holds far fewer
 // than that, so an implementation that returned the first page — or that
 // stopped before the cursor wrapped to 0 — comes up short here.
-func (r *ValkeyTests) KeysScansPattern(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1096:1)
+func (r *ValkeyTests) KeysScansPattern(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1128:1)
 	if r.keysScansPattern != nil {
 		return nil
 	}
@@ -744,7 +856,7 @@ func (r *ValkeyTests) KeysScansPattern(ctx context.Context) error { // valkey-te
 // maxMemory that never reached valkey-server would leave both nodes
 // happily holding the whole keyspace, and a maxMemoryPolicy that never
 // reached it would make the two nodes behave identically.
-func (r *ValkeyTests) MaxMemoryEvictsOverLimit(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2945:1)
+func (r *ValkeyTests) MaxMemoryEvictsOverLimit(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2977:1)
 	if r.maxMemoryEvictsOverLimit != nil {
 		return nil
 	}
@@ -762,7 +874,7 @@ func (r *ValkeyTests) MaxMemoryEvictsOverLimit(ctx context.Context) error { // v
 // default `yes`. A regression that passed `--tls-auth-clients no` for
 // MTLS too would let this certless client through and go undetected by
 // the round-trip tests.
-func (r *ValkeyTests) MtlsNodeDemandsClientCertAtWire(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2138:1)
+func (r *ValkeyTests) MtlsNodeDemandsClientCertAtWire(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2170:1)
 	if r.mtlsNodeDemandsClientCertAtWire != nil {
 		return nil
 	}
@@ -775,7 +887,7 @@ func (r *ValkeyTests) MtlsNodeDemandsClientCertAtWire(ctx context.Context) error
 // mTLS side: asking an mTLS node for a TLS-only client returns an error
 // naming both modes, before any wire activity. The SAN value on the cert
 // is irrelevant here — the guard fires in requireMode, ahead of any dial.
-func (r *ValkeyTests) MtlsServerRejectsTLSOnlyClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2093:1)
+func (r *ValkeyTests) MtlsServerRejectsTLSOnlyClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2125:1)
 	if r.mtlsServerRejectsTlsOnlyClient != nil {
 		return nil
 	}
@@ -796,7 +908,7 @@ func (r *ValkeyTests) MtlsServerRejectsTLSOnlyClient(ctx context.Context) error 
 // line and would silently override a `configFile` that set them. The
 // configFile tests further down are what catch that, and this one is what
 // makes their failure legible.
-func (r *ValkeyTests) OmittedConfigLeavesValkeyDefaults(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2826:1)
+func (r *ValkeyTests) OmittedConfigLeavesValkeyDefaults(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2858:1)
 	if r.omittedConfigLeavesValkeyDefaults != nil {
 		return nil
 	}
@@ -808,7 +920,7 @@ func (r *ValkeyTests) OmittedConfigLeavesValkeyDefaults(ctx context.Context) err
 // PasswordReusableViaClient verifies the credentials a Server hands back
 // authenticate through the standalone constructor: Endpointare enough to build a working client, which is what makes the same
 // Client usable against a remote Valkey.
-func (r *ValkeyTests) PasswordReusableViaClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:784:1)
+func (r *ValkeyTests) PasswordReusableViaClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:816:1)
 	if r.passwordReusableViaClient != nil {
 		return nil
 	}
@@ -823,7 +935,7 @@ func (r *ValkeyTests) PasswordReusableViaClient(ctx context.Context) error { // 
 // wire protocol to the encrypted listener and fails. If `--port 0` were
 // missing, a plaintext listener would still be up on 6379 and this dial
 // would succeed.
-func (r *ValkeyTests) PlaintextDialAgainstTLSNodeFails(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2206:1)
+func (r *ValkeyTests) PlaintextDialAgainstTLSNodeFails(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2238:1)
 	if r.plaintextDialAgainstTlsNodeFails != nil {
 		return nil
 	}
@@ -834,14 +946,14 @@ func (r *ValkeyTests) PlaintextDialAgainstTLSNodeFails(ctx context.Context) erro
 
 // ValkeyTestsReplicationOpts contains options for ValkeyTests.Replication
 type ValkeyTestsReplicationOpts struct {
-	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:110:2)
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:114:2)
 }
 
 // Replication runs the primary/replica topology tests. Each test boots
 // its own topology via bootReplication, whose runtime-random name folds
 // into Valkey.Replication's session-cache key and into every node's
 // hostname, so concurrent tests get independent topologies.
-func (r *ValkeyTests) Replication(ctx context.Context, opts ...ValkeyTestsReplicationOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:107:1)
+func (r *ValkeyTests) Replication(ctx context.Context, opts ...ValkeyTestsReplicationOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:111:1)
 	if r.replication != nil {
 		return nil
 	}
@@ -862,7 +974,7 @@ func (r *ValkeyTests) Replication(ctx context.Context, opts ...ValkeyTestsReplic
 // wrong never reaches — it stays `down`, retrying on NOAUTH, while every
 // other assertion in this file would still pass against its (empty but
 // readable) local keyspace.
-func (r *ValkeyTests) ReplicationLinkAuthenticates(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1658:1)
+func (r *ValkeyTests) ReplicationLinkAuthenticates(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1690:1)
 	if r.replicationLinkAuthenticates != nil {
 		return nil
 	}
@@ -879,7 +991,7 @@ func (r *ValkeyTests) ReplicationLinkAuthenticates(ctx context.Context) error { 
 //
 // Endpoint is a pure accessor, so this asserts the addressing scheme
 // without booting anything.
-func (r *ValkeyTests) ReplicationNodesHaveDistinctHostnames(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1698:1)
+func (r *ValkeyTests) ReplicationNodesHaveDistinctHostnames(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1730:1)
 	if r.replicationNodesHaveDistinctHostnames != nil {
 		return nil
 	}
@@ -892,7 +1004,7 @@ func (r *ValkeyTests) ReplicationNodesHaveDistinctHostnames(ctx context.Context)
 // path: a key written to the primary becomes readable from the replica.
 // The read polls, because the link is asynchronous and a single read
 // would race the initial sync.
-func (r *ValkeyTests) ReplicationPropagatesWritesToReplica(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1523:1)
+func (r *ValkeyTests) ReplicationPropagatesWritesToReplica(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1555:1)
 	if r.replicationPropagatesWritesToReplica != nil {
 		return nil
 	}
@@ -906,7 +1018,7 @@ func (r *ValkeyTests) ReplicationPropagatesWritesToReplica(ctx context.Context) 
 // forever on a failed handshake: a TLS node runs with `--port 0`, so the
 // replication link would also have to run over TLS, and a client-listener
 // ServerSecurity carries none of the trust material that link needs.
-func (r *ValkeyTests) ReplicationRejectsTLSSecurity(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:527:1)
+func (r *ValkeyTests) ReplicationRejectsTLSSecurity(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:559:1)
 	if r.replicationRejectsTlsSecurity != nil {
 		return nil
 	}
@@ -925,7 +1037,7 @@ func (r *ValkeyTests) ReplicationRejectsTLSSecurity(ctx context.Context) error {
 // any optional argument holding its zero value, so `Replicas: 0` never
 // reaches the module and resolves to the `the CLI does reach the guard, which is why the guard is `< 1` and not
 // `< 0`.
-func (r *ValkeyTests) ReplicationRejectsTooFewReplicas(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:494:1)
+func (r *ValkeyTests) ReplicationRejectsTooFewReplicas(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:526:1)
 	if r.replicationRejectsTooFewReplicas != nil {
 		return nil
 	}
@@ -938,7 +1050,7 @@ func (r *ValkeyTests) ReplicationRejectsTooFewReplicas(ctx context.Context) erro
 // holds: a write against a replica is refused with READONLY, so a test
 // that writes to the wrong node fails loudly instead of silently losing
 // the write on the next sync.
-func (r *ValkeyTests) ReplicationReplicaRejectsWrites(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1618:1)
+func (r *ValkeyTests) ReplicationReplicaRejectsWrites(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1650:1)
 	if r.replicationReplicaRejectsWrites != nil {
 		return nil
 	}
@@ -952,7 +1064,7 @@ func (r *ValkeyTests) ReplicationReplicaRejectsWrites(ctx context.Context) error
 // connected_slaves as there are replicas, and every replica reports the
 // replica role. Two replicas rather than one, so a count that reported
 // "some replica connected" instead of all of them fails here.
-func (r *ValkeyTests) ReplicationReportsRoles(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1565:1)
+func (r *ValkeyTests) ReplicationReportsRoles(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1597:1)
 	if r.replicationReportsRoles != nil {
 		return nil
 	}
@@ -975,7 +1087,7 @@ func (r *ValkeyTests) ReplicationReportsRoles(ctx context.Context) error { // va
 // every other node depends on". Replication.Stop still walks every node
 // explicitly rather than leaning on that dependency teardown, which is
 // not a documented guarantee.
-func (r *ValkeyTests) ReplicationStopTerminatesEveryNode(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1761:1)
+func (r *ValkeyTests) ReplicationStopTerminatesEveryNode(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1793:1)
 	if r.replicationStopTerminatesEveryNode != nil {
 		return nil
 	}
@@ -988,7 +1100,7 @@ func (r *ValkeyTests) ReplicationStopTerminatesEveryNode(ctx context.Context) er
 // resolve to one backing node: a key written through the first is
 // readable through the second. Catches session cache-key drift, which
 // would silently split a multi-step test across two empty keyspaces.
-func (r *ValkeyTests) SameNameServerSharesState(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:706:1)
+func (r *ValkeyTests) SameNameServerSharesState(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:738:1)
 	if r.sameNameServerSharesState != nil {
 		return nil
 	}
@@ -999,14 +1111,14 @@ func (r *ValkeyTests) SameNameServerSharesState(ctx context.Context) error { // 
 
 // ValkeyTestsSecurityOpts contains options for ValkeyTests.Security
 type ValkeyTestsSecurityOpts struct {
-	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:230:2)
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:234:2)
 }
 
 // Security runs the TLS / mTLS listener + client tests. Each test mints
 // its own CA, leaf certs, password, and server name at runtime (no
 // literal credentials or PEM blobs), and folds a unique name into the
 // node's session-cache key, so the tests fan out without sharing state.
-func (r *ValkeyTests) Security(ctx context.Context, opts ...ValkeyTestsSecurityOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:227:1)
+func (r *ValkeyTests) Security(ctx context.Context, opts ...ValkeyTestsSecurityOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:231:1)
 	if r.security != nil {
 		return nil
 	}
@@ -1023,14 +1135,14 @@ func (r *ValkeyTests) Security(ctx context.Context, opts ...ValkeyTestsSecurityO
 
 // ValkeyTestsServerOpts contains options for ValkeyTests.Server
 type ValkeyTestsServerOpts struct {
-	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:170:2)
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:174:2)
 }
 
 // Server runs the topology, default, and caching tests. Each test boots
 // its own node via bootServer, whose runtime-random name folds into
 // Valkey.Server's session-cache key so concurrent tests boot independent
 // backing services and never share a keyspace.
-func (r *ValkeyTests) Server(ctx context.Context, opts ...ValkeyTestsServerOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:167:1)
+func (r *ValkeyTests) Server(ctx context.Context, opts ...ValkeyTestsServerOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:171:1)
 	if r.server != nil {
 		return nil
 	}
@@ -1048,7 +1160,7 @@ func (r *ValkeyTests) Server(ctx context.Context, opts ...ValkeyTestsServerOpts)
 // ServerMtlsRoundTripFromClient boots a mutual-TLS node and proves a
 // matching mTLS client (presenting a client cert signed by the trusted
 // CA) can round-trip Set
-func (r *ValkeyTests) ServerMtlsRoundTripFromClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1998:1)
+func (r *ValkeyTests) ServerMtlsRoundTripFromClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2030:1)
 	if r.serverMtlsRoundTripFromClient != nil {
 		return nil
 	}
@@ -1071,7 +1183,7 @@ func (r *ValkeyTests) ServerMtlsRoundTripFromClient(ctx context.Context) error {
 // The accepting cases prove the guard is a mention and not an
 // interpretation: naming `default` at all — even to turn it off — is a
 // decision the caller is entitled to make.
-func (r *ValkeyTests) ServerRejectsACLFileWithoutDefaultUser(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3189:1)
+func (r *ValkeyTests) ServerRejectsACLFileWithoutDefaultUser(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3221:1)
 	if r.serverRejectsAclFileWithoutDefaultUser != nil {
 		return nil
 	}
@@ -1090,7 +1202,7 @@ func (r *ValkeyTests) ServerRejectsACLFileWithoutDefaultUser(ctx context.Context
 // The accepted cases run too, so the guard can't pass by rejecting
 // everything: `k`/`m`/`g` (powers of 1000) and `kb`/`mb`/`gb` (powers of
 // 1024) are both legal, as is a bare byte count.
-func (r *ValkeyTests) ServerRejectsInvalidMaxMemory(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:409:1)
+func (r *ValkeyTests) ServerRejectsInvalidMaxMemory(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:441:1)
 	if r.serverRejectsInvalidMaxMemory != nil {
 		return nil
 	}
@@ -1107,7 +1219,7 @@ func (r *ValkeyTests) ServerRejectsInvalidMaxMemory(ctx context.Context) error {
 // Every policy Valkey accepts is exercised on the accept side, so a guard
 // that only knew the common ones would fail here rather than in a
 // caller's pipeline.
-func (r *ValkeyTests) ServerRejectsInvalidMaxMemoryPolicy(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:448:1)
+func (r *ValkeyTests) ServerRejectsInvalidMaxMemoryPolicy(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:480:1)
 	if r.serverRejectsInvalidMaxMemoryPolicy != nil {
 		return nil
 	}
@@ -1117,7 +1229,7 @@ func (r *ValkeyTests) ServerRejectsInvalidMaxMemoryPolicy(ctx context.Context) e
 }
 
 // ServerRejectsNilPassword verifies a passwordless node must not boot.
-func (r *ValkeyTests) ServerRejectsNilPassword(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:355:1)
+func (r *ValkeyTests) ServerRejectsNilPassword(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:387:1)
 	if r.serverRejectsNilPassword != nil {
 		return nil
 	}
@@ -1129,7 +1241,7 @@ func (r *ValkeyTests) ServerRejectsNilPassword(ctx context.Context) error { // v
 // ServerRejectsNilSecurity verifies plaintext must be a deliberate
 // choice, so the TLS follow-up stays an explicit upgrade rather than a
 // silent default.
-func (r *ValkeyTests) ServerRejectsNilSecurity(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:376:1)
+func (r *ValkeyTests) ServerRejectsNilSecurity(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:408:1)
 	if r.serverRejectsNilSecurity != nil {
 		return nil
 	}
@@ -1142,7 +1254,7 @@ func (r *ValkeyTests) ServerRejectsNilSecurity(ctx context.Context) error { // v
 // matching TLS client — presenting NO client certificate — can Setagainst it over the encrypted listener. That the certless client is
 // accepted is the `--tls-auth-clients no` acceptance criterion: without
 // that flag Valkey would demand a client cert and reject this dial.
-func (r *ValkeyTests) ServerTLSRoundTripFromClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1948:1)
+func (r *ValkeyTests) ServerTLSRoundTripFromClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1980:1)
 	if r.serverTlsRoundTripFromClient != nil {
 		return nil
 	}
@@ -1153,7 +1265,7 @@ func (r *ValkeyTests) ServerTLSRoundTripFromClient(ctx context.Context) error { 
 
 // SetGetRoundTrip is the core smoke path: a value written through Set
 // comes back through Get unchanged.
-func (r *ValkeyTests) SetGetRoundTrip(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:864:1)
+func (r *ValkeyTests) SetGetRoundTrip(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:896:1)
 	if r.setGetRoundTrip != nil {
 		return nil
 	}
@@ -1172,7 +1284,7 @@ func (r *ValkeyTests) SetGetRoundTrip(ctx context.Context) error { // valkey-tes
 // an expiry check, because every step here is a round trip through a
 // re-probed service — a lower bound on the *remaining* TTL would be a
 // stopwatch race under a loaded parallel suite.
-func (r *ValkeyTests) SetWithTTLExpires(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:987:1)
+func (r *ValkeyTests) SetWithTTLExpires(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1019:1)
 	if r.setWithTtlExpires != nil {
 		return nil
 	}
@@ -1181,11 +1293,30 @@ func (r *ValkeyTests) SetWithTTLExpires(ctx context.Context) error { // valkey-t
 	return q.Execute(ctx)
 }
 
+// StockServerLacksBundleModules is the control that gives
+// BundleServerLoadsModules its teeth: the same MODULE LIST assertion run
+// against a node from the stock `valkey/valkey` image must NOT be
+// satisfied. Without it, a bundle node whose modules quietly stopped
+// loading would still pass every other test in this group by way of an
+// assertion that any Valkey node happens to satisfy.
+//
+// It is also what the boot-time readiness check would report: a node
+// missing these modules fails Server.Client with a message naming them,
+// rather than booting and failing later on the first JSON.SET.
+func (r *ValkeyTests) StockServerLacksBundleModules(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3501:1)
+	if r.stockServerLacksBundleModules != nil {
+		return nil
+	}
+	q := r.query.Select("stockServerLacksBundleModules")
+
+	return q.Execute(ctx)
+}
+
 // StopTerminatesServer verifies Stop actually kills the backing service.
 // The post-Stop probe goes through the standalone constructor on
 // purpose: Server.Client would re-Start the service it is asked to dial
 // and the test would pass no matter what Stop did.
-func (r *ValkeyTests) StopTerminatesServer(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:824:1)
+func (r *ValkeyTests) StopTerminatesServer(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:856:1)
 	if r.stopTerminatesServer != nil {
 		return nil
 	}
@@ -1200,7 +1331,7 @@ func (r *ValkeyTests) StopTerminatesServer(ctx context.Context) error { // valke
 // TLS/mTLS node onto the same sha256("") host and invite cert/SAN reuse.
 // The guard fires in the constructor, before any service starts, so a
 // placeholder SAN on the cert is fine here.
-func (r *ValkeyTests) TLSServerRejectsEmptyName(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2250:1)
+func (r *ValkeyTests) TLSServerRejectsEmptyName(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2282:1)
 	if r.tlsServerRejectsEmptyName != nil {
 		return nil
 	}
@@ -1212,7 +1343,7 @@ func (r *ValkeyTests) TLSServerRejectsEmptyName(ctx context.Context) error { // 
 // TlsServerRejectsPlaintextClient verifies the mode-coupling check:
 // asking a TLS node for a plaintext client returns an error naming both
 // modes, before any wire activity.
-func (r *ValkeyTests) TLSServerRejectsPlaintextClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2054:1)
+func (r *ValkeyTests) TLSServerRejectsPlaintextClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2086:1)
 	if r.tlsServerRejectsPlaintextClient != nil {
 		return nil
 	}
@@ -1223,12 +1354,12 @@ func (r *ValkeyTests) TLSServerRejectsPlaintextClient(ctx context.Context) error
 
 // ValkeyTestsValidationOpts contains options for ValkeyTests.Validation
 type ValkeyTestsValidationOpts struct {
-	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:80:2)
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:84:2)
 }
 
 // Validation runs the input-rejection tests. These boot no service, so
 // they're safe to fan out unbounded.
-func (r *ValkeyTests) Validation(ctx context.Context, opts ...ValkeyTestsValidationOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:77:1)
+func (r *ValkeyTests) Validation(ctx context.Context, opts ...ValkeyTestsValidationOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:81:1)
 	if r.validation != nil {
 		return nil
 	}

--- a/daggerverse/valkey/README.md
+++ b/daggerverse/valkey/README.md
@@ -12,10 +12,11 @@ It is the daggerverse's first key-value store, and it targets Valkey
 (BSD-3, Linux Foundation) rather than Redis (RSALv2/SSPLv1 since 7.4).
 
 It supports three client-facing listener modes — plaintext (`requirepass`
-auth over an unencrypted TCP listener), one-way TLS, and mutual TLS.
-`valkey-server` config passthrough, the `valkey-bundle` image, TLS for
-the replication link and the cluster bus, and keyspace export/import all
-land in follow-ups.
+auth over an unencrypted TCP listener), one-way TLS, and mutual TLS. A
+single node can also be booted from `valkey/valkey-bundle`, the upstream
+image carrying the JSON, Bloom, and Search modules — see
+[`BundleServer`](#bundleserver). TLS for the replication link and the
+cluster bus, and keyspace export/import, land in follow-ups.
 
 ## Why `Server` and not `Cluster`
 
@@ -181,6 +182,56 @@ and wire its IP into `/etc/hosts`. (Pre-starting from this module would
 register the service in the module's DNS domain, which a session-domain
 consumer's host-file lookup can't resolve.) For module-runtime access,
 use `Server.Client`, which starts the service itself.
+
+### BundleServer
+
+`valkey/valkey-bundle` is the upstream image carrying the module
+ecosystem preinstalled — JSON (`JSON.SET` / `JSON.GET`), Bloom (`BF.*`),
+and Search (`FT.*`). `BundleServer` boots a single node from it and
+returns the same `*Server` with the same method set; only the image and
+the readiness check differ.
+
+```go
+Valkey.BundleServer(
+    ctx,
+    name="",
+    registry="docker.io", tag="9.1",   // <registry>/valkey/valkey-bundle:<tag>
+    password *dagger.Secret,
+    clientListenerSecurity *ServerSecurity,
+) (*Server, error)
+```
+
+The module commands need no new API — `Client.Do(["JSON.SET", ...])`
+already reaches them and their replies come back JSON-encoded like any
+other. Typed sugar for JSON / Bloom / Search is deliberately out of
+scope.
+
+**Readiness asserts the modules loaded.** A bundle node is not ready
+merely because it answers `PING`: after the first successful ping,
+`Server.Client` runs `MODULE LIST` and fails the boot unless `json`,
+`bf`, and `search` are all present, naming what is missing and what the
+node did report. Those are Valkey's own module names, not the shared
+object file names (`libvalkey_bloom.so` registers as `bf`, matching its
+`BF.*` command prefix). The list is a floor, not an exact match: the
+image also ships `ldap` and every node reports the built-in `lua`, and a
+future bundle release adding a module must not fail the check.
+
+**Why a separate constructor** rather than a `bundle bool` on `Server`:
+the image choice stays legible at the call site, and readiness gets
+somewhere to hang the module assertion.
+
+**Why the modules would otherwise not load.** The bundle image ships its
+own `bundle-docker-entrypoint.sh` instead of the stock
+`docker-entrypoint.sh`; the modules are `.so` files under
+`/usr/lib/valkey` and nothing loads them unless something composes the
+`--loadmodule` flags, which is precisely what that script does. Boot the
+bundle image through the stock entrypoint and you get a perfectly healthy
+node with an empty module list, whose first `JSON.SET` fails as an
+unknown command. The readiness assertion is what turns that into a boot
+failure.
+
+The `valkey-server` configuration passthrough is not wired up here yet —
+it is a follow-up.
 
 ## Replication
 
@@ -418,5 +469,5 @@ TLS/mTLS for the replication link (`--tls-replication yes` plus the trust
 material a replica needs to verify and authenticate to its primary) and
 for the cluster bus (`--tls-cluster yes`, plus `--tls`/`--cacert` for the
 bootstrapping `valkey-cli`); configuration passthrough for `Replication`
-and `Cluster` members; the `valkey/valkey-bundle` image with module
-verification; keyspace export/import via SCAN + DUMP/RESTORE.
+and `Cluster` members and for `BundleServer`; keyspace export/import via
+SCAN + DUMP/RESTORE.

--- a/daggerverse/valkey/bundle.go
+++ b/daggerverse/valkey/bundle.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"dagger/valkey/internal/dagger"
+)
+
+// bundleEntrypoint is the wrapper script the `valkey/valkey-bundle` image
+// ships INSTEAD of the stock `docker-entrypoint.sh`. Booting a bundle
+// node through the stock script is the whole trap this constructor
+// exists to close: the modules ship as `.so` files under
+// /usr/lib/valkey, and nothing loads them unless something composes the
+// `--loadmodule` flags. `bundle-docker-entrypoint.sh` is what does that
+// — it globs the module directory and appends one flag per module — so a
+// node built the stock way comes up perfectly healthy with an empty
+// module list, and the first `JSON.SET` fails as an unknown command.
+//
+// The bundle script is otherwise a superset of the stock one: it drops to
+// the `valkey` user the same way and honours a `.conf` positional
+// argument, skipping the modules that file already loads.
+const bundleEntrypoint = "bundle-docker-entrypoint.sh"
+
+// bundleModules is the set of module names a bundle node must report in
+// MODULE LIST before readiness will call it up. These are Valkey's own
+// spellings, not the file names: `libjson.so` registers as `json`,
+// `libvalkey_bloom.so` as `bf` (matching its `BF.*` command prefix), and
+// `libsearch.so` as `search`.
+//
+// The image also carries `ldap` (an authentication backend, not a data
+// type) and every node reports the built-in `lua`; neither is a module
+// ecosystem a caller reaches through commands, so neither is required
+// here. The list is a floor, not an exact match — a future bundle
+// release adding a module must not fail this check.
+var bundleModules = []string{"bf", "json", "search"}
+
+// BundleServer spins up a single-node Valkey server from the
+// `valkey/valkey-bundle` image: the upstream build that carries the
+// module ecosystem — JSON (`JSON.SET` / `JSON.GET`), Bloom (`BF.*`), and
+// Search (`FT.*`) — preinstalled.
+//
+// Image: `<registry>/valkey/valkey-bundle:<tag>`. Everything else — the
+// listener modes, `requirepass` auth, the hostname derivation, the
+// session-cache semantics of `name` — is identical to Valkey.Server, and
+// the returned *Server is the same type with the same method set.
+//
+// This is a separate constructor rather than a `bundle bool` parameter on
+// Valkey.Server so the image choice stays legible at the call site and so
+// readiness can assert something extra: a bundle node is not ready
+// merely because it answers PING, it is ready when MODULE LIST reports
+// the JSON, Bloom, and Search modules. A missing module therefore fails
+// the boot, naming what is missing, rather than surfacing much later as
+// an unknown-command error from the first `JSON.SET`.
+//
+// The module commands themselves need no new API: `Client.Do(["JSON.SET",
+// ...])` already reaches them, and their replies come back JSON-encoded
+// like any other. Typed sugar for JSON / Bloom / Search is deliberately
+// not part of this surface.
+//
+// The `valkey-server` configuration passthrough Valkey.Server offers
+// (config file, ACL file, append-only, max-memory, extra args) is not
+// wired up here yet — a bundle node is provisioned for what its modules
+// can do, and the passthrough is a follow-up.
+//
+// Rejected inputs are exactly Valkey.Server's, for the same reasons: a
+// nil `password`, a nil `clientListenerSecurity`, an incomplete TLS /
+// MTLS profile, and an empty `name` for a TLS / MTLS node.
+//
+// Session-cached on the same terms as Valkey.Server: `name` folds into
+// the cache key, so parallel test suites should pass a unique value per
+// test and a single test should reuse the returned handle.
+//
+// +cache="session"
+func (v *Valkey) BundleServer(
+	ctx context.Context,
+	// +default=""
+	name string,
+	// +default="docker.io"
+	registry string,
+	// +default="9.1"
+	tag string,
+	password *dagger.Secret,
+	clientListenerSecurity *ServerSecurity,
+) (*Server, error) {
+	if err := validateServerInputs(name, password, clientListenerSecurity); err != nil {
+		return nil, err
+	}
+
+	server := buildServer(name, bundleImage(registry, tag), bundleEntrypoint, password, clientListenerSecurity, nil, nil, nil, nil)
+	server.RequiredModules = bundleModules
+	return server, nil
+}
+
+// bundleImage renders the bundle image reference a node boots from. As
+// with valkeyImage the repository portion is fixed; only the registry
+// and tag are caller-overridable.
+func bundleImage(registry, tag string) string {
+	return fmt.Sprintf("%s/valkey/valkey-bundle:%s", registry, tag)
+}
+
+// requireModules asserts the node has loaded every module it was built to
+// carry. It runs once, after the first successful PING, rather than
+// inside the readiness retry loop: valkey-server loads its modules before
+// it binds the client port, so a node that answers PING has already
+// decided which modules it has and retrying could only burn the deadline.
+//
+// A node with no RequiredModules — every node built by Valkey.Server,
+// Valkey.Replication, and Valkey.Cluster — skips the round trip entirely.
+func (s *Server) requireModules(ctx context.Context, probe *Client) error {
+	if len(s.RequiredModules) == 0 {
+		return nil
+	}
+	loaded, err := probe.loadedModules(ctx)
+	if err != nil {
+		return fmt.Errorf("valkey %s module list: %w", s.Host, err)
+	}
+	var missing []string
+	for _, want := range s.RequiredModules {
+		if _, ok := loaded[want]; !ok {
+			missing = append(missing, want)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	present := make([]string, 0, len(loaded))
+	for name := range loaded {
+		present = append(present, name)
+	}
+	sort.Strings(present)
+	return fmt.Errorf(
+		"valkey %s booted without the expected module(s) %s; MODULE LIST reports [%s]",
+		s.Host, strings.Join(missing, ", "), strings.Join(present, ", "),
+	)
+}
+
+// loadedModules returns the set of module names the node reports through
+// MODULE LIST. Each element of the reply is a map (RESP3) or a flat
+// key/value array (RESP2) describing one module; AsStrMap reads both, and
+// `name` is the field that identifies the module to its commands.
+func (c *Client) loadedModules(ctx context.Context) (map[string]struct{}, error) {
+	client, cleanup, err := c.dial(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+
+	entries, err := client.Do(ctx, client.B().Arbitrary("MODULE", "LIST").Build()).ToArray()
+	if err != nil {
+		return nil, err
+	}
+	names := make(map[string]struct{}, len(entries))
+	for _, entry := range entries {
+		fields, err := entry.AsStrMap()
+		if err != nil {
+			return nil, err
+		}
+		if name := fields["name"]; name != "" {
+			names[name] = struct{}{}
+		}
+	}
+	return names, nil
+}

--- a/daggerverse/valkey/cluster.go
+++ b/daggerverse/valkey/cluster.go
@@ -163,6 +163,7 @@ func (v *Valkey) Cluster(
 		nodes = append(nodes, buildServer(
 			nodeName,
 			image,
+			valkeyEntrypoint,
 			password,
 			clientListenerSecurity,
 			// The configuration passthrough is Valkey.Server's alone: a

--- a/daggerverse/valkey/dagger.gen.go
+++ b/daggerverse/valkey/dagger.gen.go
@@ -73,6 +73,78 @@ func (r *Valkey) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
+func (r Server) MarshalJSON() ([]byte, error) {
+	var concrete struct {
+		Svc                *dagger.Service
+		Host               string
+		UserName           string
+		Pass               *dagger.Secret
+		ClientListenerMode string
+		RequiredModules    []string
+	}
+	concrete.Svc = r.Svc
+	concrete.Host = r.Host
+	concrete.UserName = r.UserName
+	concrete.Pass = r.Pass
+	concrete.ClientListenerMode = r.ClientListenerMode
+	concrete.RequiredModules = r.RequiredModules
+	return json.Marshal(&concrete)
+}
+
+func (r *Server) UnmarshalJSON(bs []byte) error {
+	var concrete struct {
+		Svc                *dagger.Service
+		Host               string
+		UserName           string
+		Pass               *dagger.Secret
+		ClientListenerMode string
+		RequiredModules    []string
+	}
+	err := json.Unmarshal(bs, &concrete)
+	if err != nil {
+		return err
+	}
+	r.Svc = concrete.Svc
+	r.Host = concrete.Host
+	r.UserName = concrete.UserName
+	r.Pass = concrete.Pass
+	r.ClientListenerMode = concrete.ClientListenerMode
+	r.RequiredModules = concrete.RequiredModules
+	return nil
+}
+
+func (r ServerSecurity) MarshalJSON() ([]byte, error) {
+	var concrete struct {
+		Mode       string
+		ServerCert *dagger.File
+		ServerKey  *dagger.Secret
+		ClientCa   *dagger.File
+	}
+	concrete.Mode = r.Mode
+	concrete.ServerCert = r.ServerCert
+	concrete.ServerKey = r.ServerKey
+	concrete.ClientCa = r.ClientCa
+	return json.Marshal(&concrete)
+}
+
+func (r *ServerSecurity) UnmarshalJSON(bs []byte) error {
+	var concrete struct {
+		Mode       string
+		ServerCert *dagger.File
+		ServerKey  *dagger.Secret
+		ClientCa   *dagger.File
+	}
+	err := json.Unmarshal(bs, &concrete)
+	if err != nil {
+		return err
+	}
+	r.Mode = concrete.Mode
+	r.ServerCert = concrete.ServerCert
+	r.ServerKey = concrete.ServerKey
+	r.ClientCa = concrete.ClientCa
+	return nil
+}
+
 func (r Client) MarshalJSON() ([]byte, error) {
 	var concrete struct {
 		Host         string
@@ -189,38 +261,6 @@ func (r *Cluster) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
-func (r ServerSecurity) MarshalJSON() ([]byte, error) {
-	var concrete struct {
-		Mode       string
-		ServerCert *dagger.File
-		ServerKey  *dagger.Secret
-		ClientCa   *dagger.File
-	}
-	concrete.Mode = r.Mode
-	concrete.ServerCert = r.ServerCert
-	concrete.ServerKey = r.ServerKey
-	concrete.ClientCa = r.ClientCa
-	return json.Marshal(&concrete)
-}
-
-func (r *ServerSecurity) UnmarshalJSON(bs []byte) error {
-	var concrete struct {
-		Mode       string
-		ServerCert *dagger.File
-		ServerKey  *dagger.Secret
-		ClientCa   *dagger.File
-	}
-	err := json.Unmarshal(bs, &concrete)
-	if err != nil {
-		return err
-	}
-	r.Mode = concrete.Mode
-	r.ServerCert = concrete.ServerCert
-	r.ServerKey = concrete.ServerKey
-	r.ClientCa = concrete.ClientCa
-	return nil
-}
-
 func (r Replication) MarshalJSON() ([]byte, error) {
 	var concrete struct {
 		Nodes []*Server
@@ -238,42 +278,6 @@ func (r *Replication) UnmarshalJSON(bs []byte) error {
 		return err
 	}
 	r.Nodes = concrete.Nodes
-	return nil
-}
-
-func (r Server) MarshalJSON() ([]byte, error) {
-	var concrete struct {
-		Svc                *dagger.Service
-		Host               string
-		UserName           string
-		Pass               *dagger.Secret
-		ClientListenerMode string
-	}
-	concrete.Svc = r.Svc
-	concrete.Host = r.Host
-	concrete.UserName = r.UserName
-	concrete.Pass = r.Pass
-	concrete.ClientListenerMode = r.ClientListenerMode
-	return json.Marshal(&concrete)
-}
-
-func (r *Server) UnmarshalJSON(bs []byte) error {
-	var concrete struct {
-		Svc                *dagger.Service
-		Host               string
-		UserName           string
-		Pass               *dagger.Secret
-		ClientListenerMode string
-	}
-	err := json.Unmarshal(bs, &concrete)
-	if err != nil {
-		return err
-	}
-	r.Svc = concrete.Svc
-	r.Host = concrete.Host
-	r.UserName = concrete.UserName
-	r.Pass = concrete.Pass
-	r.ClientListenerMode = concrete.ClientListenerMode
 	return nil
 }
 
@@ -668,6 +672,48 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 		}
 	case "Valkey":
 		switch fnName {
+		case "BundleServer":
+			var parent Valkey
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var name string
+			if inputArgs["name"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["name"]), &name)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg name", err))
+				}
+			}
+			var registry string
+			if inputArgs["registry"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["registry"]), &registry)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg registry", err))
+				}
+			}
+			var tag string
+			if inputArgs["tag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["tag"]), &tag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg tag", err))
+				}
+			}
+			var password *dagger.Secret
+			if inputArgs["password"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["password"]), &password)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg password", err))
+				}
+			}
+			var clientListenerSecurity *ServerSecurity
+			if inputArgs["clientListenerSecurity"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["clientListenerSecurity"]), &clientListenerSecurity)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg clientListenerSecurity", err))
+				}
+			}
+			return (*Valkey).BundleServer(&parent, ctx, name, registry, tag, password, clientListenerSecurity)
 		case "Client":
 			var parent Valkey
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/valkey/main.go
+++ b/daggerverse/valkey/main.go
@@ -1,6 +1,8 @@
 // Valkey provides Dagger functions for spinning up Valkey topologies
-// (from the upstream `valkey/valkey` image) — a single node, a primary
-// with N read replicas, or a slot-sharded Valkey Cluster — plus a pure-Go
+// (from the upstream `valkey/valkey` image, or `valkey/valkey-bundle` for
+// a node carrying the JSON / Bloom / Search modules) — a single node, a
+// primary with N read replicas, or a slot-sharded Valkey Cluster — plus
+// a pure-Go
 // valkey-go based client that can target either a local topology or any
 // reachable remote Valkey (e.g. ElastiCache Serverless, MemoryDB, a
 // self-hosted node).
@@ -24,6 +26,9 @@
 //   - server.go      — *Server + Valkey.Server, input validation, the
 //     shared node builder (buildServer), and the Endpoint / User /
 //     Password / BindServer / Client / Stop methods.
+//   - bundle.go      — Valkey.BundleServer, the `valkey-bundle` image and
+//     its own entrypoint script, and the MODULE LIST assertion readiness
+//     runs against a node that is supposed to carry modules.
 //   - config.go      — the `valkey-server` configuration passthrough a
 //     caller hands Valkey.Server (config file, ACL file, append-only,
 //     max-memory, extra args), its validation, and its rendering into

--- a/daggerverse/valkey/replication.go
+++ b/daggerverse/valkey/replication.go
@@ -90,7 +90,7 @@ func (v *Valkey) Replication(
 
 	image := valkeyImage(registry, tag)
 
-	primary := buildServer(replicationNodeName(name, 0), image, password, clientListenerSecurity, nil, nil, nil, nil)
+	primary := buildServer(replicationNodeName(name, 0), image, valkeyEntrypoint, password, clientListenerSecurity, nil, nil, nil, nil)
 
 	nodes := make([]*Server, 0, replicas+1)
 	nodes = append(nodes, primary)
@@ -98,6 +98,7 @@ func (v *Valkey) Replication(
 		nodes = append(nodes, buildServer(
 			replicationNodeName(name, i),
 			image,
+			valkeyEntrypoint,
 			password,
 			clientListenerSecurity,
 			// The configuration passthrough is Valkey.Server's alone: a

--- a/daggerverse/valkey/server.go
+++ b/daggerverse/valkey/server.go
@@ -32,6 +32,8 @@ type Server struct {
 	Pass *dagger.Secret
 	// +private
 	ClientListenerMode string // PLAINTEXT | TLS | MTLS — drives Client coupling validation.
+	// +private
+	RequiredModules []string // Module names readiness must find in MODULE LIST; empty for a stock node.
 }
 
 // Server spins up a single-node Valkey server listening on 6379 with
@@ -153,27 +155,8 @@ func (v *Valkey) Server(
 	// +optional
 	extraArgs []string,
 ) (*Server, error) {
-	if password == nil {
-		return nil, fmt.Errorf("password must not be nil; pass a *dagger.Secret with the requirepass value")
-	}
-	if clientListenerSecurity == nil {
-		return nil, fmt.Errorf("clientListenerSecurity must not be nil; pass PlaintextServerSecurity() explicitly")
-	}
-	if err := validateServerSecurity(clientListenerSecurity); err != nil {
+	if err := validateServerInputs(name, password, clientListenerSecurity); err != nil {
 		return nil, err
-	}
-	// For TLS / mTLS the hostname is derived from `name` alone (so the
-	// caller can mint a server cert whose SAN matches the dialed host).
-	// An empty `name` collapses every such node onto the same sha256("")
-	// hostname, colliding within one engine session and inviting the wrong
-	// cert/SAN to be reused — so require a discriminator. valkey-go pins
-	// ServerName to the dialed host and verifies it against the cert SAN,
-	// exactly as postgres' sslmode=verify-full does.
-	if name == "" && clientListenerSecurity.Mode != "PLAINTEXT" {
-		return nil, fmt.Errorf(
-			"name must not be empty for %s servers: the hostname derives from name and the server certificate's SAN must match it, so each TLS/mTLS server needs a unique name",
-			securityModeLabel(clientListenerSecurity.Mode),
-		)
 	}
 
 	cfg := &serverConfig{
@@ -193,7 +176,37 @@ func (v *Valkey) Server(
 		}
 	}
 
-	return buildServer(name, valkeyImage(registry, tag), password, clientListenerSecurity, cfg, nil, nil, nil), nil
+	return buildServer(name, valkeyImage(registry, tag), valkeyEntrypoint, password, clientListenerSecurity, cfg, nil, nil, nil), nil
+}
+
+// validateServerInputs applies the rejections every single-node
+// constructor shares — Valkey.Server and Valkey.BundleServer differ only
+// in the image they boot, so they must agree on what they refuse to boot
+// at all.
+func validateServerInputs(name string, password *dagger.Secret, security *ServerSecurity) error {
+	if password == nil {
+		return fmt.Errorf("password must not be nil; pass a *dagger.Secret with the requirepass value")
+	}
+	if security == nil {
+		return fmt.Errorf("clientListenerSecurity must not be nil; pass PlaintextServerSecurity() explicitly")
+	}
+	if err := validateServerSecurity(security); err != nil {
+		return err
+	}
+	// For TLS / mTLS the hostname is derived from `name` alone (so the
+	// caller can mint a server cert whose SAN matches the dialed host).
+	// An empty `name` collapses every such node onto the same sha256("")
+	// hostname, colliding within one engine session and inviting the wrong
+	// cert/SAN to be reused — so require a discriminator. valkey-go pins
+	// ServerName to the dialed host and verifies it against the cert SAN,
+	// exactly as postgres' sslmode=verify-full does.
+	if name == "" && security.Mode != "PLAINTEXT" {
+		return fmt.Errorf(
+			"name must not be empty for %s servers: the hostname derives from name and the server certificate's SAN must match it, so each TLS/mTLS server needs a unique name",
+			securityModeLabel(security.Mode),
+		)
+	}
+	return nil
 }
 
 // valkeyImage renders the image reference a node boots from. The
@@ -202,6 +215,13 @@ func (v *Valkey) Server(
 func valkeyImage(registry, tag string) string {
 	return fmt.Sprintf("%s/valkey/valkey:%s", registry, tag)
 }
+
+// valkeyEntrypoint is the wrapper script the stock `valkey/valkey` image
+// ships. It prepares /data and drops to the `valkey` user before exec'ing
+// the server, so the boot command runs through it rather than invoking
+// valkey-server directly. The bundle image ships a different one — see
+// bundleEntrypoint.
+const valkeyEntrypoint = "docker-entrypoint.sh"
 
 // serverHostname derives a node's stable hostname from its name. The
 // hostname is scoped per-node so parallel invocations don't collide on a
@@ -224,17 +244,19 @@ type serviceBinding struct {
 }
 
 // buildServer assembles a single valkey-server node: the container, the
-// security-derived listener flags, the caller's configuration
-// passthrough, any topology `valkey-server` arguments (replication or
-// cluster flags, say), the service bindings the node needs in order to
-// dial its peers, and any ports beyond the client listener the node must
-// expose (the cluster bus, say). Inputs are assumed already validated —
-// Valkey.Server, Valkey.Replication, and Valkey.Cluster each validate
-// before calling. A nil cfg means no passthrough, which is what the
-// topology constructors pass.
+// image's own entrypoint wrapper, the security-derived listener flags,
+// the caller's configuration passthrough, any topology `valkey-server`
+// arguments (replication or cluster flags, say), the service bindings the
+// node needs in order to dial its peers, and any ports beyond the client
+// listener the node must expose (the cluster bus, say). Inputs are
+// assumed already validated — Valkey.Server, Valkey.BundleServer,
+// Valkey.Replication, and Valkey.Cluster each validate before calling. A
+// nil cfg means no passthrough, which is what the topology constructors
+// pass.
 func buildServer(
 	name string,
 	image string,
+	entrypoint string,
 	password *dagger.Secret,
 	security *ServerSecurity,
 	cfg *serverConfig,
@@ -295,15 +317,16 @@ func buildServer(
 
 	// A shell wrapper is what makes "$VALKEY_PASSWORD" expand at boot;
 	// AsService args are exec'd directly, with no shell to expand them.
-	// docker-entrypoint.sh is retained (it prepares /data and drops to the
-	// valkey user) and `exec` keeps valkey-server as PID 1's successor so
-	// Service.Stop's signal reaches the server, not a shell.
+	// The image's entrypoint script is retained (it prepares /data and
+	// drops to the valkey user — and, for the bundle image, composes the
+	// --loadmodule flags) and `exec` keeps valkey-server as PID 1's
+	// successor so Service.Stop's signal reaches the server, not a shell.
 	//
 	// Long-running commands belong in AsService(Args), never WithExec —
 	// valkey-server never exits, so a WithExec would deadlock the chain.
 	svc := ctr.
 		AsService(dagger.ContainerAsServiceOpts{
-			Args: []string{"sh", "-c", "exec docker-entrypoint.sh valkey-server " + strings.Join(args, " ")},
+			Args: []string{"sh", "-c", "exec " + entrypoint + " valkey-server " + strings.Join(args, " ")},
 		}).
 		WithHostname(host)
 
@@ -418,9 +441,10 @@ func (s *Server) Stop(ctx context.Context) error {
 
 // start explicitly Starts the service so its WithHostname alias becomes
 // session-reachable from the valkey module runtime, then polls the
-// supplied probe Client until the node accepts authenticated commands.
-// Probing through the Client means the dial honours the listener's
-// security mode using the caller's own credentials.
+// supplied probe Client until the node accepts authenticated commands
+// and, for a node that declares RequiredModules, until it proves those
+// modules are loaded. Probing through the Client means the dial honours
+// the listener's security mode using the caller's own credentials.
 //
 // valkey-server binds 6379 only after it finishes loading, so an early
 // dial returns "connection refused" or LOADING; the retry loop absorbs
@@ -444,7 +468,7 @@ func (s *Server) start(ctx context.Context, probe *Client) error {
 		err := probe.Ping(attemptCtx)
 		cancel()
 		if err == nil {
-			return nil
+			return s.requireModules(ctx, probe)
 		}
 		lastErr = err
 		select {

--- a/daggerverse/valkey/tests/dagger.gen.go
+++ b/daggerverse/valkey/tests/dagger.gen.go
@@ -248,6 +248,55 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).BindServerReachableUnderTls(&parent, ctx)
+		case "Bundle":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var parallel int
+			if inputArgs["parallel"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["parallel"]), &parallel)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg parallel", err))
+				}
+			}
+			return nil, (*Tests).Bundle(&parent, ctx, parallel)
+		case "BundleBindServerReachableFromConsumer":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).BundleBindServerReachableFromConsumer(&parent, ctx)
+		case "BundleBloomRoundTrip":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).BundleBloomRoundTrip(&parent, ctx)
+		case "BundleJsonRoundTrip":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).BundleJsonRoundTrip(&parent, ctx)
+		case "BundleServerLoadsModules":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).BundleServerLoadsModules(&parent, ctx)
+		case "BundleServerMethodsMatchStock":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).BundleServerMethodsMatchStock(&parent, ctx)
 		case "Client":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -661,6 +710,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).SetWithTtlExpires(&parent, ctx)
+		case "StockServerLacksBundleModules":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).StockServerLacksBundleModules(&parent, ctx)
 		case "StopTerminatesServer":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/valkey/tests/internal/dagger/valkey.gen.go
+++ b/daggerverse/valkey/tests/internal/dagger/valkey.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type Valkey
-func (r *Binding) AsValkey() *Valkey { // valkey (../../../../../daggerverse/valkey/main.go:47:6)
+func (r *Binding) AsValkey() *Valkey { // valkey (../../../../../daggerverse/valkey/main.go:52:6)
 	q := r.query.Select("asValkey")
 
 	return &Valkey{
@@ -145,7 +145,7 @@ func (r *Env) WithValkeyClusterOutput(name string, description string) *Env { //
 }
 
 // Create or update a binding of type Valkey in the environment
-func (r *Env) WithValkeyInput(name string, value *Valkey, description string) *Env { // valkey (../../../../../daggerverse/valkey/main.go:47:6)
+func (r *Env) WithValkeyInput(name string, value *Valkey, description string) *Env { // valkey (../../../../../daggerverse/valkey/main.go:52:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withValkeyInput")
 	q = q.Arg("name", name)
@@ -158,7 +158,7 @@ func (r *Env) WithValkeyInput(name string, value *Valkey, description string) *E
 }
 
 // Declare a desired Valkey output to be assigned in the environment
-func (r *Env) WithValkeyOutput(name string, description string) *Env { // valkey (../../../../../daggerverse/valkey/main.go:47:6)
+func (r *Env) WithValkeyOutput(name string, description string) *Env { // valkey (../../../../../daggerverse/valkey/main.go:52:6)
 	q := r.query.Select("withValkeyOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -244,7 +244,7 @@ func (r *Env) WithValkeyServerSecurityOutput(name string, description string) *E
 // module. The server constructor, security helpers, and the
 // remote-client factory all hang off *Valkey so the generated Dagger SDK
 // surfaces them under `dag.Valkey().<Func>(...)`.
-func (r *Query) Valkey() *Valkey { // valkey (../../../../../daggerverse/valkey/main.go:47:6)
+func (r *Query) Valkey() *Valkey { // valkey (../../../../../daggerverse/valkey/main.go:52:6)
 	q := r.query.Select("valkey")
 
 	return &Valkey{
@@ -256,7 +256,7 @@ func (r *Query) Valkey() *Valkey { // valkey (../../../../../daggerverse/valkey/
 // module. The server constructor, security helpers, and the
 // remote-client factory all hang off *Valkey so the generated Dagger SDK
 // surfaces them under `dag.Valkey().<Func>(...)`.
-type Valkey struct { // valkey (../../../../../daggerverse/valkey/main.go:47:6)
+type Valkey struct { // valkey (../../../../../daggerverse/valkey/main.go:52:6)
 	query *querybuilder.Selection
 
 	id *ID
@@ -264,6 +264,78 @@ type Valkey struct { // valkey (../../../../../daggerverse/valkey/main.go:47:6)
 
 func (r *Valkey) WithGraphQLQuery(q *querybuilder.Selection) *Valkey {
 	return &Valkey{
+		query: q,
+	}
+}
+
+// ValkeyBundleServerOpts contains options for Valkey.BundleServer
+type ValkeyBundleServerOpts struct {
+	Name string // valkey (../../../../../daggerverse/valkey/bundle.go:80:2)
+
+	// Default: "docker.io"
+	Registry string // valkey (../../../../../daggerverse/valkey/bundle.go:82:2)
+
+	// Default: "9.1"
+	Tag string // valkey (../../../../../daggerverse/valkey/bundle.go:84:2)
+}
+
+// BundleServer spins up a single-node Valkey server from the
+// `valkey/valkey-bundle` image: the upstream build that carries the
+// module ecosystem — JSON (`JSON.SET` / `JSON.GET`), Bloom (`BF.*`), and
+// Search (`FT.*`) — preinstalled.
+//
+// Image: `<registry>/valkey/valkey-bundle:<tag>`. Everything else — the
+// listener modes, `requirepass` auth, the hostname derivation, the
+// session-cache semantics of `name` — is identical to Valkey.Server, and
+// the returned *Server is the same type with the same method set.
+//
+// This is a separate constructor rather than a `bundle bool` parameter on
+// Valkey.Server so the image choice stays legible at the call site and so
+// readiness can assert something extra: a bundle node is not ready
+// merely because it answers PING, it is ready when MODULE LIST reports
+// the JSON, Bloom, and Search modules. A missing module therefore fails
+// the boot, naming what is missing, rather than surfacing much later as
+// an unknown-command error from the first `JSON.SET`.
+//
+// The module commands themselves need no new API: `Client.Do(["JSON.SET",
+// ...])` already reaches them, and their replies come back JSON-encoded
+// like any other. Typed sugar for JSON / Bloom / Search is deliberately
+// not part of this surface.
+//
+// The `valkey-server` configuration passthrough Valkey.Server offers
+// (config file, ACL file, append-only, max-memory, extra args) is not
+// wired up here yet — a bundle node is provisioned for what its modules
+// can do, and the passthrough is a follow-up.
+//
+// Rejected inputs are exactly Valkey.Server's, for the same reasons: a
+// nil `password`, a nil `clientListenerSecurity`, an incomplete TLS /
+// MTLS profile, and an empty `name` for a TLS / MTLS node.
+//
+// Session-cached on the same terms as Valkey.Server: `name` folds into
+// the cache key, so parallel test suites should pass a unique value per
+// test and a single test should reuse the returned handle.
+func (r *Valkey) BundleServer(password *Secret, clientListenerSecurity *ValkeyServerSecurity, opts ...ValkeyBundleServerOpts) *ValkeyServer { // valkey (../../../../../daggerverse/valkey/bundle.go:77:1)
+	assertNotNil("password", password)
+	assertNotNil("clientListenerSecurity", clientListenerSecurity)
+	q := r.query.Select("bundleServer")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `name` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Name) {
+			q = q.Arg("name", opts[i].Name)
+		}
+		// `registry` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Registry) {
+			q = q.Arg("registry", opts[i].Registry)
+		}
+		// `tag` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Tag) {
+			q = q.Arg("tag", opts[i].Tag)
+		}
+	}
+	q = q.Arg("password", password)
+	q = q.Arg("clientListenerSecurity", clientListenerSecurity)
+
+	return &ValkeyServer{
 		query: q,
 	}
 }
@@ -596,40 +668,40 @@ func (r *Valkey) Replication(password *Secret, clientListenerSecurity *ValkeySer
 
 // ValkeyServerOpts contains options for Valkey.Server
 type ValkeyServerOpts struct {
-	Name string // valkey (../../../../../daggerverse/valkey/server.go:123:2)
+	Name string // valkey (../../../../../daggerverse/valkey/server.go:125:2)
 
 	// Default: "docker.io"
-	Registry string // valkey (../../../../../daggerverse/valkey/server.go:125:2)
+	Registry string // valkey (../../../../../daggerverse/valkey/server.go:127:2)
 
 	// Default: "9.1"
-	Tag string // valkey (../../../../../daggerverse/valkey/server.go:127:2)
+	Tag string // valkey (../../../../../daggerverse/valkey/server.go:129:2)
 	//
 	// A valkey.conf loaded before every flag argument; conflicting flags win.
 	//
-	ConfigFile *File // valkey (../../../../../daggerverse/valkey/server.go:133:2)
+	ConfigFile *File // valkey (../../../../../daggerverse/valkey/server.go:135:2)
 	//
 	// An ACL file loaded via --aclfile. A secret, not a file: it carries
 	// per-user password material.
 	//
-	ACLFile *Secret // valkey (../../../../../daggerverse/valkey/server.go:138:2)
+	ACLFile *Secret // valkey (../../../../../daggerverse/valkey/server.go:140:2)
 	//
 	// Turn the append-only file on. Defaults to false, matching Valkey.
 	//
-	AppendOnly bool // valkey (../../../../../daggerverse/valkey/server.go:142:2)
+	AppendOnly bool // valkey (../../../../../daggerverse/valkey/server.go:144:2)
 	//
 	// Memory ceiling in Valkey's notation ("512mb", "1gb", "104857600").
 	//
-	MaxMemory string // valkey (../../../../../daggerverse/valkey/server.go:146:2)
+	MaxMemory string // valkey (../../../../../daggerverse/valkey/server.go:148:2)
 	//
 	// Eviction policy applied once maxMemory is reached.
 	//
 	//
 	// Default: "noeviction"
-	MaxMemoryPolicy string // valkey (../../../../../daggerverse/valkey/server.go:150:2)
+	MaxMemoryPolicy string // valkey (../../../../../daggerverse/valkey/server.go:152:2)
 	//
 	// Unvalidated, unsupported valkey-server arguments, appended last.
 	//
-	ExtraArgs []string // valkey (../../../../../daggerverse/valkey/server.go:154:2)
+	ExtraArgs []string // valkey (../../../../../daggerverse/valkey/server.go:156:2)
 }
 
 // Server spins up a single-node Valkey server listening on 6379 with
@@ -713,7 +785,7 @@ type ValkeyServerOpts struct {
 // what a single test's chained Client calls need. Leaving the default
 // empty is fine for ad-hoc `dagger call` use where only one node is in
 // play.
-func (r *Valkey) Server(password *Secret, clientListenerSecurity *ValkeyServerSecurity, opts ...ValkeyServerOpts) *ValkeyServer { // valkey (../../../../../daggerverse/valkey/server.go:120:1)
+func (r *Valkey) Server(password *Secret, clientListenerSecurity *ValkeyServerSecurity, opts ...ValkeyServerOpts) *ValkeyServer { // valkey (../../../../../daggerverse/valkey/server.go:122:1)
 	assertNotNil("password", password)
 	assertNotNil("clientListenerSecurity", clientListenerSecurity)
 	q := r.query.Select("server")
@@ -1181,7 +1253,7 @@ func (r *ValkeyCluster) WithGraphQLQuery(q *querybuilder.Selection) *ValkeyClust
 // bootstrap a build-time dependency of whatever the consumer runs next,
 // so the container's first command meets a cluster whose slots are
 // already assigned rather than one answering CLUSTERDOWN.
-func (r *ValkeyCluster) BindNodes(ctr *Container) *Container { // valkey (../../../../../daggerverse/valkey/cluster.go:409:1)
+func (r *ValkeyCluster) BindNodes(ctr *Container) *Container { // valkey (../../../../../daggerverse/valkey/cluster.go:410:1)
 	assertNotNil("ctr", ctr)
 	q := r.query.Select("bindNodes")
 	q = q.Arg("ctr", ctr)
@@ -1209,7 +1281,7 @@ func (r *ValkeyCluster) BindNodes(ctr *Container) *Container { // valkey (../../
 // makes BindNodes unusable on the same cluster afterwards — see
 // Valkey.Cluster — so a consumer container should bind a cluster this
 // module has not already dialled.
-func (r *ValkeyCluster) Client(security *ValkeyClientSecurity) *ValkeyClient { // valkey (../../../../../daggerverse/valkey/cluster.go:437:1)
+func (r *ValkeyCluster) Client(security *ValkeyClientSecurity) *ValkeyClient { // valkey (../../../../../daggerverse/valkey/cluster.go:438:1)
 	assertNotNil("security", security)
 	q := r.query.Select("client")
 	q = q.Arg("security", security)
@@ -1226,7 +1298,7 @@ func (r *ValkeyCluster) Client(security *ValkeyClientSecurity) *ValkeyClient { /
 //
 // Session-cached rather than never-cached: Dagger v0.21 detaches module
 // objects returned from a `module reads their fields lazily, and `tests/` is such a consumer.
-func (r *ValkeyCluster) Endpoints(ctx context.Context) ([]string, error) { // valkey (../../../../../daggerverse/valkey/cluster.go:387:1)
+func (r *ValkeyCluster) Endpoints(ctx context.Context) ([]string, error) { // valkey (../../../../../daggerverse/valkey/cluster.go:388:1)
 	q := r.query.Select("endpoints")
 
 	var response []string
@@ -1288,7 +1360,7 @@ func (r *ValkeyCluster) UnmarshalJSON(bs []byte) error {
 // earlier one fails, and the failures are joined — a partial teardown
 // that reported only the first error would leave services running with
 // nothing naming them.
-func (r *ValkeyCluster) Stop(ctx context.Context) error { // valkey (../../../../../daggerverse/valkey/cluster.go:464:1)
+func (r *ValkeyCluster) Stop(ctx context.Context) error { // valkey (../../../../../daggerverse/valkey/cluster.go:465:1)
 	if r.stop != nil {
 		return nil
 	}
@@ -1381,7 +1453,7 @@ func (r *ValkeyReplication) UnmarshalJSON(bs []byte) error {
 // objects returned from a `module reads their fields lazily, and `tests/` is such a consumer. The
 // methods on the returned *Server are individually never-cached, so no
 // data-returning call is served stale.
-func (r *ValkeyReplication) Primary() *ValkeyServer { // valkey (../../../../../daggerverse/valkey/replication.go:165:1)
+func (r *ValkeyReplication) Primary() *ValkeyServer { // valkey (../../../../../daggerverse/valkey/replication.go:166:1)
 	q := r.query.Select("primary")
 
 	return &ValkeyServer{
@@ -1391,7 +1463,7 @@ func (r *ValkeyReplication) Primary() *ValkeyServer { // valkey (../../../../../
 
 // Replicas returns the topology's read replicas, in creation order.
 // Session-cached for the same reason Primary is.
-func (r *ValkeyReplication) Replicas(ctx context.Context) ([]ValkeyServer, error) { // valkey (../../../../../daggerverse/valkey/replication.go:176:1)
+func (r *ValkeyReplication) Replicas(ctx context.Context) ([]ValkeyServer, error) { // valkey (../../../../../daggerverse/valkey/replication.go:177:1)
 	q := r.query.Select("replicas")
 
 	q = q.Select("id")
@@ -1428,7 +1500,7 @@ func (r *ValkeyReplication) Replicas(ctx context.Context) ([]ValkeyServer, error
 // node is attempted even if an earlier one fails, and the failures are
 // joined — a partial teardown that reported only the first error would
 // leave services running with nothing naming them.
-func (r *ValkeyReplication) Stop(ctx context.Context) error { // valkey (../../../../../daggerverse/valkey/replication.go:190:1)
+func (r *ValkeyReplication) Stop(ctx context.Context) error { // valkey (../../../../../daggerverse/valkey/replication.go:191:1)
 	if r.stop != nil {
 		return nil
 	}
@@ -1467,7 +1539,7 @@ func (r *ValkeyServer) WithGraphQLQuery(q *querybuilder.Selection) *ValkeyServer
 // BindServer attaches the Valkey service to the given container under
 // the same hostname Endpoint reports, so the container can dial the node
 // at `Endpoint()` (e.g. `valkey-cli -h <host> -a <pw> PING`).
-func (r *ValkeyServer) BindServer(ctr *Container) *Container { // valkey (../../../../../daggerverse/valkey/server.go:359:1)
+func (r *ValkeyServer) BindServer(ctr *Container) *Container { // valkey (../../../../../daggerverse/valkey/server.go:382:1)
 	assertNotNil("ctr", ctr)
 	q := r.query.Select("bindServer")
 	q = q.Arg("ctr", ctr)
@@ -1485,7 +1557,7 @@ func (r *ValkeyServer) BindServer(ctr *Container) *Container { // valkey (../../
 // rather than failing opaquely at the wire. Readiness is then probed
 // with the client itself, so a TLS / mTLS listener would be polled over
 // TLS using the caller's own cert material.
-func (r *ValkeyServer) Client(security *ValkeyClientSecurity) *ValkeyClient { // valkey (../../../../../daggerverse/valkey/server.go:373:1)
+func (r *ValkeyServer) Client(security *ValkeyClientSecurity) *ValkeyClient { // valkey (../../../../../daggerverse/valkey/server.go:396:1)
 	assertNotNil("security", security)
 	q := r.query.Select("client")
 	q = q.Arg("security", security)
@@ -1506,7 +1578,7 @@ func (r *ValkeyServer) Client(security *ValkeyClientSecurity) *ValkeyClient { //
 // would register the service in the module's DNS domain, which the
 // binding's host-file lookup can't resolve from a session-domain
 // consumer — so the start must be driven by the binding, not here.
-func (r *ValkeyServer) Endpoint(ctx context.Context) (string, error) { // valkey (../../../../../daggerverse/valkey/server.go:332:1)
+func (r *ValkeyServer) Endpoint(ctx context.Context) (string, error) { // valkey (../../../../../daggerverse/valkey/server.go:355:1)
 	if r.endpoint != nil {
 		return *r.endpoint, nil
 	}
@@ -1570,7 +1642,7 @@ func (r *ValkeyServer) UnmarshalJSON(bs []byte) error {
 // Password returns the `requirepass` secret the node was provisioned
 // with, so callers can re-use it via Valkey.Client against the same
 // endpoint.
-func (r *ValkeyServer) Password() *Secret { // valkey (../../../../../daggerverse/valkey/server.go:350:1)
+func (r *ValkeyServer) Password() *Secret { // valkey (../../../../../daggerverse/valkey/server.go:373:1)
 	q := r.query.Select("password")
 
 	return &Secret{
@@ -1582,7 +1654,7 @@ func (r *ValkeyServer) Password() *Secret { // valkey (../../../../../daggervers
 // call this in a defer so the service span closes when the test returns.
 // SIGKILL skips graceful shutdown — Valkey's save-on-shutdown path is
 // wasted work for a torn-down test node.
-func (r *ValkeyServer) Stop(ctx context.Context) error { // valkey (../../../../../daggerverse/valkey/server.go:409:1)
+func (r *ValkeyServer) Stop(ctx context.Context) error { // valkey (../../../../../daggerverse/valkey/server.go:432:1)
 	if r.stop != nil {
 		return nil
 	}
@@ -1594,7 +1666,7 @@ func (r *ValkeyServer) Stop(ctx context.Context) error { // valkey (../../../../
 // User returns the ACL user clients authenticate as. `requirepass` sets
 // the password of the built-in `default` user, so this is always
 // "default" in this story; an ACL-file follow-up is what makes it vary.
-func (r *ValkeyServer) User(ctx context.Context) (string, error) { // valkey (../../../../../daggerverse/valkey/server.go:341:1)
+func (r *ValkeyServer) User(ctx context.Context) (string, error) { // valkey (../../../../../daggerverse/valkey/server.go:364:1)
 	if r.user != nil {
 		return *r.user, nil
 	}

--- a/daggerverse/valkey/tests/main.go
+++ b/daggerverse/valkey/tests/main.go
@@ -16,6 +16,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -65,6 +66,9 @@ func (t *Tests) All(
 	})
 	jobs = jobs.WithJob("Cluster", func(ctx context.Context) error {
 		return t.Cluster(ctx, parallel)
+	})
+	jobs = jobs.WithJob("Bundle", func(ctx context.Context) error {
+		return t.Bundle(ctx, parallel)
 	})
 	return jobs.Run(ctx)
 }
@@ -271,6 +275,34 @@ func (t *Tests) Config(
 	jobs = jobs.WithJob("config-file-directives-apply", t.ConfigFileDirectivesApply)
 	jobs = jobs.WithJob("flag-argument-beats-config-file", t.FlagArgumentBeatsConfigFile)
 	jobs = jobs.WithJob("extra-args-reach-server-last", t.ExtraArgsReachServerLast)
+	return jobs.Run(ctx)
+}
+
+// Bundle runs the `valkey/valkey-bundle` image tests: that the module
+// ecosystem it ships actually loads, that JSON and Bloom commands round
+// trip through Do, and that every *Server method behaves the same
+// against a bundle node as against a stock one. Each test boots its own
+// node under a runtime-random name, so the group fans out safely.
+//
+// +check
+// +cache="session"
+func (t *Tests) Bundle(
+	ctx context.Context,
+	// +default=0
+	parallel int,
+) error {
+	jobs := par.New().
+		WithRollupLogs(true).
+		WithRollupSpans(true)
+	if parallel > 0 {
+		jobs = jobs.WithLimit(parallel)
+	}
+	jobs = jobs.WithJob("bundle-server-loads-modules", t.BundleServerLoadsModules)
+	jobs = jobs.WithJob("stock-server-lacks-bundle-modules", t.StockServerLacksBundleModules)
+	jobs = jobs.WithJob("bundle-json-round-trip", t.BundleJsonRoundTrip)
+	jobs = jobs.WithJob("bundle-bloom-round-trip", t.BundleBloomRoundTrip)
+	jobs = jobs.WithJob("bundle-server-methods-match-stock", t.BundleServerMethodsMatchStock)
+	jobs = jobs.WithJob("bundle-bind-server-reachable-from-consumer", t.BundleBindServerReachableFromConsumer)
 	return jobs.Run(ctx)
 }
 
@@ -3367,6 +3399,359 @@ func (t *Tests) ExtraArgsReachServerLast(ctx context.Context) error {
 		return err
 	} else if want := strconv.Itoa(64 * 1024 * 1024); got != want {
 		return fmt.Errorf("expected maxMemory to survive alongside extraArgs, CONFIG GET reports %q (wanted %q)", got, want)
+	}
+	return nil
+}
+
+// -----------------------------------------------------------------------------
+// Bundle tests — the `valkey/valkey-bundle` image and the module ecosystem
+// it carries preinstalled (JSON, Bloom, Search).
+// -----------------------------------------------------------------------------
+
+// BundleServerLoadsModules verifies a bundle node boots with the JSON,
+// Bloom, and Search modules actually loaded. The bundle image only loads
+// them when its own `bundle-docker-entrypoint.sh` composes the
+// `--loadmodule` flags, so a node built through the stock
+// `docker-entrypoint.sh` comes up healthy with an empty module list —
+// which is exactly the silent failure this asserts against.
+//
+// +cache="never"
+func (t *Tests) BundleServerLoadsModules(ctx context.Context) error {
+	server, _, err := bootBundleServer(ctx)
+	if err != nil {
+		return err
+	}
+	client := plaintextClient(server)
+	loaded, err := moduleNames(ctx, client)
+	if err != nil {
+		return err
+	}
+	for _, want := range []string{"json", "bf", "search"} {
+		if _, ok := loaded[want]; !ok {
+			return fmt.Errorf("expected MODULE LIST to report the %q module, got %v", want, sortedKeys(loaded))
+		}
+	}
+	return nil
+}
+
+// moduleNames returns the set of module names a node reports through
+// MODULE LIST. The reply arrives through Do as JSON — an array of one
+// object per module — so `name` is read straight back off it.
+func moduleNames(ctx context.Context, client *dagger.ValkeyClient) (map[string]struct{}, error) {
+	reply, err := client.Do(ctx, []string{"MODULE", "LIST"})
+	if err != nil {
+		return nil, fmt.Errorf("module list: %w", err)
+	}
+	var modules []map[string]any
+	if err := json.Unmarshal([]byte(reply), &modules); err != nil {
+		return nil, fmt.Errorf("decode MODULE LIST reply %q: %w", reply, err)
+	}
+	names := make(map[string]struct{}, len(modules))
+	for _, module := range modules {
+		name, _ := module["name"].(string)
+		if name != "" {
+			names[name] = struct{}{}
+		}
+	}
+	return names, nil
+}
+
+// sortedKeys renders a name set in a stable order so a failure message
+// reads the same on every run.
+func sortedKeys(set map[string]struct{}) []string {
+	keys := make([]string, 0, len(set))
+	for key := range set {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// bootBundleServer mints a fresh single-node bundle server under a
+// runtime-random name, exactly as bootServer does for the stock image.
+func bootBundleServer(ctx context.Context) (*dagger.ValkeyServer, *dagger.Secret, error) {
+	name, err := randHex(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	pass, err := randSecret(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	server := dag.Valkey().BundleServer(
+		pass,
+		dag.Valkey().PlaintextServerSecurity(),
+		dagger.ValkeyBundleServerOpts{Name: name},
+	)
+	return server, pass, nil
+}
+
+// StockServerLacksBundleModules is the control that gives
+// BundleServerLoadsModules its teeth: the same MODULE LIST assertion run
+// against a node from the stock `valkey/valkey` image must NOT be
+// satisfied. Without it, a bundle node whose modules quietly stopped
+// loading would still pass every other test in this group by way of an
+// assertion that any Valkey node happens to satisfy.
+//
+// It is also what the boot-time readiness check would report: a node
+// missing these modules fails Server.Client with a message naming them,
+// rather than booting and failing later on the first JSON.SET.
+//
+// +cache="never"
+func (t *Tests) StockServerLacksBundleModules(ctx context.Context) error {
+	server, _, err := bootServer(ctx)
+	if err != nil {
+		return err
+	}
+	loaded, err := moduleNames(ctx, plaintextClient(server))
+	if err != nil {
+		return err
+	}
+	for _, unwanted := range []string{"json", "bf", "search"} {
+		if _, ok := loaded[unwanted]; ok {
+			return fmt.Errorf("expected the stock valkey image to carry no %q module, MODULE LIST reports %v", unwanted, sortedKeys(loaded))
+		}
+	}
+	return nil
+}
+
+// BundleJsonRoundTrip verifies the JSON module answers through Do: a
+// document written with JSON.SET reads back through a JSONPath JSON.GET.
+// The reply is a bulk string holding the JSONPath result array, so it
+// arrives double-encoded — a JSON string whose contents are themselves
+// JSON — and both layers are decoded here rather than string-matched.
+//
+// +cache="never"
+func (t *Tests) BundleJsonRoundTrip(ctx context.Context) error {
+	server, _, err := bootBundleServer(ctx)
+	if err != nil {
+		return err
+	}
+	key, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+	want, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+	client := plaintextClient(server)
+
+	document, err := json.Marshal(map[string]string{"name": want})
+	if err != nil {
+		return err
+	}
+	set, err := client.Do(ctx, []string{"JSON.SET", key, "$", string(document)})
+	if err != nil {
+		return fmt.Errorf("json.set: %w", err)
+	}
+	if set != strconv.Quote("OK") {
+		return fmt.Errorf("expected JSON.SET to reply OK, got %s", set)
+	}
+
+	reply, err := client.Do(ctx, []string{"JSON.GET", key, "$.name"})
+	if err != nil {
+		return fmt.Errorf("json.get: %w", err)
+	}
+	var encoded string
+	if err := json.Unmarshal([]byte(reply), &encoded); err != nil {
+		return fmt.Errorf("expected JSON.GET to reply with a bulk string, got %s: %w", reply, err)
+	}
+	var got []string
+	if err := json.Unmarshal([]byte(encoded), &got); err != nil {
+		return fmt.Errorf("expected the JSON.GET payload to be a JSONPath result array, got %q: %w", encoded, err)
+	}
+	if len(got) != 1 || got[0] != want {
+		return fmt.Errorf("expected JSON.GET $.name to yield [%q], got %v", want, got)
+	}
+
+	// A path that was never written must stay distinguishable from one
+	// that was, exactly as a missing key does for GET.
+	missing, err := client.Do(ctx, []string{"JSON.GET", key, "$.absent"})
+	if err != nil {
+		return fmt.Errorf("json.get absent path: %w", err)
+	}
+	if missing != strconv.Quote("[]") {
+		return fmt.Errorf("expected JSON.GET on an unwritten path to yield an empty result array, got %s", missing)
+	}
+	return nil
+}
+
+// BundleBloomRoundTrip verifies the Bloom module answers through Do. A
+// Bloom filter admits false positives but never false negatives, so the
+// load-bearing assertions are that an added item is reported present and
+// that a second BF.ADD of it reports "already there"; the absent-item
+// check rides along on a filter holding exactly one item, where a false
+// positive is vanishingly unlikely.
+//
+// +cache="never"
+func (t *Tests) BundleBloomRoundTrip(ctx context.Context) error {
+	server, _, err := bootBundleServer(ctx)
+	if err != nil {
+		return err
+	}
+	key, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+	item, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+	absent, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+	client := plaintextClient(server)
+
+	cases := []struct {
+		what string
+		args []string
+		want string
+	}{
+		{"first add", []string{"BF.ADD", key, item}, "1"},
+		{"re-add of the same item", []string{"BF.ADD", key, item}, "0"},
+		{"added item exists", []string{"BF.EXISTS", key, item}, "1"},
+		{"never-added item", []string{"BF.EXISTS", key, absent}, "0"},
+	}
+	for _, tc := range cases {
+		got, err := client.Do(ctx, tc.args)
+		if err != nil {
+			return fmt.Errorf("%s (%v): %w", tc.what, tc.args, err)
+		}
+		if got != tc.want {
+			return fmt.Errorf("%s (%v): expected %s, got %s", tc.what, tc.args, tc.want, got)
+		}
+	}
+	return nil
+}
+
+// BundleServerMethodsMatchStock verifies the *Server contract is
+// unchanged by the image swap: the same endpoint shape, the same
+// requirepass user, credentials that still build a working standalone
+// client, a working Set/Get/DbSize round trip, an INFO that reports the
+// pinned Valkey version, and a Stop that really terminates the node.
+// BindServer is the one method missing here — it must run against a node
+// nothing has started yet, so it gets its own test below.
+//
+// +cache="never"
+func (t *Tests) BundleServerMethodsMatchStock(ctx context.Context) error {
+	server, pass, err := bootBundleServer(ctx)
+	if err != nil {
+		return err
+	}
+	client := plaintextClient(server)
+	if err := client.Ping(ctx); err != nil {
+		return fmt.Errorf("ping: %w", err)
+	}
+
+	user, err := server.User(ctx)
+	if err != nil {
+		return fmt.Errorf("user: %w", err)
+	}
+	if user != "default" {
+		return fmt.Errorf("expected the built-in requirepass user %q, got %q", "default", user)
+	}
+	endpoint, err := server.Endpoint(ctx)
+	if err != nil {
+		return fmt.Errorf("endpoint: %w", err)
+	}
+	host, port, ok := strings.Cut(endpoint, ":")
+	if !ok || port != "6379" {
+		return fmt.Errorf("expected a host:6379 endpoint, got %q", endpoint)
+	}
+
+	key, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+	want, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+	if err := client.Set(ctx, key, want); err != nil {
+		return fmt.Errorf("set: %w", err)
+	}
+	got, err := client.Get(ctx, key)
+	if err != nil {
+		return fmt.Errorf("get: %w", err)
+	}
+	if got != want {
+		return fmt.Errorf("expected %q back from Get, got %q", want, got)
+	}
+	size, err := client.DbSize(ctx)
+	if err != nil {
+		return fmt.Errorf("dbsize: %w", err)
+	}
+	if size != 1 {
+		return fmt.Errorf("expected DbSize to report the single key just written, got %d", size)
+	}
+	info, err := client.Info(ctx, dagger.ValkeyClientInfoOpts{Section: "server"})
+	if err != nil {
+		return fmt.Errorf("info server: %w", err)
+	}
+	if !strings.Contains(info, "valkey_version:9.1") {
+		return fmt.Errorf("expected INFO server to report valkey_version:9.1.x, got:\n%s", info)
+	}
+
+	// Password() has to be good enough to build a client from scratch:
+	// Endpoint + Password is what makes the same *Client usable against
+	// a node this module did not construct.
+	standalone := dag.Valkey().Client(host, pass, dag.Valkey().PlaintextClientSecurity())
+	if err := standalone.Ping(ctx); err != nil {
+		return fmt.Errorf("standalone ping before stop: %w", err)
+	}
+	if err := server.Stop(ctx); err != nil {
+		return fmt.Errorf("stop: %w", err)
+	}
+	if err := standalone.Ping(ctx); err == nil {
+		return fmt.Errorf("expected ping to fail after Stop, but the node still answered")
+	}
+	return nil
+}
+
+// BundleBindServerReachableFromConsumer verifies BindServer wires a
+// bundle node into a consumer container exactly as it does a stock one,
+// and that the consumer gets a real PONG back rather than merely finding
+// something listening.
+//
+// The node is deliberately untouched before the binding: starting a
+// service from the valkey module's runtime registers it in that module's
+// DNS domain, which a consumer in the session domain then cannot resolve
+// ("lookup valkey-<host> ... no such host"). That is the trap
+// Server.Endpoint documents, and it is why this cannot ride along inside
+// BundleServerMethodsMatchStock.
+//
+// +cache="never"
+func (t *Tests) BundleBindServerReachableFromConsumer(ctx context.Context) error {
+	server, pass, err := bootBundleServer(ctx)
+	if err != nil {
+		return err
+	}
+	endpoint, err := server.Endpoint(ctx)
+	if err != nil {
+		return fmt.Errorf("endpoint: %w", err)
+	}
+	host, port, ok := strings.Cut(endpoint, ":")
+	if !ok {
+		return fmt.Errorf("expected a host:port endpoint, got %q", endpoint)
+	}
+	// The consumer is the small alpine-flavoured stock image — it only
+	// needs valkey-cli, not the modules — and the password rides in as a
+	// secret env var so it never enters the exec's argv.
+	ctr := dag.Container().
+		From("docker.io/valkey/valkey:9.1-alpine").
+		WithSecretVariable("VALKEY_PW", pass)
+	out, err := server.BindServer(ctr).
+		WithExec([]string{"sh", "-c", fmt.Sprintf(
+			`valkey-cli --no-auth-warning -h %s -p %s -a "$VALKEY_PW" JSON.SET doc $ '{"ok":true}'`, host, port,
+		)}).
+		Stdout(ctx)
+	if err != nil {
+		return fmt.Errorf("valkey-cli JSON.SET from consumer container: %w", err)
+	}
+	if !strings.Contains(out, "OK") {
+		return fmt.Errorf("expected OK from %s, got %q", endpoint, out)
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #201.

Adds `Valkey.BundleServer` — a single node booted from `<registry>/valkey/valkey-bundle:<tag>`, the upstream image carrying the module ecosystem (JSON, Bloom, Search) preinstalled. It returns the same `*Server` as `Valkey.Server` with the same method set; only the image and the readiness check differ. The signature is the one the issue specifies, so the `valkey-server` configuration passthrough is not wired up here — that stays a follow-up, noted in the README and the doc comment.

The module commands need no new API: `Client.Do(["JSON.SET", ...])` already reaches them and their replies come back JSON-encoded like any other. Typed sugar for JSON/Bloom/Search is deliberately out of scope.

## The bundle image ships its own entrypoint

This is the part worth reviewing. `valkey/valkey-bundle` carries the modules as `.so` files under `/usr/lib/valkey`, and **nothing loads them** unless something composes the `--loadmodule` flags. What does that is `bundle-docker-entrypoint.sh`, which the image ships *instead of* the stock `docker-entrypoint.sh` — though it carries the stock one too, so the wrong choice fails silently rather than loudly.

Confirmed empirically before writing any code: booting the bundle image through `docker-entrypoint.sh` yields a perfectly healthy node whose `MODULE LIST` contains only the built-in `lua`, and whose first `JSON.SET` fails as an unknown command.

`buildServer` therefore takes the entrypoint as a parameter; `Server`, `Replication`, and `Cluster` pass the stock one (`valkeyEntrypoint`), `BundleServer` passes `bundleEntrypoint`.

## Readiness asserts the modules loaded

`Server` gained a private `RequiredModules`. After the first successful PING, `start` runs `MODULE LIST` and fails the boot unless every required module is present, naming both what is missing and what the node did report:

```
valkey valkey-ced8cb97ed1b booted without the expected module(s) nosuchmodule; MODULE LIST reports [bf, json, ldap, lua, search]
```

Three details:

- **The names are Valkey's, not the file names.** `libvalkey_bloom.so` registers as `bf` (matching its `BF.*` command prefix), `libjson.so` as `json`, `libsearch.so` as `search`.
- **It runs once, not inside the retry loop.** valkey-server loads modules before it binds the client port, so a node answering PING has already decided what it has; retrying could only burn the deadline.
- **The list is a floor, not an exact match.** The image also ships `ldap` and every node reports the built-in `lua`; a future bundle release adding a module must not fail the check.

A node with no `RequiredModules` — everything `Server`, `Replication`, and `Cluster` build — skips the round trip entirely.

A separate constructor rather than a `bundle bool` on `Server` keeps the image choice legible at the call site and gives readiness somewhere to hang the assertion.

## Tests

New `Bundle` check (registered via `+check`, wired into `All`, appears as `valkey-tests:bundle`):

- `bundle-server-loads-modules` — `MODULE LIST` reports `json`, `bf`, `search`
- `stock-server-lacks-bundle-modules` — the control that stops the above being vacuous: the same assertion against a stock node must *not* hold, so a bundle node whose modules quietly stopped loading can't pass by way of a check any Valkey node satisfies
- `bundle-json-round-trip` — `JSON.SET` / JSONPath `JSON.GET`, both encoding layers decoded rather than string-matched, plus an unwritten path staying distinguishable
- `bundle-bloom-round-trip` — `BF.ADD` (first add, re-add) / `BF.EXISTS` (present, absent)
- `bundle-server-methods-match-stock` — endpoint shape, `default` user, Set/Get/DbSize, `INFO` version, credentials that build a working standalone client, and a `Stop` that really terminates the node
- `bundle-bind-server-reachable-from-consumer` — `BindServer` gets its own test rather than riding inside the parity one: a node started from the module runtime lands in that module's DNS domain and a session-domain consumer then can't resolve it, the trap `Server.Endpoint` already documents

The readiness guard itself was verified by temporarily adding a bogus module name and watching the boot fail with the message quoted above, then reverting.

## Verification

- `dagger -m daggerverse/valkey/tests call bundle` — green
- `dagger -m daggerverse/valkey/tests call all` — green (1m57s), so the `buildServer` entrypoint refactor left replication and cluster untouched
- `dagger call generated` — green; `dagger develop` re-run in the module, `tests/`, and the repo root
- `dagger check -l` lists `valkey-tests:bundle`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
