### PR TITLE
story(issue-202): add keyspace export and import to the valkey client

### DIFF
--- a/ci/internal/dagger/valkey-tests.gen.go
+++ b/ci/internal/dagger/valkey-tests.gen.go
@@ -95,14 +95,21 @@ type ValkeyTests struct { // valkey-tests (../../../daggerverse/valkey/tests/mai
 	delRemovesKeys                         *Void
 	doReturnsJsonReplies                   *Void
 	endpointShouldNotBeCached              *Void
+	exportHonoursPatternAcrossScanPages    *Void
+	exportImportPreservesTtls              *Void
+	exportImportRoundTripsEveryType        *Void
+	exportShouldNotBeCached                *Void
+	exportedFileIsReadableByConsumer       *Void
 	extraArgsReachServerLast               *Void
 	flagArgumentBeatsConfigFile            *Void
 	flushAllClearsKeys                     *Void
 	getMissingKeyFails                     *Void
 	getShouldNotBeCached                   *Void
 	id                                     *ID
+	importRejectsCollisionWithoutReplace   *Void
 	infoReportsRole                        *Void
 	keysScansPattern                       *Void
+	keyspace                               *Void
 	maxMemoryEvictsOverLimit               *Void
 	mtlsNodeDemandsClientCertAtWire        *Void
 	mtlsServerRejectsTlsOnlyClient         *Void
@@ -154,7 +161,7 @@ func (r *ValkeyTests) WithGraphQLQuery(q *querybuilder.Selection) *ValkeyTests {
 // other half of that: it proves the users arrived through the mounted
 // file rather than through `user ...` directives on the command line,
 // where they would be visible in the Dagger graph.
-func (r *ValkeyTests) ACLFileProvisionsUser(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3074:1)
+func (r *ValkeyTests) ACLFileProvisionsUser(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3103:1)
 	if r.aclFileProvisionsUser != nil {
 		return nil
 	}
@@ -196,7 +203,7 @@ func (r *ValkeyTests) All(ctx context.Context, opts ...ValkeyTestsAllOpts) error
 // aof_enabled:0 in the same test. Without it, an image that shipped with
 // the AOF already on would make the positive assertion pass while the
 // parameter did nothing at all — the classic vacuous config test.
-func (r *ValkeyTests) AppendOnlyEnablesAof(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2894:1)
+func (r *ValkeyTests) AppendOnlyEnablesAof(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2923:1)
 	if r.appendOnlyEnablesAof != nil {
 		return nil
 	}
@@ -207,7 +214,7 @@ func (r *ValkeyTests) AppendOnlyEnablesAof(ctx context.Context) error { // valke
 
 // ApplyFileReportsFailingCommand verifies a mid-file failure is not
 // swallowed and that the error names the offending line.
-func (r *ValkeyTests) ApplyFileReportsFailingCommand(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1294:1)
+func (r *ValkeyTests) ApplyFileReportsFailingCommand(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1323:1)
 	if r.applyFileReportsFailingCommand != nil {
 		return nil
 	}
@@ -219,7 +226,7 @@ func (r *ValkeyTests) ApplyFileReportsFailingCommand(ctx context.Context) error 
 // ApplyFileSeedsData verifies a command file lands as data on one
 // connection, and that its quoting and line splitting survive: values
 // with spaces, embedded quotes, blank lines, and `#` comments.
-func (r *ValkeyTests) ApplyFileSeedsData(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1239:1)
+func (r *ValkeyTests) ApplyFileSeedsData(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1268:1)
 	if r.applyFileSeedsData != nil {
 		return nil
 	}
@@ -232,7 +239,7 @@ func (r *ValkeyTests) ApplyFileSeedsData(ctx context.Context) error { // valkey-
 // a consumer container under the hostname Endpoint reports, and that the
 // consumer gets a real PONG back. A port probe would be a false
 // positive: it proves something is listening, not that Valkey answers.
-func (r *ValkeyTests) BindServerReachableFromAlpine(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:777:1)
+func (r *ValkeyTests) BindServerReachableFromAlpine(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:806:1)
 	if r.bindServerReachableFromAlpine != nil {
 		return nil
 	}
@@ -246,7 +253,7 @@ func (r *ValkeyTests) BindServerReachableFromAlpine(ctx context.Context) error {
 // the right CA gets a PONG, proving BindServer stays reachable under TLS
 // from a consumer container. The password rides in as a secret env var so
 // it never enters the exec's argv.
-func (r *ValkeyTests) BindServerReachableUnderTLS(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2317:1)
+func (r *ValkeyTests) BindServerReachableUnderTLS(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2346:1)
 	if r.bindServerReachableUnderTls != nil {
 		return nil
 	}
@@ -257,7 +264,7 @@ func (r *ValkeyTests) BindServerReachableUnderTLS(ctx context.Context) error { /
 
 // ValkeyTestsBundleOpts contains options for ValkeyTests.Bundle
 type ValkeyTestsBundleOpts struct {
-	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:292:2)
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:295:2)
 }
 
 // Bundle runs the `valkey/valkey-bundle` image tests: that the module
@@ -265,7 +272,7 @@ type ValkeyTestsBundleOpts struct {
 // trip through Do, and that every *Server method behaves the same
 // against a bundle node as against a stock one. Each test boots its own
 // node under a runtime-random name, so the group fans out safely.
-func (r *ValkeyTests) Bundle(ctx context.Context, opts ...ValkeyTestsBundleOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:289:1)
+func (r *ValkeyTests) Bundle(ctx context.Context, opts ...ValkeyTestsBundleOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:292:1)
 	if r.bundle != nil {
 		return nil
 	}
@@ -291,7 +298,7 @@ func (r *ValkeyTests) Bundle(ctx context.Context, opts ...ValkeyTestsBundleOpts)
 // ("lookup valkey-<host> ... no such host"). That is the trap
 // Server.Endpoint documents, and it is why this cannot ride along inside
 // BundleServerMethodsMatchStock.
-func (r *ValkeyTests) BundleBindServerReachableFromConsumer(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3726:1)
+func (r *ValkeyTests) BundleBindServerReachableFromConsumer(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3755:1)
 	if r.bundleBindServerReachableFromConsumer != nil {
 		return nil
 	}
@@ -306,7 +313,7 @@ func (r *ValkeyTests) BundleBindServerReachableFromConsumer(ctx context.Context)
 // that a second BF.ADD of it reports "already there"; the absent-item
 // check rides along on a filter holding exactly one item, where a false
 // positive is vanishingly unlikely.
-func (r *ValkeyTests) BundleBloomRoundTrip(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3588:1)
+func (r *ValkeyTests) BundleBloomRoundTrip(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3617:1)
 	if r.bundleBloomRoundTrip != nil {
 		return nil
 	}
@@ -320,7 +327,7 @@ func (r *ValkeyTests) BundleBloomRoundTrip(ctx context.Context) error { // valke
 // The reply is a bulk string holding the JSONPath result array, so it
 // arrives double-encoded — a JSON string whose contents are themselves
 // JSON — and both layers are decoded here rather than string-matched.
-func (r *ValkeyTests) BundleJSONRoundTrip(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3525:1)
+func (r *ValkeyTests) BundleJSONRoundTrip(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3554:1)
 	if r.bundleJsonRoundTrip != nil {
 		return nil
 	}
@@ -335,7 +342,7 @@ func (r *ValkeyTests) BundleJSONRoundTrip(ctx context.Context) error { // valkey
 // `--loadmodule` flags, so a node built through the stock
 // `docker-entrypoint.sh` comes up healthy with an empty module list —
 // which is exactly the silent failure this asserts against.
-func (r *ValkeyTests) BundleServerLoadsModules(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3419:1)
+func (r *ValkeyTests) BundleServerLoadsModules(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3448:1)
 	if r.bundleServerLoadsModules != nil {
 		return nil
 	}
@@ -351,7 +358,7 @@ func (r *ValkeyTests) BundleServerLoadsModules(ctx context.Context) error { // v
 // pinned Valkey version, and a Stop that really terminates the node.
 // BindServer is the one method missing here — it must run against a node
 // nothing has started yet, so it gets its own test below.
-func (r *ValkeyTests) BundleServerMethodsMatchStock(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3638:1)
+func (r *ValkeyTests) BundleServerMethodsMatchStock(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3667:1)
 	if r.bundleServerMethodsMatchStock != nil {
 		return nil
 	}
@@ -362,13 +369,13 @@ func (r *ValkeyTests) BundleServerMethodsMatchStock(ctx context.Context) error {
 
 // ValkeyTestsClientOpts contains options for ValkeyTests.Client
 type ValkeyTestsClientOpts struct {
-	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:200:2)
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:203:2)
 }
 
 // Client runs the command round-trip tests. Each test boots its own node
 // via bootServer, so the keyspaces stay disjoint and the group fans out
 // safely.
-func (r *ValkeyTests) Client(ctx context.Context, opts ...ValkeyTestsClientOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:197:1)
+func (r *ValkeyTests) Client(ctx context.Context, opts ...ValkeyTestsClientOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:200:1)
 	if r.client != nil {
 		return nil
 	}
@@ -386,7 +393,7 @@ func (r *ValkeyTests) Client(ctx context.Context, opts ...ValkeyTestsClientOpts)
 // ClientPingWrongPasswordFails proves requirepass is genuinely applied
 // and the node is not wide open: a client holding a different password
 // cannot authenticate.
-func (r *ValkeyTests) ClientPingWrongPasswordFails(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1386:1)
+func (r *ValkeyTests) ClientPingWrongPasswordFails(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1415:1)
 	if r.clientPingWrongPasswordFails != nil {
 		return nil
 	}
@@ -397,7 +404,7 @@ func (r *ValkeyTests) ClientPingWrongPasswordFails(ctx context.Context) error { 
 
 // ValkeyTestsClusterOpts contains options for ValkeyTests.Cluster
 type ValkeyTestsClusterOpts struct {
-	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:146:2)
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:149:2)
 }
 
 // Cluster runs the slot-sharded Valkey Cluster tests. Each test boots its
@@ -409,7 +416,7 @@ type ValkeyTestsClusterOpts struct {
 // cluster is three nodes, and every one of them has to boot before the
 // bootstrap can even start — so they get their own aggregator rather than
 // riding along with the single-node groups.
-func (r *ValkeyTests) Cluster(ctx context.Context, opts ...ValkeyTestsClusterOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:143:1)
+func (r *ValkeyTests) Cluster(ctx context.Context, opts ...ValkeyTestsClusterOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:146:1)
 	if r.cluster != nil {
 		return nil
 	}
@@ -433,7 +440,7 @@ func (r *ValkeyTests) Cluster(ctx context.Context, opts ...ValkeyTestsClusterOpt
 // "another" node, dials itself. The cluster never forms, or forms and
 // then answers for the wrong shard, and CLUSTER INFO alone would not say
 // why. Asserting the announced identity is what pins the fix.
-func (r *ValkeyTests) ClusterAdvertisesPinnedHostnames(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2439:1)
+func (r *ValkeyTests) ClusterAdvertisesPinnedHostnames(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2468:1)
 	if r.clusterAdvertisesPinnedHostnames != nil {
 		return nil
 	}
@@ -459,7 +466,7 @@ func (r *ValkeyTests) ClusterAdvertisesPinnedHostnames(ctx context.Context) erro
 //
 // The whole probe runs in one exec so a partial failure names the node it
 // failed on rather than surfacing as an opaque non-zero exit.
-func (r *ValkeyTests) ClusterBindNodesReachableFromConsumer(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2689:1)
+func (r *ValkeyTests) ClusterBindNodesReachableFromConsumer(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2718:1)
 	if r.clusterBindNodesReachableFromConsumer != nil {
 		return nil
 	}
@@ -477,7 +484,7 @@ func (r *ValkeyTests) ClusterBindNodesReachableFromConsumer(ctx context.Context)
 // One key in the list never existed, so a Del that reported the number of
 // keys it was asked about rather than the number it removed is caught
 // too.
-func (r *ValkeyTests) ClusterDelSpansMultipleSlots(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2631:1)
+func (r *ValkeyTests) ClusterDelSpansMultipleSlots(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2660:1)
 	if r.clusterDelSpansMultipleSlots != nil {
 		return nil
 	}
@@ -497,7 +504,7 @@ func (r *ValkeyTests) ClusterDelSpansMultipleSlots(ctx context.Context) error { 
 // really were split across more than one primary, so the first assertion
 // can't pass vacuously on a cluster that happened to pile everything into
 // one shard.
-func (r *ValkeyTests) ClusterKeysScansEveryShard(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2548:1)
+func (r *ValkeyTests) ClusterKeysScansEveryShard(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2577:1)
 	if r.clusterKeysScansEveryShard != nil {
 		return nil
 	}
@@ -512,7 +519,7 @@ func (r *ValkeyTests) ClusterKeysScansEveryShard(ctx context.Context) error { //
 // would also have to run over TLS, and neither the peers nor the
 // valkey-cli that bootstraps them get the trust material they'd need from
 // a client-listener ServerSecurity.
-func (r *ValkeyTests) ClusterRejectsTLSSecurity(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:641:1)
+func (r *ValkeyTests) ClusterRejectsTLSSecurity(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:670:1)
 	if r.clusterRejectsTlsSecurity != nil {
 		return nil
 	}
@@ -531,7 +538,7 @@ func (r *ValkeyTests) ClusterRejectsTLSSecurity(ctx context.Context) error { // 
 //
 // The guard is checked before anything starts, so this test costs no
 // containers.
-func (r *ValkeyTests) ClusterRejectsTooFewShards(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:604:1)
+func (r *ValkeyTests) ClusterRejectsTooFewShards(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:633:1)
 	if r.clusterRejectsTooFewShards != nil {
 		return nil
 	}
@@ -548,7 +555,7 @@ func (r *ValkeyTests) ClusterRejectsTooFewShards(ctx context.Context) error { //
 // didn't finish: a node whose gossip never reached the others still
 // reports state:ok for the slots it can see, and only cluster_known_nodes
 // gives it away.
-func (r *ValkeyTests) ClusterReportsFormedState(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2407:1)
+func (r *ValkeyTests) ClusterReportsFormedState(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2436:1)
 	if r.clusterReportsFormedState != nil {
 		return nil
 	}
@@ -568,7 +575,7 @@ func (r *ValkeyTests) ClusterReportsFormedState(ctx context.Context) error { // 
 // A client that silently talked to one node would fail the write, not the
 // read: a key that hashes elsewhere is refused with MOVED, never stored
 // locally.
-func (r *ValkeyTests) ClusterRoundTripsKeysAcrossSlots(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2480:1)
+func (r *ValkeyTests) ClusterRoundTripsKeysAcrossSlots(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2509:1)
 	if r.clusterRoundTripsKeysAcrossSlots != nil {
 		return nil
 	}
@@ -586,7 +593,7 @@ func (r *ValkeyTests) ClusterRoundTripsKeysAcrossSlots(ctx context.Context) erro
 // Cluster members have no service bindings between them, so unlike the
 // replication topology there is no dependency teardown to hide behind:
 // every node that is still up after Stop is a node Stop failed to kill.
-func (r *ValkeyTests) ClusterStopTerminatesEveryNode(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2754:1)
+func (r *ValkeyTests) ClusterStopTerminatesEveryNode(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2783:1)
 	if r.clusterStopTerminatesEveryNode != nil {
 		return nil
 	}
@@ -597,14 +604,14 @@ func (r *ValkeyTests) ClusterStopTerminatesEveryNode(ctx context.Context) error 
 
 // ValkeyTestsConfigOpts contains options for ValkeyTests.Config
 type ValkeyTestsConfigOpts struct {
-	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:263:2)
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:266:2)
 }
 
 // Config runs the `valkey-server` configuration passthrough tests: the
 // config file, the ACL file, the append-only log, the memory ceiling, and
 // the extraArgs escape hatch. Each test boots its own node under a
 // runtime-random name, so the group fans out safely.
-func (r *ValkeyTests) Config(ctx context.Context, opts ...ValkeyTestsConfigOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:260:1)
+func (r *ValkeyTests) Config(ctx context.Context, opts ...ValkeyTestsConfigOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:263:1)
 	if r.config != nil {
 		return nil
 	}
@@ -631,7 +638,7 @@ func (r *ValkeyTests) Config(ctx context.Context, opts ...ValkeyTestsConfigOpts)
 // left at its default emits no flag" rule. `hash-max-listpack-entries` is
 // along for the ride as a directive the module has no opinion about at
 // all.
-func (r *ValkeyTests) ConfigFileDirectivesApply(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3282:1)
+func (r *ValkeyTests) ConfigFileDirectivesApply(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3311:1)
 	if r.configFileDirectivesApply != nil {
 		return nil
 	}
@@ -643,7 +650,7 @@ func (r *ValkeyTests) ConfigFileDirectivesApply(ctx context.Context) error { // 
 // DbSelectsLogicalDatabase verifies db is honoured end to end: a write
 // on db 0 is invisible to a client on db 1, and each database keeps its
 // own DbSize.
-func (r *ValkeyTests) DbSelectsLogicalDatabase(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1421:1)
+func (r *ValkeyTests) DbSelectsLogicalDatabase(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1450:1)
 	if r.dbSelectsLogicalDatabase != nil {
 		return nil
 	}
@@ -655,7 +662,7 @@ func (r *ValkeyTests) DbSelectsLogicalDatabase(ctx context.Context) error { // v
 // DefaultsProduceHealthyServer boots a default node and proves it is a
 // healthy Valkey by answering PING and self-reporting 9.1 in INFO
 // server. Catches image-path drift and a silently moved default tag.
-func (r *ValkeyTests) DefaultsProduceHealthyServer(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:683:1)
+func (r *ValkeyTests) DefaultsProduceHealthyServer(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:712:1)
 	if r.defaultsProduceHealthyServer != nil {
 		return nil
 	}
@@ -666,7 +673,7 @@ func (r *ValkeyTests) DefaultsProduceHealthyServer(ctx context.Context) error { 
 
 // DelRemovesKeys verifies Del reports how many keys it actually removed
 // and that DbSize agrees with the survivors.
-func (r *ValkeyTests) DelRemovesKeys(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1088:1)
+func (r *ValkeyTests) DelRemovesKeys(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1117:1)
 	if r.delRemovesKeys != nil {
 		return nil
 	}
@@ -678,7 +685,7 @@ func (r *ValkeyTests) DelRemovesKeys(ctx context.Context) error { // valkey-test
 // DoReturnsJsonReplies verifies each RESP type survives the JSON
 // encoding distinctly. The dangerous pair is nil versus empty string: a
 // naive encoder collapses both to "".
-func (r *ValkeyTests) DoReturnsJSONReplies(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1179:1)
+func (r *ValkeyTests) DoReturnsJSONReplies(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1208:1)
 	if r.doReturnsJsonReplies != nil {
 		return nil
 	}
@@ -690,11 +697,106 @@ func (r *ValkeyTests) DoReturnsJSONReplies(ctx context.Context) error { // valke
 // EndpointShouldNotBeCached verifies Endpoint re-executes against the
 // receiver it was called on rather than freezing on the first result.
 // Valkey.Server isaddress.
-func (r *ValkeyTests) EndpointShouldNotBeCached(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:709:1)
+func (r *ValkeyTests) EndpointShouldNotBeCached(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:738:1)
 	if r.endpointShouldNotBeCached != nil {
 		return nil
 	}
 	q := r.query.Select("endpointShouldNotBeCached")
+
+	return q.Execute(ctx)
+}
+
+// ExportHonoursPatternAcrossScanPages seeds far more matching keys than
+// one SCAN page holds, plus a decoy prefix, and checks the export is
+// exactly the match set. An implementation that captured only SCAN's
+// first page — or that stopped before the cursor wrapped back to 0 —
+// comes up short, and one that ignored pattern picks up the decoys.
+//
+// The unfiltered export runs too, so a pattern that was over-applied
+// (matching nothing, or being handed to DUMP as well) cannot pass by
+// exporting an empty file both times.
+func (r *ValkeyTests) ExportHonoursPatternAcrossScanPages(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:4019:1)
+	if r.exportHonoursPatternAcrossScanPages != nil {
+		return nil
+	}
+	q := r.query.Select("exportHonoursPatternAcrossScanPages")
+
+	return q.Execute(ctx)
+}
+
+// ExportImportPreservesTtls verifies expiry survives the round trip in
+// both directions: a key with a TTL arrives with one still ticking, and
+// a persistent key arrives persistent rather than inheriting an expiry
+// from its neighbour.
+//
+// The persistent half matters as much as the other: RESTORE spells "no
+// expiry" as a 0 TTL and "expire in 0ms" is not expressible, so an
+// implementation that recorded PTTL's -1 verbatim would send `RESTORE k
+// -1 …` (rejected outright), and one that clamped every non-positive
+// PTTL to some small positive number would hand back a key that quietly
+// evaporates.
+func (r *ValkeyTests) ExportImportPreservesTtls(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3941:1)
+	if r.exportImportPreservesTtls != nil {
+		return nil
+	}
+	q := r.query.Select("exportImportPreservesTtls")
+
+	return q.Execute(ctx)
+}
+
+// ExportImportRoundTripsEveryType is the core keyspace round trip: seed
+// one node with a value of every core type, export it, import into a
+// second fresh node, and check both nodes answer the same read command
+// identically.
+//
+// The assertion compares *replies* rather than hand-written expectations
+// so it stays honest about encoding: a DUMP payload carries the value's
+// internal encoding, and a comparison against a literal would pass even
+// if RESTORE had quietly reshaped a listpack-backed hash into something
+// else that stringifies the same way. TYPE is checked separately, since
+// two different types can share a read command's reply shape.
+func (r *ValkeyTests) ExportImportRoundTripsEveryType(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3838:1)
+	if r.exportImportRoundTripsEveryType != nil {
+		return nil
+	}
+	q := r.query.Select("exportImportRoundTripsEveryType")
+
+	return q.Execute(ctx)
+}
+
+// ExportShouldNotBeCached verifies Export re-executes on every call
+// rather than freezing on its first result: export, write a key that did
+// not exist yet, export again. A cached Export would hand back the
+// earlier file and the new key would never appear — the same stale-read
+// bug a missingquietly ship an incomplete fixture.
+//
+// Both calls use the same pattern and the same receiver on purpose:
+// anything that varied between them would give a cached Export a fresh
+// cache key and let the bug through.
+func (r *ValkeyTests) ExportShouldNotBeCached(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:4246:1)
+	if r.exportShouldNotBeCached != nil {
+		return nil
+	}
+	q := r.query.Select("exportShouldNotBeCached")
+
+	return q.Execute(ctx)
+}
+
+// ExportedFileIsReadableByConsumer verifies the *dagger.File handed back
+// through WorkdirFile is a real, portable file rather than something
+// only the producing module can dereference: this test module decodes it
+// directly, and a plain container reads the very same handle off its own
+// filesystem.
+//
+// The container leg is the stronger claim of the two. A workdir file that
+// was never materialized, or that the module runtime tore down with its
+// scratch dir, still satisfies an in-process read on the module's own
+// side but cannot be mounted anywhere.
+func (r *ValkeyTests) ExportedFileIsReadableByConsumer(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:4170:1)
+	if r.exportedFileIsReadableByConsumer != nil {
+		return nil
+	}
+	q := r.query.Select("exportedFileIsReadableByConsumer")
 
 	return q.Execute(ctx)
 }
@@ -708,7 +810,7 @@ func (r *ValkeyTests) EndpointShouldNotBeCached(ctx context.Context) error { // 
 // BOTH ways, with different values, so the reply says which one Valkey
 // saw last — and therefore whether extraArgs really is appended after
 // the module's own flags rather than merely somewhere among them.
-func (r *ValkeyTests) ExtraArgsReachServerLast(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3370:1)
+func (r *ValkeyTests) ExtraArgsReachServerLast(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3399:1)
 	if r.extraArgsReachServerLast != nil {
 		return nil
 	}
@@ -726,7 +828,7 @@ func (r *ValkeyTests) ExtraArgsReachServerLast(ctx context.Context) error { // v
 // mirror of ConfigFileDirectivesApply — together they say the file is
 // loaded first and the flags are applied on top, which is the whole
 // ordering guarantee.
-func (r *ValkeyTests) FlagArgumentBeatsConfigFile(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3330:1)
+func (r *ValkeyTests) FlagArgumentBeatsConfigFile(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3359:1)
 	if r.flagArgumentBeatsConfigFile != nil {
 		return nil
 	}
@@ -737,7 +839,7 @@ func (r *ValkeyTests) FlagArgumentBeatsConfigFile(ctx context.Context) error { /
 
 // FlushAllClearsKeys verifies FlushAll empties the keyspace and DbSize
 // returns to 0.
-func (r *ValkeyTests) FlushAllClearsKeys(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1347:1)
+func (r *ValkeyTests) FlushAllClearsKeys(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1376:1)
 	if r.flushAllClearsKeys != nil {
 		return nil
 	}
@@ -749,7 +851,7 @@ func (r *ValkeyTests) FlushAllClearsKeys(ctx context.Context) error { // valkey-
 // GetMissingKeyFails verifies absence stays distinguishable from an
 // empty value: an unset key errors, while a key holding "" reads back as
 // "".
-func (r *ValkeyTests) GetMissingKeyFails(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:975:1)
+func (r *ValkeyTests) GetMissingKeyFails(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1004:1)
 	if r.getMissingKeyFails != nil {
 		return nil
 	}
@@ -761,7 +863,7 @@ func (r *ValkeyTests) GetMissingKeyFails(ctx context.Context) error { // valkey-
 // GetShouldNotBeCached verifies Get re-executes on every call: write v1,
 // read it, overwrite with v2, read again. A cached Get would still
 // report v1 — the canonical stale-read bug a missingproduces.
-func (r *ValkeyTests) GetShouldNotBeCached(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:929:1)
+func (r *ValkeyTests) GetShouldNotBeCached(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:958:1)
 	if r.getShouldNotBeCached != nil {
 		return nil
 	}
@@ -819,10 +921,24 @@ func (r *ValkeyTests) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
+// ImportRejectsCollisionWithoutReplace verifies the default refuses to
+// clobber. A fixture load that silently overwrote whatever the target
+// already held would be discovered only as someone else's missing data,
+// so RESTORE's BUSYKEY is allowed through as a failure and `replace` is
+// the opt-in.
+func (r *ValkeyTests) ImportRejectsCollisionWithoutReplace(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:4088:1)
+	if r.importRejectsCollisionWithoutReplace != nil {
+		return nil
+	}
+	q := r.query.Select("importRejectsCollisionWithoutReplace")
+
+	return q.Execute(ctx)
+}
+
 // InfoReportsRole verifies INFO replication reports a standalone node as
 // the primary. ReplicationReportsRoles is the multi-node counterpart,
 // where a replica reports role:slave instead.
-func (r *ValkeyTests) InfoReportsRole(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1328:1)
+func (r *ValkeyTests) InfoReportsRole(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1357:1)
 	if r.infoReportsRole != nil {
 		return nil
 	}
@@ -835,11 +951,34 @@ func (r *ValkeyTests) InfoReportsRole(ctx context.Context) error { // valkey-tes
 // checks the full match set comes back. One SCAN page holds far fewer
 // than that, so an implementation that returned the first page — or that
 // stopped before the cursor wrapped to 0 — comes up short here.
-func (r *ValkeyTests) KeysScansPattern(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1128:1)
+func (r *ValkeyTests) KeysScansPattern(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1157:1)
 	if r.keysScansPattern != nil {
 		return nil
 	}
 	q := r.query.Select("keysScansPattern")
+
+	return q.Execute(ctx)
+}
+
+// ValkeyTestsKeyspaceOpts contains options for ValkeyTests.Keyspace
+type ValkeyTestsKeyspaceOpts struct {
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:321:2)
+}
+
+// Keyspace runs the SCAN + DUMP/RESTORE export/import tests. Most boot
+// two nodes — a source to capture and a fresh target to restore into —
+// each under its own runtime-random name, so the group fans out safely.
+func (r *ValkeyTests) Keyspace(ctx context.Context, opts ...ValkeyTestsKeyspaceOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:318:1)
+	if r.keyspace != nil {
+		return nil
+	}
+	q := r.query.Select("keyspace")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `parallel` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Parallel) {
+			q = q.Arg("parallel", opts[i].Parallel)
+		}
+	}
 
 	return q.Execute(ctx)
 }
@@ -856,7 +995,7 @@ func (r *ValkeyTests) KeysScansPattern(ctx context.Context) error { // valkey-te
 // maxMemory that never reached valkey-server would leave both nodes
 // happily holding the whole keyspace, and a maxMemoryPolicy that never
 // reached it would make the two nodes behave identically.
-func (r *ValkeyTests) MaxMemoryEvictsOverLimit(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2977:1)
+func (r *ValkeyTests) MaxMemoryEvictsOverLimit(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3006:1)
 	if r.maxMemoryEvictsOverLimit != nil {
 		return nil
 	}
@@ -874,7 +1013,7 @@ func (r *ValkeyTests) MaxMemoryEvictsOverLimit(ctx context.Context) error { // v
 // default `yes`. A regression that passed `--tls-auth-clients no` for
 // MTLS too would let this certless client through and go undetected by
 // the round-trip tests.
-func (r *ValkeyTests) MtlsNodeDemandsClientCertAtWire(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2170:1)
+func (r *ValkeyTests) MtlsNodeDemandsClientCertAtWire(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2199:1)
 	if r.mtlsNodeDemandsClientCertAtWire != nil {
 		return nil
 	}
@@ -887,7 +1026,7 @@ func (r *ValkeyTests) MtlsNodeDemandsClientCertAtWire(ctx context.Context) error
 // mTLS side: asking an mTLS node for a TLS-only client returns an error
 // naming both modes, before any wire activity. The SAN value on the cert
 // is irrelevant here — the guard fires in requireMode, ahead of any dial.
-func (r *ValkeyTests) MtlsServerRejectsTLSOnlyClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2125:1)
+func (r *ValkeyTests) MtlsServerRejectsTLSOnlyClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2154:1)
 	if r.mtlsServerRejectsTlsOnlyClient != nil {
 		return nil
 	}
@@ -908,7 +1047,7 @@ func (r *ValkeyTests) MtlsServerRejectsTLSOnlyClient(ctx context.Context) error 
 // line and would silently override a `configFile` that set them. The
 // configFile tests further down are what catch that, and this one is what
 // makes their failure legible.
-func (r *ValkeyTests) OmittedConfigLeavesValkeyDefaults(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2858:1)
+func (r *ValkeyTests) OmittedConfigLeavesValkeyDefaults(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2887:1)
 	if r.omittedConfigLeavesValkeyDefaults != nil {
 		return nil
 	}
@@ -920,7 +1059,7 @@ func (r *ValkeyTests) OmittedConfigLeavesValkeyDefaults(ctx context.Context) err
 // PasswordReusableViaClient verifies the credentials a Server hands back
 // authenticate through the standalone constructor: Endpointare enough to build a working client, which is what makes the same
 // Client usable against a remote Valkey.
-func (r *ValkeyTests) PasswordReusableViaClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:816:1)
+func (r *ValkeyTests) PasswordReusableViaClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:845:1)
 	if r.passwordReusableViaClient != nil {
 		return nil
 	}
@@ -935,7 +1074,7 @@ func (r *ValkeyTests) PasswordReusableViaClient(ctx context.Context) error { // 
 // wire protocol to the encrypted listener and fails. If `--port 0` were
 // missing, a plaintext listener would still be up on 6379 and this dial
 // would succeed.
-func (r *ValkeyTests) PlaintextDialAgainstTLSNodeFails(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2238:1)
+func (r *ValkeyTests) PlaintextDialAgainstTLSNodeFails(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2267:1)
 	if r.plaintextDialAgainstTlsNodeFails != nil {
 		return nil
 	}
@@ -946,14 +1085,14 @@ func (r *ValkeyTests) PlaintextDialAgainstTLSNodeFails(ctx context.Context) erro
 
 // ValkeyTestsReplicationOpts contains options for ValkeyTests.Replication
 type ValkeyTestsReplicationOpts struct {
-	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:114:2)
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:117:2)
 }
 
 // Replication runs the primary/replica topology tests. Each test boots
 // its own topology via bootReplication, whose runtime-random name folds
 // into Valkey.Replication's session-cache key and into every node's
 // hostname, so concurrent tests get independent topologies.
-func (r *ValkeyTests) Replication(ctx context.Context, opts ...ValkeyTestsReplicationOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:111:1)
+func (r *ValkeyTests) Replication(ctx context.Context, opts ...ValkeyTestsReplicationOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:114:1)
 	if r.replication != nil {
 		return nil
 	}
@@ -974,7 +1113,7 @@ func (r *ValkeyTests) Replication(ctx context.Context, opts ...ValkeyTestsReplic
 // wrong never reaches — it stays `down`, retrying on NOAUTH, while every
 // other assertion in this file would still pass against its (empty but
 // readable) local keyspace.
-func (r *ValkeyTests) ReplicationLinkAuthenticates(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1690:1)
+func (r *ValkeyTests) ReplicationLinkAuthenticates(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1719:1)
 	if r.replicationLinkAuthenticates != nil {
 		return nil
 	}
@@ -991,7 +1130,7 @@ func (r *ValkeyTests) ReplicationLinkAuthenticates(ctx context.Context) error { 
 //
 // Endpoint is a pure accessor, so this asserts the addressing scheme
 // without booting anything.
-func (r *ValkeyTests) ReplicationNodesHaveDistinctHostnames(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1730:1)
+func (r *ValkeyTests) ReplicationNodesHaveDistinctHostnames(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1759:1)
 	if r.replicationNodesHaveDistinctHostnames != nil {
 		return nil
 	}
@@ -1004,7 +1143,7 @@ func (r *ValkeyTests) ReplicationNodesHaveDistinctHostnames(ctx context.Context)
 // path: a key written to the primary becomes readable from the replica.
 // The read polls, because the link is asynchronous and a single read
 // would race the initial sync.
-func (r *ValkeyTests) ReplicationPropagatesWritesToReplica(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1555:1)
+func (r *ValkeyTests) ReplicationPropagatesWritesToReplica(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1584:1)
 	if r.replicationPropagatesWritesToReplica != nil {
 		return nil
 	}
@@ -1018,7 +1157,7 @@ func (r *ValkeyTests) ReplicationPropagatesWritesToReplica(ctx context.Context) 
 // forever on a failed handshake: a TLS node runs with `--port 0`, so the
 // replication link would also have to run over TLS, and a client-listener
 // ServerSecurity carries none of the trust material that link needs.
-func (r *ValkeyTests) ReplicationRejectsTLSSecurity(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:559:1)
+func (r *ValkeyTests) ReplicationRejectsTLSSecurity(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:588:1)
 	if r.replicationRejectsTlsSecurity != nil {
 		return nil
 	}
@@ -1037,7 +1176,7 @@ func (r *ValkeyTests) ReplicationRejectsTLSSecurity(ctx context.Context) error {
 // any optional argument holding its zero value, so `Replicas: 0` never
 // reaches the module and resolves to the `the CLI does reach the guard, which is why the guard is `< 1` and not
 // `< 0`.
-func (r *ValkeyTests) ReplicationRejectsTooFewReplicas(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:526:1)
+func (r *ValkeyTests) ReplicationRejectsTooFewReplicas(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:555:1)
 	if r.replicationRejectsTooFewReplicas != nil {
 		return nil
 	}
@@ -1050,7 +1189,7 @@ func (r *ValkeyTests) ReplicationRejectsTooFewReplicas(ctx context.Context) erro
 // holds: a write against a replica is refused with READONLY, so a test
 // that writes to the wrong node fails loudly instead of silently losing
 // the write on the next sync.
-func (r *ValkeyTests) ReplicationReplicaRejectsWrites(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1650:1)
+func (r *ValkeyTests) ReplicationReplicaRejectsWrites(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1679:1)
 	if r.replicationReplicaRejectsWrites != nil {
 		return nil
 	}
@@ -1064,7 +1203,7 @@ func (r *ValkeyTests) ReplicationReplicaRejectsWrites(ctx context.Context) error
 // connected_slaves as there are replicas, and every replica reports the
 // replica role. Two replicas rather than one, so a count that reported
 // "some replica connected" instead of all of them fails here.
-func (r *ValkeyTests) ReplicationReportsRoles(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1597:1)
+func (r *ValkeyTests) ReplicationReportsRoles(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1626:1)
 	if r.replicationReportsRoles != nil {
 		return nil
 	}
@@ -1087,7 +1226,7 @@ func (r *ValkeyTests) ReplicationReportsRoles(ctx context.Context) error { // va
 // every other node depends on". Replication.Stop still walks every node
 // explicitly rather than leaning on that dependency teardown, which is
 // not a documented guarantee.
-func (r *ValkeyTests) ReplicationStopTerminatesEveryNode(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1793:1)
+func (r *ValkeyTests) ReplicationStopTerminatesEveryNode(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1822:1)
 	if r.replicationStopTerminatesEveryNode != nil {
 		return nil
 	}
@@ -1100,7 +1239,7 @@ func (r *ValkeyTests) ReplicationStopTerminatesEveryNode(ctx context.Context) er
 // resolve to one backing node: a key written through the first is
 // readable through the second. Catches session cache-key drift, which
 // would silently split a multi-step test across two empty keyspaces.
-func (r *ValkeyTests) SameNameServerSharesState(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:738:1)
+func (r *ValkeyTests) SameNameServerSharesState(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:767:1)
 	if r.sameNameServerSharesState != nil {
 		return nil
 	}
@@ -1111,14 +1250,14 @@ func (r *ValkeyTests) SameNameServerSharesState(ctx context.Context) error { // 
 
 // ValkeyTestsSecurityOpts contains options for ValkeyTests.Security
 type ValkeyTestsSecurityOpts struct {
-	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:234:2)
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:237:2)
 }
 
 // Security runs the TLS / mTLS listener + client tests. Each test mints
 // its own CA, leaf certs, password, and server name at runtime (no
 // literal credentials or PEM blobs), and folds a unique name into the
 // node's session-cache key, so the tests fan out without sharing state.
-func (r *ValkeyTests) Security(ctx context.Context, opts ...ValkeyTestsSecurityOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:231:1)
+func (r *ValkeyTests) Security(ctx context.Context, opts ...ValkeyTestsSecurityOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:234:1)
 	if r.security != nil {
 		return nil
 	}
@@ -1135,14 +1274,14 @@ func (r *ValkeyTests) Security(ctx context.Context, opts ...ValkeyTestsSecurityO
 
 // ValkeyTestsServerOpts contains options for ValkeyTests.Server
 type ValkeyTestsServerOpts struct {
-	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:174:2)
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:177:2)
 }
 
 // Server runs the topology, default, and caching tests. Each test boots
 // its own node via bootServer, whose runtime-random name folds into
 // Valkey.Server's session-cache key so concurrent tests boot independent
 // backing services and never share a keyspace.
-func (r *ValkeyTests) Server(ctx context.Context, opts ...ValkeyTestsServerOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:171:1)
+func (r *ValkeyTests) Server(ctx context.Context, opts ...ValkeyTestsServerOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:174:1)
 	if r.server != nil {
 		return nil
 	}
@@ -1160,7 +1299,7 @@ func (r *ValkeyTests) Server(ctx context.Context, opts ...ValkeyTestsServerOpts)
 // ServerMtlsRoundTripFromClient boots a mutual-TLS node and proves a
 // matching mTLS client (presenting a client cert signed by the trusted
 // CA) can round-trip Set
-func (r *ValkeyTests) ServerMtlsRoundTripFromClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2030:1)
+func (r *ValkeyTests) ServerMtlsRoundTripFromClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2059:1)
 	if r.serverMtlsRoundTripFromClient != nil {
 		return nil
 	}
@@ -1183,7 +1322,7 @@ func (r *ValkeyTests) ServerMtlsRoundTripFromClient(ctx context.Context) error {
 // The accepting cases prove the guard is a mention and not an
 // interpretation: naming `default` at all — even to turn it off — is a
 // decision the caller is entitled to make.
-func (r *ValkeyTests) ServerRejectsACLFileWithoutDefaultUser(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3221:1)
+func (r *ValkeyTests) ServerRejectsACLFileWithoutDefaultUser(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3250:1)
 	if r.serverRejectsAclFileWithoutDefaultUser != nil {
 		return nil
 	}
@@ -1202,7 +1341,7 @@ func (r *ValkeyTests) ServerRejectsACLFileWithoutDefaultUser(ctx context.Context
 // The accepted cases run too, so the guard can't pass by rejecting
 // everything: `k`/`m`/`g` (powers of 1000) and `kb`/`mb`/`gb` (powers of
 // 1024) are both legal, as is a bare byte count.
-func (r *ValkeyTests) ServerRejectsInvalidMaxMemory(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:441:1)
+func (r *ValkeyTests) ServerRejectsInvalidMaxMemory(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:470:1)
 	if r.serverRejectsInvalidMaxMemory != nil {
 		return nil
 	}
@@ -1219,7 +1358,7 @@ func (r *ValkeyTests) ServerRejectsInvalidMaxMemory(ctx context.Context) error {
 // Every policy Valkey accepts is exercised on the accept side, so a guard
 // that only knew the common ones would fail here rather than in a
 // caller's pipeline.
-func (r *ValkeyTests) ServerRejectsInvalidMaxMemoryPolicy(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:480:1)
+func (r *ValkeyTests) ServerRejectsInvalidMaxMemoryPolicy(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:509:1)
 	if r.serverRejectsInvalidMaxMemoryPolicy != nil {
 		return nil
 	}
@@ -1229,7 +1368,7 @@ func (r *ValkeyTests) ServerRejectsInvalidMaxMemoryPolicy(ctx context.Context) e
 }
 
 // ServerRejectsNilPassword verifies a passwordless node must not boot.
-func (r *ValkeyTests) ServerRejectsNilPassword(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:387:1)
+func (r *ValkeyTests) ServerRejectsNilPassword(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:416:1)
 	if r.serverRejectsNilPassword != nil {
 		return nil
 	}
@@ -1241,7 +1380,7 @@ func (r *ValkeyTests) ServerRejectsNilPassword(ctx context.Context) error { // v
 // ServerRejectsNilSecurity verifies plaintext must be a deliberate
 // choice, so the TLS follow-up stays an explicit upgrade rather than a
 // silent default.
-func (r *ValkeyTests) ServerRejectsNilSecurity(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:408:1)
+func (r *ValkeyTests) ServerRejectsNilSecurity(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:437:1)
 	if r.serverRejectsNilSecurity != nil {
 		return nil
 	}
@@ -1254,7 +1393,7 @@ func (r *ValkeyTests) ServerRejectsNilSecurity(ctx context.Context) error { // v
 // matching TLS client — presenting NO client certificate — can Setagainst it over the encrypted listener. That the certless client is
 // accepted is the `--tls-auth-clients no` acceptance criterion: without
 // that flag Valkey would demand a client cert and reject this dial.
-func (r *ValkeyTests) ServerTLSRoundTripFromClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1980:1)
+func (r *ValkeyTests) ServerTLSRoundTripFromClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2009:1)
 	if r.serverTlsRoundTripFromClient != nil {
 		return nil
 	}
@@ -1265,7 +1404,7 @@ func (r *ValkeyTests) ServerTLSRoundTripFromClient(ctx context.Context) error { 
 
 // SetGetRoundTrip is the core smoke path: a value written through Set
 // comes back through Get unchanged.
-func (r *ValkeyTests) SetGetRoundTrip(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:896:1)
+func (r *ValkeyTests) SetGetRoundTrip(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:925:1)
 	if r.setGetRoundTrip != nil {
 		return nil
 	}
@@ -1284,7 +1423,7 @@ func (r *ValkeyTests) SetGetRoundTrip(ctx context.Context) error { // valkey-tes
 // an expiry check, because every step here is a round trip through a
 // re-probed service — a lower bound on the *remaining* TTL would be a
 // stopwatch race under a loaded parallel suite.
-func (r *ValkeyTests) SetWithTTLExpires(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1019:1)
+func (r *ValkeyTests) SetWithTTLExpires(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:1048:1)
 	if r.setWithTtlExpires != nil {
 		return nil
 	}
@@ -1303,7 +1442,7 @@ func (r *ValkeyTests) SetWithTTLExpires(ctx context.Context) error { // valkey-t
 // It is also what the boot-time readiness check would report: a node
 // missing these modules fails Server.Client with a message naming them,
 // rather than booting and failing later on the first JSON.SET.
-func (r *ValkeyTests) StockServerLacksBundleModules(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3501:1)
+func (r *ValkeyTests) StockServerLacksBundleModules(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:3530:1)
 	if r.stockServerLacksBundleModules != nil {
 		return nil
 	}
@@ -1316,7 +1455,7 @@ func (r *ValkeyTests) StockServerLacksBundleModules(ctx context.Context) error {
 // The post-Stop probe goes through the standalone constructor on
 // purpose: Server.Client would re-Start the service it is asked to dial
 // and the test would pass no matter what Stop did.
-func (r *ValkeyTests) StopTerminatesServer(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:856:1)
+func (r *ValkeyTests) StopTerminatesServer(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:885:1)
 	if r.stopTerminatesServer != nil {
 		return nil
 	}
@@ -1331,7 +1470,7 @@ func (r *ValkeyTests) StopTerminatesServer(ctx context.Context) error { // valke
 // TLS/mTLS node onto the same sha256("") host and invite cert/SAN reuse.
 // The guard fires in the constructor, before any service starts, so a
 // placeholder SAN on the cert is fine here.
-func (r *ValkeyTests) TLSServerRejectsEmptyName(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2282:1)
+func (r *ValkeyTests) TLSServerRejectsEmptyName(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2311:1)
 	if r.tlsServerRejectsEmptyName != nil {
 		return nil
 	}
@@ -1343,7 +1482,7 @@ func (r *ValkeyTests) TLSServerRejectsEmptyName(ctx context.Context) error { // 
 // TlsServerRejectsPlaintextClient verifies the mode-coupling check:
 // asking a TLS node for a plaintext client returns an error naming both
 // modes, before any wire activity.
-func (r *ValkeyTests) TLSServerRejectsPlaintextClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2086:1)
+func (r *ValkeyTests) TLSServerRejectsPlaintextClient(ctx context.Context) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:2115:1)
 	if r.tlsServerRejectsPlaintextClient != nil {
 		return nil
 	}
@@ -1354,12 +1493,12 @@ func (r *ValkeyTests) TLSServerRejectsPlaintextClient(ctx context.Context) error
 
 // ValkeyTestsValidationOpts contains options for ValkeyTests.Validation
 type ValkeyTestsValidationOpts struct {
-	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:84:2)
+	Parallel int // valkey-tests (../../../daggerverse/valkey/tests/main.go:87:2)
 }
 
 // Validation runs the input-rejection tests. These boot no service, so
 // they're safe to fan out unbounded.
-func (r *ValkeyTests) Validation(ctx context.Context, opts ...ValkeyTestsValidationOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:81:1)
+func (r *ValkeyTests) Validation(ctx context.Context, opts ...ValkeyTestsValidationOpts) error { // valkey-tests (../../../daggerverse/valkey/tests/main.go:84:1)
 	if r.validation != nil {
 		return nil
 	}

--- a/daggerverse/CLAUDE.md
+++ b/daggerverse/CLAUDE.md
@@ -110,6 +110,31 @@ applies to other Go/GraphQL keywords on exported fields: avoid
 a *consumer* module after adding a new exported field to surface
 this early.
 
+### Scalar-returning methods named after Go keywords break the same way
+
+The generator also caches every *scalar*-returning method on a private
+struct field of the consumer's generated type, named after the GraphQL
+field. A method named `Import` returning `(int, error)` therefore emits
+
+```go
+type <Dep><Type> struct {
+    query *querybuilder.Selection
+
+    import *int   // ← not valid Go
+}
+```
+
+and the consumer's `dagger develop` fails with the same
+`error formatting generated code: NNN:9: expected '}', found 'import'`.
+
+This bites only methods whose return type is a scalar (`int`, `string`,
+`bool`, `Void`); one returning `*dagger.File` or a module object gets no
+cache field and is unaffected — which is why `Client.Export` (returns a
+`*dagger.File`) is fine while `Client.Import` was not, and became
+`ImportFile`. Avoid `Import`, `Range`, `Select`, `Go`, `Func`, `Map`,
+`Chan`, `Default`, `Package`, and the rest of the Go keyword list as
+scalar-returning method names.
+
 ### Method parameters named `r` collide with the generated receiver
 
 The codegen renders methods as `func (r *<Type>) Method(<args>) ...`,

--- a/daggerverse/valkey/README.md
+++ b/daggerverse/valkey/README.md
@@ -413,6 +413,8 @@ Client.Set(ctx, key, value string, ttl="") error   // ttl is a Go duration strin
 Client.Del(ctx, keys []string) (int, error)        // number of keys actually removed
 Client.Keys(ctx, pattern string) ([]string, error) // SCAN-backed, cursor walked to exhaustion
 Client.ApplyFile(ctx, file *dagger.File) error     // one command per line, on one connection
+Client.Export(ctx, pattern="*") (*dagger.File, error)            // SCAN + DUMP, one JSON file
+Client.ImportFile(ctx, file *dagger.File, replace=false) (int, error) // RESTORE, returns keys written
 Client.Info(ctx, section="") (string, error)
 Client.DbSize(ctx) (int, error)
 Client.FlushAll(ctx) error
@@ -463,11 +465,53 @@ valkey-cli syntax, run in order on a single connection. Blank lines and
 double-quoted runs kept intact (`\` escapes inside double quotes). A
 failing command aborts the run and reports its line number.
 
+### Keyspace export / import
+
+`Export` and `ImportFile` are the *binary-faithful* fixture path, for
+when hand-written commands are the wrong shape — you already have a
+populated cache and want the same one somewhere else.
+
+`Export` walks the keyspace with SCAN (cursor to exhaustion, with the
+same cluster fan-out `Keys` performs) and captures each key with `DUMP`
+plus its `PTTL`, writing one JSON file of base64 payloads returned
+through `dag.CurrentModule().WorkdirFile`. `ImportFile` reverses it with
+`RESTORE`. Because `DUMP` is the same serialization the RDB uses, every
+type and encoding survives — strings, hashes, lists, sets, sorted sets,
+streams, and module types alike — and TTLs come across as remaining
+milliseconds, so a key with an expiry arrives with one still ticking and
+a persistent key arrives persistent.
+
+The export is a plain JSON file — `{"version", "pattern", "keys":
+[{"key", "ttlMs", "payload"}]}`, payloads base64-encoded — so it stays
+inspectable (`jq '.keys[].key'` lists the keyspace) and can be committed
+as a fixture, mounted into a container, or handed straight back to
+`ImportFile`. `ttlMs` is 0 for a persistent key.
+
+This deliberately avoids the obvious approach of extracting
+`/data/dump.rdb`: a running Dagger `Service`'s filesystem is not directly
+readable, so pulling the RDB out would mean restructuring the node as a
+`Container` with an exported mount. `DUMP`/`RESTORE` is pure client-side
+work in the module runtime with no helper container, and it works
+unchanged against a remote managed instance where there is no filesystem
+to reach at all.
+
+`ImportFile` refuses to clobber by default — a key already present makes
+`RESTORE` answer `BUSYKEY` and the import fails — because a fixture load
+that silently overwrote someone else's data is discovered only as their
+missing data. Pass `replace` to overwrite. The import is not
+transactional: a mid-file failure leaves the keys already written in
+place, and re-running with `replace` is the intended recovery.
+
+It is `ImportFile` rather than the symmetric `Import` because the Go SDK
+caches every scalar-returning function on a generated struct field named
+after the GraphQL field: an `Import` returning `Int` renders as
+`import *int` in every consumer module's bindings, which is not valid Go.
+See the keyword-collision pitfall in `daggerverse/CLAUDE.md`.
+
 ## Follow-ups
 
 TLS/mTLS for the replication link (`--tls-replication yes` plus the trust
 material a replica needs to verify and authenticate to its primary) and
 for the cluster bus (`--tls-cluster yes`, plus `--tls`/`--cacert` for the
 bootstrapping `valkey-cli`); configuration passthrough for `Replication`
-and `Cluster` members and for `BundleServer`; keyspace export/import via
-SCAN + DUMP/RESTORE.
+and `Cluster` members and for `BundleServer`.

--- a/daggerverse/valkey/client.go
+++ b/daggerverse/valkey/client.go
@@ -421,6 +421,14 @@ func (c *Client) Keys(ctx context.Context, pattern string) ([]string, error) {
 	}
 	defer cleanup()
 
+	return c.scanKeys(ctx, client, pattern)
+}
+
+// scanKeys is the guts of Keys, factored out so Export can walk the same
+// keyspace on the connection it already holds rather than dialing a
+// second time. It applies the cluster fan-out and de-duplication
+// described on Keys.
+func (c *Client) scanKeys(ctx context.Context, client valkey.Client, pattern string) ([]string, error) {
 	targets := []valkey.Client{client}
 	if c.ClusterMode {
 		// Nodes() is a map, so its iteration order varies per call; walking

--- a/daggerverse/valkey/dagger.gen.go
+++ b/daggerverse/valkey/dagger.gen.go
@@ -449,6 +449,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Client).Do(&parent, ctx, args)
+		case "Export":
+			var parent Client
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var pattern string
+			if inputArgs["pattern"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["pattern"]), &pattern)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg pattern", err))
+				}
+			}
+			return (*Client).Export(&parent, ctx, pattern)
 		case "FlushAll":
 			var parent Client
 			err = json.Unmarshal(parentJSON, &parent)
@@ -470,6 +484,27 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Client).Get(&parent, ctx, key)
+		case "ImportFile":
+			var parent Client
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var file *dagger.File
+			if inputArgs["file"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["file"]), &file)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg file", err))
+				}
+			}
+			var replace bool
+			if inputArgs["replace"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["replace"]), &replace)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg replace", err))
+				}
+			}
+			return (*Client).ImportFile(&parent, ctx, file, replace)
 		case "Info":
 			var parent Client
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/valkey/keyspace.go
+++ b/daggerverse/valkey/keyspace.go
@@ -1,0 +1,299 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/valkey-io/valkey-go"
+
+	"dagger/valkey/internal/dagger"
+)
+
+// keyspaceExportVersion is stamped into every file Export writes and
+// checked by ImportFile. It exists so a file written by a future module
+// whose schema moved is refused with an explanation rather than
+// half-decoded into a keyspace.
+const keyspaceExportVersion = 1
+
+// keyspaceExportFile is the name the export lands under inside its
+// content-addressed workdir subdir. It is what a caller sees in
+// `dagger call export -o .`.
+const keyspaceExportFile = "keyspace.json"
+
+// keyspaceBatch is how many keys Export captures — and ImportFile
+// restores — per pipelined round trip. Batching keeps a large keyspace
+// from turning into one round trip per key without building a single
+// command list proportional to the whole database.
+const keyspaceBatch = 256
+
+// keyspaceExport is the on-disk form of an export. It is JSON rather
+// than a concatenation of raw DUMP payloads so the file stays
+// inspectable (`jq '.keys[].key'` lists the keyspace) and so a payload,
+// which is arbitrary binary, has an unambiguous framing.
+type keyspaceExport struct {
+	Version int           `json:"version"`
+	Pattern string        `json:"pattern"`
+	Keys    []exportedKey `json:"keys"`
+}
+
+// exportedKey is one key's captured state: its name, what was left of
+// its TTL at capture time, and its DUMP payload.
+type exportedKey struct {
+	Key string `json:"key"`
+	// TtlMs is the remaining TTL in milliseconds at capture time; 0
+	// means the key was persistent. It is deliberately relative rather
+	// than an absolute deadline: an import into a fresh server is
+	// usually replaying a fixture much later, and RESTORE's ABSTTL form
+	// would land every one of those keys already expired.
+	TtlMs int64 `json:"ttlMs"`
+	// Payload is the base64 of the raw DUMP serialization — the same
+	// binary format the RDB uses, carrying the value's type, its
+	// encoding, an RDB version, and a CRC64 footer that RESTORE
+	// verifies.
+	Payload string `json:"payload"`
+}
+
+// Export captures every key matching pattern and writes it to a single
+// JSON file, returned via `dag.CurrentModule().WorkdirFile`. ImportFile
+// reverses it, so the pair moves a pre-seeded cache between servers —
+// the fixture path for a test that needs a populated keyspace it did not
+// build command by command.
+//
+// Each key is captured with DUMP (the binary serialization RDB itself
+// uses, so every type and encoding survives — strings, hashes, lists,
+// sets, sorted sets, streams, and module types alike) plus its PTTL. The
+// keyspace is walked with SCAN, cursor to exhaustion, with the same
+// cluster fan-out Keys performs.
+//
+// This deliberately avoids the obvious approach of extracting
+// `/data/dump.rdb`: a running Dagger Service's filesystem is not
+// directly readable, so pulling the RDB out would mean restructuring the
+// node as a Container with an exported mount. DUMP/RESTORE is pure
+// client-side work and needs no filesystem access at all, which is also
+// what makes it work unchanged against a remote managed instance
+// (ElastiCache, MemoryDB) where there is no filesystem to reach.
+//
+// Only the client's logical database is exported. A key that expires
+// between the SCAN that named it and the DUMP that captures it is
+// skipped rather than failing the export.
+//
+// +cache="never"
+func (c *Client) Export(
+	ctx context.Context,
+	// +default="*"
+	pattern string,
+) (*dagger.File, error) {
+	if pattern == "" {
+		return nil, fmt.Errorf(`pattern must not be empty; pass "*" to export the whole keyspace`)
+	}
+
+	client, cleanup, err := c.dial(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+
+	keys, err := c.scanKeys(ctx, client, pattern)
+	if err != nil {
+		return nil, err
+	}
+
+	out := keyspaceExport{
+		Version: keyspaceExportVersion,
+		Pattern: pattern,
+		Keys:    make([]exportedKey, 0, len(keys)),
+	}
+	for start := 0; start < len(keys); start += keyspaceBatch {
+		batch := keys[start:min(start+keyspaceBatch, len(keys))]
+
+		// DUMP and PTTL are issued as one interleaved pipeline so a
+		// batch costs a single round trip rather than two per key.
+		cmds := make([]valkey.Completed, 0, 2*len(batch))
+		for _, key := range batch {
+			cmds = append(cmds,
+				client.B().Dump().Key(key).Build(),
+				client.B().Pttl().Key(key).Build(),
+			)
+		}
+		replies := client.DoMulti(ctx, cmds...)
+
+		for i, key := range batch {
+			payload, err := replies[2*i].AsBytes()
+			if err != nil {
+				if valkey.IsValkeyNil(err) {
+					// Expired (or was deleted) between the SCAN that
+					// named it and this DUMP.
+					continue
+				}
+				return nil, fmt.Errorf("dump %s: %w", key, err)
+			}
+			pttl, err := replies[2*i+1].ToInt64()
+			if err != nil {
+				return nil, fmt.Errorf("pttl %s: %w", key, err)
+			}
+			// -2 is "no such key" — the same race as a nil DUMP, just
+			// lost on the second half of the pipeline. -1 is "no
+			// expiry", which RESTORE spells as a 0 TTL.
+			if pttl == -2 {
+				continue
+			}
+			if pttl < 0 {
+				pttl = 0
+			}
+			out.Keys = append(out.Keys, exportedKey{
+				Key:     key,
+				TtlMs:   pttl,
+				Payload: base64.StdEncoding.EncodeToString(payload),
+			})
+		}
+	}
+
+	body, err := json.Marshal(out)
+	if err != nil {
+		return nil, fmt.Errorf("marshal export: %w", err)
+	}
+	return writeWorkdirFile(keyspaceExportFile, body)
+}
+
+// ImportFile restores a file written by Export into the client's logical
+// database and returns how many keys it wrote, TTLs included.
+//
+// It is not called `Import`, which is what the symmetry with Export
+// wants, because it cannot be: the Go SDK caches every scalar-returning
+// function on a generated struct field named after the GraphQL field, so
+// an `Import` returning an Int renders as `import *int` in every
+// consumer module's bindings and refuses to compile. `ApplyFile` is the
+// naming this module already uses for the other file-taking method.
+//
+// Without replace a key already present in the target is a hard error:
+// RESTORE answers BUSYKEY, which is the desired default for a fixture
+// load — silently clobbering a keyspace someone else is using is worse
+// than refusing. Pass replace to overwrite instead.
+//
+// The import is not transactional. The restores are pipelined in
+// batches, so a mid-file failure (a collision, a corrupt payload, an RDB
+// version the server is too old to read) leaves the keys already written
+// in place. Re-running with replace after fixing the cause is the
+// intended recovery.
+//
+// +cache="never"
+func (c *Client) ImportFile(
+	ctx context.Context,
+	file *dagger.File,
+	// +default=false
+	replace bool,
+) (int, error) {
+	contents, err := file.Contents(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("read export file: %w", err)
+	}
+
+	var payload keyspaceExport
+	if err := json.Unmarshal([]byte(contents), &payload); err != nil {
+		return 0, fmt.Errorf("parse export file: %w", err)
+	}
+	if payload.Version != keyspaceExportVersion {
+		return 0, fmt.Errorf("export file is version %d; this module reads version %d", payload.Version, keyspaceExportVersion)
+	}
+
+	// Every payload is decoded before a single command is sent, so a
+	// truncated or hand-edited file is rejected without having written
+	// half of itself into the keyspace first.
+	type restorable struct {
+		key   string
+		ttlMs int64
+		blob  string
+	}
+	entries := make([]restorable, 0, len(payload.Keys))
+	for i, entry := range payload.Keys {
+		if entry.Key == "" {
+			return 0, fmt.Errorf("export file entry %d has an empty key name", i)
+		}
+		if entry.TtlMs < 0 {
+			return 0, fmt.Errorf("export file entry %q has a negative ttl of %dms", entry.Key, entry.TtlMs)
+		}
+		blob, err := base64.StdEncoding.DecodeString(entry.Payload)
+		if err != nil {
+			return 0, fmt.Errorf("decode payload for %q: %w", entry.Key, err)
+		}
+		entries = append(entries, restorable{key: entry.Key, ttlMs: entry.TtlMs, blob: string(blob)})
+	}
+
+	client, cleanup, err := c.dial(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer cleanup()
+
+	restored := 0
+	for start := 0; start < len(entries); start += keyspaceBatch {
+		batch := entries[start:min(start+keyspaceBatch, len(entries))]
+
+		cmds := make([]valkey.Completed, 0, len(batch))
+		for _, entry := range batch {
+			cmd := client.B().Restore().Key(entry.key).Ttl(entry.ttlMs).SerializedValue(entry.blob)
+			if replace {
+				cmds = append(cmds, cmd.Replace().Build())
+				continue
+			}
+			cmds = append(cmds, cmd.Build())
+		}
+
+		for i, res := range client.DoMulti(ctx, cmds...) {
+			if err := res.Error(); err != nil {
+				return 0, fmt.Errorf("restore %s: %w", batch[i].key, err)
+			}
+			restored++
+		}
+	}
+	return restored, nil
+}
+
+// writeWorkdirFile writes content to a content-addressed subdir of the
+// module's scratch workdir and returns it as a *dagger.File. The subdir
+// name is derived from a hash of the content, so distinct outputs land
+// at distinct WorkdirFile paths (different Dagger File IDs) and
+// identical outputs are idempotent.
+//
+// The write goes through a sibling temp file plus an atomic rename, so
+// concurrent callers materializing the same content can never observe a
+// partially written file.
+func writeWorkdirFile(name string, content []byte) (*dagger.File, error) {
+	sum := sha256.Sum256(content)
+	dir := "out-" + hex.EncodeToString(sum[:])
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, err
+	}
+	path := filepath.Join(dir, name)
+
+	tmp, err := os.CreateTemp(dir, "."+name+"-*")
+	if err != nil {
+		return nil, err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(content); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return nil, err
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return nil, err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return nil, err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		return nil, err
+	}
+	return dag.CurrentModule().WorkdirFile(path), nil
+}

--- a/daggerverse/valkey/main.go
+++ b/daggerverse/valkey/main.go
@@ -43,6 +43,9 @@
 //   - client.go      — *Client + Valkey.Client, valkey-go wiring, and the
 //     Ping / Do / Get / Set / Del / Keys / ApplyFile / Info / DbSize /
 //     FlushAll method set — the last of which are cluster-aware.
+//   - keyspace.go    — Client.Export / Client.ImportFile, the SCAN +
+//     DUMP / RESTORE keyspace round trip, its on-disk JSON schema, and
+//     the workdir-file materialisation the export is returned through.
 package main
 
 // Valkey is the root namespace for every exported function in this

--- a/daggerverse/valkey/tests/dagger.gen.go
+++ b/daggerverse/valkey/tests/dagger.gen.go
@@ -451,6 +451,41 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).EndpointShouldNotBeCached(&parent, ctx)
+		case "ExportHonoursPatternAcrossScanPages":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ExportHonoursPatternAcrossScanPages(&parent, ctx)
+		case "ExportImportPreservesTtls":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ExportImportPreservesTtls(&parent, ctx)
+		case "ExportImportRoundTripsEveryType":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ExportImportRoundTripsEveryType(&parent, ctx)
+		case "ExportShouldNotBeCached":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ExportShouldNotBeCached(&parent, ctx)
+		case "ExportedFileIsReadableByConsumer":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ExportedFileIsReadableByConsumer(&parent, ctx)
 		case "ExtraArgsReachServerLast":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -486,6 +521,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).GetShouldNotBeCached(&parent, ctx)
+		case "ImportRejectsCollisionWithoutReplace":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ImportRejectsCollisionWithoutReplace(&parent, ctx)
 		case "InfoReportsRole":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -500,6 +542,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).KeysScansPattern(&parent, ctx)
+		case "Keyspace":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var parallel int
+			if inputArgs["parallel"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["parallel"]), &parallel)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg parallel", err))
+				}
+			}
+			return nil, (*Tests).Keyspace(&parent, ctx, parallel)
 		case "MaxMemoryEvictsOverLimit":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/valkey/tests/internal/dagger/valkey.gen.go
+++ b/daggerverse/valkey/tests/internal/dagger/valkey.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type Valkey
-func (r *Binding) AsValkey() *Valkey { // valkey (../../../../../daggerverse/valkey/main.go:52:6)
+func (r *Binding) AsValkey() *Valkey { // valkey (../../../../../daggerverse/valkey/main.go:55:6)
 	q := r.query.Select("asValkey")
 
 	return &Valkey{
@@ -145,7 +145,7 @@ func (r *Env) WithValkeyClusterOutput(name string, description string) *Env { //
 }
 
 // Create or update a binding of type Valkey in the environment
-func (r *Env) WithValkeyInput(name string, value *Valkey, description string) *Env { // valkey (../../../../../daggerverse/valkey/main.go:52:6)
+func (r *Env) WithValkeyInput(name string, value *Valkey, description string) *Env { // valkey (../../../../../daggerverse/valkey/main.go:55:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withValkeyInput")
 	q = q.Arg("name", name)
@@ -158,7 +158,7 @@ func (r *Env) WithValkeyInput(name string, value *Valkey, description string) *E
 }
 
 // Declare a desired Valkey output to be assigned in the environment
-func (r *Env) WithValkeyOutput(name string, description string) *Env { // valkey (../../../../../daggerverse/valkey/main.go:52:6)
+func (r *Env) WithValkeyOutput(name string, description string) *Env { // valkey (../../../../../daggerverse/valkey/main.go:55:6)
 	q := r.query.Select("withValkeyOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -244,7 +244,7 @@ func (r *Env) WithValkeyServerSecurityOutput(name string, description string) *E
 // module. The server constructor, security helpers, and the
 // remote-client factory all hang off *Valkey so the generated Dagger SDK
 // surfaces them under `dag.Valkey().<Func>(...)`.
-func (r *Query) Valkey() *Valkey { // valkey (../../../../../daggerverse/valkey/main.go:52:6)
+func (r *Query) Valkey() *Valkey { // valkey (../../../../../daggerverse/valkey/main.go:55:6)
 	q := r.query.Select("valkey")
 
 	return &Valkey{
@@ -256,7 +256,7 @@ func (r *Query) Valkey() *Valkey { // valkey (../../../../../daggerverse/valkey/
 // module. The server constructor, security helpers, and the
 // remote-client factory all hang off *Valkey so the generated Dagger SDK
 // surfaces them under `dag.Valkey().<Func>(...)`.
-type Valkey struct { // valkey (../../../../../daggerverse/valkey/main.go:52:6)
+type Valkey struct { // valkey (../../../../../daggerverse/valkey/main.go:55:6)
 	query *querybuilder.Selection
 
 	id *ID
@@ -882,16 +882,17 @@ func (r *Valkey) AsNode() Node {
 type ValkeyClient struct { // valkey (../../../../../daggerverse/valkey/client.go:35:6)
 	query *querybuilder.Selection
 
-	applyFile *Void
-	dbSize    *int
-	del       *int
-	do        *string
-	flushAll  *Void
-	get       *string
-	id        *ID
-	info      *string
-	ping      *Void
-	set       *Void
+	applyFile  *Void
+	dbSize     *int
+	del        *int
+	do         *string
+	flushAll   *Void
+	get        *string
+	id         *ID
+	importFile *int
+	info       *string
+	ping       *Void
+	set        *Void
 }
 
 func (r *ValkeyClient) WithGraphQLQuery(q *querybuilder.Selection) *ValkeyClient {
@@ -908,7 +909,7 @@ func (r *ValkeyClient) WithGraphQLQuery(q *querybuilder.Selection) *ValkeyClient
 // whitespace, with single- and double-quoted runs kept intact so values
 // containing spaces survive; `\` escapes inside double quotes. A command
 // that fails aborts the run and reports the offending line number.
-func (r *ValkeyClient) ApplyFile(ctx context.Context, file *File) error { // valkey (../../../../../daggerverse/valkey/client.go:490:1)
+func (r *ValkeyClient) ApplyFile(ctx context.Context, file *File) error { // valkey (../../../../../daggerverse/valkey/client.go:498:1)
 	assertNotNil("file", file)
 	if r.applyFile != nil {
 		return nil
@@ -920,7 +921,7 @@ func (r *ValkeyClient) ApplyFile(ctx context.Context, file *File) error { // val
 }
 
 // DbSize returns the number of keys in the client's logical database.
-func (r *ValkeyClient) DbSize(ctx context.Context) (int, error) { // valkey (../../../../../daggerverse/valkey/client.go:615:1)
+func (r *ValkeyClient) DbSize(ctx context.Context) (int, error) { // valkey (../../../../../daggerverse/valkey/client.go:623:1)
 	if r.dbSize != nil {
 		return *r.dbSize, nil
 	}
@@ -976,8 +977,52 @@ func (r *ValkeyClient) Do(ctx context.Context, args []string) (string, error) { 
 	return response, q.Execute(ctx)
 }
 
+// ValkeyClientExportOpts contains options for ValkeyClient.Export
+type ValkeyClientExportOpts struct {
+
+	// Default: "*"
+	Pattern string // valkey (../../../../../daggerverse/valkey/keyspace.go:90:2)
+}
+
+// Export captures every key matching pattern and writes it to a single
+// JSON file, returned via `dag.CurrentModule().WorkdirFile`. ImportFile
+// reverses it, so the pair moves a pre-seeded cache between servers —
+// the fixture path for a test that needs a populated keyspace it did not
+// build command by command.
+//
+// Each key is captured with DUMP (the binary serialization RDB itself
+// uses, so every type and encoding survives — strings, hashes, lists,
+// sets, sorted sets, streams, and module types alike) plus its PTTL. The
+// keyspace is walked with SCAN, cursor to exhaustion, with the same
+// cluster fan-out Keys performs.
+//
+// This deliberately avoids the obvious approach of extracting
+// `/data/dump.rdb`: a running Dagger Service's filesystem is not
+// directly readable, so pulling the RDB out would mean restructuring the
+// node as a Container with an exported mount. DUMP/RESTORE is pure
+// client-side work and needs no filesystem access at all, which is also
+// what makes it work unchanged against a remote managed instance
+// (ElastiCache, MemoryDB) where there is no filesystem to reach.
+//
+// Only the client's logical database is exported. A key that expires
+// between the SCAN that named it and the DUMP that captures it is
+// skipped rather than failing the export.
+func (r *ValkeyClient) Export(opts ...ValkeyClientExportOpts) *File { // valkey (../../../../../daggerverse/valkey/keyspace.go:87:1)
+	q := r.query.Select("export")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `pattern` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Pattern) {
+			q = q.Arg("pattern", opts[i].Pattern)
+		}
+	}
+
+	return &File{
+		query: q,
+	}
+}
+
 // FlushAll removes every key from every logical database on the node.
-func (r *ValkeyClient) FlushAll(ctx context.Context) error { // valkey (../../../../../daggerverse/valkey/client.go:632:1)
+func (r *ValkeyClient) FlushAll(ctx context.Context) error { // valkey (../../../../../daggerverse/valkey/client.go:640:1)
 	if r.flushAll != nil {
 		return nil
 	}
@@ -1051,15 +1096,60 @@ func (r *ValkeyClient) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
+// ValkeyClientImportFileOpts contains options for ValkeyClient.ImportFile
+type ValkeyClientImportFileOpts struct {
+	Replace bool // valkey (../../../../../daggerverse/valkey/keyspace.go:190:2)
+}
+
+// ImportFile restores a file written by Export into the client's logical
+// database and returns how many keys it wrote, TTLs included.
+//
+// It is not called `Import`, which is what the symmetry with Export
+// wants, because it cannot be: the Go SDK caches every scalar-returning
+// function on a generated struct field named after the GraphQL field, so
+// an `Import` returning an Int renders as `import *int` in every
+// consumer module's bindings and refuses to compile. `ApplyFile` is the
+// naming this module already uses for the other file-taking method.
+//
+// Without replace a key already present in the target is a hard error:
+// RESTORE answers BUSYKEY, which is the desired default for a fixture
+// load — silently clobbering a keyspace someone else is using is worse
+// than refusing. Pass replace to overwrite instead.
+//
+// The import is not transactional. The restores are pipelined in
+// batches, so a mid-file failure (a collision, a corrupt payload, an RDB
+// version the server is too old to read) leaves the keys already written
+// in place. Re-running with replace after fixing the cause is the
+// intended recovery.
+func (r *ValkeyClient) ImportFile(ctx context.Context, file *File, opts ...ValkeyClientImportFileOpts) (int, error) { // valkey (../../../../../daggerverse/valkey/keyspace.go:186:1)
+	assertNotNil("file", file)
+	if r.importFile != nil {
+		return *r.importFile, nil
+	}
+	q := r.query.Select("importFile")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `replace` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Replace) {
+			q = q.Arg("replace", opts[i].Replace)
+		}
+	}
+	q = q.Arg("file", file)
+
+	var response int
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
 // ValkeyClientInfoOpts contains options for ValkeyClient.Info
 type ValkeyClientInfoOpts struct {
-	Section string // valkey (../../../../../daggerverse/valkey/client.go:597:2)
+	Section string // valkey (../../../../../daggerverse/valkey/client.go:605:2)
 }
 
 // Info returns the server's INFO output. An empty section returns the
 // default set; pass a section name (`"server"`, `"replication"`,
 // `"keyspace"`, …) to narrow it.
-func (r *ValkeyClient) Info(ctx context.Context, opts ...ValkeyClientInfoOpts) (string, error) { // valkey (../../../../../daggerverse/valkey/client.go:594:1)
+func (r *ValkeyClient) Info(ctx context.Context, opts ...ValkeyClientInfoOpts) (string, error) { // valkey (../../../../../daggerverse/valkey/client.go:602:1)
 	if r.info != nil {
 		return *r.info, nil
 	}

--- a/daggerverse/valkey/tests/main.go
+++ b/daggerverse/valkey/tests/main.go
@@ -70,6 +70,9 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("Bundle", func(ctx context.Context) error {
 		return t.Bundle(ctx, parallel)
 	})
+	jobs = jobs.WithJob("Keyspace", func(ctx context.Context) error {
+		return t.Keyspace(ctx, parallel)
+	})
 	return jobs.Run(ctx)
 }
 
@@ -303,6 +306,32 @@ func (t *Tests) Bundle(
 	jobs = jobs.WithJob("bundle-bloom-round-trip", t.BundleBloomRoundTrip)
 	jobs = jobs.WithJob("bundle-server-methods-match-stock", t.BundleServerMethodsMatchStock)
 	jobs = jobs.WithJob("bundle-bind-server-reachable-from-consumer", t.BundleBindServerReachableFromConsumer)
+	return jobs.Run(ctx)
+}
+
+// Keyspace runs the SCAN + DUMP/RESTORE export/import tests. Most boot
+// two nodes — a source to capture and a fresh target to restore into —
+// each under its own runtime-random name, so the group fans out safely.
+//
+// +check
+// +cache="session"
+func (t *Tests) Keyspace(
+	ctx context.Context,
+	// +default=0
+	parallel int,
+) error {
+	jobs := par.New().
+		WithRollupLogs(true).
+		WithRollupSpans(true)
+	if parallel > 0 {
+		jobs = jobs.WithLimit(parallel)
+	}
+	jobs = jobs.WithJob("export-import-round-trips-every-type", t.ExportImportRoundTripsEveryType)
+	jobs = jobs.WithJob("export-import-preserves-ttls", t.ExportImportPreservesTtls)
+	jobs = jobs.WithJob("export-honours-pattern-across-scan-pages", t.ExportHonoursPatternAcrossScanPages)
+	jobs = jobs.WithJob("import-rejects-collision-without-replace", t.ImportRejectsCollisionWithoutReplace)
+	jobs = jobs.WithJob("exported-file-is-readable-by-consumer", t.ExportedFileIsReadableByConsumer)
+	jobs = jobs.WithJob("export-should-not-be-cached", t.ExportShouldNotBeCached)
 	return jobs.Run(ctx)
 }
 
@@ -3752,6 +3781,515 @@ func (t *Tests) BundleBindServerReachableFromConsumer(ctx context.Context) error
 	}
 	if !strings.Contains(out, "OK") {
 		return fmt.Errorf("expected OK from %s, got %q", endpoint, out)
+	}
+	return nil
+}
+
+// -----------------------------------------------------------------------------
+// Keyspace tests — SCAN + DUMP/RESTORE export and import.
+//
+// The export file's schema is mirrored here rather than imported from the
+// valkey module: the tests are a *consumer* of that file, and a consumer
+// that re-used the producer's struct could not catch a field rename that
+// silently broke every other reader.
+// -----------------------------------------------------------------------------
+
+// exportFile is the JSON layout Client.Export writes.
+type exportFile struct {
+	Version int               `json:"version"`
+	Pattern string            `json:"pattern"`
+	Keys    []exportFileEntry `json:"keys"`
+}
+
+type exportFileEntry struct {
+	Key     string `json:"key"`
+	TtlMs   int64  `json:"ttlMs"`
+	Payload string `json:"payload"`
+}
+
+// readExport decodes an export *dagger.File from the consumer side —
+// which is also what proves the file the module returned through
+// WorkdirFile is readable outside the module that wrote it.
+func readExport(ctx context.Context, file *dagger.File) (exportFile, error) {
+	contents, err := file.Contents(ctx)
+	if err != nil {
+		return exportFile{}, fmt.Errorf("read export file: %w", err)
+	}
+	var decoded exportFile
+	if err := json.Unmarshal([]byte(contents), &decoded); err != nil {
+		return exportFile{}, fmt.Errorf("decode export file (%d bytes): %w", len(contents), err)
+	}
+	return decoded, nil
+}
+
+// ExportImportRoundTripsEveryType is the core keyspace round trip: seed
+// one node with a value of every core type, export it, import into a
+// second fresh node, and check both nodes answer the same read command
+// identically.
+//
+// The assertion compares *replies* rather than hand-written expectations
+// so it stays honest about encoding: a DUMP payload carries the value's
+// internal encoding, and a comparison against a literal would pass even
+// if RESTORE had quietly reshaped a listpack-backed hash into something
+// else that stringifies the same way. TYPE is checked separately, since
+// two different types can share a read command's reply shape.
+//
+// +cache="never"
+func (t *Tests) ExportImportRoundTripsEveryType(ctx context.Context) error {
+	source, _, err := bootServer(ctx)
+	if err != nil {
+		return err
+	}
+	target, _, err := bootServer(ctx)
+	if err != nil {
+		return err
+	}
+	prefix, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Read commands chosen so every reply is order-deterministic: SORT
+	// ALPHA rather than SMEMBERS (set iteration order is an encoding
+	// detail), ZRANGE by rank rather than by score, and HGETALL — a map
+	// reply, which the JSON encoder emits key-sorted.
+	cases := []struct {
+		key      string
+		wantType string
+		read     []string
+	}{
+		{prefix + ":str", "string", []string{"GET", prefix + ":str"}},
+		{prefix + ":hash", "hash", []string{"HGETALL", prefix + ":hash"}},
+		{prefix + ":list", "list", []string{"LRANGE", prefix + ":list", "0", "-1"}},
+		{prefix + ":set", "set", []string{"SORT", prefix + ":set", "ALPHA"}},
+		{prefix + ":zset", "zset", []string{"ZRANGE", prefix + ":zset", "0", "-1", "WITHSCORES"}},
+	}
+
+	seed := fmt.Sprintf(`SET %[1]s:str a-string-value
+HSET %[1]s:hash f1 v1 f2 v2 f3 v3
+RPUSH %[1]s:list first second third
+SADD %[1]s:set alpha beta gamma
+ZADD %[1]s:zset 1 one 2 two 3 three
+`, prefix)
+
+	sourceClient := plaintextClient(source)
+	if err := sourceClient.ApplyFile(ctx, commandFile(seed)); err != nil {
+		return fmt.Errorf("seed source: %w", err)
+	}
+
+	file := sourceClient.Export(dagger.ValkeyClientExportOpts{Pattern: prefix + ":*"})
+	decoded, err := readExport(ctx, file)
+	if err != nil {
+		return err
+	}
+	if len(decoded.Keys) != len(cases) {
+		return fmt.Errorf("expected the export to hold %d keys, got %d", len(cases), len(decoded.Keys))
+	}
+
+	targetClient := plaintextClient(target)
+	restored, err := targetClient.ImportFile(ctx, file)
+	if err != nil {
+		return fmt.Errorf("import: %w", err)
+	}
+	if restored != len(cases) {
+		return fmt.Errorf("expected Import to report %d restored keys, got %d", len(cases), restored)
+	}
+	size, err := targetClient.DbSize(ctx)
+	if err != nil {
+		return fmt.Errorf("dbsize: %w", err)
+	}
+	if size != len(cases) {
+		return fmt.Errorf("expected the target keyspace to hold %d keys, DbSize reports %d", len(cases), size)
+	}
+
+	for _, tc := range cases {
+		gotType, err := targetClient.Do(ctx, []string{"TYPE", tc.key})
+		if err != nil {
+			return fmt.Errorf("type %s: %w", tc.key, err)
+		}
+		if want := strconv.Quote(tc.wantType); gotType != want {
+			return fmt.Errorf("expected %s to restore as %s, got %s", tc.key, want, gotType)
+		}
+		want, err := sourceClient.Do(ctx, tc.read)
+		if err != nil {
+			return fmt.Errorf("read %s from the source: %w", tc.key, err)
+		}
+		got, err := targetClient.Do(ctx, tc.read)
+		if err != nil {
+			return fmt.Errorf("read %s from the target: %w", tc.key, err)
+		}
+		if got != want {
+			return fmt.Errorf("expected %s to round trip: source answered %s, target answered %s", tc.key, want, got)
+		}
+	}
+	return nil
+}
+
+// ExportImportPreservesTtls verifies expiry survives the round trip in
+// both directions: a key with a TTL arrives with one still ticking, and
+// a persistent key arrives persistent rather than inheriting an expiry
+// from its neighbour.
+//
+// The persistent half matters as much as the other: RESTORE spells "no
+// expiry" as a 0 TTL and "expire in 0ms" is not expressible, so an
+// implementation that recorded PTTL's -1 verbatim would send `RESTORE k
+// -1 …` (rejected outright), and one that clamped every non-positive
+// PTTL to some small positive number would hand back a key that quietly
+// evaporates.
+//
+// +cache="never"
+func (t *Tests) ExportImportPreservesTtls(ctx context.Context) error {
+	source, _, err := bootServer(ctx)
+	if err != nil {
+		return err
+	}
+	target, _, err := bootServer(ctx)
+	if err != nil {
+		return err
+	}
+	prefix, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+	value, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+
+	volatile := prefix + ":volatile"
+	persistent := prefix + ":persistent"
+
+	sourceClient := plaintextClient(source)
+	if err := sourceClient.Set(ctx, volatile, value, dagger.ValkeyClientSetOpts{TTL: "1h"}); err != nil {
+		return fmt.Errorf("set the volatile key: %w", err)
+	}
+	if err := sourceClient.Set(ctx, persistent, value); err != nil {
+		return fmt.Errorf("set the persistent key: %w", err)
+	}
+
+	file := sourceClient.Export(dagger.ValkeyClientExportOpts{Pattern: prefix + ":*"})
+	decoded, err := readExport(ctx, file)
+	if err != nil {
+		return err
+	}
+	ttls := make(map[string]int64, len(decoded.Keys))
+	for _, entry := range decoded.Keys {
+		ttls[entry.Key] = entry.TtlMs
+	}
+	if got := ttls[volatile]; got <= 0 || got > int64(time.Hour/time.Millisecond) {
+		return fmt.Errorf("expected the export to record a ttl within (0, 3600000]ms for %s, got %d", volatile, got)
+	}
+	if got := ttls[persistent]; got != 0 {
+		return fmt.Errorf("expected the export to record ttl 0 (no expiry) for %s, got %d", persistent, got)
+	}
+
+	targetClient := plaintextClient(target)
+	if _, err := targetClient.ImportFile(ctx, file); err != nil {
+		return fmt.Errorf("import: %w", err)
+	}
+
+	volatilePttl, err := pttlOf(ctx, targetClient, volatile)
+	if err != nil {
+		return err
+	}
+	if volatilePttl <= 0 || volatilePttl > int(time.Hour/time.Millisecond) {
+		return fmt.Errorf("expected PTTL within (0, 3600000]ms for the restored %s, got %d (-1 means the expiry was dropped, -2 means the key never arrived)", volatile, volatilePttl)
+	}
+	persistentPttl, err := pttlOf(ctx, targetClient, persistent)
+	if err != nil {
+		return err
+	}
+	if persistentPttl != -1 {
+		return fmt.Errorf("expected the restored %s to stay persistent (PTTL -1), got %d", persistent, persistentPttl)
+	}
+	return nil
+}
+
+// ExportHonoursPatternAcrossScanPages seeds far more matching keys than
+// one SCAN page holds, plus a decoy prefix, and checks the export is
+// exactly the match set. An implementation that captured only SCAN's
+// first page — or that stopped before the cursor wrapped back to 0 —
+// comes up short, and one that ignored pattern picks up the decoys.
+//
+// The unfiltered export runs too, so a pattern that was over-applied
+// (matching nothing, or being handed to DUMP as well) cannot pass by
+// exporting an empty file both times.
+//
+// +cache="never"
+func (t *Tests) ExportHonoursPatternAcrossScanPages(ctx context.Context) error {
+	server, _, err := bootServer(ctx)
+	if err != nil {
+		return err
+	}
+	wanted, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+	decoy, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+
+	const (
+		matching = 1000
+		decoys   = 10
+	)
+	var seed strings.Builder
+	for i := 0; i < matching; i++ {
+		fmt.Fprintf(&seed, "SET %s:%04d %d\n", wanted, i, i)
+	}
+	for i := 0; i < decoys; i++ {
+		fmt.Fprintf(&seed, "SET %s:%04d %d\n", decoy, i, i)
+	}
+
+	client := plaintextClient(server)
+	if err := client.ApplyFile(ctx, commandFile(seed.String())); err != nil {
+		return fmt.Errorf("seed keys: %w", err)
+	}
+
+	matched, err := readExport(ctx, client.Export(dagger.ValkeyClientExportOpts{Pattern: wanted + ":*"}))
+	if err != nil {
+		return err
+	}
+	if len(matched.Keys) != matching {
+		return fmt.Errorf("expected %d keys across every SCAN page, the export holds %d", matching, len(matched.Keys))
+	}
+	seen := make(map[string]struct{}, len(matched.Keys))
+	for _, entry := range matched.Keys {
+		if !strings.HasPrefix(entry.Key, wanted+":") {
+			return fmt.Errorf("expected only %s:* keys, the export holds %q", wanted, entry.Key)
+		}
+		if entry.Payload == "" {
+			return fmt.Errorf("expected a DUMP payload for %s, got an empty one", entry.Key)
+		}
+		seen[entry.Key] = struct{}{}
+	}
+	if len(seen) != matching {
+		return fmt.Errorf("expected %d distinct keys, the export holds %d (cursor pages likely overlap)", matching, len(seen))
+	}
+
+	everything, err := readExport(ctx, client.Export())
+	if err != nil {
+		return err
+	}
+	if len(everything.Keys) != matching+decoys {
+		return fmt.Errorf("expected the default pattern to export all %d keys, it holds %d", matching+decoys, len(everything.Keys))
+	}
+	return nil
+}
+
+// ImportRejectsCollisionWithoutReplace verifies the default refuses to
+// clobber. A fixture load that silently overwrote whatever the target
+// already held would be discovered only as someone else's missing data,
+// so RESTORE's BUSYKEY is allowed through as a failure and `replace` is
+// the opt-in.
+//
+// +cache="never"
+func (t *Tests) ImportRejectsCollisionWithoutReplace(ctx context.Context) error {
+	source, _, err := bootServer(ctx)
+	if err != nil {
+		return err
+	}
+	target, _, err := bootServer(ctx)
+	if err != nil {
+		return err
+	}
+	prefix, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+	exported, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+	squatter, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+
+	collides := prefix + ":collides"
+	fresh := prefix + ":fresh"
+
+	sourceClient := plaintextClient(source)
+	for _, key := range []string{collides, fresh} {
+		if err := sourceClient.Set(ctx, key, exported); err != nil {
+			return fmt.Errorf("seed source %s: %w", key, err)
+		}
+	}
+	file := sourceClient.Export(dagger.ValkeyClientExportOpts{Pattern: prefix + ":*"})
+
+	targetClient := plaintextClient(target)
+	if err := targetClient.Set(ctx, collides, squatter); err != nil {
+		return fmt.Errorf("seed target %s: %w", collides, err)
+	}
+
+	if _, err := targetClient.ImportFile(ctx, file); err == nil {
+		return fmt.Errorf("expected the import to fail on the colliding key %s, but it reported success", collides)
+	} else if !strings.Contains(err.Error(), collides) {
+		return fmt.Errorf("expected the failure to name the colliding key %s, got: %v", collides, err)
+	}
+	held, err := targetClient.Get(ctx, collides)
+	if err != nil {
+		return fmt.Errorf("get %s after the refused import: %w", collides, err)
+	}
+	if held != squatter {
+		return fmt.Errorf("expected the refused import to leave %s untouched, it now holds %q", collides, held)
+	}
+
+	restored, err := targetClient.ImportFile(ctx, file, dagger.ValkeyClientImportFileOpts{Replace: true})
+	if err != nil {
+		return fmt.Errorf("import with replace: %w", err)
+	}
+	if restored != 2 {
+		return fmt.Errorf("expected the replacing import to report 2 restored keys, got %d", restored)
+	}
+	for _, key := range []string{collides, fresh} {
+		got, err := targetClient.Get(ctx, key)
+		if err != nil {
+			return fmt.Errorf("get %s after the replacing import: %w", key, err)
+		}
+		if got != exported {
+			return fmt.Errorf("expected %s to hold the exported value %q, got %q", key, exported, got)
+		}
+	}
+	return nil
+}
+
+// ExportedFileIsReadableByConsumer verifies the *dagger.File handed back
+// through WorkdirFile is a real, portable file rather than something
+// only the producing module can dereference: this test module decodes it
+// directly, and a plain container reads the very same handle off its own
+// filesystem.
+//
+// The container leg is the stronger claim of the two. A workdir file that
+// was never materialized, or that the module runtime tore down with its
+// scratch dir, still satisfies an in-process read on the module's own
+// side but cannot be mounted anywhere.
+//
+// +cache="never"
+func (t *Tests) ExportedFileIsReadableByConsumer(ctx context.Context) error {
+	server, _, err := bootServer(ctx)
+	if err != nil {
+		return err
+	}
+	prefix, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+	value, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+	key := prefix + ":only"
+
+	client := plaintextClient(server)
+	if err := client.Set(ctx, key, value); err != nil {
+		return fmt.Errorf("seed: %w", err)
+	}
+
+	file := client.Export(dagger.ValkeyClientExportOpts{Pattern: prefix + ":*"})
+	decoded, err := readExport(ctx, file)
+	if err != nil {
+		return err
+	}
+	if decoded.Version != 1 {
+		return fmt.Errorf("expected the export to declare version 1, got %d", decoded.Version)
+	}
+	if want := prefix + ":*"; decoded.Pattern != want {
+		return fmt.Errorf("expected the export to record the pattern %q, got %q", want, decoded.Pattern)
+	}
+	if len(decoded.Keys) != 1 || decoded.Keys[0].Key != key {
+		return fmt.Errorf("expected the export to hold exactly %s, got %+v", key, decoded.Keys)
+	}
+
+	name, err := file.Name(ctx)
+	if err != nil {
+		return fmt.Errorf("file name: %w", err)
+	}
+	if name != "keyspace.json" {
+		return fmt.Errorf("expected the export to be named keyspace.json, got %q", name)
+	}
+
+	// The container reads the mounted file rather than being handed the
+	// contents, so this fails if the workdir file cannot be materialized
+	// into a filesystem.
+	out, err := dag.Container().
+		From("docker.io/library/alpine:3.22").
+		WithFile("/fixture/keyspace.json", file).
+		WithExec([]string{"cat", "/fixture/keyspace.json"}).
+		Stdout(ctx)
+	if err != nil {
+		return fmt.Errorf("read the export from a consumer container: %w", err)
+	}
+	var fromContainer exportFile
+	if err := json.Unmarshal([]byte(out), &fromContainer); err != nil {
+		return fmt.Errorf("decode the export the container read back: %w", err)
+	}
+	if len(fromContainer.Keys) != 1 || fromContainer.Keys[0].Key != key {
+		return fmt.Errorf("expected the mounted export to hold exactly %s, got %+v", key, fromContainer.Keys)
+	}
+	return nil
+}
+
+// ExportShouldNotBeCached verifies Export re-executes on every call
+// rather than freezing on its first result: export, write a key that did
+// not exist yet, export again. A cached Export would hand back the
+// earlier file and the new key would never appear — the same stale-read
+// bug a missing +cache="never" produces on Get, except here it would
+// quietly ship an incomplete fixture.
+//
+// Both calls use the same pattern and the same receiver on purpose:
+// anything that varied between them would give a cached Export a fresh
+// cache key and let the bug through.
+//
+// +cache="never"
+func (t *Tests) ExportShouldNotBeCached(ctx context.Context) error {
+	server, _, err := bootServer(ctx)
+	if err != nil {
+		return err
+	}
+	prefix, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+	value, err := randHex(ctx)
+	if err != nil {
+		return err
+	}
+	first := prefix + ":first"
+	second := prefix + ":second"
+	pattern := dagger.ValkeyClientExportOpts{Pattern: prefix + ":*"}
+
+	client := plaintextClient(server)
+	if err := client.Set(ctx, first, value); err != nil {
+		return fmt.Errorf("set 1: %w", err)
+	}
+	before, err := readExport(ctx, client.Export(pattern))
+	if err != nil {
+		return err
+	}
+	if len(before.Keys) != 1 || before.Keys[0].Key != first {
+		return fmt.Errorf("expected the first export to hold exactly %s, got %+v", first, before.Keys)
+	}
+
+	if err := client.Set(ctx, second, value); err != nil {
+		return fmt.Errorf("set 2: %w", err)
+	}
+	after, err := readExport(ctx, client.Export(pattern))
+	if err != nil {
+		return err
+	}
+	if len(after.Keys) != 2 {
+		return fmt.Errorf("expected the second export to hold 2 keys after the intervening write (Export likely cached), got %d", len(after.Keys))
+	}
+	names := make(map[string]struct{}, len(after.Keys))
+	for _, entry := range after.Keys {
+		names[entry.Key] = struct{}{}
+	}
+	for _, key := range []string{first, second} {
+		if _, ok := names[key]; !ok {
+			return fmt.Errorf("expected the second export to hold %s, it holds %v", key, names)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #202.

Adds a portable, binary-faithful keyspace round trip to the valkey
client, so a pre-seeded cache can be captured from one server and
replayed into another without hand-writing the commands that built it.

## What's here

- **`daggerverse/valkey/keyspace.go`** (new) — `Client.Export` and
  `Client.ImportFile`, both `+cache="never"`.
  - `Export(pattern="*") (*dagger.File, error)` walks SCAN to cursor
    exhaustion (reusing `Keys`' cluster fan-out through a new `scanKeys`
    helper factored out of `client.go`), captures each key with an
    interleaved `DUMP`+`PTTL` pipeline in batches of 256, and writes one
    JSON file of base64 payloads via the content-addressed
    `writeWorkdirFile` → `dag.CurrentModule().WorkdirFile` pattern from
    crypto/postgres. A key that expires between the SCAN that named it
    and the DUMP that captures it is skipped; `PTTL -1` is recorded as
    `ttlMs: 0`.
  - `ImportFile(file, replace=false) (int, error)` validates the schema
    version and decodes every payload *before* sending a command, then
    pipelines `RESTORE` (with `REPLACE` when asked) and returns the
    count.
- **`daggerverse/valkey/tests/main.go`** — a new `Keyspace` `+check`
  aggregator with six tests, wired into `All`.
- README section, `main.go` file map, and regenerated bindings in the
  module, `tests/`, and `ci/`.

## Why DUMP/RESTORE and not the RDB

A running Dagger `Service`'s filesystem is not directly readable, so
extracting `/data/dump.rdb` would mean restructuring the node as a
`Container` with an exported mount. `DUMP`/`RESTORE` is pure client-side
work in the module runtime with no helper container, produces the same
serialization format the RDB uses, and works unchanged against a remote
managed instance where there is no filesystem access at all.

## One deviation from the issue: `ImportFile`, not `Import`

`Import` is not expressible. The Go SDK caches every scalar-returning
function on a private struct field of the consumer's generated type,
named after the GraphQL field — so an `Import` returning `Int` emits
`import *int` and every consumer module's `dagger develop` dies with
`error formatting generated code: NNN:9: expected '}', found 'import'`.
Confirmed by renaming and re-running codegen. `Export` is unaffected
because it returns a `*dagger.File`, which gets no cache field.

`ImportFile` follows the naming the module already uses for its other
file-taking method (`ApplyFile`). The general rule is now written up
alongside the existing `Type`-field pitfall in `daggerverse/CLAUDE.md`.

## Acceptance criteria

- [x] `Export` then `ImportFile` into a fresh server reproduces every
      key, value, and type — strings, hashes, lists, sets, and sorted
      sets all round-trip. The test compares *replies* between source and
      target rather than hand-written literals, so a RESTORE that
      reshaped an encoding cannot pass, and checks `TYPE` separately.
- [x] TTLs survive both directions: a key with a TTL arrives with a
      positive PTTL, and one without arrives persistent (`PTTL -1`).
- [x] `Export` honours `pattern` and walks every SCAN cursor page — 1000
      matching keys plus a decoy prefix, with an unfiltered export as the
      control so an over-applied pattern can't pass by exporting nothing
      twice.
- [x] `ImportFile` into a keyspace holding a colliding key fails without
      `replace` (leaving the incumbent value untouched) and overwrites
      with it, returning the restored count.
- [x] The exported file is returned via `WorkdirFile`, decoded by this
      test module and separately mounted into and `cat`-ed from a plain
      container.
- [x] `Export` and `ImportFile` carry `+cache="never"`, with a test
      proving `Export` re-executes after an intervening write.
- [x] `dagger develop` re-run in the module, `tests/`, and `ci/`;
      generated code committed.

## Testing

Each new test individually, then `call keyspace`, `call client`,
`call cluster`, the full `call all` (1m56s), and `ci call generated` —
all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)