### PR TITLE
story(issue-242): generate bruno collections from an OpenAPI document

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ dagger install github.com/z5labs/devex/daggerverse/<module>
 
 | Module | Description |
 | ------ | ----------- |
-| [`bruno`](daggerverse/bruno) | Run Bruno API collections — a pass/fail gate or a JUnit report. |
+| [`bruno`](daggerverse/bruno) | Run Bruno API collections — a pass/fail gate or a JUnit report — or generate one from OpenAPI. |
 | [`certificate-management`](daggerverse/certificate-management) | Manage X.509 certificate authorities and issue TLS certificates. |
 | [`crypto`](daggerverse/crypto) | Common crypto utilities — file digests and ephemeral keys. |
 | [`dgraph`](daggerverse/dgraph) | Spin up a Dgraph graph-database cluster. |

--- a/ci/internal/dagger/bruno-tests.gen.go
+++ b/ci/internal/dagger/bruno-tests.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type BrunoTests
-func (r *Binding) AsBrunoTests() *BrunoTests { // bruno-tests (../../../daggerverse/bruno/tests/main.go:25:6)
+func (r *Binding) AsBrunoTests() *BrunoTests { // bruno-tests (../../../daggerverse/bruno/tests/main.go:31:6)
 	q := r.query.Select("asBrunoTests")
 
 	return &BrunoTests{
@@ -18,24 +18,27 @@ func (r *Binding) AsBrunoTests() *BrunoTests { // bruno-tests (../../../daggerve
 	}
 }
 
-type BrunoTests struct { // bruno-tests (../../../daggerverse/bruno/tests/main.go:25:6)
+type BrunoTests struct { // bruno-tests (../../../daggerverse/bruno/tests/main.go:31:6)
 	query *querybuilder.Selection
 
-	all                               *Void
-	id                                *ID
-	jsonEnvFileKeepsItsExtension      *Void
-	passThroughFlagsAreAccepted       *Void
-	recursiveDefaultReachesSubfolders *Void
-	reportEmitsJunitForFailingRun     *Void
-	reportRejectsUnknownFormat        *Void
-	reportShouldNotBeCached           *Void
-	runFailsOnAssertionFailure        *Void
-	runPassesAgainstBoundService      *Void
-	runShouldNotBeCached              *Void
-	secretVarIsNotOnArgv              *Void
-	unknownEnvironmentIsRejected      *Void
-	versionReportsPinnedRelease       *Void
-	withVarOverridesEnvironmentValue  *Void
+	all                                 *Void
+	generateHonoursOpenCollectionFormat *Void
+	generateProducesRunnableCollection  *Void
+	generateRejectsUnknownFormat        *Void
+	id                                  *ID
+	jsonEnvFileKeepsItsExtension        *Void
+	passThroughFlagsAreAccepted         *Void
+	recursiveDefaultReachesSubfolders   *Void
+	reportEmitsJunitForFailingRun       *Void
+	reportRejectsUnknownFormat          *Void
+	reportShouldNotBeCached             *Void
+	runFailsOnAssertionFailure          *Void
+	runPassesAgainstBoundService        *Void
+	runShouldNotBeCached                *Void
+	secretVarIsNotOnArgv                *Void
+	unknownEnvironmentIsRejected        *Void
+	versionReportsPinnedRelease         *Void
+	withVarOverridesEnvironmentValue    *Void
 }
 
 func (r *BrunoTests) WithGraphQLQuery(q *querybuilder.Selection) *BrunoTests {
@@ -46,11 +49,11 @@ func (r *BrunoTests) WithGraphQLQuery(q *querybuilder.Selection) *BrunoTests {
 
 // BrunoTestsAllOpts contains options for BrunoTests.All
 type BrunoTestsAllOpts struct {
-	Parallel int // bruno-tests (../../../daggerverse/bruno/tests/main.go:34:2)
+	Parallel int // bruno-tests (../../../daggerverse/bruno/tests/main.go:40:2)
 }
 
 // All runs every bruno-module test in parallel.
-func (r *BrunoTests) All(ctx context.Context, opts ...BrunoTestsAllOpts) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:31:1)
+func (r *BrunoTests) All(ctx context.Context, opts ...BrunoTestsAllOpts) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:37:1)
 	if r.all != nil {
 		return nil
 	}
@@ -61,6 +64,57 @@ func (r *BrunoTests) All(ctx context.Context, opts ...BrunoTestsAllOpts) error {
 			q = q.Arg("parallel", opts[i].Parallel)
 		}
 	}
+
+	return q.Execute(ctx)
+}
+
+// GenerateHonoursOpenCollectionFormat checks that the format argument reaches
+// bru at all: every other assertion in this suite would pass just as well
+// against a Generate that had "bru" hardcoded.
+//
+// It also pins the reason the default diverges from upstream's. The
+// opencollection shape carries no bruno.json, so it is not something Collection
+// could run — which is why this module defaults to the other one.
+func (r *BrunoTests) GenerateHonoursOpenCollectionFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:581:1)
+	if r.generateHonoursOpenCollectionFormat != nil {
+		return nil
+	}
+	q := r.query.Select("generateHonoursOpenCollectionFormat")
+
+	return q.Execute(ctx)
+}
+
+// GenerateProducesRunnableCollection checks the claim the default format is
+// chosen for: what Generate hands back is a collection this module can run,
+// with nothing rearranged in between.
+//
+// Structure alone would not establish that — a tree can hold a bruno.json and
+// still fail at exit 4 — so the generated directory is fed straight into
+// Collection and run against the recording responder, which is the host the
+// fixture's `servers:` entry names and therefore the baseUrl `bru import`
+// writes into the generated environment.
+//
+// The environment's name is read off the generated tree rather than hardcoded:
+// bru derives it from the server's description, which is the spec's business
+// and not this module's.
+func (r *BrunoTests) GenerateProducesRunnableCollection(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:503:1)
+	if r.generateProducesRunnableCollection != nil {
+		return nil
+	}
+	q := r.query.Select("generateProducesRunnableCollection")
+
+	return q.Execute(ctx)
+}
+
+// GenerateRejectsUnknownFormat checks that a shape `bru import` does not write
+// is refused by name. bru refuses one too, but by printing its whole help text
+// with the actual complaint on the last line — and only after a container has
+// been started to find out.
+func (r *BrunoTests) GenerateRejectsUnknownFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:601:1)
+	if r.generateRejectsUnknownFormat != nil {
+		return nil
+	}
+	q := r.query.Select("generateRejectsUnknownFormat")
 
 	return q.Execute(ctx)
 }
@@ -119,7 +173,7 @@ func (r *BrunoTests) UnmarshalJSON(bs []byte) error {
 // that extension and not from the contents, so a JSON environment staged as
 // .bru dies inside the Bruno grammar — with a Node stack trace, several layers
 // away from anything the caller did.
-func (r *BrunoTests) JSONEnvFileKeepsItsExtension(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:456:1)
+func (r *BrunoTests) JSONEnvFileKeepsItsExtension(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:465:1)
 	if r.jsonEnvFileKeepsItsExtension != nil {
 		return nil
 	}
@@ -137,7 +191,7 @@ func (r *BrunoTests) JSONEnvFileKeepsItsExtension(ctx context.Context) error { /
 // The api fixture tags its root request and leaves the nested one untagged, so
 // the tag filters also have to have selected the right request rather than
 // merely been tolerated.
-func (r *BrunoTests) PassThroughFlagsAreAccepted(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:417:1)
+func (r *BrunoTests) PassThroughFlagsAreAccepted(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:426:1)
 	if r.passThroughFlagsAreAccepted != nil {
 		return nil
 	}
@@ -155,7 +209,7 @@ func (r *BrunoTests) PassThroughFlagsAreAccepted(ctx context.Context) error { //
 // and the default wins — so `Recursive: false` would silently assert the
 // default all over again. It is reachable from the CLI as
 // `run --recursive=false`.
-func (r *BrunoTests) RecursiveDefaultReachesSubfolders(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:204:1)
+func (r *BrunoTests) RecursiveDefaultReachesSubfolders(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:213:1)
 	if r.recursiveDefaultReachesSubfolders != nil {
 		return nil
 	}
@@ -169,7 +223,7 @@ func (r *BrunoTests) RecursiveDefaultReachesSubfolders(ctx context.Context) erro
 // artifact, and the artifact says what failed. Run would have raised an error
 // here, and an error forfeits the value — which is why the two are separate
 // functions rather than one.
-func (r *BrunoTests) ReportEmitsJunitForFailingRun(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:237:1)
+func (r *BrunoTests) ReportEmitsJunitForFailingRun(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:246:1)
 	if r.reportEmitsJunitForFailingRun != nil {
 		return nil
 	}
@@ -181,7 +235,7 @@ func (r *BrunoTests) ReportEmitsJunitForFailingRun(ctx context.Context) error { 
 // ReportRejectsUnknownFormat checks that a format bru does not write is
 // refused by name, before a live collection has been run against a live
 // service to find out.
-func (r *BrunoTests) ReportRejectsUnknownFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:264:1)
+func (r *BrunoTests) ReportRejectsUnknownFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:273:1)
 	if r.reportRejectsUnknownFormat != nil {
 		return nil
 	}
@@ -193,7 +247,7 @@ func (r *BrunoTests) ReportRejectsUnknownFormat(ctx context.Context) error { // 
 // ReportShouldNotBeCached checks that two identical Reports each reach the
 // service. A report of a run that never happened describes an API nobody
 // asked about.
-func (r *BrunoTests) ReportShouldNotBeCached(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:286:1)
+func (r *BrunoTests) ReportShouldNotBeCached(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:295:1)
 	if r.reportShouldNotBeCached != nil {
 		return nil
 	}
@@ -205,7 +259,7 @@ func (r *BrunoTests) ReportShouldNotBeCached(ctx context.Context) error { // bru
 // RunFailsOnAssertionFailure checks that exit 1 — a failing request, test or
 // assertion — is an error, and that the error carries bru's own account of
 // what failed rather than just the exit code.
-func (r *BrunoTests) RunFailsOnAssertionFailure(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:111:1)
+func (r *BrunoTests) RunFailsOnAssertionFailure(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:120:1)
 	if r.runFailsOnAssertionFailure != nil {
 		return nil
 	}
@@ -216,7 +270,7 @@ func (r *BrunoTests) RunFailsOnAssertionFailure(ctx context.Context) error { // 
 
 // RunPassesAgainstBoundService checks the whole point of the module: a
 // collection whose environment names a bound service reaches it and passes.
-func (r *BrunoTests) RunPassesAgainstBoundService(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:79:1)
+func (r *BrunoTests) RunPassesAgainstBoundService(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:88:1)
 	if r.runPassesAgainstBoundService != nil {
 		return nil
 	}
@@ -228,7 +282,7 @@ func (r *BrunoTests) RunPassesAgainstBoundService(ctx context.Context) error { /
 // RunShouldNotBeCached checks that two identical Runs each reach the service.
 // A collection run hits a live API, so a cached pass would report a
 // now-broken API as green.
-func (r *BrunoTests) RunShouldNotBeCached(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:167:1)
+func (r *BrunoTests) RunShouldNotBeCached(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:176:1)
 	if r.runShouldNotBeCached != nil {
 		return nil
 	}
@@ -250,7 +304,7 @@ func (r *BrunoTests) RunShouldNotBeCached(ctx context.Context) error { // bruno-
 // command line" can actually be checked. That script needs the developer
 // sandbox — the safe one has no process — which is what makes WithSandbox
 // part of this test.
-func (r *BrunoTests) SecretVarIsNotOnArgv(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:363:1)
+func (r *BrunoTests) SecretVarIsNotOnArgv(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:372:1)
 	if r.secretVarIsNotOnArgv != nil {
 		return nil
 	}
@@ -263,7 +317,7 @@ func (r *BrunoTests) SecretVarIsNotOnArgv(ctx context.Context) error { // bruno-
 // bru exits 6 when the named environment does not exist; conflating that with
 // exit 1 would make "you typo'd the environment name" read as "your API is
 // broken".
-func (r *BrunoTests) UnknownEnvironmentIsRejected(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:141:1)
+func (r *BrunoTests) UnknownEnvironmentIsRejected(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:150:1)
 	if r.unknownEnvironmentIsRejected != nil {
 		return nil
 	}
@@ -276,7 +330,7 @@ func (r *BrunoTests) UnknownEnvironmentIsRejected(ctx context.Context) error { /
 // release the module pins. The Debian variant is not cosmetic — it is the
 // escape hatch for the Alpine image's musl/OpenSSL TLS failures — so it has
 // to be a tag that exists and ships the same CLI.
-func (r *BrunoTests) VersionReportsPinnedRelease(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:64:1)
+func (r *BrunoTests) VersionReportsPinnedRelease(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:73:1)
 	if r.versionReportsPinnedRelease != nil {
 		return nil
 	}
@@ -289,7 +343,7 @@ func (r *BrunoTests) VersionReportsPinnedRelease(ctx context.Context) error { //
 // selected environment declares. The fixture puts the variable in the request
 // path, so the responder records which of the two won rather than the module
 // having to trust bru's summary.
-func (r *BrunoTests) WithVarOverridesEnvironmentValue(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:323:1)
+func (r *BrunoTests) WithVarOverridesEnvironmentValue(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:332:1)
 	if r.withVarOverridesEnvironmentValue != nil {
 		return nil
 	}
@@ -307,7 +361,7 @@ func (r *BrunoTests) AsNode() Node {
 }
 
 // Create or update a binding of type BrunoTests in the environment
-func (r *Env) WithBrunoTestsInput(name string, value *BrunoTests, description string) *Env { // bruno-tests (../../../daggerverse/bruno/tests/main.go:25:6)
+func (r *Env) WithBrunoTestsInput(name string, value *BrunoTests, description string) *Env { // bruno-tests (../../../daggerverse/bruno/tests/main.go:31:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withBrunoTestsInput")
 	q = q.Arg("name", name)
@@ -320,7 +374,7 @@ func (r *Env) WithBrunoTestsInput(name string, value *BrunoTests, description st
 }
 
 // Declare a desired BrunoTests output to be assigned in the environment
-func (r *Env) WithBrunoTestsOutput(name string, description string) *Env { // bruno-tests (../../../daggerverse/bruno/tests/main.go:25:6)
+func (r *Env) WithBrunoTestsOutput(name string, description string) *Env { // bruno-tests (../../../daggerverse/bruno/tests/main.go:31:6)
 	q := r.query.Select("withBrunoTestsOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -334,7 +388,7 @@ func (r *Env) WithBrunoTestsOutput(name string, description string) *Env { // br
 // test is exposed as a standalone dagger function so it can be invoked
 // individually during TDD; All wires them up for parallel execution under
 // `dagger call all`.
-func (r *Query) BrunoTests() *BrunoTests { // bruno-tests (../../../daggerverse/bruno/tests/main.go:25:6)
+func (r *Query) BrunoTests() *BrunoTests { // bruno-tests (../../../daggerverse/bruno/tests/main.go:31:6)
 	q := r.query.Select("brunoTests")
 
 	return &BrunoTests{

--- a/daggerverse/bruno/README.md
+++ b/daggerverse/bruno/README.md
@@ -40,7 +40,7 @@ for exactly those.
 
 `Container()` is the escape hatch for every flag this module does not wrap —
 `--proxy`, `--disable-cookies`, `--verbose`, the reporter-redaction switches,
-`bru import` — all reachable via `dagger call container with-exec`.
+`bru import wsdl` — all reachable via `dagger call container with-exec`.
 
 ## Collection, not file
 
@@ -126,6 +126,58 @@ from the CLI.
 or workspace not found, or an unparseable collection file), 12 and 13 (global
 environment problems), and 255 for everything else.
 
+## Generating a collection from OpenAPI
+
+A collection hand-maintained beside an OpenAPI document drifts. `Generate`
+wraps `bru import openapi`, so the collection can be produced in CI instead of
+committed and forgotten.
+
+```go
+collection := dag.Bruno().Generate(spec, dagger.BrunoGenerateOpts{Name: "petstore"})
+out, err := dag.Bruno().Collection(collection).WithService("api", api).Run(ctx)
+```
+
+```sh
+dagger -m github.com/z5labs/devex/daggerverse/bruno call \
+  generate --spec=./openapi.yaml --name=petstore \
+  export --path=./api-tests
+```
+
+The spec is a `*File`, not a URL string, so a local document and a remote one
+are the same call — `dag.HTTP(url)` covers the URL case without a second
+parameter, and without needing `bru`'s `--insecure`, because the fetch never
+happens inside the container. YAML or JSON either way: `bru import` reads the
+contents, not the file name.
+
+`format` defaults to `"bru"` where **upstream defaults to
+`"opencollection"`**. Only the `bru` shape carries the `bruno.json` and `.bru`
+requests that `Collection`, `Run` and `Report` read; `"opencollection"` writes
+an `opencollection.yml` and no `bruno.json`, so it is not runnable here. The
+default is the one whose output feeds straight back in.
+
+What comes out, for a spec with a `servers:` entry and tagged operations:
+
+```
+bruno.json                     # the collection manifest, named by --name
+collection.bru                 # collection-level settings
+environments/<server>.bru      # baseUrl, from servers[].url
+<tag>/folder.bru               # one folder per OpenAPI tag
+<tag>/<summary>.bru            # one request per operation
+```
+
+Two things worth knowing about that tree. Requests are grouped by tag, so they
+land a folder deep and need `Run`'s recursive default to be reached. And the
+environment file is named after the server's *description* (falling back to
+`Environment 1`), which is the spec's business rather than this module's — read
+it off the generated directory rather than hardcoding it, or override `baseUrl`
+with `WithVar` and skip `WithEnvironment` entirely.
+
+`Generate` is `+cache="session"`, not `"never"`: conversion is a pure function
+of the document and touches no live service.
+
+`--group-by path` (the alternative to grouping by tag) and `bru import wsdl`
+are not wrapped; both are reachable through `Container()`.
+
 ## Secrets
 
 `WithSecretVar(name, secret)` is a separate function from `WithVar` rather than
@@ -161,8 +213,8 @@ module or touch the filesystem needs `WithSandbox("developer")` — and fails at
 ## Caching
 
 `Run` and `Report` carry `+cache="never"`: a collection run hits a live
-service, so a cached pass would report a now-broken API as green. `Container`
-and `Version` stay `+cache="session"` — those are pure.
+service, so a cached pass would report a now-broken API as green. `Container`,
+`Version` and `Generate` stay `+cache="session"` — those are pure.
 
 That directive governs the *function* result; the `WithExec` layer underneath
 is still content-addressed, so both terminals stamp a per-call nonce onto the
@@ -183,6 +235,7 @@ reachable through `Container()`.
 |---|---|
 | `Container()` | The pinned `usebruno/cli` image — the escape hatch for unwrapped flags. |
 | `Version()` | The Bruno CLI release the image ships. |
+| `Generate(spec, name, format)` | Convert an OpenAPI document into a collection directory. |
 | `Collection(source)` | Bind a collection tree to the toolchain. |
 | `Collection.WithEnvironment(name)` | `--env`; the file under `environments/` without its extension. |
 | `Collection.WithVar(name, value)` | `--env-var name=value`. A pair, not a map. |
@@ -216,6 +269,13 @@ that counts requests would otherwise be counting a previous session's.
 Counting requests at the service, rather than reading bru's summary, is what
 makes the caching assertions mean anything: a cached `Run` prints a perfectly
 convincing "1 request, 1 passed".
+
+`fixtures/petstore.yaml` is the one fixture that is not a Bruno collection: it
+is the OpenAPI document `Generate` converts. Its single `servers:` entry names
+that same responder, which is what makes
+`GenerateProducesRunnableCollection` a real test — the generated collection is
+handed straight to `Collection` and run, rather than merely inspected for a
+`bruno.json`.
 
 `SecretVarIsNotOnArgv` is the one test that needs the collection's own
 scripting. Its fixture reports `process.argv` — bru's own command line — back

--- a/daggerverse/bruno/dagger.gen.go
+++ b/daggerverse/bruno/dagger.gen.go
@@ -311,6 +311,34 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return (*Bruno).Container(&parent), nil
+		case "Generate":
+			var parent Bruno
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var spec *dagger.File
+			if inputArgs["spec"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["spec"]), &spec)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg spec", err))
+				}
+			}
+			var name string
+			if inputArgs["name"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["name"]), &name)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg name", err))
+				}
+			}
+			var format string
+			if inputArgs["format"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["format"]), &format)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg format", err))
+				}
+			}
+			return (*Bruno).Generate(&parent, ctx, spec, name, format)
 		case "Version":
 			var parent Bruno
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/bruno/generate.go
+++ b/daggerverse/bruno/generate.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"dagger/bruno/internal/dagger"
+)
+
+const (
+	// specPath is where the OpenAPI document is mounted. It carries no
+	// extension on purpose: unlike an environment file — where bru selects its
+	// parser from the extension — `bru import` sniffs the document's contents,
+	// so a YAML spec staged under any name is read as YAML.
+	specPath = "/tmp/bruno-spec"
+
+	// generatedDir is where `bru import` writes the collection. bru creates it,
+	// and it is outside /bruno because that is root-owned while the image runs
+	// as UID 1000.
+	generatedDir = "/tmp/bruno-collection"
+
+	// formatBru and formatOpenCollection are the two shapes `bru import`
+	// writes. Only formatBru produces the bruno.json + .bru tree that
+	// Collection, Run and Report read, which is why it is this module's default
+	// even though upstream's is the other one.
+	formatBru            = "bru"
+	formatOpenCollection = "opencollection"
+
+	// defaultCollectionName is the name Generate stamps into the collection
+	// when the caller does not choose one.
+	defaultCollectionName = "api"
+)
+
+// Generate converts an OpenAPI document into a Bruno collection directory
+// (`bru import openapi`), so a collection can be produced in CI rather than
+// hand-maintained beside the spec it drifts from.
+//
+// The spec is a *dagger.File rather than a URL string, so a local document and
+// a remote one are the same call: dag.HTTP(url) covers the URL case without a
+// second parameter — and without needing bru's `--insecure`, since the fetch
+// never happens inside the container.
+//
+// format defaults to "bru" where upstream defaults to "opencollection". Only
+// the bru shape carries the bruno.json and .bru requests that Collection, Run
+// and Report read, so the default is the one whose output feeds straight back
+// into this module. "opencollection" writes an opencollection.yml instead and
+// is not runnable here.
+//
+// Requests are grouped by OpenAPI tag, which is bru's own default, so they
+// land one folder deep and need Run's recursive default to be reached.
+//
+// It is +cache="session" rather than "never": conversion is a pure function of
+// the document and touches no live service.
+//
+// +cache="session"
+func (b *Bruno) Generate(
+	ctx context.Context,
+	// The OpenAPI document to convert. YAML or JSON — bru reads the contents,
+	// not the file name.
+	spec *dagger.File,
+	// Name stamped into the generated collection's bruno.json.
+	// +default="api"
+	name string,
+	// Output shape: "bru", the tree this module can run, or "opencollection".
+	// +default="bru"
+	format string,
+) (*dagger.Directory, error) {
+	if strings.TrimSpace(name) == "" {
+		return nil, fmt.Errorf("Generate: collection name is required")
+	}
+	if err := checkCollectionFormat(format); err != nil {
+		return nil, err
+	}
+
+	// Expect=ReturnTypeAny keeps a failed conversion on the value path: bru
+	// spends exit 1 on every import failure — a missing file, an unparseable
+	// document, a spec it cannot convert — so the exit code alone says nothing
+	// and the output has to be read back to the caller.
+	exec := b.Container().
+		WithMountedFile(specPath, spec).
+		WithExec([]string{
+			"bru", "import", "openapi",
+			"--source", specPath,
+			"--output", generatedDir,
+			"--collection-name", name,
+			"--collection-format", format,
+		}, dagger.ContainerWithExecOpts{Expect: dagger.ReturnTypeAny})
+
+	// The exit code is read here rather than the directory returned lazily
+	// because a failed import writes no output directory: deferring would turn
+	// "your spec does not parse" into "that path does not exist", one call
+	// later and somewhere else.
+	code, err := exec.ExitCode(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if code != 0 {
+		return nil, fmt.Errorf("bru import openapi failed (exit %d):\n%s", code, combinedOutput(ctx, exec))
+	}
+	return exec.Directory(generatedDir), nil
+}
+
+// checkCollectionFormat rejects a shape `bru import` does not write. bru itself
+// refuses one too, but by printing its entire help text with the actual
+// complaint on the last line; naming the two legal values costs nothing and
+// does not run a container to find out.
+func checkCollectionFormat(format string) error {
+	switch format {
+	case formatBru, formatOpenCollection:
+		return nil
+	default:
+		return fmt.Errorf("Generate: invalid format %q: must be one of %s, %s",
+			format, formatBru, formatOpenCollection)
+	}
+}

--- a/daggerverse/bruno/tests/dagger.gen.go
+++ b/daggerverse/bruno/tests/dagger.gen.go
@@ -206,6 +206,27 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Tests).All(&parent, ctx, parallel)
+		case "GenerateHonoursOpenCollectionFormat":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).GenerateHonoursOpenCollectionFormat(&parent, ctx)
+		case "GenerateProducesRunnableCollection":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).GenerateProducesRunnableCollection(&parent, ctx)
+		case "GenerateRejectsUnknownFormat":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).GenerateRejectsUnknownFormat(&parent, ctx)
 		case "JsonEnvFileKeepsItsExtension":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/bruno/tests/fixtures/petstore.yaml
+++ b/daggerverse/bruno/tests/fixtures/petstore.yaml
@@ -1,0 +1,104 @@
+# A small OpenAPI document for the generation tests.
+#
+# Its single server is the recording responder the suite binds under the `api`
+# alias, because that is what `bru import` turns into the generated
+# collection's baseUrl — so the collection it produces is runnable against the
+# suite's own service without anything being rewritten afterwards.
+#
+# Two tags and a path parameter are deliberate: `bru import` groups by tag, so
+# the requests land one folder deep rather than at the collection root, and the
+# parameter exercises the one shape that could come back unresolvable.
+#
+# The server's description is what names the generated environment file, so it
+# is kept free of punctuation a filename would rather not carry.
+openapi: 3.0.3
+info:
+  title: Petstore
+  description: A very small store, for a test that has to run what it generates.
+  version: 1.0.0
+servers:
+  - url: http://api:8080
+    description: recording responder
+paths:
+  /health:
+    get:
+      operationId: getHealth
+      tags:
+        - status
+      summary: Report service health
+      responses:
+        "200":
+          description: The service is up.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+  /pets:
+    get:
+      operationId: listPets
+      tags:
+        - pets
+      summary: List every pet
+      responses:
+        "200":
+          description: A list of pets.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+    post:
+      operationId: createPet
+      tags:
+        - pets
+      summary: Add a pet to the store
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        "200":
+          description: The pet that was stored.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+  /pets/{petId}:
+    get:
+      operationId: showPetById
+      tags:
+        - pets
+      summary: Fetch one pet
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The pet's identifier.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The requested pet.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - name
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        tag:
+          type: string

--- a/daggerverse/bruno/tests/internal/dagger/bruno.gen.go
+++ b/daggerverse/bruno/tests/internal/dagger/bruno.gen.go
@@ -65,6 +65,61 @@ func (r *Bruno) Container() *Container { // bruno (../../../../../daggerverse/br
 	}
 }
 
+// BrunoGenerateOpts contains options for Bruno.Generate
+type BrunoGenerateOpts struct {
+	//
+	// Name stamped into the generated collection's bruno.json.
+	//
+	//
+	// Default: "api"
+	Name string // bruno (../../../../../daggerverse/bruno/generate.go:64:2)
+	//
+	// Output shape: "bru", the tree this module can run, or "opencollection".
+	//
+	//
+	// Default: "bru"
+	Format string // bruno (../../../../../daggerverse/bruno/generate.go:67:2)
+}
+
+// Generate converts an OpenAPI document into a Bruno collection directory
+// (`bru import openapi`), so a collection can be produced in CI rather than
+// hand-maintained beside the spec it drifts from.
+//
+// The spec is a *dagger.File rather than a URL string, so a local document and
+// a remote one are the same call: dag.HTTP(url) covers the URL case without a
+// second parameter — and without needing bru's `--insecure`, since the fetch
+// never happens inside the container.
+//
+// format defaults to "bru" where upstream defaults to "opencollection". Only
+// the bru shape carries the bruno.json and .bru requests that Collection, Run
+// and Report read, so the default is the one whose output feeds straight back
+// into this module. "opencollection" writes an opencollection.yml instead and
+// is not runnable here.
+//
+// Requests are grouped by OpenAPI tag, which is bru's own default, so they
+// land one folder deep and need Run's recursive default to be reached.
+//
+// It isthe document and touches no live service.
+func (r *Bruno) Generate(spec *File, opts ...BrunoGenerateOpts) *Directory { // bruno (../../../../../daggerverse/bruno/generate.go:57:1)
+	assertNotNil("spec", spec)
+	q := r.query.Select("generate")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `name` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Name) {
+			q = q.Arg("name", opts[i].Name)
+		}
+		// `format` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Format) {
+			q = q.Arg("format", opts[i].Format)
+		}
+	}
+	q = q.Arg("spec", spec)
+
+	return &Directory{
+		query: q,
+	}
+}
+
 // A unique identifier for this Bruno.
 func (r *Bruno) ID(ctx context.Context) (ID, error) {
 	if r.id != nil {

--- a/daggerverse/bruno/tests/main.go
+++ b/daggerverse/bruno/tests/main.go
@@ -7,6 +7,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"path"
+	"slices"
 	"strings"
 
 	par "github.com/dagger/dagger/util/parallel"
@@ -20,6 +22,10 @@ const (
 	// resolves to a different release fails loudly rather than silently
 	// running some other CLI.
 	pinnedVersion = "3.4.2"
+
+	// specOperations is how many operations fixtures/petstore.yaml declares,
+	// and therefore how many requests a collection generated from it makes.
+	specOperations = 4
 )
 
 type Tests struct{}
@@ -53,6 +59,9 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("SecretVarIsNotOnArgv", t.SecretVarIsNotOnArgv)
 	jobs = jobs.WithJob("PassThroughFlagsAreAccepted", t.PassThroughFlagsAreAccepted)
 	jobs = jobs.WithJob("JsonEnvFileKeepsItsExtension", t.JsonEnvFileKeepsItsExtension)
+	jobs = jobs.WithJob("GenerateProducesRunnableCollection", t.GenerateProducesRunnableCollection)
+	jobs = jobs.WithJob("GenerateHonoursOpenCollectionFormat", t.GenerateHonoursOpenCollectionFormat)
+	jobs = jobs.WithJob("GenerateRejectsUnknownFormat", t.GenerateRejectsUnknownFormat)
 
 	return jobs.Run(ctx)
 }
@@ -478,6 +487,135 @@ func (t *Tests) JsonEnvFileKeepsItsExtension(ctx context.Context) error {
 	return nil
 }
 
+// GenerateProducesRunnableCollection checks the claim the default format is
+// chosen for: what Generate hands back is a collection this module can run,
+// with nothing rearranged in between.
+//
+// Structure alone would not establish that — a tree can hold a bruno.json and
+// still fail at exit 4 — so the generated directory is fed straight into
+// Collection and run against the recording responder, which is the host the
+// fixture's `servers:` entry names and therefore the baseUrl `bru import`
+// writes into the generated environment.
+//
+// The environment's name is read off the generated tree rather than hardcoded:
+// bru derives it from the server's description, which is the spec's business
+// and not this module's.
+func (t *Tests) GenerateProducesRunnableCollection(ctx context.Context) error {
+	rsp, err := newResponder(ctx)
+	if err != nil {
+		return err
+	}
+	defer rsp.stop(ctx)
+
+	const name = "petstore"
+	generated := dag.Bruno().Generate(fixtureFile("petstore.yaml"), dagger.BrunoGenerateOpts{
+		Name: name,
+	})
+
+	entries, err := generated.Entries(ctx)
+	if err != nil {
+		return fmt.Errorf("generate: %w", err)
+	}
+	if !slices.Contains(entries, "bruno.json") {
+		return fmt.Errorf("expected bruno.json at the generated collection root, got %v", entries)
+	}
+
+	manifest, err := generated.File("bruno.json").Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("read the generated bruno.json: %w", err)
+	}
+	if !strings.Contains(manifest, `"name": "`+name+`"`) {
+		return fmt.Errorf("expected the collection name %q in bruno.json, got:\n%s", name, head(manifest))
+	}
+
+	requests, err := generatedRequests(ctx, generated)
+	if err != nil {
+		return err
+	}
+	if len(requests) == 0 {
+		return fmt.Errorf("expected at least one .bru request in the generated collection, got %v", entries)
+	}
+
+	environments, err := generated.Entries(ctx, dagger.DirectoryEntriesOpts{Path: "environments"})
+	if err != nil {
+		return fmt.Errorf("read the generated environments: %w", err)
+	}
+	if len(environments) != 1 {
+		return fmt.Errorf("expected the spec's one server to become one environment, got %v", environments)
+	}
+	environment := strings.TrimSuffix(environments[0], ".bru")
+
+	out, err := dag.Bruno().
+		Collection(generated).
+		WithEnvironment(environment).
+		WithService(responderAlias, rsp.Svc).
+		Run(ctx)
+	if err != nil {
+		return fmt.Errorf("run the generated collection: %w", err)
+	}
+	if !strings.Contains(out, "List every pet") {
+		return fmt.Errorf("expected the run output to name a generated request, got:\n%s", head(out))
+	}
+
+	got, err := rsp.stats(ctx, "after-generated")
+	if err != nil {
+		return err
+	}
+	// The spec declares four operations, and `bru import` groups them by tag —
+	// so this also says the run reached requests a folder deep, which is where
+	// every generated request lives.
+	if got.Count != specOperations {
+		return fmt.Errorf("expected the generated collection to serve %d requests, got %d",
+			specOperations, got.Count)
+	}
+	return nil
+}
+
+// GenerateHonoursOpenCollectionFormat checks that the format argument reaches
+// bru at all: every other assertion in this suite would pass just as well
+// against a Generate that had "bru" hardcoded.
+//
+// It also pins the reason the default diverges from upstream's. The
+// opencollection shape carries no bruno.json, so it is not something Collection
+// could run — which is why this module defaults to the other one.
+func (t *Tests) GenerateHonoursOpenCollectionFormat(ctx context.Context) error {
+	entries, err := dag.Bruno().
+		Generate(fixtureFile("petstore.yaml"), dagger.BrunoGenerateOpts{Format: "opencollection"}).
+		Entries(ctx)
+	if err != nil {
+		return fmt.Errorf("generate opencollection: %w", err)
+	}
+	if !slices.Contains(entries, "opencollection.yml") {
+		return fmt.Errorf("expected opencollection.yml at the root, got %v", entries)
+	}
+	if slices.Contains(entries, "bruno.json") {
+		return fmt.Errorf("expected no bruno.json in the opencollection shape, got %v", entries)
+	}
+	return nil
+}
+
+// GenerateRejectsUnknownFormat checks that a shape `bru import` does not write
+// is refused by name. bru refuses one too, but by printing its whole help text
+// with the actual complaint on the last line — and only after a container has
+// been started to find out.
+func (t *Tests) GenerateRejectsUnknownFormat(ctx context.Context) error {
+	// As with Report, the rejection surfaces on the read rather than on the
+	// call: a Directory-returning function is lazy, so its error travels with
+	// the directory.
+	_, err := dag.Bruno().
+		Generate(fixtureFile("petstore.yaml"), dagger.BrunoGenerateOpts{Format: "postman"}).
+		Entries(ctx)
+	if err == nil {
+		return fmt.Errorf("expected an unknown collection format to be an error")
+	}
+	for _, want := range []string{"postman", "bru", "opencollection"} {
+		if !strings.Contains(err.Error(), want) {
+			return fmt.Errorf("expected the error to mention %q, got: %s", want, err.Error())
+		}
+	}
+	return nil
+}
+
 // ------------------------------------------------------------------ helpers
 
 // fixture returns the named hand-authored Bruno collection under fixtures/.
@@ -498,6 +636,31 @@ func exportContents(ctx context.Context, f *dagger.File, name string) (string, e
 		return "", fmt.Errorf("read exported %s: %w", name, err)
 	}
 	return contents, nil
+}
+
+// generatedRequests lists the request files in a generated collection.
+//
+// Not every .bru file is a request: `bru import` writes the collection's own
+// settings to collection.bru, one folder.bru per tag group, and the
+// environments under environments/. Counting those as requests would let a
+// collection with no requests at all satisfy "at least one .bru request".
+func generatedRequests(ctx context.Context, collection *dagger.Directory) ([]string, error) {
+	paths, err := collection.Glob(ctx, "**/*.bru")
+	if err != nil {
+		return nil, fmt.Errorf("glob the generated collection: %w", err)
+	}
+	var requests []string
+	for _, p := range paths {
+		if strings.HasPrefix(p, "environments/") {
+			continue
+		}
+		switch path.Base(p) {
+		case "collection.bru", "folder.bru":
+			continue
+		}
+		requests = append(requests, p)
+	}
+	return requests, nil
 }
 
 // fixtureFile returns a single file under fixtures/, for the inputs — an


### PR DESCRIPTION
Closes #242.

A collection hand-maintained beside an OpenAPI document drifts. This adds the
generation direction: hand the module a spec, get a Bruno collection directory
back, so the collection is produced in CI rather than committed and forgotten.

## What's here

- `daggerverse/bruno/generate.go` — `Generate(spec, name, format)` wrapping
  `bru import openapi`, plus `checkCollectionFormat`.
- `tests/fixtures/petstore.yaml` — the first fixture that is not a Bruno
  collection. Its single `servers:` entry names the suite's own recording
  responder, which is what makes the runnable-collection test a *run* rather
  than an inspection.
- Three tests, module `README.md` section, and regenerated bindings in
  `daggerverse/bruno`, `daggerverse/bruno/tests` and `ci/internal/dagger`.

## Two decisions

**The default diverges from upstream.** `--collection-format` defaults to
`opencollection` in `bru`; this module defaults to `"bru"`. Only the `bru` shape
carries the `bruno.json` and `.bru` requests that `Collection`, `Run` and
`Report` read — `opencollection` emits an `opencollection.yml` and no
`bruno.json` — so the default is the one whose output feeds straight back in.

**The exit code is read eagerly rather than the Directory returned lazily.**
`bru` spends exit 1 on every import failure (missing file, unparseable
document, bad flag value) and a failed import writes no output directory, so
deferring would turn "your spec does not parse" into "that path does not
exist", one call later and somewhere else. An unknown `format` is refused
before a container starts, because `bru` answers one by printing its entire
help text with the real complaint on the last line.

## Three upstream facts, verified against `usebruno/cli:3.4.2`

- The generated `environments/<name>.bru` is named from the OpenAPI **server's
  `description`** (falling back to `Environment 1`), *not* a fixed label. The
  first draft of the fixture produced `environments/The suite's recording
  responder..bru`. The test now reads the name off the generated tree, and the
  README says to do the same — or to skip `WithEnvironment` and override
  `baseUrl` with `WithVar`.
- `--source` is **content-sniffed**, so the spec is mounted without an
  extension. That is the exact opposite of `--env-file`, where `bru` picks the
  parser from the extension and the mount path has to preserve it.
- Requests are grouped by tag by default, so they land a folder deep and need
  `Run`'s recursive default to be reached.

## Deviations worth a look

- **One test beyond the acceptance list.** `GenerateHonoursOpenCollectionFormat`
  asserts `opencollection.yml` is present and `bruno.json` is not. Without it,
  every other assertion in the suite would pass just as well against a
  `Generate` that had `"bru"` hardcoded — and it pins the reason the default
  diverges.
- `GenerateProducesRunnableCollection` asserts the responder served exactly the
  spec's 4 operations, which also establishes that the run reached requests a
  folder deep. Negative-checked: bumping the expected count to 5 fails with
  `got 4`, so the count is live rather than a cached pass.
- The signature is the issue's, unchanged. `--group-by path` and
  `bru import wsdl` stay unwrapped and reachable through `Container()`.

## Test plan

- `dagger -m daggerverse/bruno/tests call all` — green, 16 tests.
- `dagger -m ci call generated` — green.
- The documented CLI path verified end-to-end
  (`call generate --spec=... export --path=...` produces the tree the README
  documents), and the failure path sanity-checked: `--spec=./README.md` gives
  `bru import openapi failed (exit 1): ... Failed to parse content as JSON or YAML`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)