### PR TITLE
story(issue-195): attribute changes by module input, not by directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,13 +74,26 @@ jobs:
         # push's before/after — GitHub sends all-zeros before for a new branch,
         # which the function treats as "run everything").
         #
+        # A changed path counts against a module only when it is one of that
+        # module's inputs — a member of the source context Dagger uploads for it
+        # — rather than merely living under its directory (#195). A file a module
+        # declared out via dagger.json "include" is shipped to no engine and so
+        # can affect no check.
+        #
         # A check is skipped only when it provably cannot be affected — any doubt
         # and it runs:
-        #   - a change outside a daggerverse module (CI infra, ci/, root
-        #     dagger.json, docs, ...) or an uncomputable diff -> the FULL suite.
-        #     The one exception (#179) is a regenerated per-toolchain aggregator
-        #     binding, ci/internal/dagger/<toolchain>.gen.go, which is provably
-        #     owned by that toolchain and so is attributed to it;
+        #   - CI infra (.github/workflows/**), anything in the root module's
+        #     source context (ci/**, root dagger.json), or an uncomputable diff
+        #     -> the FULL suite. The one exception (#179) is a regenerated
+        #     per-toolchain aggregator binding,
+        #     ci/internal/dagger/<toolchain>.gen.go, which is provably owned by
+        #     that toolchain and so is attributed to it;
+        #   - a path in no module's source context (repo-level prose, a module's
+        #     own README) -> an input to nothing, so it selects nothing;
+        #   - a deleted path -> attributed to its module, since no source context
+        #     can contain it;
+        #   - a module whose source context can't be read -> everything under it
+        #     counts as an input;
         #   - a check whose module can't be resolved -> kept;
         #   - ci:* checks -> always run.
         # If enumeration itself fails there is no independent universe to fall back

--- a/ci/README.md
+++ b/ci/README.md
@@ -65,10 +65,64 @@ functions directly. No `.github/workflows/ci.yml` edit needed either —
 the matrix picks up the new check from `dagger check -l` output
 automatically.
 
-That committed binding is the only file under `ci/` that does *not*
-force the change-aware selector onto the full suite: `affectedpkg`
+That committed binding is one of only two files under `ci/` that do
+*not* force the change-aware selector onto the full suite: `affectedpkg`
 attributes `ci/internal/dagger/<toolchain>.gen.go` back to the toolchain
 it was generated from (see `AggregatorBindings`), so a toolchain-adding
-PR runs that toolchain's checks rather than the whole universe. Every
-other path under `ci/` — including the module's own `dagger.gen.go` —
-still fails open to the full suite.
+PR runs that toolchain's checks rather than the whole universe. The
+other is `ci/README.md`, which this module declares out of its source
+context. Every other path under `ci/` — including the module's own
+`dagger.gen.go` — still fails open to the full suite.
+
+## What counts as a change
+
+The selector asks whether a changed path is an **input** to a module,
+not merely whether it sits inside one (#195). A module's inputs are its
+Dagger *source context* — precisely the files Dagger uploads for it —
+read from the engine via `ModuleSource.ContextDirectory`, never modelled
+in Go. A file outside that context is shipped to no engine, so it cannot
+affect any check the module feeds. That is a property Dagger enforces,
+not one this package asserts about which files look like prose.
+
+Narrow a module's inputs with a negated `include` pattern in its
+`dagger.json` (`include` unions on top of the source directory, so only
+`!` subtracts):
+
+```json
+{ "include": ["!README.md"] }
+```
+
+Every module with a root `README.md` declares it out this way, so a docs
+edit no longer drags in that module's dependents. The consequence to
+respect: **a module must not read a file it declared out.** Doing so
+fails loudly at build time rather than silently under-running CI — which
+is why `daggerverse/skill-gen`, whose `skill/render.go` embeds
+`templates/README.md.tmpl`, declares nothing out.
+
+Repo-level prose needs no declaration at all. The root module's source
+is `ci/`, so its context is exactly `ci/**` plus the root `dagger.json`;
+the top-level `README.md`, `LICENSE`, and `docs/**` were never inputs to
+anything.
+
+Attribution then falls out in four cases:
+
+| changed path | selects |
+| --- | --- |
+| in a module's source context | that module and its dependents |
+| in the root module's context (`ci/**`, root `dagger.json`) | the full suite |
+| under `.github/workflows/` | the full suite — it governs how CI runs |
+| in no module's source context | nothing beyond the always-on `ci:*` |
+
+Two deliberate asymmetries. The **innermost** module owns a path, so
+`daggerverse/crypto/tests/main.go` belongs to `crypto/tests` and not to
+`crypto`, even though Dagger's context for `crypto` contains it — nested
+modules are separate Go modules that never compile into their parent.
+And a **deleted** path is attributed to its module rather than read as
+declared out, because no head source context can contain it; that
+over-runs when a declared-out file is deleted, which is the direction
+this package errs in.
+
+Selection is a diff against one base, so it cannot skip work a previous
+run already proved good — a rebase onto an already-tested `main` re-runs
+everything. Memoizing check results by input hash is tracked in
+[#238](https://github.com/z5labs/devex/issues/238).

--- a/ci/affected.go
+++ b/ci/affected.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -43,13 +44,22 @@ func (ci *Ci) SelectionSelfTest(ctx context.Context) error {
 // implementation — no workflow-side git, no helper container. The pure selection
 // then runs in affectedpkg so the logic stays unit-testable.
 //
+// A changed path counts against a module only when it is one of that module's
+// *inputs* — a member of the source context Dagger uploads for it — rather than
+// merely living under its directory (#195). The source contexts are read from
+// the engine itself (ModuleSource.ContextDirectory), never modelled here, so a
+// file a module declared out of its context via dagger.json "include" cannot
+// affect that module's checks, and Dagger enforces that rather than this code
+// asserting it. Only the modules that own a changed path are resolved.
+//
 // Fail-safe throughout: an unusable diff range or a failed git diff yields the
 // full universe; if a single check's module cannot be resolved it is kept, never
-// skipped. If the Workspace enumeration itself fails (or a check has no readable
-// name) the function errors — with no independent universe to fall back to, CI
-// fails closed rather than risk silently under-running. The update-dagger
-// workflow guards against a Dagger upgrade making this experimental enumeration
-// diverge from stable `dagger check -l`.
+// skipped; if a module's source context cannot be read, everything under it
+// counts as an input. If the Workspace enumeration itself fails (or a check has
+// no readable name) the function errors — with no independent universe to fall
+// back to, CI fails closed rather than risk silently under-running. The
+// update-dagger workflow guards against a Dagger upgrade making this
+// experimental enumeration diverge from stable `dagger check -l`.
 //
 // +cache="never"
 func (ci *Ci) AffectedChecks(ctx context.Context, base string, head string) (string, error) {
@@ -61,6 +71,7 @@ func (ci *Ci) AffectedChecks(ctx context.Context, base string, head string) (str
 	var universe []string
 	checkModule := make(map[string]string, len(list))
 	adj := map[string][]string{}
+	sources := map[string]*dagger.ModuleSource{}
 	for i := range list {
 		chk := list[i]
 		name, err := chk.Name(ctx)
@@ -70,7 +81,7 @@ func (ci *Ci) AffectedChecks(ctx context.Context, base string, head string) (str
 			return "", fmt.Errorf("read check name: %w", err)
 		}
 		universe = append(universe, name)
-		root, err := gatherDeps(ctx, chk.OriginalModule().Source(), adj)
+		root, err := gatherDeps(ctx, chk.OriginalModule().Source(), adj, sources)
 		if err != nil {
 			// Leave this check out of checkModule -> Select keeps it (fail-safe).
 			fmt.Fprintf(os.Stderr, "affected-checks: cannot resolve module for %q (%v); keeping it\n", name, err)
@@ -84,35 +95,125 @@ func (ci *Ci) AffectedChecks(ctx context.Context, base string, head string) (str
 		// No usable diff range (new branch, missing base, ...) -> full suite.
 		return marshal(universe)
 	}
-	changedFiles, err := changedPaths(ctx, b, h)
+	changes, err := changedPaths(ctx, b, h)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "affected-checks: git diff failed (%v); running full suite\n", err)
 		return marshal(universe)
 	}
 
-	moduleDirs := make([]string, 0, len(adj))
-	for d := range adj {
-		if strings.HasPrefix(d, "daggerverse/") {
-			moduleDirs = append(moduleDirs, d)
-		}
+	moduleDirs, err := workspaceModuleDirs(ctx)
+	if err != nil {
+		// The dependency graph knows every module a check can reach, which is
+		// enough to attribute; it just cannot see modules nothing depends on.
+		fmt.Fprintf(os.Stderr, "affected-checks: cannot enumerate modules (%v); falling back to the dependency graph\n", err)
+		moduleDirs = graphModuleDirs(adj)
 	}
 
+	srcs := resolveSources(ctx, changes, moduleDirs, sources)
 	closure := affectedpkg.BuildClosures(checkModule, adj)
 	bindings := affectedpkg.AggregatorBindings(checkModule)
-	kept, full := affectedpkg.Select(universe, closure, changedFiles, moduleDirs, bindings)
+	changed, global := affectedpkg.Attribute(changes, moduleDirs, srcs, bindings)
+	kept, full := affectedpkg.Select(universe, closure, changed, global)
 	if full {
 		kept = universe
 	}
 	return marshal(kept)
 }
 
-// changedPaths returns the repo-relative paths changed between base and head. It
-// materializes the workspace's .git directory into the module's scratch workdir
-// (the Export/WorkdirFile runtime-I/O pattern) and diffs base...head with go-git
-// — pure Go, no git binary and no helper container. Export is required because
-// go-git reads an os filesystem, whereas dag.CurrentWorkspace().Directory returns
-// a lazy Directory handle rather than mounted files.
-func changedPaths(ctx context.Context, base, head string) ([]string, error) {
+// workspaceModuleDirs returns every module directory in the workspace, repo-
+// relative, with the root module reported as ".".
+//
+// It walks for dagger.json rather than reading the dependency graph because the
+// graph only contains modules some check depends on: an example module nothing
+// imports would otherwise be invisible, and its files would fall through to the
+// root module and force the full suite.
+func workspaceModuleDirs(ctx context.Context) ([]string, error) {
+	configs, err := dag.CurrentWorkspace().Directory(".").Glob(ctx, "**/dagger.json")
+	if err != nil {
+		return nil, err
+	}
+	if len(configs) == 0 {
+		return nil, fmt.Errorf("no dagger.json found in the workspace")
+	}
+	dirs := make([]string, 0, len(configs))
+	for _, c := range configs {
+		dirs = append(dirs, path.Dir(c))
+	}
+	return dirs, nil
+}
+
+// graphModuleDirs is the fallback module set, derived from the dependency graph.
+func graphModuleDirs(adj map[string][]string) []string {
+	dirs := make([]string, 0, len(adj)+1)
+	for d := range adj {
+		if strings.HasPrefix(d, "daggerverse/") {
+			dirs = append(dirs, d)
+		}
+	}
+	return append(dirs, affectedpkg.RootPkg)
+}
+
+// resolveSources returns the source contexts of just those modules that own at
+// least one changed path — typically one or two, never all of them.
+//
+// A module left out of the result is one whose context could not be read, or one
+// the dependency walk never reached; Attribute treats both as "everything under
+// it is an input" and so declines to narrow.
+func resolveSources(ctx context.Context, changes []affectedpkg.Change, moduleDirs []string, sources map[string]*dagger.ModuleSource) map[string]map[string]bool {
+	owners := map[string]bool{}
+	for _, c := range changes {
+		if dir, ok := affectedpkg.OwningModule(c.Path, moduleDirs); ok {
+			owners[dir] = true
+		}
+	}
+
+	srcs := make(map[string]map[string]bool, len(owners))
+	for dir := range owners {
+		src, ok := sources[dir]
+		if !ok {
+			continue
+		}
+		set, err := sourceContext(ctx, src, dir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "affected-checks: cannot read the source context of %q (%v); treating everything under it as an input\n", dir, err)
+			continue
+		}
+		srcs[dir] = set
+	}
+	return srcs
+}
+
+// sourceContext lists the repo-relative file paths Dagger uploads for the module
+// rooted at dir. The context directory is rooted at the repository, so the glob
+// is scoped back down to the module — except for the root module, whose context
+// is already just its own source (ci/) plus the root dagger.json.
+func sourceContext(ctx context.Context, src *dagger.ModuleSource, dir string) (map[string]bool, error) {
+	pattern := "**"
+	if dir != affectedpkg.RootPkg {
+		pattern = dir + "/**"
+	}
+	paths, err := src.ContextDirectory().Glob(ctx, pattern)
+	if err != nil {
+		return nil, err
+	}
+	set := make(map[string]bool, len(paths))
+	for _, p := range paths {
+		if strings.HasSuffix(p, "/") {
+			continue // directory entry
+		}
+		set[p] = true
+	}
+	return set, nil
+}
+
+// changedPaths returns the repo-relative paths changed between base and head,
+// each flagged with whether it survives at head. It materializes the workspace's
+// .git directory into the module's scratch workdir (the Export/WorkdirFile
+// runtime-I/O pattern) and diffs base...head with go-git — pure Go, no git binary
+// and no helper container. Export is required because go-git reads an os
+// filesystem, whereas dag.CurrentWorkspace().Directory returns a lazy Directory
+// handle rather than mounted files.
+func changedPaths(ctx context.Context, base, head string) ([]affectedpkg.Change, error) {
 	suffix, err := uniqueSuffix()
 	if err != nil {
 		return nil, err
@@ -124,14 +225,25 @@ func changedPaths(ctx context.Context, base, head string) ([]string, error) {
 	if _, err := gitDir.Export(ctx, filepath.Join(scratch, ".git")); err != nil {
 		return nil, fmt.Errorf("export .git: %w", err)
 	}
-	return gitdiff.ChangedFiles(scratch, base, head)
+	changes, err := gitdiff.Changes(scratch, base, head)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]affectedpkg.Change, 0, len(changes))
+	for _, c := range changes {
+		out = append(out, affectedpkg.Change{Path: c.Path, Deleted: c.Deleted})
+	}
+	return out, nil
 }
 
 // gatherDeps records src's direct dependency directories into adj (keyed by
 // module directory) and recurses into each dependency, memoized by directory so
 // shared and diamond dependencies are walked once. It returns src's module
 // directory. The module graph is a DAG, so the visited-marker cannot deadlock.
-func gatherDeps(ctx context.Context, src *dagger.ModuleSource, adj map[string][]string) (string, error) {
+//
+// It also keeps each module's source handle in sources, which is how the source
+// contexts are read later without re-resolving a module from a path string.
+func gatherDeps(ctx context.Context, src *dagger.ModuleSource, adj map[string][]string, sources map[string]*dagger.ModuleSource) (string, error) {
 	root, err := src.SourceRootSubpath(ctx)
 	if err != nil {
 		return "", err
@@ -140,6 +252,7 @@ func gatherDeps(ctx context.Context, src *dagger.ModuleSource, adj map[string][]
 		return root, nil
 	}
 	adj[root] = nil // mark visited before recursing
+	sources[root] = src
 	deps, err := src.Dependencies(ctx)
 	if err != nil {
 		return "", err
@@ -147,7 +260,7 @@ func gatherDeps(ctx context.Context, src *dagger.ModuleSource, adj map[string][]
 	dirs := make([]string, 0, len(deps))
 	for i := range deps {
 		dep := deps[i]
-		depDir, err := gatherDeps(ctx, &dep, adj)
+		depDir, err := gatherDeps(ctx, &dep, adj, sources)
 		if err != nil {
 			return "", err
 		}
@@ -165,7 +278,13 @@ func uniqueSuffix() (string, error) {
 	return hex.EncodeToString(b[:]), nil
 }
 
+// marshal renders the selected check names as the JSON array the workflow's
+// matrix consumes. A nil slice would marshal to `null`, which survives the
+// workflow's non-empty check and then breaks fromJSON; emit `[]` instead.
 func marshal(v []string) (string, error) {
+	if v == nil {
+		v = []string{}
+	}
 	b, err := json.Marshal(v)
 	if err != nil {
 		return "", err

--- a/ci/affectedpkg/affected.go
+++ b/ci/affectedpkg/affected.go
@@ -62,42 +62,116 @@ func closureOf(root string, adj map[string][]string, memo map[string]map[string]
 	return res
 }
 
-// Select returns the subset of check names in universe that could be affected by
-// changedFiles, together with full=true when the entire universe must run.
+// RootPkg is the module directory of the repository root module. It claims every
+// path no nested module claims, so a change to broadly-shared code lands here
+// rather than nowhere.
+const RootPkg = "."
+
+// Change is one path from the diff, together with whether it survives at head.
+// Deleted is load-bearing: see isInput.
+type Change struct {
+	Path    string
+	Deleted bool
+}
+
+// globalPrefixes are the paths that govern how CI itself runs — which checks are
+// selected, how the matrix is built, what the timeouts are — rather than what any
+// check computes. They belong to no module's source context, so nothing else
+// would attribute them, yet a change to one can invalidate the whole run.
+var globalPrefixes = []string{".github/workflows/"}
+
+// Attribute maps a change set onto the modules it is actually an input to,
+// returning the set of changed module directories and whether a global input
+// changed (which forces the full universe).
+//
+// srcs gives, per module directory, the repo-relative paths that make up that
+// module's source context — precisely what Dagger uploads for it. A path that
+// lies under a module but is absent from its source context is an input to
+// nothing and is dropped. That is what stops a module's README from triggering
+// its dependents, and it is a property Dagger enforces (the file is never
+// shipped to the engine) rather than one this package asserts about which files
+// look like prose.
+//
+// A module missing from srcs is treated as owning everything beneath it: when we
+// cannot resolve a source context we decline to narrow.
+//
+// bindings is the per-toolchain aggregator-binding reattribution map from
+// AggregatorBindings; those generated files under ci/ are provably owned by a
+// single toolchain, so they resolve to it rather than to the root module (#179).
+//
+// global is set — meaning run everything — when:
+//   - changes is empty, which means "no usable diff", not "nothing changed";
+//   - a path lies under one of globalPrefixes;
+//   - a path is an input to the root module (root dagger.json, ci/**);
+//   - a path is claimed by no module at all, not even the root.
+func Attribute(changes []Change, moduleDirs []string, srcs map[string]map[string]bool, bindings map[string]string) (changed map[string]bool, global bool) {
+	if len(changes) == 0 {
+		return nil, true
+	}
+	changed = make(map[string]bool)
+	for _, c := range changes {
+		if dir, ok := bindings[c.Path]; ok {
+			changed[dir] = true
+			continue
+		}
+		if hasAnyPrefix(c.Path, globalPrefixes) {
+			return nil, true
+		}
+		dir, ok := OwningModule(c.Path, moduleDirs)
+		if !ok {
+			return nil, true
+		}
+		if !isInput(c, dir, srcs) {
+			continue // in no module's source context: an input to nothing
+		}
+		if dir == RootPkg {
+			return nil, true
+		}
+		changed[dir] = true
+	}
+	return changed, false
+}
+
+// isInput reports whether c is part of dir's source context.
+//
+// A deleted path can never appear in the head source context, which makes it
+// indistinguishable from a path the module declared out — so deletions are
+// attributed to their module instead. That over-runs on a deleted README and
+// under-runs on nothing, which is the direction this package errs in.
+func isInput(c Change, dir string, srcs map[string]map[string]bool) bool {
+	set, resolved := srcs[dir]
+	if !resolved {
+		return true
+	}
+	return set[c.Path] || c.Deleted
+}
+
+func hasAnyPrefix(path string, prefixes []string) bool {
+	for _, p := range prefixes {
+		if strings.HasPrefix(path, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// Select returns the subset of check names in universe reachable from the
+// changed module directories, together with full=true when the entire universe
+// must run.
 //
 // closure is the per-check dependency closure from BuildClosures. A check absent
 // from closure is "unresolved" and is always kept — never skipped.
 //
-// moduleDirs is the set of all known daggerverse module directories, used to map
-// each changed file to its owning module by longest-prefix match.
-//
-// bindings is the per-toolchain aggregator-binding reattribution map from
-// AggregatorBindings: those few generated files under ci/ are provably owned by a
-// single toolchain, so they resolve to it instead of tripping the ci/ fail-safe.
-//
-// The result is full (run everything) when any fail-safe condition holds:
-//   - changedFiles is empty (no diff available or it could not be computed);
-//   - any changed file does not resolve to a daggerverse module directory (nor to
-//     a known toolchain binding) — i.e. a change to CI infra, the ci/ aggregator
-//     itself, root dagger.json, or other broadly-shared code.
+// changed and global come from Attribute. An empty changed set with global=false
+// is a real answer, not a missing one: it means every changed path was an input
+// to nothing, so only the always-on ci:* checks run.
 //
 // Otherwise only affected checks — plus every ci:* check, which always runs
 // (repo-wide generated-code freshness and this package's own self-test) — are
 // returned, in universe order.
-func Select(universe []string, closure map[string]map[string]bool, changedFiles []string, moduleDirs []string, bindings map[string]string) (kept []string, full bool) {
-	if len(changedFiles) == 0 {
+func Select(universe []string, closure map[string]map[string]bool, changed map[string]bool, global bool) (kept []string, full bool) {
+	if global {
 		return universe, true
-	}
-	changed := make(map[string]bool)
-	for _, f := range changedFiles {
-		dir, ok := bindings[f]
-		if !ok {
-			dir, ok = OwningModule(f, moduleDirs)
-		}
-		if !ok {
-			return universe, true
-		}
-		changed[dir] = true
 	}
 	for _, name := range universe {
 		switch {
@@ -171,13 +245,24 @@ func AggregatorBindings(checkModule map[string]string) map[string]string {
 // OwningModule returns the directory in moduleDirs that owns path, chosen by
 // longest-prefix match on a path-segment boundary, and ok=false when path lies
 // under no known module directory.
+//
+// The innermost module wins, so daggerverse/crypto/tests/main.go belongs to
+// daggerverse/crypto/tests and not to daggerverse/crypto — even though Dagger's
+// own source context for crypto contains it. That is deliberate: a nested module
+// is a separate Go module that never compiles into its parent, so scoping
+// ownership to the innermost dagger.json is both correct and what keeps a
+// tests-only edit from fanning out to the parent's dependents.
+//
+// RootPkg, when present in moduleDirs, matches every path. Being the shortest
+// possible directory it always loses to a real prefix, so it acts as the
+// catch-all owner for anything no nested module claims.
 func OwningModule(path string, moduleDirs []string) (dir string, ok bool) {
 	best := ""
 	for _, d := range moduleDirs {
 		if d == "" {
 			continue
 		}
-		if path == d || strings.HasPrefix(path, d+"/") {
+		if d == RootPkg || path == d || strings.HasPrefix(path, d+"/") {
 			if len(d) > len(best) {
 				best = d
 			}

--- a/ci/affectedpkg/affected_test.go
+++ b/ci/affectedpkg/affected_test.go
@@ -102,6 +102,19 @@ func TestAggregatorBindingsExcludesAmbiguous(t *testing.T) {
 	}
 }
 
+// selectPaths runs the production pipeline — attribution then selection — over a
+// plain list of changed paths, none deleted. Source contexts are left
+// unresolved, so every path under a module counts as one of its inputs, which is
+// the fail-safe default and the behaviour these older cases were written against.
+func selectPaths(universe []string, closure map[string]map[string]bool, changed []string, dirs []string, bindings map[string]string) ([]string, bool) {
+	cs := make([]Change, 0, len(changed))
+	for _, p := range changed {
+		cs = append(cs, Change{Path: p})
+	}
+	got, global := Attribute(cs, dirs, nil, bindings)
+	return Select(universe, closure, got, global)
+}
+
 func TestSelectReattributesToolchainBinding(t *testing.T) {
 	universe := []string{"ci:generated", "kicad-tests:all", "kafka-tests:native"}
 	closure := map[string]map[string]bool{
@@ -148,7 +161,7 @@ func TestSelectReattributesToolchainBinding(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			kept, full := Select(universe, closure, tc.changed, dirs, bindings)
+			kept, full := selectPaths(universe, closure, tc.changed, dirs, bindings)
 			if full != tc.wantFull {
 				t.Fatalf("full = %v, want %v", full, tc.wantFull)
 			}
@@ -159,6 +172,157 @@ func TestSelectReattributesToolchainBinding(t *testing.T) {
 				t.Errorf("selected %v, want %v", sortedCopy(kept), sortedCopy(tc.want))
 			}
 		})
+	}
+}
+
+// TestOwningModuleRootIsCatchAll pins RootPkg's role: it claims anything no
+// nested module claims, and always loses to a real prefix.
+func TestOwningModuleRootIsCatchAll(t *testing.T) {
+	dirs := []string{RootPkg, "daggerverse/kicad", "daggerverse/kicad/tests"}
+	cases := []struct {
+		path string
+		want string
+	}{
+		{"ci/main.go", RootPkg},
+		{"README.md", RootPkg},
+		{"docs/dagger-internals/nesting.md", RootPkg},
+		{"dagger.json", RootPkg},
+		{"daggerverse/kicad/main.go", "daggerverse/kicad"},
+		{"daggerverse/kicad/tests/main.go", "daggerverse/kicad/tests"}, // innermost wins over both
+	}
+	for _, tc := range cases {
+		got, ok := OwningModule(tc.path, dirs)
+		if !ok || got != tc.want {
+			t.Errorf("OwningModule(%q) = (%q, %v), want (%q, true)", tc.path, got, ok, tc.want)
+		}
+	}
+}
+
+// TestAttributeSourceContext is the core of #195: attribution asks whether a
+// path is an *input* to its module, not merely whether it sits inside it.
+func TestAttributeSourceContext(t *testing.T) {
+	dirs := []string{RootPkg, "daggerverse/crypto", "daggerverse/crypto/tests"}
+	// crypto ships its main.go but has declared its README out; the root module's
+	// context is ci/** plus dagger.json, so repo-level prose is in no context.
+	srcs := map[string]map[string]bool{
+		RootPkg:                    {"ci/main.go": true, "dagger.json": true},
+		"daggerverse/crypto":       {"daggerverse/crypto/main.go": true},
+		"daggerverse/crypto/tests": {"daggerverse/crypto/tests/main.go": true},
+	}
+
+	cases := []struct {
+		name        string
+		changes     []Change
+		wantChanged []string
+		wantGlobal  bool
+	}{
+		{
+			name:        "a source file is an input to its module",
+			changes:     []Change{{Path: "daggerverse/crypto/main.go"}},
+			wantChanged: []string{"daggerverse/crypto"},
+		},
+		{
+			name:    "a path outside its module's source context is an input to nothing",
+			changes: []Change{{Path: "daggerverse/crypto/README.md"}},
+		},
+		{
+			name:    "repo-level prose is an input to nothing",
+			changes: []Change{{Path: "README.md"}, {Path: "docs/dagger-internals/nesting.md"}},
+		},
+		{
+			name:        "a non-input alongside a real input keeps the input",
+			changes:     []Change{{Path: "daggerverse/crypto/README.md"}, {Path: "daggerverse/crypto/tests/main.go"}},
+			wantChanged: []string{"daggerverse/crypto/tests"},
+		},
+		{
+			name:       "an input to the root module is global",
+			changes:    []Change{{Path: "ci/main.go"}},
+			wantGlobal: true,
+		},
+		{
+			name:       "a workflow change is global even though no module contains it",
+			changes:    []Change{{Path: ".github/workflows/ci.yml"}},
+			wantGlobal: true,
+		},
+		{
+			name:       "an empty change set is no information, not nothing",
+			changes:    nil,
+			wantGlobal: true,
+		},
+		{
+			// A deleted path is absent from every head source context, which is
+			// indistinguishable from being declared out. Err toward its module.
+			name:        "a deleted source file is still attributed to its module",
+			changes:     []Change{{Path: "daggerverse/crypto/main.go", Deleted: true}},
+			wantChanged: []string{"daggerverse/crypto"},
+		},
+		{
+			name:        "a deleted non-input over-runs rather than under-runs",
+			changes:     []Change{{Path: "daggerverse/crypto/README.md", Deleted: true}},
+			wantChanged: []string{"daggerverse/crypto"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			changed, global := Attribute(tc.changes, dirs, srcs, nil)
+			if global != tc.wantGlobal {
+				t.Fatalf("global = %v, want %v", global, tc.wantGlobal)
+			}
+			if tc.wantGlobal {
+				return
+			}
+			got := make([]string, 0, len(changed))
+			for d := range changed {
+				got = append(got, d)
+			}
+			if !sameSet(got, tc.wantChanged) {
+				t.Errorf("changed = %v, want %v", sortedCopy(got), sortedCopy(tc.wantChanged))
+			}
+		})
+	}
+}
+
+// TestAttributeUnresolvedSourceContextDoesNotNarrow guards the fail-safe: if the
+// live Workspace cannot report a module's source context, every path under it
+// must still count as an input.
+func TestAttributeUnresolvedSourceContextDoesNotNarrow(t *testing.T) {
+	dirs := []string{RootPkg, "daggerverse/crypto"}
+	srcs := map[string]map[string]bool{RootPkg: {"ci/main.go": true}} // crypto absent
+
+	changed, global := Attribute([]Change{{Path: "daggerverse/crypto/README.md"}}, dirs, srcs, nil)
+	if global {
+		t.Fatal("did not expect the full-suite fallback")
+	}
+	if !changed["daggerverse/crypto"] {
+		t.Errorf("unresolved source context narrowed anyway: changed = %v", changed)
+	}
+}
+
+// TestAttributeBindingsBeatSourceContext pins the #179 carve-out surviving the
+// input model: a per-toolchain aggregator binding lives under ci/ and is an
+// input to the root module, which would otherwise make it global.
+func TestAttributeBindingsBeatSourceContext(t *testing.T) {
+	dirs := []string{RootPkg, "daggerverse/kicad", "daggerverse/kicad/tests"}
+	srcs := map[string]map[string]bool{
+		RootPkg: {
+			"ci/internal/dagger/kicad-tests.gen.go": true,
+			"ci/internal/dagger/dagger.gen.go":      true,
+		},
+		"daggerverse/kicad":       {},
+		"daggerverse/kicad/tests": {},
+	}
+	bindings := AggregatorBindings(map[string]string{"kicad-tests:all": "daggerverse/kicad/tests"})
+
+	changed, global := Attribute([]Change{{Path: "ci/internal/dagger/kicad-tests.gen.go"}}, dirs, srcs, bindings)
+	if global {
+		t.Fatal("toolchain binding forced the full suite; #179 regressed")
+	}
+	if !changed["daggerverse/kicad/tests"] {
+		t.Errorf("binding was not reattributed: changed = %v", changed)
+	}
+
+	if _, global := Attribute([]Change{{Path: "ci/internal/dagger/dagger.gen.go"}}, dirs, srcs, bindings); !global {
+		t.Error("the ci module's own core binding must still force the full suite")
 	}
 }
 
@@ -194,7 +358,7 @@ func TestSelectUnresolvedIsKept(t *testing.T) {
 		"kicad-tests:all": {"daggerverse/kicad/tests": true, "daggerverse/kicad": true},
 	}
 	dirs := []string{"daggerverse/kicad", "daggerverse/kicad/tests"}
-	kept, full := Select(universe, closure, []string{"daggerverse/kicad/main.go"}, dirs, nil)
+	kept, full := selectPaths(universe, closure, []string{"daggerverse/kicad/main.go"}, dirs, nil)
 	if full {
 		t.Fatal("did not expect full-suite fallback")
 	}

--- a/ci/affectedpkg/selfcheck.go
+++ b/ci/affectedpkg/selfcheck.go
@@ -76,23 +76,83 @@ func (f fixture) universe() []string {
 }
 
 func (f fixture) moduleDirs() []string {
-	dirs := make([]string, 0, len(f.adj))
+	dirs := make([]string, 0, len(f.adj)+1)
 	for d := range f.adj {
 		if strings.HasPrefix(d, "daggerverse/") {
 			dirs = append(dirs, d)
 		}
 	}
-	return dirs
+	// The root module claims whatever no nested module does, mirroring the
+	// dagger.json walk in the ci module.
+	return append(dirs, RootPkg)
+}
+
+// nonInputs are the fixture paths that no module's source context contains, and
+// so are inputs to nothing.
+//
+// Module-scoped entries are declared out in that module's dagger.json
+// ("include": ["!README.md"]), which stops Dagger uploading them at all.
+// Repo-level entries were never in any context to begin with: the root module's
+// source is ci/, so its context is exactly ci/** plus dagger.json.
+func nonInputs() map[string]bool {
+	return map[string]bool{
+		"daggerverse/crypto/README.md":      true,
+		"daggerverse/kicad/README.md":       true,
+		"daggerverse/kicad/tests/README.md": true,
+		"ci/README.md":                      true,
+		"README.md":                         true,
+		"LICENSE":                           true,
+		"docs/dagger-internals/nesting.md":  true,
+	}
+}
+
+// srcsFor models the per-module source contexts Dagger would report for the
+// paths a case touches: everything under the owning module, minus nonInputs and
+// minus anything deleted (which cannot appear in the head context). Every module
+// dir gets an entry, because a missing one means "source context unresolved" and
+// makes Attribute decline to narrow.
+func (f fixture) srcsFor(changes []Change) map[string]map[string]bool {
+	dirs := f.moduleDirs()
+	skip := nonInputs()
+	out := make(map[string]map[string]bool, len(dirs))
+	for _, d := range dirs {
+		out[d] = map[string]bool{}
+	}
+	for _, c := range changes {
+		if c.Deleted || skip[c.Path] {
+			continue
+		}
+		if d, ok := OwningModule(c.Path, dirs); ok {
+			out[d][c.Path] = true
+		}
+	}
+	return out
 }
 
 // selfCheckCase is one change -> expected selection assertion.
 type selfCheckCase struct {
 	name    string
 	changed []string
+	// removed are paths that the change set deletes, i.e. that do not exist at
+	// head. They are attributed to their module even though no source context
+	// can contain them.
+	removed []string
 	// wantFull asserts the full-suite fail-safe fired.
 	wantFull bool
 	// wantChecks, when wantFull is false, is the exact expected kept set.
 	wantChecks []string
+}
+
+// changes flattens a case into the (path, deleted) pairs Attribute consumes.
+func (c selfCheckCase) changes() []Change {
+	out := make([]Change, 0, len(c.changed)+len(c.removed))
+	for _, p := range c.changed {
+		out = append(out, Change{Path: p})
+	}
+	for _, p := range c.removed {
+		out = append(out, Change{Path: p, Deleted: true})
+	}
+	return out
 }
 
 // selfCheckCases returns the invariants that must hold. They double as the
@@ -200,8 +260,73 @@ func selfCheckCases() []selfCheckCase {
 		{name: "no changed files runs the full suite", changed: nil, wantFull: true},
 		{
 			name:     "a module change mixed with an infra change runs the full suite",
-			changed:  []string{"daggerverse/kicad/main.go", "README.md"},
+			changed:  []string{"daggerverse/kicad/main.go", "dagger.json"},
 			wantFull: true,
+		},
+
+		// Input-awareness (#195). A path that lies under a module but outside its
+		// Dagger source context is an input to nothing, so it selects nothing.
+		{
+			name:       "a module-root README triggers no dependents",
+			changed:    []string{"daggerverse/crypto/README.md"},
+			wantChecks: []string{ci1, ci2},
+		},
+		{
+			name:       "repo-level docs run no module checks instead of the full suite",
+			changed:    []string{"README.md", "LICENSE", "docs/dagger-internals/nesting.md"},
+			wantChecks: []string{ci1, ci2},
+		},
+		{
+			// ci/README.md is declared out of the root module, so unlike every
+			// other path under ci/ it no longer forces the whole universe.
+			name:       "the ci module's own README runs no module checks",
+			changed:    []string{"ci/README.md"},
+			wantChecks: []string{ci1, ci2},
+		},
+		{
+			name:       "docs alongside a module change keep that module's checks",
+			changed:    []string{"daggerverse/kicad/main.go", "README.md"},
+			wantChecks: []string{ci1, ci2, "kicad-tests:all"},
+		},
+		{
+			name:     "docs alongside an infra change still run the full suite",
+			changed:  []string{"README.md", "ci/main.go"},
+			wantFull: true,
+		},
+		{
+			// The template is embedded by daggerverse/skill-gen/skill/render.go, so
+			// it is program data. Nothing declares it out, so it stays an input —
+			// the reason this classification is a source-context question and never
+			// a question about which files look like prose.
+			name:       "an embedded markdown template is an input, not docs",
+			changed:    []string{"daggerverse/skill-gen/skill/templates/README.md.tmpl"},
+			wantChecks: []string{ci1, ci2, "skill-gen-tests:all"},
+		},
+		{
+			name:       "a golden testdata README is an input, not docs",
+			changed:    []string{"daggerverse/skill-gen/skill/testdata/golden/README.md"},
+			wantChecks: []string{ci1, ci2, "skill-gen-tests:all"},
+		},
+		{
+			// Only a module's own root README is declared out; one nested in a
+			// fixture tree is untouched by that declaration.
+			name:       "a README nested inside a module stays an input",
+			changed:    []string{"daggerverse/kicad/tests/fixtures/no-board/README.md"},
+			wantChecks: []string{ci1, ci2, "kicad-tests:all"},
+		},
+		{
+			// Deleted paths cannot appear in any head source context, so they are
+			// attributed to their module rather than read as declared out.
+			name:       "a deleted module source file still triggers its module",
+			removed:    []string{"daggerverse/kicad/main.go"},
+			wantChecks: []string{ci1, ci2, "kicad-tests:all"},
+		},
+		{
+			// The documented cost of that rule: deleting a declared-out file
+			// over-runs. Rare, and in the safe direction.
+			name:       "a deleted module README over-runs rather than under-runs",
+			removed:    []string{"daggerverse/kicad/README.md"},
+			wantChecks: []string{ci1, ci2, "kicad-tests:all"},
 		},
 	}
 }
@@ -217,7 +342,9 @@ func SelfCheck() error {
 	bindings := AggregatorBindings(f.checkModule)
 
 	for _, tc := range selfCheckCases() {
-		kept, full := Select(universe, closure, tc.changed, dirs, bindings)
+		changes := tc.changes()
+		changed, global := Attribute(changes, dirs, f.srcsFor(changes), bindings)
+		kept, full := Select(universe, closure, changed, global)
 		if full != tc.wantFull {
 			return fmt.Errorf("%s: full=%v, want %v", tc.name, full, tc.wantFull)
 		}

--- a/ci/gitdiff/gitdiff.go
+++ b/ci/gitdiff/gitdiff.go
@@ -14,16 +14,47 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 )
 
-// ChangedFiles returns the repo-relative paths changed between base and head,
-// using three-dot (merge-base) semantics: the diff is taken from the
-// merge-base of base and head to head, so changes made on the base branch after
-// the two diverged are not attributed to head. This mirrors
-// `git diff base...head` and is what a PR "changes" set means.
+// Change is one repo-relative path touched between two commits, together with
+// whether it still exists at head.
+//
+// The caller needs the distinction because a path that is absent from a
+// module's source set is indistinguishable, by path alone, from a path that was
+// deleted: the first must be ignored (it is not an input), the second must not
+// (its module really did change). Deleted is what tells them apart.
+type Change struct {
+	// Path is the repo-relative path.
+	Path string
+	// Deleted reports that Path does not exist at head, either because it was
+	// removed or because it is the old name of a rename.
+	Deleted bool
+}
+
+// ChangedFiles returns the repo-relative paths changed between base and head.
+// It is Changes with the change type dropped, kept for callers that only need
+// the path set. See Changes for the diff semantics.
+func ChangedFiles(repoDir, base, head string) ([]string, error) {
+	changes, err := Changes(repoDir, base, head)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(changes))
+	for _, c := range changes {
+		out = append(out, c.Path)
+	}
+	return out, nil
+}
+
+// Changes returns the repo-relative paths changed between base and head, using
+// three-dot (merge-base) semantics: the diff is taken from the merge-base of
+// base and head to head, so changes made on the base branch after the two
+// diverged are not attributed to head. This mirrors `git diff base...head` and
+// is what a PR "changes" set means.
 //
 // repoDir is a working-tree root containing a .git directory. Renamed paths
 // contribute both their old and new names (conservative — the change could
-// affect the module on either side). base/head are full commit SHAs.
-func ChangedFiles(repoDir, base, head string) ([]string, error) {
+// affect the module on either side), with the old name marked Deleted. base and
+// head are full commit SHAs. The result is sorted by path.
+func Changes(repoDir, base, head string) ([]Change, error) {
 	repo, err := git.PlainOpen(repoDir)
 	if err != nil {
 		return nil, fmt.Errorf("open repo %q: %w", repoDir, err)
@@ -57,19 +88,31 @@ func ChangedFiles(repoDir, base, head string) ([]string, error) {
 		return nil, fmt.Errorf("diff trees: %w", err)
 	}
 
-	set := make(map[string]struct{})
+	// A path exists at head exactly when it is the destination of some change.
+	// Collect those first so a path that is both the source of one rename and
+	// the destination of another (a swap) is not mistaken for deleted.
+	atHead := make(map[string]struct{}, len(changes))
 	for _, c := range changes {
-		if c.From.Name != "" {
-			set[c.From.Name] = struct{}{}
-		}
 		if c.To.Name != "" {
-			set[c.To.Name] = struct{}{}
+			atHead[c.To.Name] = struct{}{}
 		}
 	}
-	out := make([]string, 0, len(set))
-	for p := range set {
-		out = append(out, p)
+
+	deleted := make(map[string]bool, len(changes))
+	for _, c := range changes {
+		if n := c.From.Name; n != "" {
+			_, present := atHead[n]
+			deleted[n] = !present
+		}
+		if n := c.To.Name; n != "" {
+			deleted[n] = false
+		}
 	}
-	sort.Strings(out)
+
+	out := make([]Change, 0, len(deleted))
+	for p, gone := range deleted {
+		out = append(out, Change{Path: p, Deleted: gone})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
 	return out, nil
 }

--- a/ci/gitdiff/gitdiff_test.go
+++ b/ci/gitdiff/gitdiff_test.go
@@ -58,6 +58,15 @@ func (b *repoBuilder) commit(files map[string]string) plumbing.Hash {
 	return h
 }
 
+func (b *repoBuilder) remove(paths ...string) {
+	b.t.Helper()
+	for _, p := range paths {
+		if _, err := b.wt.Remove(p); err != nil {
+			b.t.Fatalf("remove %s: %v", p, err)
+		}
+	}
+}
+
 func (b *repoBuilder) checkout(h plumbing.Hash) {
 	b.t.Helper()
 	if err := b.wt.Checkout(&git.CheckoutOptions{Hash: h}); err != nil {
@@ -106,6 +115,54 @@ func TestChangedFilesMergeBase(t *testing.T) {
 	want := []string{"daggerverse/kicad/main.go"} // NOT kafka
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("three-dot diff = %v, want %v (base-only change must be excluded)", got, want)
+	}
+}
+
+// TestChangesMarksDeletions pins the distinction the selector depends on: a
+// removed file is reported Deleted, a surviving one is not. Without it a
+// deleted source file looks exactly like a file a module declared out of its
+// source set, and the module's checks would be skipped.
+func TestChangesMarksDeletions(t *testing.T) {
+	b := newRepo(t)
+	base := b.commit(map[string]string{
+		"daggerverse/kicad/main.go":   "v1",
+		"daggerverse/kicad/README.md": "docs",
+	})
+	b.remove("daggerverse/kicad/main.go")
+	head := b.commit(map[string]string{"daggerverse/kicad/README.md": "docs v2"})
+
+	got, err := Changes(b.dir, base.String(), head.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []Change{
+		{Path: "daggerverse/kicad/README.md", Deleted: false},
+		{Path: "daggerverse/kicad/main.go", Deleted: true},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// TestChangesRenameKeepsBothSides shows a rename contributing both names, the
+// old one marked gone. go-git's plain tree diff reports a rename as a delete
+// plus an add, which is exactly the conservative attribution we want.
+func TestChangesRenameKeepsBothSides(t *testing.T) {
+	b := newRepo(t)
+	base := b.commit(map[string]string{"daggerverse/kicad/main.go": "v1"})
+	b.remove("daggerverse/kicad/main.go")
+	head := b.commit(map[string]string{"daggerverse/kicad/renamed.go": "v1"})
+
+	got, err := Changes(b.dir, base.String(), head.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []Change{
+		{Path: "daggerverse/kicad/main.go", Deleted: true},
+		{Path: "daggerverse/kicad/renamed.go", Deleted: false},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
 	}
 }
 

--- a/dagger.json
+++ b/dagger.json
@@ -86,6 +86,9 @@
       "source": "daggerverse/zig/tests"
     }
   ],
+  "include": [
+    "!ci/README.md"
+  ],
   "source": "ci",
   "codegen": {
     "automaticGitignore": false

--- a/daggerverse/certificate-management/dagger.json
+++ b/daggerverse/certificate-management/dagger.json
@@ -4,6 +4,9 @@
   "sdk": {
     "source": "go"
   },
+  "include": [
+    "!README.md"
+  ],
   "codegen": {
     "automaticGitignore": false
   }

--- a/daggerverse/crypto/dagger.json
+++ b/daggerverse/crypto/dagger.json
@@ -4,6 +4,9 @@
   "sdk": {
     "source": "go"
   },
+  "include": [
+    "!README.md"
+  ],
   "codegen": {
     "automaticGitignore": false
   }

--- a/daggerverse/dgraph/dagger.json
+++ b/daggerverse/dgraph/dagger.json
@@ -4,6 +4,9 @@
   "sdk": {
     "source": "go"
   },
+  "include": [
+    "!README.md"
+  ],
   "codegen": {
     "automaticGitignore": false
   }

--- a/daggerverse/flash/dagger.json
+++ b/daggerverse/flash/dagger.json
@@ -4,6 +4,9 @@
   "sdk": {
     "source": "go"
   },
+  "include": [
+    "!README.md"
+  ],
   "codegen": {
     "automaticGitignore": false
   }

--- a/daggerverse/go/dagger.json
+++ b/daggerverse/go/dagger.json
@@ -4,6 +4,9 @@
   "sdk": {
     "source": "go"
   },
+  "include": [
+    "!README.md"
+  ],
   "codegen": {
     "automaticGitignore": false
   }

--- a/daggerverse/grafana-stack/dagger.json
+++ b/daggerverse/grafana-stack/dagger.json
@@ -4,6 +4,9 @@
   "sdk": {
     "source": "go"
   },
+  "include": [
+    "!README.md"
+  ],
   "codegen": {
     "automaticGitignore": false
   }

--- a/daggerverse/java/dagger.json
+++ b/daggerverse/java/dagger.json
@@ -4,6 +4,9 @@
   "sdk": {
     "source": "go"
   },
+  "include": [
+    "!README.md"
+  ],
   "codegen": {
     "automaticGitignore": false
   }

--- a/daggerverse/kafka/dagger.json
+++ b/daggerverse/kafka/dagger.json
@@ -4,6 +4,9 @@
   "sdk": {
     "source": "go"
   },
+  "include": [
+    "!README.md"
+  ],
   "dependencies": [
     {
       "name": "certificate-management",

--- a/daggerverse/kicad/dagger.json
+++ b/daggerverse/kicad/dagger.json
@@ -4,6 +4,9 @@
   "sdk": {
     "source": "go"
   },
+  "include": [
+    "!README.md"
+  ],
   "codegen": {
     "automaticGitignore": false
   }

--- a/daggerverse/opentofu/dagger.json
+++ b/daggerverse/opentofu/dagger.json
@@ -4,6 +4,9 @@
   "sdk": {
     "source": "go"
   },
+  "include": [
+    "!README.md"
+  ],
   "codegen": {
     "automaticGitignore": false
   }

--- a/daggerverse/otel/dagger.json
+++ b/daggerverse/otel/dagger.json
@@ -4,6 +4,9 @@
   "sdk": {
     "source": "go"
   },
+  "include": [
+    "!README.md"
+  ],
   "codegen": {
     "automaticGitignore": false
   }

--- a/daggerverse/postgres/dagger.json
+++ b/daggerverse/postgres/dagger.json
@@ -4,6 +4,9 @@
   "sdk": {
     "source": "go"
   },
+  "include": [
+    "!README.md"
+  ],
   "codegen": {
     "automaticGitignore": false
   }

--- a/daggerverse/qemu/dagger.json
+++ b/daggerverse/qemu/dagger.json
@@ -4,6 +4,9 @@
   "sdk": {
     "source": "go"
   },
+  "include": [
+    "!README.md"
+  ],
   "codegen": {
     "automaticGitignore": false
   }

--- a/daggerverse/random/dagger.json
+++ b/daggerverse/random/dagger.json
@@ -4,6 +4,9 @@
   "sdk": {
     "source": "go"
   },
+  "include": [
+    "!README.md"
+  ],
   "codegen": {
     "automaticGitignore": false
   }

--- a/daggerverse/tesseract/dagger.json
+++ b/daggerverse/tesseract/dagger.json
@@ -4,6 +4,9 @@
   "sdk": {
     "source": "go"
   },
+  "include": [
+    "!README.md"
+  ],
   "codegen": {
     "automaticGitignore": false
   }

--- a/daggerverse/valkey/dagger.json
+++ b/daggerverse/valkey/dagger.json
@@ -4,6 +4,9 @@
   "sdk": {
     "source": "go"
   },
+  "include": [
+    "!README.md"
+  ],
   "codegen": {
     "automaticGitignore": false
   }

--- a/daggerverse/zig/dagger.json
+++ b/daggerverse/zig/dagger.json
@@ -4,6 +4,9 @@
   "sdk": {
     "source": "go"
   },
+  "include": [
+    "!README.md"
+  ],
   "codegen": {
     "automaticGitignore": false
   }


### PR DESCRIPTION
Closes #195.

## Summary

The change-aware selector attributed every changed file to its **owning directory** and never asked whether the file was an *input*. A module-root `README.md` edit was therefore indistinguishable from a `main.go` rewrite and fanned out to every dependent's suite (37 of 49 checks on #194), while repo-level docs resolved to no module at all and tripped the full-suite fail-safe.

#195 proposed a hand-maintained docs allowlist and warned it was dangerous here — `daggerverse/skill-gen/skill/render.go` `go:embed`s `templates/README.md.tmpl`, so markdown under a module can be program data. **This takes the build-target route instead:** attribute a path to a module only when it belongs to that module's Dagger **source context** — precisely the files Dagger uploads for it — read from the engine via `ModuleSource.ContextDirectory` rather than modelled in Go.

Docs stop triggering builds not because we classified them as docs, but because they are not inputs. The classification is a property Dagger *enforces* (the file is never shipped to an engine), not one `affectedpkg` asserts about which files look like prose.

## How inputs are declared

`dagger.json` `include` unions on top of the source directory, so only `!` negation narrows it (`exclude` is deprecated sugar for the same thing). Every module with a root README declares it out:

```json
{ "include": ["!README.md"] }
```

Repo-level prose needs **no declaration**: the root module's source is `ci/`, so its context is exactly `ci/**` plus the root `dagger.json` — verified against the live engine, which reports `["ci/", "dagger.json"]`. The top-level `README.md`, `LICENSE`, `docs/**`, `plugins/**` and `.github/instructions/**` were never inputs to anything.

The one thing that does **not** fall out of the model is the #179 per-toolchain aggregator carve-out, which survives verbatim. Committed generated code is what a real build graph doesn't have: `ci/internal/dagger/<toolchain>.gen.go` is a toolchain *output* checked into the `ci` module, so `AggregatorBindings` still has to subtract it from the root module and fold it into its toolchain.

## Attribution

| changed path | selects |
| --- | --- |
| in a module's source context | that module and its dependents |
| in the root module's context (`ci/**`, root `dagger.json`) | the full suite |
| under `.github/workflows/` | the full suite — it governs how CI runs |
| in no module's source context | nothing beyond the always-on `ci:*` |

Two asymmetries are deliberate:

- The **innermost** module owns a path, so `daggerverse/crypto/tests/main.go` belongs to `crypto/tests` and not to `crypto`, even though Dagger's context for `crypto` contains it — nested modules are separate Go modules that never compile into their parent.
- A **deleted** path is attributed to its module rather than read as declared out, because no head source context can contain it. That over-runs when a declared-out file is deleted, which is the direction this package errs in.

## Also fixed along the way

- The module set is derived by walking the workspace for `dagger.json` instead of from the dependency graph, which could not see modules nothing depends on (`daggerverse/otel/examples/go`, `daggerverse/grafana-stack/examples/go`).
- `marshal` emitted JSON `null` for an empty selection, which survives the workflow's non-empty check and then breaks `fromJSON`. Now `[]`. Previously unreachable; this change makes near-empty selections routine.

## Verification

`ci:generated`, `ci:selection-self-test`, `go test ./...` and `gofmt` all pass. End-to-end against synthetic commits in a real clone, over today's 59-check universe:

| change | selected |
| --- | --- |
| module-root `README.md` only | 3 (`ci:*`) — was 37 on #194 |
| repo docs (`README.md`, `LICENSE`, `docs/**`) | 3 — was the full suite |
| `ci/README.md` only | 3 — was the full suite |
| `skill-gen/skill/templates/README.md.tmpl` | `skill-gen-tests:all` — still code |
| a deleted fixture file | `tesseract-tests:all` |
| `ci/internal/dagger/kicad-tests.gen.go` | `kicad-tests:all` — #179 intact |
| `.github/workflows/ci.yml` | full suite |
| README + code together | `kicad-tests:all` |

Note that this cannot be exercised from a `.claude/worktrees/*` checkout: there `.git` is a file, so the workspace `.git` export fails and the selector fails open to the full suite. Pre-existing, and CI's normal checkout is unaffected.

## Notes for review

- **A module must not read a file it declared out.** Doing so now fails loudly at build time rather than silently under-running CI, which is why `skill-gen` declares nothing out. This replaces the `go:embed` scanning guard #195 asked for with a structural guarantee.
- Selection is a diff against one base, so it still cannot skip work a previous run already proved good — a rebase onto an already-tested `main` re-runs everything. Memoizing check results by input hash is tracked in #238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
