### PR TITLE
story(issue-223): add the chained Ci builder to tesseract

### DIFF
--- a/ci/internal/dagger/tesseract-tests.gen.go
+++ b/ci/internal/dagger/tesseract-tests.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type TesseractTests
-func (r *Binding) AsTesseractTests() *TesseractTests { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:108:6)
+func (r *Binding) AsTesseractTests() *TesseractTests { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:120:6)
 	q := r.query.Select("asTesseractTests")
 
 	return &TesseractTests{
@@ -19,7 +19,7 @@ func (r *Binding) AsTesseractTests() *TesseractTests { // tesseract-tests (../..
 }
 
 // Create or update a binding of type TesseractTests in the environment
-func (r *Env) WithTesseractTestsInput(name string, value *TesseractTests, description string) *Env { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:108:6)
+func (r *Env) WithTesseractTestsInput(name string, value *TesseractTests, description string) *Env { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:120:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withTesseractTestsInput")
 	q = q.Arg("name", name)
@@ -32,7 +32,7 @@ func (r *Env) WithTesseractTestsInput(name string, value *TesseractTests, descri
 }
 
 // Declare a desired TesseractTests output to be assigned in the environment
-func (r *Env) WithTesseractTestsOutput(name string, description string) *Env { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:108:6)
+func (r *Env) WithTesseractTestsOutput(name string, description string) *Env { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:120:6)
 	q := r.query.Select("withTesseractTestsOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -50,7 +50,7 @@ func (r *Env) WithTesseractTestsOutput(name string, description string) *Env { /
 // The fixtures under fixtures/ are committed rather than generated in-container:
 // bare Alpine ships no fonts, so rendering text inside the toolchain image would
 // mean pulling in fontconfig and a font package purely to make the tests run.
-func (r *Query) TesseractTests() *TesseractTests { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:108:6)
+func (r *Query) TesseractTests() *TesseractTests { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:120:6)
 	q := r.query.Select("tesseractTests")
 
 	return &TesseractTests{
@@ -58,7 +58,7 @@ func (r *Query) TesseractTests() *TesseractTests { // tesseract-tests (../../../
 	}
 }
 
-type TesseractTests struct { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:108:6)
+type TesseractTests struct { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:120:6)
 	query *querybuilder.Selection
 
 	all                                          *Void
@@ -70,6 +70,12 @@ type TesseractTests struct { // tesseract-tests (../../../daggerverse/tesseract/
 	batchRejectsAmbiguousInput                   *Void
 	batchSharesDocumentOptions                   *Void
 	boxReportsCharacterBoxes                     *Void
+	ciCheckRunsTheGateWithoutArtifacts           *Void
+	ciGateKeepsItsTsvOutOfTheOutput              *Void
+	ciLanguageReachesRecognition                 *Void
+	ciMinConfidenceGatesTheRun                   *Void
+	ciRejectsUnusableThreshold                   *Void
+	ciRunProducesEnabledFormats                  *Void
 	defaultLanguagesInstallEnglish               *Void
 	exportProducesEveryRequestedFormat           *Void
 	fromPdfDpiSetsRasterResolution               *Void
@@ -113,7 +119,7 @@ func (r *TesseractTests) WithGraphQLQuery(q *querybuilder.Selection) *TesseractT
 
 // TesseractTestsAllOpts contains options for TesseractTests.All
 type TesseractTestsAllOpts struct {
-	Parallel int // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:130:2)
+	Parallel int // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:142:2)
 }
 
 // All runs every tesseract-module test in parallel.
@@ -130,7 +136,7 @@ type TesseractTestsAllOpts struct {
 // thread per pass the claim finally holds, and jobs contend for cores the way
 // any other oversubscribed workload does. The cap stays available for a host
 // that wants a narrower slice.
-func (r *TesseractTests) All(ctx context.Context, opts ...TesseractTestsAllOpts) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:127:1)
+func (r *TesseractTests) All(ctx context.Context, opts ...TesseractTestsAllOpts) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:139:1)
 	if r.all != nil {
 		return nil
 	}
@@ -148,7 +154,7 @@ func (r *TesseractTests) All(ctx context.Context, opts ...TesseractTestsAllOpts)
 // AltoIsValidXml asserts the ALTO renderer emits well-formed XML in the ALTO
 // namespace, since its consumers are schema-driven archive tooling that will
 // reject anything else outright.
-func (r *TesseractTests) AltoIsValidXML(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:334:1)
+func (r *TesseractTests) AltoIsValidXML(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:353:1)
 	if r.altoIsValidXml != nil {
 		return nil
 	}
@@ -164,7 +170,7 @@ func (r *TesseractTests) AltoIsValidXML(ctx context.Context) error { // tesserac
 // them are pages. Handing one to tesseract is not a no-op — leptonica fails to
 // decode it and the run dies — so "ignored by default" is what makes pointing
 // Batch at an existing directory work at all.
-func (r *TesseractTests) BatchDefaultGlobSkipsNonImages(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:992:1)
+func (r *TesseractTests) BatchDefaultGlobSkipsNonImages(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1011:1)
 	if r.batchDefaultGlobSkipsNonImages != nil {
 		return nil
 	}
@@ -180,7 +186,7 @@ func (r *TesseractTests) BatchDefaultGlobSkipsNonImages(ctx context.Context) err
 // would render one concatenated artifact per *format* — a single .txt with
 // form-feed page breaks and a single multi-page PDF — with no way to tell which
 // page produced what.
-func (r *TesseractTests) BatchExportProducesEveryFormatPerImage(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1088:1)
+func (r *TesseractTests) BatchExportProducesEveryFormatPerImage(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1107:1)
 	if r.batchExportProducesEveryFormatPerImage != nil {
 		return nil
 	}
@@ -196,7 +202,7 @@ func (r *TesseractTests) BatchExportProducesEveryFormatPerImage(ctx context.Cont
 // be indistinguishable from a batch that ran and found no text, so a typo in a
 // pattern would surface much later as missing output rather than here as a bad
 // glob.
-func (r *TesseractTests) BatchGlobSelectsFiles(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1036:1)
+func (r *TesseractTests) BatchGlobSelectsFiles(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1055:1)
 	if r.batchGlobSelectsFiles != nil {
 		return nil
 	}
@@ -213,7 +219,7 @@ func (r *TesseractTests) BatchGlobSelectsFiles(ctx context.Context) error { // t
 // directory of `result-1.txt`, `result-2.txt` would force every caller to
 // rebuild the correspondence between page and text that the input directory
 // already expressed.
-func (r *TesseractTests) BatchMirrorsInputLayout(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:958:1)
+func (r *TesseractTests) BatchMirrorsInputLayout(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:977:1)
 	if r.batchMirrorsInputLayout != nil {
 		return nil
 	}
@@ -229,7 +235,7 @@ func (r *TesseractTests) BatchMirrorsInputLayout(ctx context.Context) error { //
 // A collision is the subtle one: `a.png` and `a.jpg` in one folder both render
 // onto `a.txt`, so the second silently overwrites the first and the batch looks
 // like it succeeded with one page missing.
-func (r *TesseractTests) BatchRejectsAmbiguousInput(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1200:1)
+func (r *TesseractTests) BatchRejectsAmbiguousInput(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1219:1)
 	if r.batchRejectsAmbiguousInput != nil {
 		return nil
 	}
@@ -245,7 +251,7 @@ func (r *TesseractTests) BatchRejectsAmbiguousInput(ctx context.Context) error {
 // It covers both halves: an option that has to reach tesseract for every image
 // in the run, and the deferred validation that has to reject a bad option
 // before any of them are recognised.
-func (r *TesseractTests) BatchSharesDocumentOptions(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1134:1)
+func (r *TesseractTests) BatchSharesDocumentOptions(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1153:1)
 	if r.batchSharesDocumentOptions != nil {
 		return nil
 	}
@@ -257,7 +263,7 @@ func (r *TesseractTests) BatchSharesDocumentOptions(ctx context.Context) error {
 // BoxReportsCharacterBoxes asserts the box renderer descends to the character
 // level, which is the level nothing else this module offers reaches: hOCR and
 // TSV stop at the word.
-func (r *TesseractTests) BoxReportsCharacterBoxes(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1236:1)
+func (r *TesseractTests) BoxReportsCharacterBoxes(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1514:1)
 	if r.boxReportsCharacterBoxes != nil {
 		return nil
 	}
@@ -266,11 +272,123 @@ func (r *TesseractTests) BoxReportsCharacterBoxes(ctx context.Context) error { /
 	return q.Execute(ctx)
 }
 
+// CiCheckRunsTheGateWithoutArtifacts asserts Check reaches the same verdict
+// Run's gate does, and that it is a real pass over the scans rather than a
+// signature that returns nil.
+//
+// Its return type is the whole reason it exists — an error and nothing else, so
+// a PR gate that never wants the archive cannot accidentally be handed one —
+// and that makes "did it actually look?" the thing worth testing. A Check that
+// short-circuited when no threshold was set would be a green build over a
+// directory of files tesseract cannot read at all.
+func (r *TesseractTests) CiCheckRunsTheGateWithoutArtifacts(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1370:1)
+	if r.ciCheckRunsTheGateWithoutArtifacts != nil {
+		return nil
+	}
+	q := r.query.Select("ciCheckRunsTheGateWithoutArtifacts")
+
+	return q.Execute(ctx)
+}
+
+// CiGateKeepsItsTsvOutOfTheOutput asserts the output is what WithFormats asked
+// for, whether or not a threshold was set.
+//
+// The gate measures a TSV, and Run renders that TSV in the same pass as the
+// artifacts rather than paying for a second one. That is an implementation
+// decision and it has to stay one: a caller who enabled a threshold and asked
+// for PDFs did not ask for a TSV beside every page, and would find one in the
+// archive they published. A caller who did ask for TSV keeps it, which is the
+// half that catches a filter written as "drop every TSV".
+func (r *TesseractTests) CiGateKeepsItsTsvOutOfTheOutput(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1406:1)
+	if r.ciGateKeepsItsTsvOutOfTheOutput != nil {
+		return nil
+	}
+	q := r.query.Select("ciGateKeepsItsTsvOutOfTheOutput")
+
+	return q.Execute(ctx)
+}
+
+// CiLanguageReachesRecognition asserts the pipeline's language is the batch's
+// language, in both directions: a selected one recognises, and one the image
+// does not carry is rejected with the same explanation a bare batch gives.
+//
+// Ci owns no option handling of its own — that is what makes it a bundle of
+// calls rather than a second implementation — and the rejection is the half that
+// proves it, because the check that produces it lives on the shared option set
+// and could only fire if the value got there. It also fires before recognition,
+// so a wrong-language pipeline costs a message rather than a batch.
+func (r *TesseractTests) CiLanguageReachesRecognition(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1454:1)
+	if r.ciLanguageReachesRecognition != nil {
+		return nil
+	}
+	q := r.query.Select("ciLanguageReachesRecognition")
+
+	return q.Execute(ctx)
+}
+
+// CiMinConfidenceGatesTheRun asserts the quality gate: recognition that came
+// back worse than the threshold fails the run, and the failure names both the
+// value measured and the page that measured it.
+//
+// Reporting the value is what makes the threshold adjustable. "Confidence too
+// low" leaves the caller guessing whether they are one point short or thirty,
+// and the only way to find out would be to re-run the whole batch by hand
+// asking for TSV.
+//
+// Naming the page is what makes it actionable, and the mixed directory is where
+// that has to be earned: one clean scan and one blank page under a threshold
+// only the blank page misses. A gate that failed the batch as a whole would be
+// telling the caller to go and diff a hundred TSVs.
+func (r *TesseractTests) CiMinConfidenceGatesTheRun(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1314:1)
+	if r.ciMinConfidenceGatesTheRun != nil {
+		return nil
+	}
+	q := r.query.Select("ciMinConfidenceGatesTheRun")
+
+	return q.Execute(ctx)
+}
+
+// CiRejectsUnusableThreshold asserts a bar no page could miss, or none could
+// clear, is refused before anything is recognised.
+//
+// Zero is the one worth spelling out. It is not a lenient gate, it is no gate at
+// all — every page clears it — so a build configured that way reports a passing
+// quality check it never made. Accepting it silently would make the difference
+// between a gate and a decoration invisible.
+//
+// It is checked through Check rather than Run because that is where a
+// misconfiguration costs the most to discover late: Check is the call a PR gate
+// makes, and its whole answer is the error it returns.
+func (r *TesseractTests) CiRejectsUnusableThreshold(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1492:1)
+	if r.ciRejectsUnusableThreshold != nil {
+		return nil
+	}
+	q := r.query.Select("ciRejectsUnusableThreshold")
+
+	return q.Execute(ctx)
+}
+
+// CiRunProducesEnabledFormats asserts the pipeline's output is the batch it
+// wraps: every enabled format for every matched image, at the input's own path.
+//
+// The default is the half worth pinning. A pipeline that produced nothing until
+// WithFormats was called would look like a broken directory rather than an
+// unconfigured one, so an unconfigured Ci renders plain text — the format
+// tesseract itself produces when no renderer is named.
+func (r *TesseractTests) CiRunProducesEnabledFormats(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1259:1)
+	if r.ciRunProducesEnabledFormats != nil {
+		return nil
+	}
+	q := r.query.Select("ciRunProducesEnabledFormats")
+
+	return q.Execute(ctx)
+}
+
 // DefaultLanguagesInstallEnglish asserts New with no languages installs
 // English and nothing else. The base apk package carries no language data at
 // all, so an empty default would produce an image that cannot recognise
 // anything.
-func (r *TesseractTests) DefaultLanguagesInstallEnglish(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:211:1)
+func (r *TesseractTests) DefaultLanguagesInstallEnglish(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:230:1)
 	if r.defaultLanguagesInstallEnglish != nil {
 		return nil
 	}
@@ -283,7 +401,7 @@ func (r *TesseractTests) DefaultLanguagesInstallEnglish(ctx context.Context) err
 // formats. That the artifacts arrive in a single directory lifted off a single
 // exec is what proves they came from one recognition pass rather than six: the
 // per-format functions each run their own.
-func (r *TesseractTests) ExportProducesEveryRequestedFormat(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:405:1)
+func (r *TesseractTests) ExportProducesEveryRequestedFormat(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:424:1)
 	if r.exportProducesEveryRequestedFormat != nil {
 		return nil
 	}
@@ -300,7 +418,7 @@ func (r *TesseractTests) ExportProducesEveryRequestedFormat(ctx context.Context)
 // Letter, 612x792 points, so a page rasterized at D dots per inch is exactly
 // 612*D/72 by 792*D/72 pixels. Asserting on the pixels rather than on the flag
 // is what makes this a test of the rasterizer rather than of argv.
-func (r *TesseractTests) FromPdfDpiSetsRasterResolution(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:820:1)
+func (r *TesseractTests) FromPdfDpiSetsRasterResolution(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:839:1)
 	if r.fromPdfDpiSetsRasterResolution != nil {
 		return nil
 	}
@@ -322,7 +440,7 @@ func (r *TesseractTests) FromPdfDpiSetsRasterResolution(ctx context.Context) err
 // Each format is therefore checked for its own per-page structure rather than
 // for mere existence: three page elements, three page numbers, three PDF
 // pages. A renderer that kept only one page would still produce a file.
-func (r *TesseractTests) FromPdfExportRendersEveryFormatAsOneDocument(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:870:1)
+func (r *TesseractTests) FromPdfExportRendersEveryFormatAsOneDocument(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:889:1)
 	if r.fromPdfExportRendersEveryFormatAsOneDocument != nil {
 		return nil
 	}
@@ -339,7 +457,7 @@ func (r *TesseractTests) FromPdfExportRendersEveryFormatAsOneDocument(ctx contex
 // writes one file per page and the recognition pass reads them from a list, so
 // a sorting bug — page-10 before page-2, say — would still produce text for
 // every page and still look like a success.
-func (r *TesseractTests) FromPdfRecognizesEveryPageInOrder(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:804:1)
+func (r *TesseractTests) FromPdfRecognizesEveryPageInOrder(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:823:1)
 	if r.fromPdfRecognizesEveryPageInOrder != nil {
 		return nil
 	}
@@ -350,7 +468,7 @@ func (r *TesseractTests) FromPdfRecognizesEveryPageInOrder(ctx context.Context) 
 
 // HocrContainsWordBoxes asserts hOCR carries the per-word geometry that is the
 // whole reason to ask for it rather than plain text.
-func (r *TesseractTests) HocrContainsWordBoxes(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:311:1)
+func (r *TesseractTests) HocrContainsWordBoxes(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:330:1)
 	if r.hocrContainsWordBoxes != nil {
 		return nil
 	}
@@ -415,7 +533,7 @@ func (r *TesseractTests) UnmarshalJSON(bs []byte) error {
 // is that no member is dead: LEGACY and LEGACY_LSTM only work because Alpine
 // packages the *combined* tessdata models. A rebuild against tessdata_fast or
 // tessdata_best would strip the legacy data and this is where that shows up.
-func (r *TesseractTests) LstmEngineRecognizesFixture(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:552:1)
+func (r *TesseractTests) LstmEngineRecognizesFixture(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:571:1)
 	if r.lstmEngineRecognizesFixture != nil {
 		return nil
 	}
@@ -432,7 +550,7 @@ func (r *TesseractTests) LstmEngineRecognizesFixture(ctx context.Context) error 
 // it, because that is what a sample is *for*: the file pairs the line's pixels
 // with the characters they are supposed to be, and a sample built against the
 // wrong text trains the model to be wrong without ever failing.
-func (r *TesseractTests) LstmTrainBuildsTrainingSample(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1292:1)
+func (r *TesseractTests) LstmTrainBuildsTrainingSample(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1570:1)
 	if r.lstmTrainBuildsTrainingSample != nil {
 		return nil
 	}
@@ -444,7 +562,7 @@ func (r *TesseractTests) LstmTrainBuildsTrainingSample(ctx context.Context) erro
 // MalformedParameterNameIsRejected asserts an empty parameter name, and one
 // carrying its own `=`, are refused. `-c` takes `name=value`, so an embedded
 // `=` would quietly set a different variable to a different value.
-func (r *TesseractTests) MalformedParameterNameIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:748:1)
+func (r *TesseractTests) MalformedParameterNameIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:767:1)
 	if r.malformedParameterNameIsRejected != nil {
 		return nil
 	}
@@ -456,7 +574,7 @@ func (r *TesseractTests) MalformedParameterNameIsRejected(ctx context.Context) e
 // NonPositiveDpiIsRejected asserts a zero or negative resolution is refused
 // rather than handed to tesseract, which would take it as a real measurement
 // and scale its analysis by it.
-func (r *TesseractTests) NonPositiveDpiIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:774:1)
+func (r *TesseractTests) NonPositiveDpiIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:793:1)
 	if r.nonPositiveDpiIsRejected != nil {
 		return nil
 	}
@@ -475,7 +593,7 @@ func (r *TesseractTests) NonPositiveDpiIsRejected(ctx context.Context) error { /
 // works at all: without it, anything running several recognitions at once has
 // no way to stop each pass claiming every core, which cost this very suite
 // nine minutes on a four-core runner (#226).
-func (r *TesseractTests) OmpThreadLimitBoundsOpenMp(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:248:1)
+func (r *TesseractTests) OmpThreadLimitBoundsOpenMp(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:267:1)
 	if r.ompThreadLimitBoundsOpenMp != nil {
 		return nil
 	}
@@ -487,7 +605,7 @@ func (r *TesseractTests) OmpThreadLimitBoundsOpenMp(ctx context.Context) error {
 // OsdDetectsRotation asserts orientation detection reads the quarter-turn in
 // the rotated fixture and reports the rotation that would undo it, while the
 // upright fixture reports no rotation at all.
-func (r *TesseractTests) OsdDetectsRotation(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:631:1)
+func (r *TesseractTests) OsdDetectsRotation(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:650:1)
 	if r.osdDetectsRotation != nil {
 		return nil
 	}
@@ -499,7 +617,7 @@ func (r *TesseractTests) OsdDetectsRotation(ctx context.Context) error { // tess
 // OsdWithoutOsdDataIsRejected asserts orientation detection on an image built
 // without the osd model names the fix rather than failing inside tesseract,
 // which would report a missing traineddata file.
-func (r *TesseractTests) OsdWithoutOsdDataIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:712:1)
+func (r *TesseractTests) OsdWithoutOsdDataIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:731:1)
 	if r.osdWithoutOsdDataIsRejected != nil {
 		return nil
 	}
@@ -511,7 +629,7 @@ func (r *TesseractTests) OsdWithoutOsdDataIsRejected(ctx context.Context) error 
 // PdfHasPdfMagic asserts the searchable-PDF renderer emits a real PDF. The
 // bytes go through the filesystem rather than File.Contents, which mangles
 // non-UTF-8 data.
-func (r *TesseractTests) PdfHasPdfMagic(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:387:1)
+func (r *TesseractTests) PdfHasPdfMagic(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:406:1)
 	if r.pdfHasPdfMagic != nil {
 		return nil
 	}
@@ -527,7 +645,7 @@ func (r *TesseractTests) PdfHasPdfMagic(ctx context.Context) error { // tesserac
 // The error has to name FromPdf, which is the whole difference between an
 // error that ends the caller's afternoon and one that ends their next line of
 // code: rasterizing is no longer something they have to go and arrange.
-func (r *TesseractTests) PdfInputIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:732:1)
+func (r *TesseractTests) PdfInputIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:751:1)
 	if r.pdfInputIsRejected != nil {
 		return nil
 	}
@@ -540,7 +658,7 @@ func (r *TesseractTests) PdfInputIsRejected(ctx context.Context) error { // tess
 // recognised comes back, and that it is the processed one rather than the
 // source: the fixture goes in as a PNG and this comes out as a TIFF, which is
 // the observable half of "this is a derivative, not your file".
-func (r *TesseractTests) ProcessedImagesReturnsThresholdedTiff(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1272:1)
+func (r *TesseractTests) ProcessedImagesReturnsThresholdedTiff(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1550:1)
 	if r.processedImagesReturnsThresholdedTiff != nil {
 		return nil
 	}
@@ -552,7 +670,7 @@ func (r *TesseractTests) ProcessedImagesReturnsThresholdedTiff(ctx context.Conte
 // RequestedLanguagesAreInstalled asserts every requested language lands in the
 // image as its own apk package, including "osd", which is a detection model
 // rather than a recognition language.
-func (r *TesseractTests) RequestedLanguagesAreInstalled(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:225:1)
+func (r *TesseractTests) RequestedLanguagesAreInstalled(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:244:1)
 	if r.requestedLanguagesAreInstalled != nil {
 		return nil
 	}
@@ -566,7 +684,7 @@ func (r *TesseractTests) RequestedLanguagesAreInstalled(ctx context.Context) err
 // that finds the lines, so it returns far less than the default mode does —
 // which is the observable proof the flag was passed, without asserting on
 // whatever garbage the constrained mode happens to produce.
-func (r *TesseractTests) SingleWordPageSegReturnsFewerWords(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:526:1)
+func (r *TesseractTests) SingleWordPageSegReturnsFewerWords(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:545:1)
 	if r.singleWordPageSegReturnsFewerWords != nil {
 		return nil
 	}
@@ -579,7 +697,7 @@ func (r *TesseractTests) SingleWordPageSegReturnsFewerWords(ctx context.Context)
 // mounting a tessdata directory adds the models it holds and nothing else, so a
 // language neither half carries is rejected the same way it was before, with
 // both halves listed and both ways of adding one named.
-func (r *TesseractTests) TessdataDoesNotAdmitUnknownLanguage(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:692:1)
+func (r *TesseractTests) TessdataDoesNotAdmitUnknownLanguage(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:711:1)
 	if r.tessdataDoesNotAdmitUnknownLanguage != nil {
 		return nil
 	}
@@ -605,7 +723,7 @@ func (r *TesseractTests) TessdataDoesNotAdmitUnknownLanguage(ctx context.Context
 // configfiles, and pdf.ttf is what the PDF renderer draws its invisible text
 // layer with. Pointed at the caller's directory alone, every renderer breaks
 // and every packaged language disappears.
-func (r *TesseractTests) TessdataModelIsSelectable(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:458:1)
+func (r *TesseractTests) TessdataModelIsSelectable(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:477:1)
 	if r.tessdataModelIsSelectable != nil {
 		return nil
 	}
@@ -621,7 +739,7 @@ func (r *TesseractTests) TessdataModelIsSelectable(ctx context.Context) error { 
 // answered from the requested package set alone. A supplied osd.traineddata
 // would have been refused by this module while sitting right there in the
 // image, which is the failure mode this pins.
-func (r *TesseractTests) TessdataSuppliesOsdModel(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:504:1)
+func (r *TesseractTests) TessdataSuppliesOsdModel(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:523:1)
 	if r.tessdataSuppliesOsdModel != nil {
 		return nil
 	}
@@ -632,7 +750,7 @@ func (r *TesseractTests) TessdataSuppliesOsdModel(ctx context.Context) error { /
 
 // TextRecognizesFixture asserts the shortest path — image in, string out —
 // reproduces every line the fixture renders.
-func (r *TesseractTests) TextRecognizesFixture(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:282:1)
+func (r *TesseractTests) TextRecognizesFixture(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:301:1)
 	if r.textRecognizesFixture != nil {
 		return nil
 	}
@@ -650,7 +768,7 @@ func (r *TesseractTests) TextRecognizesFixture(ctx context.Context) error { // t
 // off-by-one ones: the run stops one image short, or one transcription is
 // saved under the wrong stem. "Something is unpaired" sends the caller to diff
 // two file listings; "line-3.png has no ground truth" does not.
-func (r *TesseractTests) TrainingPairsImagesWithGroundTruth(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1346:1)
+func (r *TesseractTests) TrainingPairsImagesWithGroundTruth(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1624:1)
 	if r.trainingPairsImagesWithGroundTruth != nil {
 		return nil
 	}
@@ -673,7 +791,7 @@ func (r *TesseractTests) TrainingPairsImagesWithGroundTruth(ctx context.Context)
 // what that default is for is precisely this: a bound low enough that a
 // training run belongs in a test suite. If it ever stops being, this test is
 // where that shows up.
-func (r *TesseractTests) TrainingProducesUsableModel(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1502:1)
+func (r *TesseractTests) TrainingProducesUsableModel(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1780:1)
 	if r.trainingProducesUsableModel != nil {
 		return nil
 	}
@@ -688,7 +806,7 @@ func (r *TesseractTests) TrainingProducesUsableModel(ctx context.Context) error 
 // A training run is the most expensive thing this module does, so the cost of
 // finding out late is not a slow error message — it is minutes of a machine
 // arriving at a failure that was visible from the outside the whole time.
-func (r *TesseractTests) TrainingRejectsUnusableInput(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1406:1)
+func (r *TesseractTests) TrainingRejectsUnusableInput(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1684:1)
 	if r.trainingRejectsUnusableInput != nil {
 		return nil
 	}
@@ -706,7 +824,7 @@ func (r *TesseractTests) TrainingRejectsUnusableInput(ctx context.Context) error
 // loads, recognises, and lists as a language like any other — and lstmtraining
 // says only "eng.lstm is an integer (fast) model", which names neither the
 // float models nor how to get one onto the image.
-func (r *TesseractTests) TrainingRequiresFloatBaseModel(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1471:1)
+func (r *TesseractTests) TrainingRequiresFloatBaseModel(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1749:1)
 	if r.trainingRequiresFloatBaseModel != nil {
 		return nil
 	}
@@ -718,7 +836,7 @@ func (r *TesseractTests) TrainingRequiresFloatBaseModel(ctx context.Context) err
 // TsvHasHeaderAndWordRows asserts the TSV renderer emits its column header and
 // descends all the way to word-level rows (level 5), which is the level
 // carrying the text and its confidence.
-func (r *TesseractTests) TsvHasHeaderAndWordRows(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:353:1)
+func (r *TesseractTests) TsvHasHeaderAndWordRows(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:372:1)
 	if r.tsvHasHeaderAndWordRows != nil {
 		return nil
 	}
@@ -729,7 +847,7 @@ func (r *TesseractTests) TsvHasHeaderAndWordRows(ctx context.Context) error { //
 
 // TxtFileMatchesText asserts the txt renderer and the stdout path agree, so
 // choosing a file over a string is purely a plumbing decision.
-func (r *TesseractTests) TxtFileMatchesText(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:292:1)
+func (r *TesseractTests) TxtFileMatchesText(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:311:1)
 	if r.txtFileMatchesText != nil {
 		return nil
 	}
@@ -742,7 +860,7 @@ func (r *TesseractTests) TxtFileMatchesText(ctx context.Context) error { // tess
 // rejected with the installed set named. tesseract's own failure talks about
 // traineddata paths and TESSDATA_PREFIX, which says nothing about the fact
 // that languages are chosen on New.
-func (r *TesseractTests) UnknownLanguageIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:660:1)
+func (r *TesseractTests) UnknownLanguageIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:679:1)
 	if r.unknownLanguageIsRejected != nil {
 		return nil
 	}
@@ -758,7 +876,7 @@ func (r *TesseractTests) UnknownLanguageIsRejected(ctx context.Context) error { 
 // and exits 0, so a typo would otherwise be indistinguishable from a setting
 // that simply had no effect. The same test pins the other half: a real
 // parameter still goes through, so the check is not just rejecting everything.
-func (r *TesseractTests) UnknownParameterFails(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:578:1)
+func (r *TesseractTests) UnknownParameterFails(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:597:1)
 	if r.unknownParameterFails != nil {
 		return nil
 	}
@@ -776,7 +894,7 @@ func (r *TesseractTests) UnknownParameterFails(ctx context.Context) error { // t
 // a dictionary hint on an already-clean fixture is not reliably observable.
 // What this does catch is a wrong mount path or a flag emitted in the wrong
 // position, either of which turns the whole run into a usage error.
-func (r *TesseractTests) UserWordsFileIsAccepted(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:614:1)
+func (r *TesseractTests) UserWordsFileIsAccepted(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:633:1)
 	if r.userWordsFileIsAccepted != nil {
 		return nil
 	}
@@ -788,7 +906,7 @@ func (r *TesseractTests) UserWordsFileIsAccepted(ctx context.Context) error { //
 // VersionReportsTesseractFive asserts the assembled image ships the tesseract
 // release Alpine's community repository carries, so a base-tag bump that
 // silently changes major version fails here rather than in recognition.
-func (r *TesseractTests) VersionReportsTesseractFive(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:196:1)
+func (r *TesseractTests) VersionReportsTesseractFive(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:215:1)
 	if r.versionReportsTesseractFive != nil {
 		return nil
 	}

--- a/daggerverse/tesseract/README.md
+++ b/daggerverse/tesseract/README.md
@@ -4,9 +4,11 @@ Daggerverse module that runs [Tesseract](https://tesseract-ocr.github.io/) OCR
 as a `dagger call`. Hand it an image and get back plain text, or hOCR / ALTO /
 TSV / PAGE / a searchable PDF for anything that needs word positions and
 confidences. Hand it a directory and get the same artifacts back for every page
-in it, at the paths they came in on. Hand it a PDF and it rasterizes the pages
-for you first. Hand it transcribed lines and it fine-tunes a model against them
-and gives you back a `.traineddata` the same module recognises with.
+in it, at the paths they came in on — or hand that directory to `Ci` and get the
+whole pipeline, quality gate included, as one call. Hand it a PDF and it
+rasterizes the pages for you first. Hand it transcribed lines and it fine-tunes a
+model against them and gives you back a `.traineddata` the same module recognises
+with.
 
 **There is no official Tesseract container image** — upstream ships source only,
 and every image on Docker Hub is third-party. So this module assembles its own
@@ -322,6 +324,84 @@ either way.
 `Files` reports the matched set without paying for the recognition, which is the
 answer to the question a glob always raises.
 
+## Ci — the whole pipeline as one call
+
+```go
+Tesseract.Ci(source *dagger.Directory) *Ci
+
+Ci.WithLanguage(lang string) *Ci
+Ci.WithFormats(formats []Format) *Ci        // default: TXT
+Ci.WithMinConfidence(percent int) *Ci       // default: no gate
+Ci.Check(ctx) error                         // the gate, no artifacts
+Ci.Run(ctx) (*dagger.Directory, error)      // the gate, then the artifacts
+```
+
+A document-processing repo's CI wants one declarative call: OCR everything under
+a directory, emit the archival formats, and fail the build when recognition
+quality drops. `Ci` composes `Batch` without adding capability — every stage is
+a call the caller could make by hand — so that CI is one `dagger call` rather
+than a recognition step, an export step and a hand-rolled TSV parser.
+
+Which files take part is `Batch`'s default: the image extensions above, at any
+depth. `Run` returns the same mirrored directory `Batch.Export` does.
+
+### The confidence gate
+
+`WithMinConfidence` is the part that is not merely a bundled call. It reads the
+`conf` column tesseract already publishes in its TSV output — nothing here
+re-derives a confidence — and averages the word-level rows per page:
+
+```
+level  page_num  …  conf    text
+5      1         …  96.063  The
+5      1         …  92.481  quick
+```
+
+Levels 1–4 (page, block, paragraph, line) all report `-1`, so the `level` column
+is what separates a measurement from a placeholder; word rows whose text is empty
+are skipped too, or a page would be scored by how aggressively it was segmented
+rather than by how well it was read. The columns are located by header name, not
+by position: a gate reading the wrong column would not fail, it would pass the
+wrong scans.
+
+What that catches is the class of failure recognition does not report as one. A
+page fed sideways, a scanner drifting out of focus, a language configured wrong —
+all of them recognise *something*, exit 0, and render every artifact asked for.
+
+The failure names the page that measured **worst** and how many others joined it,
+because a batch that drifted out of focus fails several pages at once and the one
+to go and find in the stack is the one furthest below the bar:
+
+```
+Ci: "scans/page-7.png" was recognised at a mean word confidence of 61.4%, below
+the required 80%, the lowest of 3 page(s) below it: check the scan and the
+recognition language, or lower the bar with WithMinConfidence
+```
+
+A page that recognised **no** words gets its own message rather than being
+reported as zero: the mean of no words is not zero, it is undefined, and a blank
+page is a different fault with a different fix.
+
+### Why the gate rides along on the artifact pass
+
+`Run` renders TSV *alongside* whatever `WithFormats` enabled, in the same
+recognition pass, then measures it — rather than recognising the directory once
+to check and again to export. Recognising everything twice is the single most
+expensive thing this module could be asked to do, and the only difference
+between a gated run and an ungated one is a TSV.
+
+A failing gate still returns the error and no directory: the artifacts exist
+inside the exec, and a caller who is refused them is no better off for their
+having been skipped. When TSV was not among the enabled formats the gate's own
+TSVs are dropped from the result, so enabling a threshold cannot silently change
+what the pipeline produces.
+
+`Check` is the same gate with nothing to export, for the PR that wants to know
+whether the scans are good enough without paying to render the archive. It runs
+recognition either way — with no threshold set the bar is simply "every matched
+file is an image tesseract can read", which is not nothing — because a page's
+confidence is not knowable without recognising it.
+
 ## PDF input — `FromPdf`
 
 ```go
@@ -518,6 +598,7 @@ letting tesseract fail in its own vocabulary.
 | `WithBaseModel` naming a quantized model | `lstmtraining` says only `is an integer (fast) model`, which names neither the float builds nor how to get one onto the image |
 | `WithIterations` at zero or negative | `lstmtraining` would write no checkpoint, and `--stop_training` would fail on its absence rather than on the argument |
 | `LstmTrain` with empty or multi-line ground truth, or on a rasterized PDF | same one-image-one-line contract; a whole PDF has no single line to claim |
+| `WithMinConfidence` outside 1–100 | confidences are percentages: a bar of 0 passes every page and one above 100 fails every page, so either is a gate that reports a verdict it never reached |
 
 Errors fold tesseract's own output in via `Expect: ReturnTypeAny` plus a
 combined stdout+stderr helper, because tesseract splits usage errors onto stderr
@@ -525,7 +606,7 @@ and progress onto stdout.
 
 ## Caching
 
-No `+cache=` directive appears on any `Document`, `Batch` or `Training` output:
+No `+cache=` directive appears on any `Document`, `Batch`, `Ci` or `Training` output:
 recognition is a pure function of the image bytes plus the flags, and so is
 fine-tuning of the samples plus the base model, so the 7-day default is correct
 and there is no chained-method propagation problem to worry about. `Container`,
@@ -534,10 +615,16 @@ a floating Alpine tag can resolve differently across sessions.
 
 ## Follow-ups
 
-A chained `Ci` builder (#223); an `examples/go` cookbook (#224); evaluation
-against a held-out set (#231).
+An `examples/go` cookbook (#224); evaluation against a held-out set (#231).
 
-The training toolchain (#222) landed — see above.
+The chained `Ci` builder (#223) and the training toolchain (#222) both landed —
+see above. `Ci` deliberately exposes only `WithLanguage` of the seven recognition
+options `Batch` carries: the rest describe *how one scan is read* — a page
+segmentation mode, a DPI, a control variable — and a pipeline whose input is a
+whole intake folder has no single answer for them. A caller who needs one is
+configuring a `Batch`, not a CI. `WithGlob` is absent for the same reason from
+the other direction: the default takes the images and leaves the manifests, which
+is what pointing this at an existing scan folder should do.
 
 Batch OCR over a directory (#220) and PDF-input rasterization (#221) both
 landed — see above. `Batch` still deliberately does not expose the concatenated

--- a/daggerverse/tesseract/ci.go
+++ b/daggerverse/tesseract/ci.go
@@ -1,0 +1,361 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"dagger/tesseract/internal/dagger"
+)
+
+const (
+	// tsvLevelColumn, tsvConfColumn and tsvTextColumn are the TSV header names
+	// the gate reads its measurement out of. They are looked up by name rather
+	// than by position because the column order is tesseract's to change, and a
+	// gate reading the wrong column would not fail — it would pass the wrong
+	// scans.
+	tsvLevelColumn = "level"
+	tsvConfColumn  = "conf"
+	tsvTextColumn  = "text"
+
+	// tsvWordLevel is the `level` a TSV row carries when it describes a word
+	// rather than the page, block, paragraph or line containing it. Only word
+	// rows carry a real confidence; every level above them reports -1.
+	tsvWordLevel = "5"
+
+	// minConfidenceFloor and minConfidenceCeiling bound the threshold.
+	// tesseract's confidences are percentages, so a bar above 100 could never
+	// be cleared; a bar of 0 could never be missed, which would be a gate that
+	// silently does nothing rather than one that was never asked for.
+	minConfidenceFloor   = 1
+	minConfidenceCeiling = 100
+)
+
+// Ci is a chained builder for a document-processing pipeline: a directory of
+// scans in, the archival formats out, and a quality gate in between.
+//
+// It composes the Batch primitive without adding capability of its own — every
+// stage is a call the caller could make by hand — so a document repo's CI is one
+// declarative `dagger call` rather than a recognition step, an export step and a
+// hand-rolled TSV parser.
+//
+// The confidence gate is the part that is not merely a bundled call. It reads
+// the `conf` column tesseract already reports in its TSV output and fails the
+// run when mean word confidence falls below the threshold, which is how a
+// scanner regression or a wrong-language configuration is caught before the
+// artifacts ship rather than after they are archived.
+type Ci struct {
+	// +private
+	Batch *Batch
+	// +private
+	Formats []Format
+	// +private
+	MinConfidence int
+	// +private
+	HasMinConfidence bool
+}
+
+// Ci returns a new pipeline builder over a directory of scans. Which files take
+// part is the batch default: the image extensions leptonica can read, at any
+// depth.
+func (t *Tesseract) Ci(source *dagger.Directory) *Ci {
+	return &Ci{Batch: t.Batch(source)}
+}
+
+// WithLanguage selects the recognition language (`-l`) for every image in the
+// source directory. See Document.WithLanguage.
+func (c *Ci) WithLanguage(lang string) *Ci {
+	out := *c
+	out.Batch = c.Batch.WithLanguage(lang)
+	return &out
+}
+
+// WithFormats replaces the set of formats the pipeline renders for each image.
+// Unset, it renders plain text.
+func (c *Ci) WithFormats(
+	// Output formats to render for every image in the source directory.
+	formats []Format,
+) *Ci {
+	out := *c
+	out.Formats = formats
+	return &out
+}
+
+// WithMinConfidence fails the pipeline when a page comes back recognised less
+// confidently than this, as a percentage from 1 to 100.
+//
+// The measurement is the mean of the per-word confidences tesseract already
+// reports in its TSV output, taken per page: the gate names the page that
+// measured worst rather than the batch, because a batch is assembled by a
+// scanner and it is one sheet that goes through crooked.
+//
+// What it catches is the class of failure recognition does not report as one. A
+// page fed sideways, a scanner drifting out of focus, a language configured
+// wrong — all of them recognise *something*, exit 0 and render every artifact
+// asked for. Unset, there is no bar and no page can be too poor to ship.
+func (c *Ci) WithMinConfidence(
+	// Lowest mean word confidence a page may be recognised at, as a percentage.
+	percent int,
+) *Ci {
+	out := *c
+	out.MinConfidence = percent
+	out.HasMinConfidence = true
+	return &out
+}
+
+// Check runs the pipeline's gate and produces nothing, for the PR that wants to
+// know whether the scans are good enough without paying to render the archive.
+//
+// The gate is recognition itself plus the confidence bar: every matched image is
+// recognised, so a page tesseract cannot read fails here, and when a threshold
+// was set every page is measured against it. Recognition is what costs, and it
+// is unavoidable — a page's confidence is not knowable without recognising it.
+func (c *Ci) Check(ctx context.Context) error {
+	if err := c.validate(); err != nil {
+		return err
+	}
+	sources, err := c.Batch.matches(ctx)
+	if err != nil {
+		return err
+	}
+	// TSV whether or not a threshold was set, so the two shapes of a check are
+	// one code path. It is also the cheapest renderer to discard: the gate
+	// reads it, and nothing here lifts it off the exec.
+	out, err := c.Batch.Export(ctx, []Format{FormatTsv})
+	if err != nil {
+		return err
+	}
+	if !c.HasMinConfidence {
+		return nil
+	}
+	return c.gate(ctx, out, sources)
+}
+
+// Run executes the pipeline and returns every enabled format for every matched
+// image, in a directory mirroring the source layout. A failing gate returns the
+// error and no directory, so artifacts never reach a caller whose scans did not
+// clear the bar.
+//
+// Gating rides along on the recognition pass that renders the artifacts rather
+// than preceding it, because recognising the whole directory twice is the
+// single most expensive thing this module could be asked to do, and the only
+// difference between a gated run and an ungated one is a TSV. So a gated run
+// renders TSV alongside whatever was enabled, measures it, and withholds the
+// whole directory if the measurement fails — the artifacts exist inside the
+// exec, and a caller who is refused them is no better off for them having been
+// skipped.
+func (c *Ci) Run(ctx context.Context) (*dagger.Directory, error) {
+	if err := c.validate(); err != nil {
+		return nil, err
+	}
+	formats := c.formats()
+	if !c.HasMinConfidence {
+		return c.Batch.Export(ctx, formats)
+	}
+	sources, err := c.Batch.matches(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out, err := c.Batch.Export(ctx, append(append([]Format(nil), formats...), FormatTsv))
+	if err != nil {
+		return nil, err
+	}
+	if err := c.gate(ctx, out, sources); err != nil {
+		return nil, err
+	}
+	if containsFormat(formats, FormatTsv) {
+		return out, nil
+	}
+	// The gate's own TSV is scaffolding, not an artifact: returning it would
+	// make enabling a threshold silently change what the pipeline produces.
+	return out.WithoutFiles(tsvPaths(sources)), nil
+}
+
+// validate reports the deferred builder checks, which live here because a
+// builder has no error return.
+func (c *Ci) validate() error {
+	if !c.HasMinConfidence {
+		return nil
+	}
+	if c.MinConfidence < minConfidenceFloor || c.MinConfidence > minConfidenceCeiling {
+		return fmt.Errorf(
+			"WithMinConfidence: percent must be between %d and %d, got %d: tesseract reports confidence as a percentage, so a bar of 0 passes every page and one above 100 fails every page",
+			minConfidenceFloor, minConfidenceCeiling, c.MinConfidence)
+	}
+	return nil
+}
+
+// gate measures every page against the threshold and reports the one that
+// measured worst, along with how many others joined it.
+//
+// The worst page rather than the first is what a caller wants to look at: a
+// batch that drifted out of focus fails several pages at once, and the one to
+// go and find in the stack is the one furthest below the bar.
+func (c *Ci) gate(ctx context.Context, out *dagger.Directory, sources []string) error {
+	var (
+		worst    confidence
+		failures int
+	)
+	for _, source := range sources {
+		tsv, err := out.File(tsvPathFor(source)).Contents(ctx)
+		if err != nil {
+			return fmt.Errorf("Ci: read the TSV output for %q: %w", source, err)
+		}
+		got, err := wordConfidence(tsv)
+		if err != nil {
+			return fmt.Errorf("Ci: read the confidence of %q: %w", source, err)
+		}
+		got.source = source
+		if got.score() >= float64(c.MinConfidence) {
+			continue
+		}
+		if failures == 0 || got.score() < worst.score() {
+			worst = got
+		}
+		failures++
+	}
+	if failures == 0 {
+		return nil
+	}
+	return c.gateError(worst, failures)
+}
+
+// gateError renders the failure, which has to carry three things: what was
+// measured, where, and what to do about it.
+func (c *Ci) gateError(worst confidence, failures int) error {
+	also := ""
+	if failures > 1 {
+		also = fmt.Sprintf(", the lowest of %d page(s) below it", failures)
+	}
+	if worst.words == 0 {
+		return fmt.Errorf(
+			"Ci: %q recognised no words at all, so there is no confidence to measure it against the required %d%%%s: check the page is not blank, and that the recognition language is the one it is written in",
+			worst.source, c.MinConfidence, also)
+	}
+	return fmt.Errorf(
+		"Ci: %q was recognised at a mean word confidence of %.1f%%, below the required %d%%%s: check the scan and the recognition language, or lower the bar with WithMinConfidence",
+		worst.source, worst.mean, c.MinConfidence, also)
+}
+
+// formats resolves the render set. Validating it is Export's job, since that is
+// where the set is turned into renderers; this only supplies the default.
+//
+// That default is plain text: it is what tesseract itself produces when no
+// renderer is named, and the one format every downstream step can read. It is
+// spelled here rather than as a named constant because a package-level constant
+// of an enum type is read as another member of that enum, and a second member
+// carrying "TXT" fails typedef generation outright.
+func (c *Ci) formats() []Format {
+	if len(c.Formats) == 0 {
+		return []Format{FormatTxt}
+	}
+	return c.Formats
+}
+
+// confidence is one page's measurement: the mean of its word confidences, and
+// how many words that mean was taken over.
+type confidence struct {
+	source string
+	mean   float64
+	words  int
+}
+
+// score is the value the threshold is compared against. A page that recognised
+// nothing scores below every legal threshold rather than at zero, because the
+// mean of no words is not zero — it is undefined, and it is a different fault
+// with a different fix.
+func (c confidence) score() float64 {
+	if c.words == 0 {
+		return -1
+	}
+	return c.mean
+}
+
+// wordConfidence measures one page out of the TSV renderer's own output.
+//
+// Nothing here re-implements the measurement: tesseract computes a confidence
+// per recognised word and publishes it in the `conf` column, and this reads
+// that column and averages it. The rows above the word level (page, block,
+// paragraph, line) all report -1, so the level column is what separates a
+// measurement from a placeholder.
+//
+// Empty text at word level is skipped for the same reason. tesseract emits word
+// rows for regions it segmented but read nothing out of, and counting those as
+// low-confidence words would score a page by how aggressively it was segmented.
+func wordConfidence(tsv string) (confidence, error) {
+	lines := strings.Split(strings.TrimRight(tsv, "\n"), "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) == "" {
+		return confidence{}, fmt.Errorf("the TSV output is empty")
+	}
+	header := strings.Split(lines[0], "\t")
+	level, err := tsvColumn(header, tsvLevelColumn)
+	if err != nil {
+		return confidence{}, err
+	}
+	conf, err := tsvColumn(header, tsvConfColumn)
+	if err != nil {
+		return confidence{}, err
+	}
+	text, err := tsvColumn(header, tsvTextColumn)
+	if err != nil {
+		return confidence{}, err
+	}
+
+	var got confidence
+	for _, line := range lines[1:] {
+		cols := strings.Split(line, "\t")
+		if len(cols) != len(header) {
+			continue
+		}
+		if cols[level] != tsvWordLevel || strings.TrimSpace(cols[text]) == "" {
+			continue
+		}
+		value, err := strconv.ParseFloat(cols[conf], 64)
+		if err != nil || value < 0 {
+			continue
+		}
+		got.mean += value
+		got.words++
+	}
+	if got.words > 0 {
+		got.mean /= float64(got.words)
+	}
+	return got, nil
+}
+
+// tsvColumn locates a column by its header name, so the reader survives
+// tesseract reordering or adding columns.
+func tsvColumn(header []string, name string) (int, error) {
+	for i, col := range header {
+		if strings.TrimSpace(col) == name {
+			return i, nil
+		}
+	}
+	return 0, fmt.Errorf(
+		"the TSV output has no %q column, so there is nothing to measure: its header is %q",
+		name, strings.Join(header, "\t"))
+}
+
+// tsvPathFor names the TSV artifact a batch renders for one source image, and
+// tsvPaths does the same for a whole batch.
+func tsvPathFor(source string) string {
+	return outputBaseFor(source) + formatTable[FormatTsv].ext
+}
+
+func tsvPaths(sources []string) []string {
+	paths := make([]string, 0, len(sources))
+	for _, source := range sources {
+		paths = append(paths, tsvPathFor(source))
+	}
+	return paths
+}
+
+func containsFormat(formats []Format, want Format) bool {
+	for _, f := range formats {
+		if f == want {
+			return true
+		}
+	}
+	return false
+}

--- a/daggerverse/tesseract/dagger.gen.go
+++ b/daggerverse/tesseract/dagger.gen.go
@@ -127,6 +127,38 @@ func (r *Batch) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
+func (r Ci) MarshalJSON() ([]byte, error) {
+	var concrete struct {
+		Batch            *Batch
+		Formats          []Format
+		MinConfidence    int
+		HasMinConfidence bool
+	}
+	concrete.Batch = r.Batch
+	concrete.Formats = r.Formats
+	concrete.MinConfidence = r.MinConfidence
+	concrete.HasMinConfidence = r.HasMinConfidence
+	return json.Marshal(&concrete)
+}
+
+func (r *Ci) UnmarshalJSON(bs []byte) error {
+	var concrete struct {
+		Batch            *Batch
+		Formats          []Format
+		MinConfidence    int
+		HasMinConfidence bool
+	}
+	err := json.Unmarshal(bs, &concrete)
+	if err != nil {
+		return err
+	}
+	r.Batch = concrete.Batch
+	r.Formats = concrete.Formats
+	r.MinConfidence = concrete.MinConfidence
+	r.HasMinConfidence = concrete.HasMinConfidence
+	return nil
+}
+
 func (r Document) MarshalJSON() ([]byte, error) {
 	var concrete struct {
 		Tesseract *Tesseract
@@ -663,6 +695,67 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 		default:
 			return nil, fmt.Errorf("unknown function %s", fnName)
 		}
+	case "Ci":
+		switch fnName {
+		case "Check":
+			var parent Ci
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Ci).Check(&parent, ctx)
+		case "Run":
+			var parent Ci
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Ci).Run(&parent, ctx)
+		case "WithFormats":
+			var parent Ci
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var formats []Format
+			if inputArgs["formats"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["formats"]), &formats)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg formats", err))
+				}
+			}
+			return (*Ci).WithFormats(&parent, formats), nil
+		case "WithLanguage":
+			var parent Ci
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var lang string
+			if inputArgs["lang"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["lang"]), &lang)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg lang", err))
+				}
+			}
+			return (*Ci).WithLanguage(&parent, lang), nil
+		case "WithMinConfidence":
+			var parent Ci
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var percent int
+			if inputArgs["percent"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["percent"]), &percent)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg percent", err))
+				}
+			}
+			return (*Ci).WithMinConfidence(&parent, percent), nil
+		default:
+			return nil, fmt.Errorf("unknown function %s", fnName)
+		}
 	case "Document":
 		switch fnName {
 		case "Alto":
@@ -887,6 +980,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Tesseract).Batch(&parent, source), nil
+		case "Ci":
+			var parent Tesseract
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var source *dagger.Directory
+			if inputArgs["source"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["source"]), &source)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg source", err))
+				}
+			}
+			return (*Tesseract).Ci(&parent, source), nil
 		case "Container":
 			var parent Tesseract
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/tesseract/main.go
+++ b/daggerverse/tesseract/main.go
@@ -38,6 +38,8 @@
 //   - document.go  — *Document, one image in and one artifact set out.
 //   - batch.go     — *Batch, a directory in and a mirrored directory out, all
 //     of it in a single container exec.
+//   - ci.go        — *Ci, a batch plus a confidence gate, for the repo that
+//     wants its whole document pipeline as one declarative call.
 //   - pdf.go       — FromPdf, the rasterizer that turns a PDF into pages a
 //     *Document can recognise.
 //   - training.go  — *Training, the other direction: images plus ground truth

--- a/daggerverse/tesseract/tests/dagger.gen.go
+++ b/daggerverse/tesseract/tests/dagger.gen.go
@@ -262,6 +262,48 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).BoxReportsCharacterBoxes(&parent, ctx)
+		case "CiCheckRunsTheGateWithoutArtifacts":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).CiCheckRunsTheGateWithoutArtifacts(&parent, ctx)
+		case "CiGateKeepsItsTsvOutOfTheOutput":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).CiGateKeepsItsTsvOutOfTheOutput(&parent, ctx)
+		case "CiLanguageReachesRecognition":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).CiLanguageReachesRecognition(&parent, ctx)
+		case "CiMinConfidenceGatesTheRun":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).CiMinConfidenceGatesTheRun(&parent, ctx)
+		case "CiRejectsUnusableThreshold":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).CiRejectsUnusableThreshold(&parent, ctx)
+		case "CiRunProducesEnabledFormats":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).CiRunProducesEnabledFormats(&parent, ctx)
 		case "DefaultLanguagesInstallEnglish":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/tesseract/tests/internal/dagger/dagger.gen.go
+++ b/daggerverse/tesseract/tests/internal/dagger/dagger.gen.go
@@ -334,6 +334,9 @@ type TerminalID string
 type TesseractBatchID string
 
 // A unique identifier for an object.
+type TesseractCiID string
+
+// A unique identifier for an object.
 type TesseractDocumentID string
 
 // A unique identifier for an object.
@@ -13366,6 +13369,16 @@ func (r *Query) LoadTesseractBatchFromID(id TesseractBatchID) *TesseractBatch {
 	q = q.Arg("id", id)
 
 	return &TesseractBatch{
+		query: q,
+	}
+}
+
+// Load a TesseractCi from its ID.
+func (r *Query) LoadTesseractCiFromID(id TesseractCiID) *TesseractCi {
+	q := r.query.Select("loadTesseractCiFromID")
+	q = q.Arg("id", id)
+
+	return &TesseractCi{
 		query: q,
 	}
 }

--- a/daggerverse/tesseract/tests/internal/dagger/tesseract.gen.go
+++ b/daggerverse/tesseract/tests/internal/dagger/tesseract.gen.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Retrieve the binding value, as type Tesseract
-func (r *Binding) AsTesseract() *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:220:6)
+func (r *Binding) AsTesseract() *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:222:6)
 	q := r.query.Select("asTesseract")
 
 	return &Tesseract{
@@ -24,6 +24,15 @@ func (r *Binding) AsTesseractBatch() *TesseractBatch { // tesseract (../../../..
 	q := r.query.Select("asTesseractBatch")
 
 	return &TesseractBatch{
+		query: q,
+	}
+}
+
+// Retrieve the binding value, as type TesseractCi
+func (r *Binding) AsTesseractCi() *TesseractCi { // tesseract (../../../../../daggerverse/tesseract/ci.go:48:6)
+	q := r.query.Select("asTesseractCi")
+
+	return &TesseractCi{
 		query: q,
 	}
 }
@@ -70,6 +79,30 @@ func (r *Env) WithTesseractBatchOutput(name string, description string) *Env { /
 	}
 }
 
+// Create or update a binding of type TesseractCi in the environment
+func (r *Env) WithTesseractCiInput(name string, value *TesseractCi, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/ci.go:48:6)
+	assertNotNil("value", value)
+	q := r.query.Select("withTesseractCiInput")
+	q = q.Arg("name", name)
+	q = q.Arg("value", value)
+	q = q.Arg("description", description)
+
+	return &Env{
+		query: q,
+	}
+}
+
+// Declare a desired TesseractCi output to be assigned in the environment
+func (r *Env) WithTesseractCiOutput(name string, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/ci.go:48:6)
+	q := r.query.Select("withTesseractCiOutput")
+	q = q.Arg("name", name)
+	q = q.Arg("description", description)
+
+	return &Env{
+		query: q,
+	}
+}
+
 // Create or update a binding of type TesseractDocument in the environment
 func (r *Env) WithTesseractDocumentInput(name string, value *TesseractDocument, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/document.go:27:6)
 	assertNotNil("value", value)
@@ -95,7 +128,7 @@ func (r *Env) WithTesseractDocumentOutput(name string, description string) *Env 
 }
 
 // Create or update a binding of type Tesseract in the environment
-func (r *Env) WithTesseractInput(name string, value *Tesseract, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/main.go:220:6)
+func (r *Env) WithTesseractInput(name string, value *Tesseract, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/main.go:222:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withTesseractInput")
 	q = q.Arg("name", name)
@@ -108,7 +141,7 @@ func (r *Env) WithTesseractInput(name string, value *Tesseract, description stri
 }
 
 // Declare a desired Tesseract output to be assigned in the environment
-func (r *Env) WithTesseractOutput(name string, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/main.go:220:6)
+func (r *Env) WithTesseractOutput(name string, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/main.go:222:6)
 	q := r.query.Select("withTesseractOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -149,18 +182,18 @@ type TesseractOpts struct {
 	//
 	//
 	// Default: "docker.io"
-	Registry string // tesseract (../../../../../daggerverse/tesseract/main.go:238:2)
+	Registry string // tesseract (../../../../../daggerverse/tesseract/main.go:240:2)
 	//
 	// Tag of the alpine image the toolchain is assembled on.
 	//
 	//
 	// Default: "3.24"
-	AlpineTag string // tesseract (../../../../../daggerverse/tesseract/main.go:241:2)
+	AlpineTag string // tesseract (../../../../../daggerverse/tesseract/main.go:243:2)
 	//
 	// Language codes to install, one apk package each. Empty installs "eng".
 	// "osd" is not a recognition language but is required by Document.Osd.
 	//
-	Languages []string // tesseract (../../../../../daggerverse/tesseract/main.go:245:2)
+	Languages []string // tesseract (../../../../../daggerverse/tesseract/main.go:247:2)
 	//
 	// Upper bound on the OpenMP threads tesseract may use, set on the
 	// assembled image as OMP_THREAD_LIMIT. Unset, tesseract uses one thread
@@ -171,12 +204,12 @@ type TesseractOpts struct {
 	// slowdown reports (tesseract-ocr/tesseract#2611, #1171, #263). One
 	// thread per pass is the usual setting there.
 	//
-	OmpThreadLimit int // tesseract (../../../../../daggerverse/tesseract/main.go:255:2)
+	OmpThreadLimit int // tesseract (../../../../../daggerverse/tesseract/main.go:257:2)
 }
 
 // New returns a Tesseract module backed by <registry>/library/alpine:<tag>
 // with tesseract-ocr and one language package per requested language.
-func (r *Query) Tesseract(opts ...TesseractOpts) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:235:1)
+func (r *Query) Tesseract(opts ...TesseractOpts) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:237:1)
 	q := r.query.Select("tesseract")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `registry` optional argument
@@ -206,7 +239,7 @@ func (r *Query) Tesseract(opts ...TesseractOpts) *Tesseract { // tesseract (../.
 // It carries the image coordinates and the language set the image is built
 // with; Document hangs off it so the generated SDK surfaces recognition under
 // `dag.Tesseract().Document(...)`.
-type Tesseract struct { // tesseract (../../../../../daggerverse/tesseract/main.go:220:6)
+type Tesseract struct { // tesseract (../../../../../daggerverse/tesseract/main.go:222:6)
 	query *querybuilder.Selection
 
 	id         *ID
@@ -236,12 +269,25 @@ func (r *Tesseract) WithGraphQLQuery(q *querybuilder.Selection) *Tesseract {
 // with whatever reads the results the same way the input directory was
 // composed. Which files take part is a glob, defaulting to the image
 // extensions leptonica can read.
-func (r *Tesseract) Batch(source *Directory) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/main.go:399:1)
+func (r *Tesseract) Batch(source *Directory) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/main.go:401:1)
 	assertNotNil("source", source)
 	q := r.query.Select("batch")
 	q = q.Arg("source", source)
 
 	return &TesseractBatch{
+		query: q,
+	}
+}
+
+// Ci returns a new pipeline builder over a directory of scans. Which files take
+// part is the batch default: the image extensions leptonica can read, at any
+// depth.
+func (r *Tesseract) Ci(source *Directory) *TesseractCi { // tesseract (../../../../../daggerverse/tesseract/ci.go:62:1)
+	assertNotNil("source", source)
+	q := r.query.Select("ci")
+	q = q.Arg("source", source)
+
+	return &TesseractCi{
 		query: q,
 	}
 }
@@ -253,7 +299,7 @@ func (r *Tesseract) Batch(source *Directory) *TesseractBatch { // tesseract (../
 //
 // A requested OpenMP bound lives here rather than on the recognition
 // invocation so everything reached through this escape hatch inherits it too.
-func (r *Tesseract) Container() *Container { // tesseract (../../../../../daggerverse/tesseract/main.go:309:1)
+func (r *Tesseract) Container() *Container { // tesseract (../../../../../daggerverse/tesseract/main.go:311:1)
 	q := r.query.Select("container")
 
 	return &Container{
@@ -266,7 +312,7 @@ func (r *Tesseract) Container() *Container { // tesseract (../../../../../dagger
 // The boundary input is a *dagger.File rather than a *dagger.Directory, unlike
 // the kicad module's Project: tesseract resolves nothing relative to its input,
 // so one image — including a multi-page TIFF — is the whole unit of work.
-func (r *Tesseract) Document(source *File) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/main.go:387:1)
+func (r *Tesseract) Document(source *File) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/main.go:389:1)
 	assertNotNil("source", source)
 	q := r.query.Select("document")
 	q = q.Arg("source", source)
@@ -371,7 +417,7 @@ func (r *Tesseract) UnmarshalJSON(bs []byte) error {
 // `tesseract --list-langs`: the packaged languages and any model WithTessdata
 // added, as one set. This is what Document.WithLanguage validates against, and
 // it includes "osd" when that model was installed or supplied.
-func (r *Tesseract) Langs(ctx context.Context) ([]string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:357:1)
+func (r *Tesseract) Langs(ctx context.Context) ([]string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:359:1)
 	q := r.query.Select("langs")
 
 	var response []string
@@ -383,7 +429,7 @@ func (r *Tesseract) Langs(ctx context.Context) ([]string, error) { // tesseract 
 // Parameters returns tesseract's control-variable table — every name, its
 // default value and a one-line description — as `tesseract --print-parameters`
 // prints it. These are the names Document.WithParameter accepts.
-func (r *Tesseract) Parameters(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:372:1)
+func (r *Tesseract) Parameters(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:374:1)
 	if r.parameters != nil {
 		return *r.parameters, nil
 	}
@@ -407,7 +453,7 @@ func (r *Tesseract) Parameters(ctx context.Context) (string, error) { // tessera
 //
 // The model it produces pairs directly with WithTessdata, so a fine-tune and
 // the recognition that uses it are two calls on the same module.
-func (r *Tesseract) Training(source *Directory) *TesseractTraining { // tesseract (../../../../../daggerverse/tesseract/main.go:415:1)
+func (r *Tesseract) Training(source *Directory) *TesseractTraining { // tesseract (../../../../../daggerverse/tesseract/main.go:417:1)
 	assertNotNil("source", source)
 	q := r.query.Select("training")
 	q = q.Arg("source", source)
@@ -419,7 +465,7 @@ func (r *Tesseract) Training(source *Directory) *TesseractTraining { // tesserac
 
 // Version returns the tesseract release the assembled image ships, as the
 // bare version number reported by `tesseract --version`.
-func (r *Tesseract) Version(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:338:1)
+func (r *Tesseract) Version(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:340:1)
 	if r.version != nil {
 		return *r.version, nil
 	}
@@ -446,7 +492,7 @@ func (r *Tesseract) Version(ctx context.Context) (string, error) { // tesseract 
 // renderer configfiles and the font the PDF renderer needs. A caller-supplied
 // model wins over a packaged one of the same name, which is what makes
 // replacing the stock `eng` with a fine-tuned one work.
-func (r *Tesseract) WithTessdata(dir *Directory) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:291:1)
+func (r *Tesseract) WithTessdata(dir *Directory) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:293:1)
 	assertNotNil("dir", dir)
 	q := r.query.Select("withTessdata")
 	q = q.Arg("dir", dir)
@@ -674,6 +720,177 @@ func (r *TesseractBatch) WithUserWords(words *File) *TesseractBatch { // tessera
 // AsNode returns this TesseractBatch as a Node.
 // This is a local type conversion — no GraphQL call.
 func (r *TesseractBatch) AsNode() Node {
+	return &NodeClient{
+		query: r.query,
+	}
+}
+
+// Ci is a chained builder for a document-processing pipeline: a directory of
+// scans in, the archival formats out, and a quality gate in between.
+//
+// It composes the Batch primitive without adding capability of its own — every
+// stage is a call the caller could make by hand — so a document repo's CI is one
+// declarative `dagger call` rather than a recognition step, an export step and a
+// hand-rolled TSV parser.
+//
+// The confidence gate is the part that is not merely a bundled call. It reads
+// the `conf` column tesseract already reports in its TSV output and fails the
+// run when mean word confidence falls below the threshold, which is how a
+// scanner regression or a wrong-language configuration is caught before the
+// artifacts ship rather than after they are archived.
+type TesseractCi struct { // tesseract (../../../../../daggerverse/tesseract/ci.go:48:6)
+	query *querybuilder.Selection
+
+	check *Void
+	id    *ID
+}
+type WithTesseractCiFunc func(r *TesseractCi) *TesseractCi
+
+// With calls the provided function with current TesseractCi.
+//
+// This is useful for reusability and readability by not breaking the calling chain.
+func (r *TesseractCi) With(f WithTesseractCiFunc) *TesseractCi {
+	return f(r)
+}
+
+func (r *TesseractCi) WithGraphQLQuery(q *querybuilder.Selection) *TesseractCi {
+	return &TesseractCi{
+		query: q,
+	}
+}
+
+// Check runs the pipeline's gate and produces nothing, for the PR that wants to
+// know whether the scans are good enough without paying to render the archive.
+//
+// The gate is recognition itself plus the confidence bar: every matched image is
+// recognised, so a page tesseract cannot read fails here, and when a threshold
+// was set every page is measured against it. Recognition is what costs, and it
+// is unavoidable — a page's confidence is not knowable without recognising it.
+func (r *TesseractCi) Check(ctx context.Context) error { // tesseract (../../../../../daggerverse/tesseract/ci.go:114:1)
+	if r.check != nil {
+		return nil
+	}
+	q := r.query.Select("check")
+
+	return q.Execute(ctx)
+}
+
+// A unique identifier for this TesseractCi.
+func (r *TesseractCi) ID(ctx context.Context) (ID, error) {
+	if r.id != nil {
+		return *r.id, nil
+	}
+	q := r.query.Select("id")
+
+	var response ID
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// XXX_GraphQLType is an internal function. It returns the native GraphQL type name
+func (r *TesseractCi) XXX_GraphQLType() string {
+	return "TesseractCi"
+}
+
+// XXX_GraphQLIDType is an internal function. It returns the native GraphQL type name for the ID of this object
+func (r *TesseractCi) XXX_GraphQLIDType() string {
+	return "ID"
+}
+
+// XXX_GraphQLID is an internal function. It returns the underlying type ID
+func (r *TesseractCi) XXX_GraphQLID(ctx context.Context) (string, error) {
+	id, err := r.ID(ctx)
+	if err != nil {
+		return "", err
+	}
+	return string(id), nil
+}
+
+func (r *TesseractCi) MarshalJSON() ([]byte, error) {
+	id, err := r.ID(marshalCtx)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(id)
+}
+func (r *TesseractCi) UnmarshalJSON(bs []byte) error {
+	var id string
+	err := json.Unmarshal(bs, &id)
+	if err != nil {
+		return err
+	}
+	*r = TesseractCi{query: selectNode(dag.query, id, "TesseractCi")}
+	return nil
+}
+
+// Run executes the pipeline and returns every enabled format for every matched
+// image, in a directory mirroring the source layout. A failing gate returns the
+// error and no directory, so artifacts never reach a caller whose scans did not
+// clear the bar.
+//
+// Gating rides along on the recognition pass that renders the artifacts rather
+// than preceding it, because recognising the whole directory twice is the
+// single most expensive thing this module could be asked to do, and the only
+// difference between a gated run and an ungated one is a TSV. So a gated run
+// renders TSV alongside whatever was enabled, measures it, and withholds the
+// whole directory if the measurement fails — the artifacts exist inside the
+// exec, and a caller who is refused them is no better off for them having been
+// skipped.
+func (r *TesseractCi) Run() *Directory { // tesseract (../../../../../daggerverse/tesseract/ci.go:148:1)
+	q := r.query.Select("run")
+
+	return &Directory{
+		query: q,
+	}
+}
+
+// WithFormats replaces the set of formats the pipeline renders for each image.
+// Unset, it renders plain text.
+func (r *TesseractCi) WithFormats(formats []TesseractFormat) *TesseractCi { // tesseract (../../../../../daggerverse/tesseract/ci.go:76:1)
+	q := r.query.Select("withFormats")
+	q = q.Arg("formats", formats)
+
+	return &TesseractCi{
+		query: q,
+	}
+}
+
+// WithLanguage selects the recognition language (`-l`) for every image in the
+// source directory. See Document.WithLanguage.
+func (r *TesseractCi) WithLanguage(lang string) *TesseractCi { // tesseract (../../../../../daggerverse/tesseract/ci.go:68:1)
+	q := r.query.Select("withLanguage")
+	q = q.Arg("lang", lang)
+
+	return &TesseractCi{
+		query: q,
+	}
+}
+
+// WithMinConfidence fails the pipeline when a page comes back recognised less
+// confidently than this, as a percentage from 1 to 100.
+//
+// The measurement is the mean of the per-word confidences tesseract already
+// reports in its TSV output, taken per page: the gate names the page that
+// measured worst rather than the batch, because a batch is assembled by a
+// scanner and it is one sheet that goes through crooked.
+//
+// What it catches is the class of failure recognition does not report as one. A
+// page fed sideways, a scanner drifting out of focus, a language configured
+// wrong — all of them recognise *something*, exit 0 and render every artifact
+// asked for. Unset, there is no bar and no page can be too poor to ship.
+func (r *TesseractCi) WithMinConfidence(percent int) *TesseractCi { // tesseract (../../../../../daggerverse/tesseract/ci.go:97:1)
+	q := r.query.Select("withMinConfidence")
+	q = q.Arg("percent", percent)
+
+	return &TesseractCi{
+		query: q,
+	}
+}
+
+// AsNode returns this TesseractCi as a Node.
+// This is a local type conversion — no GraphQL call.
+func (r *TesseractCi) AsNode() Node {
 	return &NodeClient{
 		query: r.query,
 	}

--- a/daggerverse/tesseract/tests/main.go
+++ b/daggerverse/tesseract/tests/main.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -67,6 +68,13 @@ const (
 	// able to tell the float model from the packaged one they sit beside.
 	floatModelLang = "best"
 
+	// blankPageWidth and blankPageHeight size the generated blank page. They
+	// are a page rather than a swatch because tesseract declines to analyse a
+	// layout it considers too small to have one, and a refusal to look is not
+	// the same result as looking and finding nothing.
+	blankPageWidth  = 300
+	blankPageHeight = 200
+
 	// suiteOmpThreadLimit is the bound every test here builds its image with.
 	// The module itself leaves OpenMP alone, so tesseract takes one thread per
 	// available CPU — right for a caller who owns the machine, wrong for this
@@ -104,6 +112,10 @@ var ledgerPages = [][]string{
 // each occur exactly once in the document, so their relative positions say
 // what page order says.
 var ledgerPageMarkers = []string{"lazy", "liquor", "zebras"}
+
+// confidencePattern matches the measured percentage in a Ci gate error. See
+// measuredConfidence.
+var confidencePattern = regexp.MustCompile(`([0-9]+\.[0-9]+)%`)
 
 type Tests struct{}
 
@@ -159,6 +171,13 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("BatchExportProducesEveryFormatPerImage", t.BatchExportProducesEveryFormatPerImage)
 	jobs = jobs.WithJob("BatchSharesDocumentOptions", t.BatchSharesDocumentOptions)
 	jobs = jobs.WithJob("BatchRejectsAmbiguousInput", t.BatchRejectsAmbiguousInput)
+
+	jobs = jobs.WithJob("CiRunProducesEnabledFormats", t.CiRunProducesEnabledFormats)
+	jobs = jobs.WithJob("CiMinConfidenceGatesTheRun", t.CiMinConfidenceGatesTheRun)
+	jobs = jobs.WithJob("CiCheckRunsTheGateWithoutArtifacts", t.CiCheckRunsTheGateWithoutArtifacts)
+	jobs = jobs.WithJob("CiGateKeepsItsTsvOutOfTheOutput", t.CiGateKeepsItsTsvOutOfTheOutput)
+	jobs = jobs.WithJob("CiLanguageReachesRecognition", t.CiLanguageReachesRecognition)
+	jobs = jobs.WithJob("CiRejectsUnusableThreshold", t.CiRejectsUnusableThreshold)
 
 	jobs = jobs.WithJob("TessdataModelIsSelectable", t.TessdataModelIsSelectable)
 	jobs = jobs.WithJob("TessdataSuppliesOsdModel", t.TessdataSuppliesOsdModel)
@@ -1228,6 +1247,265 @@ func (t *Tests) BatchRejectsAmbiguousInput(ctx context.Context) error {
 	return nil
 }
 
+// ------------------------------------------------------------------------- ci
+
+// CiRunProducesEnabledFormats asserts the pipeline's output is the batch it
+// wraps: every enabled format for every matched image, at the input's own path.
+//
+// The default is the half worth pinning. A pipeline that produced nothing until
+// WithFormats was called would look like a broken directory rather than an
+// unconfigured one, so an unconfigured Ci renders plain text — the format
+// tesseract itself produces when no renderer is named.
+func (t *Tests) CiRunProducesEnabledFormats(ctx context.Context) error {
+	entries, err := ocr().Ci(batchSource()).Run().Glob(ctx, "**/*")
+	if err != nil {
+		return fmt.Errorf("Run: %w", err)
+	}
+	want := []string{"scans/", "scans/deep/", "scans/deep/page-3.txt", "scans/page-1.txt", "scans/page-2.txt"}
+	sort.Strings(entries)
+	if !reflect.DeepEqual(entries, want) {
+		return fmt.Errorf("expected an unconfigured Ci to render %v, got %v", want, entries)
+	}
+
+	out := ocr().Ci(batchSource()).
+		WithFormats([]dagger.TesseractFormat{
+			dagger.TesseractFormatTxt,
+			dagger.TesseractFormatHocr,
+			dagger.TesseractFormatPdf,
+		}).
+		Run()
+	entries, err = out.Glob(ctx, "**/*")
+	if err != nil {
+		return fmt.Errorf("Run with three formats: %w", err)
+	}
+	want = []string{
+		"scans/", "scans/deep/",
+		"scans/deep/page-3.hocr", "scans/deep/page-3.pdf", "scans/deep/page-3.txt",
+		"scans/page-1.hocr", "scans/page-1.pdf", "scans/page-1.txt",
+		"scans/page-2.hocr", "scans/page-2.pdf", "scans/page-2.txt",
+	}
+	sort.Strings(entries)
+	if !reflect.DeepEqual(entries, want) {
+		return fmt.Errorf("expected every enabled format per image as %v, got %v", want, entries)
+	}
+
+	// The artifacts have to be this image's own recognised text, not merely
+	// files at the right paths.
+	got, err := out.File("scans/deep/page-3.txt").Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("read scans/deep/page-3.txt: %w", err)
+	}
+	return assertSentenceLines(got)
+}
+
+// CiMinConfidenceGatesTheRun asserts the quality gate: recognition that came
+// back worse than the threshold fails the run, and the failure names both the
+// value measured and the page that measured it.
+//
+// Reporting the value is what makes the threshold adjustable. "Confidence too
+// low" leaves the caller guessing whether they are one point short or thirty,
+// and the only way to find out would be to re-run the whole batch by hand
+// asking for TSV.
+//
+// Naming the page is what makes it actionable, and the mixed directory is where
+// that has to be earned: one clean scan and one blank page under a threshold
+// only the blank page misses. A gate that failed the batch as a whole would be
+// telling the caller to go and diff a hundred TSVs.
+func (t *Tests) CiMinConfidenceGatesTheRun(ctx context.Context) error {
+	clean := dag.Directory().WithFile("scans/page-1.png", fixture(sentencePng))
+
+	_, err := ocr().Ci(clean).WithMinConfidence(95).Run().Entries(ctx)
+	if err == nil {
+		return fmt.Errorf("expected a threshold above what the fixture measures to fail the run, got nil")
+	}
+	for _, want := range []string{"scans/page-1.png", "95"} {
+		if !strings.Contains(err.Error(), want) {
+			return fmt.Errorf("expected the gate error to mention %q, got: %v", want, err)
+		}
+	}
+	measured, ok := measuredConfidence(err.Error())
+	if !ok {
+		return fmt.Errorf("expected the gate error to report the measured confidence, got: %v", err)
+	}
+	if measured <= 0 || measured >= 95 {
+		return fmt.Errorf("expected a measured confidence in (0, 95), got %v from: %v", measured, err)
+	}
+
+	// A blank page recognises nothing at all, so there is no confidence to
+	// measure on it — which is a scan worth failing a build over, and worth
+	// saying so rather than reporting it as zero.
+	mixed := clean.WithFile("scans/blank.pbm", blankPage("blank.pbm"))
+	_, err = ocr().Ci(mixed).WithMinConfidence(80).Run().Entries(ctx)
+	if err == nil {
+		return fmt.Errorf("expected a blank page to fail an 80%% gate, got nil")
+	}
+	if !strings.Contains(err.Error(), "scans/blank.pbm") {
+		return fmt.Errorf("expected the gate error to name the offending page, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "scans/page-1.png") {
+		return fmt.Errorf("expected the gate error to name only the page below the threshold, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "no words") {
+		return fmt.Errorf("expected the gate error to say the page recognised nothing, got: %v", err)
+	}
+
+	// A threshold the scan clears produces the artifacts as usual, so the gate
+	// is a gate rather than a tax.
+	got, err := ocr().Ci(clean).WithMinConfidence(80).Run().File("scans/page-1.txt").Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("Run under a threshold the fixture clears: %w", err)
+	}
+	return assertSentenceLines(got)
+}
+
+// CiCheckRunsTheGateWithoutArtifacts asserts Check reaches the same verdict
+// Run's gate does, and that it is a real pass over the scans rather than a
+// signature that returns nil.
+//
+// Its return type is the whole reason it exists — an error and nothing else, so
+// a PR gate that never wants the archive cannot accidentally be handed one —
+// and that makes "did it actually look?" the thing worth testing. A Check that
+// short-circuited when no threshold was set would be a green build over a
+// directory of files tesseract cannot read at all.
+func (t *Tests) CiCheckRunsTheGateWithoutArtifacts(ctx context.Context) error {
+	clean := dag.Directory().WithFile("scans/page-1.png", fixture(sentencePng))
+
+	if err := ocr().Ci(clean).WithMinConfidence(80).Check(ctx); err != nil {
+		return fmt.Errorf("expected a threshold the fixture clears to pass Check: %w", err)
+	}
+
+	err := ocr().Ci(clean).WithMinConfidence(95).Check(ctx)
+	if err == nil {
+		return fmt.Errorf("expected a threshold above what the fixture measures to fail Check, got nil")
+	}
+	if !strings.Contains(err.Error(), "scans/page-1.png") {
+		return fmt.Errorf("expected Check to name the offending page, got: %v", err)
+	}
+
+	// With no threshold there is still a bar: every matched file has to be an
+	// image tesseract can read.
+	err = ocr().Ci(dag.Directory().WithNewFile("scans/page-1.png", "not an image\n")).Check(ctx)
+	if err == nil {
+		return fmt.Errorf("expected Check to recognise the scans even with no threshold set, got nil")
+	}
+	if !strings.Contains(err.Error(), "tesseract failed") {
+		return fmt.Errorf("expected the error to come from recognition, got: %v", err)
+	}
+	return nil
+}
+
+// CiGateKeepsItsTsvOutOfTheOutput asserts the output is what WithFormats asked
+// for, whether or not a threshold was set.
+//
+// The gate measures a TSV, and Run renders that TSV in the same pass as the
+// artifacts rather than paying for a second one. That is an implementation
+// decision and it has to stay one: a caller who enabled a threshold and asked
+// for PDFs did not ask for a TSV beside every page, and would find one in the
+// archive they published. A caller who did ask for TSV keeps it, which is the
+// half that catches a filter written as "drop every TSV".
+func (t *Tests) CiGateKeepsItsTsvOutOfTheOutput(ctx context.Context) error {
+	source := dag.Directory().
+		WithFile("scans/page-1.png", fixture(sentencePng)).
+		WithFile("scans/deep/page-2.png", fixture(sentencePng))
+
+	entries, err := ocr().Ci(source).
+		WithFormats([]dagger.TesseractFormat{dagger.TesseractFormatTxt}).
+		WithMinConfidence(80).
+		Run().
+		Glob(ctx, "**/*")
+	if err != nil {
+		return fmt.Errorf("Run with a gate: %w", err)
+	}
+	want := []string{"scans/", "scans/deep/", "scans/deep/page-2.txt", "scans/page-1.txt"}
+	sort.Strings(entries)
+	if !reflect.DeepEqual(entries, want) {
+		return fmt.Errorf("expected a gated run to produce only %v, got %v", want, entries)
+	}
+
+	entries, err = ocr().Ci(source).
+		WithFormats([]dagger.TesseractFormat{dagger.TesseractFormatTxt, dagger.TesseractFormatTsv}).
+		WithMinConfidence(80).
+		Run().
+		Glob(ctx, "**/*")
+	if err != nil {
+		return fmt.Errorf("Run with a gate and TSV enabled: %w", err)
+	}
+	want = []string{
+		"scans/", "scans/deep/",
+		"scans/deep/page-2.tsv", "scans/deep/page-2.txt",
+		"scans/page-1.tsv", "scans/page-1.txt",
+	}
+	sort.Strings(entries)
+	if !reflect.DeepEqual(entries, want) {
+		return fmt.Errorf("expected an enabled TSV to survive the gate as %v, got %v", want, entries)
+	}
+	return nil
+}
+
+// CiLanguageReachesRecognition asserts the pipeline's language is the batch's
+// language, in both directions: a selected one recognises, and one the image
+// does not carry is rejected with the same explanation a bare batch gives.
+//
+// Ci owns no option handling of its own — that is what makes it a bundle of
+// calls rather than a second implementation — and the rejection is the half that
+// proves it, because the check that produces it lives on the shared option set
+// and could only fire if the value got there. It also fires before recognition,
+// so a wrong-language pipeline costs a message rather than a batch.
+func (t *Tests) CiLanguageReachesRecognition(ctx context.Context) error {
+	source := dag.Directory().WithFile("scans/page-1.png", fixture(sentencePng))
+
+	got, err := ocr("eng", "deu").Ci(source).
+		WithLanguage("eng").
+		Run().
+		File("scans/page-1.txt").
+		Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("Run with a selected language: %w", err)
+	}
+	if err := assertSentenceLines(got); err != nil {
+		return err
+	}
+
+	_, err = ocr().Ci(source).WithLanguage("fra").Run().Entries(ctx)
+	if err == nil {
+		return fmt.Errorf("expected an uninstalled language to be rejected, got nil")
+	}
+	for _, want := range []string{"WithLanguage", "fra", "eng"} {
+		if !strings.Contains(err.Error(), want) {
+			return fmt.Errorf("expected the error to mention %q, got: %v", want, err)
+		}
+	}
+	return nil
+}
+
+// CiRejectsUnusableThreshold asserts a bar no page could miss, or none could
+// clear, is refused before anything is recognised.
+//
+// Zero is the one worth spelling out. It is not a lenient gate, it is no gate at
+// all — every page clears it — so a build configured that way reports a passing
+// quality check it never made. Accepting it silently would make the difference
+// between a gate and a decoration invisible.
+//
+// It is checked through Check rather than Run because that is where a
+// misconfiguration costs the most to discover late: Check is the call a PR gate
+// makes, and its whole answer is the error it returns.
+func (t *Tests) CiRejectsUnusableThreshold(ctx context.Context) error {
+	source := dag.Directory().WithFile("scans/page-1.png", fixture(sentencePng))
+
+	for _, percent := range []int{0, -10, 101} {
+		err := ocr().Ci(source).WithMinConfidence(percent).Check(ctx)
+		if err == nil {
+			return fmt.Errorf("expected a threshold of %d to be rejected, got nil", percent)
+		}
+		for _, want := range []string{"WithMinConfidence", "1 and 100"} {
+			if !strings.Contains(err.Error(), want) {
+				return fmt.Errorf("expected the error for %d to mention %q, got: %v", percent, want, err)
+			}
+		}
+	}
+	return nil
+}
+
 // -------------------------------------------------------- training-adjacent
 
 // BoxReportsCharacterBoxes asserts the box renderer descends to the character
@@ -1604,6 +1882,47 @@ func batchSource() *dagger.Directory {
 // fixture returns a committed test image by name under fixtures/.
 func fixture(name string) *dagger.File {
 	return dag.CurrentModule().Source().File("fixtures/" + name)
+}
+
+// blankPage builds an all-white page as an ASCII PBM: the "P1" netpbm format,
+// whose pixels are the literal characters "0" and "1".
+//
+// It is written here rather than committed because it is the one image these
+// tests need that can be spelled in text. Every other fixture is a PNG for the
+// reason the package comment gives — bare Alpine has no fonts, so an image with
+// writing on it has to arrive from outside — but a page with nothing on it
+// needs no font, and P1 needs no encoder.
+//
+// The pixel values are space-separated. Leptonica's ASCII netpbm reader takes
+// one whitespace-delimited token per pixel, and a P1 raster written as an
+// unbroken run of digits — which the format also permits — fails to decode.
+func blankPage(name string) *dagger.File {
+	row := strings.TrimSpace(strings.Repeat("0 ", blankPageWidth))
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "P1\n%d %d\n", blankPageWidth, blankPageHeight)
+	for i := 0; i < blankPageHeight; i++ {
+		sb.WriteString(row)
+		sb.WriteString("\n")
+	}
+	return dag.Directory().WithNewFile(name, sb.String()).File(name)
+}
+
+// measuredConfidence pulls the confidence percentage out of a gate error, so
+// the assertion is that the number reported is the measured one rather than
+// that the message reads a particular way.
+//
+// It matches only a value carrying a decimal point, which is what separates the
+// measurement from the whole-number threshold printed beside it.
+func measuredConfidence(msg string) (float64, bool) {
+	m := confidencePattern.FindStringSubmatch(msg)
+	if m == nil {
+		return 0, false
+	}
+	got, err := strconv.ParseFloat(m[1], 64)
+	if err != nil {
+		return 0, false
+	}
+	return got, true
 }
 
 // trainingSource returns the committed training set: fixtures/training holds


### PR DESCRIPTION
Closes #223.

`Ci` bundles the pipeline a document-processing repo's CI actually wants — OCR everything under a directory, emit the archival formats, fail the build when recognition quality drops — into one declarative call. It composes `Batch` without adding capability: every stage is a call the caller could make by hand.

```go
Tesseract.Ci(source *dagger.Directory) *Ci

Ci.WithLanguage(lang string) *Ci
Ci.WithFormats(formats []Format) *Ci        // default: TXT
Ci.WithMinConfidence(percent int) *Ci       // 1-100, default: no gate
Ci.Check(ctx) error                         // the gate, no artifacts
Ci.Run(ctx) (*dagger.Directory, error)      // the gate, then the artifacts
```

## The confidence gate

The gate is the part that is not merely a bundled call. It reads the `conf` column tesseract already publishes in its TSV output and averages the word-level rows per page — nothing here re-derives a confidence. Levels 1-4 (page, block, paragraph, line) all report `-1`, so the `level` column is what separates a measurement from a placeholder; word rows with empty text are skipped too, or a page would be scored by how aggressively it was segmented rather than by how well it was read. Columns are located by header **name**, not position: a gate reading the wrong column would not fail, it would pass the wrong scans.

The failure names the page that measured worst and how many others joined it, because a batch that drifted out of focus fails several pages at once and the one to go and find in the stack is the one furthest below the bar:

```
Ci: "training/line-3.png" was recognised at a mean word confidence of 91.4%,
below the required 99%, the lowest of 6 page(s) below it: check the scan and
the recognition language, or lower the bar with WithMinConfidence
```

A page that recognised **no** words gets its own message rather than being reported as zero: the mean of no words is not zero, it is undefined, and a blank page is a different fault with a different fix.

## One deliberate deviation from the acceptance criteria

The criterion reads "`Run` runs the gate before producing artifacts, so a failing gate produces none". This implements it as **one** recognition pass rather than two: `Run` renders the gate's TSV alongside whatever `WithFormats` enabled, measures it, and withholds the whole directory if the measurement fails.

Recognising the directory twice is the single most expensive thing this module could be asked to do, and the only difference between a gated run and an ungated one is a TSV. The observable behaviour is unchanged — a failing gate returns the error and no directory, and the caller is no better off for the artifacts having been skipped rather than withheld. When TSV was not among the enabled formats the gate's own TSVs are dropped from the result, so enabling a threshold cannot silently change what the pipeline produces; both halves of that are tested.

Happy to switch to the literal two-pass short-circuit if the extra pass is wanted.

## Scope

`Ci` exposes only `WithLanguage` of the seven recognition options `Batch` carries. The rest describe *how one scan is read* — a page segmentation mode, a DPI, a control variable — and a pipeline whose input is a whole intake folder has no single answer for them; a caller who needs one is configuring a `Batch`, not a CI. `WithGlob` is absent from the other direction: the default takes the images and leaves the manifests, which is what pointing this at an existing scan folder should do. Both are written up in the README's follow-ups section.

## Tests

Six new tests, driven one at a time per the module TDD loop, wired into `All`:

- `CiRunProducesEnabledFormats` — the default renders TXT; an enabled set renders all of it per image, mirroring the input layout
- `CiMinConfidenceGatesTheRun` — a threshold above what the fixture measures fails and reports the measured value; a mixed directory names only the offending page; a threshold the scan clears still produces artifacts
- `CiCheckRunsTheGateWithoutArtifacts` — same verdict as `Run`'s gate, and a real pass over the scans even with no threshold set
- `CiGateKeepsItsTsvOutOfTheOutput` — the gate's TSV is dropped when unasked-for and kept when asked for
- `CiLanguageReachesRecognition` — the language reaches the batch, and an uninstalled one is rejected by the shared option validation
- `CiRejectsUnusableThreshold` — 0, negative and >100 are refused; a bar of 0 is a gate that reports a verdict it never reached

Full suite green at 23.6s; `dagger -m ci call generated` passes byte-exact.

The blank-page fixture is generated rather than committed, as an ASCII PBM whose pixels are literal `0` characters — every other fixture is a PNG because bare Alpine has no fonts, but a page with nothing on it needs no font. Leptonica's ASCII netpbm reader takes one whitespace-delimited token per pixel, so the raster is space-separated; the unbroken run of digits the format also permits fails to decode.

## Codegen note

A package-level `const ciDefaultFormat = FormatTxt` is not usable: codegen reads a constant of an enum type as another **member** of that enum, and a second member carrying `"TXT"` fails typedef generation with `enum "FORMAT_TXT" is already defined with value "TXT"`. The owning module's own `dagger develop` succeeds — the failure only surfaces when a dependent regenerates. The default is inlined instead, with the reason recorded at the use site. This may deserve a line in `daggerverse/CLAUDE.md`'s pitfalls alongside the `Type`-named-field trap; not done here to keep the diff on-topic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)