### PR TITLE
story(issue-226): bound tesseract's OpenMP fan-out for shared runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,19 +107,17 @@ jobs:
         # its own tests module instead of the whole ci/ aggregator. ci:* checks
         # stay on the root module.
         #
-        # timeout is the leg's dagger/checks step bound in minutes. A module
-        # suite's own work is far below this: the tesseract suite (the slowest
-        # new leg) measures 22s on a cold 4-vCPU engine and 1m7s on a cold
-        # 1-vCPU one, so the bound exists only to trip on the telemetry-drain
-        # hang, not to fit the tests. Raised 6 -> 12 while we confirm whether a
-        # longer window lets a stalled drain clear on its own (run 30323420558
-        # lost tesseract-tests:all and kafka-tests:schema-registry to it across
-        # all 3 attempts). If legs still die at the bound, the drain is
-        # outlasting any practical timeout and this should go back to 6 so the
-        # auto-rerun fires sooner. ci:generated is the exception (#184) because
-        # it runs codegen for every module in the workspace, so it pays
+        # timeout is the leg's dagger/checks step bound in minutes. 6 fits every
+        # leg that runs one module's suite; ci:generated is the exception (#184)
+        # because it runs codegen for every module in the workspace, so it pays
         # in one leg the module-build cost the other legs spread across
         # themselves — measured at ~5m of engine work on a cold engine.
+        #
+        # Restored from the 12 set in a19f611, which was a workaround for #226:
+        # tesseract-tests:all really was taking 9m5s on a runner, not stalling
+        # on the telemetry drain. Its OpenMP fan-out is bounded now, so the
+        # tighter bound is honest again and the auto-rerun fires sooner on a
+        # genuinely stuck leg.
         env:
           CHECKS: ${{ steps.select.outputs.checks }}
         run: |
@@ -144,7 +142,7 @@ jobs:
                   timeout: ({"ci:generated": 15, "ci:generated-self-test": 8}[.] // 6) }
               else
                 { name: ., module: $module_for[$prefix], filter: ("tests:" + (split(":")[1])),
-                  timeout: 12 }
+                  timeout: 6 }
               end
             )
             # jobTimeout is the job cap: the step bound plus setup headroom.
@@ -205,7 +203,7 @@ jobs:
 
       # Fail fast on the Dagger Cloud telemetry-drain hang. The check itself runs
       # in ~1-4m (matrix.job.timeout, set by the route step, is that leg's bound:
-      # 12m for a module suite, 15m for the whole-workspace ci:generated codegen
+      # 6m for a normal suite, 15m for the whole-workspace ci:generated codegen
       # sweep); a leg still going past it is almost certainly stuck draining
       # telemetry to api.dagger.cloud (upstream dagger/dagger#7048, #12178),
       # which otherwise hangs the leg until the job timeout. Bounding the step

--- a/ci/internal/dagger/tesseract-tests.gen.go
+++ b/ci/internal/dagger/tesseract-tests.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type TesseractTests
-func (r *Binding) AsTesseractTests() *TesseractTests { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:45:6)
+func (r *Binding) AsTesseractTests() *TesseractTests { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:57:6)
 	q := r.query.Select("asTesseractTests")
 
 	return &TesseractTests{
@@ -19,7 +19,7 @@ func (r *Binding) AsTesseractTests() *TesseractTests { // tesseract-tests (../..
 }
 
 // Create or update a binding of type TesseractTests in the environment
-func (r *Env) WithTesseractTestsInput(name string, value *TesseractTests, description string) *Env { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:45:6)
+func (r *Env) WithTesseractTestsInput(name string, value *TesseractTests, description string) *Env { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:57:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withTesseractTestsInput")
 	q = q.Arg("name", name)
@@ -32,7 +32,7 @@ func (r *Env) WithTesseractTestsInput(name string, value *TesseractTests, descri
 }
 
 // Declare a desired TesseractTests output to be assigned in the environment
-func (r *Env) WithTesseractTestsOutput(name string, description string) *Env { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:45:6)
+func (r *Env) WithTesseractTestsOutput(name string, description string) *Env { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:57:6)
 	q := r.query.Select("withTesseractTestsOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -50,7 +50,7 @@ func (r *Env) WithTesseractTestsOutput(name string, description string) *Env { /
 // The fixtures under fixtures/ are committed rather than generated in-container:
 // bare Alpine ships no fonts, so rendering text inside the toolchain image would
 // mean pulling in fontconfig and a font package purely to make the tests run.
-func (r *Query) TesseractTests() *TesseractTests { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:45:6)
+func (r *Query) TesseractTests() *TesseractTests { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:57:6)
 	q := r.query.Select("tesseractTests")
 
 	return &TesseractTests{
@@ -58,7 +58,7 @@ func (r *Query) TesseractTests() *TesseractTests { // tesseract-tests (../../../
 	}
 }
 
-type TesseractTests struct { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:45:6)
+type TesseractTests struct { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:57:6)
 	query *querybuilder.Selection
 
 	all                                *Void
@@ -70,6 +70,7 @@ type TesseractTests struct { // tesseract-tests (../../../daggerverse/tesseract/
 	lstmEngineRecognizesFixture        *Void
 	malformedParameterNameIsRejected   *Void
 	nonPositiveDpiIsRejected           *Void
+	ompThreadLimitBoundsOpenMp         *Void
 	osdDetectsRotation                 *Void
 	osdWithoutOsdDataIsRejected        *Void
 	pdfHasPdfMagic                     *Void
@@ -93,16 +94,24 @@ func (r *TesseractTests) WithGraphQLQuery(q *querybuilder.Selection) *TesseractT
 
 // TesseractTestsAllOpts contains options for TesseractTests.All
 type TesseractTestsAllOpts struct {
-	Parallel int // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:59:2)
+	Parallel int // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:79:2)
 }
 
 // All runs every tesseract-module test in parallel.
 //
 // parallel caps how many tests run concurrently inside this suite. Defaults to
-// 0 (unbounded fan-out) — each `dagger check` job runs on its own GH Actions
-// runner, so in-runner parallelism is bounded by the VM's CPU/memory, not by
-// the scheduler. Pass any positive integer to opt into a specific cap.
-func (r *TesseractTests) All(ctx context.Context, opts ...TesseractTestsAllOpts) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:56:1)
+// 0 (unbounded fan-out), which used to be justified with "in-runner
+// parallelism is bounded by the VM's CPU/memory, not by the scheduler". That
+// was false: an unbounded tesseract sizes its OpenMP teams by CPU count, so a
+// four-core runner bounded nothing — it multiplied. Twenty concurrent jobs
+// each fanning out to four threads is eighty threads over four cores, and the
+// suite took 9m5s on a runner it takes 22s to finish on locally (#226).
+//
+// What makes the fan-out safe is suiteOmpThreadLimit, not this cap: with one
+// thread per pass the claim finally holds, and jobs contend for cores the way
+// any other oversubscribed workload does. The cap stays available for a host
+// that wants a narrower slice.
+func (r *TesseractTests) All(ctx context.Context, opts ...TesseractTestsAllOpts) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:76:1)
 	if r.all != nil {
 		return nil
 	}
@@ -120,7 +129,7 @@ func (r *TesseractTests) All(ctx context.Context, opts ...TesseractTestsAllOpts)
 // AltoIsValidXml asserts the ALTO renderer emits well-formed XML in the ALTO
 // namespace, since its consumers are schema-driven archive tooling that will
 // reject anything else outright.
-func (r *TesseractTests) AltoIsValidXML(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:200:1)
+func (r *TesseractTests) AltoIsValidXML(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:259:1)
 	if r.altoIsValidXml != nil {
 		return nil
 	}
@@ -133,7 +142,7 @@ func (r *TesseractTests) AltoIsValidXML(ctx context.Context) error { // tesserac
 // English and nothing else. The base apk package carries no language data at
 // all, so an empty default would produce an image that cannot recognise
 // anything.
-func (r *TesseractTests) DefaultLanguagesInstallEnglish(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:115:1)
+func (r *TesseractTests) DefaultLanguagesInstallEnglish(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:136:1)
 	if r.defaultLanguagesInstallEnglish != nil {
 		return nil
 	}
@@ -146,7 +155,7 @@ func (r *TesseractTests) DefaultLanguagesInstallEnglish(ctx context.Context) err
 // formats. That the artifacts arrive in a single directory lifted off a single
 // exec is what proves they came from one recognition pass rather than six: the
 // per-format functions each run their own.
-func (r *TesseractTests) ExportProducesEveryRequestedFormat(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:271:1)
+func (r *TesseractTests) ExportProducesEveryRequestedFormat(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:330:1)
 	if r.exportProducesEveryRequestedFormat != nil {
 		return nil
 	}
@@ -157,7 +166,7 @@ func (r *TesseractTests) ExportProducesEveryRequestedFormat(ctx context.Context)
 
 // HocrContainsWordBoxes asserts hOCR carries the per-word geometry that is the
 // whole reason to ask for it rather than plain text.
-func (r *TesseractTests) HocrContainsWordBoxes(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:177:1)
+func (r *TesseractTests) HocrContainsWordBoxes(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:236:1)
 	if r.hocrContainsWordBoxes != nil {
 		return nil
 	}
@@ -222,7 +231,7 @@ func (r *TesseractTests) UnmarshalJSON(bs []byte) error {
 // is that no member is dead: LEGACY and LEGACY_LSTM only work because Alpine
 // packages the *combined* tessdata models. A rebuild against tessdata_fast or
 // tessdata_best would strip the legacy data and this is where that shows up.
-func (r *TesseractTests) LstmEngineRecognizesFixture(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:338:1)
+func (r *TesseractTests) LstmEngineRecognizesFixture(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:397:1)
 	if r.lstmEngineRecognizesFixture != nil {
 		return nil
 	}
@@ -234,7 +243,7 @@ func (r *TesseractTests) LstmEngineRecognizesFixture(ctx context.Context) error 
 // MalformedParameterNameIsRejected asserts an empty parameter name, and one
 // carrying its own `=`, are refused. `-c` takes `name=value`, so an embedded
 // `=` would quietly set a different variable to a different value.
-func (r *TesseractTests) MalformedParameterNameIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:509:1)
+func (r *TesseractTests) MalformedParameterNameIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:568:1)
 	if r.malformedParameterNameIsRejected != nil {
 		return nil
 	}
@@ -246,7 +255,7 @@ func (r *TesseractTests) MalformedParameterNameIsRejected(ctx context.Context) e
 // NonPositiveDpiIsRejected asserts a zero or negative resolution is refused
 // rather than handed to tesseract, which would take it as a real measurement
 // and scale its analysis by it.
-func (r *TesseractTests) NonPositiveDpiIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:535:1)
+func (r *TesseractTests) NonPositiveDpiIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:594:1)
 	if r.nonPositiveDpiIsRejected != nil {
 		return nil
 	}
@@ -255,10 +264,29 @@ func (r *TesseractTests) NonPositiveDpiIsRejected(ctx context.Context) error { /
 	return q.Execute(ctx)
 }
 
+// OmpThreadLimitBoundsOpenMp asserts the OpenMP bound is absent by default and
+// otherwise reaches the environment tesseract runs in.
+//
+// The default is as much the point as the override. Alpine's tesseract links
+// libgomp and reports `Found OpenMP 201511`, so unbounded it takes one thread
+// per available CPU — right for a caller who owns the machine, and the reason
+// the bound is opt-in rather than baked in. What this pins is that opting in
+// works at all: without it, anything running several recognitions at once has
+// no way to stop each pass claiming every core, which cost this very suite
+// nine minutes on a four-core runner (#226).
+func (r *TesseractTests) OmpThreadLimitBoundsOpenMp(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:173:1)
+	if r.ompThreadLimitBoundsOpenMp != nil {
+		return nil
+	}
+	q := r.query.Select("ompThreadLimitBoundsOpenMp")
+
+	return q.Execute(ctx)
+}
+
 // OsdDetectsRotation asserts orientation detection reads the quarter-turn in
 // the rotated fixture and reports the rotation that would undo it, while the
 // upright fixture reports no rotation at all.
-func (r *TesseractTests) OsdDetectsRotation(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:417:1)
+func (r *TesseractTests) OsdDetectsRotation(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:476:1)
 	if r.osdDetectsRotation != nil {
 		return nil
 	}
@@ -270,7 +298,7 @@ func (r *TesseractTests) OsdDetectsRotation(ctx context.Context) error { // tess
 // OsdWithoutOsdDataIsRejected asserts orientation detection on an image built
 // without the osd model names the fix rather than failing inside tesseract,
 // which would report a missing traineddata file.
-func (r *TesseractTests) OsdWithoutOsdDataIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:477:1)
+func (r *TesseractTests) OsdWithoutOsdDataIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:536:1)
 	if r.osdWithoutOsdDataIsRejected != nil {
 		return nil
 	}
@@ -282,7 +310,7 @@ func (r *TesseractTests) OsdWithoutOsdDataIsRejected(ctx context.Context) error 
 // PdfHasPdfMagic asserts the searchable-PDF renderer emits a real PDF. The
 // bytes go through the filesystem rather than File.Contents, which mangles
 // non-UTF-8 data.
-func (r *TesseractTests) PdfHasPdfMagic(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:253:1)
+func (r *TesseractTests) PdfHasPdfMagic(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:312:1)
 	if r.pdfHasPdfMagic != nil {
 		return nil
 	}
@@ -294,7 +322,7 @@ func (r *TesseractTests) PdfHasPdfMagic(ctx context.Context) error { // tesserac
 // PdfInputIsRejected asserts a PDF source is refused up front. Leptonica has
 // no PDF support and reports the failure as if the file's first line were a
 // file name it could not open, which sends people looking in the wrong place.
-func (r *TesseractTests) PdfInputIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:493:1)
+func (r *TesseractTests) PdfInputIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:552:1)
 	if r.pdfInputIsRejected != nil {
 		return nil
 	}
@@ -306,7 +334,7 @@ func (r *TesseractTests) PdfInputIsRejected(ctx context.Context) error { // tess
 // RequestedLanguagesAreInstalled asserts every requested language lands in the
 // image as its own apk package, including "osd", which is a detection model
 // rather than a recognition language.
-func (r *TesseractTests) RequestedLanguagesAreInstalled(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:129:1)
+func (r *TesseractTests) RequestedLanguagesAreInstalled(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:150:1)
 	if r.requestedLanguagesAreInstalled != nil {
 		return nil
 	}
@@ -320,7 +348,7 @@ func (r *TesseractTests) RequestedLanguagesAreInstalled(ctx context.Context) err
 // that finds the lines, so it returns far less than the default mode does —
 // which is the observable proof the flag was passed, without asserting on
 // whatever garbage the constrained mode happens to produce.
-func (r *TesseractTests) SingleWordPageSegReturnsFewerWords(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:312:1)
+func (r *TesseractTests) SingleWordPageSegReturnsFewerWords(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:371:1)
 	if r.singleWordPageSegReturnsFewerWords != nil {
 		return nil
 	}
@@ -331,7 +359,7 @@ func (r *TesseractTests) SingleWordPageSegReturnsFewerWords(ctx context.Context)
 
 // TextRecognizesFixture asserts the shortest path — image in, string out —
 // reproduces every line the fixture renders.
-func (r *TesseractTests) TextRecognizesFixture(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:148:1)
+func (r *TesseractTests) TextRecognizesFixture(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:207:1)
 	if r.textRecognizesFixture != nil {
 		return nil
 	}
@@ -343,7 +371,7 @@ func (r *TesseractTests) TextRecognizesFixture(ctx context.Context) error { // t
 // TsvHasHeaderAndWordRows asserts the TSV renderer emits its column header and
 // descends all the way to word-level rows (level 5), which is the level
 // carrying the text and its confidence.
-func (r *TesseractTests) TsvHasHeaderAndWordRows(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:219:1)
+func (r *TesseractTests) TsvHasHeaderAndWordRows(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:278:1)
 	if r.tsvHasHeaderAndWordRows != nil {
 		return nil
 	}
@@ -354,7 +382,7 @@ func (r *TesseractTests) TsvHasHeaderAndWordRows(ctx context.Context) error { //
 
 // TxtFileMatchesText asserts the txt renderer and the stdout path agree, so
 // choosing a file over a string is purely a plumbing decision.
-func (r *TesseractTests) TxtFileMatchesText(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:158:1)
+func (r *TesseractTests) TxtFileMatchesText(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:217:1)
 	if r.txtFileMatchesText != nil {
 		return nil
 	}
@@ -367,7 +395,7 @@ func (r *TesseractTests) TxtFileMatchesText(ctx context.Context) error { // tess
 // rejected with the installed set named. tesseract's own failure talks about
 // traineddata paths and TESSDATA_PREFIX, which says nothing about the fact
 // that languages are chosen on New.
-func (r *TesseractTests) UnknownLanguageIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:446:1)
+func (r *TesseractTests) UnknownLanguageIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:505:1)
 	if r.unknownLanguageIsRejected != nil {
 		return nil
 	}
@@ -383,7 +411,7 @@ func (r *TesseractTests) UnknownLanguageIsRejected(ctx context.Context) error { 
 // and exits 0, so a typo would otherwise be indistinguishable from a setting
 // that simply had no effect. The same test pins the other half: a real
 // parameter still goes through, so the check is not just rejecting everything.
-func (r *TesseractTests) UnknownParameterFails(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:364:1)
+func (r *TesseractTests) UnknownParameterFails(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:423:1)
 	if r.unknownParameterFails != nil {
 		return nil
 	}
@@ -401,7 +429,7 @@ func (r *TesseractTests) UnknownParameterFails(ctx context.Context) error { // t
 // a dictionary hint on an already-clean fixture is not reliably observable.
 // What this does catch is a wrong mount path or a flag emitted in the wrong
 // position, either of which turns the whole run into a usage error.
-func (r *TesseractTests) UserWordsFileIsAccepted(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:400:1)
+func (r *TesseractTests) UserWordsFileIsAccepted(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:459:1)
 	if r.userWordsFileIsAccepted != nil {
 		return nil
 	}
@@ -413,7 +441,7 @@ func (r *TesseractTests) UserWordsFileIsAccepted(ctx context.Context) error { //
 // VersionReportsTesseractFive asserts the assembled image ships the tesseract
 // release Alpine's community repository carries, so a base-tag bump that
 // silently changes major version fails here rather than in recognition.
-func (r *TesseractTests) VersionReportsTesseractFive(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:100:1)
+func (r *TesseractTests) VersionReportsTesseractFive(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:121:1)
 	if r.versionReportsTesseractFive != nil {
 		return nil
 	}

--- a/daggerverse/tesseract/README.md
+++ b/daggerverse/tesseract/README.md
@@ -37,30 +37,55 @@ dag.Tesseract(dagger.TesseractOpts{Registry: "ghcr.io"})            // mirror
 
 ## OpenMP fan-out — `ompThreadLimit`
 
-Alpine's tesseract links `libgomp` and reports `Found OpenMP 201511`. Left alone
-it sizes every thread team by the CPUs it can see, which is what a caller who
-owns the machine wants — so that is the default, and `ompThreadLimit` is opt-in.
+Alpine's tesseract links `libgomp` and reports `Found OpenMP 201511`, so left
+alone it sizes every thread team by the CPUs it can see. Whether that is what
+you want depends entirely on how many images you have.
 
-Opt in when several recognitions share the cores. Each pass claiming every core
-does not merely fail to help, it collapses: eleven concurrent passes over the
-4-line test fixture, pinned to four CPUs, measure
+**One image, idle cores — threads help, modestly.** A single pass over a full
+page of text, pinned to four CPUs:
 
-| CPUs | `OMP_THREAD_LIMIT` | wall |
+| threads | wall | CPU | speedup | CPU cost |
+| --- | --- | --- | --- | --- |
+| 1 | 1.96s | 1.77s | 1.00x | 1.00x |
+| 2 | 1.70s | 2.53s | 1.15x | 1.43x |
+| 4 | 1.50s | 3.86s | 1.31x | 2.18x |
+
+Four threads buy 31% off the clock for 2.18x the CPU — 33% parallel efficiency.
+Tesseract's OpenMP regions sit inside the LSTM inner loops and do not amortize.
+It is still free wall-clock when nothing else wants the cores, which is why
+unbounded is the default and `ompThreadLimit` is opt-in.
+
+**More than one image — processes win outright.** Eleven passes over that same
+page, four CPUs, every way of spending them:
+
+| shape | wall | CPU |
+| --- | --- | --- |
+| serial, 4 threads each | 17.70s | 45.69s |
+| 2 concurrent, 2 threads each | 10.53s | 28.95s |
+| 4 concurrent, 1 thread each | 6.39s | 21.17s |
+| 11 concurrent, 1 thread each | **5.95s** | 21.17s |
+
+Same output; the thread-parallel shape burns 2.2x the CPU to take 3x as long.
+Process-level parallelism runs at ~90% efficiency where OpenMP manages 33%.
+
+**Oversubscribe both at once and it collapses.** Concurrency multiplied by
+per-process threads, rather than bounded by the core count:
+
+| CPUs | `OMP_THREAD_LIMIT` | 11 concurrent passes |
 | --- | --- | --- |
 | 4 | unset | **8m34s** |
 | 4 | `1` | **1.06s** |
 | 32 | unset | 0.68s |
 | 32 | `1` | 0.55s |
 
-Same work, ~485x apart. Upstream has carried reports of this shape for years
-([#2611](https://github.com/tesseract-ocr/tesseract/issues/2611), #1171, #263)
-and `OMP_THREAD_LIMIT` is the standard answer. This module's own test suite sets
-it to `1` for exactly this reason (#226); a shared CI runner is the textbook
-case.
+~485x apart on the small fixture. Upstream has carried reports of this shape for
+years ([#2611](https://github.com/tesseract-ocr/tesseract/issues/2611), #1171,
+#263) and `OMP_THREAD_LIMIT` is the standard answer. This module's own test
+suite sets it to `1` (#226); a shared CI runner is the textbook case.
 
 ```go
-dag.Tesseract(dagger.TesseractOpts{OmpThreadLimit: 1})   // sharing the box
-dag.Tesseract()                                          // one thread per CPU
+dag.Tesseract()                                          // one image, own machine
+dag.Tesseract(dagger.TesseractOpts{OmpThreadLimit: 1})   // many images, or sharing
 ```
 
 The variable is set on the image after `apk add`, so it applies to everything

--- a/daggerverse/tesseract/README.md
+++ b/daggerverse/tesseract/README.md
@@ -18,7 +18,7 @@ Nothing here handles secrets and nothing opens a port.
 ## Languages live on the root object
 
 ```go
-New(registry="docker.io", alpineTag="3.24", languages []string) *Tesseract
+New(registry="docker.io", alpineTag="3.24", languages []string, ompThreadLimit int) *Tesseract
 ```
 
 On Alpine each language is a **separate apk package**, and the base package
@@ -34,6 +34,40 @@ dag.Tesseract()                                                     // eng
 dag.Tesseract(dagger.TesseractOpts{Languages: []string{"eng","deu","osd"}})
 dag.Tesseract(dagger.TesseractOpts{Registry: "ghcr.io"})            // mirror
 ```
+
+## OpenMP fan-out — `ompThreadLimit`
+
+Alpine's tesseract links `libgomp` and reports `Found OpenMP 201511`. Left alone
+it sizes every thread team by the CPUs it can see, which is what a caller who
+owns the machine wants — so that is the default, and `ompThreadLimit` is opt-in.
+
+Opt in when several recognitions share the cores. Each pass claiming every core
+does not merely fail to help, it collapses: eleven concurrent passes over the
+4-line test fixture, pinned to four CPUs, measure
+
+| CPUs | `OMP_THREAD_LIMIT` | wall |
+| --- | --- | --- |
+| 4 | unset | **8m34s** |
+| 4 | `1` | **1.06s** |
+| 32 | unset | 0.68s |
+| 32 | `1` | 0.55s |
+
+Same work, ~485x apart. Upstream has carried reports of this shape for years
+([#2611](https://github.com/tesseract-ocr/tesseract/issues/2611), #1171, #263)
+and `OMP_THREAD_LIMIT` is the standard answer. This module's own test suite sets
+it to `1` for exactly this reason (#226); a shared CI runner is the textbook
+case.
+
+```go
+dag.Tesseract(dagger.TesseractOpts{OmpThreadLimit: 1})   // sharing the box
+dag.Tesseract()                                          // one thread per CPU
+```
+
+The variable is set on the image after `apk add`, so it applies to everything
+reached through `Container()` too, and two images differing only in their limit
+still share the package fetch. A negative value is rejected on `New` — libgomp
+reads an unparseable `OMP_THREAD_LIMIT` as absent and silently goes back to one
+thread per CPU, the opposite of what was asked for.
 
 ## Toolchain
 

--- a/daggerverse/tesseract/dagger.gen.go
+++ b/daggerverse/tesseract/dagger.gen.go
@@ -61,21 +61,24 @@ func convertSlice[I any, O any](in []I, f func(I) O) []O {
 
 func (r Tesseract) MarshalJSON() ([]byte, error) {
 	var concrete struct {
-		Registry  string
-		AlpineTag string
-		Languages []string
+		Registry       string
+		AlpineTag      string
+		Languages      []string
+		OmpThreadLimit int
 	}
 	concrete.Registry = r.Registry
 	concrete.AlpineTag = r.AlpineTag
 	concrete.Languages = r.Languages
+	concrete.OmpThreadLimit = r.OmpThreadLimit
 	return json.Marshal(&concrete)
 }
 
 func (r *Tesseract) UnmarshalJSON(bs []byte) error {
 	var concrete struct {
-		Registry  string
-		AlpineTag string
-		Languages []string
+		Registry       string
+		AlpineTag      string
+		Languages      []string
+		OmpThreadLimit int
 	}
 	err := json.Unmarshal(bs, &concrete)
 	if err != nil {
@@ -84,6 +87,7 @@ func (r *Tesseract) UnmarshalJSON(bs []byte) error {
 	r.Registry = concrete.Registry
 	r.AlpineTag = concrete.AlpineTag
 	r.Languages = concrete.Languages
+	r.OmpThreadLimit = concrete.OmpThreadLimit
 	return nil
 }
 
@@ -721,7 +725,14 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg languages", err))
 				}
 			}
-			return New(registry, alpineTag, languages), nil
+			var ompThreadLimit int
+			if inputArgs["ompThreadLimit"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["ompThreadLimit"]), &ompThreadLimit)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg ompThreadLimit", err))
+				}
+			}
+			return New(registry, alpineTag, languages, ompThreadLimit)
 		default:
 			return nil, fmt.Errorf("unknown function %s", fnName)
 		}

--- a/daggerverse/tesseract/main.go
+++ b/daggerverse/tesseract/main.go
@@ -27,6 +27,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"dagger/tesseract/internal/dagger"
@@ -72,6 +73,17 @@ const (
 
 	userWordsPath    = workDir + "/user-words.txt"
 	userPatternsPath = workDir + "/user-patterns.txt"
+
+	// ompThreadLimitEnv caps the OpenMP team size tesseract's recognition
+	// loops fan out to.
+	ompThreadLimitEnv = "OMP_THREAD_LIMIT"
+
+	// hostCpuOmpThreadLimit is the unset value: no OMP_THREAD_LIMIT on the
+	// image, so libgomp sizes every thread team by the CPUs it can see. That
+	// is the right default for the common case — one image, one machine, a
+	// caller who wants the whole box — and the wrong one as soon as several
+	// recognitions share the cores, which is what the bound exists for.
+	hostCpuOmpThreadLimit = 0
 )
 
 // Tesseract is the root namespace for every exported function in this module.
@@ -85,6 +97,8 @@ type Tesseract struct {
 	AlpineTag string
 	// +private
 	Languages []string
+	// +private
+	OmpThreadLimit int
 }
 
 // New returns a Tesseract module backed by <registry>/library/alpine:<tag>
@@ -100,18 +114,34 @@ func New(
 	// "osd" is not a recognition language but is required by Document.Osd.
 	// +optional
 	languages []string,
-) *Tesseract {
+	// Upper bound on the OpenMP threads tesseract may use, set on the
+	// assembled image as OMP_THREAD_LIMIT. Unset, tesseract uses one thread
+	// per available CPU, which is what a caller who owns the machine wants.
+	// Set it when several recognitions share the cores — concurrent passes
+	// each claiming every CPU oversubscribe the box badly enough to cost an
+	// order of magnitude, which is the shape of the long-standing upstream
+	// slowdown reports (tesseract-ocr/tesseract#2611, #1171, #263). One
+	// thread per pass is the usual setting there.
+	// +optional
+	ompThreadLimit int,
+) (*Tesseract, error) {
 	if registry == "" {
 		registry = defaultRegistry
 	}
 	if alpineTag == "" {
 		alpineTag = defaultAlpineTag
 	}
-	return &Tesseract{
-		Registry:  registry,
-		AlpineTag: alpineTag,
-		Languages: normalizeLanguages(languages),
+	if ompThreadLimit < 0 {
+		return nil, fmt.Errorf(
+			"New: ompThreadLimit must not be negative, got %d: pass a positive thread cap, or leave it unset for one thread per available CPU",
+			ompThreadLimit)
 	}
+	return &Tesseract{
+		Registry:       registry,
+		AlpineTag:      alpineTag,
+		Languages:      normalizeLanguages(languages),
+		OmpThreadLimit: ompThreadLimit,
+	}, nil
 }
 
 // Container returns the assembled toolchain image. This is the escape hatch
@@ -119,15 +149,25 @@ func New(
 // package ships, `combine_tessdata`, and tesseract's long tail of renderers
 // stay reachable via `container with-exec`.
 //
+// A requested OpenMP bound lives here rather than on the recognition
+// invocation so everything reached through this escape hatch inherits it too.
+//
 // +cache="session"
 func (t *Tesseract) Container() *dagger.Container {
 	args := []string{"apk", "add", "--no-cache", tesseractPkg}
 	for _, lang := range t.Languages {
 		args = append(args, langPkgPrefix+lang)
 	}
-	return dag.Container().
+	ctr := dag.Container().
 		From(t.image()).
 		WithExec(args)
+	// Applied after the install so the thread bound does not become part of
+	// the apk layer's cache key: two images differing only in their limit
+	// still share the package fetch.
+	if t.OmpThreadLimit > hostCpuOmpThreadLimit {
+		ctr = ctr.WithEnvVariable(ompThreadLimitEnv, strconv.Itoa(t.OmpThreadLimit))
+	}
+	return ctr
 }
 
 // Version returns the tesseract release the assembled image ships, as the

--- a/daggerverse/tesseract/tests/dagger.gen.go
+++ b/daggerverse/tesseract/tests/dagger.gen.go
@@ -255,6 +255,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).NonPositiveDpiIsRejected(&parent, ctx)
+		case "OmpThreadLimitBoundsOpenMp":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).OmpThreadLimitBoundsOpenMp(&parent, ctx)
 		case "OsdDetectsRotation":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/tesseract/tests/internal/dagger/tesseract.gen.go
+++ b/daggerverse/tesseract/tests/internal/dagger/tesseract.gen.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Retrieve the binding value, as type Tesseract
-func (r *Binding) AsTesseract() *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:81:6)
+func (r *Binding) AsTesseract() *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:93:6)
 	q := r.query.Select("asTesseract")
 
 	return &Tesseract{
@@ -53,7 +53,7 @@ func (r *Env) WithTesseractDocumentOutput(name string, description string) *Env 
 }
 
 // Create or update a binding of type Tesseract in the environment
-func (r *Env) WithTesseractInput(name string, value *Tesseract, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/main.go:81:6)
+func (r *Env) WithTesseractInput(name string, value *Tesseract, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/main.go:93:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withTesseractInput")
 	q = q.Arg("name", name)
@@ -66,7 +66,7 @@ func (r *Env) WithTesseractInput(name string, value *Tesseract, description stri
 }
 
 // Declare a desired Tesseract output to be assigned in the environment
-func (r *Env) WithTesseractOutput(name string, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/main.go:81:6)
+func (r *Env) WithTesseractOutput(name string, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/main.go:93:6)
 	q := r.query.Select("withTesseractOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -83,23 +83,34 @@ type TesseractOpts struct {
 	//
 	//
 	// Default: "docker.io"
-	Registry string // tesseract (../../../../../daggerverse/tesseract/main.go:95:2)
+	Registry string // tesseract (../../../../../daggerverse/tesseract/main.go:109:2)
 	//
 	// Tag of the alpine image the toolchain is assembled on.
 	//
 	//
 	// Default: "3.24"
-	AlpineTag string // tesseract (../../../../../daggerverse/tesseract/main.go:98:2)
+	AlpineTag string // tesseract (../../../../../daggerverse/tesseract/main.go:112:2)
 	//
 	// Language codes to install, one apk package each. Empty installs "eng".
 	// "osd" is not a recognition language but is required by Document.Osd.
 	//
-	Languages []string // tesseract (../../../../../daggerverse/tesseract/main.go:102:2)
+	Languages []string // tesseract (../../../../../daggerverse/tesseract/main.go:116:2)
+	//
+	// Upper bound on the OpenMP threads tesseract may use, set on the
+	// assembled image as OMP_THREAD_LIMIT. Unset, tesseract uses one thread
+	// per available CPU, which is what a caller who owns the machine wants.
+	// Set it when several recognitions share the cores — concurrent passes
+	// each claiming every CPU oversubscribe the box badly enough to cost an
+	// order of magnitude, which is the shape of the long-standing upstream
+	// slowdown reports (tesseract-ocr/tesseract#2611, #1171, #263). One
+	// thread per pass is the usual setting there.
+	//
+	OmpThreadLimit int // tesseract (../../../../../daggerverse/tesseract/main.go:126:2)
 }
 
 // New returns a Tesseract module backed by <registry>/library/alpine:<tag>
 // with tesseract-ocr and one language package per requested language.
-func (r *Query) Tesseract(opts ...TesseractOpts) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:92:1)
+func (r *Query) Tesseract(opts ...TesseractOpts) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:106:1)
 	q := r.query.Select("tesseract")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `registry` optional argument
@@ -114,6 +125,10 @@ func (r *Query) Tesseract(opts ...TesseractOpts) *Tesseract { // tesseract (../.
 		if !querybuilder.IsZeroValue(opts[i].Languages) {
 			q = q.Arg("languages", opts[i].Languages)
 		}
+		// `ompThreadLimit` optional argument
+		if !querybuilder.IsZeroValue(opts[i].OmpThreadLimit) {
+			q = q.Arg("ompThreadLimit", opts[i].OmpThreadLimit)
+		}
 	}
 
 	return &Tesseract{
@@ -125,7 +140,7 @@ func (r *Query) Tesseract(opts ...TesseractOpts) *Tesseract { // tesseract (../.
 // It carries the image coordinates and the language set the image is built
 // with; Document hangs off it so the generated SDK surfaces recognition under
 // `dag.Tesseract().Document(...)`.
-type Tesseract struct { // tesseract (../../../../../daggerverse/tesseract/main.go:81:6)
+type Tesseract struct { // tesseract (../../../../../daggerverse/tesseract/main.go:93:6)
 	query *querybuilder.Selection
 
 	id         *ID
@@ -143,7 +158,10 @@ func (r *Tesseract) WithGraphQLQuery(q *querybuilder.Selection) *Tesseract {
 // for everything this module does not wrap — the training binaries the apk
 // package ships, `combine_tessdata`, and tesseract's long tail of renderers
 // stay reachable via `container with-exec`.
-func (r *Tesseract) Container() *Container { // tesseract (../../../../../daggerverse/tesseract/main.go:123:1)
+//
+// A requested OpenMP bound lives here rather than on the recognition
+// invocation so everything reached through this escape hatch inherits it too.
+func (r *Tesseract) Container() *Container { // tesseract (../../../../../daggerverse/tesseract/main.go:156:1)
 	q := r.query.Select("container")
 
 	return &Container{
@@ -156,7 +174,7 @@ func (r *Tesseract) Container() *Container { // tesseract (../../../../../dagger
 // The boundary input is a *dagger.File rather than a *dagger.Directory, unlike
 // the kicad module's Project: tesseract resolves nothing relative to its input,
 // so one image — including a multi-page TIFF — is the whole unit of work.
-func (r *Tesseract) Document(source *File) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/main.go:185:1)
+func (r *Tesseract) Document(source *File) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/main.go:225:1)
 	assertNotNil("source", source)
 	q := r.query.Select("document")
 	q = q.Arg("source", source)
@@ -218,7 +236,7 @@ func (r *Tesseract) UnmarshalJSON(bs []byte) error {
 // Langs returns the language codes installed in the image, as reported by
 // `tesseract --list-langs`. This is the set Document.WithLanguage validates
 // against, and it includes "osd" when that package was requested.
-func (r *Tesseract) Langs(ctx context.Context) ([]string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:155:1)
+func (r *Tesseract) Langs(ctx context.Context) ([]string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:195:1)
 	q := r.query.Select("langs")
 
 	var response []string
@@ -230,7 +248,7 @@ func (r *Tesseract) Langs(ctx context.Context) ([]string, error) { // tesseract 
 // Parameters returns tesseract's control-variable table — every name, its
 // default value and a one-line description — as `tesseract --print-parameters`
 // prints it. These are the names Document.WithParameter accepts.
-func (r *Tesseract) Parameters(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:170:1)
+func (r *Tesseract) Parameters(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:210:1)
 	if r.parameters != nil {
 		return *r.parameters, nil
 	}
@@ -244,7 +262,7 @@ func (r *Tesseract) Parameters(ctx context.Context) (string, error) { // tessera
 
 // Version returns the tesseract release the assembled image ships, as the
 // bare version number reported by `tesseract --version`.
-func (r *Tesseract) Version(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:137:1)
+func (r *Tesseract) Version(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:177:1)
 	if r.version != nil {
 		return *r.version, nil
 	}

--- a/daggerverse/tesseract/tests/main.go
+++ b/daggerverse/tesseract/tests/main.go
@@ -30,6 +30,18 @@ const (
 	// which is what makes orientation detection have something to report.
 	sentencePng      = "sentence.png"
 	sentenceRot90Png = "sentence-rot90.png"
+
+	// ompThreadLimitEnv is the OpenMP variable New's ompThreadLimit sets on
+	// the assembled image.
+	ompThreadLimitEnv = "OMP_THREAD_LIMIT"
+
+	// suiteOmpThreadLimit is the bound every test here builds its image with.
+	// The module itself leaves OpenMP alone, so tesseract takes one thread per
+	// available CPU — right for a caller who owns the machine, wrong for this
+	// suite, which fires ~20 recognitions at once onto a shared 4-vCPU runner.
+	// Unbounded, each of them claims all four cores and the suite goes from
+	// 22s to over 9m (#226).
+	suiteOmpThreadLimit = 1
 )
 
 // sentenceLines is what sentence.png renders, and therefore what recognition
@@ -47,9 +59,17 @@ type Tests struct{}
 // All runs every tesseract-module test in parallel.
 //
 // parallel caps how many tests run concurrently inside this suite. Defaults to
-// 0 (unbounded fan-out) — each `dagger check` job runs on its own GH Actions
-// runner, so in-runner parallelism is bounded by the VM's CPU/memory, not by
-// the scheduler. Pass any positive integer to opt into a specific cap.
+// 0 (unbounded fan-out), which used to be justified with "in-runner
+// parallelism is bounded by the VM's CPU/memory, not by the scheduler". That
+// was false: an unbounded tesseract sizes its OpenMP teams by CPU count, so a
+// four-core runner bounded nothing — it multiplied. Twenty concurrent jobs
+// each fanning out to four threads is eighty threads over four cores, and the
+// suite took 9m5s on a runner it takes 22s to finish on locally (#226).
+//
+// What makes the fan-out safe is suiteOmpThreadLimit, not this cap: with one
+// thread per pass the claim finally holds, and jobs contend for cores the way
+// any other oversubscribed workload does. The cap stays available for a host
+// that wants a narrower slice.
 //
 // +check
 // +cache="session"
@@ -68,6 +88,7 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("VersionReportsTesseractFive", t.VersionReportsTesseractFive)
 	jobs = jobs.WithJob("DefaultLanguagesInstallEnglish", t.DefaultLanguagesInstallEnglish)
 	jobs = jobs.WithJob("RequestedLanguagesAreInstalled", t.RequestedLanguagesAreInstalled)
+	jobs = jobs.WithJob("OmpThreadLimitBoundsOpenMp", t.OmpThreadLimitBoundsOpenMp)
 
 	jobs = jobs.WithJob("TextRecognizesFixture", t.TextRecognizesFixture)
 	jobs = jobs.WithJob("TxtFileMatchesText", t.TxtFileMatchesText)
@@ -98,7 +119,7 @@ func (t *Tests) All(
 // release Alpine's community repository carries, so a base-tag bump that
 // silently changes major version fails here rather than in recognition.
 func (t *Tests) VersionReportsTesseractFive(ctx context.Context) error {
-	got, err := dag.Tesseract().Version(ctx)
+	got, err := ocr().Version(ctx)
 	if err != nil {
 		return fmt.Errorf("Version: %w", err)
 	}
@@ -113,7 +134,7 @@ func (t *Tests) VersionReportsTesseractFive(ctx context.Context) error {
 // all, so an empty default would produce an image that cannot recognise
 // anything.
 func (t *Tests) DefaultLanguagesInstallEnglish(ctx context.Context) error {
-	got, err := dag.Tesseract().Langs(ctx)
+	got, err := ocr().Langs(ctx)
 	if err != nil {
 		return fmt.Errorf("Langs: %w", err)
 	}
@@ -127,9 +148,7 @@ func (t *Tests) DefaultLanguagesInstallEnglish(ctx context.Context) error {
 // image as its own apk package, including "osd", which is a detection model
 // rather than a recognition language.
 func (t *Tests) RequestedLanguagesAreInstalled(ctx context.Context) error {
-	got, err := dag.Tesseract(dagger.TesseractOpts{
-		Languages: []string{"eng", "deu", "osd"},
-	}).Langs(ctx)
+	got, err := ocr("eng", "deu", "osd").Langs(ctx)
 	if err != nil {
 		return fmt.Errorf("Langs: %w", err)
 	}
@@ -141,12 +160,52 @@ func (t *Tests) RequestedLanguagesAreInstalled(ctx context.Context) error {
 	return nil
 }
 
+// OmpThreadLimitBoundsOpenMp asserts the OpenMP bound is absent by default and
+// otherwise reaches the environment tesseract runs in.
+//
+// The default is as much the point as the override. Alpine's tesseract links
+// libgomp and reports `Found OpenMP 201511`, so unbounded it takes one thread
+// per available CPU — right for a caller who owns the machine, and the reason
+// the bound is opt-in rather than baked in. What this pins is that opting in
+// works at all: without it, anything running several recognitions at once has
+// no way to stop each pass claiming every core, which cost this very suite
+// nine minutes on a four-core runner (#226).
+func (t *Tests) OmpThreadLimitBoundsOpenMp(ctx context.Context) error {
+	got, err := readOmpThreadLimit(ctx, dag.Tesseract())
+	if err != nil {
+		return err
+	}
+	if got != "" {
+		return fmt.Errorf("expected %s to be unset by default, got %q", ompThreadLimitEnv, got)
+	}
+
+	got, err = readOmpThreadLimit(ctx, dag.Tesseract(dagger.TesseractOpts{OmpThreadLimit: 3}))
+	if err != nil {
+		return err
+	}
+	if got != "3" {
+		return fmt.Errorf("expected %s=3 in the image, got %q", ompThreadLimitEnv, got)
+	}
+
+	// A negative cap is refused on New rather than handed to libgomp, which
+	// reads an unparseable OMP_THREAD_LIMIT as absent and silently goes back
+	// to one thread per CPU — the exact opposite of what was asked for.
+	_, err = dag.Tesseract(dagger.TesseractOpts{OmpThreadLimit: -1}).Langs(ctx)
+	if err == nil {
+		return fmt.Errorf("expected a negative ompThreadLimit to be rejected, got nil")
+	}
+	if !strings.Contains(err.Error(), "must not be negative") {
+		return fmt.Errorf("expected the error to name the negative rule, got: %v", err)
+	}
+	return nil
+}
+
 // ---------------------------------------------------------------- recognition
 
 // TextRecognizesFixture asserts the shortest path — image in, string out —
 // reproduces every line the fixture renders.
 func (t *Tests) TextRecognizesFixture(ctx context.Context) error {
-	got, err := dag.Tesseract().Document(fixture(sentencePng)).Text(ctx)
+	got, err := ocr().Document(fixture(sentencePng)).Text(ctx)
 	if err != nil {
 		return fmt.Errorf("Text: %w", err)
 	}
@@ -156,7 +215,7 @@ func (t *Tests) TextRecognizesFixture(ctx context.Context) error {
 // TxtFileMatchesText asserts the txt renderer and the stdout path agree, so
 // choosing a file over a string is purely a plumbing decision.
 func (t *Tests) TxtFileMatchesText(ctx context.Context) error {
-	doc := dag.Tesseract().Document(fixture(sentencePng))
+	doc := ocr().Document(fixture(sentencePng))
 
 	text, err := doc.Text(ctx)
 	if err != nil {
@@ -175,7 +234,7 @@ func (t *Tests) TxtFileMatchesText(ctx context.Context) error {
 // HocrContainsWordBoxes asserts hOCR carries the per-word geometry that is the
 // whole reason to ask for it rather than plain text.
 func (t *Tests) HocrContainsWordBoxes(ctx context.Context) error {
-	got, err := dag.Tesseract().Document(fixture(sentencePng)).Hocr().Contents(ctx)
+	got, err := ocr().Document(fixture(sentencePng)).Hocr().Contents(ctx)
 	if err != nil {
 		return fmt.Errorf("Hocr: %w", err)
 	}
@@ -198,7 +257,7 @@ func (t *Tests) HocrContainsWordBoxes(ctx context.Context) error {
 // namespace, since its consumers are schema-driven archive tooling that will
 // reject anything else outright.
 func (t *Tests) AltoIsValidXml(ctx context.Context) error {
-	got, err := dag.Tesseract().Document(fixture(sentencePng)).Alto().Contents(ctx)
+	got, err := ocr().Document(fixture(sentencePng)).Alto().Contents(ctx)
 	if err != nil {
 		return fmt.Errorf("Alto: %w", err)
 	}
@@ -217,7 +276,7 @@ func (t *Tests) AltoIsValidXml(ctx context.Context) error {
 // descends all the way to word-level rows (level 5), which is the level
 // carrying the text and its confidence.
 func (t *Tests) TsvHasHeaderAndWordRows(ctx context.Context) error {
-	got, err := dag.Tesseract().Document(fixture(sentencePng)).Tsv().Contents(ctx)
+	got, err := ocr().Document(fixture(sentencePng)).Tsv().Contents(ctx)
 	if err != nil {
 		return fmt.Errorf("Tsv: %w", err)
 	}
@@ -251,7 +310,7 @@ func (t *Tests) TsvHasHeaderAndWordRows(ctx context.Context) error {
 // bytes go through the filesystem rather than File.Contents, which mangles
 // non-UTF-8 data.
 func (t *Tests) PdfHasPdfMagic(ctx context.Context) error {
-	got, err := exportBytes(ctx, dag.Tesseract().Document(fixture(sentencePng)).Pdf(), "result.pdf")
+	got, err := exportBytes(ctx, ocr().Document(fixture(sentencePng)).Pdf(), "result.pdf")
 	if err != nil {
 		return err
 	}
@@ -269,7 +328,7 @@ func (t *Tests) PdfHasPdfMagic(ctx context.Context) error {
 // exec is what proves they came from one recognition pass rather than six: the
 // per-format functions each run their own.
 func (t *Tests) ExportProducesEveryRequestedFormat(ctx context.Context) error {
-	out := dag.Tesseract().Document(fixture(sentencePng)).Export([]dagger.TesseractFormat{
+	out := ocr().Document(fixture(sentencePng)).Export([]dagger.TesseractFormat{
 		dagger.TesseractFormatTxt,
 		dagger.TesseractFormatHocr,
 		dagger.TesseractFormatAlto,
@@ -289,7 +348,7 @@ func (t *Tests) ExportProducesEveryRequestedFormat(ctx context.Context) error {
 
 	// A subset request renders only that subset, so the trailing configfile
 	// list really is what drives the renderers.
-	entries, err = dag.Tesseract().Document(fixture(sentencePng)).
+	entries, err = ocr().Document(fixture(sentencePng)).
 		Export([]dagger.TesseractFormat{dagger.TesseractFormatTxt, dagger.TesseractFormatTsv}).
 		Entries(ctx)
 	if err != nil {
@@ -310,7 +369,7 @@ func (t *Tests) ExportProducesEveryRequestedFormat(ctx context.Context) error {
 // which is the observable proof the flag was passed, without asserting on
 // whatever garbage the constrained mode happens to produce.
 func (t *Tests) SingleWordPageSegReturnsFewerWords(ctx context.Context) error {
-	doc := dag.Tesseract().Document(fixture(sentencePng))
+	doc := ocr().Document(fixture(sentencePng))
 
 	full, err := doc.Text(ctx)
 	if err != nil {
@@ -343,7 +402,7 @@ func (t *Tests) LstmEngineRecognizesFixture(ctx context.Context) error {
 		dagger.TesseractEngineModeDefault,
 	}
 	for _, mode := range modes {
-		got, err := dag.Tesseract().Document(fixture(sentencePng)).WithEngine(mode).Text(ctx)
+		got, err := ocr().Document(fixture(sentencePng)).WithEngine(mode).Text(ctx)
 		if err != nil {
 			return fmt.Errorf("Text with engine %s: %w", mode, err)
 		}
@@ -362,7 +421,7 @@ func (t *Tests) LstmEngineRecognizesFixture(ctx context.Context) error {
 // that simply had no effect. The same test pins the other half: a real
 // parameter still goes through, so the check is not just rejecting everything.
 func (t *Tests) UnknownParameterFails(ctx context.Context) error {
-	_, err := dag.Tesseract().Document(fixture(sentencePng)).
+	_, err := ocr().Document(fixture(sentencePng)).
 		WithParameter("not_a_real_parameter", "1").
 		Text(ctx)
 	if err == nil {
@@ -376,7 +435,7 @@ func (t *Tests) UnknownParameterFails(ctx context.Context) error {
 
 	// tessedit_char_whitelist restricts recognition to the listed characters,
 	// which is both a real parameter and one whose effect is visible.
-	got, err := dag.Tesseract().Document(fixture(sentencePng)).
+	got, err := ocr().Document(fixture(sentencePng)).
 		WithParameter("tessedit_char_whitelist", "0123456789").
 		Text(ctx)
 	if err != nil {
@@ -401,7 +460,7 @@ func (t *Tests) UserWordsFileIsAccepted(ctx context.Context) error {
 	words := textFile("user-words.txt", "vexingly\nSphinx\nquartz\n")
 	patterns := textFile("user-patterns.txt", `\d\d\d-\d\d\d\d`+"\n")
 
-	got, err := dag.Tesseract().Document(fixture(sentencePng)).
+	got, err := ocr().Document(fixture(sentencePng)).
 		WithUserWords(words).
 		WithUserPatterns(patterns).
 		Text(ctx)
@@ -415,9 +474,9 @@ func (t *Tests) UserWordsFileIsAccepted(ctx context.Context) error {
 // the rotated fixture and reports the rotation that would undo it, while the
 // upright fixture reports no rotation at all.
 func (t *Tests) OsdDetectsRotation(ctx context.Context) error {
-	ocr := dag.Tesseract(dagger.TesseractOpts{Languages: []string{"eng", "osd"}})
+	withOsd := ocr("eng", "osd")
 
-	rotated, err := ocr.Document(fixture(sentenceRot90Png)).Osd(ctx)
+	rotated, err := withOsd.Document(fixture(sentenceRot90Png)).Osd(ctx)
 	if err != nil {
 		return fmt.Errorf("Osd on the rotated fixture: %w", err)
 	}
@@ -427,7 +486,7 @@ func (t *Tests) OsdDetectsRotation(ctx context.Context) error {
 		}
 	}
 
-	upright, err := ocr.Document(fixture(sentencePng)).Osd(ctx)
+	upright, err := withOsd.Document(fixture(sentencePng)).Osd(ctx)
 	if err != nil {
 		return fmt.Errorf("Osd on the upright fixture: %w", err)
 	}
@@ -444,7 +503,7 @@ func (t *Tests) OsdDetectsRotation(ctx context.Context) error {
 // traineddata paths and TESSDATA_PREFIX, which says nothing about the fact
 // that languages are chosen on New.
 func (t *Tests) UnknownLanguageIsRejected(ctx context.Context) error {
-	_, err := dag.Tesseract().Document(fixture(sentencePng)).
+	_, err := ocr().Document(fixture(sentencePng)).
 		WithLanguage("deu").
 		Text(ctx)
 	if err == nil {
@@ -458,7 +517,7 @@ func (t *Tests) UnknownLanguageIsRejected(ctx context.Context) error {
 
 	// A `+`-joined selection is validated code by code, so one bad member in
 	// an otherwise-installed list is caught too.
-	_, err = dag.Tesseract(dagger.TesseractOpts{Languages: []string{"eng", "deu"}}).
+	_, err = ocr("eng", "deu").
 		Document(fixture(sentencePng)).
 		WithLanguage("eng+deu+fra").
 		Text(ctx)
@@ -475,7 +534,7 @@ func (t *Tests) UnknownLanguageIsRejected(ctx context.Context) error {
 // without the osd model names the fix rather than failing inside tesseract,
 // which would report a missing traineddata file.
 func (t *Tests) OsdWithoutOsdDataIsRejected(ctx context.Context) error {
-	_, err := dag.Tesseract().Document(fixture(sentenceRot90Png)).Osd(ctx)
+	_, err := ocr().Document(fixture(sentenceRot90Png)).Osd(ctx)
 	if err == nil {
 		return fmt.Errorf("expected Osd without the osd model to be rejected, got nil")
 	}
@@ -491,7 +550,7 @@ func (t *Tests) OsdWithoutOsdDataIsRejected(ctx context.Context) error {
 // no PDF support and reports the failure as if the file's first line were a
 // file name it could not open, which sends people looking in the wrong place.
 func (t *Tests) PdfInputIsRejected(ctx context.Context) error {
-	_, err := dag.Tesseract().Document(textFile("scan.pdf", "%PDF-1.7\n")).Text(ctx)
+	_, err := ocr().Document(textFile("scan.pdf", "%PDF-1.7\n")).Text(ctx)
 	if err == nil {
 		return fmt.Errorf("expected a PDF source to be rejected, got nil")
 	}
@@ -507,7 +566,7 @@ func (t *Tests) PdfInputIsRejected(ctx context.Context) error {
 // carrying its own `=`, are refused. `-c` takes `name=value`, so an embedded
 // `=` would quietly set a different variable to a different value.
 func (t *Tests) MalformedParameterNameIsRejected(ctx context.Context) error {
-	_, err := dag.Tesseract().Document(fixture(sentencePng)).
+	_, err := ocr().Document(fixture(sentencePng)).
 		WithParameter("tessedit_char_whitelist=0123", "9").
 		Text(ctx)
 	if err == nil {
@@ -517,7 +576,7 @@ func (t *Tests) MalformedParameterNameIsRejected(ctx context.Context) error {
 		return fmt.Errorf("expected the error to name the = rule, got: %v", err)
 	}
 
-	_, err = dag.Tesseract().Document(fixture(sentencePng)).
+	_, err = ocr().Document(fixture(sentencePng)).
 		WithParameter("  ", "9").
 		Text(ctx)
 	if err == nil {
@@ -534,7 +593,7 @@ func (t *Tests) MalformedParameterNameIsRejected(ctx context.Context) error {
 // and scale its analysis by it.
 func (t *Tests) NonPositiveDpiIsRejected(ctx context.Context) error {
 	for _, dpi := range []int{0, -300} {
-		_, err := dag.Tesseract().Document(fixture(sentencePng)).WithDpi(dpi).Text(ctx)
+		_, err := ocr().Document(fixture(sentencePng)).WithDpi(dpi).Text(ctx)
 		if err == nil {
 			return fmt.Errorf("expected dpi %d to be rejected, got nil", dpi)
 		}
@@ -545,7 +604,7 @@ func (t *Tests) NonPositiveDpiIsRejected(ctx context.Context) error {
 
 	// A positive value still goes through, so the check is not just
 	// rejecting every use of the flag.
-	got, err := dag.Tesseract().Document(fixture(sentencePng)).WithDpi(300).Text(ctx)
+	got, err := ocr().Document(fixture(sentencePng)).WithDpi(300).Text(ctx)
 	if err != nil {
 		return fmt.Errorf("Text with dpi 300: %w", err)
 	}
@@ -553,6 +612,35 @@ func (t *Tests) NonPositiveDpiIsRejected(ctx context.Context) error {
 }
 
 // ------------------------------------------------------------------ helpers
+
+// ocr builds the module under test with the suite's OpenMP bound and the given
+// language set; no languages leaves New's own default in place.
+//
+// Every test that recognises anything goes through this rather than
+// dag.Tesseract() directly, so the bound cannot be forgotten on a newly added
+// test. The failure mode it guards against is a slow suite, not a red one,
+// which is exactly the kind that goes unnoticed for a release.
+// OmpThreadLimitBoundsOpenMp is the deliberate exception: it is the test of
+// what the unbounded default does.
+func ocr(languages ...string) *dagger.Tesseract {
+	return dag.Tesseract(dagger.TesseractOpts{
+		Languages:      languages,
+		OmpThreadLimit: suiteOmpThreadLimit,
+	})
+}
+
+// readOmpThreadLimit reports the OpenMP bound as the environment inside the
+// image sees it rather than as container metadata, because what decides
+// recognition's fan-out is what the tesseract process inherits.
+func readOmpThreadLimit(ctx context.Context, t *dagger.Tesseract) (string, error) {
+	out, err := t.Container().
+		WithExec([]string{"sh", "-c", `printf %s "$` + ompThreadLimitEnv + `"`}).
+		Stdout(ctx)
+	if err != nil {
+		return "", fmt.Errorf("read %s from the image: %w", ompThreadLimitEnv, err)
+	}
+	return out, nil
+}
 
 // fixture returns a committed test image by name under fixtures/.
 func fixture(name string) *dagger.File {


### PR DESCRIPTION
Closes #226

`tesseract-tests:all` needed **9m5s** on a GitHub Actions runner while the same suite finishes in 22s on a cold 4-vCPU engine locally. Every other leg in that run matched its historical time — tesseract was an outlier against itself.

## Cause

Alpine's tesseract links `libgomp` and reports `Found OpenMP 201511`, and the module set no OMP environment at all, so every recognition sized its thread teams by the host CPU count. `Tests.All` fires ~20 of them at once: on a four-core runner that is ~80 threads over 4 cores.

Reproduced directly — eleven concurrent passes over the 4-line test fixture, pinned with `taskset`:

| CPUs | `OMP_THREAD_LIMIT` | wall | user |
| --- | --- | --- | --- |
| 4 | unset | **8m34s** | 34m7s |
| 4 | `1` | **1.06s** | 3.02s |
| 32 | unset | 0.68s | 9.36s |
| 32 | `1` | 0.55s | 3.56s |

Same work, ~485x apart, and the 8m34s lands on top of the 9m5s the runner reported. Load average during the first leg sat at 44 — exactly 11 processes × 4 threads.

## Change

`New` gains an optional `ompThreadLimit` that sets `OMP_THREAD_LIMIT` on the assembled image.

It is **opt-in rather than defaulted**: unbounded is right for the common case of one caller who owns the machine, and the 32-CPU rows show that case costs nothing. Callers sharing cores set it — the tests module sets `1` for every image it builds, routed through an `ocr()` helper so a newly added test cannot forget. A negative value is rejected on `New`, because libgomp reads an unparseable `OMP_THREAD_LIMIT` as absent and silently goes back to one thread per CPU.

The variable is applied after `apk add`, so two images differing only in their limit still share the package fetch, and it rides on `Container()` so everything reached through the escape hatch inherits it.

## `Tests.All` parallel default

Kept at `0`. Its old justification — *"in-runner parallelism is bounded by the VM's CPU/memory"* — was the false claim this issue disproves: an unbounded tesseract **multiplied** by the core count rather than being bounded by it. With one thread per pass the claim finally holds, and the comment now names which of the two knobs is load-bearing.

## CI

Reverts the 6m → 12m module-suite leg bound from a19f611, which was a workaround for this bug — the leg really was running for nine minutes, not stalling on the Dagger Cloud telemetry drain.

## Verification

- `dagger -m daggerverse/tesseract/tests call all` — green
- `dagger check ci:generated` — OK (bindings regenerated in module, tests, and root)
- The 6m bound is exercised by this PR's own `tesseract-tests:all` leg

🤖 Generated with [Claude Code](https://claude.com/claude-code)