### PR TITLE
story(issue-238): memoize check results by input hash across runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,30 @@ on:
 
 permissions:
   contents: read
+  # Read-only listing of the Actions cache, which is where the memoization store
+  # lives (see MEMO_PREFIX). Writes go through actions/cache/save, which uses its
+  # own scoped token rather than this one.
+  actions: read
 
 env:
   DAGGER_VERSION: "0.21.7"
+
+  # Memoization of check results by input hash (#238). A leg that passes records
+  # its input hash as a (near-empty) Actions cache entry under this prefix; a
+  # later run that computes the same hash skips that check.
+  MEMO_PREFIX: "ci-memo-v1-"
+
+  # How long a recorded pass may be honoured. This is the repo's answer to
+  # base-image drift, which a source-derived hash cannot see: these checks boot
+  # real services from floating tags, so an identical tree does not imply an
+  # identical container. Rather than fold resolved image digests into the hash —
+  # which would mean resolving every module's images, most of the cost
+  # memoization is meant to avoid, and would break the "derived from git object
+  # ids" property that makes the hash stable across engine releases — the window
+  # in which upstream drift can hide behind a memo hit is bounded outright.
+  # 24h captures essentially all the reuse, which is concentrated in hours-scale
+  # PR iteration. Do NOT raise this without re-reading ci/README.md.
+  MEMO_TTL_SECONDS: "86400"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -63,6 +84,66 @@ jobs:
             | DAGGER_VERSION="$DAGGER_VERSION" BIN_DIR="$HOME/.local/bin" sh
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
+      - id: memo
+        # Read the known-good set: the input hashes that some earlier leg already
+        # passed on (#238). Selection can only skip work unaffected by *this*
+        # diff; this is what lets it also skip work a previous run already proved
+        # good — most visibly a PR's second and later pushes, which today re-run
+        # everything that was green on the first.
+        #
+        # Only two cache scopes are trusted, and both are ones GitHub itself
+        # confines: the default branch, and (on a PR) that PR's own scope. A run
+        # can only write caches under its own GITHUB_REF, so no other branch and
+        # no fork can plant an entry either job here will read. That is stricter
+        # than GitHub's own restore rules, which would also expose the base
+        # branch of a stacked PR.
+        #
+        # Within a PR's own scope the writer is that PR — which is why
+        # affectedpkg refuses to honour any recorded pass once a global input
+        # (.github/workflows/**, the root module's context) changed: those are
+        # the only paths that can alter how a pass gets recorded, and a change to
+        # one also perturbs every input hash, so a forged entry lands in a hash
+        # space no untampered tree computes. See MemoTrusted. The exceptions are
+        # the root dagger.json and the core binding dagger regenerates with it,
+        # which decide which checks exist and never what one computes — see
+        # nonGlobalRootPaths and ci/README.md.
+        #
+        # Every failure here is soft: an unreadable store, a stale entry, an
+        # unparseable response all shrink the known-good set, which costs CI time
+        # and never correctness. Hence `set -uo pipefail` without -e, and the
+        # scratch file under RUNNER_TEMP rather than in the checkout, whose tree
+        # is what the next step hashes.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRUSTED_REFS: >-
+            refs/heads/${{ github.event.repository.default_branch }}
+            ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
+        run: |
+          set -uo pipefail
+          now=$(date -u +%s)
+          # fd 3 carries the hashes so stdout stays free for ::warning:: — a
+          # workflow command swallowed into the list would read back as a hash.
+          exec 3> "$RUNNER_TEMP/known-good.txt"
+          for ref in $TRUSTED_REFS; do
+            raw=$(gh api --paginate -X GET \
+              "repos/${GITHUB_REPOSITORY}/actions/caches" \
+              -f key="$MEMO_PREFIX" -f ref="$ref" -f per_page=100 \
+              --jq '.actions_caches[] | [.key, .created_at] | @tsv') || {
+                echo "::warning::cannot read the memo store for $ref; those checks will just run"
+                continue
+              }
+            while IFS=$'\t' read -r key created; do
+              [ -n "$key" ] || continue
+              stamp=$(date -u -d "$created" +%s 2>/dev/null) || continue
+              [ $(( now - stamp )) -le "$MEMO_TTL_SECONDS" ] || continue
+              printf '%s\n' "${key#"$MEMO_PREFIX"}" >&3
+            done <<< "$raw"
+          done
+          exec 3>&-
+          known=$(jq -Rsc 'split("\n") | map(select(length > 0)) | unique' < "$RUNNER_TEMP/known-good.txt")
+          echo "recorded passes within ${MEMO_TTL_SECONDS}s: $(jq -r 'length' <<< "$known")"
+          echo "known-good=$known" >> "$GITHUB_OUTPUT"
+
       - id: select
         # Emit the minimum set of checks a change could affect (issue #170). The
         # whole computation is the ci module's affected-checks function: it
@@ -98,9 +179,17 @@ jobs:
         #   - ci:* checks -> always run.
         # If enumeration itself fails there is no independent universe to fall back
         # to, so the step fails closed (CI blocks) rather than risk under-running.
+        #
+        # The surviving set is then filtered against the known-good hashes from
+        # the memo step (#238): a check whose whole input closure hashes to a
+        # value some earlier leg already passed on is dropped. Each returned
+        # {name, hash} pair carries the hash forward so the leg that runs it can
+        # record its own pass. An empty hash means "never memoize this check" —
+        # a ci:* check, or one whose inputs could not be hashed from git objects.
         env:
           BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
           HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
+          KNOWN_GOOD: ${{ steps.memo.outputs.known-good }}
           # Export this selection to Dagger Cloud so a run's check set can be
           # traced back to the decision that produced it (#180). A raw
           # `dagger call` reads the token from its environment, unlike the
@@ -109,16 +198,20 @@ jobs:
           DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
         run: |
           set -euo pipefail
-          jobs="$(dagger -m . call affected-checks --base="$BASE" --head="$HEAD")"
+          jobs="$(dagger -m . call affected-checks \
+            --base="$BASE" --head="$HEAD" --known-good="$KNOWN_GOOD")"
           [ -n "$jobs" ] || { echo "::error::affected-checks returned no checks"; exit 1; }
           echo "selected checks: $jobs"
           echo "checks=$jobs" >> "$GITHUB_OUTPUT"
 
       - id: route
-        # Re-shape the (already-filtered) check list into
-        # {name, module, filter, timeout} objects so each run job can load only
-        # its own tests module instead of the whole ci/ aggregator. ci:* checks
-        # stay on the root module.
+        # Re-shape the (already-filtered) {name, hash} list into
+        # {name, module, filter, hash, timeout} objects so each run job can load
+        # only its own tests module instead of the whole ci/ aggregator. ci:*
+        # checks stay on the root module. hash is passed through untouched so the
+        # leg records exactly the hash selection computed — it is never
+        # recomputed on the run job, which checks out at depth 1 and could not
+        # reproduce it.
         #
         # timeout is the leg's dagger/checks step bound in minutes. 6 fits every
         # leg that runs one module's suite; ci:generated is the exception (#184)
@@ -149,12 +242,14 @@ jobs:
               value: .source
             }) | from_entries) as $module_for |
             $checks | map(
-              (split(":")[0]) as $prefix |
+              .name as $name | .hash as $hash |
+              ($name | split(":")[0]) as $prefix |
               if $prefix == "ci" then
-                { name: ., module: ".", filter: .,
-                  timeout: ({"ci:generated": 15, "ci:generated-self-test": 8}[.] // 6) }
+                { name: $name, module: ".", filter: $name, hash: $hash,
+                  timeout: ({"ci:generated": 15, "ci:generated-self-test": 8}[$name] // 6) }
               else
-                { name: ., module: $module_for[$prefix], filter: ("tests:" + (split(":")[1])),
+                { name: $name, module: $module_for[$prefix],
+                  filter: ("tests:" + ($name | split(":")[1])), hash: $hash,
                   timeout: 6 }
               end
             )
@@ -233,13 +328,38 @@ jobs:
           filter: ${{ matrix.job.filter }}
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
 
+      # Record the pass (#238). The entry's whole meaning is its key: the input
+      # hash the list job computed for this check. A later run that computes the
+      # same hash — same source closure, same global inputs, same engineVersion —
+      # skips this leg. The payload exists only because a cache entry needs a
+      # path; nothing ever reads it back.
+      #
+      # Guarded on success() so only a green leg records, and on a non-empty hash
+      # so ci:* checks and unhashable inputs never do. Best-effort: the write is
+      # refused outright on a fork PR and is a no-op when the key already exists,
+      # neither of which should fail a leg that passed.
+      - name: Record the input hash
+        if: ${{ success() && matrix.job.hash != '' }}
+        env:
+          NAME: ${{ matrix.job.name }}
+        run: |
+          printf 'passed %s\n' "$NAME" > .ci-memo
+
+      - uses: actions/cache/save@v4
+        if: ${{ success() && matrix.job.hash != '' }}
+        continue-on-error: true
+        with:
+          path: .ci-memo
+          key: ${{ env.MEMO_PREFIX }}${{ matrix.job.hash }}
+
   # Single, stable status check for branch protection. Because the run matrix is
-  # dynamic — and now change-aware, so unaffected legs are intentionally absent
-  # (issue #170) — the per-leg check names cannot be required directly: a skipped
-  # leg would leave its required check pending forever. Require ONLY "CI Gate" in
-  # branch protection instead. It always runs and passes iff `list` succeeded and
-  # no executed leg failed (an all-skipped `run` — impossible today since ci:*
-  # always runs — is treated as success).
+  # dynamic — and now change-aware (#170) and memoized (#238), so unaffected legs
+  # and already-proven ones are intentionally absent — the per-leg check names
+  # cannot be required directly: a skipped leg would leave its required check
+  # pending forever. Require ONLY "CI Gate" in branch protection instead. It
+  # always runs and passes iff `list` succeeded and no executed leg failed (an
+  # all-skipped `run` — impossible today, since ci:* always runs and is never
+  # memoized — is treated as success).
   gate:
     name: CI Gate
     needs: [list, run]

--- a/ci/README.md
+++ b/ci/README.md
@@ -122,7 +122,124 @@ declared out, because no head source context can contain it; that
 over-runs when a declared-out file is deleted, which is the direction
 this package errs in.
 
-Selection is a diff against one base, so it cannot skip work a previous
-run already proved good — a rebase onto an already-tested `main` re-runs
-everything. Memoizing check results by input hash is tracked in
-[#238](https://github.com/z5labs/devex/issues/238).
+## Skipping work a previous run already proved good
+
+Selection is a diff against one base, so on its own it can only skip work
+unaffected by *this* PR — never work an earlier run already proved good.
+A PR's second and later pushes re-run everything that was green on the
+first, because the diff is still measured from the PR base. Memoization
+closes that gap (#238): every check gets an **input hash**, a passing
+check records it, and a later run that computes the same hash skips the
+check.
+
+The hash is a Merkle fold over **git blob object ids** — sorted
+`(path, blobOID)` per module source context, folded over the check's
+transitive dependency closure, plus the check's own name and the global
+inputs. Git object ids, not `Directory.digest`: Dagger's digest format is
+explicitly not stable across releases, so a persisted set keyed on it
+would be invalidated wholesale by every engine bump. An engine bump still
+invalidates every check, correctly — `engineVersion` is a field in all
+~50 `dagger.json` files, and each is in its own module's source context.
+
+Two checks on one module hash apart (the name is in the digest), and the
+per-toolchain aggregator bindings are folded into their own toolchain
+rather than the global inputs, for the same reason `AggregatorBindings`
+exists (#179): repo convention regenerates one on nearly every module
+change, and treating it as global would mean memoization never hit.
+
+The store is the **GitHub Actions cache**: a passing leg writes a marker
+entry keyed `ci-memo-v1-<hash>`, and the `list` job reads back the keys.
+Only two cache scopes are read — the default branch, and a PR's own scope
+— both of which GitHub itself confines, since a run can only write caches
+under its own `GITHUB_REF`. No other branch and no fork can plant an
+entry CI will read; that is stricter than GitHub's own restore rules,
+which would also expose a stacked PR's base branch.
+
+Within a PR's own scope the writer is that PR, so the selector refuses to
+honour *any* recorded pass once a **global input** changed —
+`.github/workflows/**` or the root module's source context. Those are the
+only paths that can alter how a pass is recorded, and a change to one
+also perturbs every input hash, so a forged entry lands in a hash space
+no untampered tree ever computes and reverting the tamper restores the
+honest hashes rather than matching the forged ones. See `MemoTrusted`.
+
+### The two root-context paths that are not global
+
+Adding a daggerverse module is the change that touches least and, left
+alone, would cost most. It necessarily edits three files under the root
+module, and if all three were global inputs it would retire the entire
+store. So `nonGlobalRootPaths` excludes two of them from both the global
+hash and the trust judgement, and `AggregatorBindings` already handled
+the third:
+
+| file the PR touches | treatment |
+| --- | --- |
+| `dagger.json` (the toolchain entry) | not a global input (`rootConfig`) |
+| `ci/internal/dagger/dagger.gen.go` (regenerated: one ID type + one loader) | not a global input (`coreBinding`) |
+| `ci/internal/dagger/<new>-tests.gen.go` | attributed to the new toolchain (#179) |
+
+**`dagger.json`** decides which checks *exist*, never what an existing
+check *computes*. Everything it carries is covered downstream:
+
+| field | already covered by |
+| --- | --- |
+| `engineVersion` | all 47 `dagger.json` carry it, and the other 46 are each in their own module's source context |
+| `toolchains` | repointing an entry changes `Check.OriginalModule`, hence the closure, hence the hash; and no non-`ci` leg ever loads the root module — `ci.yml` routes each at its own tests module |
+| `sdk`, `source`, `include`, `codegen` | scope the root module, which is never memoized; and `include`/`source` decide which paths are in the root context at all, so hiding a file with them removes it from the global set and moves the digest anyway |
+
+**`ci/internal/dagger/dagger.gen.go`** is the sharper case, because it is
+the API surface the hasher itself executes: a hand-patched `Glob` could
+make some module's hash go blind to that module's sources, recording a
+pass on good content and matching it against bad. What forecloses that
+is not the digest but **`ci:generated`** — it proves every committed
+generated file equals what `dagger develop` produces, it always runs,
+and it is never memoized (with `ci:generated-self-test` guarding it,
+after #184). A tampered binding is red at the gate on the very push that
+would act on it, and reverting to go green restores the honest hash,
+which the recorded entry no longer matches.
+
+Generalised: **a generated file need not be a global input, because a
+never-memoized check already proves it is derived from inputs that are.**
+That is the reasoning `AggregatorBindings` applies to the per-toolchain
+bindings, extended to the one binding attributable to no toolchain.
+
+Both are subtractions of a path's *content*, not of set membership —
+every other root-context path still reaches every hash, so the authored
+machinery under `ci/**` stays covered. Selection is untouched: either
+path changing still runs the full universe, because the set of checks
+really did change. Together they give the intended shape: **adding a
+module runs `ci:*` plus the new module's checks, and retires every
+untouched check on its unchanged hash.**
+
+### Base-image drift
+
+A source-derived hash cannot see upstream drift: these checks boot real
+services from floating tags, so an identical tree does not imply an
+identical container. The answer is an explicit **24h bound** on how long
+a recorded pass may be honoured (`MEMO_TTL_SECONDS` in
+`.github/workflows/ci.yml`, applied against each cache entry's
+`created_at`).
+
+Folding resolved image digests into the hash was rejected: it means
+resolving every module's images, which is most of the cost memoization is
+meant to avoid, and it breaks the git-object-id property above. Bounding
+the window instead caps drift-blindness at a day, which is where
+essentially all the reuse is anyway — memoization pays off across
+hours-scale PR iteration.
+
+### What is never memoized
+
+Same rule as selection: never skip a check a change could plausibly
+affect.
+
+| condition | result |
+| --- | --- |
+| `ci:*` checks | always run — `ci:generated` reads the whole workspace, which its closure does not describe |
+| a module's source context unreadable | that module's dependents are unhashable, so they run |
+| a source path absent from `HEAD` (untracked, dirty tree) | its module is unhashable, so its dependents run |
+| a global input changed | recorded passes are ignored wholesale |
+| the store unreadable, or an entry older than 24h | the check runs |
+
+A check that cannot be hashed reports an empty hash, and the workflow
+records nothing for it — so an unmemoizable check can never accidentally
+retire a later run.

--- a/ci/affected.go
+++ b/ci/affected.go
@@ -10,6 +10,9 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"sync"
+
+	"golang.org/x/sync/errgroup"
 
 	"dagger/ci/affectedpkg"
 	"dagger/ci/gitdiff"
@@ -28,11 +31,20 @@ func (ci *Ci) SelectionSelfTest(ctx context.Context) error {
 }
 
 // AffectedChecks returns, as a JSON array string, the subset of checks that a
-// change could plausibly affect — the input for CI's dynamic matrix.
+// change could plausibly affect — the input for CI's dynamic matrix. Each
+// element is a {"name", "hash"} object: the check to run, and the input hash
+// under which a pass may be recorded ("" when the check must never be memoized).
 //
 // base/head are the commit SHAs to diff. The CI caller passes the PR base and
 // head, or the push's before/after; an empty or all-zeros base (new branch,
 // missing base) yields the full universe.
+//
+// knownGood is a JSON array of input hashes that a previous run already proved
+// good; a selected check whose hash appears there is dropped (#238). It is
+// optional, and anything unparseable is treated as empty, so a broken or
+// unavailable store costs speed and never correctness. See InputHashes for what
+// the hash covers and MemoTrusted for when a recorded pass may be honoured at
+// all.
 //
 // The whole computation is in-engine. Both the check universe and the dependency
 // graph are enumerated once from the live Dagger Workspace
@@ -62,7 +74,14 @@ func (ci *Ci) SelectionSelfTest(ctx context.Context) error {
 // experimental enumeration diverge from stable `dagger check -l`.
 //
 // +cache="never"
-func (ci *Ci) AffectedChecks(ctx context.Context, base string, head string) (string, error) {
+func (ci *Ci) AffectedChecks(
+	ctx context.Context,
+	base string,
+	head string,
+	// +optional
+	// +default="[]"
+	knownGood string,
+) (string, error) {
 	list, err := dag.CurrentWorkspace().Checks().List(ctx)
 	if err != nil {
 		return "", fmt.Errorf("list workspace checks: %w", err)
@@ -90,15 +109,32 @@ func (ci *Ci) AffectedChecks(ctx context.Context, base string, head string) (str
 		checkModule[name] = root
 	}
 
-	b, h, ok := affectedpkg.DiffRange(base, head)
-	if !ok {
-		// No usable diff range (new branch, missing base, ...) -> full suite.
-		return marshal(universe)
-	}
-	changes, err := changedPaths(ctx, b, h)
+	closure := affectedpkg.BuildClosures(checkModule, adj)
+	bindings := affectedpkg.AggregatorBindings(checkModule)
+
+	// One export of the workspace's .git feeds both halves of the answer: the
+	// base...head change set narrows selection, and HEAD's blob object ids are
+	// what the input hashes are built from. They fail independently — a bad diff
+	// range still allows memoization, and an unreadable HEAD still allows
+	// narrowing.
+	scratch, cleanup, err := exportGit(ctx)
+	defer cleanup()
+	var changes []affectedpkg.Change
+	var blobs map[string]string
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "affected-checks: git diff failed (%v); running full suite\n", err)
-		return marshal(universe)
+		fmt.Fprintf(os.Stderr, "affected-checks: cannot export .git (%v); running the full suite with no memoization\n", err)
+	} else {
+		if b, h, ok := affectedpkg.DiffRange(base, head); !ok {
+			// No usable diff range (new branch, missing base, ...) -> full suite.
+			fmt.Fprintf(os.Stderr, "affected-checks: no usable diff range (base=%q head=%q); running the full suite\n", base, head)
+		} else if changes, err = diffChanges(scratch, b, h); err != nil {
+			fmt.Fprintf(os.Stderr, "affected-checks: git diff failed (%v); running the full suite\n", err)
+			changes = nil
+		}
+		if blobs, err = gitdiff.HeadBlobs(scratch); err != nil {
+			fmt.Fprintf(os.Stderr, "affected-checks: cannot read HEAD (%v); memoization disabled\n", err)
+			blobs = nil
+		}
 	}
 
 	moduleDirs, err := workspaceModuleDirs(ctx)
@@ -109,15 +145,72 @@ func (ci *Ci) AffectedChecks(ctx context.Context, base string, head string) (str
 		moduleDirs = graphModuleDirs(adj)
 	}
 
-	srcs := resolveSources(ctx, changes, moduleDirs, sources)
-	closure := affectedpkg.BuildClosures(checkModule, adj)
-	bindings := affectedpkg.AggregatorBindings(checkModule)
+	srcs := resolveSources(ctx, sourcesNeeded(changes, moduleDirs, closure, blobs != nil), sources)
 	changed, global := affectedpkg.Attribute(changes, moduleDirs, srcs, bindings)
 	kept, full := affectedpkg.Select(universe, closure, changed, global)
 	if full {
 		kept = universe
 	}
-	return marshal(kept)
+
+	var hashes map[string]string
+	if len(blobs) > 0 {
+		hashes = affectedpkg.InputHashes(closure, srcs, blobs, bindings)
+	}
+	if affectedpkg.MemoTrusted(changes, moduleDirs, srcs, bindings) {
+		run, skipped := affectedpkg.MemoFilter(kept, hashes, parseKnownGood(knownGood))
+		if len(skipped) > 0 {
+			fmt.Fprintf(os.Stderr, "affected-checks: %d check(s) already passed on these inputs; skipping %v\n", len(skipped), skipped)
+		}
+		kept = run
+	} else {
+		fmt.Fprintf(os.Stderr, "affected-checks: a global input changed; ignoring recorded passes\n")
+	}
+	return marshalJobs(kept, hashes)
+}
+
+// sourcesNeeded returns the module directories whose source contexts must be
+// read from the engine.
+//
+// Attribution alone only needs the handful of modules that own a changed path.
+// Hashing needs every module in every check's closure, plus the root module for
+// the global inputs — so the wider set is only paid for when there are object
+// ids to hash against.
+func sourcesNeeded(changes []affectedpkg.Change, moduleDirs []string, closure map[string]map[string]bool, hashing bool) map[string]bool {
+	need := map[string]bool{}
+	for _, c := range changes {
+		if dir, ok := affectedpkg.OwningModule(c.Path, moduleDirs); ok {
+			need[dir] = true
+		}
+	}
+	if !hashing {
+		return need
+	}
+	need[affectedpkg.RootPkg] = true
+	for _, dirs := range closure {
+		for dir := range dirs {
+			need[dir] = true
+		}
+	}
+	return need
+}
+
+// parseKnownGood turns the workflow's JSON array of recorded input hashes into a
+// set. An unparseable value yields the empty set, which memoizes nothing: a
+// store that cannot be read must cost speed, never correctness.
+func parseKnownGood(raw string) map[string]bool {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	var hashes []string
+	if err := json.Unmarshal([]byte(raw), &hashes); err != nil {
+		fmt.Fprintf(os.Stderr, "affected-checks: cannot parse known-good hashes (%v); running every selected check\n", err)
+		return nil
+	}
+	set := make(map[string]bool, len(hashes))
+	for _, h := range hashes {
+		set[h] = true
+	}
+	return set
 }
 
 // workspaceModuleDirs returns every module directory in the workspace, repo-
@@ -153,35 +246,49 @@ func graphModuleDirs(adj map[string][]string) []string {
 	return append(dirs, affectedpkg.RootPkg)
 }
 
-// resolveSources returns the source contexts of just those modules that own at
-// least one changed path — typically one or two, never all of them.
+// resolveSources returns the source contexts of the requested modules.
 //
 // A module left out of the result is one whose context could not be read, or one
 // the dependency walk never reached; Attribute treats both as "everything under
-// it is an input" and so declines to narrow.
-func resolveSources(ctx context.Context, changes []affectedpkg.Change, moduleDirs []string, sources map[string]*dagger.ModuleSource) map[string]map[string]bool {
-	owners := map[string]bool{}
-	for _, c := range changes {
-		if dir, ok := affectedpkg.OwningModule(c.Path, moduleDirs); ok {
-			owners[dir] = true
-		}
-	}
+// it is an input" and so declines to narrow, while InputHashes treats them as
+// unhashable and so declines to memoize.
+//
+// The engine round-trips are independent, so they run concurrently — bounded,
+// because hashing asks for every module in the workspace rather than the one or
+// two that own a changed path.
+func resolveSources(ctx context.Context, want map[string]bool, sources map[string]*dagger.ModuleSource) map[string]map[string]bool {
+	var mu sync.Mutex
+	srcs := make(map[string]map[string]bool, len(want))
 
-	srcs := make(map[string]map[string]bool, len(owners))
-	for dir := range owners {
+	var g errgroup.Group
+	g.SetLimit(sourceContextConcurrency)
+	for dir := range want {
 		src, ok := sources[dir]
 		if !ok {
 			continue
 		}
-		set, err := sourceContext(ctx, src, dir)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "affected-checks: cannot read the source context of %q (%v); treating everything under it as an input\n", dir, err)
-			continue
-		}
-		srcs[dir] = set
+		g.Go(func() error {
+			set, err := sourceContext(ctx, src, dir)
+			if err != nil {
+				// Never fatal: the caller's fail-safes cover an unresolved module.
+				fmt.Fprintf(os.Stderr, "affected-checks: cannot read the source context of %q (%v); treating everything under it as an input\n", dir, err)
+				return nil
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			srcs[dir] = set
+			return nil
+		})
 	}
+	g.Wait() //nolint:errcheck // every goroutine returns nil by construction
 	return srcs
 }
+
+// sourceContextConcurrency bounds the in-flight ContextDirectory globs. Each is
+// a round trip to the engine and there are ~50 modules, so some concurrency is
+// worth real wall-clock in the list job; the cap keeps a burst of glob traversals
+// from crowding out the rest of the session.
+const sourceContextConcurrency = 8
 
 // sourceContext lists the repo-relative file paths Dagger uploads for the module
 // rooted at dir. The context directory is rooted at the repository, so the glob
@@ -206,26 +313,33 @@ func sourceContext(ctx context.Context, src *dagger.ModuleSource, dir string) (m
 	return set, nil
 }
 
-// changedPaths returns the repo-relative paths changed between base and head,
-// each flagged with whether it survives at head. It materializes the workspace's
-// .git directory into the module's scratch workdir (the Export/WorkdirFile
-// runtime-I/O pattern) and diffs base...head with go-git — pure Go, no git binary
-// and no helper container. Export is required because go-git reads an os
-// filesystem, whereas dag.CurrentWorkspace().Directory returns a lazy Directory
-// handle rather than mounted files.
-func changedPaths(ctx context.Context, base, head string) ([]affectedpkg.Change, error) {
+// exportGit materializes the workspace's .git directory into the module's
+// scratch workdir (the Export/WorkdirFile runtime-I/O pattern) and returns the
+// repository root to read it from, plus a cleanup that is always safe to call.
+//
+// Export is required because go-git reads an os filesystem, whereas
+// dag.CurrentWorkspace().Directory returns a lazy Directory handle rather than
+// mounted files. One export serves both the diff and the HEAD tree walk.
+func exportGit(ctx context.Context) (string, func(), error) {
 	suffix, err := uniqueSuffix()
 	if err != nil {
-		return nil, err
+		return "", func() {}, err
 	}
 	scratch := "affected-" + suffix
-	defer os.RemoveAll(scratch)
+	cleanup := func() { os.RemoveAll(scratch) }
 
 	gitDir := dag.CurrentWorkspace().Directory(".git")
 	if _, err := gitDir.Export(ctx, filepath.Join(scratch, ".git")); err != nil {
-		return nil, fmt.Errorf("export .git: %w", err)
+		return "", cleanup, fmt.Errorf("export .git: %w", err)
 	}
-	changes, err := gitdiff.Changes(scratch, base, head)
+	return scratch, cleanup, nil
+}
+
+// diffChanges returns the repo-relative paths changed between base and head,
+// each flagged with whether it survives at head, diffed base...head with go-git
+// — pure Go, no git binary and no helper container.
+func diffChanges(repoDir, base, head string) ([]affectedpkg.Change, error) {
+	changes, err := gitdiff.Changes(repoDir, base, head)
 	if err != nil {
 		return nil, err
 	}
@@ -278,14 +392,24 @@ func uniqueSuffix() (string, error) {
 	return hex.EncodeToString(b[:]), nil
 }
 
-// marshal renders the selected check names as the JSON array the workflow's
+// selectedCheck is one entry of the JSON array the workflow's route step
+// consumes. Hash is the input hash under which a pass may be recorded, and is
+// empty for a check that must never be memoized — a ci:* check, or one whose
+// inputs could not be hashed. The workflow records nothing for an empty hash.
+type selectedCheck struct {
+	Name string `json:"name"`
+	Hash string `json:"hash"`
+}
+
+// marshalJobs renders the selected checks as the JSON array the workflow's
 // matrix consumes. A nil slice would marshal to `null`, which survives the
 // workflow's non-empty check and then breaks fromJSON; emit `[]` instead.
-func marshal(v []string) (string, error) {
-	if v == nil {
-		v = []string{}
+func marshalJobs(names []string, hashes map[string]string) (string, error) {
+	out := make([]selectedCheck, 0, len(names))
+	for _, name := range names {
+		out = append(out, selectedCheck{Name: name, Hash: hashes[name]})
 	}
-	b, err := json.Marshal(v)
+	b, err := json.Marshal(out)
 	if err != nil {
 		return "", err
 	}

--- a/ci/affectedpkg/affected.go
+++ b/ci/affectedpkg/affected.go
@@ -193,8 +193,14 @@ const (
 	bindingDir = "ci/internal/dagger/"
 	bindingExt = ".gen.go"
 	// coreBinding is the ci module's own core binding. It is not attributable to
-	// any single toolchain, so it must keep failing open even in the pathological
-	// case of a toolchain literally named "dagger".
+	// any single toolchain, so *selection* must keep failing open on it even in
+	// the pathological case of a toolchain literally named "dagger" — hence its
+	// removal from the AggregatorBindings map below.
+	//
+	// Memoization treats it differently, and deliberately: see
+	// nonGlobalRootPaths. Attribution and the input hash answer different
+	// questions, and only the first has to be conservative about a file dagger
+	// regenerates every time the toolchain set changes.
 	coreBinding = bindingDir + "dagger" + bindingExt
 )
 

--- a/ci/affectedpkg/inputhash.go
+++ b/ci/affectedpkg/inputhash.go
@@ -1,0 +1,331 @@
+package affectedpkg
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"hash"
+	"io"
+	"slices"
+	"sort"
+)
+
+// hashVersion namespaces every digest produced here. Bump it whenever the hash
+// composition changes in a way that must invalidate previously recorded passes;
+// old entries then simply stop matching rather than being silently reinterpreted.
+const hashVersion = "z5labs/devex ci input-hash v1"
+
+// InputHashes returns, per check name, a digest of everything that determines
+// what that check computes: the check's own name, the source context of every
+// module in its dependency closure, and the global inputs that govern how CI
+// runs at all. Two runs agree on a check's hash exactly when nothing the check
+// can read has changed between them, which is what makes a recorded pass
+// reusable (#238).
+//
+// The digest is built from **git blob object ids**, never Dagger digests.
+// Dagger's Directory.digest is explicitly not stable across engine releases, so
+// a persisted set keyed on it would be invalidated wholesale by every engine
+// bump; git object ids are content hashes git itself already maintains. An
+// engine bump still perturbs every hash, correctly — engineVersion is a field in
+// every module's dagger.json, and each dagger.json is in its own module's source
+// context.
+//
+//   - closure is the per-check dependency closure from BuildClosures. A check
+//     absent from it is unresolved and gets no hash.
+//   - srcs maps a module directory to the repo-relative paths in its Dagger
+//     source context, i.e. precisely what Dagger uploads for it (the same
+//     source-context notion Attribute narrows with). It must include RootPkg.
+//   - blobs maps a repo-relative path to its git blob object id at HEAD, from
+//     gitdiff.HeadBlobs.
+//   - bindings is the aggregator-binding reattribution map from
+//     AggregatorBindings, applied here for the same reason Attribute applies it
+//     (#179): ci/internal/dagger/<toolchain>.gen.go is provably owned by one
+//     toolchain, and repo convention requires regenerating it whenever that
+//     toolchain's sources shift line numbers. Folding it into the global inputs
+//     instead would make the routine binding refresh that accompanies almost
+//     every module change perturb every check's hash, and memoization would
+//     essentially never hit.
+//
+// A check is omitted from the result — meaning "unhashable", which callers must
+// treat as "always run" — whenever any part of that answer is unavailable: an
+// unresolved closure, a module whose source context could not be read, or a
+// source path with no object id at HEAD (untracked, or a dirty working tree, as
+// when running locally). A nil result means even the global inputs were
+// unhashable, so nothing may be memoized.
+func InputHashes(
+	closure map[string]map[string]bool,
+	srcs map[string]map[string]bool,
+	blobs map[string]string,
+	bindings map[string]string,
+) map[string]string {
+	reattributed := map[string][]string{}
+	for path, dir := range bindings {
+		reattributed[dir] = append(reattributed[dir], path)
+	}
+
+	global, ok := globalHash(srcs, blobs, bindings)
+	if !ok {
+		return nil
+	}
+
+	memo := map[string]string{}
+	out := make(map[string]string, len(closure))
+	for name, dirs := range closure {
+		// ci:* checks are never memoized, so they need no hash. ci:generated
+		// runs codegen for every module in the workspace, and ci's own checks
+		// read state its declared closure (the root module alone) does not
+		// describe, so a closure-derived hash would not cover their inputs.
+		// Select already runs them unconditionally; this keeps that true.
+		if isCiCheck(name) {
+			continue
+		}
+		h := newDigest("check")
+		writeField(h, name)
+		writeField(h, global)
+		hashable := true
+		for _, dir := range sortedKeys(dirs) {
+			mh, resolved := moduleHash(dir, srcs, blobs, reattributed, memo)
+			if !resolved {
+				hashable = false
+				break
+			}
+			writeField(h, dir)
+			writeField(h, mh)
+		}
+		if !hashable {
+			continue
+		}
+		out[name] = sum(h)
+	}
+	return out
+}
+
+// rootConfig is the repository-root dagger.json, the one member of the root
+// module's source context that is deliberately NOT a global input.
+//
+// Everything it can affect is already accounted for downstream, so folding it in
+// would invalidate every recorded pass for a change that alters what no existing
+// check computes — most visibly when a new daggerverse module is added, since a
+// toolchain entry here is unavoidable:
+//
+//   - engineVersion is a field in all 47 dagger.json files, and each of the other
+//     46 sits in its own module's source context, so an engine bump already moves
+//     every module hash without help from this one.
+//   - toolchains only decides which checks exist and which module each is
+//     enumerated from. Repointing an entry's source changes Check.OriginalModule,
+//     hence the closure, hence the hash — the dependency graph carries that on its
+//     own. And no non-ci leg ever loads the root module: ci.yml routes each one at
+//     its own tests module.
+//   - sdk, source, include and codegen scope the root module itself, which is
+//     never memoized. Note that include and source decide which paths are in the
+//     root context at all, so using them to hide a file from the digest removes
+//     that file from globalHash's path set and moves the digest anyway.
+const rootConfig = "dagger.json"
+
+// nonGlobalRootPaths are the members of the root module's source context that
+// are deliberately NOT global inputs, and so neither contribute to globalHash
+// nor make MemoTrusted refuse a recorded pass.
+//
+// Both change on exactly one kind of PR — adding or removing a daggerverse
+// module — and neither alters what any existing check computes. Leaving them in
+// would retire every recorded pass on the change that touches least: adding a
+// toolchain entry to rootConfig also makes dagger regenerate coreBinding, which
+// gains nothing but an ID type and a loader for the new toolchain's object.
+//
+// coreBinding is the sharper of the two, because it is the API surface the
+// hasher itself executes, and a hand-patched Glob could make some module's hash
+// go blind to that module's sources — recording a pass on good content and then
+// matching it against bad. What forecloses that is not the digest but
+// ci:generated: it proves every committed generated file equals what
+// `dagger develop` produces, it always runs, and it is never memoized (and
+// ci:generated-self-test guards it, after #184). A tampered binding is therefore
+// red at the gate on the very push that would act on it, and reverting to go
+// green restores the honest hash, which the recorded entry no longer matches. So
+// generated files need not be global inputs: a never-memoized check already
+// proves they are derived from inputs that are. That is the same reasoning
+// AggregatorBindings applies to the per-toolchain bindings (#179), extended to
+// the one binding that is attributable to no toolchain at all.
+//
+// Both subtractions are of a path's *content*, never of set membership: every
+// other root-context path still contributes to globalHash, so the authored
+// recording machinery under ci/** stays covered.
+//
+// Note this is a subtraction from the *global* inputs only. Selection is
+// untouched: Attribute still reports a change to either path as global and runs
+// the full universe, because the set of checks really did change.
+var nonGlobalRootPaths = []string{rootConfig, coreBinding}
+
+// globalHash digests the inputs that belong to no check in particular but can
+// invalidate every one of them: the root module's source context (ci/**) and
+// everything under globalPrefixes. It is folded into every check's hash, because
+// those paths decide how checks are routed and how a pass is recorded — the
+// closures alone never reach them.
+//
+// Two subtractions: the per-toolchain aggregator bindings, which live in the root
+// module's context but are attributed to their own toolchain (see InputHashes),
+// and nonGlobalRootPaths.
+func globalHash(srcs map[string]map[string]bool, blobs map[string]string, bindings map[string]string) (string, bool) {
+	root, resolved := srcs[RootPkg]
+	if !resolved {
+		return "", false
+	}
+	paths := make([]string, 0, len(root))
+	for p := range root {
+		if _, moved := bindings[p]; moved {
+			continue
+		}
+		if slices.Contains(nonGlobalRootPaths, p) {
+			continue
+		}
+		paths = append(paths, p)
+	}
+	for p := range blobs {
+		if hasAnyPrefix(p, globalPrefixes) {
+			paths = append(paths, p)
+		}
+	}
+	sort.Strings(paths)
+
+	h := newDigest("global")
+	for _, p := range paths {
+		oid, known := blobs[p]
+		if !known {
+			return "", false
+		}
+		writeField(h, p)
+		writeField(h, oid)
+	}
+	return sum(h), true
+}
+
+// moduleHash digests one module's source context as sorted (path, object id)
+// pairs, memoized by directory because a shared module (random, crypto, ...)
+// appears in most closures. A memo entry of "" records "unhashable".
+func moduleHash(
+	dir string,
+	srcs map[string]map[string]bool,
+	blobs map[string]string,
+	reattributed map[string][]string,
+	memo map[string]string,
+) (string, bool) {
+	if cached, seen := memo[dir]; seen {
+		return cached, cached != ""
+	}
+	set, resolved := srcs[dir]
+	if !resolved {
+		memo[dir] = ""
+		return "", false
+	}
+	paths := make([]string, 0, len(set)+len(reattributed[dir]))
+	for p := range set {
+		paths = append(paths, p)
+	}
+	paths = append(paths, reattributed[dir]...)
+	sort.Strings(paths)
+
+	h := newDigest("module")
+	writeField(h, dir)
+	for _, p := range paths {
+		oid, known := blobs[p]
+		if !known {
+			memo[dir] = ""
+			return "", false
+		}
+		writeField(h, p)
+		writeField(h, oid)
+	}
+	digest := sum(h)
+	memo[dir] = digest
+	return digest, true
+}
+
+// MemoTrusted reports whether recorded passes may be honoured for this change
+// set.
+//
+// Pass records are written by the same CI run that produced them, so a change
+// that can alter the recording machinery could record a pass no check earned.
+// Everything that machinery is made of lives under globalPrefixes or in the root
+// module's source context — which is exactly what makes Attribute return global —
+// so declining to memoize whenever a global input changed closes that hole by
+// construction. It is closed twice over, in fact: such a change also perturbs
+// globalHash, so any entry recorded under it lands in a hash space no untampered
+// tree ever computes, and reverting the tamper restores the honest hashes rather
+// than matching the forged ones.
+//
+// The predicate is Attribute's own, re-run over the change set with
+// nonGlobalRootPaths subtracted, so there is no second copy of the rule to drift
+// — deletions, the aggregator-binding reattribution and the source-context test
+// all behave identically here and in selection. Those paths are subtracted for
+// the reasons documented on them, and only from *this* judgement: selection still
+// treats them as global and runs the full universe, because the set of checks
+// really did change. The two together are what make adding a daggerverse module
+// run the new module's checks and ci:* while every untouched check is retired by
+// its unchanged hash.
+//
+// A change set that is empty — or empty once those paths are removed — means "no
+// usable diff" or "nothing that governs recording", not "a global input changed".
+// Selection may still fall back to the full universe there, and memoization is
+// both safe and most valuable, because the hashes are read out of HEAD and never
+// depend on the diff.
+func MemoTrusted(changes []Change, moduleDirs []string, srcs map[string]map[string]bool, bindings map[string]string) bool {
+	rest := make([]Change, 0, len(changes))
+	for _, c := range changes {
+		if slices.Contains(nonGlobalRootPaths, c.Path) {
+			continue
+		}
+		rest = append(rest, c)
+	}
+	if len(rest) == 0 {
+		return true
+	}
+	_, global := Attribute(rest, moduleDirs, srcs, bindings)
+	return !global
+}
+
+// MemoFilter splits kept into the checks that must still run and the checks a
+// previous run already proved good.
+//
+// A check with no entry in hashes — a ci:* check, an unresolved closure, an
+// unreadable source context — is never skipped, per the rule from #170: never
+// skip a check a change could plausibly affect.
+func MemoFilter(kept []string, hashes map[string]string, knownGood map[string]bool) (run, skipped []string) {
+	for _, name := range kept {
+		if h, ok := hashes[name]; ok && knownGood[h] {
+			skipped = append(skipped, name)
+			continue
+		}
+		run = append(run, name)
+	}
+	return run, skipped
+}
+
+func newDigest(kind string) hash.Hash {
+	h := sha256.New()
+	writeField(h, hashVersion)
+	writeField(h, kind)
+	return h
+}
+
+// writeField feeds s to h length-prefixed, so that no combination of paths and
+// object ids can produce the same byte stream as a different combination. Git
+// paths may contain any byte except NUL, newlines included, so a separator
+// character would not be enough.
+func writeField(h hash.Hash, s string) {
+	var n [8]byte
+	binary.BigEndian.PutUint64(n[:], uint64(len(s)))
+	h.Write(n[:])
+	io.WriteString(h, s)
+}
+
+func sum(h hash.Hash) string {
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/ci/affectedpkg/inputhash_test.go
+++ b/ci/affectedpkg/inputhash_test.go
@@ -1,0 +1,145 @@
+package affectedpkg
+
+import (
+	"reflect"
+	"testing"
+)
+
+// tinyTree is the smallest graph that exercises InputHashes: one shared module,
+// two checks over it, and a root module holding the global inputs.
+func tinyTree() (closure, srcs map[string]map[string]bool, blobs map[string]string) {
+	closure = map[string]map[string]bool{
+		"kicad-tests:all":    {"daggerverse/kicad/tests": true, "daggerverse/kicad": true},
+		"kicad-tests:native": {"daggerverse/kicad/tests": true, "daggerverse/kicad": true},
+		"crypto-tests:all":   {"daggerverse/crypto": true},
+		"ci:generated":       {".": true},
+	}
+	srcs = map[string]map[string]bool{
+		".":                       {rootConfig: true, coreBinding: true, "ci/main.go": true},
+		"daggerverse/kicad":       {"daggerverse/kicad/main.go": true},
+		"daggerverse/kicad/tests": {"daggerverse/kicad/tests/main.go": true},
+		"daggerverse/crypto":      {"daggerverse/crypto/crypto.go": true},
+	}
+	blobs = map[string]string{}
+	for _, set := range srcs {
+		for p := range set {
+			blobs[p] = "blob:" + p
+		}
+	}
+	return closure, srcs, blobs
+}
+
+// TestInputHashesAreDeterministic guards the property the whole store depends
+// on: the digest must not depend on Go's randomized map iteration order.
+func TestInputHashesAreDeterministic(t *testing.T) {
+	closure, srcs, blobs := tinyTree()
+	first := InputHashes(closure, srcs, blobs, nil)
+	for range 25 {
+		if got := InputHashes(closure, srcs, blobs, nil); !reflect.DeepEqual(got, first) {
+			t.Fatalf("hashes differ between runs:\n%v\n%v", first, got)
+		}
+	}
+}
+
+// TestInputHashesSeparateChecksOnOneModule: two checks sharing a closure must
+// still hash apart, or a pass recorded for one would retire the other.
+func TestInputHashesSeparateChecksOnOneModule(t *testing.T) {
+	closure, srcs, blobs := tinyTree()
+	h := InputHashes(closure, srcs, blobs, nil)
+	if h["kicad-tests:all"] == "" || h["kicad-tests:native"] == "" {
+		t.Fatalf("missing hashes: %v", h)
+	}
+	if h["kicad-tests:all"] == h["kicad-tests:native"] {
+		t.Error("two checks over the same closure must not share an input hash")
+	}
+	if _, ok := h["ci:generated"]; ok {
+		t.Error("ci:* checks must not be hashed")
+	}
+}
+
+func TestInputHashesUnhashableWithoutRootContext(t *testing.T) {
+	closure, srcs, blobs := tinyTree()
+	delete(srcs, RootPkg)
+	if got := InputHashes(closure, srcs, blobs, nil); got != nil {
+		t.Errorf("got %v, want nil when the global inputs cannot be read", got)
+	}
+}
+
+func TestInputHashesUnresolvedCheckIsUnhashable(t *testing.T) {
+	closure, srcs, blobs := tinyTree()
+	// A check whose module could not be resolved never reaches closure at all.
+	delete(closure, "crypto-tests:all")
+	h := InputHashes(closure, srcs, blobs, nil)
+	if _, ok := h["crypto-tests:all"]; ok {
+		t.Error("an unresolved check must not be hashed")
+	}
+	run, skipped := MemoFilter([]string{"crypto-tests:all"}, h, map[string]bool{"": true})
+	if !reflect.DeepEqual(run, []string{"crypto-tests:all"}) || skipped != nil {
+		t.Errorf("unhashed check was skipped: run=%v skipped=%v", run, skipped)
+	}
+}
+
+func TestMemoFilter(t *testing.T) {
+	hashes := map[string]string{"a:all": "h1", "b:all": "h2"}
+	run, skipped := MemoFilter(
+		[]string{"ci:generated", "a:all", "b:all", "c:all"},
+		hashes,
+		map[string]bool{"h1": true},
+	)
+	// ci:generated and c:all are unhashed, b:all's hash is not recorded.
+	if want := []string{"ci:generated", "b:all", "c:all"}; !reflect.DeepEqual(run, want) {
+		t.Errorf("run = %v, want %v", run, want)
+	}
+	if want := []string{"a:all"}; !reflect.DeepEqual(skipped, want) {
+		t.Errorf("skipped = %v, want %v", skipped, want)
+	}
+}
+
+// TestInputHashesIgnoreNonGlobalRootPaths pins the nonGlobalRootPaths
+// subtraction: adding a toolchain edits the repo-root dagger.json and makes
+// dagger regenerate the core binding, and neither may retire recorded passes.
+func TestInputHashesIgnoreNonGlobalRootPaths(t *testing.T) {
+	closure, srcs, blobs := tinyTree()
+	before := InputHashes(closure, srcs, blobs, nil)
+
+	after := map[string]string{}
+	for p, oid := range blobs {
+		after[p] = oid
+	}
+	after[rootConfig] = "blob:a-new-toolchain-entry"
+	after[coreBinding] = "blob:a-new-id-type-and-loader"
+	if got := InputHashes(closure, srcs, after, nil); !reflect.DeepEqual(got, before) {
+		t.Errorf("a module-adding edit changed check hashes:\nbefore %v\nafter  %v", before, got)
+	}
+
+	// The rest of the root context is still global.
+	after["ci/main.go"] = "blob:edited"
+	got := InputHashes(closure, srcs, after, nil)
+	for name, h := range before {
+		if got[name] == h {
+			t.Errorf("%s kept its hash across a ci/ change", name)
+		}
+	}
+}
+
+func TestMemoTrustedSubtractsOnlyNonGlobalRootPaths(t *testing.T) {
+	_, srcs, _ := tinyTree()
+	dirs := []string{".", "daggerverse/kicad", "daggerverse/kicad/tests", "daggerverse/crypto"}
+	cases := []struct {
+		name    string
+		changes []Change
+		want    bool
+	}{
+		{"root config alone", []Change{{Path: rootConfig}}, true},
+		{"core binding alone", []Change{{Path: coreBinding}}, true},
+		{"both, as a module addition", []Change{{Path: rootConfig}, {Path: coreBinding}}, true},
+		{"with a module change", []Change{{Path: rootConfig}, {Path: "daggerverse/kicad/main.go"}}, true},
+		{"with a ci/ change", []Change{{Path: coreBinding}, {Path: "ci/main.go"}}, false},
+		{"no changes", nil, true},
+	}
+	for _, tc := range cases {
+		if got := MemoTrusted(tc.changes, dirs, srcs, nil); got != tc.want {
+			t.Errorf("%s: MemoTrusted = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/ci/affectedpkg/memo_selfcheck.go
+++ b/ci/affectedpkg/memo_selfcheck.go
@@ -1,0 +1,401 @@
+package affectedpkg
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// hashTree is a synthetic worktree for the fixture graph: every module's Dagger
+// source context, plus the global inputs, plus a git blob object id per path.
+//
+// It stands in for the real repository the way `fixture` stands in for the real
+// dependency graph, so the memoization invariants can be asserted without an
+// engine or a checkout. The object ids are opaque to InputHashes — all it ever
+// does is compare them — so a synthetic id exercises the real code path.
+type hashTree struct {
+	srcs  map[string]map[string]bool
+	blobs map[string]string
+}
+
+// workflowPath is the one global input that lives outside any module's source
+// context. Its prefix is what globalPrefixes matches.
+const workflowPath = ".github/workflows/ci.yml"
+
+// hashTree builds the pristine tree: two source files per module (a dagger.json
+// carrying engineVersion and a main.go), the root module's own context, one
+// aggregator binding per toolchain, and the CI workflow. Each module also gets a
+// README.md that is deliberately absent from its source context, so the "a
+// non-input change hits every check" invariant has something to touch.
+func (f fixture) hashTree() hashTree {
+	t := hashTree{
+		srcs:  map[string]map[string]bool{},
+		blobs: map[string]string{},
+	}
+
+	for _, dir := range f.moduleDirs() {
+		if dir == RootPkg {
+			continue
+		}
+		t.addInputs(dir, dir+"/dagger.json", dir+"/main.go")
+		t.blobs[dir+"/README.md"] = "blob:" + dir + "/README.md" // declared out
+	}
+
+	root := []string{
+		"dagger.json",
+		"ci/main.go",
+		"ci/affectedpkg/affected.go",
+		"ci/internal/dagger/dagger.gen.go",
+	}
+	for path := range AggregatorBindings(f.checkModule) {
+		root = append(root, path)
+	}
+	t.addInputs(RootPkg, root...)
+
+	t.blobs[workflowPath] = "blob:" + workflowPath
+	return t
+}
+
+func (t hashTree) addInputs(dir string, paths ...string) {
+	if t.srcs[dir] == nil {
+		t.srcs[dir] = map[string]bool{}
+	}
+	for _, p := range paths {
+		t.srcs[dir][p] = true
+		t.blobs[p] = "blob:" + p
+	}
+}
+
+// touch returns a copy of the tree in which every listed path has different
+// content — a new object id — exactly as an edit to that file would produce.
+func (t hashTree) touch(paths ...string) hashTree {
+	next := hashTree{srcs: t.srcs, blobs: make(map[string]string, len(t.blobs))}
+	for p, oid := range t.blobs {
+		next.blobs[p] = oid
+	}
+	for _, p := range paths {
+		next.blobs[p] = "blob:edited:" + p
+	}
+	return next
+}
+
+// withoutDeleted returns a copy of the tree's source contexts with every deleted
+// path removed, which is the state a head context is actually in — nothing that
+// no longer exists can be in it.
+func (t hashTree) withoutDeleted(changes []Change) map[string]map[string]bool {
+	out := make(map[string]map[string]bool, len(t.srcs))
+	for dir, set := range t.srcs {
+		copied := make(map[string]bool, len(set))
+		for p := range set {
+			copied[p] = true
+		}
+		out[dir] = copied
+	}
+	for _, c := range changes {
+		if !c.Deleted {
+			continue
+		}
+		for _, set := range out {
+			delete(set, c.Path)
+		}
+	}
+	return out
+}
+
+// dropModule returns a copy of the tree with dir's source context unreadable,
+// modelling a module whose ContextDirectory the engine could not glob.
+func (t hashTree) dropModule(dir string) hashTree {
+	next := hashTree{srcs: make(map[string]map[string]bool, len(t.srcs)), blobs: t.blobs}
+	for d, set := range t.srcs {
+		if d == dir {
+			continue
+		}
+		next.srcs[d] = set
+	}
+	return next
+}
+
+// everyDaggerJSON is the shape of an engineVersion bump: the field lives in all
+// ~50 dagger.json files, so every module's source context changes at once.
+func (t hashTree) everyDaggerJSON() []string {
+	var out []string
+	for p := range t.blobs {
+		if p == "dagger.json" || strings.HasSuffix(p, "/dagger.json") {
+			out = append(out, p)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// memoCase asserts which checks a given edit must invalidate: after touching
+// `touch`, exactly the checks in wantMiss must compute a different input hash
+// than they did on the pristine tree, and every other check must still match.
+type memoCase struct {
+	name  string
+	touch []string
+	// engineBump touches every dagger.json instead, which is what bumping
+	// engineVersion does; the paths are only known once a tree exists.
+	engineBump bool
+	// wantMiss is the exact set of checks whose hash must change. Empty means
+	// every check still hits.
+	wantMiss []string
+	// wantAllMiss asserts no check may hit — the fail-safe direction.
+	wantAllMiss bool
+}
+
+// cryptoDependents is every check that reaches daggerverse/crypto in the fixture
+// graph, i.e. the blast radius memoization must reproduce exactly.
+var cryptoDependents = []string{
+	"certificate-management-tests:all",
+	"crypto-tests:all",
+	"kafka-tests:native",
+	"skill-gen-tests:all",
+	"postgres-tests:cluster",
+	"envoy-tests:admin",
+	"otel-tests:core",
+}
+
+func memoCases() []memoCase {
+	return []memoCase{
+		{
+			// The whole point: an unchanged input closure reproduces the same
+			// hash, so a recorded pass is reusable.
+			name: "an untouched tree hits every check",
+		},
+		{
+			name:     "a leaf module misses only its own suite",
+			touch:    []string{"daggerverse/kicad/main.go"},
+			wantMiss: []string{"kicad-tests:all"},
+		},
+		{
+			name:     "a module's own tests dir misses only its own suite",
+			touch:    []string{"daggerverse/kicad/tests/main.go"},
+			wantMiss: []string{"kicad-tests:all"},
+		},
+		{
+			// Any member of the closure, however deep, invalidates the check.
+			name:     "a shared module misses every dependent",
+			touch:    []string{"daggerverse/crypto/main.go"},
+			wantMiss: cryptoDependents,
+		},
+		{
+			// The reason the aggregator bindings are attributed to their
+			// toolchain (#179) rather than folded into the global inputs: repo
+			// convention regenerates one on almost every module change, and
+			// folding it in globally would make memoization never hit.
+			name:     "a per-toolchain aggregator binding misses only its own suite",
+			touch:    []string{bindingDir + "kicad-tests" + bindingExt},
+			wantMiss: []string{"kicad-tests:all"},
+		},
+		{
+			name:        "an engine-version bump misses every check",
+			engineBump:  true,
+			wantAllMiss: true,
+		},
+		{
+			// A workflow decides which checks run and how a pass is recorded, so
+			// it must reach every hash.
+			name:        "a CI workflow change misses every check",
+			touch:       []string{workflowPath},
+			wantAllMiss: true,
+		},
+		{
+			name:        "the ci module's own source misses every check",
+			touch:       []string{"ci/affectedpkg/affected.go"},
+			wantAllMiss: true,
+		},
+		{
+			// Not global, unlike every other path under ci/: dagger regenerates
+			// it whenever the toolchain set changes, adding only an ID type and
+			// a loader for the new toolchain. ci:generated is what keeps that
+			// safe. See nonGlobalRootPaths.
+			name:  "the ci module's core binding misses nothing",
+			touch: []string{coreBinding},
+		},
+		{
+			// A path in no module's source context is an input to nothing, so it
+			// cannot invalidate a recorded pass any more than it can select a
+			// check (#195).
+			name:  "a module README, an input to nothing, misses nothing",
+			touch: []string{"daggerverse/crypto/README.md"},
+		},
+		{
+			name:  "adding a toolchain to the root dagger.json misses nothing",
+			touch: []string{rootConfig},
+		},
+		{
+			// The case nonGlobalRootPaths exists for: adding a daggerverse module
+			// edits the toolchain entry and makes dagger regenerate the core
+			// binding alongside it. Every pre-existing check must keep its hash.
+			// (The third file such a PR adds, the new toolchain's own binding,
+			// is reattributed by AggregatorBindings to a toolchain that has no
+			// recorded pass yet — covered by the per-toolchain case above.)
+			name:  "adding a daggerverse module misses no pre-existing check",
+			touch: []string{rootConfig, coreBinding},
+		},
+		{
+			// Those exclusions are of two paths' content, not of the root
+			// context as a whole — every other path there still reaches every
+			// hash.
+			name:        "the exclusions do not spare the rest of ci/",
+			touch:       []string{rootConfig, coreBinding, "ci/affectedpkg/affected.go"},
+			wantAllMiss: true,
+		},
+	}
+}
+
+// memoSelfCheck asserts the input-hash invariants (#238) against the fixture
+// graph and its synthetic worktree.
+func memoSelfCheck() error {
+	f := repoFixture()
+	closure := BuildClosures(f.checkModule, f.adj)
+	bindings := AggregatorBindings(f.checkModule)
+	base := f.hashTree()
+
+	recorded := InputHashes(closure, base.srcs, base.blobs, bindings)
+	if len(recorded) == 0 {
+		return fmt.Errorf("InputHashes produced no hashes for the fixture tree")
+	}
+	for name := range f.checkModule {
+		_, hashed := recorded[name]
+		if isCiCheck(name) == hashed {
+			return fmt.Errorf("%s: hashed=%v, want %v (ci:* checks are never memoized)", name, hashed, !hashed)
+		}
+	}
+
+	for _, tc := range memoCases() {
+		touch := tc.touch
+		if tc.engineBump {
+			touch = base.everyDaggerJSON()
+		}
+		after := InputHashes(closure, base.srcs, base.touch(touch...).blobs, bindings)
+
+		var miss []string
+		for name, h := range recorded {
+			next, ok := after[name]
+			if !ok {
+				return fmt.Errorf("%s: %s lost its hash", tc.name, name)
+			}
+			if next != h {
+				miss = append(miss, name)
+			}
+		}
+		if tc.wantAllMiss {
+			if len(miss) != len(recorded) {
+				return fmt.Errorf("%s: only %v missed, want every check", tc.name, sortedCopy(miss))
+			}
+			continue
+		}
+		if !sameSet(miss, tc.wantMiss) {
+			return fmt.Errorf("%s: missed %v, want %v", tc.name, sortedCopy(miss), sortedCopy(tc.wantMiss))
+		}
+	}
+
+	if err := memoFailSafeSelfCheck(f, closure, bindings, base); err != nil {
+		return err
+	}
+	return memoTrustSelfCheck(f, base, bindings)
+}
+
+// memoFailSafeSelfCheck asserts that anything the hash cannot account for leaves
+// the check unhashed, and that an unhashed check is never skipped.
+func memoFailSafeSelfCheck(f fixture, closure map[string]map[string]bool, bindings map[string]string, base hashTree) error {
+	// A module whose source context could not be read poisons every check that
+	// depends on it, and only those.
+	blind := InputHashes(closure, base.dropModule("daggerverse/crypto").srcs, base.blobs, bindings)
+	for _, name := range cryptoDependents {
+		if _, hashed := blind[name]; hashed {
+			return fmt.Errorf("%s kept a hash despite an unreadable dependency source context", name)
+		}
+	}
+	if _, hashed := blind["kicad-tests:all"]; !hashed {
+		return fmt.Errorf("kicad-tests:all lost its hash to an unrelated module's unreadable source context")
+	}
+
+	// A source path with no object id at HEAD — untracked, or a dirty tree —
+	// is equally unaccountable.
+	dirty := base.touch()
+	delete(dirty.blobs, "daggerverse/kicad/main.go")
+	if h := InputHashes(closure, base.srcs, dirty.blobs, bindings); len(h) > 0 {
+		if _, hashed := h["kicad-tests:all"]; hashed {
+			return fmt.Errorf("kicad-tests:all kept a hash despite a source path missing from HEAD")
+		}
+	}
+
+	// Unhashed checks — ci:* and the unresolvable — survive the filter even when
+	// every recorded hash is offered as known-good.
+	hashes := InputHashes(closure, base.srcs, base.blobs, bindings)
+	knownGood := map[string]bool{}
+	for _, h := range hashes {
+		knownGood[h] = true
+	}
+	universe := f.universe()
+	run, skipped := MemoFilter(universe, hashes, knownGood)
+	for _, name := range run {
+		if !isCiCheck(name) {
+			return fmt.Errorf("%s ran despite a recorded pass on identical inputs", name)
+		}
+	}
+	if len(run)+len(skipped) != len(universe) {
+		return fmt.Errorf("MemoFilter dropped checks: %d run + %d skipped != %d", len(run), len(skipped), len(universe))
+	}
+	if got := len(skipped); got != len(hashes) {
+		return fmt.Errorf("MemoFilter skipped %d checks, want %d", got, len(hashes))
+	}
+	return nil
+}
+
+// memoTrustSelfCheck asserts the trust boundary: a change that could alter how a
+// pass is recorded must disable memoization outright, while a change that only
+// alters which checks exist must not.
+func memoTrustSelfCheck(f fixture, base hashTree, bindings map[string]string) error {
+	dirs := f.moduleDirs()
+	cases := []struct {
+		name    string
+		changes []Change
+		want    bool
+	}{
+		{"an ordinary module change honours recorded passes", []Change{{Path: "daggerverse/kicad/main.go"}}, true},
+		{"a ci/ change ignores recorded passes", []Change{{Path: "ci/main.go"}}, false},
+		{"a workflow change ignores recorded passes", []Change{{Path: workflowPath}}, false},
+		{"a deleted ci/ file ignores recorded passes", []Change{{Path: "ci/main.go", Deleted: true}}, false},
+		{"an unusable diff still honours recorded passes", nil, true},
+		// Adding a daggerverse module. Neither of nonGlobalRootPaths may retire
+		// the store, alone or together, but neither may shield anything else.
+		{"a root dagger.json change alone honours recorded passes", []Change{{Path: rootConfig}}, true},
+		{"a core binding change alone honours recorded passes", []Change{{Path: coreBinding}}, true},
+		{
+			"adding a daggerverse module honours recorded passes",
+			[]Change{
+				{Path: rootConfig},
+				{Path: coreBinding},
+				{Path: bindingDir + "kicad-tests" + bindingExt},
+				{Path: "daggerverse/kicad/main.go"},
+			},
+			true,
+		},
+		{
+			"the exclusions alongside a ci/ change still ignore recorded passes",
+			[]Change{{Path: rootConfig}, {Path: coreBinding}, {Path: "ci/main.go"}},
+			false,
+		},
+		{
+			"the exclusions alongside a workflow change still ignore recorded passes",
+			[]Change{{Path: coreBinding}, {Path: workflowPath}},
+			false,
+		},
+	}
+	for _, tc := range cases {
+		srcs := base.srcs
+		if len(tc.changes) > 0 {
+			// Deleted paths cannot appear in a head source context; model that
+			// so the deletion case exercises Attribute's real behaviour.
+			srcs = base.withoutDeleted(tc.changes)
+		}
+		if got := MemoTrusted(tc.changes, dirs, srcs, bindings); got != tc.want {
+			return fmt.Errorf("%s: MemoTrusted = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+	return nil
+}

--- a/ci/affectedpkg/selfcheck.go
+++ b/ci/affectedpkg/selfcheck.go
@@ -334,7 +334,18 @@ func selfCheckCases() []selfCheckCase {
 // SelfCheck runs every invariant against the fixture graph and returns a non-nil
 // error describing the first failure. It backs both the ci:selection-self-test
 // Dagger check and the Go unit test.
+//
+// It covers both halves of the selector: which checks a change selects
+// (selectionSelfCheck) and which selected checks a recorded pass may retire
+// (memoSelfCheck).
 func SelfCheck() error {
+	if err := selectionSelfCheck(); err != nil {
+		return err
+	}
+	return memoSelfCheck()
+}
+
+func selectionSelfCheck() error {
 	f := repoFixture()
 	closure := BuildClosures(f.checkModule, f.adj)
 	universe := f.universe()

--- a/ci/dagger.gen.go
+++ b/ci/dagger.gen.go
@@ -212,7 +212,14 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg head", err))
 				}
 			}
-			return (*Ci).AffectedChecks(&parent, ctx, base, head)
+			var knownGood string
+			if inputArgs["knownGood"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["knownGood"]), &knownGood)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg knownGood", err))
+				}
+			}
+			return (*Ci).AffectedChecks(&parent, ctx, base, head, knownGood)
 		case "Generated":
 			var parent Ci
 			err = json.Unmarshal(parentJSON, &parent)

--- a/ci/gitdiff/gitdiff.go
+++ b/ci/gitdiff/gitdiff.go
@@ -12,7 +12,50 @@ import (
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
 )
+
+// HeadBlobs returns the blob object id of every file in the commit HEAD points
+// at, keyed by repo-relative path.
+//
+// It reads HEAD rather than a caller-supplied SHA on purpose: the object ids are
+// paired with file lists read out of the *checked-out* tree (a module's Dagger
+// source context), and only HEAD is guaranteed to be the commit those files came
+// from. On a pull_request event GitHub checks out refs/pull/N/merge, whose tree
+// is not the head SHA's tree, so hashing against the event's head SHA would pair
+// paths from one tree with object ids from another. A detached HEAD — which is
+// what actions/checkout leaves behind — resolves fine.
+//
+// Git blob ids are content hashes computed by git itself, so this is a Merkle
+// digest of the tree that costs nothing to recompute and, unlike a Dagger
+// directory digest, is stable across engine releases.
+func HeadBlobs(repoDir string) (map[string]string, error) {
+	repo, err := git.PlainOpen(repoDir)
+	if err != nil {
+		return nil, fmt.Errorf("open repo %q: %w", repoDir, err)
+	}
+	ref, err := repo.Head()
+	if err != nil {
+		return nil, fmt.Errorf("resolve HEAD: %w", err)
+	}
+	commit, err := repo.CommitObject(ref.Hash())
+	if err != nil {
+		return nil, fmt.Errorf("resolve HEAD commit %s: %w", ref.Hash(), err)
+	}
+	tree, err := commit.Tree()
+	if err != nil {
+		return nil, fmt.Errorf("HEAD tree: %w", err)
+	}
+	blobs := map[string]string{}
+	err = tree.Files().ForEach(func(f *object.File) error {
+		blobs[f.Name] = f.Hash.String()
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walk HEAD tree: %w", err)
+	}
+	return blobs, nil
+}
 
 // Change is one repo-relative path touched between two commits, together with
 // whether it still exists at head.

--- a/ci/gitdiff/gitdiff_test.go
+++ b/ci/gitdiff/gitdiff_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"testing"
 	"time"
 
@@ -172,4 +173,62 @@ func TestChangedFilesBadSHA(t *testing.T) {
 	if _, err := ChangedFiles(b.dir, "deadbeef", head.String()); err == nil {
 		t.Error("expected error for unresolvable base SHA")
 	}
+}
+
+// TestHeadBlobs covers the property the input hashes rest on: the object id of
+// a path is a function of its content and nothing else, so two runs over the
+// same tree agree and any edit disagrees.
+func TestHeadBlobs(t *testing.T) {
+	b := newRepo(t)
+	first := b.commit(map[string]string{
+		"daggerverse/kicad/main.go": "v1",
+		"daggerverse/go/main.go":    "g1",
+		"docs/copy.go":              "v1", // byte-identical to kicad's file
+	})
+	second := b.commit(map[string]string{"daggerverse/kicad/main.go": "v2"})
+
+	// Checking out by hash leaves a detached HEAD, which is the shape
+	// actions/checkout produces and so the shape HeadBlobs must handle.
+	b.checkout(first)
+	before, err := HeadBlobs(b.dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"daggerverse/go/main.go", "daggerverse/kicad/main.go", "docs/copy.go"}
+	if got := sortedKeys(before); !reflect.DeepEqual(got, want) {
+		t.Errorf("paths = %v, want %v", got, want)
+	}
+	if before["daggerverse/kicad/main.go"] != before["docs/copy.go"] {
+		t.Error("identical content must share an object id")
+	}
+
+	b.checkout(second)
+	after, err := HeadBlobs(b.dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := sortedKeys(after); !reflect.DeepEqual(got, want) {
+		t.Errorf("paths = %v, want %v", got, want)
+	}
+	if after["daggerverse/kicad/main.go"] == before["daggerverse/kicad/main.go"] {
+		t.Error("edited content must change its object id")
+	}
+	if after["daggerverse/go/main.go"] != before["daggerverse/go/main.go"] {
+		t.Error("untouched content must keep its object id")
+	}
+}
+
+func TestHeadBlobsNoRepo(t *testing.T) {
+	if _, err := HeadBlobs(t.TempDir()); err == nil {
+		t.Error("expected error when there is no repository to read")
+	}
+}
+
+func sortedKeys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }


### PR DESCRIPTION
Closes #238.

Selection has only ever been a diff against one base, so it can skip work
unaffected by the current PR but never work a previous run already proved good:
a PR's second and later pushes re-run everything that was green on the first.

Each check now gets an **input hash**; a passing leg records it, and a later run
that computes the same hash skips the check.

## The hash

A Merkle fold over sorted `(path, blobOID)` per module source context, folded
over the check's transitive dependency closure, plus the check's own name and the
global inputs.

Built from **git blob object ids**, never `Directory.digest` — Dagger's digest
format is explicitly unstable across engine releases, so a persisted set keyed on
it would be invalidated wholesale by every engine bump. An engine bump still
invalidates every check, correctly: `engineVersion` is a field in all 47
`dagger.json` files, each in its own module's source context.

Two checks on one module hash apart (the name is in the digest). A check that
cannot be hashed — `ci:*`, an unresolved closure, an unreadable source context, a
path absent from `HEAD` — reports an empty hash and records nothing, so it can
never retire a later run.

## Where records live, and who may write them

The GitHub Actions cache. A passing leg writes a marker keyed
`ci-memo-v1-<hash>`; the `list` job reads the keys back.

Only two scopes are read — the default branch and, on a PR, that PR's own scope —
both confined by GitHub itself, since a run can only write caches under its own
`GITHUB_REF`. That is stricter than GitHub's restore rules, which would also
expose a stacked PR's base branch.

Within a PR's own scope the writer is that PR, so `MemoTrusted` refuses to honour
any recorded pass once a **global input** changed: `.github/workflows/**` or the
root module's source context. Those are the only paths that can alter how a pass
is recorded, and a change to one also perturbs every hash, so a forged entry
lands in a hash space no untampered tree computes — and reverting the tamper
restores the honest hashes rather than matching the forged ones.

## Base-image drift

A source-derived hash cannot see upstream drift: these checks boot real services
from floating tags, so an identical tree does not imply an identical container.
Answered with an explicit **24h bound** (`MEMO_TTL_SECONDS`) applied against each
cache entry's `created_at`.

Folding resolved image digests into the hash was rejected — it means resolving
every module's images, most of the cost memoization is meant to avoid, and it
breaks the git-object-id property. Bounding the window caps drift-blindness at a
day, which is where essentially all the reuse is anyway.

## Not every root-context path is global

Adding a daggerverse module is the change that touches least and would otherwise
cost most: it necessarily edits three files under the root module, and if all
three were global inputs it would retire the entire store.

| file the PR touches | treatment |
| --- | --- |
| `dagger.json` (the toolchain entry) | not a global input (`rootConfig`) |
| `ci/internal/dagger/dagger.gen.go` (regenerated: one ID type + one loader) | not a global input (`coreBinding`) |
| `ci/internal/dagger/<new>-tests.gen.go` | attributed to the new toolchain (#179, already there) |

`dagger.json` decides which checks *exist*, never what an existing check
*computes* — `engineVersion` is covered by the other 46 `dagger.json`, `toolchains`
by the closure (repointing an entry moves `Check.OriginalModule`), and no non-`ci`
leg ever loads the root module since `ci.yml` routes each at its own tests module.

The core binding is the sharper case, since it is the API surface the hasher
executes: a hand-patched `Glob` could make a module's hash go blind to its own
sources. What forecloses that is `ci:generated` — it proves every committed
generated file equals what `dagger develop` produces, always runs, and is never
memoized (guarded by `ci:generated-self-test`, after #184). A tampered binding is
red at the gate on the very push that would act on it. Generalised: **a generated
file need not be a global input, because a never-memoized check already proves it
is derived from inputs that are** — the reasoning `AggregatorBindings` already
applied to the per-toolchain bindings, extended to the one attributable to none.

Both are subtractions of a path's *content*, not of set membership. Selection is
untouched: either path changing still runs the full universe.

## Verified

Locally in real clones (a git worktree's `.git` is a pointer file, so the export
degrades to the full suite there — noted for anyone reproducing):

| case | result |
| --- | --- |
| identical tree, all hashes known-good | 60 → 3 (`ci:*` only) |
| `daggerverse/kicad/main.go` touched | 4 — kicad + `ci:*` |
| `daggerverse/crypto/main.go` touched | 46 — its exact blast radius |
| **a brand-new `daggerverse/widget` module added** | **61 → 4** — `widget-tests:all` + `ci:*` |
| module addition + a `ci/` edit | 61 — records ignored |
| module addition + a workflow edit | 61 — records ignored |
| empty / malformed `--known-good` | 60 — runs everything |

`affected-checks` still returns in ~3.4s despite resolving every module's source
context (bounded concurrent globs).

Self-check coverage is mutation-tested in both directions — dropping the global
fold, dropping the closure fold, folding the bindings globally, putting
`coreBinding` back, and over-loosening the exemption each fail it.

## Notes for review

- `AffectedChecks` returns `[{name, hash}]` now; the route step carries `hash`
  through to the leg, which never recomputes it (the run job checks out at depth 1
  and could not).
- Needs `actions: read` at workflow level to list the cache.
- No branch-protection change: `CI Gate` still covers it, and `ci:*` is never
  memoized so the matrix cannot empty out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
