### PR TITLE
story(issue-221): rasterize PDF input for OCR

### DIFF
--- a/ci/internal/dagger/tesseract-tests.gen.go
+++ b/ci/internal/dagger/tesseract-tests.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type TesseractTests
-func (r *Binding) AsTesseractTests() *TesseractTests { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:62:6)
+func (r *Binding) AsTesseractTests() *TesseractTests { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:93:6)
 	q := r.query.Select("asTesseractTests")
 
 	return &TesseractTests{
@@ -19,7 +19,7 @@ func (r *Binding) AsTesseractTests() *TesseractTests { // tesseract-tests (../..
 }
 
 // Create or update a binding of type TesseractTests in the environment
-func (r *Env) WithTesseractTestsInput(name string, value *TesseractTests, description string) *Env { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:62:6)
+func (r *Env) WithTesseractTestsInput(name string, value *TesseractTests, description string) *Env { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:93:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withTesseractTestsInput")
 	q = q.Arg("name", name)
@@ -32,7 +32,7 @@ func (r *Env) WithTesseractTestsInput(name string, value *TesseractTests, descri
 }
 
 // Declare a desired TesseractTests output to be assigned in the environment
-func (r *Env) WithTesseractTestsOutput(name string, description string) *Env { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:62:6)
+func (r *Env) WithTesseractTestsOutput(name string, description string) *Env { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:93:6)
 	q := r.query.Select("withTesseractTestsOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -50,7 +50,7 @@ func (r *Env) WithTesseractTestsOutput(name string, description string) *Env { /
 // The fixtures under fixtures/ are committed rather than generated in-container:
 // bare Alpine ships no fonts, so rendering text inside the toolchain image would
 // mean pulling in fontconfig and a font package purely to make the tests run.
-func (r *Query) TesseractTests() *TesseractTests { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:62:6)
+func (r *Query) TesseractTests() *TesseractTests { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:93:6)
 	q := r.query.Select("tesseractTests")
 
 	return &TesseractTests{
@@ -58,41 +58,44 @@ func (r *Query) TesseractTests() *TesseractTests { // tesseract-tests (../../../
 	}
 }
 
-type TesseractTests struct { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:62:6)
+type TesseractTests struct { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:93:6)
 	query *querybuilder.Selection
 
-	all                                    *Void
-	altoIsValidXml                         *Void
-	batchDefaultGlobSkipsNonImages         *Void
-	batchExportProducesEveryFormatPerImage *Void
-	batchGlobSelectsFiles                  *Void
-	batchMirrorsInputLayout                *Void
-	batchRejectsAmbiguousInput             *Void
-	batchSharesDocumentOptions             *Void
-	defaultLanguagesInstallEnglish         *Void
-	exportProducesEveryRequestedFormat     *Void
-	hocrContainsWordBoxes                  *Void
-	id                                     *ID
-	lstmEngineRecognizesFixture            *Void
-	malformedParameterNameIsRejected       *Void
-	nonPositiveDpiIsRejected               *Void
-	ompThreadLimitBoundsOpenMp             *Void
-	osdDetectsRotation                     *Void
-	osdWithoutOsdDataIsRejected            *Void
-	pdfHasPdfMagic                         *Void
-	pdfInputIsRejected                     *Void
-	requestedLanguagesAreInstalled         *Void
-	singleWordPageSegReturnsFewerWords     *Void
-	tessdataDoesNotAdmitUnknownLanguage    *Void
-	tessdataModelIsSelectable              *Void
-	tessdataSuppliesOsdModel               *Void
-	textRecognizesFixture                  *Void
-	tsvHasHeaderAndWordRows                *Void
-	txtFileMatchesText                     *Void
-	unknownLanguageIsRejected              *Void
-	unknownParameterFails                  *Void
-	userWordsFileIsAccepted                *Void
-	versionReportsTesseractFive            *Void
+	all                                          *Void
+	altoIsValidXml                               *Void
+	batchDefaultGlobSkipsNonImages               *Void
+	batchExportProducesEveryFormatPerImage       *Void
+	batchGlobSelectsFiles                        *Void
+	batchMirrorsInputLayout                      *Void
+	batchRejectsAmbiguousInput                   *Void
+	batchSharesDocumentOptions                   *Void
+	defaultLanguagesInstallEnglish               *Void
+	exportProducesEveryRequestedFormat           *Void
+	fromPdfDpiSetsRasterResolution               *Void
+	fromPdfExportRendersEveryFormatAsOneDocument *Void
+	fromPdfRecognizesEveryPageInOrder            *Void
+	hocrContainsWordBoxes                        *Void
+	id                                           *ID
+	lstmEngineRecognizesFixture                  *Void
+	malformedParameterNameIsRejected             *Void
+	nonPositiveDpiIsRejected                     *Void
+	ompThreadLimitBoundsOpenMp                   *Void
+	osdDetectsRotation                           *Void
+	osdWithoutOsdDataIsRejected                  *Void
+	pdfHasPdfMagic                               *Void
+	pdfInputIsRejected                           *Void
+	requestedLanguagesAreInstalled               *Void
+	singleWordPageSegReturnsFewerWords           *Void
+	tessdataDoesNotAdmitUnknownLanguage          *Void
+	tessdataModelIsSelectable                    *Void
+	tessdataSuppliesOsdModel                     *Void
+	textRecognizesFixture                        *Void
+	tsvHasHeaderAndWordRows                      *Void
+	txtFileMatchesText                           *Void
+	unknownLanguageIsRejected                    *Void
+	unknownParameterFails                        *Void
+	userWordsFileIsAccepted                      *Void
+	versionReportsTesseractFive                  *Void
 }
 
 func (r *TesseractTests) WithGraphQLQuery(q *querybuilder.Selection) *TesseractTests {
@@ -103,7 +106,7 @@ func (r *TesseractTests) WithGraphQLQuery(q *querybuilder.Selection) *TesseractT
 
 // TesseractTestsAllOpts contains options for TesseractTests.All
 type TesseractTestsAllOpts struct {
-	Parallel int // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:84:2)
+	Parallel int // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:115:2)
 }
 
 // All runs every tesseract-module test in parallel.
@@ -120,7 +123,7 @@ type TesseractTestsAllOpts struct {
 // thread per pass the claim finally holds, and jobs contend for cores the way
 // any other oversubscribed workload does. The cap stays available for a host
 // that wants a narrower slice.
-func (r *TesseractTests) All(ctx context.Context, opts ...TesseractTestsAllOpts) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:81:1)
+func (r *TesseractTests) All(ctx context.Context, opts ...TesseractTestsAllOpts) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:112:1)
 	if r.all != nil {
 		return nil
 	}
@@ -138,7 +141,7 @@ func (r *TesseractTests) All(ctx context.Context, opts ...TesseractTestsAllOpts)
 // AltoIsValidXml asserts the ALTO renderer emits well-formed XML in the ALTO
 // namespace, since its consumers are schema-driven archive tooling that will
 // reject anything else outright.
-func (r *TesseractTests) AltoIsValidXML(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:275:1)
+func (r *TesseractTests) AltoIsValidXML(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:310:1)
 	if r.altoIsValidXml != nil {
 		return nil
 	}
@@ -154,7 +157,7 @@ func (r *TesseractTests) AltoIsValidXML(ctx context.Context) error { // tesserac
 // them are pages. Handing one to tesseract is not a no-op — leptonica fails to
 // decode it and the run dies — so "ignored by default" is what makes pointing
 // Batch at an existing directory work at all.
-func (r *TesseractTests) BatchDefaultGlobSkipsNonImages(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:775:1)
+func (r *TesseractTests) BatchDefaultGlobSkipsNonImages(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:968:1)
 	if r.batchDefaultGlobSkipsNonImages != nil {
 		return nil
 	}
@@ -170,7 +173,7 @@ func (r *TesseractTests) BatchDefaultGlobSkipsNonImages(ctx context.Context) err
 // would render one concatenated artifact per *format* — a single .txt with
 // form-feed page breaks and a single multi-page PDF — with no way to tell which
 // page produced what.
-func (r *TesseractTests) BatchExportProducesEveryFormatPerImage(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:871:1)
+func (r *TesseractTests) BatchExportProducesEveryFormatPerImage(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1064:1)
 	if r.batchExportProducesEveryFormatPerImage != nil {
 		return nil
 	}
@@ -186,7 +189,7 @@ func (r *TesseractTests) BatchExportProducesEveryFormatPerImage(ctx context.Cont
 // be indistinguishable from a batch that ran and found no text, so a typo in a
 // pattern would surface much later as missing output rather than here as a bad
 // glob.
-func (r *TesseractTests) BatchGlobSelectsFiles(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:819:1)
+func (r *TesseractTests) BatchGlobSelectsFiles(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1012:1)
 	if r.batchGlobSelectsFiles != nil {
 		return nil
 	}
@@ -203,7 +206,7 @@ func (r *TesseractTests) BatchGlobSelectsFiles(ctx context.Context) error { // t
 // directory of `result-1.txt`, `result-2.txt` would force every caller to
 // rebuild the correspondence between page and text that the input directory
 // already expressed.
-func (r *TesseractTests) BatchMirrorsInputLayout(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:741:1)
+func (r *TesseractTests) BatchMirrorsInputLayout(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:934:1)
 	if r.batchMirrorsInputLayout != nil {
 		return nil
 	}
@@ -219,7 +222,7 @@ func (r *TesseractTests) BatchMirrorsInputLayout(ctx context.Context) error { //
 // A collision is the subtle one: `a.png` and `a.jpg` in one folder both render
 // onto `a.txt`, so the second silently overwrites the first and the batch looks
 // like it succeeded with one page missing.
-func (r *TesseractTests) BatchRejectsAmbiguousInput(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:983:1)
+func (r *TesseractTests) BatchRejectsAmbiguousInput(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1176:1)
 	if r.batchRejectsAmbiguousInput != nil {
 		return nil
 	}
@@ -235,7 +238,7 @@ func (r *TesseractTests) BatchRejectsAmbiguousInput(ctx context.Context) error {
 // It covers both halves: an option that has to reach tesseract for every image
 // in the run, and the deferred validation that has to reject a bad option
 // before any of them are recognised.
-func (r *TesseractTests) BatchSharesDocumentOptions(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:917:1)
+func (r *TesseractTests) BatchSharesDocumentOptions(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1110:1)
 	if r.batchSharesDocumentOptions != nil {
 		return nil
 	}
@@ -248,7 +251,7 @@ func (r *TesseractTests) BatchSharesDocumentOptions(ctx context.Context) error {
 // English and nothing else. The base apk package carries no language data at
 // all, so an empty default would produce an image that cannot recognise
 // anything.
-func (r *TesseractTests) DefaultLanguagesInstallEnglish(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:152:1)
+func (r *TesseractTests) DefaultLanguagesInstallEnglish(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:187:1)
 	if r.defaultLanguagesInstallEnglish != nil {
 		return nil
 	}
@@ -261,7 +264,7 @@ func (r *TesseractTests) DefaultLanguagesInstallEnglish(ctx context.Context) err
 // formats. That the artifacts arrive in a single directory lifted off a single
 // exec is what proves they came from one recognition pass rather than six: the
 // per-format functions each run their own.
-func (r *TesseractTests) ExportProducesEveryRequestedFormat(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:346:1)
+func (r *TesseractTests) ExportProducesEveryRequestedFormat(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:381:1)
 	if r.exportProducesEveryRequestedFormat != nil {
 		return nil
 	}
@@ -270,9 +273,65 @@ func (r *TesseractTests) ExportProducesEveryRequestedFormat(ctx context.Context)
 	return q.Execute(ctx)
 }
 
+// FromPdfDpiSetsRasterResolution asserts the rasterization resolution defaults
+// to 300 and that a caller's value replaces it.
+//
+// It reads the resolution back off the page geometry hOCR reports, because
+// that is the only place the module publishes it: ledger.pdf's pages are US
+// Letter, 612x792 points, so a page rasterized at D dots per inch is exactly
+// 612*D/72 by 792*D/72 pixels. Asserting on the pixels rather than on the flag
+// is what makes this a test of the rasterizer rather than of argv.
+func (r *TesseractTests) FromPdfDpiSetsRasterResolution(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:796:1)
+	if r.fromPdfDpiSetsRasterResolution != nil {
+		return nil
+	}
+	q := r.query.Select("fromPdfDpiSetsRasterResolution")
+
+	return q.Execute(ctx)
+}
+
+// FromPdfExportRendersEveryFormatAsOneDocument asserts a multi-page PDF stays
+// one document through every renderer, not just through plain text.
+//
+// This is the assumption the whole design rests on. Rasterization produces one
+// image per page, and recognition feeds them to tesseract as a file list — so
+// the question is whether each renderer accumulates the pages into a single
+// artifact or whether only the text one does. If any of them emitted just the
+// last page, the fix would not be a patch: it would mean rasterizing to a
+// multi-page TIFF instead, which needs another package on the image.
+//
+// Each format is therefore checked for its own per-page structure rather than
+// for mere existence: three page elements, three page numbers, three PDF
+// pages. A renderer that kept only one page would still produce a file.
+func (r *TesseractTests) FromPdfExportRendersEveryFormatAsOneDocument(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:846:1)
+	if r.fromPdfExportRendersEveryFormatAsOneDocument != nil {
+		return nil
+	}
+	q := r.query.Select("fromPdfExportRendersEveryFormatAsOneDocument")
+
+	return q.Execute(ctx)
+}
+
+// FromPdfRecognizesEveryPageInOrder asserts the whole PDF entry point: every
+// page is rasterized, every page is recognised, and the pages arrive in
+// document order.
+//
+// Order is the half that needs a fixture with distinct pages. Rasterization
+// writes one file per page and the recognition pass reads them from a list, so
+// a sorting bug — page-10 before page-2, say — would still produce text for
+// every page and still look like a success.
+func (r *TesseractTests) FromPdfRecognizesEveryPageInOrder(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:780:1)
+	if r.fromPdfRecognizesEveryPageInOrder != nil {
+		return nil
+	}
+	q := r.query.Select("fromPdfRecognizesEveryPageInOrder")
+
+	return q.Execute(ctx)
+}
+
 // HocrContainsWordBoxes asserts hOCR carries the per-word geometry that is the
 // whole reason to ask for it rather than plain text.
-func (r *TesseractTests) HocrContainsWordBoxes(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:252:1)
+func (r *TesseractTests) HocrContainsWordBoxes(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:287:1)
 	if r.hocrContainsWordBoxes != nil {
 		return nil
 	}
@@ -337,7 +396,7 @@ func (r *TesseractTests) UnmarshalJSON(bs []byte) error {
 // is that no member is dead: LEGACY and LEGACY_LSTM only work because Alpine
 // packages the *combined* tessdata models. A rebuild against tessdata_fast or
 // tessdata_best would strip the legacy data and this is where that shows up.
-func (r *TesseractTests) LstmEngineRecognizesFixture(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:493:1)
+func (r *TesseractTests) LstmEngineRecognizesFixture(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:528:1)
 	if r.lstmEngineRecognizesFixture != nil {
 		return nil
 	}
@@ -349,7 +408,7 @@ func (r *TesseractTests) LstmEngineRecognizesFixture(ctx context.Context) error 
 // MalformedParameterNameIsRejected asserts an empty parameter name, and one
 // carrying its own `=`, are refused. `-c` takes `name=value`, so an embedded
 // `=` would quietly set a different variable to a different value.
-func (r *TesseractTests) MalformedParameterNameIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:685:1)
+func (r *TesseractTests) MalformedParameterNameIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:724:1)
 	if r.malformedParameterNameIsRejected != nil {
 		return nil
 	}
@@ -361,7 +420,7 @@ func (r *TesseractTests) MalformedParameterNameIsRejected(ctx context.Context) e
 // NonPositiveDpiIsRejected asserts a zero or negative resolution is refused
 // rather than handed to tesseract, which would take it as a real measurement
 // and scale its analysis by it.
-func (r *TesseractTests) NonPositiveDpiIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:711:1)
+func (r *TesseractTests) NonPositiveDpiIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:750:1)
 	if r.nonPositiveDpiIsRejected != nil {
 		return nil
 	}
@@ -380,7 +439,7 @@ func (r *TesseractTests) NonPositiveDpiIsRejected(ctx context.Context) error { /
 // works at all: without it, anything running several recognitions at once has
 // no way to stop each pass claiming every core, which cost this very suite
 // nine minutes on a four-core runner (#226).
-func (r *TesseractTests) OmpThreadLimitBoundsOpenMp(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:189:1)
+func (r *TesseractTests) OmpThreadLimitBoundsOpenMp(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:224:1)
 	if r.ompThreadLimitBoundsOpenMp != nil {
 		return nil
 	}
@@ -392,7 +451,7 @@ func (r *TesseractTests) OmpThreadLimitBoundsOpenMp(ctx context.Context) error {
 // OsdDetectsRotation asserts orientation detection reads the quarter-turn in
 // the rotated fixture and reports the rotation that would undo it, while the
 // upright fixture reports no rotation at all.
-func (r *TesseractTests) OsdDetectsRotation(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:572:1)
+func (r *TesseractTests) OsdDetectsRotation(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:607:1)
 	if r.osdDetectsRotation != nil {
 		return nil
 	}
@@ -404,7 +463,7 @@ func (r *TesseractTests) OsdDetectsRotation(ctx context.Context) error { // tess
 // OsdWithoutOsdDataIsRejected asserts orientation detection on an image built
 // without the osd model names the fix rather than failing inside tesseract,
 // which would report a missing traineddata file.
-func (r *TesseractTests) OsdWithoutOsdDataIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:653:1)
+func (r *TesseractTests) OsdWithoutOsdDataIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:688:1)
 	if r.osdWithoutOsdDataIsRejected != nil {
 		return nil
 	}
@@ -416,7 +475,7 @@ func (r *TesseractTests) OsdWithoutOsdDataIsRejected(ctx context.Context) error 
 // PdfHasPdfMagic asserts the searchable-PDF renderer emits a real PDF. The
 // bytes go through the filesystem rather than File.Contents, which mangles
 // non-UTF-8 data.
-func (r *TesseractTests) PdfHasPdfMagic(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:328:1)
+func (r *TesseractTests) PdfHasPdfMagic(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:363:1)
 	if r.pdfHasPdfMagic != nil {
 		return nil
 	}
@@ -428,7 +487,11 @@ func (r *TesseractTests) PdfHasPdfMagic(ctx context.Context) error { // tesserac
 // PdfInputIsRejected asserts a PDF source is refused up front. Leptonica has
 // no PDF support and reports the failure as if the file's first line were a
 // file name it could not open, which sends people looking in the wrong place.
-func (r *TesseractTests) PdfInputIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:669:1)
+//
+// The error has to name FromPdf, which is the whole difference between an
+// error that ends the caller's afternoon and one that ends their next line of
+// code: rasterizing is no longer something they have to go and arrange.
+func (r *TesseractTests) PdfInputIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:708:1)
 	if r.pdfInputIsRejected != nil {
 		return nil
 	}
@@ -440,7 +503,7 @@ func (r *TesseractTests) PdfInputIsRejected(ctx context.Context) error { // tess
 // RequestedLanguagesAreInstalled asserts every requested language lands in the
 // image as its own apk package, including "osd", which is a detection model
 // rather than a recognition language.
-func (r *TesseractTests) RequestedLanguagesAreInstalled(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:166:1)
+func (r *TesseractTests) RequestedLanguagesAreInstalled(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:201:1)
 	if r.requestedLanguagesAreInstalled != nil {
 		return nil
 	}
@@ -454,7 +517,7 @@ func (r *TesseractTests) RequestedLanguagesAreInstalled(ctx context.Context) err
 // that finds the lines, so it returns far less than the default mode does —
 // which is the observable proof the flag was passed, without asserting on
 // whatever garbage the constrained mode happens to produce.
-func (r *TesseractTests) SingleWordPageSegReturnsFewerWords(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:467:1)
+func (r *TesseractTests) SingleWordPageSegReturnsFewerWords(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:502:1)
 	if r.singleWordPageSegReturnsFewerWords != nil {
 		return nil
 	}
@@ -467,7 +530,7 @@ func (r *TesseractTests) SingleWordPageSegReturnsFewerWords(ctx context.Context)
 // mounting a tessdata directory adds the models it holds and nothing else, so a
 // language neither half carries is rejected the same way it was before, with
 // both halves listed and both ways of adding one named.
-func (r *TesseractTests) TessdataDoesNotAdmitUnknownLanguage(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:633:1)
+func (r *TesseractTests) TessdataDoesNotAdmitUnknownLanguage(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:668:1)
 	if r.tessdataDoesNotAdmitUnknownLanguage != nil {
 		return nil
 	}
@@ -493,7 +556,7 @@ func (r *TesseractTests) TessdataDoesNotAdmitUnknownLanguage(ctx context.Context
 // configfiles, and pdf.ttf is what the PDF renderer draws its invisible text
 // layer with. Pointed at the caller's directory alone, every renderer breaks
 // and every packaged language disappears.
-func (r *TesseractTests) TessdataModelIsSelectable(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:399:1)
+func (r *TesseractTests) TessdataModelIsSelectable(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:434:1)
 	if r.tessdataModelIsSelectable != nil {
 		return nil
 	}
@@ -509,7 +572,7 @@ func (r *TesseractTests) TessdataModelIsSelectable(ctx context.Context) error { 
 // answered from the requested package set alone. A supplied osd.traineddata
 // would have been refused by this module while sitting right there in the
 // image, which is the failure mode this pins.
-func (r *TesseractTests) TessdataSuppliesOsdModel(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:445:1)
+func (r *TesseractTests) TessdataSuppliesOsdModel(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:480:1)
 	if r.tessdataSuppliesOsdModel != nil {
 		return nil
 	}
@@ -520,7 +583,7 @@ func (r *TesseractTests) TessdataSuppliesOsdModel(ctx context.Context) error { /
 
 // TextRecognizesFixture asserts the shortest path — image in, string out —
 // reproduces every line the fixture renders.
-func (r *TesseractTests) TextRecognizesFixture(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:223:1)
+func (r *TesseractTests) TextRecognizesFixture(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:258:1)
 	if r.textRecognizesFixture != nil {
 		return nil
 	}
@@ -532,7 +595,7 @@ func (r *TesseractTests) TextRecognizesFixture(ctx context.Context) error { // t
 // TsvHasHeaderAndWordRows asserts the TSV renderer emits its column header and
 // descends all the way to word-level rows (level 5), which is the level
 // carrying the text and its confidence.
-func (r *TesseractTests) TsvHasHeaderAndWordRows(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:294:1)
+func (r *TesseractTests) TsvHasHeaderAndWordRows(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:329:1)
 	if r.tsvHasHeaderAndWordRows != nil {
 		return nil
 	}
@@ -543,7 +606,7 @@ func (r *TesseractTests) TsvHasHeaderAndWordRows(ctx context.Context) error { //
 
 // TxtFileMatchesText asserts the txt renderer and the stdout path agree, so
 // choosing a file over a string is purely a plumbing decision.
-func (r *TesseractTests) TxtFileMatchesText(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:233:1)
+func (r *TesseractTests) TxtFileMatchesText(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:268:1)
 	if r.txtFileMatchesText != nil {
 		return nil
 	}
@@ -556,7 +619,7 @@ func (r *TesseractTests) TxtFileMatchesText(ctx context.Context) error { // tess
 // rejected with the installed set named. tesseract's own failure talks about
 // traineddata paths and TESSDATA_PREFIX, which says nothing about the fact
 // that languages are chosen on New.
-func (r *TesseractTests) UnknownLanguageIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:601:1)
+func (r *TesseractTests) UnknownLanguageIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:636:1)
 	if r.unknownLanguageIsRejected != nil {
 		return nil
 	}
@@ -572,7 +635,7 @@ func (r *TesseractTests) UnknownLanguageIsRejected(ctx context.Context) error { 
 // and exits 0, so a typo would otherwise be indistinguishable from a setting
 // that simply had no effect. The same test pins the other half: a real
 // parameter still goes through, so the check is not just rejecting everything.
-func (r *TesseractTests) UnknownParameterFails(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:519:1)
+func (r *TesseractTests) UnknownParameterFails(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:554:1)
 	if r.unknownParameterFails != nil {
 		return nil
 	}
@@ -590,7 +653,7 @@ func (r *TesseractTests) UnknownParameterFails(ctx context.Context) error { // t
 // a dictionary hint on an already-clean fixture is not reliably observable.
 // What this does catch is a wrong mount path or a flag emitted in the wrong
 // position, either of which turns the whole run into a usage error.
-func (r *TesseractTests) UserWordsFileIsAccepted(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:555:1)
+func (r *TesseractTests) UserWordsFileIsAccepted(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:590:1)
 	if r.userWordsFileIsAccepted != nil {
 		return nil
 	}
@@ -602,7 +665,7 @@ func (r *TesseractTests) UserWordsFileIsAccepted(ctx context.Context) error { //
 // VersionReportsTesseractFive asserts the assembled image ships the tesseract
 // release Alpine's community repository carries, so a base-tag bump that
 // silently changes major version fails here rather than in recognition.
-func (r *TesseractTests) VersionReportsTesseractFive(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:137:1)
+func (r *TesseractTests) VersionReportsTesseractFive(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:172:1)
 	if r.versionReportsTesseractFive != nil {
 		return nil
 	}

--- a/daggerverse/tesseract/README.md
+++ b/daggerverse/tesseract/README.md
@@ -4,7 +4,8 @@ Daggerverse module that runs [Tesseract](https://tesseract-ocr.github.io/) OCR
 as a `dagger call`. Hand it an image and get back plain text, or hOCR / ALTO /
 TSV / PAGE / a searchable PDF for anything that needs word positions and
 confidences. Hand it a directory and get the same artifacts back for every page
-in it, at the paths they came in on.
+in it, at the paths they came in on. Hand it a PDF and it rasterizes the pages
+for you first.
 
 **There is no official Tesseract container image** — upstream ships source only,
 and every image on Docker Hub is third-party. So this module assembles its own
@@ -154,7 +155,8 @@ Tesseract.Document(source *dagger.File) *Document
 
 Unlike `kicad.Project`, the boundary input is a lone `*dagger.File`: tesseract
 resolves nothing relative to its input, so one image — including a multi-page
-TIFF — is the whole unit of work. A folder of pages is `Batch`, below; the
+TIFF — is the whole unit of work. A PDF is `FromPdf`, which rasterizes first and
+hands back one of these. A folder of pages is `Batch`, below; the
 directory there is a *set of independent inputs*, not context the recognition
 resolves against, which is why it is a second entry point rather than a widening
 of this one.
@@ -265,7 +267,9 @@ proposed exactly that. It does not do what the name suggests: it treats the list
 as one multi-page **document** and renders a *single concatenated artifact set* —
 one `.txt` with form-feed page breaks, one multi-page PDF, one hOCR carrying
 `page_1`/`page_2` divs. There is no way to recover per-image files from it, least
-of all for PDF.
+of all for PDF. (That behaviour is not useless — it is precisely what the pages
+of one PDF want, and `FromPdf` below is built on it. It is just not what a
+folder of independent scans wants.)
 
 So the batch is one container **exec** rather than one tesseract **process**: the
 exec loops over a manifest, recognising each image onto its own output base. That
@@ -298,6 +302,62 @@ either way.
 `Files` reports the matched set without paying for the recognition, which is the
 answer to the question a glob always raises.
 
+## PDF input — `FromPdf`
+
+```go
+Tesseract.FromPdf(source *dagger.File, dpi int /* +default=300 */) *Document
+```
+
+Leptonica cannot read PDF, so `Document` rejects one outright. `FromPdf` is the
+way in: it rasterizes the pages with `pdftoppm` and returns an ordinary
+`Document` over them, so every output, option and error path above works on a
+PDF exactly as it does on an image.
+
+A multi-page PDF stays **one** document. The pages are recognised through
+tesseract's list-file mode, which accumulates them into a single artifact per
+format — `Text` returns the whole document with form feeds between pages, `Pdf`
+returns one searchable PDF with the source's page count, and the structured
+formats carry one page element per page. This is the same list-file mode `Batch`
+deliberately avoids, and for the opposite reason: for a folder of independent
+scans a concatenated result is wrong, and for the pages of one PDF it is exactly
+right.
+
+`dpi` is what the pages are rasterized at, and is declared to tesseract as the
+source resolution too, since it is exactly known at that point. 300 is the
+default because it is tesseract's own long-standing recommendation for input
+resolution; raising it costs time and memory roughly with its square, and
+lowering it costs accuracy on body text.
+
+### Why a separate container
+
+Rasterization runs on its own container — Alpine at the same pinned tag, plus
+`poppler-utils` and `ttf-liberation` — rather than on the toolchain image, so
+the cost lands on the callers who asked for it:
+
+| | image | cost |
+| --- | --- | --- |
+| toolchain today | 67.1MiB | — |
+| toolchain with poppler + font installed unconditionally | 81.4MiB | +21% for every caller, PDF or not |
+| separate rasterizer | 35.0MiB | paid only by `FromPdf` callers; 8.0MiB of it is the shared Alpine base |
+
+It also caches separately, so changing a recognition option does not re-rasterize
+the document.
+
+The font package is not decoration. A PDF that names one of the base-14 fonts
+without embedding it — the usual shape for anything not born as a scan — is
+drawn by poppler through a fontconfig substitute, and with no font installed at
+all there is nothing to substitute: **the page renders blank, recognition finds
+no text, and the call succeeds**. Liberation is the family to install for it,
+being metric-compatible with Helvetica, Times and Courier, so substituted text
+keeps the line breaks and positions the document was written with. DejaVu covers
+more of Unicode but is 5.8MiB larger and matches none of those metrics.
+
+Page files are listed by globbing rather than by counting pages, because
+`pdftoppm` names them with the page number zero-padded to the width of the
+*last* page: a 9-page document yields `page-1.png` and a 10-page one
+`page-01.png`. One document means one padding width, so a lexicographic sort is
+page order.
+
 ## Validation
 
 Builders have no error return, so every check below is deferred to the output
@@ -308,7 +368,8 @@ letting tesseract fail in its own vocabulary.
 | --- | --- |
 | `WithLanguage` naming a language neither installed nor supplied | tesseract talks about traineddata paths and `TESSDATA_PREFIX`, never about the fact that models arrive via `New` or `WithTessdata` |
 | `Osd` with no `osd` model installed or supplied | same, plus the fix is a different function's argument |
-| a `.pdf` source | Leptonica has no PDF support and reports the file's first line as if it were a file name it could not open |
+| a `.pdf` source to `Document` or `Batch` | Leptonica has no PDF support and reports the file's first line as if it were a file name it could not open; the message names `FromPdf`, so the fix is a function call rather than an errand |
+| `FromPdf` at zero or negative `dpi` | `pdftoppm` would fail much later, talking about its own `-r` flag rather than about the argument the caller passed |
 | `WithParameter` with an empty name, or one containing `=` | `-c` takes `name=value`, so an embedded `=` silently sets a *different* variable |
 | `WithParameter` naming an unknown control variable | tesseract only warns (`Warning: The parameter '...' was not found.`) and exits 0, so a typo is indistinguishable from a no-op |
 | `WithDpi` at zero or negative | tesseract would take it as a real measurement and scale its analysis by it |
@@ -331,12 +392,14 @@ a floating Alpine tag can resolve differently across sessions.
 
 ## Follow-ups
 
-PDF-input rasterization (#221); the training toolchain (#222); a chained `Ci`
-builder (#223); an `examples/go` cookbook (#224).
+The training toolchain (#222); a chained `Ci` builder (#223); an `examples/go`
+cookbook (#224).
 
-Batch OCR over a directory (#220) landed — see above. It deliberately does not
-expose the concatenated multi-page output tesseract's list-file mode produces; if
-"a folder of pages in, one document out" turns out to be wanted, that is a
+Batch OCR over a directory (#220) and PDF-input rasterization (#221) both
+landed — see above. `Batch` still deliberately does not expose the concatenated
+multi-page output tesseract's list-file mode produces; that mode now has exactly
+one caller, `FromPdf`, where the pages really are one document. If "a folder of
+pages in, one document out" turns out to be wanted for a `Batch` too, that is a
 separate function, not a flag on `Export`.
 
 GPU acceleration is **not** a follow-up: tesseract has no CUDA path and upstream

--- a/daggerverse/tesseract/dagger.gen.go
+++ b/daggerverse/tesseract/dagger.gen.go
@@ -131,10 +131,14 @@ func (r Document) MarshalJSON() ([]byte, error) {
 	var concrete struct {
 		Tesseract *Tesseract
 		Source    *dagger.File
+		Pages     *dagger.Directory
+		PdfDpi    int
 		Options   options
 	}
 	concrete.Tesseract = r.Tesseract
 	concrete.Source = r.Source
+	concrete.Pages = r.Pages
+	concrete.PdfDpi = r.PdfDpi
 	concrete.Options = r.Options
 	return json.Marshal(&concrete)
 }
@@ -143,6 +147,8 @@ func (r *Document) UnmarshalJSON(bs []byte) error {
 	var concrete struct {
 		Tesseract *Tesseract
 		Source    *dagger.File
+		Pages     *dagger.Directory
+		PdfDpi    int
 		Options   options
 	}
 	err := json.Unmarshal(bs, &concrete)
@@ -151,6 +157,8 @@ func (r *Document) UnmarshalJSON(bs []byte) error {
 	}
 	r.Tesseract = concrete.Tesseract
 	r.Source = concrete.Source
+	r.Pages = concrete.Pages
+	r.PdfDpi = concrete.PdfDpi
 	r.Options = concrete.Options
 	return nil
 }
@@ -840,6 +848,27 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Tesseract).Document(&parent, source), nil
+		case "FromPdf":
+			var parent Tesseract
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var source *dagger.File
+			if inputArgs["source"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["source"]), &source)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg source", err))
+				}
+			}
+			var dpi int
+			if inputArgs["dpi"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["dpi"]), &dpi)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg dpi", err))
+				}
+			}
+			return (*Tesseract).FromPdf(&parent, source, dpi), nil
 		case "Langs":
 			var parent Tesseract
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/tesseract/document.go
+++ b/daggerverse/tesseract/document.go
@@ -10,9 +10,16 @@ import (
 	"dagger/tesseract/internal/dagger"
 )
 
-// Document is one image plus the recognition options that apply to it. It is
+// Document is one unit of recognition plus the options that apply to it. It is
 // immutable: every With* returns a copy, so a configured Document can be
 // branched into several outputs without the branches interfering.
+//
+// The unit comes in two shapes, and a document holds whichever it was built
+// as: a single image in Source, or the rasterized pages of a PDF in Pages.
+// They are alternatives rather than layers — exactly one is ever set — and
+// everything downstream of validate is written against the resolved FILE
+// argument, so the outputs, the options and the error paths are shared rather
+// than reimplemented per shape.
 //
 // The options themselves live on the shared options type, which Batch carries
 // too — the builders here are forwarders, so a new recognition option reaches
@@ -22,6 +29,10 @@ type Document struct {
 	Tesseract *Tesseract
 	// +private
 	Source *dagger.File
+	// +private
+	Pages *dagger.Directory
+	// +private
+	PdfDpi int
 	// +private
 	Options options
 }
@@ -274,17 +285,29 @@ func execTesseract(ctx context.Context, ctr *dagger.Container, args []string) (*
 	return exec, nil
 }
 
-// container mounts the source and any user word/pattern lists, and stages the
-// writable output directory recognition renders into.
+// container mounts whichever shape of source the document holds, alongside any
+// user word/pattern lists, and stages the writable output directory
+// recognition renders into.
+//
+// A rasterized PDF mounts its whole page directory, at the path the page list
+// names its entries by — the list holds absolute paths, so this mount and the
+// one the rasterizer wrote them under have to agree.
 func (d *Document) container(source string) *dagger.Container {
-	return d.Options.mount(d.Tesseract.Container().
-		WithMountedFile(source, d.Source).
-		WithExec([]string{"mkdir", "-p", outputDir}))
+	ctr := d.Tesseract.Container()
+	if d.Pages != nil {
+		ctr = ctr.WithMountedDirectory(pdfPagesDir, d.Pages)
+	} else {
+		ctr = ctr.WithMountedFile(source, d.Source)
+	}
+	return d.Options.mount(ctr.WithExec([]string{"mkdir", "-p", outputDir}))
 }
 
 // validate reports every deferred builder check and returns the path the
 // source is mounted at.
 func (d *Document) validate(ctx context.Context) (string, error) {
+	if err := d.validatePdfDpi(); err != nil {
+		return "", err
+	}
 	source, err := d.sourcePath(ctx)
 	if err != nil {
 		return "", err
@@ -295,10 +318,18 @@ func (d *Document) validate(ctx context.Context) (string, error) {
 	return source, nil
 }
 
-// sourcePath resolves where the source is mounted, keeping the caller's
-// extension so container logs name something recognisable, and rejects PDF
-// input along the way.
+// sourcePath resolves the FILE argument recognition runs against.
+//
+// For a rasterized PDF that is the page list rather than an image: handed a
+// file it cannot identify as one, tesseract reads it as a list of image paths
+// and processes them in order as a single document, which is exactly the unit
+// of work a PDF is. For a single image it is the mount path, keeping the
+// caller's extension so container logs name something recognisable, and PDF
+// input is rejected along the way.
 func (d *Document) sourcePath(ctx context.Context) (string, error) {
+	if d.Pages != nil {
+		return pdfPageListPath, nil
+	}
 	name, err := d.Source.Name(ctx)
 	if err != nil {
 		return "", fmt.Errorf("read source file name: %w", err)
@@ -314,12 +345,13 @@ func (d *Document) sourcePath(ctx context.Context) (string, error) {
 // Leptonica — the image library tesseract reads through — has no PDF support
 // at all, and says so unhelpfully: it reports the file's first line as if it
 // were a file name it could not open. Rejecting the extension here is the
-// difference between an actionable error and a confusing one.
+// difference between an actionable error and a confusing one, and now that
+// FromPdf exists the fix is a function name rather than an errand.
 func rejectPdf(name string) error {
 	if !strings.EqualFold(path.Ext(name), ".pdf") {
 		return nil
 	}
 	return fmt.Errorf(
-		"source %q is a PDF: tesseract reads images through leptonica, which has no PDF support; rasterize the pages to PNG or TIFF first",
+		"source %q is a PDF: tesseract reads images through leptonica, which has no PDF support; call FromPdf instead, which rasterizes the pages first and returns a Document over them",
 		name)
 }

--- a/daggerverse/tesseract/main.go
+++ b/daggerverse/tesseract/main.go
@@ -17,6 +17,17 @@
 // Alpine has no package for — a directory of `.traineddata` merged into the
 // image's datadir, and from there indistinguishable from a packaged language.
 //
+// PDF input is rasterized rather than read, because leptonica cannot read PDF
+// at all. That work happens in its own container — Alpine at the same pinned
+// tag, plus poppler-utils and a font — instead of on the toolchain image,
+// which is a decision about who pays for it. Unconditionally installing both
+// packages takes the toolchain image from 67.1MiB to 81.4MiB, a 21% tax on
+// every caller who only ever hands this module a PNG. Rasterizing separately
+// leaves that image untouched and costs a PDF caller a 35.0MiB container of
+// which the 8.0MiB Alpine base is already shared, so the extra bytes are paid
+// once, by the callers who asked for them, and the rasterization caches
+// separately from recognition on top of that.
+//
 // File map (all `package main`, surfaced as one Dagger module):
 //
 //   - enums.go     — PageSegMode / EngineMode / Format enums plus the token and
@@ -27,6 +38,8 @@
 //   - document.go  — *Document, one image in and one artifact set out.
 //   - batch.go     — *Batch, a directory in and a mirrored directory out, all
 //     of it in a single container exec.
+//   - pdf.go       — FromPdf, the rasterizer that turns a PDF into pages a
+//     *Document can recognise.
 package main
 
 import (
@@ -103,6 +116,36 @@ const (
 	// extension filter isImagePath applies on top of it, because Dagger's glob
 	// has no brace expansion to spell the alternation with.
 	defaultBatchGlob = "**/*"
+
+	// popplerPkg carries pdftoppm, the rasterizer FromPdf drives. fontPkg is
+	// the substitute font family poppler draws with when a PDF names one of
+	// the base-14 fonts without embedding it; see rasterize for why it is not
+	// optional.
+	popplerPkg = "poppler-utils"
+	fontPkg    = "ttf-liberation"
+
+	// pdfSourcePath is where the PDF is mounted in the rasterizer. It sits
+	// outside workDir because the rasterizer is a different container from the
+	// one recognition runs in, and shares nothing with it but the page
+	// directory.
+	pdfSourcePath = "/pdf/source.pdf"
+
+	// pdfPagesDir holds the rasterized pages. The rasterizer writes them here
+	// and recognition mounts them back at the same path, which is what lets
+	// the page list name them by absolute path.
+	pdfPagesDir = workDir + "/pages"
+
+	// pdfPageBase is the OUTPUTBASE handed to pdftoppm, which appends a page
+	// number and the format's extension to it; pdfPageListPath is the file
+	// list recognition then takes as its FILE argument.
+	pdfPageBase     = pdfPagesDir + "/page"
+	pdfPageListPath = pdfPagesDir + "/pages.txt"
+
+	// defaultPdfDpi is the resolution pages are rasterized at. 300 is the
+	// long-standing recommendation for OCR input in tesseract's own quality
+	// documentation, and the resolution scanners are set to for the same
+	// reason.
+	defaultPdfDpi = 300
 
 	// ompThreadLimitEnv caps the OpenMP team size tesseract's recognition
 	// loops fan out to.

--- a/daggerverse/tesseract/pdf.go
+++ b/daggerverse/tesseract/pdf.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+
+	"dagger/tesseract/internal/dagger"
+)
+
+// rasterizeArgv0 is the `$0` the rasterize script runs under, so the DPI
+// reaches it as `$1` rather than being interpolated into the script text.
+const rasterizeArgv0 = "tesseract-rasterize"
+
+// rasterizeScript renders every page of the PDF and writes the list
+// recognition reads them back from.
+//
+// `set -e` makes a PDF poppler cannot open fail here, carrying pdftoppm's own
+// message, rather than turning into an empty page directory that recognition
+// would report as a document with no text in it.
+//
+// The list is built by globbing rather than by counting pages, because
+// pdftoppm decides the file names: it appends the page number zero-padded to
+// the width of the last page, so a 9-page document yields `page-1.png` and a
+// 10-page one `page-01.png`. Sorting is safe within a single document for
+// exactly that reason — one document, one padding width, so lexicographic
+// order is page order.
+const rasterizeScript = `set -e
+mkdir -p ` + pdfPagesDir + `
+pdftoppm -png -r "$1" ` + pdfSourcePath + ` ` + pdfPageBase + `
+ls ` + pdfPageBase + `-*.png | sort > ` + pdfPageListPath
+
+// FromPdf binds a PDF to the toolchain by rasterizing its pages first, which
+// is the one thing Document cannot do for itself: tesseract reads images
+// through leptonica, and leptonica has no PDF support at all.
+//
+// The result is an ordinary Document, so every output the module offers —
+// Text, the per-format renderers, Export, and the recognition options — works
+// on a PDF exactly as it does on an image. A multi-page PDF stays one
+// document: the renderers accumulate pages, so Text returns the whole document
+// with form feeds between pages and Pdf returns one searchable PDF with the
+// same page count as the source.
+//
+// dpi is the resolution the pages are rasterized at, and is declared to
+// tesseract as the source resolution too, since it is exactly known here.
+// Raising it costs time and memory roughly with its square; lowering it below
+// 300 costs recognition accuracy on body text, because tesseract's models were
+// trained on characters of a certain pixel height.
+func (t *Tesseract) FromPdf(
+	// PDF whose pages are rasterized and then recognised.
+	source *dagger.File,
+	// Resolution to rasterize each page at, in dots per inch.
+	// +default=300
+	dpi int,
+) *Document {
+	if dpi == 0 {
+		dpi = defaultPdfDpi
+	}
+	return &Document{
+		Tesseract: t,
+		Pages:     t.rasterize(source, dpi),
+		PdfDpi:    dpi,
+		Options:   options{}.withDpi(dpi),
+	}
+}
+
+// rasterize renders the PDF's pages and returns the directory holding them
+// alongside the list naming them in order.
+//
+// It runs in its own container rather than on the toolchain image so that
+// poppler and its font are paid for only by the callers who rasterize
+// something. Sharing the pinned Alpine tag with the toolchain keeps the base
+// layer shared, and keeps a PDF rasterized by the same distribution release
+// the recognition runs on.
+//
+// The font package is not decoration. Poppler draws a PDF that names a base-14
+// font without embedding one — the usual shape for anything not born as a scan
+// — by asking fontconfig for a substitute, and with no font installed at all
+// there is nothing to substitute: the page renders blank, recognition finds no
+// text, and the call succeeds. Liberation is the family to install for it,
+// being metric-compatible with Helvetica, Times and Courier, so substituted
+// text keeps the line breaks and positions the document was written with.
+func (t *Tesseract) rasterize(source *dagger.File, dpi int) *dagger.Directory {
+	return dag.Container().
+		From(t.image()).
+		WithExec([]string{"apk", "add", "--no-cache", popplerPkg, fontPkg}).
+		WithMountedFile(pdfSourcePath, source).
+		WithExec([]string{"sh", "-c", rasterizeScript, rasterizeArgv0, strconv.Itoa(dpi)}).
+		Directory(pdfPagesDir)
+}
+
+// validatePdfDpi rejects a non-positive rasterization resolution, which
+// pdftoppm would otherwise reject much later with a message about its own
+// `-r` flag rather than about the argument the caller actually passed.
+func (d *Document) validatePdfDpi() error {
+	if d.Pages == nil || d.PdfDpi > 0 {
+		return nil
+	}
+	return fmt.Errorf("FromPdf: dpi must be positive, got %d", d.PdfDpi)
+}

--- a/daggerverse/tesseract/tests/dagger.gen.go
+++ b/daggerverse/tesseract/tests/dagger.gen.go
@@ -269,6 +269,27 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).ExportProducesEveryRequestedFormat(&parent, ctx)
+		case "FromPdfDpiSetsRasterResolution":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).FromPdfDpiSetsRasterResolution(&parent, ctx)
+		case "FromPdfExportRendersEveryFormatAsOneDocument":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).FromPdfExportRendersEveryFormatAsOneDocument(&parent, ctx)
+		case "FromPdfRecognizesEveryPageInOrder":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).FromPdfRecognizesEveryPageInOrder(&parent, ctx)
 		case "HocrContainsWordBoxes":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/tesseract/tests/fixtures/ledger.pdf
+++ b/daggerverse/tesseract/tests/fixtures/ledger.pdf
@@ -1,0 +1,73 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 3 /Kids [4 0 R 6 0 R 8 0 R] >>
+endobj
+3 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>
+endobj
+4 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R >> >> /Contents 5 0 R >>
+endobj
+5 0 obj
+<< /Length 116 >>
+stream
+BT
+/F1 24 Tf
+72 680 Td
+40 TL
+(Page one of the ledger.) Tj T*
+(The quick brown fox jumps over the lazy dog.) Tj T*
+ET
+endstream
+endobj
+6 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R >> >> /Contents 7 0 R >>
+endobj
+7 0 obj
+<< /Length 118 >>
+stream
+BT
+/F1 24 Tf
+72 680 Td
+40 TL
+(Page two of the ledger.) Tj T*
+(Pack my box with five dozen liquor jugs today.) Tj T*
+ET
+endstream
+endobj
+8 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R >> >> /Contents 9 0 R >>
+endobj
+9 0 obj
+<< /Length 120 >>
+stream
+BT
+/F1 24 Tf
+72 680 Td
+40 TL
+(Page three of the ledger.) Tj T*
+(How vexingly quick daft zebras jump about now.) Tj T*
+ET
+endstream
+endobj
+xref
+0 10
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000133 00000 n 
+0000000230 00000 n 
+0000000356 00000 n 
+0000000523 00000 n 
+0000000649 00000 n 
+0000000818 00000 n 
+0000000944 00000 n 
+trailer
+<< /Size 10 /Root 1 0 R >>
+startxref
+1115
+%%EOF

--- a/daggerverse/tesseract/tests/internal/dagger/tesseract.gen.go
+++ b/daggerverse/tesseract/tests/internal/dagger/tesseract.gen.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Retrieve the binding value, as type Tesseract
-func (r *Binding) AsTesseract() *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:123:6)
+func (r *Binding) AsTesseract() *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:166:6)
 	q := r.query.Select("asTesseract")
 
 	return &Tesseract{
@@ -29,7 +29,7 @@ func (r *Binding) AsTesseractBatch() *TesseractBatch { // tesseract (../../../..
 }
 
 // Retrieve the binding value, as type TesseractDocument
-func (r *Binding) AsTesseractDocument() *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:20:6)
+func (r *Binding) AsTesseractDocument() *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:27:6)
 	q := r.query.Select("asTesseractDocument")
 
 	return &TesseractDocument{
@@ -62,7 +62,7 @@ func (r *Env) WithTesseractBatchOutput(name string, description string) *Env { /
 }
 
 // Create or update a binding of type TesseractDocument in the environment
-func (r *Env) WithTesseractDocumentInput(name string, value *TesseractDocument, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/document.go:20:6)
+func (r *Env) WithTesseractDocumentInput(name string, value *TesseractDocument, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/document.go:27:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withTesseractDocumentInput")
 	q = q.Arg("name", name)
@@ -75,7 +75,7 @@ func (r *Env) WithTesseractDocumentInput(name string, value *TesseractDocument, 
 }
 
 // Declare a desired TesseractDocument output to be assigned in the environment
-func (r *Env) WithTesseractDocumentOutput(name string, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/document.go:20:6)
+func (r *Env) WithTesseractDocumentOutput(name string, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/document.go:27:6)
 	q := r.query.Select("withTesseractDocumentOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -86,7 +86,7 @@ func (r *Env) WithTesseractDocumentOutput(name string, description string) *Env 
 }
 
 // Create or update a binding of type Tesseract in the environment
-func (r *Env) WithTesseractInput(name string, value *Tesseract, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/main.go:123:6)
+func (r *Env) WithTesseractInput(name string, value *Tesseract, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/main.go:166:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withTesseractInput")
 	q = q.Arg("name", name)
@@ -99,7 +99,7 @@ func (r *Env) WithTesseractInput(name string, value *Tesseract, description stri
 }
 
 // Declare a desired Tesseract output to be assigned in the environment
-func (r *Env) WithTesseractOutput(name string, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/main.go:123:6)
+func (r *Env) WithTesseractOutput(name string, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/main.go:166:6)
 	q := r.query.Select("withTesseractOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -116,18 +116,18 @@ type TesseractOpts struct {
 	//
 	//
 	// Default: "docker.io"
-	Registry string // tesseract (../../../../../daggerverse/tesseract/main.go:141:2)
+	Registry string // tesseract (../../../../../daggerverse/tesseract/main.go:184:2)
 	//
 	// Tag of the alpine image the toolchain is assembled on.
 	//
 	//
 	// Default: "3.24"
-	AlpineTag string // tesseract (../../../../../daggerverse/tesseract/main.go:144:2)
+	AlpineTag string // tesseract (../../../../../daggerverse/tesseract/main.go:187:2)
 	//
 	// Language codes to install, one apk package each. Empty installs "eng".
 	// "osd" is not a recognition language but is required by Document.Osd.
 	//
-	Languages []string // tesseract (../../../../../daggerverse/tesseract/main.go:148:2)
+	Languages []string // tesseract (../../../../../daggerverse/tesseract/main.go:191:2)
 	//
 	// Upper bound on the OpenMP threads tesseract may use, set on the
 	// assembled image as OMP_THREAD_LIMIT. Unset, tesseract uses one thread
@@ -138,12 +138,12 @@ type TesseractOpts struct {
 	// slowdown reports (tesseract-ocr/tesseract#2611, #1171, #263). One
 	// thread per pass is the usual setting there.
 	//
-	OmpThreadLimit int // tesseract (../../../../../daggerverse/tesseract/main.go:158:2)
+	OmpThreadLimit int // tesseract (../../../../../daggerverse/tesseract/main.go:201:2)
 }
 
 // New returns a Tesseract module backed by <registry>/library/alpine:<tag>
 // with tesseract-ocr and one language package per requested language.
-func (r *Query) Tesseract(opts ...TesseractOpts) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:138:1)
+func (r *Query) Tesseract(opts ...TesseractOpts) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:181:1)
 	q := r.query.Select("tesseract")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `registry` optional argument
@@ -173,7 +173,7 @@ func (r *Query) Tesseract(opts ...TesseractOpts) *Tesseract { // tesseract (../.
 // It carries the image coordinates and the language set the image is built
 // with; Document hangs off it so the generated SDK surfaces recognition under
 // `dag.Tesseract().Document(...)`.
-type Tesseract struct { // tesseract (../../../../../daggerverse/tesseract/main.go:123:6)
+type Tesseract struct { // tesseract (../../../../../daggerverse/tesseract/main.go:166:6)
 	query *querybuilder.Selection
 
 	id         *ID
@@ -203,7 +203,7 @@ func (r *Tesseract) WithGraphQLQuery(q *querybuilder.Selection) *Tesseract {
 // with whatever reads the results the same way the input directory was
 // composed. Which files take part is a glob, defaulting to the image
 // extensions leptonica can read.
-func (r *Tesseract) Batch(source *Directory) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/main.go:302:1)
+func (r *Tesseract) Batch(source *Directory) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/main.go:345:1)
 	assertNotNil("source", source)
 	q := r.query.Select("batch")
 	q = q.Arg("source", source)
@@ -220,7 +220,7 @@ func (r *Tesseract) Batch(source *Directory) *TesseractBatch { // tesseract (../
 //
 // A requested OpenMP bound lives here rather than on the recognition
 // invocation so everything reached through this escape hatch inherits it too.
-func (r *Tesseract) Container() *Container { // tesseract (../../../../../daggerverse/tesseract/main.go:212:1)
+func (r *Tesseract) Container() *Container { // tesseract (../../../../../daggerverse/tesseract/main.go:255:1)
 	q := r.query.Select("container")
 
 	return &Container{
@@ -233,9 +233,51 @@ func (r *Tesseract) Container() *Container { // tesseract (../../../../../dagger
 // The boundary input is a *dagger.File rather than a *dagger.Directory, unlike
 // the kicad module's Project: tesseract resolves nothing relative to its input,
 // so one image — including a multi-page TIFF — is the whole unit of work.
-func (r *Tesseract) Document(source *File) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/main.go:290:1)
+func (r *Tesseract) Document(source *File) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/main.go:333:1)
 	assertNotNil("source", source)
 	q := r.query.Select("document")
+	q = q.Arg("source", source)
+
+	return &TesseractDocument{
+		query: q,
+	}
+}
+
+// TesseractFromPdfOpts contains options for Tesseract.FromPdf
+type TesseractFromPdfOpts struct {
+	//
+	// Resolution to rasterize each page at, in dots per inch.
+	//
+	//
+	// Default: 300
+	Dpi int // tesseract (../../../../../daggerverse/tesseract/pdf.go:53:2)
+}
+
+// FromPdf binds a PDF to the toolchain by rasterizing its pages first, which
+// is the one thing Document cannot do for itself: tesseract reads images
+// through leptonica, and leptonica has no PDF support at all.
+//
+// The result is an ordinary Document, so every output the module offers —
+// Text, the per-format renderers, Export, and the recognition options — works
+// on a PDF exactly as it does on an image. A multi-page PDF stays one
+// document: the renderers accumulate pages, so Text returns the whole document
+// with form feeds between pages and Pdf returns one searchable PDF with the
+// same page count as the source.
+//
+// dpi is the resolution the pages are rasterized at, and is declared to
+// tesseract as the source resolution too, since it is exactly known here.
+// Raising it costs time and memory roughly with its square; lowering it below
+// 300 costs recognition accuracy on body text, because tesseract's models were
+// trained on characters of a certain pixel height.
+func (r *Tesseract) FromPdf(source *File, opts ...TesseractFromPdfOpts) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/pdf.go:48:1)
+	assertNotNil("source", source)
+	q := r.query.Select("fromPdf")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `dpi` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Dpi) {
+			q = q.Arg("dpi", opts[i].Dpi)
+		}
+	}
 	q = q.Arg("source", source)
 
 	return &TesseractDocument{
@@ -296,7 +338,7 @@ func (r *Tesseract) UnmarshalJSON(bs []byte) error {
 // `tesseract --list-langs`: the packaged languages and any model WithTessdata
 // added, as one set. This is what Document.WithLanguage validates against, and
 // it includes "osd" when that model was installed or supplied.
-func (r *Tesseract) Langs(ctx context.Context) ([]string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:260:1)
+func (r *Tesseract) Langs(ctx context.Context) ([]string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:303:1)
 	q := r.query.Select("langs")
 
 	var response []string
@@ -308,7 +350,7 @@ func (r *Tesseract) Langs(ctx context.Context) ([]string, error) { // tesseract 
 // Parameters returns tesseract's control-variable table — every name, its
 // default value and a one-line description — as `tesseract --print-parameters`
 // prints it. These are the names Document.WithParameter accepts.
-func (r *Tesseract) Parameters(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:275:1)
+func (r *Tesseract) Parameters(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:318:1)
 	if r.parameters != nil {
 		return *r.parameters, nil
 	}
@@ -322,7 +364,7 @@ func (r *Tesseract) Parameters(ctx context.Context) (string, error) { // tessera
 
 // Version returns the tesseract release the assembled image ships, as the
 // bare version number reported by `tesseract --version`.
-func (r *Tesseract) Version(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:241:1)
+func (r *Tesseract) Version(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:284:1)
 	if r.version != nil {
 		return *r.version, nil
 	}
@@ -349,7 +391,7 @@ func (r *Tesseract) Version(ctx context.Context) (string, error) { // tesseract 
 // renderer configfiles and the font the PDF renderer needs. A caller-supplied
 // model wins over a packaged one of the same name, which is what makes
 // replacing the stock `eng` with a fine-tuned one work.
-func (r *Tesseract) WithTessdata(dir *Directory) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:194:1)
+func (r *Tesseract) WithTessdata(dir *Directory) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:237:1)
 	assertNotNil("dir", dir)
 	q := r.query.Select("withTessdata")
 	q = q.Arg("dir", dir)
@@ -582,14 +624,21 @@ func (r *TesseractBatch) AsNode() Node {
 	}
 }
 
-// Document is one image plus the recognition options that apply to it. It is
+// Document is one unit of recognition plus the options that apply to it. It is
 // immutable: every With* returns a copy, so a configured Document can be
 // branched into several outputs without the branches interfering.
+//
+// The unit comes in two shapes, and a document holds whichever it was built
+// as: a single image in Source, or the rasterized pages of a PDF in Pages.
+// They are alternatives rather than layers — exactly one is ever set — and
+// everything downstream of validate is written against the resolved FILE
+// argument, so the outputs, the options and the error paths are shared rather
+// than reimplemented per shape.
 //
 // The options themselves live on the shared options type, which Batch carries
 // too — the builders here are forwarders, so a new recognition option reaches
 // both units of work at once instead of being implemented twice.
-type TesseractDocument struct { // tesseract (../../../../../daggerverse/tesseract/document.go:20:6)
+type TesseractDocument struct { // tesseract (../../../../../daggerverse/tesseract/document.go:27:6)
 	query *querybuilder.Selection
 
 	id   *ID
@@ -612,7 +661,7 @@ func (r *TesseractDocument) WithGraphQLQuery(q *querybuilder.Selection) *Tessera
 }
 
 // Alto returns ALTO XML, the layout schema libraries and archives ingest.
-func (r *TesseractDocument) Alto() *File { // tesseract (../../../../../daggerverse/tesseract/document.go:116:1)
+func (r *TesseractDocument) Alto() *File { // tesseract (../../../../../daggerverse/tesseract/document.go:127:1)
 	q := r.query.Select("alto")
 
 	return &File{
@@ -627,7 +676,7 @@ func (r *TesseractDocument) Alto() *File { // tesseract (../../../../../daggerve
 // several renderers per invocation: asking for text, hOCR and PDF together is
 // one pass over the image, not three. Each artifact is named `result` plus the
 // renderer's own extension.
-func (r *TesseractDocument) Export(formats []TesseractFormat) *Directory { // tesseract (../../../../../daggerverse/tesseract/document.go:145:1)
+func (r *TesseractDocument) Export(formats []TesseractFormat) *Directory { // tesseract (../../../../../daggerverse/tesseract/document.go:156:1)
 	q := r.query.Select("export")
 	q = q.Arg("formats", formats)
 
@@ -638,7 +687,7 @@ func (r *TesseractDocument) Export(formats []TesseractFormat) *Directory { // te
 
 // Hocr returns hOCR: HTML in which every recognised word carries its bounding
 // box and confidence, which is what layout-aware post-processing reads.
-func (r *TesseractDocument) Hocr() *File { // tesseract (../../../../../daggerverse/tesseract/document.go:111:1)
+func (r *TesseractDocument) Hocr() *File { // tesseract (../../../../../daggerverse/tesseract/document.go:122:1)
 	q := r.query.Select("hocr")
 
 	return &File{
@@ -703,7 +752,7 @@ func (r *TesseractDocument) UnmarshalJSON(bs []byte) error {
 // language, engine and page-segmentation mode have nothing to say about it.
 // The osd model has to be in the image: either as the package New installs for
 // it, or as an osd.traineddata WithTessdata supplied.
-func (r *TesseractDocument) Osd(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/document.go:169:1)
+func (r *TesseractDocument) Osd(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/document.go:180:1)
 	if r.osd != nil {
 		return *r.osd, nil
 	}
@@ -717,7 +766,7 @@ func (r *TesseractDocument) Osd(ctx context.Context) (string, error) { // tesser
 
 // Page returns PAGE XML, the PRImA layout-analysis schema — the alternative to
 // ALTO for tools built around that ecosystem.
-func (r *TesseractDocument) Page() *File { // tesseract (../../../../../daggerverse/tesseract/document.go:134:1)
+func (r *TesseractDocument) Page() *File { // tesseract (../../../../../daggerverse/tesseract/document.go:145:1)
 	q := r.query.Select("page")
 
 	return &File{
@@ -727,7 +776,7 @@ func (r *TesseractDocument) Page() *File { // tesseract (../../../../../daggerve
 
 // Pdf returns a searchable PDF: the source image with an invisible text layer
 // positioned behind it, so the page looks untouched but selects and greps.
-func (r *TesseractDocument) Pdf() *File { // tesseract (../../../../../daggerverse/tesseract/document.go:128:1)
+func (r *TesseractDocument) Pdf() *File { // tesseract (../../../../../daggerverse/tesseract/document.go:139:1)
 	q := r.query.Select("pdf")
 
 	return &File{
@@ -738,7 +787,7 @@ func (r *TesseractDocument) Pdf() *File { // tesseract (../../../../../daggerver
 // Text recognises the document and returns the plain text directly, by asking
 // tesseract to write to stdout instead of a file. This is the shortest path
 // for the common case; Txt is the same content as a *dagger.File.
-func (r *TesseractDocument) Text(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/document.go:90:1)
+func (r *TesseractDocument) Text(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/document.go:101:1)
 	if r.text != nil {
 		return *r.text, nil
 	}
@@ -752,7 +801,7 @@ func (r *TesseractDocument) Text(ctx context.Context) (string, error) { // tesse
 
 // Tsv returns tab-separated recognition results: one row per layout element,
 // descending from page to word, each with its box and confidence.
-func (r *TesseractDocument) Tsv() *File { // tesseract (../../../../../daggerverse/tesseract/document.go:122:1)
+func (r *TesseractDocument) Tsv() *File { // tesseract (../../../../../daggerverse/tesseract/document.go:133:1)
 	q := r.query.Select("tsv")
 
 	return &File{
@@ -763,7 +812,7 @@ func (r *TesseractDocument) Tsv() *File { // tesseract (../../../../../daggerver
 // Txt recognises the document and returns the plain text as a file. It is the
 // same content Text returns; take this when the next step wants a file rather
 // than a string.
-func (r *TesseractDocument) Txt() *File { // tesseract (../../../../../daggerverse/tesseract/document.go:105:1)
+func (r *TesseractDocument) Txt() *File { // tesseract (../../../../../daggerverse/tesseract/document.go:116:1)
 	q := r.query.Select("txt")
 
 	return &File{
@@ -775,7 +824,7 @@ func (r *TesseractDocument) Txt() *File { // tesseract (../../../../../daggerver
 // otherwise guesses from the image metadata. Guessing wrong hurts recognition
 // on images that carry no resolution at all. A non-positive value is rejected
 // at output time.
-func (r *TesseractDocument) WithDpi(dpi int) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:59:1)
+func (r *TesseractDocument) WithDpi(dpi int) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:70:1)
 	q := r.query.Select("withDpi")
 	q = q.Arg("dpi", dpi)
 
@@ -786,7 +835,7 @@ func (r *TesseractDocument) WithDpi(dpi int) *TesseractDocument { // tesseract (
 
 // WithEngine selects the OCR engine (`--oem`). Unset, tesseract picks based on
 // what the language data provides.
-func (r *TesseractDocument) WithEngine(mode TesseractEngineMode) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:51:1)
+func (r *TesseractDocument) WithEngine(mode TesseractEngineMode) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:62:1)
 	q := r.query.Select("withEngine")
 	q = q.Arg("mode", mode)
 
@@ -804,7 +853,7 @@ func (r *TesseractDocument) WithEngine(mode TesseractEngineMode) *TesseractDocum
 // both of those are baked in when the image is assembled. An unknown value is
 // rejected at output time with the available set listed. Unset, recognition
 // runs in the first language New installed.
-func (r *TesseractDocument) WithLanguage(lang string) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:38:1)
+func (r *TesseractDocument) WithLanguage(lang string) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:49:1)
 	q := r.query.Select("withLanguage")
 	q = q.Arg("lang", lang)
 
@@ -816,7 +865,7 @@ func (r *TesseractDocument) WithLanguage(lang string) *TesseractDocument { // te
 // WithPageSegmentation sets how much layout analysis precedes recognition
 // (`--psm`). Unset, tesseract uses fully automatic segmentation without
 // orientation detection.
-func (r *TesseractDocument) WithPageSegmentation(mode TesseractPageSegMode) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:45:1)
+func (r *TesseractDocument) WithPageSegmentation(mode TesseractPageSegMode) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:56:1)
 	q := r.query.Select("withPageSegmentation")
 	q = q.Arg("mode", mode)
 
@@ -832,7 +881,7 @@ func (r *TesseractDocument) WithPageSegmentation(mode TesseractPageSegMode) *Tes
 // functions cannot accept map parameters. An unknown name is rejected at
 // output time: tesseract itself only warns and carries on, so a typo would
 // otherwise silently do nothing.
-func (r *TesseractDocument) WithParameter(name string, value string) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:70:1)
+func (r *TesseractDocument) WithParameter(name string, value string) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:81:1)
 	q := r.query.Select("withParameter")
 	q = q.Arg("name", name)
 	q = q.Arg("value", value)
@@ -844,7 +893,7 @@ func (r *TesseractDocument) WithParameter(name string, value string) *TesseractD
 
 // WithUserPatterns supplies a pattern list (`--user-patterns`): one pattern
 // per line describing the shape of expected strings, such as part numbers.
-func (r *TesseractDocument) WithUserPatterns(patterns *File) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:83:1)
+func (r *TesseractDocument) WithUserPatterns(patterns *File) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:94:1)
 	assertNotNil("patterns", patterns)
 	q := r.query.Select("withUserPatterns")
 	q = q.Arg("patterns", patterns)
@@ -857,7 +906,7 @@ func (r *TesseractDocument) WithUserPatterns(patterns *File) *TesseractDocument 
 // WithUserWords supplies a word list (`--user-words`): one word per line,
 // which recognition then favours. Useful for jargon and proper nouns the
 // packaged dictionary does not know.
-func (r *TesseractDocument) WithUserWords(words *File) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:77:1)
+func (r *TesseractDocument) WithUserWords(words *File) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/document.go:88:1)
 	assertNotNil("words", words)
 	q := r.query.Select("withUserWords")
 	q = q.Arg("words", words)

--- a/daggerverse/tesseract/tests/main.go
+++ b/daggerverse/tesseract/tests/main.go
@@ -31,6 +31,18 @@ const (
 	sentencePng      = "sentence.png"
 	sentenceRot90Png = "sentence-rot90.png"
 
+	// ledgerPdf is a three-page PDF carrying different text on every page. It
+	// is hand-authored rather than produced by a generator: the content
+	// streams are uncompressed, so the text a page is supposed to render is
+	// readable in the fixture itself, and the whole file is 1.4KB.
+	//
+	// Its pages name the base-14 font Helvetica without embedding it, which is
+	// the common shape for a PDF that was never meant to be a scan. That makes
+	// it the fixture for the rasterizer's font substitution too: with no font
+	// installed, poppler draws these pages blank and OCR returns nothing at
+	// all, which is a silent wrong answer rather than a failure.
+	ledgerPdf = "ledger.pdf"
+
 	// ompThreadLimitEnv is the OpenMP variable New's ompThreadLimit sets on
 	// the assembled image.
 	ompThreadLimitEnv = "OMP_THREAD_LIMIT"
@@ -58,6 +70,25 @@ var sentenceLines = []string{
 	"How vexingly quick daft zebras jump about now.",
 	"Sphinx of black quartz, judge my vow tonight.",
 }
+
+// ledgerPages is what ledger.pdf renders, one entry per page in document
+// order. Every page leads with its own ordinal, which is what makes a dropped
+// or reordered page visible: without it, three pages of the same text would
+// recognise identically however they were shuffled.
+var ledgerPages = [][]string{
+	{"Page one of the ledger.", "The quick brown fox jumps over the lazy dog."},
+	{"Page two of the ledger.", "Pack my box with five dozen liquor jugs today."},
+	{"Page three of the ledger.", "How vexingly quick daft zebras jump about now."},
+}
+
+// ledgerPageMarkers is one word per page of ledger.pdf, in page order.
+//
+// The structured renderers wrap every word in its own element, so no whole
+// line is ever contiguous text in their output and the line-level assertions
+// cannot be used on them. A single word always is contiguous, and these three
+// each occur exactly once in the document, so their relative positions say
+// what page order says.
+var ledgerPageMarkers = []string{"lazy", "liquor", "zebras"}
 
 type Tests struct{}
 
@@ -102,6 +133,10 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("TsvHasHeaderAndWordRows", t.TsvHasHeaderAndWordRows)
 	jobs = jobs.WithJob("PdfHasPdfMagic", t.PdfHasPdfMagic)
 	jobs = jobs.WithJob("ExportProducesEveryRequestedFormat", t.ExportProducesEveryRequestedFormat)
+
+	jobs = jobs.WithJob("FromPdfRecognizesEveryPageInOrder", t.FromPdfRecognizesEveryPageInOrder)
+	jobs = jobs.WithJob("FromPdfDpiSetsRasterResolution", t.FromPdfDpiSetsRasterResolution)
+	jobs = jobs.WithJob("FromPdfExportRendersEveryFormatAsOneDocument", t.FromPdfExportRendersEveryFormatAsOneDocument)
 
 	jobs = jobs.WithJob("BatchMirrorsInputLayout", t.BatchMirrorsInputLayout)
 	jobs = jobs.WithJob("BatchDefaultGlobSkipsNonImages", t.BatchDefaultGlobSkipsNonImages)
@@ -666,12 +701,16 @@ func (t *Tests) OsdWithoutOsdDataIsRejected(ctx context.Context) error {
 // PdfInputIsRejected asserts a PDF source is refused up front. Leptonica has
 // no PDF support and reports the failure as if the file's first line were a
 // file name it could not open, which sends people looking in the wrong place.
+//
+// The error has to name FromPdf, which is the whole difference between an
+// error that ends the caller's afternoon and one that ends their next line of
+// code: rasterizing is no longer something they have to go and arrange.
 func (t *Tests) PdfInputIsRejected(ctx context.Context) error {
 	_, err := ocr().Document(textFile("scan.pdf", "%PDF-1.7\n")).Text(ctx)
 	if err == nil {
 		return fmt.Errorf("expected a PDF source to be rejected, got nil")
 	}
-	for _, want := range []string{"scan.pdf", "leptonica", "rasterize"} {
+	for _, want := range []string{"scan.pdf", "leptonica", "rasterize", "FromPdf"} {
 		if !strings.Contains(err.Error(), want) {
 			return fmt.Errorf("expected the error to mention %q, got: %v", want, err)
 		}
@@ -726,6 +765,160 @@ func (t *Tests) NonPositiveDpiIsRejected(ctx context.Context) error {
 		return fmt.Errorf("Text with dpi 300: %w", err)
 	}
 	return assertSentenceLines(got)
+}
+
+// ------------------------------------------------------------------------ pdf
+
+// FromPdfRecognizesEveryPageInOrder asserts the whole PDF entry point: every
+// page is rasterized, every page is recognised, and the pages arrive in
+// document order.
+//
+// Order is the half that needs a fixture with distinct pages. Rasterization
+// writes one file per page and the recognition pass reads them from a list, so
+// a sorting bug — page-10 before page-2, say — would still produce text for
+// every page and still look like a success.
+func (t *Tests) FromPdfRecognizesEveryPageInOrder(ctx context.Context) error {
+	got, err := ocr().FromPdf(fixture(ledgerPdf)).Text(ctx)
+	if err != nil {
+		return fmt.Errorf("FromPdf: %w", err)
+	}
+	return assertLedgerPages(got)
+}
+
+// FromPdfDpiSetsRasterResolution asserts the rasterization resolution defaults
+// to 300 and that a caller's value replaces it.
+//
+// It reads the resolution back off the page geometry hOCR reports, because
+// that is the only place the module publishes it: ledger.pdf's pages are US
+// Letter, 612x792 points, so a page rasterized at D dots per inch is exactly
+// 612*D/72 by 792*D/72 pixels. Asserting on the pixels rather than on the flag
+// is what makes this a test of the rasterizer rather than of argv.
+func (t *Tests) FromPdfDpiSetsRasterResolution(ctx context.Context) error {
+	for _, tc := range []struct {
+		dpi  int
+		want string
+	}{
+		// Zero is not "rasterize at nothing": the SDK drops a zero-valued
+		// argument, so this is the call with no dpi at all, and what it pins
+		// is the 300 the default declares.
+		{0, "bbox 0 0 2550 3300"},
+		{150, "bbox 0 0 1275 1650"},
+		{72, "bbox 0 0 612 792"},
+	} {
+		got, err := ocr().
+			FromPdf(fixture(ledgerPdf), dagger.TesseractFromPdfOpts{Dpi: tc.dpi}).
+			Hocr().
+			Contents(ctx)
+		if err != nil {
+			return fmt.Errorf("Hocr at dpi %d: %w", tc.dpi, err)
+		}
+		if !strings.Contains(got, tc.want) {
+			return fmt.Errorf("expected dpi %d to rasterize pages of %q, got:\n%s", tc.dpi, tc.want, pageTitles(got))
+		}
+	}
+
+	// A resolution that is not a resolution is refused here rather than by
+	// pdftoppm, whose own message talks about its `-r` flag and says nothing
+	// about where the value came from.
+	_, err := ocr().FromPdf(fixture(ledgerPdf), dagger.TesseractFromPdfOpts{Dpi: -300}).Text(ctx)
+	if err == nil {
+		return fmt.Errorf("expected a negative dpi to be rejected, got nil")
+	}
+	if !strings.Contains(err.Error(), "FromPdf: dpi must be positive") {
+		return fmt.Errorf("expected the error to name the positive rule, got: %v", err)
+	}
+	return nil
+}
+
+// FromPdfExportRendersEveryFormatAsOneDocument asserts a multi-page PDF stays
+// one document through every renderer, not just through plain text.
+//
+// This is the assumption the whole design rests on. Rasterization produces one
+// image per page, and recognition feeds them to tesseract as a file list — so
+// the question is whether each renderer accumulates the pages into a single
+// artifact or whether only the text one does. If any of them emitted just the
+// last page, the fix would not be a patch: it would mean rasterizing to a
+// multi-page TIFF instead, which needs another package on the image.
+//
+// Each format is therefore checked for its own per-page structure rather than
+// for mere existence: three page elements, three page numbers, three PDF
+// pages. A renderer that kept only one page would still produce a file.
+func (t *Tests) FromPdfExportRendersEveryFormatAsOneDocument(ctx context.Context) error {
+	out := ocr().FromPdf(fixture(ledgerPdf)).Export([]dagger.TesseractFormat{
+		dagger.TesseractFormatTxt,
+		dagger.TesseractFormatHocr,
+		dagger.TesseractFormatAlto,
+		dagger.TesseractFormatTsv,
+		dagger.TesseractFormatPdf,
+		dagger.TesseractFormatPage,
+	})
+	entries, err := out.Entries(ctx)
+	if err != nil {
+		return fmt.Errorf("Export: %w", err)
+	}
+	want := []string{"result.hocr", "result.page.xml", "result.pdf", "result.tsv", "result.txt", "result.xml"}
+	sort.Strings(entries)
+	if !reflect.DeepEqual(entries, want) {
+		return fmt.Errorf("expected exactly %v, got %v", want, entries)
+	}
+
+	// Plain text is the one format whose lines survive intact, so it gets the
+	// full line-by-line check.
+	txt, err := out.File("result.txt").Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("read result.txt: %w", err)
+	}
+	if err := assertLedgerPages(txt); err != nil {
+		return fmt.Errorf("result.txt: %w", err)
+	}
+
+	// The structured formats each mark their page boundaries their own way,
+	// and all of them have to show one boundary per page with that page's own
+	// text between them, in order.
+	for _, tc := range []struct {
+		name   string
+		marker string
+	}{
+		{"result.hocr", "class='ocr_page'"},
+		{"result.xml", "<Page "},
+		{"result.page.xml", "<Page "},
+	} {
+		got, err := out.File(tc.name).Contents(ctx)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", tc.name, err)
+		}
+		if n := strings.Count(got, tc.marker); n != len(ledgerPages) {
+			return fmt.Errorf("expected %d %q in %s, got %d", len(ledgerPages), tc.marker, tc.name, n)
+		}
+		if err := assertPageOrder(got); err != nil {
+			return fmt.Errorf("%s: %w", tc.name, err)
+		}
+	}
+
+	// TSV numbers its pages in a column rather than nesting them, so the
+	// evidence there is the set of page numbers the rows carry.
+	tsv, err := out.File("result.tsv").Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("read result.tsv: %w", err)
+	}
+	if got := tsvPageNums(tsv); !reflect.DeepEqual(got, []string{"1", "2", "3"}) {
+		return fmt.Errorf("expected TSV rows for pages 1, 2 and 3, got %v", got)
+	}
+
+	// The searchable PDF has to come back out with the page count it went in
+	// with — a renderer that overwrote rather than appended would still be a
+	// valid, single-page PDF.
+	pdf, err := exportBytes(ctx, out.File("result.pdf"), "result.pdf")
+	if err != nil {
+		return err
+	}
+	if !bytes.HasPrefix(pdf, []byte("%PDF-")) {
+		return fmt.Errorf("expected a PDF header, got %q", firstBytes(pdf, 8))
+	}
+	if n := bytes.Count(pdf, []byte("/Type /Page\n")); n != len(ledgerPages) {
+		return fmt.Errorf("expected the searchable PDF to carry %d pages, got %d", len(ledgerPages), n)
+	}
+	return nil
 }
 
 // ---------------------------------------------------------------------- batch
@@ -1107,6 +1300,85 @@ func assertSentenceLines(got string) error {
 		}
 	}
 	return nil
+}
+
+// assertLedgerPages checks recognised text against what ledger.pdf renders,
+// and — the point of a multi-page source — that the pages appear in document
+// order rather than merely all being present.
+//
+// Order is checked by where each line was found rather than by splitting on
+// the page separator, because that separator differs by renderer: plain text
+// gets a form feed, the structured formats get their own page elements. A
+// monotonic position says the same thing for all of them.
+func assertLedgerPages(got string) error {
+	prev := -1
+	for i, lines := range ledgerPages {
+		for _, want := range lines {
+			at := strings.Index(got, want)
+			if at < 0 {
+				return fmt.Errorf("expected page %d to contribute %q, got:\n%s", i+1, want, got)
+			}
+			if at < prev {
+				return fmt.Errorf("expected page %d's %q to follow the preceding page, got:\n%s", i+1, want, got)
+			}
+			prev = at
+		}
+	}
+	return nil
+}
+
+// assertPageOrder checks that each page contributed its own marker word and
+// that the markers appear in page order. It is the check assertLedgerPages
+// cannot make on a format that puts every word in its own element.
+func assertPageOrder(got string) error {
+	prev := -1
+	for i, want := range ledgerPageMarkers {
+		at := strings.Index(got, want)
+		if at < 0 {
+			return fmt.Errorf("expected page %d to contribute the word %q, got:\n%s", i+1, want, got)
+		}
+		if at < prev {
+			return fmt.Errorf("expected page %d's %q to follow the preceding page, got:\n%s", i+1, want, got)
+		}
+		prev = at
+	}
+	return nil
+}
+
+// pageTitles pulls the ocr_page title lines out of hOCR, so a geometry
+// mismatch reports the handful of lines that carry the geometry instead of the
+// whole document.
+func pageTitles(hocr string) string {
+	var out []string
+	for _, line := range strings.Split(hocr, "\n") {
+		if strings.Contains(line, "ocr_page") {
+			out = append(out, strings.TrimSpace(line))
+		}
+	}
+	return strings.Join(out, "\n")
+}
+
+// tsvPageNums returns the distinct page numbers the TSV rows carry, in the
+// order they first appear, which is both what pages were recognised and what
+// order they arrived in.
+func tsvPageNums(tsv string) []string {
+	var (
+		out  []string
+		seen = map[string]struct{}{}
+	)
+	for i, line := range strings.Split(strings.TrimSpace(tsv), "\n") {
+		cols := strings.Split(line, "\t")
+		// Row 0 is the column header; page_num is the second column.
+		if i == 0 || len(cols) < 2 {
+			continue
+		}
+		if _, dup := seen[cols[1]]; dup {
+			continue
+		}
+		seen[cols[1]] = struct{}{}
+		out = append(out, cols[1])
+	}
+	return out
 }
 
 func contains(haystack []string, needle string) bool {


### PR DESCRIPTION
Closes #221.

`Tesseract.FromPdf(pdf)` rasterizes the pages and hands back an ordinary `Document`, so every output, option and error path the module already has works on a PDF unchanged.

```go
Tesseract.FromPdf(source *dagger.File, dpi int /* +default=300 */) *Document
```

A multi-page PDF stays **one** document: `Text` returns the whole thing with form feeds between pages, `Pdf` returns one searchable PDF with the source's page count, and the structured formats carry one page element per page.

## The issue's mechanism doesn't work as specified

The description called for "a `Document` over the resulting multi-page TIFF". As [@Zaba505 noted on the issue](https://github.com/z5labs/devex/issues/221#issuecomment-5098985630), `pdftoppm` cannot produce one — both poppler raster backends write one file per page, and building a real multi-page TIFF would need `tiffcp` from `tiff-tools`, a second package on top of `poppler-utils`.

Took option 2 from that comment: rasterize to per-page PNGs and feed them to tesseract's file-list mode. That mode is exactly the behaviour #220 rejected for `Batch` — it treats the list as one concatenated **document** — which is wrong for a folder of independent scans and precisely right for the pages of one PDF.

**The open question from that comment is answered: file-list input renders every format `Export` emits, not just plain text.** Verified in-container and pinned by a test:

| format | evidence of all 3 pages |
| --- | --- |
| `result.txt` | 3 pages, form-feed separated, in order |
| `result.hocr` | 3 `class='ocr_page'` divs |
| `result.xml` (ALTO) | 3 `<Page ` elements |
| `result.page.xml` | 3 `<Page ` elements |
| `result.tsv` | `page_num` 1, 2, 3 |
| `result.pdf` | 3 `/Type /Page` objects |

So no `tiff-tools`, and no multi-page TIFF handling on either side.

## Where poppler is installed — the size decision (AC #4)

Rasterization runs in its **own container** (Alpine at the same pinned tag) rather than on the toolchain image, so the cost lands on the callers who asked for it. Measured with `apk add --simulate`:

| | image | cost |
| --- | --- | --- |
| toolchain today | 67.1 MiB | — |
| toolchain with poppler + font installed unconditionally | 81.4 MiB | **+21% for every caller, PDF or not** |
| separate rasterizer | 35.0 MiB | paid only by `FromPdf` callers; 8.0 MiB of it is the shared Alpine base |

Unconditional install is cheaper in total *for a PDF caller* (81.4 vs 67.1 + 27), but taxes the majority who only ever hand this module a PNG, and would invalidate every existing user's cached toolchain image once. Rasterizing separately also caches independently, so changing a recognition option does not re-rasterize the document. Recorded in the module doc comment and the README.

## A font is not optional — silent blank pages

Not in the ACs, but found while building the fixture and worth flagging.

Poppler draws a PDF that names a base-14 font without embedding it — the usual shape for anything not born as a scan — by asking fontconfig for a substitute. **With no font installed at all there is nothing to substitute: the page renders blank, recognition finds no text, and the call succeeds.** All three fixture pages came back byte-identical at 32,063 bytes and OCR'd to nothing.

So the rasterizer installs `ttf-liberation`, which is metric-compatible with Helvetica, Times and Courier, so substituted text keeps the line breaks and positions the document was written with. DejaVu covers more of Unicode but is 5.8 MiB larger and matches none of those metrics.

## Page ordering

`pdftoppm` names its output with the page number zero-padded to the width of the *last* page — a 9-page document yields `page-1.png`, a 10-page one `page-01.png`. One document means one padding width, so the page list is built by globbing and sorting rather than by counting pages.

## Validation added

| Rejected | Why the raw failure is worse |
| --- | --- |
| a `.pdf` source to `Document` or `Batch` | unchanged behaviour, but the message now names `FromPdf`, so the fix is a function call rather than an errand (AC #3) |
| `FromPdf` at zero or negative `dpi` | `pdftoppm` would fail much later, talking about its own `-r` flag rather than about the argument the caller passed |

## Testing

New fixture `tests/fixtures/ledger.pdf`: hand-authored, 1.4 KB, three pages with distinct text. The content streams are uncompressed, so the text each page renders is readable in the fixture itself rather than being an opaque blob. It deliberately names Helvetica **without embedding it**, which makes it the regression test for the font substitution above.

Three new tests, each run individually during development and green in the full suite (33 tests, `dagger -m daggerverse/tesseract/tests call all`):

- `FromPdfRecognizesEveryPageInOrder` — every page rasterized and recognised, in document order (AC #1)
- `FromPdfDpiSetsRasterResolution` — default 300, `150` and `72` honoured, negative rejected (AC #2). Reads the resolution back off the page geometry hOCR reports rather than off argv, so it tests the rasterizer and not the flag: ledger.pdf's pages are US Letter, so page 1 at 300 dpi is exactly `bbox 0 0 2550 3300`
- `FromPdfExportRendersEveryFormatAsOneDocument` — the table above

`PdfInputIsRejected` extended to require the error name `FromPdf`.

`dagger develop` re-run in the module, `tests/`, and the root aggregator; generated code committed and `dagger -m ci call generated` is clean (AC #5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
