### PR TITLE
story(issue-220): add batch OCR over a directory of images

### DIFF
--- a/ci/internal/dagger/tesseract-tests.gen.go
+++ b/ci/internal/dagger/tesseract-tests.gen.go
@@ -61,32 +61,38 @@ func (r *Query) TesseractTests() *TesseractTests { // tesseract-tests (../../../
 type TesseractTests struct { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:62:6)
 	query *querybuilder.Selection
 
-	all                                 *Void
-	altoIsValidXml                      *Void
-	defaultLanguagesInstallEnglish      *Void
-	exportProducesEveryRequestedFormat  *Void
-	hocrContainsWordBoxes               *Void
-	id                                  *ID
-	lstmEngineRecognizesFixture         *Void
-	malformedParameterNameIsRejected    *Void
-	nonPositiveDpiIsRejected            *Void
-	ompThreadLimitBoundsOpenMp          *Void
-	osdDetectsRotation                  *Void
-	osdWithoutOsdDataIsRejected         *Void
-	pdfHasPdfMagic                      *Void
-	pdfInputIsRejected                  *Void
-	requestedLanguagesAreInstalled      *Void
-	singleWordPageSegReturnsFewerWords  *Void
-	tessdataDoesNotAdmitUnknownLanguage *Void
-	tessdataModelIsSelectable           *Void
-	tessdataSuppliesOsdModel            *Void
-	textRecognizesFixture               *Void
-	tsvHasHeaderAndWordRows             *Void
-	txtFileMatchesText                  *Void
-	unknownLanguageIsRejected           *Void
-	unknownParameterFails               *Void
-	userWordsFileIsAccepted             *Void
-	versionReportsTesseractFive         *Void
+	all                                    *Void
+	altoIsValidXml                         *Void
+	batchDefaultGlobSkipsNonImages         *Void
+	batchExportProducesEveryFormatPerImage *Void
+	batchGlobSelectsFiles                  *Void
+	batchMirrorsInputLayout                *Void
+	batchRejectsAmbiguousInput             *Void
+	batchSharesDocumentOptions             *Void
+	defaultLanguagesInstallEnglish         *Void
+	exportProducesEveryRequestedFormat     *Void
+	hocrContainsWordBoxes                  *Void
+	id                                     *ID
+	lstmEngineRecognizesFixture            *Void
+	malformedParameterNameIsRejected       *Void
+	nonPositiveDpiIsRejected               *Void
+	ompThreadLimitBoundsOpenMp             *Void
+	osdDetectsRotation                     *Void
+	osdWithoutOsdDataIsRejected            *Void
+	pdfHasPdfMagic                         *Void
+	pdfInputIsRejected                     *Void
+	requestedLanguagesAreInstalled         *Void
+	singleWordPageSegReturnsFewerWords     *Void
+	tessdataDoesNotAdmitUnknownLanguage    *Void
+	tessdataModelIsSelectable              *Void
+	tessdataSuppliesOsdModel               *Void
+	textRecognizesFixture                  *Void
+	tsvHasHeaderAndWordRows                *Void
+	txtFileMatchesText                     *Void
+	unknownLanguageIsRejected              *Void
+	unknownParameterFails                  *Void
+	userWordsFileIsAccepted                *Void
+	versionReportsTesseractFive            *Void
 }
 
 func (r *TesseractTests) WithGraphQLQuery(q *querybuilder.Selection) *TesseractTests {
@@ -132,7 +138,7 @@ func (r *TesseractTests) All(ctx context.Context, opts ...TesseractTestsAllOpts)
 // AltoIsValidXml asserts the ALTO renderer emits well-formed XML in the ALTO
 // namespace, since its consumers are schema-driven archive tooling that will
 // reject anything else outright.
-func (r *TesseractTests) AltoIsValidXML(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:268:1)
+func (r *TesseractTests) AltoIsValidXML(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:275:1)
 	if r.altoIsValidXml != nil {
 		return nil
 	}
@@ -141,11 +147,108 @@ func (r *TesseractTests) AltoIsValidXML(ctx context.Context) error { // tesserac
 	return q.Execute(ctx)
 }
 
+// BatchDefaultGlobSkipsNonImages asserts the default glob takes the images out
+// of a real scan folder and leaves the rest alone.
+//
+// A folder of scans collects README files, manifests and checksums, and none of
+// them are pages. Handing one to tesseract is not a no-op — leptonica fails to
+// decode it and the run dies — so "ignored by default" is what makes pointing
+// Batch at an existing directory work at all.
+func (r *TesseractTests) BatchDefaultGlobSkipsNonImages(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:775:1)
+	if r.batchDefaultGlobSkipsNonImages != nil {
+		return nil
+	}
+	q := r.query.Select("batchDefaultGlobSkipsNonImages")
+
+	return q.Execute(ctx)
+}
+
+// BatchExportProducesEveryFormatPerImage asserts each image gets its own full
+// artifact set, named off its own path rather than off a shared output base.
+//
+// This is where the per-image design earns itself: tesseract's list-file mode
+// would render one concatenated artifact per *format* — a single .txt with
+// form-feed page breaks and a single multi-page PDF — with no way to tell which
+// page produced what.
+func (r *TesseractTests) BatchExportProducesEveryFormatPerImage(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:871:1)
+	if r.batchExportProducesEveryFormatPerImage != nil {
+		return nil
+	}
+	q := r.query.Select("batchExportProducesEveryFormatPerImage")
+
+	return q.Execute(ctx)
+}
+
+// BatchGlobSelectsFiles asserts WithGlob decides what takes part, and that a
+// pattern matching nothing fails the call.
+//
+// The empty case is the one worth pinning. Returning an empty directory would
+// be indistinguishable from a batch that ran and found no text, so a typo in a
+// pattern would surface much later as missing output rather than here as a bad
+// glob.
+func (r *TesseractTests) BatchGlobSelectsFiles(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:819:1)
+	if r.batchGlobSelectsFiles != nil {
+		return nil
+	}
+	q := r.query.Select("batchGlobSelectsFiles")
+
+	return q.Execute(ctx)
+}
+
+// BatchMirrorsInputLayout asserts a directory in gives a directory out with the
+// same shape: one artifact per image, at the input's own path with the
+// renderer's extension, nested folders and all.
+//
+// Mirroring is the whole point of the return type. A batch that returned a flat
+// directory of `result-1.txt`, `result-2.txt` would force every caller to
+// rebuild the correspondence between page and text that the input directory
+// already expressed.
+func (r *TesseractTests) BatchMirrorsInputLayout(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:741:1)
+	if r.batchMirrorsInputLayout != nil {
+		return nil
+	}
+	q := r.query.Select("batchMirrorsInputLayout")
+
+	return q.Execute(ctx)
+}
+
+// BatchRejectsAmbiguousInput asserts the two ways a matched set cannot be
+// recognised are refused before the run, rather than producing quietly wrong
+// output.
+//
+// A collision is the subtle one: `a.png` and `a.jpg` in one folder both render
+// onto `a.txt`, so the second silently overwrites the first and the batch looks
+// like it succeeded with one page missing.
+func (r *TesseractTests) BatchRejectsAmbiguousInput(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:983:1)
+	if r.batchRejectsAmbiguousInput != nil {
+		return nil
+	}
+	q := r.query.Select("batchRejectsAmbiguousInput")
+
+	return q.Execute(ctx)
+}
+
+// BatchSharesDocumentOptions asserts the recognition options behave the same on
+// a batch as on a single document, which is the reason both hold one shared
+// option set rather than two parallel copies.
+//
+// It covers both halves: an option that has to reach tesseract for every image
+// in the run, and the deferred validation that has to reject a bad option
+// before any of them are recognised.
+func (r *TesseractTests) BatchSharesDocumentOptions(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:917:1)
+	if r.batchSharesDocumentOptions != nil {
+		return nil
+	}
+	q := r.query.Select("batchSharesDocumentOptions")
+
+	return q.Execute(ctx)
+}
+
 // DefaultLanguagesInstallEnglish asserts New with no languages installs
 // English and nothing else. The base apk package carries no language data at
 // all, so an empty default would produce an image that cannot recognise
 // anything.
-func (r *TesseractTests) DefaultLanguagesInstallEnglish(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:145:1)
+func (r *TesseractTests) DefaultLanguagesInstallEnglish(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:152:1)
 	if r.defaultLanguagesInstallEnglish != nil {
 		return nil
 	}
@@ -158,7 +261,7 @@ func (r *TesseractTests) DefaultLanguagesInstallEnglish(ctx context.Context) err
 // formats. That the artifacts arrive in a single directory lifted off a single
 // exec is what proves they came from one recognition pass rather than six: the
 // per-format functions each run their own.
-func (r *TesseractTests) ExportProducesEveryRequestedFormat(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:339:1)
+func (r *TesseractTests) ExportProducesEveryRequestedFormat(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:346:1)
 	if r.exportProducesEveryRequestedFormat != nil {
 		return nil
 	}
@@ -169,7 +272,7 @@ func (r *TesseractTests) ExportProducesEveryRequestedFormat(ctx context.Context)
 
 // HocrContainsWordBoxes asserts hOCR carries the per-word geometry that is the
 // whole reason to ask for it rather than plain text.
-func (r *TesseractTests) HocrContainsWordBoxes(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:245:1)
+func (r *TesseractTests) HocrContainsWordBoxes(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:252:1)
 	if r.hocrContainsWordBoxes != nil {
 		return nil
 	}
@@ -234,7 +337,7 @@ func (r *TesseractTests) UnmarshalJSON(bs []byte) error {
 // is that no member is dead: LEGACY and LEGACY_LSTM only work because Alpine
 // packages the *combined* tessdata models. A rebuild against tessdata_fast or
 // tessdata_best would strip the legacy data and this is where that shows up.
-func (r *TesseractTests) LstmEngineRecognizesFixture(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:486:1)
+func (r *TesseractTests) LstmEngineRecognizesFixture(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:493:1)
 	if r.lstmEngineRecognizesFixture != nil {
 		return nil
 	}
@@ -246,7 +349,7 @@ func (r *TesseractTests) LstmEngineRecognizesFixture(ctx context.Context) error 
 // MalformedParameterNameIsRejected asserts an empty parameter name, and one
 // carrying its own `=`, are refused. `-c` takes `name=value`, so an embedded
 // `=` would quietly set a different variable to a different value.
-func (r *TesseractTests) MalformedParameterNameIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:678:1)
+func (r *TesseractTests) MalformedParameterNameIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:685:1)
 	if r.malformedParameterNameIsRejected != nil {
 		return nil
 	}
@@ -258,7 +361,7 @@ func (r *TesseractTests) MalformedParameterNameIsRejected(ctx context.Context) e
 // NonPositiveDpiIsRejected asserts a zero or negative resolution is refused
 // rather than handed to tesseract, which would take it as a real measurement
 // and scale its analysis by it.
-func (r *TesseractTests) NonPositiveDpiIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:704:1)
+func (r *TesseractTests) NonPositiveDpiIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:711:1)
 	if r.nonPositiveDpiIsRejected != nil {
 		return nil
 	}
@@ -277,7 +380,7 @@ func (r *TesseractTests) NonPositiveDpiIsRejected(ctx context.Context) error { /
 // works at all: without it, anything running several recognitions at once has
 // no way to stop each pass claiming every core, which cost this very suite
 // nine minutes on a four-core runner (#226).
-func (r *TesseractTests) OmpThreadLimitBoundsOpenMp(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:182:1)
+func (r *TesseractTests) OmpThreadLimitBoundsOpenMp(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:189:1)
 	if r.ompThreadLimitBoundsOpenMp != nil {
 		return nil
 	}
@@ -289,7 +392,7 @@ func (r *TesseractTests) OmpThreadLimitBoundsOpenMp(ctx context.Context) error {
 // OsdDetectsRotation asserts orientation detection reads the quarter-turn in
 // the rotated fixture and reports the rotation that would undo it, while the
 // upright fixture reports no rotation at all.
-func (r *TesseractTests) OsdDetectsRotation(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:565:1)
+func (r *TesseractTests) OsdDetectsRotation(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:572:1)
 	if r.osdDetectsRotation != nil {
 		return nil
 	}
@@ -301,7 +404,7 @@ func (r *TesseractTests) OsdDetectsRotation(ctx context.Context) error { // tess
 // OsdWithoutOsdDataIsRejected asserts orientation detection on an image built
 // without the osd model names the fix rather than failing inside tesseract,
 // which would report a missing traineddata file.
-func (r *TesseractTests) OsdWithoutOsdDataIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:646:1)
+func (r *TesseractTests) OsdWithoutOsdDataIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:653:1)
 	if r.osdWithoutOsdDataIsRejected != nil {
 		return nil
 	}
@@ -313,7 +416,7 @@ func (r *TesseractTests) OsdWithoutOsdDataIsRejected(ctx context.Context) error 
 // PdfHasPdfMagic asserts the searchable-PDF renderer emits a real PDF. The
 // bytes go through the filesystem rather than File.Contents, which mangles
 // non-UTF-8 data.
-func (r *TesseractTests) PdfHasPdfMagic(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:321:1)
+func (r *TesseractTests) PdfHasPdfMagic(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:328:1)
 	if r.pdfHasPdfMagic != nil {
 		return nil
 	}
@@ -325,7 +428,7 @@ func (r *TesseractTests) PdfHasPdfMagic(ctx context.Context) error { // tesserac
 // PdfInputIsRejected asserts a PDF source is refused up front. Leptonica has
 // no PDF support and reports the failure as if the file's first line were a
 // file name it could not open, which sends people looking in the wrong place.
-func (r *TesseractTests) PdfInputIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:662:1)
+func (r *TesseractTests) PdfInputIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:669:1)
 	if r.pdfInputIsRejected != nil {
 		return nil
 	}
@@ -337,7 +440,7 @@ func (r *TesseractTests) PdfInputIsRejected(ctx context.Context) error { // tess
 // RequestedLanguagesAreInstalled asserts every requested language lands in the
 // image as its own apk package, including "osd", which is a detection model
 // rather than a recognition language.
-func (r *TesseractTests) RequestedLanguagesAreInstalled(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:159:1)
+func (r *TesseractTests) RequestedLanguagesAreInstalled(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:166:1)
 	if r.requestedLanguagesAreInstalled != nil {
 		return nil
 	}
@@ -351,7 +454,7 @@ func (r *TesseractTests) RequestedLanguagesAreInstalled(ctx context.Context) err
 // that finds the lines, so it returns far less than the default mode does —
 // which is the observable proof the flag was passed, without asserting on
 // whatever garbage the constrained mode happens to produce.
-func (r *TesseractTests) SingleWordPageSegReturnsFewerWords(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:460:1)
+func (r *TesseractTests) SingleWordPageSegReturnsFewerWords(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:467:1)
 	if r.singleWordPageSegReturnsFewerWords != nil {
 		return nil
 	}
@@ -364,7 +467,7 @@ func (r *TesseractTests) SingleWordPageSegReturnsFewerWords(ctx context.Context)
 // mounting a tessdata directory adds the models it holds and nothing else, so a
 // language neither half carries is rejected the same way it was before, with
 // both halves listed and both ways of adding one named.
-func (r *TesseractTests) TessdataDoesNotAdmitUnknownLanguage(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:626:1)
+func (r *TesseractTests) TessdataDoesNotAdmitUnknownLanguage(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:633:1)
 	if r.tessdataDoesNotAdmitUnknownLanguage != nil {
 		return nil
 	}
@@ -390,7 +493,7 @@ func (r *TesseractTests) TessdataDoesNotAdmitUnknownLanguage(ctx context.Context
 // configfiles, and pdf.ttf is what the PDF renderer draws its invisible text
 // layer with. Pointed at the caller's directory alone, every renderer breaks
 // and every packaged language disappears.
-func (r *TesseractTests) TessdataModelIsSelectable(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:392:1)
+func (r *TesseractTests) TessdataModelIsSelectable(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:399:1)
 	if r.tessdataModelIsSelectable != nil {
 		return nil
 	}
@@ -406,7 +509,7 @@ func (r *TesseractTests) TessdataModelIsSelectable(ctx context.Context) error { 
 // answered from the requested package set alone. A supplied osd.traineddata
 // would have been refused by this module while sitting right there in the
 // image, which is the failure mode this pins.
-func (r *TesseractTests) TessdataSuppliesOsdModel(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:438:1)
+func (r *TesseractTests) TessdataSuppliesOsdModel(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:445:1)
 	if r.tessdataSuppliesOsdModel != nil {
 		return nil
 	}
@@ -417,7 +520,7 @@ func (r *TesseractTests) TessdataSuppliesOsdModel(ctx context.Context) error { /
 
 // TextRecognizesFixture asserts the shortest path — image in, string out —
 // reproduces every line the fixture renders.
-func (r *TesseractTests) TextRecognizesFixture(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:216:1)
+func (r *TesseractTests) TextRecognizesFixture(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:223:1)
 	if r.textRecognizesFixture != nil {
 		return nil
 	}
@@ -429,7 +532,7 @@ func (r *TesseractTests) TextRecognizesFixture(ctx context.Context) error { // t
 // TsvHasHeaderAndWordRows asserts the TSV renderer emits its column header and
 // descends all the way to word-level rows (level 5), which is the level
 // carrying the text and its confidence.
-func (r *TesseractTests) TsvHasHeaderAndWordRows(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:287:1)
+func (r *TesseractTests) TsvHasHeaderAndWordRows(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:294:1)
 	if r.tsvHasHeaderAndWordRows != nil {
 		return nil
 	}
@@ -440,7 +543,7 @@ func (r *TesseractTests) TsvHasHeaderAndWordRows(ctx context.Context) error { //
 
 // TxtFileMatchesText asserts the txt renderer and the stdout path agree, so
 // choosing a file over a string is purely a plumbing decision.
-func (r *TesseractTests) TxtFileMatchesText(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:226:1)
+func (r *TesseractTests) TxtFileMatchesText(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:233:1)
 	if r.txtFileMatchesText != nil {
 		return nil
 	}
@@ -453,7 +556,7 @@ func (r *TesseractTests) TxtFileMatchesText(ctx context.Context) error { // tess
 // rejected with the installed set named. tesseract's own failure talks about
 // traineddata paths and TESSDATA_PREFIX, which says nothing about the fact
 // that languages are chosen on New.
-func (r *TesseractTests) UnknownLanguageIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:594:1)
+func (r *TesseractTests) UnknownLanguageIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:601:1)
 	if r.unknownLanguageIsRejected != nil {
 		return nil
 	}
@@ -469,7 +572,7 @@ func (r *TesseractTests) UnknownLanguageIsRejected(ctx context.Context) error { 
 // and exits 0, so a typo would otherwise be indistinguishable from a setting
 // that simply had no effect. The same test pins the other half: a real
 // parameter still goes through, so the check is not just rejecting everything.
-func (r *TesseractTests) UnknownParameterFails(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:512:1)
+func (r *TesseractTests) UnknownParameterFails(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:519:1)
 	if r.unknownParameterFails != nil {
 		return nil
 	}
@@ -487,7 +590,7 @@ func (r *TesseractTests) UnknownParameterFails(ctx context.Context) error { // t
 // a dictionary hint on an already-clean fixture is not reliably observable.
 // What this does catch is a wrong mount path or a flag emitted in the wrong
 // position, either of which turns the whole run into a usage error.
-func (r *TesseractTests) UserWordsFileIsAccepted(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:548:1)
+func (r *TesseractTests) UserWordsFileIsAccepted(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:555:1)
 	if r.userWordsFileIsAccepted != nil {
 		return nil
 	}
@@ -499,7 +602,7 @@ func (r *TesseractTests) UserWordsFileIsAccepted(ctx context.Context) error { //
 // VersionReportsTesseractFive asserts the assembled image ships the tesseract
 // release Alpine's community repository carries, so a base-tag bump that
 // silently changes major version fails here rather than in recognition.
-func (r *TesseractTests) VersionReportsTesseractFive(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:130:1)
+func (r *TesseractTests) VersionReportsTesseractFive(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:137:1)
 	if r.versionReportsTesseractFive != nil {
 		return nil
 	}

--- a/daggerverse/tesseract/README.md
+++ b/daggerverse/tesseract/README.md
@@ -3,7 +3,8 @@
 Daggerverse module that runs [Tesseract](https://tesseract-ocr.github.io/) OCR
 as a `dagger call`. Hand it an image and get back plain text, or hOCR / ALTO /
 TSV / PAGE / a searchable PDF for anything that needs word positions and
-confidences.
+confidences. Hand it a directory and get the same artifacts back for every page
+in it, at the paths they came in on.
 
 **There is no official Tesseract container image** — upstream ships source only,
 and every image on Docker Hub is third-party. So this module assembles its own
@@ -153,7 +154,10 @@ Tesseract.Document(source *dagger.File) *Document
 
 Unlike `kicad.Project`, the boundary input is a lone `*dagger.File`: tesseract
 resolves nothing relative to its input, so one image — including a multi-page
-TIFF — is the whole unit of work.
+TIFF — is the whole unit of work. A folder of pages is `Batch`, below; the
+directory there is a *set of independent inputs*, not context the recognition
+resolves against, which is why it is a second entry point rather than a widening
+of this one.
 
 `Document` is immutable; every `With*` returns a copy, so one configured
 document can be branched into several outputs without the branches interfering.
@@ -176,6 +180,12 @@ an image built with only `deu` still works.
 
 `WithParameter` takes a name and a value separately because Dagger functions
 cannot accept map parameters (the `kicad.Project.WithVar` precedent).
+
+Those seven builders are not implemented here. They forward to an internal
+`options` type that `Batch` carries too, so each option is written once — as a
+builder, as a piece of argv, and as a deferred check — and the two units of work
+cannot drift apart. Adding an option means touching `options.go` plus a
+three-line forwarder on each.
 
 ## Enums
 
@@ -230,6 +240,64 @@ Artifacts come back as `exec.File(path)` off the recognition container. The
 `dag.CurrentModule().Workdir` staging pattern does not apply — this module
 generates no bytes in Go.
 
+## Batch — a directory in, a mirrored directory out
+
+```go
+Tesseract.Batch(source *dagger.Directory) *Batch
+
+Batch.WithGlob(pattern string) *Batch    // default: the image extensions below
+Batch.WithLanguage(lang string) *Batch   // …and the six other Document builders
+Batch.Files(ctx) ([]string, error)
+Batch.Export(ctx, formats []Format) (*dagger.Directory, error)
+```
+
+A scanned-document pipeline has a folder, not a file. `Export` returns a
+directory mirroring the input layout with one artifact per requested format per
+image, so `scans/deep/page-3.png` becomes `scans/deep/page-3.txt` next to
+`scans/deep/page-3.pdf`. Mirroring is the point of the return type: a flat
+`result-1.txt`, `result-2.txt` would force every caller to rebuild the
+page-to-text correspondence the input directory already expressed.
+
+### Why not tesseract's own list-file mode
+
+Tesseract accepts a text file of image paths as its `FILE` argument, and #220
+proposed exactly that. It does not do what the name suggests: it treats the list
+as one multi-page **document** and renders a *single concatenated artifact set* —
+one `.txt` with form-feed page breaks, one multi-page PDF, one hOCR carrying
+`page_1`/`page_2` divs. There is no way to recover per-image files from it, least
+of all for PDF.
+
+So the batch is one container **exec** rather than one tesseract **process**: the
+exec loops over a manifest, recognising each image onto its own output base. That
+collapses the part that actually costs anything in Dagger — a `WithExec`, its
+mounts and its cache lookup, per page — to one, while each page keeps its own
+artifacts. The loop reaches flags and configfiles through `"$@"` rather than
+string interpolation, so no value needs escaping.
+
+### Which files take part
+
+`Directory.Glob` has no brace expansion, so "common image extensions" cannot be
+spelled as one pattern. The default is `**/*` narrowed by a case-insensitive
+extension filter:
+
+```
+.bmp .gif .jpe .jpeg .jpg .pbm .pgm .pnm .png .ppm .tif .tiff .webp
+```
+
+That set is what this image can decode — `tesseract --version` reports leptonica
+linked against libgif, libjpeg, libpng, libtiff and libwebp, and leptonica reads
+BMP and the PNM family itself. The README, manifest and checksum files a real
+scan folder collects are therefore ignored rather than fed to leptonica, which
+would fail the run.
+
+`WithGlob` replaces both halves: a caller who names a pattern owns it, and gets
+no extension filtering, because leptonica sniffs content rather than trusting
+extensions and `**/*.scan` is a reasonable thing to ask for. PDFs stay rejected
+either way.
+
+`Files` reports the matched set without paying for the recognition, which is the
+answer to the question a glob always raises.
+
 ## Validation
 
 Builders have no error return, so every check below is deferred to the output
@@ -244,6 +312,10 @@ letting tesseract fail in its own vocabulary.
 | `WithParameter` with an empty name, or one containing `=` | `-c` takes `name=value`, so an embedded `=` silently sets a *different* variable |
 | `WithParameter` naming an unknown control variable | tesseract only warns (`Warning: The parameter '...' was not found.`) and exits 0, so a typo is indistinguishable from a no-op |
 | `WithDpi` at zero or negative | tesseract would take it as a real measurement and scale its analysis by it |
+| a `Batch` glob matching nothing | an empty directory is indistinguishable from a batch that ran and found no text, so a typo would surface much later as missing output |
+| a `Batch` source holding no images | same, but the fix is `WithGlob` rather than the pattern, so the message names the default extension set |
+| two `Batch` inputs sharing an output base | `a.png` and `a.jpg` both render onto `a.txt`; the second silently overwrites the first and the run looks like it succeeded with a page missing |
+| a `Batch` file name containing a tab or newline | the manifest is tab-separated and newline-delimited, so the loop would recognise the wrong file |
 
 Errors fold tesseract's own output in via `Expect: ReturnTypeAny` plus a
 combined stdout+stderr helper, because tesseract splits usage errors onto stderr
@@ -251,17 +323,21 @@ and progress onto stdout.
 
 ## Caching
 
-No `+cache=` directive appears on any `Document` output: recognition is a pure
-function of the image bytes plus the flags, so the 7-day default is correct and
-there is no chained-method propagation problem to worry about. `Container`,
+No `+cache=` directive appears on any `Document` or `Batch` output: recognition
+is a pure function of the image bytes plus the flags, so the 7-day default is
+correct and there is no chained-method propagation problem to worry about. `Container`,
 `Version`, `Langs` and `Parameters` take `+cache="session"` per `kicad`, because
 a floating Alpine tag can resolve differently across sessions.
 
 ## Follow-ups
 
-Batch OCR over a directory of images (#220); PDF-input rasterization (#221);
-the training toolchain (#222); a chained `Ci` builder (#223); an `examples/go`
-cookbook (#224).
+PDF-input rasterization (#221); the training toolchain (#222); a chained `Ci`
+builder (#223); an `examples/go` cookbook (#224).
+
+Batch OCR over a directory (#220) landed — see above. It deliberately does not
+expose the concatenated multi-page output tesseract's list-file mode produces; if
+"a folder of pages in, one document out" turns out to be wanted, that is a
+separate function, not a flag on `Export`.
 
 GPU acceleration is **not** a follow-up: tesseract has no CUDA path and upstream
 does not plan one, Alpine builds without OpenCL, and Dagger's GPU passthrough is

--- a/daggerverse/tesseract/batch.go
+++ b/daggerverse/tesseract/batch.go
@@ -1,0 +1,305 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+
+	"dagger/tesseract/internal/dagger"
+)
+
+// batchArgv0 is the `$0` the batch loop runs under. Every recognition flag and
+// configfile reaches the loop as `"$@"` rather than being interpolated into the
+// script, which is what keeps a parameter value with a space or a quote in it
+// from needing any escaping at all.
+const batchArgv0 = "tesseract-batch"
+
+// batchScript is the whole of the batch mechanism: read one record per image,
+// create its output directory, recognise it.
+//
+// `set -e` aborts on the first failure, so a page tesseract cannot read fails
+// the run carrying its own message instead of going quietly missing from the
+// results. IFS is a literal tab, so a file name with spaces survives the read;
+// checkManifestSafe rejects the tabs and newlines that would not.
+const batchScript = `set -e
+while IFS="` + "\t" + `" read -r src out dir; do
+	mkdir -p "$dir"
+	tesseract "$src" "$out" "$@"
+done < ` + batchManifestPath
+
+// imageExtensions is what the default glob accepts, lower-cased for a
+// case-insensitive comparison. It is the set this image can actually decode:
+// `tesseract --version` reports leptonica linked against libgif, libjpeg,
+// libpng, libtiff and libwebp, and leptonica reads BMP and the PNM family
+// itself.
+//
+// PDF is absent because leptonica cannot read it at all, which is the same
+// reason Document rejects a PDF source outright.
+var imageExtensions = []string{
+	".bmp", ".gif", ".jpe", ".jpeg", ".jpg", ".pbm",
+	".pgm", ".pnm", ".png", ".ppm", ".tif", ".tiff", ".webp",
+}
+
+// Batch is a directory of images plus the recognition options that apply to
+// all of them. It carries the same options type Document does, so the two
+// cannot drift: every With* here forwards to the shared builder.
+type Batch struct {
+	// +private
+	Tesseract *Tesseract
+	// +private
+	Source *dagger.Directory
+	// +private
+	Glob string
+	// +private
+	Options options
+}
+
+// WithGlob replaces the set of files to recognise with everything matching one
+// glob pattern, resolved against the directory root. `**` crosses directory
+// boundaries, so `**/*.tif` reaches nested scans and `receipts/*.png` stays in
+// one folder.
+//
+// Setting a pattern also takes over the extension filtering the default does.
+// That is deliberate: a caller who names the pattern knows what is in the
+// directory, and leptonica sniffs content rather than trusting extensions, so
+// `**/*.scan` is a reasonable thing to ask for. PDFs stay rejected either way,
+// because leptonica genuinely cannot read them.
+func (b *Batch) WithGlob(pattern string) *Batch {
+	out := *b
+	out.Glob = pattern
+	return &out
+}
+
+// WithLanguage selects the recognition language (`-l`) for every image in the
+// batch. See Document.WithLanguage.
+func (b *Batch) WithLanguage(lang string) *Batch {
+	return b.with(b.Options.withLanguage(lang))
+}
+
+// WithPageSegmentation sets how much layout analysis precedes recognition
+// (`--psm`) for every image in the batch. See Document.WithPageSegmentation.
+func (b *Batch) WithPageSegmentation(mode PageSegMode) *Batch {
+	return b.with(b.Options.withPageSegmentation(mode))
+}
+
+// WithEngine selects the OCR engine (`--oem`) for every image in the batch.
+// See Document.WithEngine.
+func (b *Batch) WithEngine(mode EngineMode) *Batch {
+	return b.with(b.Options.withEngine(mode))
+}
+
+// WithDpi declares the source resolution (`--dpi`) for every image in the
+// batch. See Document.WithDpi.
+func (b *Batch) WithDpi(dpi int) *Batch {
+	return b.with(b.Options.withDpi(dpi))
+}
+
+// WithParameter sets one of tesseract's control variables (`-c name=value`)
+// for every image in the batch. See Document.WithParameter.
+func (b *Batch) WithParameter(name string, value string) *Batch {
+	return b.with(b.Options.withParameter(name, value))
+}
+
+// WithUserWords supplies a word list (`--user-words`) for every image in the
+// batch. See Document.WithUserWords.
+func (b *Batch) WithUserWords(words *dagger.File) *Batch {
+	return b.with(b.Options.withUserWords(words))
+}
+
+// WithUserPatterns supplies a pattern list (`--user-patterns`) for every image
+// in the batch. See Document.WithUserPatterns.
+func (b *Batch) WithUserPatterns(patterns *dagger.File) *Batch {
+	return b.with(b.Options.withUserPatterns(patterns))
+}
+
+// Files lists the images the batch will recognise, as paths relative to the
+// source directory root, in the order they are processed.
+//
+// It answers the question a glob always raises — did that pattern pick up what
+// I meant? — without paying for the recognition, and it fails on an empty match
+// exactly as Export does.
+func (b *Batch) Files(ctx context.Context) ([]string, error) {
+	return b.matches(ctx)
+}
+
+// Export recognises every matched image and returns a directory mirroring the
+// input layout, with one artifact per requested format per image: `scans/a.png`
+// becomes `scans/a.txt` alongside `scans/a.pdf`.
+//
+// The whole batch is one container exec. tesseract's own list-file mode — a
+// text file of image paths as the FILE argument — is not what does that here,
+// because it treats the list as one multi-page *document*: it renders a single
+// concatenated artifact set (one .txt with form-feed page breaks, one
+// multi-page PDF) and offers no way to get the per-image files this returns.
+// So the exec loops over the manifest instead, which keeps the expensive part
+// — a container exec, its mounts and its cache lookup, per page — collapsed to
+// one, while each image still gets its own output base.
+func (b *Batch) Export(
+	ctx context.Context,
+	// Output formats to render for each image in the batch.
+	formats []Format,
+) (*dagger.Directory, error) {
+	configs, err := selectFormats(formats)
+	if err != nil {
+		return nil, err
+	}
+	sources, err := b.matches(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := b.Options.validate(ctx, b.Tesseract); err != nil {
+		return nil, err
+	}
+	manifest, err := batchManifest(sources)
+	if err != nil {
+		return nil, err
+	}
+	flags, err := b.Options.flags(b.Tesseract)
+	if err != nil {
+		return nil, err
+	}
+
+	args := append([]string{"sh", "-c", batchScript, batchArgv0}, flags...)
+	exec, err := execTesseract(ctx, b.container(manifest), append(args, configs...))
+	if err != nil {
+		return nil, err
+	}
+	return exec.Directory(outputDir), nil
+}
+
+// with returns a copy of the batch carrying a new option set, which is what
+// keeps every builder immutable.
+func (b *Batch) with(opts options) *Batch {
+	out := *b
+	out.Options = opts
+	return &out
+}
+
+// container mounts the source directory and the manifest the exec loops over,
+// alongside whatever the options bring with them.
+func (b *Batch) container(manifest *dagger.File) *dagger.Container {
+	return b.Options.mount(b.Tesseract.Container().
+		WithMountedDirectory(batchSourceDir, b.Source).
+		WithMountedFile(batchManifestPath, manifest))
+}
+
+// matches resolves the glob into the sorted list of images to recognise, and
+// reports the reasons a batch cannot run: nothing matched, a PDF matched, or
+// two images would render onto the same output base.
+func (b *Batch) matches(ctx context.Context) ([]string, error) {
+	pattern := b.Glob
+	if pattern == "" {
+		pattern = defaultBatchGlob
+	}
+	found, err := b.Source.Glob(ctx, pattern)
+	if err != nil {
+		return nil, fmt.Errorf("Batch: glob %q: %w", pattern, err)
+	}
+
+	var (
+		sources  []string
+		filtered int
+	)
+	for _, p := range found {
+		// Glob reports directories too, with a trailing separator. They are
+		// not inputs, and handing one to tesseract is an error rather than a
+		// no-op.
+		if strings.HasSuffix(p, "/") {
+			continue
+		}
+		if b.Glob == "" && !isImagePath(p) {
+			filtered++
+			continue
+		}
+		if err := rejectPdf(p); err != nil {
+			return nil, fmt.Errorf("Batch: %w", err)
+		}
+		if err := checkManifestSafe(p); err != nil {
+			return nil, err
+		}
+		sources = append(sources, p)
+	}
+	sort.Strings(sources)
+
+	if len(sources) == 0 {
+		return nil, emptyMatchError(b.Glob, pattern, filtered)
+	}
+	if err := checkOutputCollisions(sources); err != nil {
+		return nil, err
+	}
+	return sources, nil
+}
+
+// emptyMatchError explains an empty match in terms of whichever filter was
+// responsible, so the fix named is the one that applies. An empty directory
+// returned instead would look like a batch that succeeded and found no text.
+func emptyMatchError(glob string, pattern string, filtered int) error {
+	if glob != "" {
+		return fmt.Errorf(
+			"Batch: glob %q matched no files in the source directory: check the pattern against the directory layout (%q crosses directory boundaries, %q does not)",
+			pattern, "**", "*")
+	}
+	if filtered > 0 {
+		return fmt.Errorf(
+			"Batch: the source directory holds no images: %d file(s) were skipped because the default glob takes only %s; pass WithGlob to recognise other extensions",
+			filtered, strings.Join(imageExtensions, " "))
+	}
+	return fmt.Errorf("Batch: the source directory is empty")
+}
+
+// checkOutputCollisions rejects two inputs that would render onto the same
+// output base, which is what `a.png` and `a.tif` in one folder do: both become
+// `a.txt`, and the second silently overwrites the first.
+func checkOutputCollisions(sources []string) error {
+	seen := make(map[string]string, len(sources))
+	for _, p := range sources {
+		base := outputBaseFor(p)
+		if first, dup := seen[base]; dup {
+			return fmt.Errorf(
+				"Batch: %q and %q both render onto %q: rename one, or narrow the glob so only one of them matches",
+				first, p, base)
+		}
+		seen[base] = p
+	}
+	return nil
+}
+
+// checkManifestSafe rejects a path the tab-separated manifest cannot carry
+// unambiguously. Spaces are fine — the exec splits on tabs alone — but a tab or
+// a newline in a file name would be read as a field or record boundary and
+// recognise the wrong file.
+func checkManifestSafe(p string) error {
+	if strings.ContainsAny(p, "\t\n") {
+		return fmt.Errorf("Batch: file name %q contains a tab or newline, which the batch manifest cannot represent: rename it, or recognise it on its own with Document", p)
+	}
+	return nil
+}
+
+// batchManifest renders the file the exec loops over: one record per image,
+// holding the source path, the output base and the directory to create for it.
+// All three are absolute container paths, resolved here rather than in the
+// shell so the loop needs no path arithmetic of its own.
+func batchManifest(sources []string) (*dagger.File, error) {
+	var sb strings.Builder
+	for _, p := range sources {
+		out := outputDir + "/" + outputBaseFor(p)
+		fmt.Fprintf(&sb, "%s\t%s\t%s\n", batchSourceDir+"/"+p, out, path.Dir(out))
+	}
+	name := path.Base(batchManifestPath)
+	return dag.Directory().WithNewFile(name, sb.String()).File(name), nil
+}
+
+// outputBaseFor maps an input path onto the output base that mirrors it, by
+// dropping the extension each renderer then replaces with its own.
+func outputBaseFor(p string) string {
+	return strings.TrimSuffix(p, path.Ext(p))
+}
+
+// isImagePath reports whether a path carries one of the extensions the default
+// glob accepts. The comparison is case-insensitive because scanner software
+// writes `.JPG` as readily as `.jpg`.
+func isImagePath(p string) bool {
+	return contains(imageExtensions, strings.ToLower(path.Ext(p)))
+}

--- a/daggerverse/tesseract/dagger.gen.go
+++ b/daggerverse/tesseract/dagger.gen.go
@@ -95,47 +95,26 @@ func (r *Tesseract) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
-func (r Document) MarshalJSON() ([]byte, error) {
+func (r Batch) MarshalJSON() ([]byte, error) {
 	var concrete struct {
-		Tesseract    *Tesseract
-		Source       *dagger.File
-		Language     string
-		PageSeg      PageSegMode
-		Engine       EngineMode
-		Dpi          int
-		HasDpi       bool
-		ParamNames   []string
-		ParamValues  []string
-		UserWords    *dagger.File
-		UserPatterns *dagger.File
+		Tesseract *Tesseract
+		Source    *dagger.Directory
+		Glob      string
+		Options   options
 	}
 	concrete.Tesseract = r.Tesseract
 	concrete.Source = r.Source
-	concrete.Language = r.Language
-	concrete.PageSeg = r.PageSeg
-	concrete.Engine = r.Engine
-	concrete.Dpi = r.Dpi
-	concrete.HasDpi = r.HasDpi
-	concrete.ParamNames = r.ParamNames
-	concrete.ParamValues = r.ParamValues
-	concrete.UserWords = r.UserWords
-	concrete.UserPatterns = r.UserPatterns
+	concrete.Glob = r.Glob
+	concrete.Options = r.Options
 	return json.Marshal(&concrete)
 }
 
-func (r *Document) UnmarshalJSON(bs []byte) error {
+func (r *Batch) UnmarshalJSON(bs []byte) error {
 	var concrete struct {
-		Tesseract    *Tesseract
-		Source       *dagger.File
-		Language     string
-		PageSeg      PageSegMode
-		Engine       EngineMode
-		Dpi          int
-		HasDpi       bool
-		ParamNames   []string
-		ParamValues  []string
-		UserWords    *dagger.File
-		UserPatterns *dagger.File
+		Tesseract *Tesseract
+		Source    *dagger.Directory
+		Glob      string
+		Options   options
 	}
 	err := json.Unmarshal(bs, &concrete)
 	if err != nil {
@@ -143,15 +122,36 @@ func (r *Document) UnmarshalJSON(bs []byte) error {
 	}
 	r.Tesseract = concrete.Tesseract
 	r.Source = concrete.Source
-	r.Language = concrete.Language
-	r.PageSeg = concrete.PageSeg
-	r.Engine = concrete.Engine
-	r.Dpi = concrete.Dpi
-	r.HasDpi = concrete.HasDpi
-	r.ParamNames = concrete.ParamNames
-	r.ParamValues = concrete.ParamValues
-	r.UserWords = concrete.UserWords
-	r.UserPatterns = concrete.UserPatterns
+	r.Glob = concrete.Glob
+	r.Options = concrete.Options
+	return nil
+}
+
+func (r Document) MarshalJSON() ([]byte, error) {
+	var concrete struct {
+		Tesseract *Tesseract
+		Source    *dagger.File
+		Options   options
+	}
+	concrete.Tesseract = r.Tesseract
+	concrete.Source = r.Source
+	concrete.Options = r.Options
+	return json.Marshal(&concrete)
+}
+
+func (r *Document) UnmarshalJSON(bs []byte) error {
+	var concrete struct {
+		Tesseract *Tesseract
+		Source    *dagger.File
+		Options   options
+	}
+	err := json.Unmarshal(bs, &concrete)
+	if err != nil {
+		return err
+	}
+	r.Tesseract = concrete.Tesseract
+	r.Source = concrete.Source
+	r.Options = concrete.Options
 	return nil
 }
 
@@ -478,6 +478,151 @@ func dispatch(ctx context.Context) (rerr error) {
 func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName string, inputArgs map[string][]byte) (_ any, err error) {
 	_ = inputArgs
 	switch parentName {
+	case "Batch":
+		switch fnName {
+		case "Export":
+			var parent Batch
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var formats []Format
+			if inputArgs["formats"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["formats"]), &formats)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg formats", err))
+				}
+			}
+			return (*Batch).Export(&parent, ctx, formats)
+		case "Files":
+			var parent Batch
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Batch).Files(&parent, ctx)
+		case "WithDpi":
+			var parent Batch
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var dpi int
+			if inputArgs["dpi"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["dpi"]), &dpi)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg dpi", err))
+				}
+			}
+			return (*Batch).WithDpi(&parent, dpi), nil
+		case "WithEngine":
+			var parent Batch
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var mode EngineMode
+			if inputArgs["mode"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["mode"]), &mode)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg mode", err))
+				}
+			}
+			return (*Batch).WithEngine(&parent, mode), nil
+		case "WithGlob":
+			var parent Batch
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var pattern string
+			if inputArgs["pattern"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["pattern"]), &pattern)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg pattern", err))
+				}
+			}
+			return (*Batch).WithGlob(&parent, pattern), nil
+		case "WithLanguage":
+			var parent Batch
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var lang string
+			if inputArgs["lang"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["lang"]), &lang)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg lang", err))
+				}
+			}
+			return (*Batch).WithLanguage(&parent, lang), nil
+		case "WithPageSegmentation":
+			var parent Batch
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var mode PageSegMode
+			if inputArgs["mode"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["mode"]), &mode)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg mode", err))
+				}
+			}
+			return (*Batch).WithPageSegmentation(&parent, mode), nil
+		case "WithParameter":
+			var parent Batch
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var name string
+			if inputArgs["name"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["name"]), &name)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg name", err))
+				}
+			}
+			var value string
+			if inputArgs["value"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["value"]), &value)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg value", err))
+				}
+			}
+			return (*Batch).WithParameter(&parent, name, value), nil
+		case "WithUserPatterns":
+			var parent Batch
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var patterns *dagger.File
+			if inputArgs["patterns"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["patterns"]), &patterns)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg patterns", err))
+				}
+			}
+			return (*Batch).WithUserPatterns(&parent, patterns), nil
+		case "WithUserWords":
+			var parent Batch
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var words *dagger.File
+			if inputArgs["words"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["words"]), &words)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg words", err))
+				}
+			}
+			return (*Batch).WithUserWords(&parent, words), nil
+		default:
+			return nil, fmt.Errorf("unknown function %s", fnName)
+		}
 	case "Document":
 		switch fnName {
 		case "Alto":
@@ -660,6 +805,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 		}
 	case "Tesseract":
 		switch fnName {
+		case "Batch":
+			var parent Tesseract
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var source *dagger.Directory
+			if inputArgs["source"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["source"]), &source)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg source", err))
+				}
+			}
+			return (*Tesseract).Batch(&parent, source), nil
 		case "Container":
 			var parent Tesseract
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/tesseract/document.go
+++ b/daggerverse/tesseract/document.go
@@ -14,32 +14,16 @@ import (
 // immutable: every With* returns a copy, so a configured Document can be
 // branched into several outputs without the branches interfering.
 //
-// Options are validated at output time rather than in the builders, because a
-// builder has no error return and some checks (is this language installed? is
-// this a real control variable?) need the image itself to answer.
+// The options themselves live on the shared options type, which Batch carries
+// too — the builders here are forwarders, so a new recognition option reaches
+// both units of work at once instead of being implemented twice.
 type Document struct {
 	// +private
 	Tesseract *Tesseract
 	// +private
 	Source *dagger.File
 	// +private
-	Language string
-	// +private
-	PageSeg PageSegMode
-	// +private
-	Engine EngineMode
-	// +private
-	Dpi int
-	// +private
-	HasDpi bool
-	// +private
-	ParamNames []string
-	// +private
-	ParamValues []string
-	// +private
-	UserWords *dagger.File
-	// +private
-	UserPatterns *dagger.File
+	Options options
 }
 
 // WithLanguage selects the recognition language (`-l`). Several languages can
@@ -52,26 +36,20 @@ type Document struct {
 // rejected at output time with the available set listed. Unset, recognition
 // runs in the first language New installed.
 func (d *Document) WithLanguage(lang string) *Document {
-	out := d.clone()
-	out.Language = lang
-	return out
+	return d.with(d.Options.withLanguage(lang))
 }
 
 // WithPageSegmentation sets how much layout analysis precedes recognition
 // (`--psm`). Unset, tesseract uses fully automatic segmentation without
 // orientation detection.
 func (d *Document) WithPageSegmentation(mode PageSegMode) *Document {
-	out := d.clone()
-	out.PageSeg = mode
-	return out
+	return d.with(d.Options.withPageSegmentation(mode))
 }
 
 // WithEngine selects the OCR engine (`--oem`). Unset, tesseract picks based on
 // what the language data provides.
 func (d *Document) WithEngine(mode EngineMode) *Document {
-	out := d.clone()
-	out.Engine = mode
-	return out
+	return d.with(d.Options.withEngine(mode))
 }
 
 // WithDpi declares the source image's resolution (`--dpi`), which tesseract
@@ -79,10 +57,7 @@ func (d *Document) WithEngine(mode EngineMode) *Document {
 // on images that carry no resolution at all. A non-positive value is rejected
 // at output time.
 func (d *Document) WithDpi(dpi int) *Document {
-	out := d.clone()
-	out.Dpi = dpi
-	out.HasDpi = true
-	return out
+	return d.with(d.Options.withDpi(dpi))
 }
 
 // WithParameter sets one of tesseract's control variables (`-c name=value`);
@@ -93,27 +68,20 @@ func (d *Document) WithDpi(dpi int) *Document {
 // output time: tesseract itself only warns and carries on, so a typo would
 // otherwise silently do nothing.
 func (d *Document) WithParameter(name string, value string) *Document {
-	out := d.clone()
-	out.ParamNames = append(out.ParamNames, name)
-	out.ParamValues = append(out.ParamValues, value)
-	return out
+	return d.with(d.Options.withParameter(name, value))
 }
 
 // WithUserWords supplies a word list (`--user-words`): one word per line,
 // which recognition then favours. Useful for jargon and proper nouns the
 // packaged dictionary does not know.
 func (d *Document) WithUserWords(words *dagger.File) *Document {
-	out := d.clone()
-	out.UserWords = words
-	return out
+	return d.with(d.Options.withUserWords(words))
 }
 
 // WithUserPatterns supplies a pattern list (`--user-patterns`): one pattern
 // per line describing the shape of expected strings, such as part numbers.
 func (d *Document) WithUserPatterns(patterns *dagger.File) *Document {
-	out := d.clone()
-	out.UserPatterns = patterns
-	return out
+	return d.with(d.Options.withUserPatterns(patterns))
 }
 
 // Text recognises the document and returns the plain text directly, by asking
@@ -215,8 +183,8 @@ func (d *Document) Osd(ctx context.Context) (string, error) {
 	args := []string{"tesseract", source, stdoutBase}
 	args = append(args, d.Tesseract.tessdataArgs()...)
 	args = append(args, "-l", osdLanguage, "--psm", pageSegTokens[PageSegModeOsdOnly])
-	if d.HasDpi {
-		args = append(args, "--dpi", strconv.Itoa(d.Dpi))
+	if d.Options.HasDpi {
+		args = append(args, "--dpi", strconv.Itoa(d.Options.Dpi))
 	}
 	exec, err := execTesseract(ctx, d.container(source), args)
 	if err != nil {
@@ -263,10 +231,11 @@ func selectFormats(formats []Format) ([]string, error) {
 	return configs, nil
 }
 
-func (d *Document) clone() *Document {
+// with returns a copy of the document carrying a new option set, which is what
+// keeps every builder immutable.
+func (d *Document) with(opts options) *Document {
 	out := *d
-	out.ParamNames = append([]string(nil), d.ParamNames...)
-	out.ParamValues = append([]string(nil), d.ParamValues...)
+	out.Options = opts
 	return &out
 }
 
@@ -282,11 +251,12 @@ func (d *Document) run(ctx context.Context, output string, configs ...string) (*
 	if err != nil {
 		return nil, err
 	}
-	args, err := d.args(source, output, configs...)
+	flags, err := d.Options.flags(d.Tesseract)
 	if err != nil {
 		return nil, err
 	}
-	return execTesseract(ctx, d.container(source), args)
+	args := append([]string{"tesseract", source, output}, flags...)
+	return execTesseract(ctx, d.container(source), append(args, configs...))
 }
 
 // execTesseract runs one tesseract invocation, turning a non-zero exit into an
@@ -307,62 +277,9 @@ func execTesseract(ctx context.Context, ctr *dagger.Container, args []string) (*
 // container mounts the source and any user word/pattern lists, and stages the
 // writable output directory recognition renders into.
 func (d *Document) container(source string) *dagger.Container {
-	ctr := d.Tesseract.Container().
+	return d.Options.mount(d.Tesseract.Container().
 		WithMountedFile(source, d.Source).
-		WithExec([]string{"mkdir", "-p", outputDir})
-	if d.UserWords != nil {
-		ctr = ctr.WithMountedFile(userWordsPath, d.UserWords)
-	}
-	if d.UserPatterns != nil {
-		ctr = ctr.WithMountedFile(userPatternsPath, d.UserPatterns)
-	}
-	return ctr
-}
-
-// args renders the tesseract argv. Everything except the trailing configfiles
-// is a flag, and tesseract requires the flags first.
-func (d *Document) args(source string, output string, configs ...string) ([]string, error) {
-	args := []string{"tesseract", source, output}
-	args = append(args, d.Tesseract.tessdataArgs()...)
-	args = append(args, "-l", d.language())
-	if d.PageSeg != "" {
-		tok, ok := d.PageSeg.token()
-		if !ok {
-			return nil, fmt.Errorf("WithPageSegmentation: unknown mode %q", string(d.PageSeg))
-		}
-		args = append(args, "--psm", tok)
-	}
-	if d.Engine != "" {
-		tok, ok := d.Engine.token()
-		if !ok {
-			return nil, fmt.Errorf("WithEngine: unknown mode %q", string(d.Engine))
-		}
-		args = append(args, "--oem", tok)
-	}
-	if d.HasDpi {
-		args = append(args, "--dpi", strconv.Itoa(d.Dpi))
-	}
-	if d.UserWords != nil {
-		args = append(args, "--user-words", userWordsPath)
-	}
-	if d.UserPatterns != nil {
-		args = append(args, "--user-patterns", userPatternsPath)
-	}
-	for i, name := range d.ParamNames {
-		args = append(args, "-c", name+"="+d.ParamValues[i])
-	}
-	return append(args, configs...), nil
-}
-
-// language resolves the `-l` value: the caller's selection, or the first
-// installed language. Defaulting to the installed set rather than omitting the
-// flag matters when English was not installed — tesseract's own default is
-// "eng", which would fail to load.
-func (d *Document) language() string {
-	if strings.TrimSpace(d.Language) != "" {
-		return d.Language
-	}
-	return d.Tesseract.Languages[0]
+		WithExec([]string{"mkdir", "-p", outputDir}))
 }
 
 // validate reports every deferred builder check and returns the path the
@@ -372,13 +289,7 @@ func (d *Document) validate(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if err := d.validateDpi(); err != nil {
-		return "", err
-	}
-	if err := d.validateLanguage(ctx); err != nil {
-		return "", err
-	}
-	if err := d.validateParameters(ctx); err != nil {
+	if err := d.Options.validate(ctx, d.Tesseract); err != nil {
 		return "", err
 	}
 	return source, nil
@@ -387,116 +298,28 @@ func (d *Document) validate(ctx context.Context) (string, error) {
 // sourcePath resolves where the source is mounted, keeping the caller's
 // extension so container logs name something recognisable, and rejects PDF
 // input along the way.
-//
-// Leptonica — the image library tesseract reads through — has no PDF support
-// at all, and says so unhelpfully: it reports the file's first line as if it
-// were a file name it could not open. Rejecting the extension up front is the
-// difference between an actionable error and a confusing one.
 func (d *Document) sourcePath(ctx context.Context) (string, error) {
 	name, err := d.Source.Name(ctx)
 	if err != nil {
 		return "", fmt.Errorf("read source file name: %w", err)
 	}
-	if strings.EqualFold(path.Ext(name), ".pdf") {
-		return "", fmt.Errorf(
-			"source %q is a PDF: tesseract reads images through leptonica, which has no PDF support; rasterize the pages to PNG or TIFF first",
-			name)
+	if err := rejectPdf(name); err != nil {
+		return "", err
 	}
 	return workDir + "/source" + path.Ext(name), nil
 }
 
-// validateDpi rejects a non-positive `--dpi`, which tesseract would take as a
-// real resolution and scale its analysis by.
-func (d *Document) validateDpi() error {
-	if d.HasDpi && d.Dpi <= 0 {
-		return fmt.Errorf("WithDpi: dpi must be positive, got %d", d.Dpi)
-	}
-	return nil
-}
-
-// validateLanguage checks every `+`-joined code against what the image
-// actually carries. tesseract does fail on an unknown language, but its error
-// talks about traineddata paths and TESSDATA_PREFIX rather than about the
-// language set this module built the image with.
-func (d *Document) validateLanguage(ctx context.Context) error {
-	if strings.TrimSpace(d.Language) == "" {
-		return nil
-	}
-	installed, err := d.Tesseract.Langs(ctx)
-	if err != nil {
-		return err
-	}
-	for _, lang := range strings.Split(d.Language, "+") {
-		lang = strings.TrimSpace(lang)
-		if lang == "" {
-			return fmt.Errorf(
-				"WithLanguage: empty language code in %q: installed languages are %s",
-				d.Language, strings.Join(installed, ", "))
-		}
-		if !contains(installed, lang) {
-			return fmt.Errorf(
-				"WithLanguage: language %q is not installed: installed languages are %s; pass it to New(languages:) to add its package, or supply its model with WithTessdata",
-				lang, strings.Join(installed, ", "))
-		}
-	}
-	return nil
-}
-
-// validateParameters rejects a malformed or unknown control-variable name.
+// rejectPdf refuses a PDF source up front.
 //
-// The `=` and empty-name checks matter because `-c` takes `name=value`: an
-// embedded `=` would silently set a different variable to a different value.
-// The unknown-name check matters because tesseract only prints
-// `Warning: The parameter '...' was not found.` and exits 0, so a typo would
-// otherwise be indistinguishable from a setting that had no effect.
-func (d *Document) validateParameters(ctx context.Context) error {
-	for _, name := range d.ParamNames {
-		if strings.TrimSpace(name) == "" {
-			return fmt.Errorf("WithParameter: parameter name is required")
-		}
-		if strings.Contains(name, "=") {
-			return fmt.Errorf("WithParameter: parameter name %q must not contain %q", name, "=")
-		}
-	}
-	if len(d.ParamNames) == 0 {
+// Leptonica — the image library tesseract reads through — has no PDF support
+// at all, and says so unhelpfully: it reports the file's first line as if it
+// were a file name it could not open. Rejecting the extension here is the
+// difference between an actionable error and a confusing one.
+func rejectPdf(name string) error {
+	if !strings.EqualFold(path.Ext(name), ".pdf") {
 		return nil
 	}
-	known, err := d.Tesseract.Parameters(ctx)
-	if err != nil {
-		return err
-	}
-	names := parseParameterNames(known)
-	for _, name := range d.ParamNames {
-		if !contains(names, name) {
-			return fmt.Errorf(
-				"WithParameter: unknown parameter %q: tesseract reports %d control variables and this is not one of them; call Parameters() for the full list",
-				name, len(names))
-		}
-	}
-	return nil
-}
-
-// parseParameterNames pulls the names out of `--print-parameters`, whose rows
-// are `name<TAB>default<TAB>description` under a one-line header.
-func parseParameterNames(out string) []string {
-	var names []string
-	for _, line := range strings.Split(out, "\n") {
-		name, _, ok := strings.Cut(line, "\t")
-		if !ok {
-			continue
-		}
-		if name = strings.TrimSpace(name); name != "" {
-			names = append(names, name)
-		}
-	}
-	return names
-}
-
-func contains(haystack []string, needle string) bool {
-	for _, h := range haystack {
-		if h == needle {
-			return true
-		}
-	}
-	return false
+	return fmt.Errorf(
+		"source %q is a PDF: tesseract reads images through leptonica, which has no PDF support; rasterize the pages to PNG or TIFF first",
+		name)
 }

--- a/daggerverse/tesseract/main.go
+++ b/daggerverse/tesseract/main.go
@@ -21,8 +21,12 @@
 //
 //   - enums.go     — PageSegMode / EngineMode / Format enums plus the token and
 //     output-extension tables that map them onto the CLI.
-//   - document.go  — *Document, its immutable With* builders, the deferred
-//     validation, the argument builder, and every output.
+//   - options.go   — the recognition option set Document and Batch share: one
+//     builder, one piece of argv and one deferred check per option, so the two
+//     units of work cannot drift apart.
+//   - document.go  — *Document, one image in and one artifact set out.
+//   - batch.go     — *Batch, a directory in and a mirrored directory out, all
+//     of it in a single container exec.
 package main
 
 import (
@@ -86,6 +90,19 @@ const (
 
 	userWordsPath    = workDir + "/user-words.txt"
 	userPatternsPath = workDir + "/user-patterns.txt"
+
+	// batchSourceDir is where Batch mounts the caller's directory, and
+	// batchManifestPath the record list its exec loops over. Both sit beside
+	// the single-document mounts rather than replacing them, so the user word
+	// and pattern lists land in the same place for either unit of work.
+	batchSourceDir    = workDir + "/batch"
+	batchManifestPath = workDir + "/batch.tsv"
+
+	// defaultBatchGlob matches every path in the source directory. It is not
+	// the whole default: what actually narrows a batch to images is the
+	// extension filter isImagePath applies on top of it, because Dagger's glob
+	// has no brace expansion to spell the alternation with.
+	defaultBatchGlob = "**/*"
 
 	// ompThreadLimitEnv caps the OpenMP team size tesseract's recognition
 	// loops fan out to.
@@ -272,6 +289,18 @@ func (t *Tesseract) Parameters(ctx context.Context) (string, error) {
 // so one image — including a multi-page TIFF — is the whole unit of work.
 func (t *Tesseract) Document(source *dagger.File) *Document {
 	return &Document{Tesseract: t, Source: source}
+}
+
+// Batch binds a directory of images to the toolchain, for the shape a
+// scanned-document pipeline actually arrives in: a folder of pages rather than
+// one file at a time.
+//
+// Export returns a directory mirroring the input layout, so a batch composes
+// with whatever reads the results the same way the input directory was
+// composed. Which files take part is a glob, defaulting to the image
+// extensions leptonica can read.
+func (t *Tesseract) Batch(source *dagger.Directory) *Batch {
+	return &Batch{Tesseract: t, Source: source}
 }
 
 func (t *Tesseract) image() string {

--- a/daggerverse/tesseract/options.go
+++ b/daggerverse/tesseract/options.go
@@ -1,0 +1,261 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"dagger/tesseract/internal/dagger"
+)
+
+// options is the recognition option set that applies to a unit of work,
+// whatever that unit is: one image for Document, a whole directory for Batch.
+//
+// It exists as its own type so those two cannot drift. Every option is
+// expressed exactly once here — as a builder, as a piece of argv, and as a
+// deferred check — and Document and Batch each hold one of these and forward to
+// it. Adding an option means touching this file plus one three-line forwarder
+// per unit of work, rather than reimplementing the flag and its validation.
+//
+// It is a plain struct rather than a module object: Dagger surfaces it as a
+// `+private` field, so it round-trips as part of its owner's state and never
+// appears in the API. Callers still see the builders on Document and Batch,
+// which is where they read naturally.
+type options struct {
+	Language     string
+	PageSeg      PageSegMode
+	Engine       EngineMode
+	Dpi          int
+	HasDpi       bool
+	ParamNames   []string
+	ParamValues  []string
+	UserWords    *dagger.File
+	UserPatterns *dagger.File
+}
+
+// The builders are value-in, value-out: the owner copies itself and swaps its
+// options field, which is what makes a configured Document or Batch safe to
+// branch into several outputs without the branches interfering.
+
+func (o options) withLanguage(lang string) options {
+	out := o.clone()
+	out.Language = lang
+	return out
+}
+
+func (o options) withPageSegmentation(mode PageSegMode) options {
+	out := o.clone()
+	out.PageSeg = mode
+	return out
+}
+
+func (o options) withEngine(mode EngineMode) options {
+	out := o.clone()
+	out.Engine = mode
+	return out
+}
+
+func (o options) withDpi(dpi int) options {
+	out := o.clone()
+	out.Dpi = dpi
+	out.HasDpi = true
+	return out
+}
+
+func (o options) withParameter(name string, value string) options {
+	out := o.clone()
+	out.ParamNames = append(out.ParamNames, name)
+	out.ParamValues = append(out.ParamValues, value)
+	return out
+}
+
+func (o options) withUserWords(words *dagger.File) options {
+	out := o.clone()
+	out.UserWords = words
+	return out
+}
+
+func (o options) withUserPatterns(patterns *dagger.File) options {
+	out := o.clone()
+	out.UserPatterns = patterns
+	return out
+}
+
+// clone copies the slices as well as the struct, so appending a parameter to
+// one branch cannot be seen by another that shares the same backing array.
+func (o options) clone() options {
+	out := o
+	out.ParamNames = append([]string(nil), o.ParamNames...)
+	out.ParamValues = append([]string(nil), o.ParamValues...)
+	return out
+}
+
+// mount attaches whatever the options reference from the host: the user word
+// and pattern lists, at the paths flags names them by.
+func (o options) mount(ctr *dagger.Container) *dagger.Container {
+	if o.UserWords != nil {
+		ctr = ctr.WithMountedFile(userWordsPath, o.UserWords)
+	}
+	if o.UserPatterns != nil {
+		ctr = ctr.WithMountedFile(userPatternsPath, o.UserPatterns)
+	}
+	return ctr
+}
+
+// flags renders everything between `tesseract IMAGE OUTPUTBASE` and the
+// trailing configfiles. The split matters: tesseract stops parsing flags at the
+// first configfile, so a `-l` emitted after one is read as a file name to open.
+func (o options) flags(t *Tesseract) ([]string, error) {
+	args := append([]string(nil), t.tessdataArgs()...)
+	args = append(args, "-l", o.language(t))
+	if o.PageSeg != "" {
+		tok, ok := o.PageSeg.token()
+		if !ok {
+			return nil, fmt.Errorf("WithPageSegmentation: unknown mode %q", string(o.PageSeg))
+		}
+		args = append(args, "--psm", tok)
+	}
+	if o.Engine != "" {
+		tok, ok := o.Engine.token()
+		if !ok {
+			return nil, fmt.Errorf("WithEngine: unknown mode %q", string(o.Engine))
+		}
+		args = append(args, "--oem", tok)
+	}
+	if o.HasDpi {
+		args = append(args, "--dpi", strconv.Itoa(o.Dpi))
+	}
+	if o.UserWords != nil {
+		args = append(args, "--user-words", userWordsPath)
+	}
+	if o.UserPatterns != nil {
+		args = append(args, "--user-patterns", userPatternsPath)
+	}
+	for i, name := range o.ParamNames {
+		args = append(args, "-c", name+"="+o.ParamValues[i])
+	}
+	return args, nil
+}
+
+// language resolves the `-l` value: the caller's selection, or the first
+// installed language. Defaulting to the installed set rather than omitting the
+// flag matters when English was not installed — tesseract's own default is
+// "eng", which would fail to load.
+func (o options) language(t *Tesseract) string {
+	if strings.TrimSpace(o.Language) != "" {
+		return o.Language
+	}
+	return t.Languages[0]
+}
+
+// validate reports every deferred builder check.
+//
+// The checks live here rather than in the builders because a builder has no
+// error return, and because some of them (is this language installed? is this a
+// real control variable?) need the assembled image itself to answer.
+func (o options) validate(ctx context.Context, t *Tesseract) error {
+	if err := o.validateDpi(); err != nil {
+		return err
+	}
+	if err := o.validateLanguage(ctx, t); err != nil {
+		return err
+	}
+	return o.validateParameters(ctx, t)
+}
+
+// validateDpi rejects a non-positive `--dpi`, which tesseract would take as a
+// real resolution and scale its analysis by.
+func (o options) validateDpi() error {
+	if o.HasDpi && o.Dpi <= 0 {
+		return fmt.Errorf("WithDpi: dpi must be positive, got %d", o.Dpi)
+	}
+	return nil
+}
+
+// validateLanguage checks every `+`-joined code against what the image
+// actually carries. tesseract does fail on an unknown language, but its error
+// talks about traineddata paths and TESSDATA_PREFIX rather than about the
+// language set this module built the image with.
+func (o options) validateLanguage(ctx context.Context, t *Tesseract) error {
+	if strings.TrimSpace(o.Language) == "" {
+		return nil
+	}
+	installed, err := t.Langs(ctx)
+	if err != nil {
+		return err
+	}
+	for _, lang := range strings.Split(o.Language, "+") {
+		lang = strings.TrimSpace(lang)
+		if lang == "" {
+			return fmt.Errorf(
+				"WithLanguage: empty language code in %q: installed languages are %s",
+				o.Language, strings.Join(installed, ", "))
+		}
+		if !contains(installed, lang) {
+			return fmt.Errorf(
+				"WithLanguage: language %q is not installed: installed languages are %s; pass it to New(languages:) to add its package, or supply its model with WithTessdata",
+				lang, strings.Join(installed, ", "))
+		}
+	}
+	return nil
+}
+
+// validateParameters rejects a malformed or unknown control-variable name.
+//
+// The `=` and empty-name checks matter because `-c` takes `name=value`: an
+// embedded `=` would silently set a different variable to a different value.
+// The unknown-name check matters because tesseract only prints
+// `Warning: The parameter '...' was not found.` and exits 0, so a typo would
+// otherwise be indistinguishable from a setting that had no effect.
+func (o options) validateParameters(ctx context.Context, t *Tesseract) error {
+	for _, name := range o.ParamNames {
+		if strings.TrimSpace(name) == "" {
+			return fmt.Errorf("WithParameter: parameter name is required")
+		}
+		if strings.Contains(name, "=") {
+			return fmt.Errorf("WithParameter: parameter name %q must not contain %q", name, "=")
+		}
+	}
+	if len(o.ParamNames) == 0 {
+		return nil
+	}
+	known, err := t.Parameters(ctx)
+	if err != nil {
+		return err
+	}
+	names := parseParameterNames(known)
+	for _, name := range o.ParamNames {
+		if !contains(names, name) {
+			return fmt.Errorf(
+				"WithParameter: unknown parameter %q: tesseract reports %d control variables and this is not one of them; call Parameters() for the full list",
+				name, len(names))
+		}
+	}
+	return nil
+}
+
+// parseParameterNames pulls the names out of `--print-parameters`, whose rows
+// are `name<TAB>default<TAB>description` under a one-line header.
+func parseParameterNames(out string) []string {
+	var names []string
+	for _, line := range strings.Split(out, "\n") {
+		name, _, ok := strings.Cut(line, "\t")
+		if !ok {
+			continue
+		}
+		if name = strings.TrimSpace(name); name != "" {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/daggerverse/tesseract/tests/dagger.gen.go
+++ b/daggerverse/tesseract/tests/dagger.gen.go
@@ -213,6 +213,48 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).AltoIsValidXml(&parent, ctx)
+		case "BatchDefaultGlobSkipsNonImages":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).BatchDefaultGlobSkipsNonImages(&parent, ctx)
+		case "BatchExportProducesEveryFormatPerImage":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).BatchExportProducesEveryFormatPerImage(&parent, ctx)
+		case "BatchGlobSelectsFiles":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).BatchGlobSelectsFiles(&parent, ctx)
+		case "BatchMirrorsInputLayout":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).BatchMirrorsInputLayout(&parent, ctx)
+		case "BatchRejectsAmbiguousInput":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).BatchRejectsAmbiguousInput(&parent, ctx)
+		case "BatchSharesDocumentOptions":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).BatchSharesDocumentOptions(&parent, ctx)
 		case "DefaultLanguagesInstallEnglish":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/tesseract/tests/internal/dagger/dagger.gen.go
+++ b/daggerverse/tesseract/tests/internal/dagger/dagger.gen.go
@@ -331,6 +331,9 @@ type SyncerID string
 type TerminalID string
 
 // A unique identifier for an object.
+type TesseractBatchID string
+
+// A unique identifier for an object.
 type TesseractDocumentID string
 
 // A unique identifier for an object.
@@ -13350,6 +13353,16 @@ func (r *Query) LoadTerminalFromID(id TerminalID) *Terminal {
 	q = q.Arg("id", id)
 
 	return &Terminal{
+		query: q,
+	}
+}
+
+// Load a TesseractBatch from its ID.
+func (r *Query) LoadTesseractBatchFromID(id TesseractBatchID) *TesseractBatch {
+	q := r.query.Select("loadTesseractBatchFromID")
+	q = q.Arg("id", id)
+
+	return &TesseractBatch{
 		query: q,
 	}
 }

--- a/daggerverse/tesseract/tests/internal/dagger/tesseract.gen.go
+++ b/daggerverse/tesseract/tests/internal/dagger/tesseract.gen.go
@@ -11,10 +11,19 @@ import (
 )
 
 // Retrieve the binding value, as type Tesseract
-func (r *Binding) AsTesseract() *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:106:6)
+func (r *Binding) AsTesseract() *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:123:6)
 	q := r.query.Select("asTesseract")
 
 	return &Tesseract{
+		query: q,
+	}
+}
+
+// Retrieve the binding value, as type TesseractBatch
+func (r *Binding) AsTesseractBatch() *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:48:6)
+	q := r.query.Select("asTesseractBatch")
+
+	return &TesseractBatch{
 		query: q,
 	}
 }
@@ -24,6 +33,30 @@ func (r *Binding) AsTesseractDocument() *TesseractDocument { // tesseract (../..
 	q := r.query.Select("asTesseractDocument")
 
 	return &TesseractDocument{
+		query: q,
+	}
+}
+
+// Create or update a binding of type TesseractBatch in the environment
+func (r *Env) WithTesseractBatchInput(name string, value *TesseractBatch, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/batch.go:48:6)
+	assertNotNil("value", value)
+	q := r.query.Select("withTesseractBatchInput")
+	q = q.Arg("name", name)
+	q = q.Arg("value", value)
+	q = q.Arg("description", description)
+
+	return &Env{
+		query: q,
+	}
+}
+
+// Declare a desired TesseractBatch output to be assigned in the environment
+func (r *Env) WithTesseractBatchOutput(name string, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/batch.go:48:6)
+	q := r.query.Select("withTesseractBatchOutput")
+	q = q.Arg("name", name)
+	q = q.Arg("description", description)
+
+	return &Env{
 		query: q,
 	}
 }
@@ -53,7 +86,7 @@ func (r *Env) WithTesseractDocumentOutput(name string, description string) *Env 
 }
 
 // Create or update a binding of type Tesseract in the environment
-func (r *Env) WithTesseractInput(name string, value *Tesseract, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/main.go:106:6)
+func (r *Env) WithTesseractInput(name string, value *Tesseract, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/main.go:123:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withTesseractInput")
 	q = q.Arg("name", name)
@@ -66,7 +99,7 @@ func (r *Env) WithTesseractInput(name string, value *Tesseract, description stri
 }
 
 // Declare a desired Tesseract output to be assigned in the environment
-func (r *Env) WithTesseractOutput(name string, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/main.go:106:6)
+func (r *Env) WithTesseractOutput(name string, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/main.go:123:6)
 	q := r.query.Select("withTesseractOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -83,18 +116,18 @@ type TesseractOpts struct {
 	//
 	//
 	// Default: "docker.io"
-	Registry string // tesseract (../../../../../daggerverse/tesseract/main.go:124:2)
+	Registry string // tesseract (../../../../../daggerverse/tesseract/main.go:141:2)
 	//
 	// Tag of the alpine image the toolchain is assembled on.
 	//
 	//
 	// Default: "3.24"
-	AlpineTag string // tesseract (../../../../../daggerverse/tesseract/main.go:127:2)
+	AlpineTag string // tesseract (../../../../../daggerverse/tesseract/main.go:144:2)
 	//
 	// Language codes to install, one apk package each. Empty installs "eng".
 	// "osd" is not a recognition language but is required by Document.Osd.
 	//
-	Languages []string // tesseract (../../../../../daggerverse/tesseract/main.go:131:2)
+	Languages []string // tesseract (../../../../../daggerverse/tesseract/main.go:148:2)
 	//
 	// Upper bound on the OpenMP threads tesseract may use, set on the
 	// assembled image as OMP_THREAD_LIMIT. Unset, tesseract uses one thread
@@ -105,12 +138,12 @@ type TesseractOpts struct {
 	// slowdown reports (tesseract-ocr/tesseract#2611, #1171, #263). One
 	// thread per pass is the usual setting there.
 	//
-	OmpThreadLimit int // tesseract (../../../../../daggerverse/tesseract/main.go:141:2)
+	OmpThreadLimit int // tesseract (../../../../../daggerverse/tesseract/main.go:158:2)
 }
 
 // New returns a Tesseract module backed by <registry>/library/alpine:<tag>
 // with tesseract-ocr and one language package per requested language.
-func (r *Query) Tesseract(opts ...TesseractOpts) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:121:1)
+func (r *Query) Tesseract(opts ...TesseractOpts) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:138:1)
 	q := r.query.Select("tesseract")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `registry` optional argument
@@ -140,7 +173,7 @@ func (r *Query) Tesseract(opts ...TesseractOpts) *Tesseract { // tesseract (../.
 // It carries the image coordinates and the language set the image is built
 // with; Document hangs off it so the generated SDK surfaces recognition under
 // `dag.Tesseract().Document(...)`.
-type Tesseract struct { // tesseract (../../../../../daggerverse/tesseract/main.go:106:6)
+type Tesseract struct { // tesseract (../../../../../daggerverse/tesseract/main.go:123:6)
 	query *querybuilder.Selection
 
 	id         *ID
@@ -162,6 +195,24 @@ func (r *Tesseract) WithGraphQLQuery(q *querybuilder.Selection) *Tesseract {
 	}
 }
 
+// Batch binds a directory of images to the toolchain, for the shape a
+// scanned-document pipeline actually arrives in: a folder of pages rather than
+// one file at a time.
+//
+// Export returns a directory mirroring the input layout, so a batch composes
+// with whatever reads the results the same way the input directory was
+// composed. Which files take part is a glob, defaulting to the image
+// extensions leptonica can read.
+func (r *Tesseract) Batch(source *Directory) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/main.go:302:1)
+	assertNotNil("source", source)
+	q := r.query.Select("batch")
+	q = q.Arg("source", source)
+
+	return &TesseractBatch{
+		query: q,
+	}
+}
+
 // Container returns the assembled toolchain image. This is the escape hatch
 // for everything this module does not wrap — the training binaries the apk
 // package ships, `combine_tessdata`, and tesseract's long tail of renderers
@@ -169,7 +220,7 @@ func (r *Tesseract) WithGraphQLQuery(q *querybuilder.Selection) *Tesseract {
 //
 // A requested OpenMP bound lives here rather than on the recognition
 // invocation so everything reached through this escape hatch inherits it too.
-func (r *Tesseract) Container() *Container { // tesseract (../../../../../daggerverse/tesseract/main.go:195:1)
+func (r *Tesseract) Container() *Container { // tesseract (../../../../../daggerverse/tesseract/main.go:212:1)
 	q := r.query.Select("container")
 
 	return &Container{
@@ -182,7 +233,7 @@ func (r *Tesseract) Container() *Container { // tesseract (../../../../../dagger
 // The boundary input is a *dagger.File rather than a *dagger.Directory, unlike
 // the kicad module's Project: tesseract resolves nothing relative to its input,
 // so one image — including a multi-page TIFF — is the whole unit of work.
-func (r *Tesseract) Document(source *File) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/main.go:273:1)
+func (r *Tesseract) Document(source *File) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/main.go:290:1)
 	assertNotNil("source", source)
 	q := r.query.Select("document")
 	q = q.Arg("source", source)
@@ -245,7 +296,7 @@ func (r *Tesseract) UnmarshalJSON(bs []byte) error {
 // `tesseract --list-langs`: the packaged languages and any model WithTessdata
 // added, as one set. This is what Document.WithLanguage validates against, and
 // it includes "osd" when that model was installed or supplied.
-func (r *Tesseract) Langs(ctx context.Context) ([]string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:243:1)
+func (r *Tesseract) Langs(ctx context.Context) ([]string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:260:1)
 	q := r.query.Select("langs")
 
 	var response []string
@@ -257,7 +308,7 @@ func (r *Tesseract) Langs(ctx context.Context) ([]string, error) { // tesseract 
 // Parameters returns tesseract's control-variable table — every name, its
 // default value and a one-line description — as `tesseract --print-parameters`
 // prints it. These are the names Document.WithParameter accepts.
-func (r *Tesseract) Parameters(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:258:1)
+func (r *Tesseract) Parameters(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:275:1)
 	if r.parameters != nil {
 		return *r.parameters, nil
 	}
@@ -271,7 +322,7 @@ func (r *Tesseract) Parameters(ctx context.Context) (string, error) { // tessera
 
 // Version returns the tesseract release the assembled image ships, as the
 // bare version number reported by `tesseract --version`.
-func (r *Tesseract) Version(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:224:1)
+func (r *Tesseract) Version(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:241:1)
 	if r.version != nil {
 		return *r.version, nil
 	}
@@ -298,7 +349,7 @@ func (r *Tesseract) Version(ctx context.Context) (string, error) { // tesseract 
 // renderer configfiles and the font the PDF renderer needs. A caller-supplied
 // model wins over a packaged one of the same name, which is what makes
 // replacing the stock `eng` with a fine-tuned one work.
-func (r *Tesseract) WithTessdata(dir *Directory) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:177:1)
+func (r *Tesseract) WithTessdata(dir *Directory) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:194:1)
 	assertNotNil("dir", dir)
 	q := r.query.Select("withTessdata")
 	q = q.Arg("dir", dir)
@@ -316,13 +367,228 @@ func (r *Tesseract) AsNode() Node {
 	}
 }
 
+// Batch is a directory of images plus the recognition options that apply to
+// all of them. It carries the same options type Document does, so the two
+// cannot drift: every With* here forwards to the shared builder.
+type TesseractBatch struct { // tesseract (../../../../../daggerverse/tesseract/batch.go:48:6)
+	query *querybuilder.Selection
+
+	id *ID
+}
+type WithTesseractBatchFunc func(r *TesseractBatch) *TesseractBatch
+
+// With calls the provided function with current TesseractBatch.
+//
+// This is useful for reusability and readability by not breaking the calling chain.
+func (r *TesseractBatch) With(f WithTesseractBatchFunc) *TesseractBatch {
+	return f(r)
+}
+
+func (r *TesseractBatch) WithGraphQLQuery(q *querybuilder.Selection) *TesseractBatch {
+	return &TesseractBatch{
+		query: q,
+	}
+}
+
+// Export recognises every matched image and returns a directory mirroring the
+// input layout, with one artifact per requested format per image: `scans/a.png`
+// becomes `scans/a.txt` alongside `scans/a.pdf`.
+//
+// The whole batch is one container exec. tesseract's own list-file mode — a
+// text file of image paths as the FILE argument — is not what does that here,
+// because it treats the list as one multi-page *document*: it renders a single
+// concatenated artifact set (one .txt with form-feed page breaks, one
+// multi-page PDF) and offers no way to get the per-image files this returns.
+// So the exec loops over the manifest instead, which keeps the expensive part
+// — a container exec, its mounts and its cache lookup, per page — collapsed to
+// one, while each image still gets its own output base.
+func (r *TesseractBatch) Export(formats []TesseractFormat) *Directory { // tesseract (../../../../../daggerverse/tesseract/batch.go:139:1)
+	q := r.query.Select("export")
+	q = q.Arg("formats", formats)
+
+	return &Directory{
+		query: q,
+	}
+}
+
+// Files lists the images the batch will recognise, as paths relative to the
+// source directory root, in the order they are processed.
+//
+// It answers the question a glob always raises — did that pattern pick up what
+// I meant? — without paying for the recognition, and it fails on an empty match
+// exactly as Export does.
+func (r *TesseractBatch) Files(ctx context.Context) ([]string, error) { // tesseract (../../../../../daggerverse/tesseract/batch.go:123:1)
+	q := r.query.Select("files")
+
+	var response []string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// A unique identifier for this TesseractBatch.
+func (r *TesseractBatch) ID(ctx context.Context) (ID, error) {
+	if r.id != nil {
+		return *r.id, nil
+	}
+	q := r.query.Select("id")
+
+	var response ID
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// XXX_GraphQLType is an internal function. It returns the native GraphQL type name
+func (r *TesseractBatch) XXX_GraphQLType() string {
+	return "TesseractBatch"
+}
+
+// XXX_GraphQLIDType is an internal function. It returns the native GraphQL type name for the ID of this object
+func (r *TesseractBatch) XXX_GraphQLIDType() string {
+	return "ID"
+}
+
+// XXX_GraphQLID is an internal function. It returns the underlying type ID
+func (r *TesseractBatch) XXX_GraphQLID(ctx context.Context) (string, error) {
+	id, err := r.ID(ctx)
+	if err != nil {
+		return "", err
+	}
+	return string(id), nil
+}
+
+func (r *TesseractBatch) MarshalJSON() ([]byte, error) {
+	id, err := r.ID(marshalCtx)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(id)
+}
+func (r *TesseractBatch) UnmarshalJSON(bs []byte) error {
+	var id string
+	err := json.Unmarshal(bs, &id)
+	if err != nil {
+		return err
+	}
+	*r = TesseractBatch{query: selectNode(dag.query, id, "TesseractBatch")}
+	return nil
+}
+
+// WithDpi declares the source resolution (`--dpi`) for every image in the
+// batch. See Document.WithDpi.
+func (r *TesseractBatch) WithDpi(dpi int) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:95:1)
+	q := r.query.Select("withDpi")
+	q = q.Arg("dpi", dpi)
+
+	return &TesseractBatch{
+		query: q,
+	}
+}
+
+// WithEngine selects the OCR engine (`--oem`) for every image in the batch.
+// See Document.WithEngine.
+func (r *TesseractBatch) WithEngine(mode TesseractEngineMode) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:89:1)
+	q := r.query.Select("withEngine")
+	q = q.Arg("mode", mode)
+
+	return &TesseractBatch{
+		query: q,
+	}
+}
+
+// WithGlob replaces the set of files to recognise with everything matching one
+// glob pattern, resolved against the directory root. `**` crosses directory
+// boundaries, so `**/*.tif` reaches nested scans and `receipts/*.png` stays in
+// one folder.
+//
+// Setting a pattern also takes over the extension filtering the default does.
+// That is deliberate: a caller who names the pattern knows what is in the
+// directory, and leptonica sniffs content rather than trusting extensions, so
+// `**/*.scan` is a reasonable thing to ask for. PDFs stay rejected either way,
+// because leptonica genuinely cannot read them.
+func (r *TesseractBatch) WithGlob(pattern string) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:69:1)
+	q := r.query.Select("withGlob")
+	q = q.Arg("pattern", pattern)
+
+	return &TesseractBatch{
+		query: q,
+	}
+}
+
+// WithLanguage selects the recognition language (`-l`) for every image in the
+// batch. See Document.WithLanguage.
+func (r *TesseractBatch) WithLanguage(lang string) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:77:1)
+	q := r.query.Select("withLanguage")
+	q = q.Arg("lang", lang)
+
+	return &TesseractBatch{
+		query: q,
+	}
+}
+
+// WithPageSegmentation sets how much layout analysis precedes recognition
+// (`--psm`) for every image in the batch. See Document.WithPageSegmentation.
+func (r *TesseractBatch) WithPageSegmentation(mode TesseractPageSegMode) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:83:1)
+	q := r.query.Select("withPageSegmentation")
+	q = q.Arg("mode", mode)
+
+	return &TesseractBatch{
+		query: q,
+	}
+}
+
+// WithParameter sets one of tesseract's control variables (`-c name=value`)
+// for every image in the batch. See Document.WithParameter.
+func (r *TesseractBatch) WithParameter(name string, value string) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:101:1)
+	q := r.query.Select("withParameter")
+	q = q.Arg("name", name)
+	q = q.Arg("value", value)
+
+	return &TesseractBatch{
+		query: q,
+	}
+}
+
+// WithUserPatterns supplies a pattern list (`--user-patterns`) for every image
+// in the batch. See Document.WithUserPatterns.
+func (r *TesseractBatch) WithUserPatterns(patterns *File) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:113:1)
+	assertNotNil("patterns", patterns)
+	q := r.query.Select("withUserPatterns")
+	q = q.Arg("patterns", patterns)
+
+	return &TesseractBatch{
+		query: q,
+	}
+}
+
+// WithUserWords supplies a word list (`--user-words`) for every image in the
+// batch. See Document.WithUserWords.
+func (r *TesseractBatch) WithUserWords(words *File) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:107:1)
+	assertNotNil("words", words)
+	q := r.query.Select("withUserWords")
+	q = q.Arg("words", words)
+
+	return &TesseractBatch{
+		query: q,
+	}
+}
+
+// AsNode returns this TesseractBatch as a Node.
+// This is a local type conversion — no GraphQL call.
+func (r *TesseractBatch) AsNode() Node {
+	return &NodeClient{
+		query: r.query,
+	}
+}
+
 // Document is one image plus the recognition options that apply to it. It is
 // immutable: every With* returns a copy, so a configured Document can be
 // branched into several outputs without the branches interfering.
 //
-// Options are validated at output time rather than in the builders, because a
-// builder has no error return and some checks (is this language installed? is
-// this a real control variable?) need the image itself to answer.
+// The options themselves live on the shared options type, which Batch carries
+// too — the builders here are forwarders, so a new recognition option reaches
+// both units of work at once instead of being implemented twice.
 type TesseractDocument struct { // tesseract (../../../../../daggerverse/tesseract/document.go:20:6)
 	query *querybuilder.Selection
 
@@ -346,7 +612,7 @@ func (r *TesseractDocument) WithGraphQLQuery(q *querybuilder.Selection) *Tessera
 }
 
 // Alto returns ALTO XML, the layout schema libraries and archives ingest.
-func (r *TesseractDocument) Alto() *File { // tesseract (../../../../../daggerverse/tesseract/document.go:148:1)
+func (r *TesseractDocument) Alto() *File { // tesseract (../../../../../daggerverse/tesseract/document.go:116:1)
 	q := r.query.Select("alto")
 
 	return &File{
@@ -361,7 +627,7 @@ func (r *TesseractDocument) Alto() *File { // tesseract (../../../../../daggerve
 // several renderers per invocation: asking for text, hOCR and PDF together is
 // one pass over the image, not three. Each artifact is named `result` plus the
 // renderer's own extension.
-func (r *TesseractDocument) Export(formats []TesseractFormat) *Directory { // tesseract (../../../../../daggerverse/tesseract/document.go:177:1)
+func (r *TesseractDocument) Export(formats []TesseractFormat) *Directory { // tesseract (../../../../../daggerverse/tesseract/document.go:145:1)
 	q := r.query.Select("export")
 	q = q.Arg("formats", formats)
 
@@ -372,7 +638,7 @@ func (r *TesseractDocument) Export(formats []TesseractFormat) *Directory { // te
 
 // Hocr returns hOCR: HTML in which every recognised word carries its bounding
 // box and confidence, which is what layout-aware post-processing reads.
-func (r *TesseractDocument) Hocr() *File { // tesseract (../../../../../daggerverse/tesseract/document.go:143:1)
+func (r *TesseractDocument) Hocr() *File { // tesseract (../../../../../daggerverse/tesseract/document.go:111:1)
 	q := r.query.Select("hocr")
 
 	return &File{
@@ -437,7 +703,7 @@ func (r *TesseractDocument) UnmarshalJSON(bs []byte) error {
 // language, engine and page-segmentation mode have nothing to say about it.
 // The osd model has to be in the image: either as the package New installs for
 // it, or as an osd.traineddata WithTessdata supplied.
-func (r *TesseractDocument) Osd(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/document.go:201:1)
+func (r *TesseractDocument) Osd(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/document.go:169:1)
 	if r.osd != nil {
 		return *r.osd, nil
 	}
@@ -451,7 +717,7 @@ func (r *TesseractDocument) Osd(ctx context.Context) (string, error) { // tesser
 
 // Page returns PAGE XML, the PRImA layout-analysis schema — the alternative to
 // ALTO for tools built around that ecosystem.
-func (r *TesseractDocument) Page() *File { // tesseract (../../../../../daggerverse/tesseract/document.go:166:1)
+func (r *TesseractDocument) Page() *File { // tesseract (../../../../../daggerverse/tesseract/document.go:134:1)
 	q := r.query.Select("page")
 
 	return &File{
@@ -461,7 +727,7 @@ func (r *TesseractDocument) Page() *File { // tesseract (../../../../../daggerve
 
 // Pdf returns a searchable PDF: the source image with an invisible text layer
 // positioned behind it, so the page looks untouched but selects and greps.
-func (r *TesseractDocument) Pdf() *File { // tesseract (../../../../../daggerverse/tesseract/document.go:160:1)
+func (r *TesseractDocument) Pdf() *File { // tesseract (../../../../../daggerverse/tesseract/document.go:128:1)
 	q := r.query.Select("pdf")
 
 	return &File{
@@ -472,7 +738,7 @@ func (r *TesseractDocument) Pdf() *File { // tesseract (../../../../../daggerver
 // Text recognises the document and returns the plain text directly, by asking
 // tesseract to write to stdout instead of a file. This is the shortest path
 // for the common case; Txt is the same content as a *dagger.File.
-func (r *TesseractDocument) Text(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/document.go:122:1)
+func (r *TesseractDocument) Text(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/document.go:90:1)
 	if r.text != nil {
 		return *r.text, nil
 	}
@@ -486,7 +752,7 @@ func (r *TesseractDocument) Text(ctx context.Context) (string, error) { // tesse
 
 // Tsv returns tab-separated recognition results: one row per layout element,
 // descending from page to word, each with its box and confidence.
-func (r *TesseractDocument) Tsv() *File { // tesseract (../../../../../daggerverse/tesseract/document.go:154:1)
+func (r *TesseractDocument) Tsv() *File { // tesseract (../../../../../daggerverse/tesseract/document.go:122:1)
 	q := r.query.Select("tsv")
 
 	return &File{
@@ -497,7 +763,7 @@ func (r *TesseractDocument) Tsv() *File { // tesseract (../../../../../daggerver
 // Txt recognises the document and returns the plain text as a file. It is the
 // same content Text returns; take this when the next step wants a file rather
 // than a string.
-func (r *TesseractDocument) Txt() *File { // tesseract (../../../../../daggerverse/tesseract/document.go:137:1)
+func (r *TesseractDocument) Txt() *File { // tesseract (../../../../../daggerverse/tesseract/document.go:105:1)
 	q := r.query.Select("txt")
 
 	return &File{
@@ -509,7 +775,7 @@ func (r *TesseractDocument) Txt() *File { // tesseract (../../../../../daggerver
 // otherwise guesses from the image metadata. Guessing wrong hurts recognition
 // on images that carry no resolution at all. A non-positive value is rejected
 // at output time.
-func (r *TesseractDocument) WithDpi(dpi int) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:81:1)
+func (r *TesseractDocument) WithDpi(dpi int) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:59:1)
 	q := r.query.Select("withDpi")
 	q = q.Arg("dpi", dpi)
 
@@ -520,7 +786,7 @@ func (r *TesseractDocument) WithDpi(dpi int) *TesseractDocument { // tesseract (
 
 // WithEngine selects the OCR engine (`--oem`). Unset, tesseract picks based on
 // what the language data provides.
-func (r *TesseractDocument) WithEngine(mode TesseractEngineMode) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:71:1)
+func (r *TesseractDocument) WithEngine(mode TesseractEngineMode) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:51:1)
 	q := r.query.Select("withEngine")
 	q = q.Arg("mode", mode)
 
@@ -538,7 +804,7 @@ func (r *TesseractDocument) WithEngine(mode TesseractEngineMode) *TesseractDocum
 // both of those are baked in when the image is assembled. An unknown value is
 // rejected at output time with the available set listed. Unset, recognition
 // runs in the first language New installed.
-func (r *TesseractDocument) WithLanguage(lang string) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:54:1)
+func (r *TesseractDocument) WithLanguage(lang string) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:38:1)
 	q := r.query.Select("withLanguage")
 	q = q.Arg("lang", lang)
 
@@ -550,7 +816,7 @@ func (r *TesseractDocument) WithLanguage(lang string) *TesseractDocument { // te
 // WithPageSegmentation sets how much layout analysis precedes recognition
 // (`--psm`). Unset, tesseract uses fully automatic segmentation without
 // orientation detection.
-func (r *TesseractDocument) WithPageSegmentation(mode TesseractPageSegMode) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:63:1)
+func (r *TesseractDocument) WithPageSegmentation(mode TesseractPageSegMode) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:45:1)
 	q := r.query.Select("withPageSegmentation")
 	q = q.Arg("mode", mode)
 
@@ -566,7 +832,7 @@ func (r *TesseractDocument) WithPageSegmentation(mode TesseractPageSegMode) *Tes
 // functions cannot accept map parameters. An unknown name is rejected at
 // output time: tesseract itself only warns and carries on, so a typo would
 // otherwise silently do nothing.
-func (r *TesseractDocument) WithParameter(name string, value string) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:95:1)
+func (r *TesseractDocument) WithParameter(name string, value string) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:70:1)
 	q := r.query.Select("withParameter")
 	q = q.Arg("name", name)
 	q = q.Arg("value", value)
@@ -578,7 +844,7 @@ func (r *TesseractDocument) WithParameter(name string, value string) *TesseractD
 
 // WithUserPatterns supplies a pattern list (`--user-patterns`): one pattern
 // per line describing the shape of expected strings, such as part numbers.
-func (r *TesseractDocument) WithUserPatterns(patterns *File) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:113:1)
+func (r *TesseractDocument) WithUserPatterns(patterns *File) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:83:1)
 	assertNotNil("patterns", patterns)
 	q := r.query.Select("withUserPatterns")
 	q = q.Arg("patterns", patterns)
@@ -591,7 +857,7 @@ func (r *TesseractDocument) WithUserPatterns(patterns *File) *TesseractDocument 
 // WithUserWords supplies a word list (`--user-words`): one word per line,
 // which recognition then favours. Useful for jargon and proper nouns the
 // packaged dictionary does not know.
-func (r *TesseractDocument) WithUserWords(words *File) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:105:1)
+func (r *TesseractDocument) WithUserWords(words *File) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:77:1)
 	assertNotNil("words", words)
 	q := r.query.Select("withUserWords")
 	q = q.Arg("words", words)

--- a/daggerverse/tesseract/tests/main.go
+++ b/daggerverse/tesseract/tests/main.go
@@ -103,6 +103,13 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("PdfHasPdfMagic", t.PdfHasPdfMagic)
 	jobs = jobs.WithJob("ExportProducesEveryRequestedFormat", t.ExportProducesEveryRequestedFormat)
 
+	jobs = jobs.WithJob("BatchMirrorsInputLayout", t.BatchMirrorsInputLayout)
+	jobs = jobs.WithJob("BatchDefaultGlobSkipsNonImages", t.BatchDefaultGlobSkipsNonImages)
+	jobs = jobs.WithJob("BatchGlobSelectsFiles", t.BatchGlobSelectsFiles)
+	jobs = jobs.WithJob("BatchExportProducesEveryFormatPerImage", t.BatchExportProducesEveryFormatPerImage)
+	jobs = jobs.WithJob("BatchSharesDocumentOptions", t.BatchSharesDocumentOptions)
+	jobs = jobs.WithJob("BatchRejectsAmbiguousInput", t.BatchRejectsAmbiguousInput)
+
 	jobs = jobs.WithJob("TessdataModelIsSelectable", t.TessdataModelIsSelectable)
 	jobs = jobs.WithJob("TessdataSuppliesOsdModel", t.TessdataSuppliesOsdModel)
 
@@ -721,6 +728,289 @@ func (t *Tests) NonPositiveDpiIsRejected(ctx context.Context) error {
 	return assertSentenceLines(got)
 }
 
+// ---------------------------------------------------------------------- batch
+
+// BatchMirrorsInputLayout asserts a directory in gives a directory out with the
+// same shape: one artifact per image, at the input's own path with the
+// renderer's extension, nested folders and all.
+//
+// Mirroring is the whole point of the return type. A batch that returned a flat
+// directory of `result-1.txt`, `result-2.txt` would force every caller to
+// rebuild the correspondence between page and text that the input directory
+// already expressed.
+func (t *Tests) BatchMirrorsInputLayout(ctx context.Context) error {
+	out := ocr().Batch(batchSource()).Export([]dagger.TesseractFormat{dagger.TesseractFormatTxt})
+
+	entries, err := out.Glob(ctx, "**/*")
+	if err != nil {
+		return fmt.Errorf("Export: %w", err)
+	}
+	want := []string{"scans/", "scans/deep/", "scans/deep/page-3.txt", "scans/page-1.txt", "scans/page-2.txt"}
+	sort.Strings(entries)
+	if !reflect.DeepEqual(entries, want) {
+		return fmt.Errorf("expected the output to mirror the input layout as %v, got %v", want, entries)
+	}
+
+	// Every mirrored artifact has to hold that image's own recognised text,
+	// not just exist at the right path.
+	for _, name := range []string{"scans/page-1.txt", "scans/page-2.txt", "scans/deep/page-3.txt"} {
+		got, err := out.File(name).Contents(ctx)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", name, err)
+		}
+		if err := assertSentenceLines(got); err != nil {
+			return fmt.Errorf("%s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+// BatchDefaultGlobSkipsNonImages asserts the default glob takes the images out
+// of a real scan folder and leaves the rest alone.
+//
+// A folder of scans collects README files, manifests and checksums, and none of
+// them are pages. Handing one to tesseract is not a no-op — leptonica fails to
+// decode it and the run dies — so "ignored by default" is what makes pointing
+// Batch at an existing directory work at all.
+func (t *Tests) BatchDefaultGlobSkipsNonImages(ctx context.Context) error {
+	got, err := ocr().Batch(batchSource()).Files(ctx)
+	if err != nil {
+		return fmt.Errorf("Files: %w", err)
+	}
+	want := []string{"scans/deep/page-3.png", "scans/page-1.png", "scans/page-2.png"}
+	if !reflect.DeepEqual(got, want) {
+		return fmt.Errorf("expected the default glob to select %v, got %v", want, got)
+	}
+
+	// Scanner software writes .JPG as readily as .jpg, so the extension match
+	// is case-insensitive.
+	got, err = ocr().Batch(dag.Directory().WithFile("PAGE.PNG", fixture(sentencePng))).Files(ctx)
+	if err != nil {
+		return fmt.Errorf("Files with an upper-case extension: %w", err)
+	}
+	if want := []string{"PAGE.PNG"}; !reflect.DeepEqual(got, want) {
+		return fmt.Errorf("expected %v, got %v", want, got)
+	}
+
+	// A directory with nothing recognisable in it is an error naming the
+	// filter that rejected everything, not an empty result.
+	_, err = ocr().Batch(dag.Directory().
+		WithNewFile("notes.md", "x").
+		WithNewFile("checksums.txt", "y")).
+		Files(ctx)
+	if err == nil {
+		return fmt.Errorf("expected a directory holding no images to be rejected, got nil")
+	}
+	for _, want := range []string{"holds no images", "2 file(s)", ".png", "WithGlob"} {
+		if !strings.Contains(err.Error(), want) {
+			return fmt.Errorf("expected the error to mention %q, got: %v", want, err)
+		}
+	}
+	return nil
+}
+
+// BatchGlobSelectsFiles asserts WithGlob decides what takes part, and that a
+// pattern matching nothing fails the call.
+//
+// The empty case is the one worth pinning. Returning an empty directory would
+// be indistinguishable from a batch that ran and found no text, so a typo in a
+// pattern would surface much later as missing output rather than here as a bad
+// glob.
+func (t *Tests) BatchGlobSelectsFiles(ctx context.Context) error {
+	batch := ocr().Batch(batchSource())
+
+	// A single-level pattern stays in its folder; ** crosses into deep/.
+	got, err := batch.WithGlob("scans/*.png").Files(ctx)
+	if err != nil {
+		return fmt.Errorf("Files with a single-level glob: %w", err)
+	}
+	if want := []string{"scans/page-1.png", "scans/page-2.png"}; !reflect.DeepEqual(got, want) {
+		return fmt.Errorf("expected a single-level glob to select %v, got %v", want, got)
+	}
+
+	got, err = batch.WithGlob("**/deep/*.png").Files(ctx)
+	if err != nil {
+		return fmt.Errorf("Files with a nested glob: %w", err)
+	}
+	if want := []string{"scans/deep/page-3.png"}; !reflect.DeepEqual(got, want) {
+		return fmt.Errorf("expected a nested glob to select %v, got %v", want, got)
+	}
+
+	// The narrowed set is what gets recognised, so the glob reaches the exec
+	// rather than only the listing.
+	entries, err := batch.WithGlob("**/deep/*.png").
+		Export([]dagger.TesseractFormat{dagger.TesseractFormatTxt}).
+		Glob(ctx, "**/*")
+	if err != nil {
+		return fmt.Errorf("Export with a nested glob: %w", err)
+	}
+	sort.Strings(entries)
+	if want := []string{"scans/", "scans/deep/", "scans/deep/page-3.txt"}; !reflect.DeepEqual(entries, want) {
+		return fmt.Errorf("expected the glob to narrow the output to %v, got %v", want, entries)
+	}
+
+	_, err = batch.WithGlob("**/*.tif").Files(ctx)
+	if err == nil {
+		return fmt.Errorf("expected a glob matching nothing to be rejected, got nil")
+	}
+	for _, want := range []string{`"**/*.tif"`, "matched no files"} {
+		if !strings.Contains(err.Error(), want) {
+			return fmt.Errorf("expected the error to mention %q, got: %v", want, err)
+		}
+	}
+	return nil
+}
+
+// BatchExportProducesEveryFormatPerImage asserts each image gets its own full
+// artifact set, named off its own path rather than off a shared output base.
+//
+// This is where the per-image design earns itself: tesseract's list-file mode
+// would render one concatenated artifact per *format* — a single .txt with
+// form-feed page breaks and a single multi-page PDF — with no way to tell which
+// page produced what.
+func (t *Tests) BatchExportProducesEveryFormatPerImage(ctx context.Context) error {
+	source := dag.Directory().
+		WithFile("a.png", fixture(sentencePng)).
+		WithFile("nested/b.png", fixture(sentencePng))
+
+	out := ocr().Batch(source).Export([]dagger.TesseractFormat{
+		dagger.TesseractFormatTxt,
+		dagger.TesseractFormatHocr,
+		dagger.TesseractFormatAlto,
+		dagger.TesseractFormatTsv,
+		dagger.TesseractFormatPdf,
+		dagger.TesseractFormatPage,
+	})
+	entries, err := out.Glob(ctx, "**/*")
+	if err != nil {
+		return fmt.Errorf("Export: %w", err)
+	}
+	want := []string{
+		"a.hocr", "a.page.xml", "a.pdf", "a.tsv", "a.txt", "a.xml",
+		"nested/", "nested/b.hocr", "nested/b.page.xml", "nested/b.pdf",
+		"nested/b.tsv", "nested/b.txt", "nested/b.xml",
+	}
+	sort.Strings(entries)
+	if !reflect.DeepEqual(entries, want) {
+		return fmt.Errorf("expected every format for every image as %v, got %v", want, entries)
+	}
+
+	// The PDF is a real one rather than an empty file left behind by a
+	// renderer that ran against the wrong output base.
+	pdf, err := exportBytes(ctx, out.File("nested/b.pdf"), "b.pdf")
+	if err != nil {
+		return err
+	}
+	if !bytes.HasPrefix(pdf, []byte("%PDF-")) {
+		return fmt.Errorf("expected a PDF header in the nested artifact, got %q", firstBytes(pdf, 8))
+	}
+	return nil
+}
+
+// BatchSharesDocumentOptions asserts the recognition options behave the same on
+// a batch as on a single document, which is the reason both hold one shared
+// option set rather than two parallel copies.
+//
+// It covers both halves: an option that has to reach tesseract for every image
+// in the run, and the deferred validation that has to reject a bad option
+// before any of them are recognised.
+func (t *Tests) BatchSharesDocumentOptions(ctx context.Context) error {
+	batch := ocr().Batch(batchSource())
+
+	// A digits-only whitelist suppresses every word, and has to do so in each
+	// image's own artifact — so `-c` reached every iteration of the loop, not
+	// just the first.
+	out := batch.
+		WithParameter("tessedit_char_whitelist", "0123456789").
+		Export([]dagger.TesseractFormat{dagger.TesseractFormatTxt})
+	for _, name := range []string{"scans/page-1.txt", "scans/page-2.txt", "scans/deep/page-3.txt"} {
+		got, err := out.File(name).Contents(ctx)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", name, err)
+		}
+		if strings.Contains(got, "quick") {
+			return fmt.Errorf("expected the whitelist to suppress words in %s, got:\n%s", name, got)
+		}
+	}
+
+	// A word list still has to mount and recognise, which is what catches a
+	// flag emitted in the wrong position for the batch argv.
+	got, err := batch.
+		WithUserWords(textFile("user-words.txt", "vexingly\nSphinx\n")).
+		Export([]dagger.TesseractFormat{dagger.TesseractFormatTxt}).
+		File("scans/page-1.txt").
+		Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("Export with user words: %w", err)
+	}
+	if err := assertSentenceLines(got); err != nil {
+		return fmt.Errorf("batch with user words: %w", err)
+	}
+
+	// The deferred checks are the same ones Document defers, with the same
+	// messages, and they fire before anything is recognised.
+	for _, tc := range []struct {
+		name  string
+		build func(*dagger.TesseractBatch) *dagger.TesseractBatch
+		want  string
+	}{
+		{"WithLanguage", func(b *dagger.TesseractBatch) *dagger.TesseractBatch { return b.WithLanguage("deu") }, "is not installed"},
+		{"WithDpi", func(b *dagger.TesseractBatch) *dagger.TesseractBatch { return b.WithDpi(0) }, "dpi must be positive"},
+		{"WithParameter", func(b *dagger.TesseractBatch) *dagger.TesseractBatch {
+			return b.WithParameter("not_a_real_parameter", "1")
+		}, "unknown parameter"},
+	} {
+		_, err := tc.build(batch).
+			Export([]dagger.TesseractFormat{dagger.TesseractFormatTxt}).
+			Entries(ctx)
+		if err == nil {
+			return fmt.Errorf("expected batch %s to be rejected, got nil", tc.name)
+		}
+		if !strings.Contains(err.Error(), tc.want) {
+			return fmt.Errorf("expected batch %s to fail with %q, got: %v", tc.name, tc.want, err)
+		}
+	}
+	return nil
+}
+
+// BatchRejectsAmbiguousInput asserts the two ways a matched set cannot be
+// recognised are refused before the run, rather than producing quietly wrong
+// output.
+//
+// A collision is the subtle one: `a.png` and `a.jpg` in one folder both render
+// onto `a.txt`, so the second silently overwrites the first and the batch looks
+// like it succeeded with one page missing.
+func (t *Tests) BatchRejectsAmbiguousInput(ctx context.Context) error {
+	_, err := ocr().Batch(dag.Directory().
+		WithFile("scans/page.png", fixture(sentencePng)).
+		WithFile("scans/page.jpg", fixture(sentencePng))).
+		Files(ctx)
+	if err == nil {
+		return fmt.Errorf("expected two images sharing an output base to be rejected, got nil")
+	}
+	for _, want := range []string{"scans/page.jpg", "scans/page.png", "scans/page"} {
+		if !strings.Contains(err.Error(), want) {
+			return fmt.Errorf("expected the collision error to name %q, got: %v", want, err)
+		}
+	}
+
+	// A PDF reached by an explicit glob is refused with the same explanation
+	// Document gives, since leptonica is the thing that cannot read it either
+	// way.
+	_, err = ocr().Batch(dag.Directory().WithNewFile("scan.pdf", "%PDF-1.7\n")).
+		WithGlob("**/*.pdf").
+		Files(ctx)
+	if err == nil {
+		return fmt.Errorf("expected a PDF reached by an explicit glob to be rejected, got nil")
+	}
+	for _, want := range []string{"scan.pdf", "leptonica", "rasterize"} {
+		if !strings.Contains(err.Error(), want) {
+			return fmt.Errorf("expected the error to mention %q, got: %v", want, err)
+		}
+	}
+	return nil
+}
+
 // ------------------------------------------------------------------ helpers
 
 // ocr builds the module under test with the suite's OpenMP bound and the given
@@ -759,6 +1049,19 @@ func readOmpThreadLimit(ctx context.Context, t *dagger.Tesseract) (string, error
 // work, not to publish where Alpine keeps its own.
 func traineddata(t *dagger.Tesseract, lang string) *dagger.File {
 	return t.Container().File(packagedTessdataDir + "/" + lang + ".traineddata")
+}
+
+// batchSource builds the directory the batch tests recognise: three copies of
+// the upright fixture at three different depths, plus the non-image files a
+// real scan folder collects. It is assembled from the committed fixtures rather
+// than adding more of them, so the layout a test needs is visible in the test.
+func batchSource() *dagger.Directory {
+	return dag.Directory().
+		WithFile("scans/page-1.png", fixture(sentencePng)).
+		WithFile("scans/page-2.png", fixture(sentencePng)).
+		WithFile("scans/deep/page-3.png", fixture(sentencePng)).
+		WithNewFile("README.md", "scanned intake, 2026-07\n").
+		WithNewFile("scans/manifest.txt", "page-1\npage-2\n")
 }
 
 // fixture returns a committed test image by name under fixtures/.


### PR DESCRIPTION
Closes #220.

`Tesseract.Batch(dir)` takes a directory and `Export` returns one mirroring it, with an artifact per requested format per image: `scans/deep/page-3.png` becomes `scans/deep/page-3.txt` next to `scans/deep/page-3.pdf`.

```go
Tesseract.Batch(source *dagger.Directory) *Batch

Batch.WithGlob(pattern string) *Batch    // default: the image extensions below
Batch.WithLanguage(lang string) *Batch   // …and the six other Document builders
Batch.Files(ctx) ([]string, error)
Batch.Export(ctx, formats []Format) (*dagger.Directory, error)
```

## The issue's mechanism doesn't work as specified

AC #3 asked for "a single tesseract invocation over a list file". Verified in-container that tesseract's list-file mode does not do what its name suggests — it treats the list as one multi-page **document** and renders a *single concatenated artifact set*:

- `result.txt` — both pages joined by a form feed (`\f`)
- `result.pdf` — one 2-page PDF
- `result.hocr` — `page_1` / `page_2` divs in one file
- `result.tsv` — one table, pages distinguished by `page_num`

There is no way to recover per-image files from that, least of all for PDF, so **AC #1 (mirrored per-image outputs) and AC #3 are mutually exclusive**. Confirmed with @Zaba505 that per-image mirrored output is what matters.

So the batch is one container **exec** rather than one tesseract **process**: the exec loops over a manifest, recognising each image onto its own output base. That still collapses the part that actually costs anything in Dagger — a `WithExec`, its mounts and its cache lookup, per page — to one. Flags and configfiles reach the loop through `"$@"` rather than string interpolation, so no value needs escaping.

## Which files take part

`Directory.Glob` has no brace expansion (`**/*.{png,tiff}` matches nothing), so "common image extensions" cannot be one pattern. The default is `**/*` narrowed by a case-insensitive extension filter:

```
.bmp .gif .jpe .jpeg .jpg .pbm .pgm .pnm .png .ppm .tif .tiff .webp
```

That set is what this image can actually decode — `tesseract --version` reports leptonica linked against libgif, libjpeg, libpng, libtiff and libwebp, and leptonica reads BMP and the PNM family itself. A scan folder's README, manifest and checksum files are therefore ignored rather than fed to leptonica, which would fail the run.

`WithGlob` replaces both halves: a caller who names a pattern owns it and gets no extension filtering, since leptonica sniffs content rather than trusting extensions. PDFs stay rejected either way.

## Validation added

| Rejected | Why |
| --- | --- |
| a glob matching nothing | an empty directory is indistinguishable from a batch that ran and found no text, so a typo would surface much later as missing output |
| a source holding no images | same, but the fix is `WithGlob` rather than the pattern, so the message names the default extension set |
| two inputs sharing an output base | **not in the ACs, but a real silent-corruption path** — `a.png` and `a.jpg` both render onto `a.txt`, and the second would overwrite the first while the run looks successful |
| a file name containing a tab or newline | the manifest is tab-separated and newline-delimited, so the loop would recognise the wrong file |

## Shared options

The recognition options moved to an internal `options` type that `Document` and `Batch` both hold, so each option is written once — as a builder, as a piece of argv, and as a deferred check. This is the issue's "shares the option builders so the two do not drift" line made structural rather than aspirational. **The public `Document` API is unchanged.**

## Testing

Six new tests, each run individually during development and green in the full suite (30 tests, `dagger -m daggerverse/tesseract/tests call all`):

- `BatchMirrorsInputLayout` — nested layout mirrored, each artifact holds its own image's text
- `BatchDefaultGlobSkipsNonImages` — default selection, case-insensitive extensions, no-images error
- `BatchGlobSelectsFiles` — `WithGlob` narrows both the listing and the exec; empty match errors
- `BatchExportProducesEveryFormatPerImage` — all six formats per image, real PDF bytes in the nested artifact
- `BatchSharesDocumentOptions` — `-c` reaches every iteration; user words mount; deferred checks fire
- `BatchRejectsAmbiguousInput` — output-base collision and PDF-via-explicit-glob

**Negative control:** flattened `outputBaseFor` to `path.Base` and confirmed `BatchMirrorsInputLayout` fails with `got [page-1.txt page-2.txt page-3.txt]` — the mirroring assertion is live, not vacuous.

`dagger develop` re-run in module, tests and root; `dagger -m ci call generated` passes.

## AC status

- [x] `Batch(dir).Export([TXT])` produces one `.txt` per matched image, mirroring the input paths
- [x] `WithGlob` filters which files are OCR'd, and a pattern matching nothing errors rather than returning an empty directory
- [ ] ~~The batch runs as a single tesseract invocation over a list file~~ — deliberately not done; incompatible with AC #1 (see above). It is a single container exec, not one exec per image.
- [x] Non-image files in the directory are excluded by the default glob rather than failing the run
- [x] `dagger develop` re-run in module and tests, generated code committed

## Follow-up not filed

The concatenated multi-page output (folder of pages → one document) is genuinely useful and is what the list-file mode gives for free. Noted in the README as a separate function rather than a flag on `Export`; happy to file an issue if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
