### PR TITLE
story(issue-234): fetch apk packages from a private repository

### DIFF
--- a/ci/internal/dagger/tesseract-tests.gen.go
+++ b/ci/internal/dagger/tesseract-tests.gen.go
@@ -61,54 +61,61 @@ func (r *Query) TesseractTests() *TesseractTests { // tesseract-tests (../../../
 type TesseractTests struct { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:120:6)
 	query *querybuilder.Selection
 
-	all                                          *Void
-	altoIsValidXml                               *Void
-	batchDefaultGlobSkipsNonImages               *Void
-	batchExportProducesEveryFormatPerImage       *Void
-	batchGlobSelectsFiles                        *Void
-	batchMirrorsInputLayout                      *Void
-	batchRejectsAmbiguousInput                   *Void
-	batchSharesDocumentOptions                   *Void
-	boxReportsCharacterBoxes                     *Void
-	ciCheckRunsTheGateWithoutArtifacts           *Void
-	ciGateKeepsItsTsvOutOfTheOutput              *Void
-	ciLanguageReachesRecognition                 *Void
-	ciMinConfidenceGatesTheRun                   *Void
-	ciRejectsUnusableThreshold                   *Void
-	ciRunProducesEnabledFormats                  *Void
-	defaultLanguagesInstallEnglish               *Void
-	exportProducesEveryRequestedFormat           *Void
-	fromPdfDpiSetsRasterResolution               *Void
-	fromPdfExportRendersEveryFormatAsOneDocument *Void
-	fromPdfRecognizesEveryPageInOrder            *Void
-	hocrContainsWordBoxes                        *Void
-	id                                           *ID
-	lstmEngineRecognizesFixture                  *Void
-	lstmTrainBuildsTrainingSample                *Void
-	malformedParameterNameIsRejected             *Void
-	nonPositiveDpiIsRejected                     *Void
-	ompThreadLimitBoundsOpenMp                   *Void
-	osdDetectsRotation                           *Void
-	osdWithoutOsdDataIsRejected                  *Void
-	pdfHasPdfMagic                               *Void
-	pdfInputIsRejected                           *Void
-	processedImagesReturnsThresholdedTiff        *Void
-	requestedLanguagesAreInstalled               *Void
-	singleWordPageSegReturnsFewerWords           *Void
-	tessdataDoesNotAdmitUnknownLanguage          *Void
-	tessdataModelIsSelectable                    *Void
-	tessdataSuppliesOsdModel                     *Void
-	textRecognizesFixture                        *Void
-	trainingPairsImagesWithGroundTruth           *Void
-	trainingProducesUsableModel                  *Void
-	trainingRejectsUnusableInput                 *Void
-	trainingRequiresFloatBaseModel               *Void
-	tsvHasHeaderAndWordRows                      *Void
-	txtFileMatchesText                           *Void
-	unknownLanguageIsRejected                    *Void
-	unknownParameterFails                        *Void
-	userWordsFileIsAccepted                      *Void
-	versionReportsTesseractFive                  *Void
+	all                                             *Void
+	altoIsValidXml                                  *Void
+	apkAuthInstallsFromAuthenticatedRepository      *Void
+	apkRepositoryAppliesToPdfRasterizer             *Void
+	apkRepositoryInstallsFromPrivateMirror          *Void
+	apkRepositoryReplacesImageDefaults              *Void
+	authenticatedRepositoryIsRejectedWithoutApkAuth *Void
+	batchDefaultGlobSkipsNonImages                  *Void
+	batchExportProducesEveryFormatPerImage          *Void
+	batchGlobSelectsFiles                           *Void
+	batchMirrorsInputLayout                         *Void
+	batchRejectsAmbiguousInput                      *Void
+	batchSharesDocumentOptions                      *Void
+	boxReportsCharacterBoxes                        *Void
+	ciCheckRunsTheGateWithoutArtifacts              *Void
+	ciGateKeepsItsTsvOutOfTheOutput                 *Void
+	ciLanguageReachesRecognition                    *Void
+	ciMinConfidenceGatesTheRun                      *Void
+	ciRejectsUnusableThreshold                      *Void
+	ciRunProducesEnabledFormats                     *Void
+	defaultApkConfigurationIsUntouched              *Void
+	defaultLanguagesInstallEnglish                  *Void
+	exportProducesEveryRequestedFormat              *Void
+	fromPdfDpiSetsRasterResolution                  *Void
+	fromPdfExportRendersEveryFormatAsOneDocument    *Void
+	fromPdfRecognizesEveryPageInOrder               *Void
+	hocrContainsWordBoxes                           *Void
+	id                                              *ID
+	lstmEngineRecognizesFixture                     *Void
+	lstmTrainBuildsTrainingSample                   *Void
+	malformedParameterNameIsRejected                *Void
+	nonPositiveDpiIsRejected                        *Void
+	ompThreadLimitBoundsOpenMp                      *Void
+	osdDetectsRotation                              *Void
+	osdWithoutOsdDataIsRejected                     *Void
+	pdfHasPdfMagic                                  *Void
+	pdfInputIsRejected                              *Void
+	processedImagesReturnsThresholdedTiff           *Void
+	requestedLanguagesAreInstalled                  *Void
+	singleWordPageSegReturnsFewerWords              *Void
+	tessdataDoesNotAdmitUnknownLanguage             *Void
+	tessdataModelIsSelectable                       *Void
+	tessdataSuppliesOsdModel                        *Void
+	textRecognizesFixture                           *Void
+	trainingPairsImagesWithGroundTruth              *Void
+	trainingProducesUsableModel                     *Void
+	trainingRejectsUnusableInput                    *Void
+	trainingRequiresFloatBaseModel                  *Void
+	tsvHasHeaderAndWordRows                         *Void
+	txtFileMatchesText                              *Void
+	unknownLanguageIsRejected                       *Void
+	unknownParameterFails                           *Void
+	untrustedIndexIsRejectedWithoutApkKey           *Void
+	userWordsFileIsAccepted                         *Void
+	versionReportsTesseractFive                     *Void
 }
 
 func (r *TesseractTests) WithGraphQLQuery(q *querybuilder.Selection) *TesseractTests {
@@ -154,11 +161,85 @@ func (r *TesseractTests) All(ctx context.Context, opts ...TesseractTestsAllOpts)
 // AltoIsValidXml asserts the ALTO renderer emits well-formed XML in the ALTO
 // namespace, since its consumers are schema-driven archive tooling that will
 // reject anything else outright.
-func (r *TesseractTests) AltoIsValidXML(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:353:1)
+func (r *TesseractTests) AltoIsValidXML(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:361:1)
 	if r.altoIsValidXml != nil {
 		return nil
 	}
 	q := r.query.Select("altoIsValidXml")
+
+	return q.Execute(ctx)
+}
+
+// ApkAuthInstallsFromAuthenticatedRepository asserts credentials reach the
+// fetch, and that they reach it without becoming part of the image.
+//
+// The second half is the reason the option takes a Secret: a mirror password
+// spelled into a repository URL would land in /etc/apk/repositories, in every
+// apk error quoting it, and in the layer a caller exports.
+func (r *TesseractTests) ApkAuthInstallsFromAuthenticatedRepository(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/apk.go:338:1)
+	if r.apkAuthInstallsFromAuthenticatedRepository != nil {
+		return nil
+	}
+	q := r.query.Select("apkAuthInstallsFromAuthenticatedRepository")
+
+	return q.Execute(ctx)
+}
+
+// ApkRepositoryAppliesToPdfRasterizer asserts the PDF rasterizer installs its
+// packages from the configured mirror too.
+//
+// It is a separate container from the toolchain — poppler and its font are
+// paid for only by callers who rasterize something — so it is a second place
+// the configuration has to reach, and covering only the first would leave PDF
+// input broken in exactly the environment this option exists for.
+func (r *TesseractTests) ApkRepositoryAppliesToPdfRasterizer(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/apk.go:293:1)
+	if r.apkRepositoryAppliesToPdfRasterizer != nil {
+		return nil
+	}
+	q := r.query.Select("apkRepositoryAppliesToPdfRasterizer")
+
+	return q.Execute(ctx)
+}
+
+// ApkRepositoryInstallsFromPrivateMirror asserts the toolchain image can be
+// assembled entirely out of a caller-supplied repository, which is the whole
+// point of the option: with the mirror configured, the packages come from it.
+func (r *TesseractTests) ApkRepositoryInstallsFromPrivateMirror(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/apk.go:245:1)
+	if r.apkRepositoryInstallsFromPrivateMirror != nil {
+		return nil
+	}
+	q := r.query.Select("apkRepositoryInstallsFromPrivateMirror")
+
+	return q.Execute(ctx)
+}
+
+// ApkRepositoryReplacesImageDefaults asserts the first WithApkRepository
+// replaces the image's repository list rather than appending to it.
+//
+// Appending would look identical in every test above — the packages would
+// still install, from the mirror or from the CDN, and nothing would say which.
+// The difference only shows on the network this option exists for, where a
+// surviving default is a repository apk waits on until it times out. So the
+// assertion is on the file, and it is that the CDN is *gone*.
+func (r *TesseractTests) ApkRepositoryReplacesImageDefaults(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/apk.go:268:1)
+	if r.apkRepositoryReplacesImageDefaults != nil {
+		return nil
+	}
+	q := r.query.Select("apkRepositoryReplacesImageDefaults")
+
+	return q.Execute(ctx)
+}
+
+// AuthenticatedRepositoryIsRejectedWithoutApkAuth asserts the authenticated
+// mirror really is authenticated — that the test above passes because the
+// credentials were supplied and used, and not because the server never asked
+// for any. Both installs run against the one mirror, so WithApkAuth is the
+// only difference between them.
+func (r *TesseractTests) AuthenticatedRepositoryIsRejectedWithoutApkAuth(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/apk.go:387:1)
+	if r.authenticatedRepositoryIsRejectedWithoutApkAuth != nil {
+		return nil
+	}
+	q := r.query.Select("authenticatedRepositoryIsRejectedWithoutApkAuth")
 
 	return q.Execute(ctx)
 }
@@ -170,7 +251,7 @@ func (r *TesseractTests) AltoIsValidXML(ctx context.Context) error { // tesserac
 // them are pages. Handing one to tesseract is not a no-op — leptonica fails to
 // decode it and the run dies — so "ignored by default" is what makes pointing
 // Batch at an existing directory work at all.
-func (r *TesseractTests) BatchDefaultGlobSkipsNonImages(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1011:1)
+func (r *TesseractTests) BatchDefaultGlobSkipsNonImages(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1019:1)
 	if r.batchDefaultGlobSkipsNonImages != nil {
 		return nil
 	}
@@ -186,7 +267,7 @@ func (r *TesseractTests) BatchDefaultGlobSkipsNonImages(ctx context.Context) err
 // would render one concatenated artifact per *format* — a single .txt with
 // form-feed page breaks and a single multi-page PDF — with no way to tell which
 // page produced what.
-func (r *TesseractTests) BatchExportProducesEveryFormatPerImage(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1107:1)
+func (r *TesseractTests) BatchExportProducesEveryFormatPerImage(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1115:1)
 	if r.batchExportProducesEveryFormatPerImage != nil {
 		return nil
 	}
@@ -202,7 +283,7 @@ func (r *TesseractTests) BatchExportProducesEveryFormatPerImage(ctx context.Cont
 // be indistinguishable from a batch that ran and found no text, so a typo in a
 // pattern would surface much later as missing output rather than here as a bad
 // glob.
-func (r *TesseractTests) BatchGlobSelectsFiles(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1055:1)
+func (r *TesseractTests) BatchGlobSelectsFiles(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1063:1)
 	if r.batchGlobSelectsFiles != nil {
 		return nil
 	}
@@ -219,7 +300,7 @@ func (r *TesseractTests) BatchGlobSelectsFiles(ctx context.Context) error { // t
 // directory of `result-1.txt`, `result-2.txt` would force every caller to
 // rebuild the correspondence between page and text that the input directory
 // already expressed.
-func (r *TesseractTests) BatchMirrorsInputLayout(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:977:1)
+func (r *TesseractTests) BatchMirrorsInputLayout(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:985:1)
 	if r.batchMirrorsInputLayout != nil {
 		return nil
 	}
@@ -235,7 +316,7 @@ func (r *TesseractTests) BatchMirrorsInputLayout(ctx context.Context) error { //
 // A collision is the subtle one: `a.png` and `a.jpg` in one folder both render
 // onto `a.txt`, so the second silently overwrites the first and the batch looks
 // like it succeeded with one page missing.
-func (r *TesseractTests) BatchRejectsAmbiguousInput(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1219:1)
+func (r *TesseractTests) BatchRejectsAmbiguousInput(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1227:1)
 	if r.batchRejectsAmbiguousInput != nil {
 		return nil
 	}
@@ -251,7 +332,7 @@ func (r *TesseractTests) BatchRejectsAmbiguousInput(ctx context.Context) error {
 // It covers both halves: an option that has to reach tesseract for every image
 // in the run, and the deferred validation that has to reject a bad option
 // before any of them are recognised.
-func (r *TesseractTests) BatchSharesDocumentOptions(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1153:1)
+func (r *TesseractTests) BatchSharesDocumentOptions(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1161:1)
 	if r.batchSharesDocumentOptions != nil {
 		return nil
 	}
@@ -263,7 +344,7 @@ func (r *TesseractTests) BatchSharesDocumentOptions(ctx context.Context) error {
 // BoxReportsCharacterBoxes asserts the box renderer descends to the character
 // level, which is the level nothing else this module offers reaches: hOCR and
 // TSV stop at the word.
-func (r *TesseractTests) BoxReportsCharacterBoxes(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1514:1)
+func (r *TesseractTests) BoxReportsCharacterBoxes(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1522:1)
 	if r.boxReportsCharacterBoxes != nil {
 		return nil
 	}
@@ -281,7 +362,7 @@ func (r *TesseractTests) BoxReportsCharacterBoxes(ctx context.Context) error { /
 // and that makes "did it actually look?" the thing worth testing. A Check that
 // short-circuited when no threshold was set would be a green build over a
 // directory of files tesseract cannot read at all.
-func (r *TesseractTests) CiCheckRunsTheGateWithoutArtifacts(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1370:1)
+func (r *TesseractTests) CiCheckRunsTheGateWithoutArtifacts(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1378:1)
 	if r.ciCheckRunsTheGateWithoutArtifacts != nil {
 		return nil
 	}
@@ -299,7 +380,7 @@ func (r *TesseractTests) CiCheckRunsTheGateWithoutArtifacts(ctx context.Context)
 // for PDFs did not ask for a TSV beside every page, and would find one in the
 // archive they published. A caller who did ask for TSV keeps it, which is the
 // half that catches a filter written as "drop every TSV".
-func (r *TesseractTests) CiGateKeepsItsTsvOutOfTheOutput(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1406:1)
+func (r *TesseractTests) CiGateKeepsItsTsvOutOfTheOutput(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1414:1)
 	if r.ciGateKeepsItsTsvOutOfTheOutput != nil {
 		return nil
 	}
@@ -317,7 +398,7 @@ func (r *TesseractTests) CiGateKeepsItsTsvOutOfTheOutput(ctx context.Context) er
 // proves it, because the check that produces it lives on the shared option set
 // and could only fire if the value got there. It also fires before recognition,
 // so a wrong-language pipeline costs a message rather than a batch.
-func (r *TesseractTests) CiLanguageReachesRecognition(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1454:1)
+func (r *TesseractTests) CiLanguageReachesRecognition(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1462:1)
 	if r.ciLanguageReachesRecognition != nil {
 		return nil
 	}
@@ -339,7 +420,7 @@ func (r *TesseractTests) CiLanguageReachesRecognition(ctx context.Context) error
 // that has to be earned: one clean scan and one blank page under a threshold
 // only the blank page misses. A gate that failed the batch as a whole would be
 // telling the caller to go and diff a hundred TSVs.
-func (r *TesseractTests) CiMinConfidenceGatesTheRun(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1314:1)
+func (r *TesseractTests) CiMinConfidenceGatesTheRun(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1322:1)
 	if r.ciMinConfidenceGatesTheRun != nil {
 		return nil
 	}
@@ -359,7 +440,7 @@ func (r *TesseractTests) CiMinConfidenceGatesTheRun(ctx context.Context) error {
 // It is checked through Check rather than Run because that is where a
 // misconfiguration costs the most to discover late: Check is the call a PR gate
 // makes, and its whole answer is the error it returns.
-func (r *TesseractTests) CiRejectsUnusableThreshold(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1492:1)
+func (r *TesseractTests) CiRejectsUnusableThreshold(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1500:1)
 	if r.ciRejectsUnusableThreshold != nil {
 		return nil
 	}
@@ -375,7 +456,7 @@ func (r *TesseractTests) CiRejectsUnusableThreshold(ctx context.Context) error {
 // WithFormats was called would look like a broken directory rather than an
 // unconfigured one, so an unconfigured Ci renders plain text — the format
 // tesseract itself produces when no renderer is named.
-func (r *TesseractTests) CiRunProducesEnabledFormats(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1259:1)
+func (r *TesseractTests) CiRunProducesEnabledFormats(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1267:1)
 	if r.ciRunProducesEnabledFormats != nil {
 		return nil
 	}
@@ -384,11 +465,28 @@ func (r *TesseractTests) CiRunProducesEnabledFormats(ctx context.Context) error 
 	return q.Execute(ctx)
 }
 
+// DefaultApkConfigurationIsUntouched asserts an image built without any of
+// these options is the image this module built before they existed: the
+// stock repository list, and no credential plumbing at all.
+//
+// It is the guard against the cheap implementation of all of the above —
+// writing a repositories file, or setting the credential variable,
+// unconditionally — which would work for the mirror and rebuild the world for
+// every existing caller.
+func (r *TesseractTests) DefaultApkConfigurationIsUntouched(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/apk.go:409:1)
+	if r.defaultApkConfigurationIsUntouched != nil {
+		return nil
+	}
+	q := r.query.Select("defaultApkConfigurationIsUntouched")
+
+	return q.Execute(ctx)
+}
+
 // DefaultLanguagesInstallEnglish asserts New with no languages installs
 // English and nothing else. The base apk package carries no language data at
 // all, so an empty default would produce an image that cannot recognise
 // anything.
-func (r *TesseractTests) DefaultLanguagesInstallEnglish(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:230:1)
+func (r *TesseractTests) DefaultLanguagesInstallEnglish(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:238:1)
 	if r.defaultLanguagesInstallEnglish != nil {
 		return nil
 	}
@@ -401,7 +499,7 @@ func (r *TesseractTests) DefaultLanguagesInstallEnglish(ctx context.Context) err
 // formats. That the artifacts arrive in a single directory lifted off a single
 // exec is what proves they came from one recognition pass rather than six: the
 // per-format functions each run their own.
-func (r *TesseractTests) ExportProducesEveryRequestedFormat(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:424:1)
+func (r *TesseractTests) ExportProducesEveryRequestedFormat(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:432:1)
 	if r.exportProducesEveryRequestedFormat != nil {
 		return nil
 	}
@@ -418,7 +516,7 @@ func (r *TesseractTests) ExportProducesEveryRequestedFormat(ctx context.Context)
 // Letter, 612x792 points, so a page rasterized at D dots per inch is exactly
 // 612*D/72 by 792*D/72 pixels. Asserting on the pixels rather than on the flag
 // is what makes this a test of the rasterizer rather than of argv.
-func (r *TesseractTests) FromPdfDpiSetsRasterResolution(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:839:1)
+func (r *TesseractTests) FromPdfDpiSetsRasterResolution(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:847:1)
 	if r.fromPdfDpiSetsRasterResolution != nil {
 		return nil
 	}
@@ -440,7 +538,7 @@ func (r *TesseractTests) FromPdfDpiSetsRasterResolution(ctx context.Context) err
 // Each format is therefore checked for its own per-page structure rather than
 // for mere existence: three page elements, three page numbers, three PDF
 // pages. A renderer that kept only one page would still produce a file.
-func (r *TesseractTests) FromPdfExportRendersEveryFormatAsOneDocument(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:889:1)
+func (r *TesseractTests) FromPdfExportRendersEveryFormatAsOneDocument(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:897:1)
 	if r.fromPdfExportRendersEveryFormatAsOneDocument != nil {
 		return nil
 	}
@@ -457,7 +555,7 @@ func (r *TesseractTests) FromPdfExportRendersEveryFormatAsOneDocument(ctx contex
 // writes one file per page and the recognition pass reads them from a list, so
 // a sorting bug — page-10 before page-2, say — would still produce text for
 // every page and still look like a success.
-func (r *TesseractTests) FromPdfRecognizesEveryPageInOrder(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:823:1)
+func (r *TesseractTests) FromPdfRecognizesEveryPageInOrder(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:831:1)
 	if r.fromPdfRecognizesEveryPageInOrder != nil {
 		return nil
 	}
@@ -468,7 +566,7 @@ func (r *TesseractTests) FromPdfRecognizesEveryPageInOrder(ctx context.Context) 
 
 // HocrContainsWordBoxes asserts hOCR carries the per-word geometry that is the
 // whole reason to ask for it rather than plain text.
-func (r *TesseractTests) HocrContainsWordBoxes(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:330:1)
+func (r *TesseractTests) HocrContainsWordBoxes(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:338:1)
 	if r.hocrContainsWordBoxes != nil {
 		return nil
 	}
@@ -533,7 +631,7 @@ func (r *TesseractTests) UnmarshalJSON(bs []byte) error {
 // is that no member is dead: LEGACY and LEGACY_LSTM only work because Alpine
 // packages the *combined* tessdata models. A rebuild against tessdata_fast or
 // tessdata_best would strip the legacy data and this is where that shows up.
-func (r *TesseractTests) LstmEngineRecognizesFixture(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:571:1)
+func (r *TesseractTests) LstmEngineRecognizesFixture(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:579:1)
 	if r.lstmEngineRecognizesFixture != nil {
 		return nil
 	}
@@ -550,7 +648,7 @@ func (r *TesseractTests) LstmEngineRecognizesFixture(ctx context.Context) error 
 // it, because that is what a sample is *for*: the file pairs the line's pixels
 // with the characters they are supposed to be, and a sample built against the
 // wrong text trains the model to be wrong without ever failing.
-func (r *TesseractTests) LstmTrainBuildsTrainingSample(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1570:1)
+func (r *TesseractTests) LstmTrainBuildsTrainingSample(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1578:1)
 	if r.lstmTrainBuildsTrainingSample != nil {
 		return nil
 	}
@@ -562,7 +660,7 @@ func (r *TesseractTests) LstmTrainBuildsTrainingSample(ctx context.Context) erro
 // MalformedParameterNameIsRejected asserts an empty parameter name, and one
 // carrying its own `=`, are refused. `-c` takes `name=value`, so an embedded
 // `=` would quietly set a different variable to a different value.
-func (r *TesseractTests) MalformedParameterNameIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:767:1)
+func (r *TesseractTests) MalformedParameterNameIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:775:1)
 	if r.malformedParameterNameIsRejected != nil {
 		return nil
 	}
@@ -574,7 +672,7 @@ func (r *TesseractTests) MalformedParameterNameIsRejected(ctx context.Context) e
 // NonPositiveDpiIsRejected asserts a zero or negative resolution is refused
 // rather than handed to tesseract, which would take it as a real measurement
 // and scale its analysis by it.
-func (r *TesseractTests) NonPositiveDpiIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:793:1)
+func (r *TesseractTests) NonPositiveDpiIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:801:1)
 	if r.nonPositiveDpiIsRejected != nil {
 		return nil
 	}
@@ -593,7 +691,7 @@ func (r *TesseractTests) NonPositiveDpiIsRejected(ctx context.Context) error { /
 // works at all: without it, anything running several recognitions at once has
 // no way to stop each pass claiming every core, which cost this very suite
 // nine minutes on a four-core runner (#226).
-func (r *TesseractTests) OmpThreadLimitBoundsOpenMp(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:267:1)
+func (r *TesseractTests) OmpThreadLimitBoundsOpenMp(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:275:1)
 	if r.ompThreadLimitBoundsOpenMp != nil {
 		return nil
 	}
@@ -605,7 +703,7 @@ func (r *TesseractTests) OmpThreadLimitBoundsOpenMp(ctx context.Context) error {
 // OsdDetectsRotation asserts orientation detection reads the quarter-turn in
 // the rotated fixture and reports the rotation that would undo it, while the
 // upright fixture reports no rotation at all.
-func (r *TesseractTests) OsdDetectsRotation(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:650:1)
+func (r *TesseractTests) OsdDetectsRotation(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:658:1)
 	if r.osdDetectsRotation != nil {
 		return nil
 	}
@@ -617,7 +715,7 @@ func (r *TesseractTests) OsdDetectsRotation(ctx context.Context) error { // tess
 // OsdWithoutOsdDataIsRejected asserts orientation detection on an image built
 // without the osd model names the fix rather than failing inside tesseract,
 // which would report a missing traineddata file.
-func (r *TesseractTests) OsdWithoutOsdDataIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:731:1)
+func (r *TesseractTests) OsdWithoutOsdDataIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:739:1)
 	if r.osdWithoutOsdDataIsRejected != nil {
 		return nil
 	}
@@ -629,7 +727,7 @@ func (r *TesseractTests) OsdWithoutOsdDataIsRejected(ctx context.Context) error 
 // PdfHasPdfMagic asserts the searchable-PDF renderer emits a real PDF. The
 // bytes go through the filesystem rather than File.Contents, which mangles
 // non-UTF-8 data.
-func (r *TesseractTests) PdfHasPdfMagic(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:406:1)
+func (r *TesseractTests) PdfHasPdfMagic(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:414:1)
 	if r.pdfHasPdfMagic != nil {
 		return nil
 	}
@@ -645,7 +743,7 @@ func (r *TesseractTests) PdfHasPdfMagic(ctx context.Context) error { // tesserac
 // The error has to name FromPdf, which is the whole difference between an
 // error that ends the caller's afternoon and one that ends their next line of
 // code: rasterizing is no longer something they have to go and arrange.
-func (r *TesseractTests) PdfInputIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:751:1)
+func (r *TesseractTests) PdfInputIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:759:1)
 	if r.pdfInputIsRejected != nil {
 		return nil
 	}
@@ -658,7 +756,7 @@ func (r *TesseractTests) PdfInputIsRejected(ctx context.Context) error { // tess
 // recognised comes back, and that it is the processed one rather than the
 // source: the fixture goes in as a PNG and this comes out as a TIFF, which is
 // the observable half of "this is a derivative, not your file".
-func (r *TesseractTests) ProcessedImagesReturnsThresholdedTiff(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1550:1)
+func (r *TesseractTests) ProcessedImagesReturnsThresholdedTiff(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1558:1)
 	if r.processedImagesReturnsThresholdedTiff != nil {
 		return nil
 	}
@@ -670,7 +768,7 @@ func (r *TesseractTests) ProcessedImagesReturnsThresholdedTiff(ctx context.Conte
 // RequestedLanguagesAreInstalled asserts every requested language lands in the
 // image as its own apk package, including "osd", which is a detection model
 // rather than a recognition language.
-func (r *TesseractTests) RequestedLanguagesAreInstalled(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:244:1)
+func (r *TesseractTests) RequestedLanguagesAreInstalled(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:252:1)
 	if r.requestedLanguagesAreInstalled != nil {
 		return nil
 	}
@@ -684,7 +782,7 @@ func (r *TesseractTests) RequestedLanguagesAreInstalled(ctx context.Context) err
 // that finds the lines, so it returns far less than the default mode does —
 // which is the observable proof the flag was passed, without asserting on
 // whatever garbage the constrained mode happens to produce.
-func (r *TesseractTests) SingleWordPageSegReturnsFewerWords(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:545:1)
+func (r *TesseractTests) SingleWordPageSegReturnsFewerWords(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:553:1)
 	if r.singleWordPageSegReturnsFewerWords != nil {
 		return nil
 	}
@@ -697,7 +795,7 @@ func (r *TesseractTests) SingleWordPageSegReturnsFewerWords(ctx context.Context)
 // mounting a tessdata directory adds the models it holds and nothing else, so a
 // language neither half carries is rejected the same way it was before, with
 // both halves listed and both ways of adding one named.
-func (r *TesseractTests) TessdataDoesNotAdmitUnknownLanguage(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:711:1)
+func (r *TesseractTests) TessdataDoesNotAdmitUnknownLanguage(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:719:1)
 	if r.tessdataDoesNotAdmitUnknownLanguage != nil {
 		return nil
 	}
@@ -723,7 +821,7 @@ func (r *TesseractTests) TessdataDoesNotAdmitUnknownLanguage(ctx context.Context
 // configfiles, and pdf.ttf is what the PDF renderer draws its invisible text
 // layer with. Pointed at the caller's directory alone, every renderer breaks
 // and every packaged language disappears.
-func (r *TesseractTests) TessdataModelIsSelectable(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:477:1)
+func (r *TesseractTests) TessdataModelIsSelectable(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:485:1)
 	if r.tessdataModelIsSelectable != nil {
 		return nil
 	}
@@ -739,7 +837,7 @@ func (r *TesseractTests) TessdataModelIsSelectable(ctx context.Context) error { 
 // answered from the requested package set alone. A supplied osd.traineddata
 // would have been refused by this module while sitting right there in the
 // image, which is the failure mode this pins.
-func (r *TesseractTests) TessdataSuppliesOsdModel(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:523:1)
+func (r *TesseractTests) TessdataSuppliesOsdModel(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:531:1)
 	if r.tessdataSuppliesOsdModel != nil {
 		return nil
 	}
@@ -750,7 +848,7 @@ func (r *TesseractTests) TessdataSuppliesOsdModel(ctx context.Context) error { /
 
 // TextRecognizesFixture asserts the shortest path — image in, string out —
 // reproduces every line the fixture renders.
-func (r *TesseractTests) TextRecognizesFixture(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:301:1)
+func (r *TesseractTests) TextRecognizesFixture(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:309:1)
 	if r.textRecognizesFixture != nil {
 		return nil
 	}
@@ -768,7 +866,7 @@ func (r *TesseractTests) TextRecognizesFixture(ctx context.Context) error { // t
 // off-by-one ones: the run stops one image short, or one transcription is
 // saved under the wrong stem. "Something is unpaired" sends the caller to diff
 // two file listings; "line-3.png has no ground truth" does not.
-func (r *TesseractTests) TrainingPairsImagesWithGroundTruth(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1624:1)
+func (r *TesseractTests) TrainingPairsImagesWithGroundTruth(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1632:1)
 	if r.trainingPairsImagesWithGroundTruth != nil {
 		return nil
 	}
@@ -791,7 +889,7 @@ func (r *TesseractTests) TrainingPairsImagesWithGroundTruth(ctx context.Context)
 // what that default is for is precisely this: a bound low enough that a
 // training run belongs in a test suite. If it ever stops being, this test is
 // where that shows up.
-func (r *TesseractTests) TrainingProducesUsableModel(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1780:1)
+func (r *TesseractTests) TrainingProducesUsableModel(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1788:1)
 	if r.trainingProducesUsableModel != nil {
 		return nil
 	}
@@ -806,7 +904,7 @@ func (r *TesseractTests) TrainingProducesUsableModel(ctx context.Context) error 
 // A training run is the most expensive thing this module does, so the cost of
 // finding out late is not a slow error message — it is minutes of a machine
 // arriving at a failure that was visible from the outside the whole time.
-func (r *TesseractTests) TrainingRejectsUnusableInput(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1684:1)
+func (r *TesseractTests) TrainingRejectsUnusableInput(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1692:1)
 	if r.trainingRejectsUnusableInput != nil {
 		return nil
 	}
@@ -824,7 +922,7 @@ func (r *TesseractTests) TrainingRejectsUnusableInput(ctx context.Context) error
 // loads, recognises, and lists as a language like any other — and lstmtraining
 // says only "eng.lstm is an integer (fast) model", which names neither the
 // float models nor how to get one onto the image.
-func (r *TesseractTests) TrainingRequiresFloatBaseModel(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1749:1)
+func (r *TesseractTests) TrainingRequiresFloatBaseModel(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1757:1)
 	if r.trainingRequiresFloatBaseModel != nil {
 		return nil
 	}
@@ -836,7 +934,7 @@ func (r *TesseractTests) TrainingRequiresFloatBaseModel(ctx context.Context) err
 // TsvHasHeaderAndWordRows asserts the TSV renderer emits its column header and
 // descends all the way to word-level rows (level 5), which is the level
 // carrying the text and its confidence.
-func (r *TesseractTests) TsvHasHeaderAndWordRows(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:372:1)
+func (r *TesseractTests) TsvHasHeaderAndWordRows(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:380:1)
 	if r.tsvHasHeaderAndWordRows != nil {
 		return nil
 	}
@@ -847,7 +945,7 @@ func (r *TesseractTests) TsvHasHeaderAndWordRows(ctx context.Context) error { //
 
 // TxtFileMatchesText asserts the txt renderer and the stdout path agree, so
 // choosing a file over a string is purely a plumbing decision.
-func (r *TesseractTests) TxtFileMatchesText(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:311:1)
+func (r *TesseractTests) TxtFileMatchesText(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:319:1)
 	if r.txtFileMatchesText != nil {
 		return nil
 	}
@@ -860,7 +958,7 @@ func (r *TesseractTests) TxtFileMatchesText(ctx context.Context) error { // tess
 // rejected with the installed set named. tesseract's own failure talks about
 // traineddata paths and TESSDATA_PREFIX, which says nothing about the fact
 // that languages are chosen on New.
-func (r *TesseractTests) UnknownLanguageIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:679:1)
+func (r *TesseractTests) UnknownLanguageIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:687:1)
 	if r.unknownLanguageIsRejected != nil {
 		return nil
 	}
@@ -876,11 +974,33 @@ func (r *TesseractTests) UnknownLanguageIsRejected(ctx context.Context) error { 
 // and exits 0, so a typo would otherwise be indistinguishable from a setting
 // that simply had no effect. The same test pins the other half: a real
 // parameter still goes through, so the check is not just rejecting everything.
-func (r *TesseractTests) UnknownParameterFails(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:597:1)
+func (r *TesseractTests) UnknownParameterFails(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:605:1)
 	if r.unknownParameterFails != nil {
 		return nil
 	}
 	q := r.query.Select("unknownParameterFails")
+
+	return q.Execute(ctx)
+}
+
+// UntrustedIndexIsRejectedWithoutApkKey asserts a repository whose index is
+// signed by a key the image does not trust is refused rather than installed
+// from, so WithApkKey is doing verification and not decoration. It is also
+// what says `--allow-untrusted` is genuinely not on offer: a module that
+// quietly installed from an unverifiable index would make the air-gapped path
+// the least trustworthy one.
+//
+// The same mirror is installed from twice, with the key and without it, so the
+// key is the only difference between the two outcomes. Asserting only that the
+// second fails would be satisfied by a mirror that was broken outright — and
+// asserting on apk's own wording (it says `UNTRUSTED signature`) is not
+// available: an exec failure crosses the module boundary as its exit status,
+// with the output left in the logs.
+func (r *TesseractTests) UntrustedIndexIsRejectedWithoutApkKey(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/apk.go:318:1)
+	if r.untrustedIndexIsRejectedWithoutApkKey != nil {
+		return nil
+	}
+	q := r.query.Select("untrustedIndexIsRejectedWithoutApkKey")
 
 	return q.Execute(ctx)
 }
@@ -894,7 +1014,7 @@ func (r *TesseractTests) UnknownParameterFails(ctx context.Context) error { // t
 // a dictionary hint on an already-clean fixture is not reliably observable.
 // What this does catch is a wrong mount path or a flag emitted in the wrong
 // position, either of which turns the whole run into a usage error.
-func (r *TesseractTests) UserWordsFileIsAccepted(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:633:1)
+func (r *TesseractTests) UserWordsFileIsAccepted(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:641:1)
 	if r.userWordsFileIsAccepted != nil {
 		return nil
 	}
@@ -906,7 +1026,7 @@ func (r *TesseractTests) UserWordsFileIsAccepted(ctx context.Context) error { //
 // VersionReportsTesseractFive asserts the assembled image ships the tesseract
 // release Alpine's community repository carries, so a base-tag bump that
 // silently changes major version fails here rather than in recognition.
-func (r *TesseractTests) VersionReportsTesseractFive(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:215:1)
+func (r *TesseractTests) VersionReportsTesseractFive(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:223:1)
 	if r.versionReportsTesseractFive != nil {
 		return nil
 	}

--- a/daggerverse/tesseract/README.md
+++ b/daggerverse/tesseract/README.md
@@ -15,10 +15,13 @@ and every image on Docker Hub is third-party. So this module assembles its own
 the way `qemu` does rather than pinning a vendor image the way `kicad` does: a
 module-pinned Alpine (`3.24`, whose community repository carries tesseract-ocr
 5.5.2) plus `apk add tesseract-ocr` and one `tesseract-ocr-data-<lang>` package
-per requested language. Only the `registry` prefix is caller-overridable, for
-air-gapped mirrors.
+per requested language. Assembling an image that way is **two** fetches, not
+one: `registry` overrides where the *image* comes from, and `WithApkRepository`
+overrides where the *packages* installed onto it come from — see
+[Air-gapped installs](#air-gapped-installs--withapkrepository-withapkkey-withapkauth).
 
-Nothing here handles secrets and nothing opens a port.
+Nothing here opens a port. The one secret it handles is `WithApkAuth`, the
+credential for a package repository that requires one.
 
 ## Languages live on the root object
 
@@ -37,7 +40,7 @@ orientation-and-script-detection model, and `Document.Osd` needs it.
 ```go
 dag.Tesseract()                                                     // eng
 dag.Tesseract(dagger.TesseractOpts{Languages: []string{"eng","deu","osd"}})
-dag.Tesseract(dagger.TesseractOpts{Registry: "ghcr.io"})            // mirror
+dag.Tesseract(dagger.TesseractOpts{Registry: "ghcr.io"})            // image only
 ```
 
 ## Models Alpine has no package for — `WithTessdata`
@@ -72,6 +75,68 @@ fine-tuned one work.
 The merge is mounted, not copied — a model set runs 20MB and up, and there is no
 reason for it to become an image layer. Nothing changes for an image without
 tessdata: the flag is omitted entirely rather than pointed at the packaged path.
+
+## Air-gapped installs — `WithApkRepository`, `WithApkKey`, `WithApkAuth`
+
+```go
+Tesseract.WithApkRepository(url string) *Tesseract            // /etc/apk/repositories
+Tesseract.WithApkKey(key *dagger.File) *Tesseract             // /etc/apk/keys/<name>
+Tesseract.WithApkAuth(credentials *dagger.Secret) *Tesseract  // $NETRC
+```
+
+`registry` moves the container image. These move the packages installed onto it,
+and on a network that cannot reach `dl-cdn.alpinelinux.org` you need both:
+mirroring Alpine into a private registry and stopping there buys a container
+that fails on its very first `apk add` — or, where the CDN is blackholed rather
+than refused, hangs until it times out.
+
+```go
+dag.Tesseract(dagger.TesseractOpts{Registry: "registry.corp"}).
+    WithApkRepository("https://mirror.corp/alpine/v3.24/main").
+    WithApkRepository("https://mirror.corp/alpine/v3.24/community").
+    WithApkKey(host.File("./mirror.rsa.pub")).
+    WithApkAuth(netrc)
+```
+
+**The first call replaces the image's list rather than appending to it.**
+Repeatable after that, in preference order. Appending would be the friendlier
+default everywhere except the case the option exists for, where a surviving
+default is a repository apk still consults and still waits on. An empty URL is
+dropped rather than written, the same way an empty language code is.
+
+**A repository index is signed, and apk refuses one it cannot verify** — so a
+private mirror needs `WithApkKey` as well, and `--allow-untrusted` is
+deliberately not offered. The key file keeps its own name in `/etc/apk/keys`,
+because the name is load-bearing: an index's signature names the key file it was
+made with and apk looks that exact name up. That is why the option takes a
+`*dagger.File` rather than the key's bytes — and why it is a File and not a
+Secret, a public key being meant to be in the image.
+
+**Credentials are a `*dagger.Secret` holding a netrc file**, mounted at
+`/run/apk/netrc` with `$NETRC` pointing at it:
+
+```
+machine mirror.corp login CI_USER password CI_TOKEN
+```
+
+Alpine 3.24 ships apk-tools 3.0, whose built-in libfetch reads credentials from
+that file when a repository answers `401`, and from nowhere else that keeps them
+out of sight — userinfo in the repository URL would land in
+`/etc/apk/repositories` and in every apk error quoting it, and `HTTP_AUTH` would
+land in the image's environment. Mounted rather than written, so the credentials
+are not a layer either: nothing reaches the cache key, the argv, the environment
+or the filesystem a caller exports. Hosts are matched by name only, so one
+stanza covers a mirror on any port.
+
+**Both `apk add` this module performs are covered** — the toolchain's, and the
+PDF rasterizer's `poppler-utils` + `ttf-liberation`. They are separate
+containers on purpose (see [Why a separate container](#why-a-separate-container)),
+so they are two places the configuration has to reach; covering only the first
+would leave `FromPdf` broken in exactly the environment this option exists for.
+
+Set none of them and nothing changes. The repositories file, the keys directory
+and the environment are the image's own, so an existing caller sees no cache-key
+churn from a feature it is not using.
 
 ## OpenMP fan-out — `ompThreadLimit`
 
@@ -615,7 +680,10 @@ a floating Alpine tag can resolve differently across sessions.
 
 ## Follow-ups
 
-An `examples/go` cookbook (#224); evaluation against a held-out set (#231).
+An `examples/go` cookbook (#224); evaluation against a held-out set (#231);
+authenticating to a private *container* registry for the mirrored Alpine image
+(#235), which the apk options above deliberately do not cover — they configure
+the package fetch, not the image pull.
 
 The chained `Ci` builder (#223) and the training toolchain (#222) both landed —
 see above. `Ci` deliberately exposes only `WithLanguage` of the seven recognition

--- a/daggerverse/tesseract/dagger.gen.go
+++ b/daggerverse/tesseract/dagger.gen.go
@@ -61,27 +61,36 @@ func convertSlice[I any, O any](in []I, f func(I) O) []O {
 
 func (r Tesseract) MarshalJSON() ([]byte, error) {
 	var concrete struct {
-		Registry       string
-		AlpineTag      string
-		Languages      []string
-		OmpThreadLimit int
-		Tessdata       *dagger.Directory
+		Registry        string
+		AlpineTag       string
+		Languages       []string
+		OmpThreadLimit  int
+		Tessdata        *dagger.Directory
+		ApkRepositories []string
+		ApkKeys         []*dagger.File
+		ApkAuth         *dagger.Secret
 	}
 	concrete.Registry = r.Registry
 	concrete.AlpineTag = r.AlpineTag
 	concrete.Languages = r.Languages
 	concrete.OmpThreadLimit = r.OmpThreadLimit
 	concrete.Tessdata = r.Tessdata
+	concrete.ApkRepositories = r.ApkRepositories
+	concrete.ApkKeys = r.ApkKeys
+	concrete.ApkAuth = r.ApkAuth
 	return json.Marshal(&concrete)
 }
 
 func (r *Tesseract) UnmarshalJSON(bs []byte) error {
 	var concrete struct {
-		Registry       string
-		AlpineTag      string
-		Languages      []string
-		OmpThreadLimit int
-		Tessdata       *dagger.Directory
+		Registry        string
+		AlpineTag       string
+		Languages       []string
+		OmpThreadLimit  int
+		Tessdata        *dagger.Directory
+		ApkRepositories []string
+		ApkKeys         []*dagger.File
+		ApkAuth         *dagger.Secret
 	}
 	err := json.Unmarshal(bs, &concrete)
 	if err != nil {
@@ -92,6 +101,9 @@ func (r *Tesseract) UnmarshalJSON(bs []byte) error {
 	r.Languages = concrete.Languages
 	r.OmpThreadLimit = concrete.OmpThreadLimit
 	r.Tessdata = concrete.Tessdata
+	r.ApkRepositories = concrete.ApkRepositories
+	r.ApkKeys = concrete.ApkKeys
+	r.ApkAuth = concrete.ApkAuth
 	return nil
 }
 
@@ -1071,6 +1083,48 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return (*Tesseract).Version(&parent, ctx)
+		case "WithApkAuth":
+			var parent Tesseract
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var credentials *dagger.Secret
+			if inputArgs["credentials"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["credentials"]), &credentials)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg credentials", err))
+				}
+			}
+			return (*Tesseract).WithApkAuth(&parent, credentials), nil
+		case "WithApkKey":
+			var parent Tesseract
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var key *dagger.File
+			if inputArgs["key"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["key"]), &key)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg key", err))
+				}
+			}
+			return (*Tesseract).WithApkKey(&parent, key), nil
+		case "WithApkRepository":
+			var parent Tesseract
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var url string
+			if inputArgs["url"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["url"]), &url)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg url", err))
+				}
+			}
+			return (*Tesseract).WithApkRepository(&parent, url), nil
 		case "WithTessdata":
 			var parent Tesseract
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/tesseract/main.go
+++ b/daggerverse/tesseract/main.go
@@ -6,8 +6,15 @@
 //
 // There is no official Tesseract container image — upstream ships source only
 // — so this module assembles its own the way the qemu module does: a
-// module-pinned Alpine plus `apk add tesseract-ocr`, with only the registry
-// prefix caller-overridable for air-gapped mirrors.
+// module-pinned Alpine plus `apk add tesseract-ocr`.
+//
+// Assembling the image means two fetches, not one, and a network that cannot
+// reach the public internet has to be told about both. New's registry argument
+// moves the *image*; WithApkRepository, WithApkKey and WithApkAuth move the
+// *packages*, and are what an air-gapped run needs — a mirrored Alpine image
+// still runs `apk add` against dl-cdn.alpinelinux.org otherwise. Both `apk add`
+// this module performs, the toolchain's and the PDF rasterizer's, are
+// configured from the one place.
 //
 // The language set lives on the root object rather than on Document because on
 // Alpine each language is a separate apk package (`tesseract-ocr-data-<lang>`,
@@ -58,8 +65,10 @@ import (
 
 const (
 	// alpineImagePath is the repository under the configured registry. Only
-	// the registry prefix is caller-overridable (air-gapped mirrors); the
-	// path is fixed so every recognition runs on a known toolchain.
+	// the registry prefix is caller-overridable, for an image mirrored into a
+	// private registry; the path is fixed so every recognition runs on a known
+	// toolchain. Where the packages come from is a separate question, answered
+	// by WithApkRepository.
 	alpineImagePath = "library/alpine"
 	defaultRegistry = "docker.io"
 
@@ -173,6 +182,29 @@ const (
 	// thresholding and deskewing.
 	processedImagesExt = ".processed.tif"
 
+	// apkRepositoriesFile is the list `apk add` resolves packages from.
+	// WithApkRepository overwrites it rather than appending to it, so a caller
+	// who names a mirror gets an image that cannot quietly fall back to the
+	// CDN the mirror exists to replace.
+	apkRepositoriesFile = "/etc/apk/repositories"
+
+	// apkKeysDir is where apk looks up the public key an index's signature
+	// names. A repository whose key is not here is untrusted, and apk refuses
+	// its index rather than installing from it — which is why a private
+	// mirror needs WithApkKey and not just WithApkRepository.
+	apkKeysDir = "/etc/apk/keys"
+
+	// apkNetrcPath is where WithApkAuth's credentials are mounted and
+	// apkNetrcEnv the variable pointing apk at them. Alpine 3.24 ships
+	// apk-tools 3.0, whose built-in libfetch reads HTTP credentials from the
+	// netrc file `$NETRC` names and from nowhere else that keeps them out of
+	// sight: userinfo in the repository URL would land in the repositories
+	// file and in every error message quoting it, and HTTP_AUTH would land in
+	// the image's environment. The file is mounted rather than written so it
+	// is not a layer either.
+	apkNetrcPath = "/run/apk/netrc"
+	apkNetrcEnv  = "NETRC"
+
 	// popplerPkg carries pdftoppm, the rasterizer FromPdf drives. fontPkg is
 	// the substitute font family poppler draws with when a PDF names one of
 	// the base-14 fonts without embedding it; see rasterize for why it is not
@@ -230,12 +262,20 @@ type Tesseract struct {
 	OmpThreadLimit int
 	// +private
 	Tessdata *dagger.Directory
+	// +private
+	ApkRepositories []string
+	// +private
+	ApkKeys []*dagger.File
+	// +private
+	ApkAuth *dagger.Secret
 }
 
 // New returns a Tesseract module backed by <registry>/library/alpine:<tag>
 // with tesseract-ocr and one language package per requested language.
 func New(
-	// Container registry hosting the alpine image.
+	// Container registry hosting the alpine image. This moves the image only:
+	// see WithApkRepository for where the packages installed onto it are
+	// fetched from.
 	// +default="docker.io"
 	registry string,
 	// Tag of the alpine image the toolchain is assembled on.
@@ -294,9 +334,89 @@ func (t *Tesseract) WithTessdata(
 	// Directory of `.traineddata` models to make available to recognition.
 	dir *dagger.Directory,
 ) *Tesseract {
-	out := *t
+	out := t.clone()
 	out.Tessdata = dir
-	return &out
+	return out
+}
+
+// WithApkRepository points package installation at an Alpine repository other
+// than the one the base image ships, which is what makes this module work on a
+// network that cannot reach dl-cdn.alpinelinux.org.
+//
+// New's registry argument is not enough on its own and never was: it moves the
+// *image*, and the packages are still fetched by `apk add` from whatever
+// /etc/apk/repositories carries — so mirroring Alpine into a private registry
+// buys a container that then fails on its first `apk add`, or, where the CDN is
+// blackholed rather than refused, hangs until it times out.
+//
+// Repeatable, in preference order. The first call replaces the image's list
+// rather than appending to it, because the air-gapped case needs the
+// unreachable defaults gone rather than merely deprioritized: a repository apk
+// still consults is a repository apk still waits for.
+//
+// The URL is the repository base, spelled the way it would be spelled in
+// /etc/apk/repositories — `https://mirror.example.com/alpine/v3.24/main`, one
+// call per component. A repository's index is signed, so pair this with
+// WithApkKey unless the mirror is signed by a key the base image already
+// trusts.
+func (t *Tesseract) WithApkRepository(
+	// Base URL of an Alpine repository to resolve packages from.
+	url string,
+) *Tesseract {
+	url = strings.TrimSpace(url)
+	if url == "" {
+		return t
+	}
+	out := t.clone()
+	if !contains(out.ApkRepositories, url) {
+		out.ApkRepositories = append(out.ApkRepositories, url)
+	}
+	return out
+}
+
+// WithApkKey trusts a repository's signing key by dropping it into
+// /etc/apk/keys, which is the other half of WithApkRepository: a private
+// mirror's index is signed by a key the stock Alpine image has never heard of,
+// and apk refuses an index it cannot verify rather than installing from it.
+//
+// The file keeps its own name, because the name is load-bearing — an index
+// signature names the key file it was made with, and apk looks that exact file
+// up in the keys directory. A key exported from `abuild-keygen` is already
+// named correctly; renaming it renames the key.
+//
+// Repeatable, for a mirror set signed by more than one key. It is a *File
+// rather than a *Secret because a public key is not a credential: it is meant
+// to be in the image, and WithApkAuth is the option for the part that is not.
+func (t *Tesseract) WithApkKey(
+	// Public key file trusting a repository's index signature.
+	key *dagger.File,
+) *Tesseract {
+	out := t.clone()
+	out.ApkKeys = append(out.ApkKeys, key)
+	return out
+}
+
+// WithApkAuth supplies credentials for a repository that requires them.
+//
+// The secret's contents are a netrc file — `machine mirror.example.com login
+// USER password PASS`, one stanza per host — which is what apk-tools 3's
+// built-in libfetch reads when a repository answers 401. Alpine 3.24 ships
+// apk-tools 3.0; see NETRC in `apk(8)`. Hosts are matched by name only, so a
+// stanza covers a mirror on any port.
+//
+// It is a *dagger.Secret rather than a string, and is mounted rather than
+// written, so the credentials stay out of the cache key, out of argv, out of
+// the image's environment and out of any layer a caller exports. That is also
+// why the credentials are not simply userinfo in the WithApkRepository URL,
+// which would put them in /etc/apk/repositories and in every apk error message
+// that quotes it.
+func (t *Tesseract) WithApkAuth(
+	// netrc-formatted credentials for the configured repositories.
+	credentials *dagger.Secret,
+) *Tesseract {
+	out := t.clone()
+	out.ApkAuth = credentials
+	return out
 }
 
 // Container returns the assembled toolchain image. This is the escape hatch
@@ -313,9 +433,7 @@ func (t *Tesseract) Container() *dagger.Container {
 	for _, lang := range t.Languages {
 		args = append(args, langPkgPrefix+lang)
 	}
-	ctr := dag.Container().
-		From(t.image()).
-		WithExec(args)
+	ctr := t.base().WithExec(args)
 	// Merged after the install because the packaged half of the union is
 	// whatever apk just wrote, and mounted rather than copied so a 20MB-plus
 	// model set does not become a layer per image.
@@ -420,6 +538,47 @@ func (t *Tesseract) Training(source *dagger.Directory) *Training {
 
 func (t *Tesseract) image() string {
 	return fmt.Sprintf("%s/%s:%s", t.Registry, alpineImagePath, t.AlpineTag)
+}
+
+// clone copies the module's configuration for a builder method, deep enough
+// that the copy's slices are its own: a builder that appended in place would
+// let a second call off the same value overwrite the first one's addition.
+func (t *Tesseract) clone() *Tesseract {
+	out := *t
+	out.Languages = append([]string(nil), t.Languages...)
+	out.ApkRepositories = append([]string(nil), t.ApkRepositories...)
+	out.ApkKeys = append([]*dagger.File(nil), t.ApkKeys...)
+	return &out
+}
+
+// base is the module's Alpine image with package installation configured, and
+// is what every `apk add` in this module starts from — the toolchain's here,
+// the rasterizer's in pdf.go — so the two cannot drift into fetching packages
+// from different places.
+func (t *Tesseract) base() *dagger.Container {
+	return t.withApkConfig(dag.Container().From(t.image()))
+}
+
+// withApkConfig applies the caller's repositories, keys and credentials to a
+// container, immediately before the `apk add` that reads them.
+//
+// Each half is applied only when it was asked for. That is not tidiness: with
+// none of the options set the container is byte-identical to the one this
+// module assembled before they existed, so an existing caller sees no
+// cache-key churn from a feature they are not using.
+func (t *Tesseract) withApkConfig(ctr *dagger.Container) *dagger.Container {
+	if len(t.ApkRepositories) > 0 {
+		ctr = ctr.WithNewFile(apkRepositoriesFile, strings.Join(t.ApkRepositories, "\n")+"\n")
+	}
+	if len(t.ApkKeys) > 0 {
+		ctr = ctr.WithFiles(apkKeysDir, t.ApkKeys)
+	}
+	if t.ApkAuth != nil {
+		ctr = ctr.
+			WithMountedSecret(apkNetrcPath, t.ApkAuth).
+			WithEnvVariable(apkNetrcEnv, apkNetrcPath)
+	}
+	return ctr
 }
 
 // datadir is the directory the image's models actually live in: the merged one

--- a/daggerverse/tesseract/pdf.go
+++ b/daggerverse/tesseract/pdf.go
@@ -80,8 +80,7 @@ func (t *Tesseract) FromPdf(
 // being metric-compatible with Helvetica, Times and Courier, so substituted
 // text keeps the line breaks and positions the document was written with.
 func (t *Tesseract) rasterize(source *dagger.File, dpi int) *dagger.Directory {
-	return dag.Container().
-		From(t.image()).
+	return t.base().
 		WithExec([]string{"apk", "add", "--no-cache", popplerPkg, fontPkg}).
 		WithMountedFile(pdfSourcePath, source).
 		WithExec([]string{"sh", "-c", rasterizeScript, rasterizeArgv0, strconv.Itoa(dpi)}).

--- a/daggerverse/tesseract/tests/apk.go
+++ b/daggerverse/tesseract/tests/apk.go
@@ -1,0 +1,435 @@
+package main
+
+// apk.go covers the air-gapped story: installing the module's packages from an
+// Alpine repository the caller controls rather than from dl-cdn.alpinelinux.org.
+//
+// The repository the tests install from is a real one — a real package set, a
+// real signed index, served over real HTTP by a Dagger service — because every
+// part of what these tests are about lives in apk rather than in this module:
+// whether a replaced /etc/apk/repositories is honoured, whether an index signed
+// by an unknown key is refused, whether credentials reach the fetch. Asserting
+// on the flags the module passes would test none of it.
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"dagger/tests/internal/dagger"
+)
+
+const (
+	// mirrorImage is what the mirror is built and served on: the same Alpine
+	// release the module pins, so the packages the mirror carries are exactly
+	// the packages the module would otherwise have fetched from the CDN.
+	mirrorImage = "docker.io/library/alpine:3.24"
+
+	// mirrorPackages is what the mirror has to carry to stand in for the
+	// public repositories completely — the toolchain's packages *and* the PDF
+	// rasterizer's, because a mirror that covers only the first leaves FromPdf
+	// broken in exactly the environment it exists for.
+	mirrorPackages = tesseractPkg + " " + tesseractDataPkg + " " + popplerPkg + " " + fontPkg
+
+	tesseractPkg     = "tesseract-ocr"
+	tesseractDataPkg = "tesseract-ocr-data-eng"
+	popplerPkg       = "poppler-utils"
+	fontPkg          = "ttf-liberation"
+
+	// mirrorBuildDir is the repository tree the build container assembles —
+	// one architecture directory holding the packages and the signed index —
+	// and mirrorKeyDir the keypair it signs with.
+	mirrorBuildDir = "/mirror"
+	mirrorKeyDir   = "/keys"
+
+	// mirrorKeyName is the file name of the key the index is signed with, and
+	// it is load-bearing at both ends: abuild-sign writes the name into the
+	// index's signature and apk looks that exact file up in /etc/apk/keys. It
+	// is what WithApkKey has to preserve, and the reason that option takes a
+	// file rather than the key's bytes.
+	mirrorKeyName = "tesseract-mirror.rsa.pub"
+	mirrorKeyFile = mirrorKeyDir + "/tesseract-mirror.rsa"
+
+	// mirrorRoot is the served document root and mirrorPath the path under it
+	// the repository sits at. The repository is not at the root of the host on
+	// purpose: a URL whose path is dropped would still resolve, and that is a
+	// bug this suite should catch rather than tolerate.
+	mirrorRoot = "/srv"
+	mirrorPath = "alpine"
+
+	// mirrorPort is where the mirror listens. It is above 1024 so the server
+	// needs no privileges it would not have anyway.
+	mirrorPort = 8080
+
+	// mirrorUser is the account the authenticated mirror requires. Its
+	// password is generated per run rather than written down here.
+	mirrorUser = "tesseract"
+
+	// httpdPkg is the server the mirror is published with. Alpine's busybox
+	// carries no httpd applet, and what this needs beyond serving a directory
+	// is one flag's worth of basic authentication — which darkhttpd has and
+	// nginx would want a config file and a password-hashing tool for.
+	httpdPkg = "darkhttpd"
+
+	// apkRepositoriesFile is the list `apk add` resolves packages from, and
+	// therefore the file that says whether the image's defaults survived.
+	apkRepositoriesFile = "/etc/apk/repositories"
+
+	// alpineCdnHost appears in every repository line a stock Alpine image
+	// ships, and in none that WithApkRepository writes.
+	alpineCdnHost = "dl-cdn.alpinelinux.org"
+
+	// apkNetrcEnv is the variable WithApkAuth points at its mounted
+	// credentials, and apkNetrcPath the mount it names. An image built without
+	// that option must carry neither.
+	apkNetrcEnv  = "NETRC"
+	apkNetrcPath = "/run/apk/netrc"
+)
+
+// mirrorBuildScript assembles the private repository.
+//
+// The packages are fetched with their whole dependency closure rather than
+// listed by hand: a mirror missing one transitive library fails the same way a
+// missing repository does, and would make these tests assert on the wrong
+// thing.
+//
+// `--rewrite-arch` is not decoration. apk resolves a package's path as
+// `$base/$arch/$name-$version.apk` using the *package's* architecture, so the
+// `noarch` packages in the closure — the tesseract language data among them —
+// would be looked for under a `noarch/` directory that no mirror has. Alpine's
+// own index generation rewrites them for the same reason; without it, the two
+// largest packages in the set fail to install and everything else succeeds,
+// which is a failure shaped exactly like a flake.
+//
+// The index is signed because an unsigned one is not a lesser mirror, it is an
+// unusable one: apk refuses an index it cannot verify rather than installing
+// from it, and `--allow-untrusted` is deliberately not something this module
+// offers.
+const mirrorBuildScript = `set -e
+arch=$(apk --print-arch)
+apk update
+apk add abuild openssl
+mkdir -p ` + mirrorBuildDir + `/$arch ` + mirrorKeyDir + `
+openssl genrsa -out ` + mirrorKeyFile + ` 2048
+openssl rsa -in ` + mirrorKeyFile + ` -pubout -out ` + mirrorKeyDir + `/` + mirrorKeyName + `
+apk fetch --recursive --output ` + mirrorBuildDir + `/$arch ` + mirrorPackages + `
+cd ` + mirrorBuildDir + `/$arch
+apk index --rewrite-arch $arch --output APKINDEX.tar.gz *.apk
+abuild-sign -k ` + mirrorKeyFile + ` -p ` + mirrorKeyName + ` APKINDEX.tar.gz`
+
+// ------------------------------------------------------------------ the mirror
+
+// apkMirror is a private Alpine repository standing in for the one an
+// air-gapped network would run: a signed package set on a host that is not the
+// CDN, optionally behind credentials.
+type apkMirror struct {
+	// URL is the repository base, spelled the way it would be spelled in
+	// /etc/apk/repositories.
+	URL string
+	// Key is the public half of what the index was signed with, named the way
+	// the signature names it.
+	Key *dagger.File
+	// Auth carries the mirror's credentials in netrc form, and is nil for a
+	// mirror that asks for none.
+	Auth *dagger.Secret
+	// Password is the plaintext inside Auth, kept so a test can go looking for
+	// it in places it must never turn up.
+	Password string
+}
+
+// startApkMirror builds the repository, serves it, and returns what a caller
+// needs to install from it.
+//
+// The service is started here rather than left to the first use: nothing binds
+// it into the module's containers, so it is reached by the hostname the engine
+// gives a running service, and that hostname does not exist until it runs.
+func startApkMirror(ctx context.Context, authenticated bool) (*apkMirror, error) {
+	build, err := mirrorBuild(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	srv := dag.Container().
+		From(mirrorImage).
+		WithExec([]string{"apk", "add", "--no-cache", httpdPkg}).
+		WithDirectory(mirrorRoot+"/"+mirrorPath, build.Directory(mirrorBuildDir)).
+		WithExposedPort(mirrorPort)
+	args := []string{httpdPkg, mirrorRoot, "--port", strconv.Itoa(mirrorPort)}
+
+	var password string
+	if authenticated {
+		if password, err = randomPassword(); err != nil {
+			return nil, err
+		}
+		args = append(args, "--auth", mirrorUser+":"+password)
+	}
+
+	// The server goes in Args rather than in a WithExec: a server does not
+	// exit, so building it as a step would hang before ever becoming a
+	// service.
+	svc := srv.AsService(dagger.ContainerAsServiceOpts{Args: args})
+	if _, err := svc.Start(ctx); err != nil {
+		return nil, fmt.Errorf("start the apk mirror: %w", err)
+	}
+	host, err := svc.Hostname(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("apk mirror hostname: %w", err)
+	}
+
+	mirror := &apkMirror{
+		URL: fmt.Sprintf("http://%s:%d/%s", host, mirrorPort, mirrorPath),
+		Key: build.File(mirrorKeyDir + "/" + mirrorKeyName),
+	}
+	if authenticated {
+		// The stanza names the host and not the port, which is all libfetch
+		// matches on. The secret's name is unique per run because two secrets
+		// sharing a name in one session are one secret, and every
+		// authenticated mirror here has its own password.
+		nonce, err := randomPassword()
+		if err != nil {
+			return nil, err
+		}
+		mirror.Auth = dag.SetSecret(
+			"apk-mirror-netrc-"+nonce,
+			fmt.Sprintf("machine %s login %s password %s\n", host, mirrorUser, password))
+		mirror.Password = password
+	}
+	return mirror, nil
+}
+
+// mirrorBuild returns the container the repository and its keypair are lifted
+// out of.
+//
+// It is resolved to an ID and loaded back before anything is selected off it,
+// because the build generates a keypair: two selections off an unpinned
+// generator are two evaluations, and a repository signed by one key with the
+// other key's public half published beside it is a mirror nothing can install
+// from.
+func mirrorBuild(ctx context.Context) (*dagger.Container, error) {
+	id, err := dag.Container().
+		From(mirrorImage).
+		WithExec([]string{"sh", "-c", mirrorBuildScript}).
+		ID(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("build the apk mirror: %w", err)
+	}
+	return dag.LoadContainerFromID(dagger.ContainerID(id)), nil
+}
+
+// apply points the module at this mirror and at nothing else.
+func (m *apkMirror) apply(t *dagger.Tesseract) *dagger.Tesseract {
+	t = t.WithApkRepository(m.URL).WithApkKey(m.Key)
+	if m.Auth != nil {
+		t = t.WithApkAuth(m.Auth)
+	}
+	return t
+}
+
+// randomPassword returns a credential that exists only for the run that
+// generated it, so no test password is ever committed.
+func randomPassword() (string, error) {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate a mirror password: %w", err)
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+// ------------------------------------------------------------------- the tests
+
+// ApkRepositoryInstallsFromPrivateMirror asserts the toolchain image can be
+// assembled entirely out of a caller-supplied repository, which is the whole
+// point of the option: with the mirror configured, the packages come from it.
+func (t *Tests) ApkRepositoryInstallsFromPrivateMirror(ctx context.Context) error {
+	mirror, err := startApkMirror(ctx, false)
+	if err != nil {
+		return err
+	}
+	got, err := mirror.apply(ocr()).Version(ctx)
+	if err != nil {
+		return fmt.Errorf("Version off a private mirror: %w", err)
+	}
+	if !strings.HasPrefix(got, "5.") {
+		return fmt.Errorf("expected a 5.x tesseract version off the mirror, got %q", got)
+	}
+	return nil
+}
+
+// ApkRepositoryReplacesImageDefaults asserts the first WithApkRepository
+// replaces the image's repository list rather than appending to it.
+//
+// Appending would look identical in every test above — the packages would
+// still install, from the mirror or from the CDN, and nothing would say which.
+// The difference only shows on the network this option exists for, where a
+// surviving default is a repository apk waits on until it times out. So the
+// assertion is on the file, and it is that the CDN is *gone*.
+func (t *Tests) ApkRepositoryReplacesImageDefaults(ctx context.Context) error {
+	mirror, err := startApkMirror(ctx, false)
+	if err != nil {
+		return err
+	}
+	got, err := readRepositories(ctx, mirror.apply(ocr()))
+	if err != nil {
+		return err
+	}
+	if strings.Contains(got, alpineCdnHost) {
+		return fmt.Errorf("expected %s gone from %s, got:\n%s", alpineCdnHost, apkRepositoriesFile, got)
+	}
+	if strings.TrimSpace(got) != mirror.URL {
+		return fmt.Errorf("expected %s to hold only %q, got:\n%s", apkRepositoriesFile, mirror.URL, got)
+	}
+	return nil
+}
+
+// ApkRepositoryAppliesToPdfRasterizer asserts the PDF rasterizer installs its
+// packages from the configured mirror too.
+//
+// It is a separate container from the toolchain — poppler and its font are
+// paid for only by callers who rasterize something — so it is a second place
+// the configuration has to reach, and covering only the first would leave PDF
+// input broken in exactly the environment this option exists for.
+func (t *Tests) ApkRepositoryAppliesToPdfRasterizer(ctx context.Context) error {
+	mirror, err := startApkMirror(ctx, false)
+	if err != nil {
+		return err
+	}
+	got, err := mirror.apply(ocr()).FromPdf(fixture(ledgerPdf)).Text(ctx)
+	if err != nil {
+		return fmt.Errorf("FromPdf off a private mirror: %w", err)
+	}
+	return assertLedgerPages(got)
+}
+
+// UntrustedIndexIsRejectedWithoutApkKey asserts a repository whose index is
+// signed by a key the image does not trust is refused rather than installed
+// from, so WithApkKey is doing verification and not decoration. It is also
+// what says `--allow-untrusted` is genuinely not on offer: a module that
+// quietly installed from an unverifiable index would make the air-gapped path
+// the least trustworthy one.
+//
+// The same mirror is installed from twice, with the key and without it, so the
+// key is the only difference between the two outcomes. Asserting only that the
+// second fails would be satisfied by a mirror that was broken outright — and
+// asserting on apk's own wording (it says `UNTRUSTED signature`) is not
+// available: an exec failure crosses the module boundary as its exit status,
+// with the output left in the logs.
+func (t *Tests) UntrustedIndexIsRejectedWithoutApkKey(ctx context.Context) error {
+	mirror, err := startApkMirror(ctx, false)
+	if err != nil {
+		return err
+	}
+	if _, err := mirror.apply(ocr()).Version(ctx); err != nil {
+		return fmt.Errorf("Version off a mirror whose key was supplied: %w", err)
+	}
+	if _, err := ocr().WithApkRepository(mirror.URL).Version(ctx); err == nil {
+		return fmt.Errorf("expected an index signed by an untrusted key to be refused, got a working image")
+	}
+	return nil
+}
+
+// ApkAuthInstallsFromAuthenticatedRepository asserts credentials reach the
+// fetch, and that they reach it without becoming part of the image.
+//
+// The second half is the reason the option takes a Secret: a mirror password
+// spelled into a repository URL would land in /etc/apk/repositories, in every
+// apk error quoting it, and in the layer a caller exports.
+func (t *Tests) ApkAuthInstallsFromAuthenticatedRepository(ctx context.Context) error {
+	mirror, err := startApkMirror(ctx, true)
+	if err != nil {
+		return err
+	}
+	ctr := mirror.apply(ocr()).Container()
+	if _, err := ctr.WithExec([]string{"tesseract", "--version"}).Stdout(ctx); err != nil {
+		return fmt.Errorf("install from an authenticated mirror: %w", err)
+	}
+
+	// The credentials are mounted rather than written, so the assembled
+	// image's own filesystem carries nothing under the mount point.
+	leaked, err := ctr.Directory("/").Glob(ctx, strings.TrimPrefix(apkNetrcPath, "/"))
+	if err != nil {
+		return fmt.Errorf("look for %s in the assembled image: %w", apkNetrcPath, err)
+	}
+	if len(leaked) > 0 {
+		return fmt.Errorf("expected %s to be a mount and not a layer, found %v", apkNetrcPath, leaked)
+	}
+
+	// What the environment carries is the path, never the credential.
+	env, err := ctr.EnvVariables(ctx)
+	if err != nil {
+		return fmt.Errorf("read the assembled image's environment: %w", err)
+	}
+	for _, v := range env {
+		name, err := v.Name(ctx)
+		if err != nil {
+			return fmt.Errorf("read an environment variable's name: %w", err)
+		}
+		value, err := v.Value(ctx)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", name, err)
+		}
+		if name == apkNetrcEnv && value != apkNetrcPath {
+			return fmt.Errorf("expected %s to name the mount %q, got %q", apkNetrcEnv, apkNetrcPath, value)
+		}
+		if strings.Contains(value, mirror.Password) {
+			return fmt.Errorf("expected no credentials in the image's environment, %s carries them", name)
+		}
+	}
+	return nil
+}
+
+// AuthenticatedRepositoryIsRejectedWithoutApkAuth asserts the authenticated
+// mirror really is authenticated — that the test above passes because the
+// credentials were supplied and used, and not because the server never asked
+// for any. Both installs run against the one mirror, so WithApkAuth is the
+// only difference between them.
+func (t *Tests) AuthenticatedRepositoryIsRejectedWithoutApkAuth(ctx context.Context) error {
+	mirror, err := startApkMirror(ctx, true)
+	if err != nil {
+		return err
+	}
+	if _, err := mirror.apply(ocr()).Version(ctx); err != nil {
+		return fmt.Errorf("Version off an authenticated mirror with credentials: %w", err)
+	}
+	if _, err := ocr().WithApkRepository(mirror.URL).WithApkKey(mirror.Key).Version(ctx); err == nil {
+		return fmt.Errorf("expected a fetch with no credentials to be refused, got a working image")
+	}
+	return nil
+}
+
+// DefaultApkConfigurationIsUntouched asserts an image built without any of
+// these options is the image this module built before they existed: the
+// stock repository list, and no credential plumbing at all.
+//
+// It is the guard against the cheap implementation of all of the above —
+// writing a repositories file, or setting the credential variable,
+// unconditionally — which would work for the mirror and rebuild the world for
+// every existing caller.
+func (t *Tests) DefaultApkConfigurationIsUntouched(ctx context.Context) error {
+	got, err := readRepositories(ctx, ocr())
+	if err != nil {
+		return err
+	}
+	if !strings.Contains(got, alpineCdnHost) {
+		return fmt.Errorf("expected the image's own repositories to survive, got:\n%s", got)
+	}
+	env, err := ocr().Container().WithExec([]string{"sh", "-c", `printf %s "$` + apkNetrcEnv + `"`}).Stdout(ctx)
+	if err != nil {
+		return fmt.Errorf("read %s from an unconfigured image: %w", apkNetrcEnv, err)
+	}
+	if env != "" {
+		return fmt.Errorf("expected no %s on an unconfigured image, got %q", apkNetrcEnv, env)
+	}
+	return nil
+}
+
+// readRepositories reports the repository list of an assembled image, which is
+// what says where its packages came from.
+func readRepositories(ctx context.Context, t *dagger.Tesseract) (string, error) {
+	out, err := t.Container().WithExec([]string{"cat", apkRepositoriesFile}).Stdout(ctx)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", apkRepositoriesFile, err)
+	}
+	return out, nil
+}

--- a/daggerverse/tesseract/tests/dagger.gen.go
+++ b/daggerverse/tesseract/tests/dagger.gen.go
@@ -213,6 +213,41 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).AltoIsValidXml(&parent, ctx)
+		case "ApkAuthInstallsFromAuthenticatedRepository":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ApkAuthInstallsFromAuthenticatedRepository(&parent, ctx)
+		case "ApkRepositoryAppliesToPdfRasterizer":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ApkRepositoryAppliesToPdfRasterizer(&parent, ctx)
+		case "ApkRepositoryInstallsFromPrivateMirror":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ApkRepositoryInstallsFromPrivateMirror(&parent, ctx)
+		case "ApkRepositoryReplacesImageDefaults":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ApkRepositoryReplacesImageDefaults(&parent, ctx)
+		case "AuthenticatedRepositoryIsRejectedWithoutApkAuth":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).AuthenticatedRepositoryIsRejectedWithoutApkAuth(&parent, ctx)
 		case "BatchDefaultGlobSkipsNonImages":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -304,6 +339,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).CiRunProducesEnabledFormats(&parent, ctx)
+		case "DefaultApkConfigurationIsUntouched":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).DefaultApkConfigurationIsUntouched(&parent, ctx)
 		case "DefaultLanguagesInstallEnglish":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -514,6 +556,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).UnknownParameterFails(&parent, ctx)
+		case "UntrustedIndexIsRejectedWithoutApkKey":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).UntrustedIndexIsRejectedWithoutApkKey(&parent, ctx)
 		case "UserWordsFileIsAccepted":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/tesseract/tests/internal/dagger/tesseract.gen.go
+++ b/daggerverse/tesseract/tests/internal/dagger/tesseract.gen.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Retrieve the binding value, as type Tesseract
-func (r *Binding) AsTesseract() *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:222:6)
+func (r *Binding) AsTesseract() *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:254:6)
 	q := r.query.Select("asTesseract")
 
 	return &Tesseract{
@@ -128,7 +128,7 @@ func (r *Env) WithTesseractDocumentOutput(name string, description string) *Env 
 }
 
 // Create or update a binding of type Tesseract in the environment
-func (r *Env) WithTesseractInput(name string, value *Tesseract, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/main.go:222:6)
+func (r *Env) WithTesseractInput(name string, value *Tesseract, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/main.go:254:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withTesseractInput")
 	q = q.Arg("name", name)
@@ -141,7 +141,7 @@ func (r *Env) WithTesseractInput(name string, value *Tesseract, description stri
 }
 
 // Declare a desired Tesseract output to be assigned in the environment
-func (r *Env) WithTesseractOutput(name string, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/main.go:222:6)
+func (r *Env) WithTesseractOutput(name string, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/main.go:254:6)
 	q := r.query.Select("withTesseractOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -178,22 +178,24 @@ func (r *Env) WithTesseractTrainingOutput(name string, description string) *Env 
 // TesseractOpts contains options for Query.Tesseract
 type TesseractOpts struct {
 	//
-	// Container registry hosting the alpine image.
+	// Container registry hosting the alpine image. This moves the image only:
+	// see WithApkRepository for where the packages installed onto it are
+	// fetched from.
 	//
 	//
 	// Default: "docker.io"
-	Registry string // tesseract (../../../../../daggerverse/tesseract/main.go:240:2)
+	Registry string // tesseract (../../../../../daggerverse/tesseract/main.go:280:2)
 	//
 	// Tag of the alpine image the toolchain is assembled on.
 	//
 	//
 	// Default: "3.24"
-	AlpineTag string // tesseract (../../../../../daggerverse/tesseract/main.go:243:2)
+	AlpineTag string // tesseract (../../../../../daggerverse/tesseract/main.go:283:2)
 	//
 	// Language codes to install, one apk package each. Empty installs "eng".
 	// "osd" is not a recognition language but is required by Document.Osd.
 	//
-	Languages []string // tesseract (../../../../../daggerverse/tesseract/main.go:247:2)
+	Languages []string // tesseract (../../../../../daggerverse/tesseract/main.go:287:2)
 	//
 	// Upper bound on the OpenMP threads tesseract may use, set on the
 	// assembled image as OMP_THREAD_LIMIT. Unset, tesseract uses one thread
@@ -204,12 +206,12 @@ type TesseractOpts struct {
 	// slowdown reports (tesseract-ocr/tesseract#2611, #1171, #263). One
 	// thread per pass is the usual setting there.
 	//
-	OmpThreadLimit int // tesseract (../../../../../daggerverse/tesseract/main.go:257:2)
+	OmpThreadLimit int // tesseract (../../../../../daggerverse/tesseract/main.go:297:2)
 }
 
 // New returns a Tesseract module backed by <registry>/library/alpine:<tag>
 // with tesseract-ocr and one language package per requested language.
-func (r *Query) Tesseract(opts ...TesseractOpts) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:237:1)
+func (r *Query) Tesseract(opts ...TesseractOpts) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:275:1)
 	q := r.query.Select("tesseract")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `registry` optional argument
@@ -239,7 +241,7 @@ func (r *Query) Tesseract(opts ...TesseractOpts) *Tesseract { // tesseract (../.
 // It carries the image coordinates and the language set the image is built
 // with; Document hangs off it so the generated SDK surfaces recognition under
 // `dag.Tesseract().Document(...)`.
-type Tesseract struct { // tesseract (../../../../../daggerverse/tesseract/main.go:222:6)
+type Tesseract struct { // tesseract (../../../../../daggerverse/tesseract/main.go:254:6)
 	query *querybuilder.Selection
 
 	id         *ID
@@ -269,7 +271,7 @@ func (r *Tesseract) WithGraphQLQuery(q *querybuilder.Selection) *Tesseract {
 // with whatever reads the results the same way the input directory was
 // composed. Which files take part is a glob, defaulting to the image
 // extensions leptonica can read.
-func (r *Tesseract) Batch(source *Directory) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/main.go:401:1)
+func (r *Tesseract) Batch(source *Directory) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/main.go:519:1)
 	assertNotNil("source", source)
 	q := r.query.Select("batch")
 	q = q.Arg("source", source)
@@ -299,7 +301,7 @@ func (r *Tesseract) Ci(source *Directory) *TesseractCi { // tesseract (../../../
 //
 // A requested OpenMP bound lives here rather than on the recognition
 // invocation so everything reached through this escape hatch inherits it too.
-func (r *Tesseract) Container() *Container { // tesseract (../../../../../daggerverse/tesseract/main.go:311:1)
+func (r *Tesseract) Container() *Container { // tesseract (../../../../../daggerverse/tesseract/main.go:431:1)
 	q := r.query.Select("container")
 
 	return &Container{
@@ -312,7 +314,7 @@ func (r *Tesseract) Container() *Container { // tesseract (../../../../../dagger
 // The boundary input is a *dagger.File rather than a *dagger.Directory, unlike
 // the kicad module's Project: tesseract resolves nothing relative to its input,
 // so one image — including a multi-page TIFF — is the whole unit of work.
-func (r *Tesseract) Document(source *File) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/main.go:389:1)
+func (r *Tesseract) Document(source *File) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/main.go:507:1)
 	assertNotNil("source", source)
 	q := r.query.Select("document")
 	q = q.Arg("source", source)
@@ -417,7 +419,7 @@ func (r *Tesseract) UnmarshalJSON(bs []byte) error {
 // `tesseract --list-langs`: the packaged languages and any model WithTessdata
 // added, as one set. This is what Document.WithLanguage validates against, and
 // it includes "osd" when that model was installed or supplied.
-func (r *Tesseract) Langs(ctx context.Context) ([]string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:359:1)
+func (r *Tesseract) Langs(ctx context.Context) ([]string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:477:1)
 	q := r.query.Select("langs")
 
 	var response []string
@@ -429,7 +431,7 @@ func (r *Tesseract) Langs(ctx context.Context) ([]string, error) { // tesseract 
 // Parameters returns tesseract's control-variable table — every name, its
 // default value and a one-line description — as `tesseract --print-parameters`
 // prints it. These are the names Document.WithParameter accepts.
-func (r *Tesseract) Parameters(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:374:1)
+func (r *Tesseract) Parameters(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:492:1)
 	if r.parameters != nil {
 		return *r.parameters, nil
 	}
@@ -453,7 +455,7 @@ func (r *Tesseract) Parameters(ctx context.Context) (string, error) { // tessera
 //
 // The model it produces pairs directly with WithTessdata, so a fine-tune and
 // the recognition that uses it are two calls on the same module.
-func (r *Tesseract) Training(source *Directory) *TesseractTraining { // tesseract (../../../../../daggerverse/tesseract/main.go:417:1)
+func (r *Tesseract) Training(source *Directory) *TesseractTraining { // tesseract (../../../../../daggerverse/tesseract/main.go:535:1)
 	assertNotNil("source", source)
 	q := r.query.Select("training")
 	q = q.Arg("source", source)
@@ -465,7 +467,7 @@ func (r *Tesseract) Training(source *Directory) *TesseractTraining { // tesserac
 
 // Version returns the tesseract release the assembled image ships, as the
 // bare version number reported by `tesseract --version`.
-func (r *Tesseract) Version(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:340:1)
+func (r *Tesseract) Version(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:458:1)
 	if r.version != nil {
 		return *r.version, nil
 	}
@@ -475,6 +477,82 @@ func (r *Tesseract) Version(ctx context.Context) (string, error) { // tesseract 
 
 	q = q.Bind(&response)
 	return response, q.Execute(ctx)
+}
+
+// WithApkAuth supplies credentials for a repository that requires them.
+//
+// The secret's contents are a netrc file — `machine mirror.example.com login
+// USER password PASS`, one stanza per host — which is what apk-tools 3's
+// built-in libfetch reads when a repository answers 401. Alpine 3.24 ships
+// apk-tools 3.0; see NETRC in `apk(8)`. Hosts are matched by name only, so a
+// stanza covers a mirror on any port.
+//
+// It is a *dagger.Secret rather than a string, and is mounted rather than
+// written, so the credentials stay out of the cache key, out of argv, out of
+// the image's environment and out of any layer a caller exports. That is also
+// why the credentials are not simply userinfo in the WithApkRepository URL,
+// which would put them in /etc/apk/repositories and in every apk error message
+// that quotes it.
+func (r *Tesseract) WithApkAuth(credentials *Secret) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:413:1)
+	assertNotNil("credentials", credentials)
+	q := r.query.Select("withApkAuth")
+	q = q.Arg("credentials", credentials)
+
+	return &Tesseract{
+		query: q,
+	}
+}
+
+// WithApkKey trusts a repository's signing key by dropping it into
+// /etc/apk/keys, which is the other half of WithApkRepository: a private
+// mirror's index is signed by a key the stock Alpine image has never heard of,
+// and apk refuses an index it cannot verify rather than installing from it.
+//
+// The file keeps its own name, because the name is load-bearing — an index
+// signature names the key file it was made with, and apk looks that exact file
+// up in the keys directory. A key exported from `abuild-keygen` is already
+// named correctly; renaming it renames the key.
+//
+// Repeatable, for a mirror set signed by more than one key. It is a *File
+// rather than a *Secret because a public key is not a credential: it is meant
+// to be in the image, and WithApkAuth is the option for the part that is not.
+func (r *Tesseract) WithApkKey(key *File) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:390:1)
+	assertNotNil("key", key)
+	q := r.query.Select("withApkKey")
+	q = q.Arg("key", key)
+
+	return &Tesseract{
+		query: q,
+	}
+}
+
+// WithApkRepository points package installation at an Alpine repository other
+// than the one the base image ships, which is what makes this module work on a
+// network that cannot reach dl-cdn.alpinelinux.org.
+//
+// New's registry argument is not enough on its own and never was: it moves the
+// *image*, and the packages are still fetched by `apk add` from whatever
+// /etc/apk/repositories carries — so mirroring Alpine into a private registry
+// buys a container that then fails on its first `apk add`, or, where the CDN is
+// blackholed rather than refused, hangs until it times out.
+//
+// Repeatable, in preference order. The first call replaces the image's list
+// rather than appending to it, because the air-gapped case needs the
+// unreachable defaults gone rather than merely deprioritized: a repository apk
+// still consults is a repository apk still waits for.
+//
+// The URL is the repository base, spelled the way it would be spelled in
+// /etc/apk/repositories — `https://mirror.example.com/alpine/v3.24/main`, one
+// call per component. A repository's index is signed, so pair this with
+// WithApkKey unless the mirror is signed by a key the base image already
+// trusts.
+func (r *Tesseract) WithApkRepository(url string) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:362:1)
+	q := r.query.Select("withApkRepository")
+	q = q.Arg("url", url)
+
+	return &Tesseract{
+		query: q,
+	}
 }
 
 // WithTessdata adds a directory of `.traineddata` models to the image, which
@@ -492,7 +570,7 @@ func (r *Tesseract) Version(ctx context.Context) (string, error) { // tesseract 
 // renderer configfiles and the font the PDF renderer needs. A caller-supplied
 // model wins over a packaged one of the same name, which is what makes
 // replacing the stock `eng` with a fine-tuned one work.
-func (r *Tesseract) WithTessdata(dir *Directory) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:293:1)
+func (r *Tesseract) WithTessdata(dir *Directory) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:333:1)
 	assertNotNil("dir", dir)
 	q := r.query.Select("withTessdata")
 	q = q.Arg("dir", dir)

--- a/daggerverse/tesseract/tests/main.go
+++ b/daggerverse/tesseract/tests/main.go
@@ -179,6 +179,14 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("CiLanguageReachesRecognition", t.CiLanguageReachesRecognition)
 	jobs = jobs.WithJob("CiRejectsUnusableThreshold", t.CiRejectsUnusableThreshold)
 
+	jobs = jobs.WithJob("ApkRepositoryInstallsFromPrivateMirror", t.ApkRepositoryInstallsFromPrivateMirror)
+	jobs = jobs.WithJob("ApkRepositoryReplacesImageDefaults", t.ApkRepositoryReplacesImageDefaults)
+	jobs = jobs.WithJob("ApkRepositoryAppliesToPdfRasterizer", t.ApkRepositoryAppliesToPdfRasterizer)
+	jobs = jobs.WithJob("UntrustedIndexIsRejectedWithoutApkKey", t.UntrustedIndexIsRejectedWithoutApkKey)
+	jobs = jobs.WithJob("ApkAuthInstallsFromAuthenticatedRepository", t.ApkAuthInstallsFromAuthenticatedRepository)
+	jobs = jobs.WithJob("AuthenticatedRepositoryIsRejectedWithoutApkAuth", t.AuthenticatedRepositoryIsRejectedWithoutApkAuth)
+	jobs = jobs.WithJob("DefaultApkConfigurationIsUntouched", t.DefaultApkConfigurationIsUntouched)
+
 	jobs = jobs.WithJob("TessdataModelIsSelectable", t.TessdataModelIsSelectable)
 	jobs = jobs.WithJob("TessdataSuppliesOsdModel", t.TessdataSuppliesOsdModel)
 


### PR DESCRIPTION
Closes #234.

`New`'s `registry` argument only ever moved the **container image**. The packages
were still fetched by `apk add` from whatever `/etc/apk/repositories` the Alpine
image ships — the public CDN — so mirroring Alpine into a private registry bought
a container that failed on its very first `apk add`. The module documented that
override *as* the air-gapped story, which is the sentence that sends you down the
path before discovering it doesn't hold.

## Surface

```go
Tesseract.WithApkRepository(url string) *Tesseract            // /etc/apk/repositories
Tesseract.WithApkKey(key *dagger.File) *Tesseract             // /etc/apk/keys/<name>
Tesseract.WithApkAuth(credentials *dagger.Secret) *Tesseract  // $NETRC
```

Same copy-the-struct builder shape as `WithTessdata`, `+private` fields, plus a
`clone()` so repeated calls accumulate instead of overwriting. All three are
applied in one `base()` helper that **both** `apk add` this module performs now
start from — `Container()` and `rasterize()` — so the toolchain and the PDF
rasterizer cannot drift into fetching packages from different places. Covering
only the first would have left `FromPdf` broken in exactly the environment the
option exists for.

**The first `WithApkRepository` replaces the image's list rather than appending
to it.** Appending is friendlier everywhere except the case this exists for,
where a surviving default is a repository apk still consults and still waits on.

## The credential mechanism, confirmed against 3.24

The issue asked whether this is netrc or apk-tools 3's auth file. Alpine 3.24
ships **apk-tools 3.0.6** with the built-in libfetch, and there is no auth file:
libfetch reads `$NETRC` (an arbitrary path, no permission check) once a
repository answers `401`, matching on host name only. So `WithApkAuth` takes a
netrc-formatted `*dagger.Secret`, **mounted** at `/run/apk/netrc` rather than
written, keeping the credential out of argv, out of the image's environment and
out of any layer a caller exports. Userinfo in the repository URL would have
landed in `/etc/apk/repositories` and in every apk error quoting it; `HTTP_AUTH`
would have landed in the environment.

`WithApkKey` takes a `*dagger.File` and preserves its name, because the name is
load-bearing: an index signature names the key file it was made with and apk
looks that exact name up. `--allow-untrusted` stays off the table — a module
that quietly installed from an unverifiable index would make the air-gapped path
the least trustworthy one.

## Tests

Seven new tests in `daggerverse/tesseract/tests/apk.go`, all wired into `All`.
They install from a **real** private repository — full dependency closure via
`apk fetch --recursive`, a signed index, served over HTTP by a Dagger service —
because everything under test lives in apk rather than in this module; asserting
on the flags the module passes would test none of it.

Two things cost real time and are documented in the code:

- **Alpine's busybox has no `httpd` applet.** The mirror is served by
  `darkhttpd`, whose `--auth user:pass` is the whole of what an authenticated
  mirror needs (nginx would want a config file and a password-hashing tool).
- **`apk index --rewrite-arch` is required.** apk resolves a package path as
  `$base/$arch/$name-$version.apk` using the *package's* architecture, so the
  `noarch` packages in the closure — the tesseract language data among them —
  are looked for under a `noarch/` directory no mirror has. Without it the two
  largest packages fail to install and everything else succeeds, which is a
  failure shaped exactly like a flake.

The two negative tests install from the **same** mirror twice, with and without
the key/credentials, so that option is the only difference between the outcomes.
Asserting on apk's own wording is not available: an exec failure crosses the
module boundary as its exit status, with `UNTRUSTED signature` left in the logs.

Mirror passwords are generated per run with `crypto/rand`; nothing is committed.

## Verification

- `dagger -m daggerverse/tesseract/tests call all` — green, 49 tests, 23.0s (rebased onto #233, so the `Ci` builder is in the run too)
- `dagger -m ci call generated` — green after `dagger develop` in
  `daggerverse/tesseract`, `daggerverse/tesseract/tests` and the root (the root
  aggregator's `ci/internal/dagger/tesseract-tests.gen.go` needed regenerating)
- `gofmt` / `go vet` clean

## Notes

- Set none of the options and the image is byte-identical to the one this module
  built before they existed, so existing callers see no cache-key churn. There is
  a test for that, since the cheap implementation — writing the files
  unconditionally — would work for the mirror and rebuild the world for everyone
  else.
- One acceptance criterion is met in substance rather than literally:
  "`FromPdf` succeeds with no public repository reachable" is proven by the CDN
  being absent from `/etc/apk/repositories` (so the packages demonstrably came
  from the mirror), not by blackholing the network — a Dagger exec has no way to
  cut outbound traffic for one container.
- Authenticating the **container registry** pull for a mirrored Alpine image was
  explicitly out of scope here and is filed as #235.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
