### PR TITLE
story(issue-219): mount caller-supplied traineddata via --tessdata-dir

### DIFF
--- a/ci/internal/dagger/tesseract-tests.gen.go
+++ b/ci/internal/dagger/tesseract-tests.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type TesseractTests
-func (r *Binding) AsTesseractTests() *TesseractTests { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:57:6)
+func (r *Binding) AsTesseractTests() *TesseractTests { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:62:6)
 	q := r.query.Select("asTesseractTests")
 
 	return &TesseractTests{
@@ -19,7 +19,7 @@ func (r *Binding) AsTesseractTests() *TesseractTests { // tesseract-tests (../..
 }
 
 // Create or update a binding of type TesseractTests in the environment
-func (r *Env) WithTesseractTestsInput(name string, value *TesseractTests, description string) *Env { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:57:6)
+func (r *Env) WithTesseractTestsInput(name string, value *TesseractTests, description string) *Env { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:62:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withTesseractTestsInput")
 	q = q.Arg("name", name)
@@ -32,7 +32,7 @@ func (r *Env) WithTesseractTestsInput(name string, value *TesseractTests, descri
 }
 
 // Declare a desired TesseractTests output to be assigned in the environment
-func (r *Env) WithTesseractTestsOutput(name string, description string) *Env { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:57:6)
+func (r *Env) WithTesseractTestsOutput(name string, description string) *Env { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:62:6)
 	q := r.query.Select("withTesseractTestsOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -50,7 +50,7 @@ func (r *Env) WithTesseractTestsOutput(name string, description string) *Env { /
 // The fixtures under fixtures/ are committed rather than generated in-container:
 // bare Alpine ships no fonts, so rendering text inside the toolchain image would
 // mean pulling in fontconfig and a font package purely to make the tests run.
-func (r *Query) TesseractTests() *TesseractTests { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:57:6)
+func (r *Query) TesseractTests() *TesseractTests { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:62:6)
 	q := r.query.Select("tesseractTests")
 
 	return &TesseractTests{
@@ -58,32 +58,35 @@ func (r *Query) TesseractTests() *TesseractTests { // tesseract-tests (../../../
 	}
 }
 
-type TesseractTests struct { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:57:6)
+type TesseractTests struct { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:62:6)
 	query *querybuilder.Selection
 
-	all                                *Void
-	altoIsValidXml                     *Void
-	defaultLanguagesInstallEnglish     *Void
-	exportProducesEveryRequestedFormat *Void
-	hocrContainsWordBoxes              *Void
-	id                                 *ID
-	lstmEngineRecognizesFixture        *Void
-	malformedParameterNameIsRejected   *Void
-	nonPositiveDpiIsRejected           *Void
-	ompThreadLimitBoundsOpenMp         *Void
-	osdDetectsRotation                 *Void
-	osdWithoutOsdDataIsRejected        *Void
-	pdfHasPdfMagic                     *Void
-	pdfInputIsRejected                 *Void
-	requestedLanguagesAreInstalled     *Void
-	singleWordPageSegReturnsFewerWords *Void
-	textRecognizesFixture              *Void
-	tsvHasHeaderAndWordRows            *Void
-	txtFileMatchesText                 *Void
-	unknownLanguageIsRejected          *Void
-	unknownParameterFails              *Void
-	userWordsFileIsAccepted            *Void
-	versionReportsTesseractFive        *Void
+	all                                 *Void
+	altoIsValidXml                      *Void
+	defaultLanguagesInstallEnglish      *Void
+	exportProducesEveryRequestedFormat  *Void
+	hocrContainsWordBoxes               *Void
+	id                                  *ID
+	lstmEngineRecognizesFixture         *Void
+	malformedParameterNameIsRejected    *Void
+	nonPositiveDpiIsRejected            *Void
+	ompThreadLimitBoundsOpenMp          *Void
+	osdDetectsRotation                  *Void
+	osdWithoutOsdDataIsRejected         *Void
+	pdfHasPdfMagic                      *Void
+	pdfInputIsRejected                  *Void
+	requestedLanguagesAreInstalled      *Void
+	singleWordPageSegReturnsFewerWords  *Void
+	tessdataDoesNotAdmitUnknownLanguage *Void
+	tessdataModelIsSelectable           *Void
+	tessdataSuppliesOsdModel            *Void
+	textRecognizesFixture               *Void
+	tsvHasHeaderAndWordRows             *Void
+	txtFileMatchesText                  *Void
+	unknownLanguageIsRejected           *Void
+	unknownParameterFails               *Void
+	userWordsFileIsAccepted             *Void
+	versionReportsTesseractFive         *Void
 }
 
 func (r *TesseractTests) WithGraphQLQuery(q *querybuilder.Selection) *TesseractTests {
@@ -94,7 +97,7 @@ func (r *TesseractTests) WithGraphQLQuery(q *querybuilder.Selection) *TesseractT
 
 // TesseractTestsAllOpts contains options for TesseractTests.All
 type TesseractTestsAllOpts struct {
-	Parallel int // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:79:2)
+	Parallel int // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:84:2)
 }
 
 // All runs every tesseract-module test in parallel.
@@ -111,7 +114,7 @@ type TesseractTestsAllOpts struct {
 // thread per pass the claim finally holds, and jobs contend for cores the way
 // any other oversubscribed workload does. The cap stays available for a host
 // that wants a narrower slice.
-func (r *TesseractTests) All(ctx context.Context, opts ...TesseractTestsAllOpts) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:76:1)
+func (r *TesseractTests) All(ctx context.Context, opts ...TesseractTestsAllOpts) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:81:1)
 	if r.all != nil {
 		return nil
 	}
@@ -129,7 +132,7 @@ func (r *TesseractTests) All(ctx context.Context, opts ...TesseractTestsAllOpts)
 // AltoIsValidXml asserts the ALTO renderer emits well-formed XML in the ALTO
 // namespace, since its consumers are schema-driven archive tooling that will
 // reject anything else outright.
-func (r *TesseractTests) AltoIsValidXML(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:259:1)
+func (r *TesseractTests) AltoIsValidXML(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:268:1)
 	if r.altoIsValidXml != nil {
 		return nil
 	}
@@ -142,7 +145,7 @@ func (r *TesseractTests) AltoIsValidXML(ctx context.Context) error { // tesserac
 // English and nothing else. The base apk package carries no language data at
 // all, so an empty default would produce an image that cannot recognise
 // anything.
-func (r *TesseractTests) DefaultLanguagesInstallEnglish(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:136:1)
+func (r *TesseractTests) DefaultLanguagesInstallEnglish(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:145:1)
 	if r.defaultLanguagesInstallEnglish != nil {
 		return nil
 	}
@@ -155,7 +158,7 @@ func (r *TesseractTests) DefaultLanguagesInstallEnglish(ctx context.Context) err
 // formats. That the artifacts arrive in a single directory lifted off a single
 // exec is what proves they came from one recognition pass rather than six: the
 // per-format functions each run their own.
-func (r *TesseractTests) ExportProducesEveryRequestedFormat(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:330:1)
+func (r *TesseractTests) ExportProducesEveryRequestedFormat(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:339:1)
 	if r.exportProducesEveryRequestedFormat != nil {
 		return nil
 	}
@@ -166,7 +169,7 @@ func (r *TesseractTests) ExportProducesEveryRequestedFormat(ctx context.Context)
 
 // HocrContainsWordBoxes asserts hOCR carries the per-word geometry that is the
 // whole reason to ask for it rather than plain text.
-func (r *TesseractTests) HocrContainsWordBoxes(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:236:1)
+func (r *TesseractTests) HocrContainsWordBoxes(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:245:1)
 	if r.hocrContainsWordBoxes != nil {
 		return nil
 	}
@@ -231,7 +234,7 @@ func (r *TesseractTests) UnmarshalJSON(bs []byte) error {
 // is that no member is dead: LEGACY and LEGACY_LSTM only work because Alpine
 // packages the *combined* tessdata models. A rebuild against tessdata_fast or
 // tessdata_best would strip the legacy data and this is where that shows up.
-func (r *TesseractTests) LstmEngineRecognizesFixture(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:397:1)
+func (r *TesseractTests) LstmEngineRecognizesFixture(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:486:1)
 	if r.lstmEngineRecognizesFixture != nil {
 		return nil
 	}
@@ -243,7 +246,7 @@ func (r *TesseractTests) LstmEngineRecognizesFixture(ctx context.Context) error 
 // MalformedParameterNameIsRejected asserts an empty parameter name, and one
 // carrying its own `=`, are refused. `-c` takes `name=value`, so an embedded
 // `=` would quietly set a different variable to a different value.
-func (r *TesseractTests) MalformedParameterNameIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:568:1)
+func (r *TesseractTests) MalformedParameterNameIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:678:1)
 	if r.malformedParameterNameIsRejected != nil {
 		return nil
 	}
@@ -255,7 +258,7 @@ func (r *TesseractTests) MalformedParameterNameIsRejected(ctx context.Context) e
 // NonPositiveDpiIsRejected asserts a zero or negative resolution is refused
 // rather than handed to tesseract, which would take it as a real measurement
 // and scale its analysis by it.
-func (r *TesseractTests) NonPositiveDpiIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:594:1)
+func (r *TesseractTests) NonPositiveDpiIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:704:1)
 	if r.nonPositiveDpiIsRejected != nil {
 		return nil
 	}
@@ -274,7 +277,7 @@ func (r *TesseractTests) NonPositiveDpiIsRejected(ctx context.Context) error { /
 // works at all: without it, anything running several recognitions at once has
 // no way to stop each pass claiming every core, which cost this very suite
 // nine minutes on a four-core runner (#226).
-func (r *TesseractTests) OmpThreadLimitBoundsOpenMp(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:173:1)
+func (r *TesseractTests) OmpThreadLimitBoundsOpenMp(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:182:1)
 	if r.ompThreadLimitBoundsOpenMp != nil {
 		return nil
 	}
@@ -286,7 +289,7 @@ func (r *TesseractTests) OmpThreadLimitBoundsOpenMp(ctx context.Context) error {
 // OsdDetectsRotation asserts orientation detection reads the quarter-turn in
 // the rotated fixture and reports the rotation that would undo it, while the
 // upright fixture reports no rotation at all.
-func (r *TesseractTests) OsdDetectsRotation(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:476:1)
+func (r *TesseractTests) OsdDetectsRotation(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:565:1)
 	if r.osdDetectsRotation != nil {
 		return nil
 	}
@@ -298,7 +301,7 @@ func (r *TesseractTests) OsdDetectsRotation(ctx context.Context) error { // tess
 // OsdWithoutOsdDataIsRejected asserts orientation detection on an image built
 // without the osd model names the fix rather than failing inside tesseract,
 // which would report a missing traineddata file.
-func (r *TesseractTests) OsdWithoutOsdDataIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:536:1)
+func (r *TesseractTests) OsdWithoutOsdDataIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:646:1)
 	if r.osdWithoutOsdDataIsRejected != nil {
 		return nil
 	}
@@ -310,7 +313,7 @@ func (r *TesseractTests) OsdWithoutOsdDataIsRejected(ctx context.Context) error 
 // PdfHasPdfMagic asserts the searchable-PDF renderer emits a real PDF. The
 // bytes go through the filesystem rather than File.Contents, which mangles
 // non-UTF-8 data.
-func (r *TesseractTests) PdfHasPdfMagic(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:312:1)
+func (r *TesseractTests) PdfHasPdfMagic(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:321:1)
 	if r.pdfHasPdfMagic != nil {
 		return nil
 	}
@@ -322,7 +325,7 @@ func (r *TesseractTests) PdfHasPdfMagic(ctx context.Context) error { // tesserac
 // PdfInputIsRejected asserts a PDF source is refused up front. Leptonica has
 // no PDF support and reports the failure as if the file's first line were a
 // file name it could not open, which sends people looking in the wrong place.
-func (r *TesseractTests) PdfInputIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:552:1)
+func (r *TesseractTests) PdfInputIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:662:1)
 	if r.pdfInputIsRejected != nil {
 		return nil
 	}
@@ -334,7 +337,7 @@ func (r *TesseractTests) PdfInputIsRejected(ctx context.Context) error { // tess
 // RequestedLanguagesAreInstalled asserts every requested language lands in the
 // image as its own apk package, including "osd", which is a detection model
 // rather than a recognition language.
-func (r *TesseractTests) RequestedLanguagesAreInstalled(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:150:1)
+func (r *TesseractTests) RequestedLanguagesAreInstalled(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:159:1)
 	if r.requestedLanguagesAreInstalled != nil {
 		return nil
 	}
@@ -348,7 +351,7 @@ func (r *TesseractTests) RequestedLanguagesAreInstalled(ctx context.Context) err
 // that finds the lines, so it returns far less than the default mode does —
 // which is the observable proof the flag was passed, without asserting on
 // whatever garbage the constrained mode happens to produce.
-func (r *TesseractTests) SingleWordPageSegReturnsFewerWords(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:371:1)
+func (r *TesseractTests) SingleWordPageSegReturnsFewerWords(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:460:1)
 	if r.singleWordPageSegReturnsFewerWords != nil {
 		return nil
 	}
@@ -357,9 +360,64 @@ func (r *TesseractTests) SingleWordPageSegReturnsFewerWords(ctx context.Context)
 	return q.Execute(ctx)
 }
 
+// TessdataDoesNotAdmitUnknownLanguage asserts the union is still a closed set:
+// mounting a tessdata directory adds the models it holds and nothing else, so a
+// language neither half carries is rejected the same way it was before, with
+// both halves listed and both ways of adding one named.
+func (r *TesseractTests) TessdataDoesNotAdmitUnknownLanguage(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:626:1)
+	if r.tessdataDoesNotAdmitUnknownLanguage != nil {
+		return nil
+	}
+	q := r.query.Select("tessdataDoesNotAdmitUnknownLanguage")
+
+	return q.Execute(ctx)
+}
+
+// TessdataModelIsSelectable asserts a caller-supplied model is a first-class
+// language: Langs lists it alongside the packaged set, WithLanguage accepts it,
+// and recognition under that name reproduces the fixture.
+//
+// The model is the image's own eng.traineddata lifted back out and re-mounted
+// under a different stem. That needs no committed binary fixture and still
+// proves the whole path: "custom" is a name no Alpine package could ever
+// install, so recognising English text under it can only mean the caller's
+// directory reached tesseract.
+//
+// The packaged language and the PDF render are asserted through the same
+// module because the caller's directory has to be merged with the packaged one
+// rather than swapped for it. `--tessdata-dir` moves the whole datadir, and
+// that directory carries more than models: `configs/` holds the renderer
+// configfiles, and pdf.ttf is what the PDF renderer draws its invisible text
+// layer with. Pointed at the caller's directory alone, every renderer breaks
+// and every packaged language disappears.
+func (r *TesseractTests) TessdataModelIsSelectable(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:392:1)
+	if r.tessdataModelIsSelectable != nil {
+		return nil
+	}
+	q := r.query.Select("tessdataModelIsSelectable")
+
+	return q.Execute(ctx)
+}
+
+// TessdataSuppliesOsdModel asserts orientation detection accepts an osd model
+// that arrived through WithTessdata rather than through its apk package.
+//
+// Osd is the one place that asks whether a specific model is present, and it
+// answered from the requested package set alone. A supplied osd.traineddata
+// would have been refused by this module while sitting right there in the
+// image, which is the failure mode this pins.
+func (r *TesseractTests) TessdataSuppliesOsdModel(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:438:1)
+	if r.tessdataSuppliesOsdModel != nil {
+		return nil
+	}
+	q := r.query.Select("tessdataSuppliesOsdModel")
+
+	return q.Execute(ctx)
+}
+
 // TextRecognizesFixture asserts the shortest path — image in, string out —
 // reproduces every line the fixture renders.
-func (r *TesseractTests) TextRecognizesFixture(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:207:1)
+func (r *TesseractTests) TextRecognizesFixture(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:216:1)
 	if r.textRecognizesFixture != nil {
 		return nil
 	}
@@ -371,7 +429,7 @@ func (r *TesseractTests) TextRecognizesFixture(ctx context.Context) error { // t
 // TsvHasHeaderAndWordRows asserts the TSV renderer emits its column header and
 // descends all the way to word-level rows (level 5), which is the level
 // carrying the text and its confidence.
-func (r *TesseractTests) TsvHasHeaderAndWordRows(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:278:1)
+func (r *TesseractTests) TsvHasHeaderAndWordRows(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:287:1)
 	if r.tsvHasHeaderAndWordRows != nil {
 		return nil
 	}
@@ -382,7 +440,7 @@ func (r *TesseractTests) TsvHasHeaderAndWordRows(ctx context.Context) error { //
 
 // TxtFileMatchesText asserts the txt renderer and the stdout path agree, so
 // choosing a file over a string is purely a plumbing decision.
-func (r *TesseractTests) TxtFileMatchesText(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:217:1)
+func (r *TesseractTests) TxtFileMatchesText(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:226:1)
 	if r.txtFileMatchesText != nil {
 		return nil
 	}
@@ -395,7 +453,7 @@ func (r *TesseractTests) TxtFileMatchesText(ctx context.Context) error { // tess
 // rejected with the installed set named. tesseract's own failure talks about
 // traineddata paths and TESSDATA_PREFIX, which says nothing about the fact
 // that languages are chosen on New.
-func (r *TesseractTests) UnknownLanguageIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:505:1)
+func (r *TesseractTests) UnknownLanguageIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:594:1)
 	if r.unknownLanguageIsRejected != nil {
 		return nil
 	}
@@ -411,7 +469,7 @@ func (r *TesseractTests) UnknownLanguageIsRejected(ctx context.Context) error { 
 // and exits 0, so a typo would otherwise be indistinguishable from a setting
 // that simply had no effect. The same test pins the other half: a real
 // parameter still goes through, so the check is not just rejecting everything.
-func (r *TesseractTests) UnknownParameterFails(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:423:1)
+func (r *TesseractTests) UnknownParameterFails(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:512:1)
 	if r.unknownParameterFails != nil {
 		return nil
 	}
@@ -429,7 +487,7 @@ func (r *TesseractTests) UnknownParameterFails(ctx context.Context) error { // t
 // a dictionary hint on an already-clean fixture is not reliably observable.
 // What this does catch is a wrong mount path or a flag emitted in the wrong
 // position, either of which turns the whole run into a usage error.
-func (r *TesseractTests) UserWordsFileIsAccepted(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:459:1)
+func (r *TesseractTests) UserWordsFileIsAccepted(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:548:1)
 	if r.userWordsFileIsAccepted != nil {
 		return nil
 	}
@@ -441,7 +499,7 @@ func (r *TesseractTests) UserWordsFileIsAccepted(ctx context.Context) error { //
 // VersionReportsTesseractFive asserts the assembled image ships the tesseract
 // release Alpine's community repository carries, so a base-tag bump that
 // silently changes major version fails here rather than in recognition.
-func (r *TesseractTests) VersionReportsTesseractFive(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:121:1)
+func (r *TesseractTests) VersionReportsTesseractFive(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:130:1)
 	if r.versionReportsTesseractFive != nil {
 		return nil
 	}

--- a/daggerverse/tesseract/README.md
+++ b/daggerverse/tesseract/README.md
@@ -35,6 +35,39 @@ dag.Tesseract(dagger.TesseractOpts{Languages: []string{"eng","deu","osd"}})
 dag.Tesseract(dagger.TesseractOpts{Registry: "ghcr.io"})            // mirror
 ```
 
+## Models Alpine has no package for — `WithTessdata`
+
+```go
+Tesseract.WithTessdata(dir *dagger.Directory) *Tesseract    // --tessdata-dir
+```
+
+The package set is a floor, not a ceiling. A fine-tuned model, a `tessdata_best`
+or `tessdata_fast` variant, or a language with no apk package at all comes in as
+a directory of `.traineddata` files. Each file becomes a language named after its
+stem — `deu_frak.traineddata` is the language `deu_frak` — so renaming the file
+renames the model.
+
+```go
+dag.Tesseract().WithTessdata(host.Directory("./models"))
+```
+
+From there a supplied model is indistinguishable from a packaged one: `Langs`
+reports the union, `WithLanguage` accepts either, and `Osd` is satisfied by an
+`osd.traineddata` that arrived this way.
+
+The directory is **merged** with the packaged one rather than swapped for it.
+`--tessdata-dir` moves the whole datadir, and that directory holds more than
+models: `configs/` carries the renderer configfiles that recognition names as
+its trailing arguments, and `pdf.ttf` is what the PDF renderer draws its
+invisible text layer with. Pointed at the caller's directory alone, every
+renderer breaks and every packaged language disappears. On a name collision the
+caller's file wins, which is what makes replacing the stock `eng` with a
+fine-tuned one work.
+
+The merge is mounted, not copied — a model set runs 20MB and up, and there is no
+reason for it to become an image layer. Nothing changes for an image without
+tessdata: the flag is omitted entirely rather than pointed at the packaged path.
+
 ## OpenMP fan-out — `ompThreadLimit`
 
 Alpine's tesseract links `libgomp` and reports `Found OpenMP 201511`, so left
@@ -97,6 +130,7 @@ thread per CPU, the opposite of what was asked for.
 ## Toolchain
 
 ```go
+Tesseract.WithTessdata(dir *dagger.Directory) *Tesseract
 Tesseract.Container() *dagger.Container            // +cache="session"
 Tesseract.Version(ctx) (string, error)             // +cache="session"
 Tesseract.Langs(ctx) ([]string, error)             // +cache="session"
@@ -134,9 +168,11 @@ Document.WithUserWords(words *dagger.File) *Document        // --user-words
 Document.WithUserPatterns(patterns *dagger.File) *Document  // --user-patterns
 ```
 
-`WithLanguage` selects from what `New` installed; it cannot add a language.
-Unset, recognition runs in the first installed language rather than tesseract's
-hardcoded `eng`, so an image built with only `deu` still works.
+`WithLanguage` selects from what the image carries — the packages `New`
+installed and any model `WithTessdata` supplied — and cannot itself add one,
+since both are baked in when the image is assembled. Unset, recognition runs in
+the first language `New` installed rather than tesseract's hardcoded `eng`, so
+an image built with only `deu` still works.
 
 `WithParameter` takes a name and a value separately because Dagger functions
 cannot accept map parameters (the `kicad.Project.WithVar` precedent).
@@ -202,8 +238,8 @@ letting tesseract fail in its own vocabulary.
 
 | Rejected | Why the raw failure is worse |
 | --- | --- |
-| `WithLanguage` naming an uninstalled language | tesseract talks about traineddata paths and `TESSDATA_PREFIX`, never about the fact that languages are chosen on `New` |
-| `Osd` without `osd` in the language set | same, plus the fix is a different function's argument |
+| `WithLanguage` naming a language neither installed nor supplied | tesseract talks about traineddata paths and `TESSDATA_PREFIX`, never about the fact that models arrive via `New` or `WithTessdata` |
+| `Osd` with no `osd` model installed or supplied | same, plus the fix is a different function's argument |
 | a `.pdf` source | Leptonica has no PDF support and reports the file's first line as if it were a file name it could not open |
 | `WithParameter` with an empty name, or one containing `=` | `-c` takes `name=value`, so an embedded `=` silently sets a *different* variable |
 | `WithParameter` naming an unknown control variable | tesseract only warns (`Warning: The parameter '...' was not found.`) and exits 0, so a typo is indistinguishable from a no-op |
@@ -223,10 +259,9 @@ a floating Alpine tag can resolve differently across sessions.
 
 ## Follow-ups
 
-Caller-supplied traineddata via `--tessdata-dir` (#219); batch OCR over a
-directory of images (#220); PDF-input rasterization (#221); the training
-toolchain (#222); a chained `Ci` builder (#223); an `examples/go` cookbook
-(#224).
+Batch OCR over a directory of images (#220); PDF-input rasterization (#221);
+the training toolchain (#222); a chained `Ci` builder (#223); an `examples/go`
+cookbook (#224).
 
 GPU acceleration is **not** a follow-up: tesseract has no CUDA path and upstream
 does not plan one, Alpine builds without OpenCL, and Dagger's GPU passthrough is

--- a/daggerverse/tesseract/dagger.gen.go
+++ b/daggerverse/tesseract/dagger.gen.go
@@ -65,11 +65,13 @@ func (r Tesseract) MarshalJSON() ([]byte, error) {
 		AlpineTag      string
 		Languages      []string
 		OmpThreadLimit int
+		Tessdata       *dagger.Directory
 	}
 	concrete.Registry = r.Registry
 	concrete.AlpineTag = r.AlpineTag
 	concrete.Languages = r.Languages
 	concrete.OmpThreadLimit = r.OmpThreadLimit
+	concrete.Tessdata = r.Tessdata
 	return json.Marshal(&concrete)
 }
 
@@ -79,6 +81,7 @@ func (r *Tesseract) UnmarshalJSON(bs []byte) error {
 		AlpineTag      string
 		Languages      []string
 		OmpThreadLimit int
+		Tessdata       *dagger.Directory
 	}
 	err := json.Unmarshal(bs, &concrete)
 	if err != nil {
@@ -88,6 +91,7 @@ func (r *Tesseract) UnmarshalJSON(bs []byte) error {
 	r.AlpineTag = concrete.AlpineTag
 	r.Languages = concrete.Languages
 	r.OmpThreadLimit = concrete.OmpThreadLimit
+	r.Tessdata = concrete.Tessdata
 	return nil
 }
 
@@ -698,6 +702,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return (*Tesseract).Version(&parent, ctx)
+		case "WithTessdata":
+			var parent Tesseract
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var dir *dagger.Directory
+			if inputArgs["dir"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["dir"]), &dir)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg dir", err))
+				}
+			}
+			return (*Tesseract).WithTessdata(&parent, dir), nil
 		case "":
 			var parent Tesseract
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/tesseract/document.go
+++ b/daggerverse/tesseract/document.go
@@ -46,10 +46,11 @@ type Document struct {
 // be combined with `+`, as in "eng+deu", in which case tesseract loads all of
 // them for one pass.
 //
-// The value picks from what New installed; it cannot add a language, because
-// each one is a separate apk package baked into the image. An unknown value is
-// rejected at output time with the installed set listed. Unset, recognition
-// runs in the first installed language.
+// The value picks from what the image carries — the packages New installed and
+// any model WithTessdata supplied — and cannot itself add a language, since
+// both of those are baked in when the image is assembled. An unknown value is
+// rejected at output time with the available set listed. Unset, recognition
+// runs in the first language New installed.
 func (d *Document) WithLanguage(lang string) *Document {
 	out := d.clone()
 	out.Language = lang
@@ -195,18 +196,25 @@ func (d *Document) Export(
 // It builds its own invocation rather than reusing the document's recognition
 // options: orientation detection runs off the osd model alone, so the selected
 // language, engine and page-segmentation mode have nothing to say about it.
-// The `osd` package must be in the language set New was given.
+// The osd model has to be in the image: either as the package New installs for
+// it, or as an osd.traineddata WithTessdata supplied.
 func (d *Document) Osd(ctx context.Context) (string, error) {
-	if !d.Tesseract.hasLanguage(osdLanguage) {
+	ok, err := d.Tesseract.hasModel(ctx, osdLanguage)
+	if err != nil {
+		return "", err
+	}
+	if !ok {
 		return "", fmt.Errorf(
-			"Osd: the %q model is not installed: pass it to New(languages:) alongside the recognition languages (installed: %s)",
+			"Osd: the %q model is not installed: pass it to New(languages:) alongside the recognition languages, or supply it with WithTessdata (installed packages: %s)",
 			osdLanguage, strings.Join(d.Tesseract.Languages, ", "))
 	}
 	source, err := d.validate(ctx)
 	if err != nil {
 		return "", err
 	}
-	args := []string{"tesseract", source, stdoutBase, "-l", osdLanguage, "--psm", pageSegTokens[PageSegModeOsdOnly]}
+	args := []string{"tesseract", source, stdoutBase}
+	args = append(args, d.Tesseract.tessdataArgs()...)
+	args = append(args, "-l", osdLanguage, "--psm", pageSegTokens[PageSegModeOsdOnly])
 	if d.HasDpi {
 		args = append(args, "--dpi", strconv.Itoa(d.Dpi))
 	}
@@ -315,6 +323,7 @@ func (d *Document) container(source string) *dagger.Container {
 // is a flag, and tesseract requires the flags first.
 func (d *Document) args(source string, output string, configs ...string) ([]string, error) {
 	args := []string{"tesseract", source, output}
+	args = append(args, d.Tesseract.tessdataArgs()...)
 	args = append(args, "-l", d.language())
 	if d.PageSeg != "" {
 		tok, ok := d.PageSeg.token()
@@ -426,7 +435,7 @@ func (d *Document) validateLanguage(ctx context.Context) error {
 		}
 		if !contains(installed, lang) {
 			return fmt.Errorf(
-				"WithLanguage: language %q is not installed: installed languages are %s; pass it to New(languages:) to add it",
+				"WithLanguage: language %q is not installed: installed languages are %s; pass it to New(languages:) to add its package, or supply its model with WithTessdata",
 				lang, strings.Join(installed, ", "))
 		}
 	}

--- a/daggerverse/tesseract/main.go
+++ b/daggerverse/tesseract/main.go
@@ -13,7 +13,9 @@
 // Alpine each language is a separate apk package (`tesseract-ocr-data-<lang>`,
 // none of which the base package pulls in). Selecting a language changes what
 // the image *is*, not just what a flag says; Document.WithLanguage only picks a
-// subset of what was installed.
+// subset of what was installed. WithTessdata is the same decision for models
+// Alpine has no package for — a directory of `.traineddata` merged into the
+// image's datadir, and from there indistinguishable from a packaged language.
 //
 // File map (all `package main`, surfaced as one Dagger module):
 //
@@ -63,6 +65,17 @@ const (
 	workDir   = "/work"
 	outputDir = "/out"
 
+	// packagedTessdataDir is where the apk packages drop their models. It
+	// holds more than models: `configs/` carries the renderer configfiles
+	// recognition names as its trailing arguments, and pdf.ttf is what the
+	// PDF renderer draws its invisible text layer with.
+	packagedTessdataDir = "/usr/share/tessdata"
+
+	// tessdataDir is the module-owned datadir WithTessdata merges the
+	// packaged models and the caller's into, and the path recognition then
+	// points --tessdata-dir at.
+	tessdataDir = "/tessdata"
+
 	// outputBase is the `tesseract IMAGE OUTPUTBASE` argument. Each renderer
 	// appends its own extension to it (see Format.ext).
 	outputBase = outputDir + "/result"
@@ -99,6 +112,8 @@ type Tesseract struct {
 	Languages []string
 	// +private
 	OmpThreadLimit int
+	// +private
+	Tessdata *dagger.Directory
 }
 
 // New returns a Tesseract module backed by <registry>/library/alpine:<tag>
@@ -144,6 +159,30 @@ func New(
 	}, nil
 }
 
+// WithTessdata adds a directory of `.traineddata` models to the image, which
+// is the only way to reach a model Alpine has no package for: a fine-tuned
+// model, a tessdata_best or tessdata_fast variant, or a language whose package
+// simply does not exist.
+//
+// Every file whose name ends in `.traineddata` becomes a language named after
+// its stem — `deu_frak.traineddata` is the language `deu_frak` — so a model is
+// renamed by renaming its file. Langs reports the union of these and the
+// packaged ones, and everything that takes a language name accepts either.
+//
+// The directory is merged with the packaged models rather than replacing them,
+// because tesseract's datadir is more than a bag of models: it also holds the
+// renderer configfiles and the font the PDF renderer needs. A caller-supplied
+// model wins over a packaged one of the same name, which is what makes
+// replacing the stock `eng` with a fine-tuned one work.
+func (t *Tesseract) WithTessdata(
+	// Directory of `.traineddata` models to make available to recognition.
+	dir *dagger.Directory,
+) *Tesseract {
+	out := *t
+	out.Tessdata = dir
+	return &out
+}
+
 // Container returns the assembled toolchain image. This is the escape hatch
 // for everything this module does not wrap — the training binaries the apk
 // package ships, `combine_tessdata`, and tesseract's long tail of renderers
@@ -161,6 +200,14 @@ func (t *Tesseract) Container() *dagger.Container {
 	ctr := dag.Container().
 		From(t.image()).
 		WithExec(args)
+	// Merged after the install because the packaged half of the union is
+	// whatever apk just wrote, and mounted rather than copied so a 20MB-plus
+	// model set does not become a layer per image.
+	if t.Tessdata != nil {
+		ctr = ctr.WithMountedDirectory(
+			tessdataDir,
+			ctr.Directory(packagedTessdataDir).WithDirectory("/", t.Tessdata))
+	}
 	// Applied after the install so the thread bound does not become part of
 	// the apk layer's cache key: two images differing only in their limit
 	// still share the package fetch.
@@ -187,14 +234,15 @@ func (t *Tesseract) Version(ctx context.Context) (string, error) {
 	return strings.TrimSpace(strings.TrimPrefix(first, "tesseract")), nil
 }
 
-// Langs returns the language codes installed in the image, as reported by
-// `tesseract --list-langs`. This is the set Document.WithLanguage validates
-// against, and it includes "osd" when that package was requested.
+// Langs returns the language codes the image can recognise in, as reported by
+// `tesseract --list-langs`: the packaged languages and any model WithTessdata
+// added, as one set. This is what Document.WithLanguage validates against, and
+// it includes "osd" when that model was installed or supplied.
 //
 // +cache="session"
 func (t *Tesseract) Langs(ctx context.Context) ([]string, error) {
 	out, err := t.Container().
-		WithExec([]string{"tesseract", "--list-langs"}).
+		WithExec(append([]string{"tesseract", "--list-langs"}, t.tessdataArgs()...)).
 		Stdout(ctx)
 	if err != nil {
 		return nil, err
@@ -230,9 +278,39 @@ func (t *Tesseract) image() string {
 	return fmt.Sprintf("%s/%s:%s", t.Registry, alpineImagePath, t.AlpineTag)
 }
 
-// hasLanguage reports whether a language code was installed into the image.
-// It reads the requested set rather than `--list-langs` so it stays a pure
-// function; the exec-backed check is Langs.
+// tessdataArgs returns the flag that moves tesseract's datadir to the merged
+// directory, and nothing at all when no caller-supplied models were added.
+// Leaving the flag off entirely in that case keeps the packaged path the
+// default one, so an image with no tessdata behaves exactly as it did before
+// the flag existed.
+func (t *Tesseract) tessdataArgs() []string {
+	if t.Tessdata == nil {
+		return nil
+	}
+	return []string{"--tessdata-dir", tessdataDir}
+}
+
+// hasModel reports whether a model is available under the given name. It
+// answers from the requested package set without an exec whenever it can, and
+// only asks the image itself when a caller-supplied directory could have added
+// the model — so the common case stays a pure function.
+func (t *Tesseract) hasModel(ctx context.Context, name string) (bool, error) {
+	if t.hasLanguage(name) {
+		return true, nil
+	}
+	if t.Tessdata == nil {
+		return false, nil
+	}
+	installed, err := t.Langs(ctx)
+	if err != nil {
+		return false, err
+	}
+	return contains(installed, name), nil
+}
+
+// hasLanguage reports whether a language code was requested from apk. It reads
+// the requested set rather than `--list-langs` so it stays a pure function;
+// hasModel is the one that accounts for caller-supplied models.
 func (t *Tesseract) hasLanguage(lang string) bool {
 	for _, l := range t.Languages {
 		if l == lang {

--- a/daggerverse/tesseract/tests/dagger.gen.go
+++ b/daggerverse/tesseract/tests/dagger.gen.go
@@ -304,6 +304,27 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).SingleWordPageSegReturnsFewerWords(&parent, ctx)
+		case "TessdataDoesNotAdmitUnknownLanguage":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).TessdataDoesNotAdmitUnknownLanguage(&parent, ctx)
+		case "TessdataModelIsSelectable":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).TessdataModelIsSelectable(&parent, ctx)
+		case "TessdataSuppliesOsdModel":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).TessdataSuppliesOsdModel(&parent, ctx)
 		case "TextRecognizesFixture":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/tesseract/tests/internal/dagger/tesseract.gen.go
+++ b/daggerverse/tesseract/tests/internal/dagger/tesseract.gen.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Retrieve the binding value, as type Tesseract
-func (r *Binding) AsTesseract() *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:93:6)
+func (r *Binding) AsTesseract() *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:106:6)
 	q := r.query.Select("asTesseract")
 
 	return &Tesseract{
@@ -53,7 +53,7 @@ func (r *Env) WithTesseractDocumentOutput(name string, description string) *Env 
 }
 
 // Create or update a binding of type Tesseract in the environment
-func (r *Env) WithTesseractInput(name string, value *Tesseract, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/main.go:93:6)
+func (r *Env) WithTesseractInput(name string, value *Tesseract, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/main.go:106:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withTesseractInput")
 	q = q.Arg("name", name)
@@ -66,7 +66,7 @@ func (r *Env) WithTesseractInput(name string, value *Tesseract, description stri
 }
 
 // Declare a desired Tesseract output to be assigned in the environment
-func (r *Env) WithTesseractOutput(name string, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/main.go:93:6)
+func (r *Env) WithTesseractOutput(name string, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/main.go:106:6)
 	q := r.query.Select("withTesseractOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -83,18 +83,18 @@ type TesseractOpts struct {
 	//
 	//
 	// Default: "docker.io"
-	Registry string // tesseract (../../../../../daggerverse/tesseract/main.go:109:2)
+	Registry string // tesseract (../../../../../daggerverse/tesseract/main.go:124:2)
 	//
 	// Tag of the alpine image the toolchain is assembled on.
 	//
 	//
 	// Default: "3.24"
-	AlpineTag string // tesseract (../../../../../daggerverse/tesseract/main.go:112:2)
+	AlpineTag string // tesseract (../../../../../daggerverse/tesseract/main.go:127:2)
 	//
 	// Language codes to install, one apk package each. Empty installs "eng".
 	// "osd" is not a recognition language but is required by Document.Osd.
 	//
-	Languages []string // tesseract (../../../../../daggerverse/tesseract/main.go:116:2)
+	Languages []string // tesseract (../../../../../daggerverse/tesseract/main.go:131:2)
 	//
 	// Upper bound on the OpenMP threads tesseract may use, set on the
 	// assembled image as OMP_THREAD_LIMIT. Unset, tesseract uses one thread
@@ -105,12 +105,12 @@ type TesseractOpts struct {
 	// slowdown reports (tesseract-ocr/tesseract#2611, #1171, #263). One
 	// thread per pass is the usual setting there.
 	//
-	OmpThreadLimit int // tesseract (../../../../../daggerverse/tesseract/main.go:126:2)
+	OmpThreadLimit int // tesseract (../../../../../daggerverse/tesseract/main.go:141:2)
 }
 
 // New returns a Tesseract module backed by <registry>/library/alpine:<tag>
 // with tesseract-ocr and one language package per requested language.
-func (r *Query) Tesseract(opts ...TesseractOpts) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:106:1)
+func (r *Query) Tesseract(opts ...TesseractOpts) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:121:1)
 	q := r.query.Select("tesseract")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `registry` optional argument
@@ -140,12 +140,20 @@ func (r *Query) Tesseract(opts ...TesseractOpts) *Tesseract { // tesseract (../.
 // It carries the image coordinates and the language set the image is built
 // with; Document hangs off it so the generated SDK surfaces recognition under
 // `dag.Tesseract().Document(...)`.
-type Tesseract struct { // tesseract (../../../../../daggerverse/tesseract/main.go:93:6)
+type Tesseract struct { // tesseract (../../../../../daggerverse/tesseract/main.go:106:6)
 	query *querybuilder.Selection
 
 	id         *ID
 	parameters *string
 	version    *string
+}
+type WithTesseractFunc func(r *Tesseract) *Tesseract
+
+// With calls the provided function with current Tesseract.
+//
+// This is useful for reusability and readability by not breaking the calling chain.
+func (r *Tesseract) With(f WithTesseractFunc) *Tesseract {
+	return f(r)
 }
 
 func (r *Tesseract) WithGraphQLQuery(q *querybuilder.Selection) *Tesseract {
@@ -161,7 +169,7 @@ func (r *Tesseract) WithGraphQLQuery(q *querybuilder.Selection) *Tesseract {
 //
 // A requested OpenMP bound lives here rather than on the recognition
 // invocation so everything reached through this escape hatch inherits it too.
-func (r *Tesseract) Container() *Container { // tesseract (../../../../../daggerverse/tesseract/main.go:156:1)
+func (r *Tesseract) Container() *Container { // tesseract (../../../../../daggerverse/tesseract/main.go:195:1)
 	q := r.query.Select("container")
 
 	return &Container{
@@ -174,7 +182,7 @@ func (r *Tesseract) Container() *Container { // tesseract (../../../../../dagger
 // The boundary input is a *dagger.File rather than a *dagger.Directory, unlike
 // the kicad module's Project: tesseract resolves nothing relative to its input,
 // so one image — including a multi-page TIFF — is the whole unit of work.
-func (r *Tesseract) Document(source *File) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/main.go:225:1)
+func (r *Tesseract) Document(source *File) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/main.go:273:1)
 	assertNotNil("source", source)
 	q := r.query.Select("document")
 	q = q.Arg("source", source)
@@ -233,10 +241,11 @@ func (r *Tesseract) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
-// Langs returns the language codes installed in the image, as reported by
-// `tesseract --list-langs`. This is the set Document.WithLanguage validates
-// against, and it includes "osd" when that package was requested.
-func (r *Tesseract) Langs(ctx context.Context) ([]string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:195:1)
+// Langs returns the language codes the image can recognise in, as reported by
+// `tesseract --list-langs`: the packaged languages and any model WithTessdata
+// added, as one set. This is what Document.WithLanguage validates against, and
+// it includes "osd" when that model was installed or supplied.
+func (r *Tesseract) Langs(ctx context.Context) ([]string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:243:1)
 	q := r.query.Select("langs")
 
 	var response []string
@@ -248,7 +257,7 @@ func (r *Tesseract) Langs(ctx context.Context) ([]string, error) { // tesseract 
 // Parameters returns tesseract's control-variable table — every name, its
 // default value and a one-line description — as `tesseract --print-parameters`
 // prints it. These are the names Document.WithParameter accepts.
-func (r *Tesseract) Parameters(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:210:1)
+func (r *Tesseract) Parameters(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:258:1)
 	if r.parameters != nil {
 		return *r.parameters, nil
 	}
@@ -262,7 +271,7 @@ func (r *Tesseract) Parameters(ctx context.Context) (string, error) { // tessera
 
 // Version returns the tesseract release the assembled image ships, as the
 // bare version number reported by `tesseract --version`.
-func (r *Tesseract) Version(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:177:1)
+func (r *Tesseract) Version(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:224:1)
 	if r.version != nil {
 		return *r.version, nil
 	}
@@ -272,6 +281,31 @@ func (r *Tesseract) Version(ctx context.Context) (string, error) { // tesseract 
 
 	q = q.Bind(&response)
 	return response, q.Execute(ctx)
+}
+
+// WithTessdata adds a directory of `.traineddata` models to the image, which
+// is the only way to reach a model Alpine has no package for: a fine-tuned
+// model, a tessdata_best or tessdata_fast variant, or a language whose package
+// simply does not exist.
+//
+// Every file whose name ends in `.traineddata` becomes a language named after
+// its stem — `deu_frak.traineddata` is the language `deu_frak` — so a model is
+// renamed by renaming its file. Langs reports the union of these and the
+// packaged ones, and everything that takes a language name accepts either.
+//
+// The directory is merged with the packaged models rather than replacing them,
+// because tesseract's datadir is more than a bag of models: it also holds the
+// renderer configfiles and the font the PDF renderer needs. A caller-supplied
+// model wins over a packaged one of the same name, which is what makes
+// replacing the stock `eng` with a fine-tuned one work.
+func (r *Tesseract) WithTessdata(dir *Directory) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:177:1)
+	assertNotNil("dir", dir)
+	q := r.query.Select("withTessdata")
+	q = q.Arg("dir", dir)
+
+	return &Tesseract{
+		query: q,
+	}
 }
 
 // AsNode returns this Tesseract as a Node.
@@ -312,7 +346,7 @@ func (r *TesseractDocument) WithGraphQLQuery(q *querybuilder.Selection) *Tessera
 }
 
 // Alto returns ALTO XML, the layout schema libraries and archives ingest.
-func (r *TesseractDocument) Alto() *File { // tesseract (../../../../../daggerverse/tesseract/document.go:147:1)
+func (r *TesseractDocument) Alto() *File { // tesseract (../../../../../daggerverse/tesseract/document.go:148:1)
 	q := r.query.Select("alto")
 
 	return &File{
@@ -327,7 +361,7 @@ func (r *TesseractDocument) Alto() *File { // tesseract (../../../../../daggerve
 // several renderers per invocation: asking for text, hOCR and PDF together is
 // one pass over the image, not three. Each artifact is named `result` plus the
 // renderer's own extension.
-func (r *TesseractDocument) Export(formats []TesseractFormat) *Directory { // tesseract (../../../../../daggerverse/tesseract/document.go:176:1)
+func (r *TesseractDocument) Export(formats []TesseractFormat) *Directory { // tesseract (../../../../../daggerverse/tesseract/document.go:177:1)
 	q := r.query.Select("export")
 	q = q.Arg("formats", formats)
 
@@ -338,7 +372,7 @@ func (r *TesseractDocument) Export(formats []TesseractFormat) *Directory { // te
 
 // Hocr returns hOCR: HTML in which every recognised word carries its bounding
 // box and confidence, which is what layout-aware post-processing reads.
-func (r *TesseractDocument) Hocr() *File { // tesseract (../../../../../daggerverse/tesseract/document.go:142:1)
+func (r *TesseractDocument) Hocr() *File { // tesseract (../../../../../daggerverse/tesseract/document.go:143:1)
 	q := r.query.Select("hocr")
 
 	return &File{
@@ -401,8 +435,9 @@ func (r *TesseractDocument) UnmarshalJSON(bs []byte) error {
 // It builds its own invocation rather than reusing the document's recognition
 // options: orientation detection runs off the osd model alone, so the selected
 // language, engine and page-segmentation mode have nothing to say about it.
-// The `osd` package must be in the language set New was given.
-func (r *TesseractDocument) Osd(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/document.go:199:1)
+// The osd model has to be in the image: either as the package New installs for
+// it, or as an osd.traineddata WithTessdata supplied.
+func (r *TesseractDocument) Osd(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/document.go:201:1)
 	if r.osd != nil {
 		return *r.osd, nil
 	}
@@ -416,7 +451,7 @@ func (r *TesseractDocument) Osd(ctx context.Context) (string, error) { // tesser
 
 // Page returns PAGE XML, the PRImA layout-analysis schema — the alternative to
 // ALTO for tools built around that ecosystem.
-func (r *TesseractDocument) Page() *File { // tesseract (../../../../../daggerverse/tesseract/document.go:165:1)
+func (r *TesseractDocument) Page() *File { // tesseract (../../../../../daggerverse/tesseract/document.go:166:1)
 	q := r.query.Select("page")
 
 	return &File{
@@ -426,7 +461,7 @@ func (r *TesseractDocument) Page() *File { // tesseract (../../../../../daggerve
 
 // Pdf returns a searchable PDF: the source image with an invisible text layer
 // positioned behind it, so the page looks untouched but selects and greps.
-func (r *TesseractDocument) Pdf() *File { // tesseract (../../../../../daggerverse/tesseract/document.go:159:1)
+func (r *TesseractDocument) Pdf() *File { // tesseract (../../../../../daggerverse/tesseract/document.go:160:1)
 	q := r.query.Select("pdf")
 
 	return &File{
@@ -437,7 +472,7 @@ func (r *TesseractDocument) Pdf() *File { // tesseract (../../../../../daggerver
 // Text recognises the document and returns the plain text directly, by asking
 // tesseract to write to stdout instead of a file. This is the shortest path
 // for the common case; Txt is the same content as a *dagger.File.
-func (r *TesseractDocument) Text(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/document.go:121:1)
+func (r *TesseractDocument) Text(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/document.go:122:1)
 	if r.text != nil {
 		return *r.text, nil
 	}
@@ -451,7 +486,7 @@ func (r *TesseractDocument) Text(ctx context.Context) (string, error) { // tesse
 
 // Tsv returns tab-separated recognition results: one row per layout element,
 // descending from page to word, each with its box and confidence.
-func (r *TesseractDocument) Tsv() *File { // tesseract (../../../../../daggerverse/tesseract/document.go:153:1)
+func (r *TesseractDocument) Tsv() *File { // tesseract (../../../../../daggerverse/tesseract/document.go:154:1)
 	q := r.query.Select("tsv")
 
 	return &File{
@@ -462,7 +497,7 @@ func (r *TesseractDocument) Tsv() *File { // tesseract (../../../../../daggerver
 // Txt recognises the document and returns the plain text as a file. It is the
 // same content Text returns; take this when the next step wants a file rather
 // than a string.
-func (r *TesseractDocument) Txt() *File { // tesseract (../../../../../daggerverse/tesseract/document.go:136:1)
+func (r *TesseractDocument) Txt() *File { // tesseract (../../../../../daggerverse/tesseract/document.go:137:1)
 	q := r.query.Select("txt")
 
 	return &File{
@@ -474,7 +509,7 @@ func (r *TesseractDocument) Txt() *File { // tesseract (../../../../../daggerver
 // otherwise guesses from the image metadata. Guessing wrong hurts recognition
 // on images that carry no resolution at all. A non-positive value is rejected
 // at output time.
-func (r *TesseractDocument) WithDpi(dpi int) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:80:1)
+func (r *TesseractDocument) WithDpi(dpi int) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:81:1)
 	q := r.query.Select("withDpi")
 	q = q.Arg("dpi", dpi)
 
@@ -485,7 +520,7 @@ func (r *TesseractDocument) WithDpi(dpi int) *TesseractDocument { // tesseract (
 
 // WithEngine selects the OCR engine (`--oem`). Unset, tesseract picks based on
 // what the language data provides.
-func (r *TesseractDocument) WithEngine(mode TesseractEngineMode) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:70:1)
+func (r *TesseractDocument) WithEngine(mode TesseractEngineMode) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:71:1)
 	q := r.query.Select("withEngine")
 	q = q.Arg("mode", mode)
 
@@ -498,11 +533,12 @@ func (r *TesseractDocument) WithEngine(mode TesseractEngineMode) *TesseractDocum
 // be combined with `+`, as in "eng+deu", in which case tesseract loads all of
 // them for one pass.
 //
-// The value picks from what New installed; it cannot add a language, because
-// each one is a separate apk package baked into the image. An unknown value is
-// rejected at output time with the installed set listed. Unset, recognition
-// runs in the first installed language.
-func (r *TesseractDocument) WithLanguage(lang string) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:53:1)
+// The value picks from what the image carries — the packages New installed and
+// any model WithTessdata supplied — and cannot itself add a language, since
+// both of those are baked in when the image is assembled. An unknown value is
+// rejected at output time with the available set listed. Unset, recognition
+// runs in the first language New installed.
+func (r *TesseractDocument) WithLanguage(lang string) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:54:1)
 	q := r.query.Select("withLanguage")
 	q = q.Arg("lang", lang)
 
@@ -514,7 +550,7 @@ func (r *TesseractDocument) WithLanguage(lang string) *TesseractDocument { // te
 // WithPageSegmentation sets how much layout analysis precedes recognition
 // (`--psm`). Unset, tesseract uses fully automatic segmentation without
 // orientation detection.
-func (r *TesseractDocument) WithPageSegmentation(mode TesseractPageSegMode) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:62:1)
+func (r *TesseractDocument) WithPageSegmentation(mode TesseractPageSegMode) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:63:1)
 	q := r.query.Select("withPageSegmentation")
 	q = q.Arg("mode", mode)
 
@@ -530,7 +566,7 @@ func (r *TesseractDocument) WithPageSegmentation(mode TesseractPageSegMode) *Tes
 // functions cannot accept map parameters. An unknown name is rejected at
 // output time: tesseract itself only warns and carries on, so a typo would
 // otherwise silently do nothing.
-func (r *TesseractDocument) WithParameter(name string, value string) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:94:1)
+func (r *TesseractDocument) WithParameter(name string, value string) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:95:1)
 	q := r.query.Select("withParameter")
 	q = q.Arg("name", name)
 	q = q.Arg("value", value)
@@ -542,7 +578,7 @@ func (r *TesseractDocument) WithParameter(name string, value string) *TesseractD
 
 // WithUserPatterns supplies a pattern list (`--user-patterns`): one pattern
 // per line describing the shape of expected strings, such as part numbers.
-func (r *TesseractDocument) WithUserPatterns(patterns *File) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:112:1)
+func (r *TesseractDocument) WithUserPatterns(patterns *File) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:113:1)
 	assertNotNil("patterns", patterns)
 	q := r.query.Select("withUserPatterns")
 	q = q.Arg("patterns", patterns)
@@ -555,7 +591,7 @@ func (r *TesseractDocument) WithUserPatterns(patterns *File) *TesseractDocument 
 // WithUserWords supplies a word list (`--user-words`): one word per line,
 // which recognition then favours. Useful for jargon and proper nouns the
 // packaged dictionary does not know.
-func (r *TesseractDocument) WithUserWords(words *File) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:104:1)
+func (r *TesseractDocument) WithUserWords(words *File) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:105:1)
 	assertNotNil("words", words)
 	q := r.query.Select("withUserWords")
 	q = q.Arg("words", words)

--- a/daggerverse/tesseract/tests/main.go
+++ b/daggerverse/tesseract/tests/main.go
@@ -35,6 +35,11 @@ const (
 	// the assembled image.
 	ompThreadLimitEnv = "OMP_THREAD_LIMIT"
 
+	// packagedTessdataDir is where the apk packages drop their models. It is
+	// the source the tessdata tests round-trip a model out of, never a path
+	// the module itself asks anyone to know about.
+	packagedTessdataDir = "/usr/share/tessdata"
+
 	// suiteOmpThreadLimit is the bound every test here builds its image with.
 	// The module itself leaves OpenMP alone, so tesseract takes one thread per
 	// available CPU — right for a caller who owns the machine, wrong for this
@@ -98,6 +103,9 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("PdfHasPdfMagic", t.PdfHasPdfMagic)
 	jobs = jobs.WithJob("ExportProducesEveryRequestedFormat", t.ExportProducesEveryRequestedFormat)
 
+	jobs = jobs.WithJob("TessdataModelIsSelectable", t.TessdataModelIsSelectable)
+	jobs = jobs.WithJob("TessdataSuppliesOsdModel", t.TessdataSuppliesOsdModel)
+
 	jobs = jobs.WithJob("SingleWordPageSegReturnsFewerWords", t.SingleWordPageSegReturnsFewerWords)
 	jobs = jobs.WithJob("LstmEngineRecognizesFixture", t.LstmEngineRecognizesFixture)
 	jobs = jobs.WithJob("UnknownParameterFails", t.UnknownParameterFails)
@@ -105,6 +113,7 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("OsdDetectsRotation", t.OsdDetectsRotation)
 
 	jobs = jobs.WithJob("UnknownLanguageIsRejected", t.UnknownLanguageIsRejected)
+	jobs = jobs.WithJob("TessdataDoesNotAdmitUnknownLanguage", t.TessdataDoesNotAdmitUnknownLanguage)
 	jobs = jobs.WithJob("OsdWithoutOsdDataIsRejected", t.OsdWithoutOsdDataIsRejected)
 	jobs = jobs.WithJob("PdfInputIsRejected", t.PdfInputIsRejected)
 	jobs = jobs.WithJob("MalformedParameterNameIsRejected", t.MalformedParameterNameIsRejected)
@@ -361,6 +370,86 @@ func (t *Tests) ExportProducesEveryRequestedFormat(ctx context.Context) error {
 	return nil
 }
 
+// ------------------------------------------------------------------- tessdata
+
+// TessdataModelIsSelectable asserts a caller-supplied model is a first-class
+// language: Langs lists it alongside the packaged set, WithLanguage accepts it,
+// and recognition under that name reproduces the fixture.
+//
+// The model is the image's own eng.traineddata lifted back out and re-mounted
+// under a different stem. That needs no committed binary fixture and still
+// proves the whole path: "custom" is a name no Alpine package could ever
+// install, so recognising English text under it can only mean the caller's
+// directory reached tesseract.
+//
+// The packaged language and the PDF render are asserted through the same
+// module because the caller's directory has to be merged with the packaged one
+// rather than swapped for it. `--tessdata-dir` moves the whole datadir, and
+// that directory carries more than models: `configs/` holds the renderer
+// configfiles, and pdf.ttf is what the PDF renderer draws its invisible text
+// layer with. Pointed at the caller's directory alone, every renderer breaks
+// and every packaged language disappears.
+func (t *Tests) TessdataModelIsSelectable(ctx context.Context) error {
+	custom := ocr().WithTessdata(
+		dag.Directory().WithFile("custom.traineddata", traineddata(ocr(), "eng")),
+	)
+
+	langs, err := custom.Langs(ctx)
+	if err != nil {
+		return fmt.Errorf("Langs: %w", err)
+	}
+	if want := []string{"custom", "eng"}; !reflect.DeepEqual(langs, want) {
+		return fmt.Errorf("expected Langs to report the union %v, got %v", want, langs)
+	}
+
+	got, err := custom.Document(fixture(sentencePng)).WithLanguage("custom").Text(ctx)
+	if err != nil {
+		return fmt.Errorf("Text under the caller-supplied model: %w", err)
+	}
+	if err := assertSentenceLines(got); err != nil {
+		return fmt.Errorf("caller-supplied model: %w", err)
+	}
+
+	got, err = custom.Document(fixture(sentencePng)).WithLanguage("eng").Text(ctx)
+	if err != nil {
+		return fmt.Errorf("Text under the packaged model with tessdata mounted: %w", err)
+	}
+	if err := assertSentenceLines(got); err != nil {
+		return fmt.Errorf("packaged model with tessdata mounted: %w", err)
+	}
+
+	pdf, err := exportBytes(ctx, custom.Document(fixture(sentencePng)).WithLanguage("custom").Pdf(), "result.pdf")
+	if err != nil {
+		return err
+	}
+	if !bytes.HasPrefix(pdf, []byte("%PDF-")) {
+		return fmt.Errorf("expected the PDF renderer to still work with tessdata mounted, got %q", firstBytes(pdf, 8))
+	}
+	return nil
+}
+
+// TessdataSuppliesOsdModel asserts orientation detection accepts an osd model
+// that arrived through WithTessdata rather than through its apk package.
+//
+// Osd is the one place that asks whether a specific model is present, and it
+// answered from the requested package set alone. A supplied osd.traineddata
+// would have been refused by this module while sitting right there in the
+// image, which is the failure mode this pins.
+func (t *Tests) TessdataSuppliesOsdModel(ctx context.Context) error {
+	supplied := ocr().WithTessdata(
+		dag.Directory().WithFile("osd.traineddata", traineddata(ocr("eng", "osd"), "osd")),
+	)
+
+	got, err := supplied.Document(fixture(sentenceRot90Png)).Osd(ctx)
+	if err != nil {
+		return fmt.Errorf("Osd with a supplied osd model: %w", err)
+	}
+	if !strings.Contains(got, "Orientation in degrees: 90") {
+		return fmt.Errorf("expected the OSD report to read the quarter turn, got:\n%s", got)
+	}
+	return nil
+}
+
 // ------------------------------------------------------------- recognition options
 
 // SingleWordPageSegReturnsFewerWords asserts --psm actually reaches tesseract.
@@ -530,6 +619,27 @@ func (t *Tests) UnknownLanguageIsRejected(ctx context.Context) error {
 	return nil
 }
 
+// TessdataDoesNotAdmitUnknownLanguage asserts the union is still a closed set:
+// mounting a tessdata directory adds the models it holds and nothing else, so a
+// language neither half carries is rejected the same way it was before, with
+// both halves listed and both ways of adding one named.
+func (t *Tests) TessdataDoesNotAdmitUnknownLanguage(ctx context.Context) error {
+	custom := ocr().WithTessdata(
+		dag.Directory().WithFile("custom.traineddata", traineddata(ocr(), "eng")),
+	)
+
+	_, err := custom.Document(fixture(sentencePng)).WithLanguage("fra").Text(ctx)
+	if err == nil {
+		return fmt.Errorf("expected a language in neither the package set nor the tessdata directory to be rejected, got nil")
+	}
+	for _, want := range []string{`"fra"`, "custom, eng", "New(languages:)", "WithTessdata"} {
+		if !strings.Contains(err.Error(), want) {
+			return fmt.Errorf("expected the error to mention %q, got: %v", want, err)
+		}
+	}
+	return nil
+}
+
 // OsdWithoutOsdDataIsRejected asserts orientation detection on an image built
 // without the osd model names the fix rather than failing inside tesseract,
 // which would report a missing traineddata file.
@@ -640,6 +750,15 @@ func readOmpThreadLimit(ctx context.Context, t *dagger.Tesseract) (string, error
 		return "", fmt.Errorf("read %s from the image: %w", ompThreadLimitEnv, err)
 	}
 	return out, nil
+}
+
+// traineddata lifts a packaged model back out of the assembled image so a test
+// can re-mount it under a different name. The path is the apk package's own,
+// not the one WithTessdata mounts at, and it is spelled out here rather than
+// exported by the module: the module's job is to make caller-supplied models
+// work, not to publish where Alpine keeps its own.
+func traineddata(t *dagger.Tesseract, lang string) *dagger.File {
+	return t.Container().File(packagedTessdataDir + "/" + lang + ".traineddata")
 }
 
 // fixture returns a committed test image by name under fixtures/.


### PR DESCRIPTION
Closes #219.

The package set was a ceiling. A language reachable only as a fine-tuned model, a `tessdata_best` / `tessdata_fast` variant, or one Alpine ships no `tesseract-ocr-data-<lang>` package for, could not be recognised at all. `WithTessdata(dir *dagger.Directory)` takes a directory of `.traineddata` and makes each file a language named after its stem.

From there a supplied model is indistinguishable from a packaged one: `Langs` reports the union, `Document.WithLanguage` accepts either and still rejects a name in neither, and `Osd` is satisfied by a supplied `osd.traineddata`.

## Merged, not swapped

`--tessdata-dir` moves the *whole* datadir, and that directory holds more than models — `configs/` carries the renderer configfiles recognition names as its trailing arguments, and `pdf.ttf` is what the PDF renderer draws its invisible text layer with. Pointed at the caller's directory alone, every renderer breaks and every packaged language disappears. So the caller's directory is merged over the packaged one, caller's file winning on a name collision, which is also what makes replacing the stock `eng` with a fine-tuned model work.

The merge is mounted rather than copied (a model set runs 20MB and up), and an image with no tessdata omits the flag entirely — behaviour there is byte-for-byte what it was.

`Osd` answered its "is this model present?" question from the requested apk set alone, so it would have refused a supplied `osd.traineddata` sitting right there in the image. `hasModel` now falls back to the image's own `--list-langs`, but only when a tessdata directory could have added the model, so the common case stays a pure function with no exec.

## Tests

No committed binary fixture. `eng.traineddata` is lifted back out of the assembled image and re-mounted under a stem no apk package could ever install, so recognising English text under it can only mean the caller's directory reached tesseract.

- `tessdata-model-is-selectable` — `Langs` returns `[custom eng]`; recognition under both the supplied and the packaged name reproduces the fixture; a PDF still renders, which is what pins the merge (`configs/` and `pdf.ttf` come from the packaged half)
- `tessdata-supplies-osd-model` — orientation detection off an `osd.traineddata` that arrived through `WithTessdata`, on an image built without the package
- `tessdata-does-not-admit-unknown-language` — the union is still a closed set; the rejection lists both halves and names both ways of adding a model

`dagger -m daggerverse/tesseract/tests call all` and `dagger -m ci call generated` both green locally; bindings regenerated in the module, its tests, and the root `ci` aggregator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)