### PR TITLE
story(issue-243): lint a bruno collection

### DIFF
--- a/ci/internal/dagger/bruno-tests.gen.go
+++ b/ci/internal/dagger/bruno-tests.gen.go
@@ -27,6 +27,13 @@ type BrunoTests struct { // bruno-tests (../../../daggerverse/bruno/tests/main.g
 	generateRejectsUnknownFormat        *Void
 	id                                  *ID
 	jsonEnvFileKeepsItsExtension        *Void
+	lintAcceptsValidCollection          *Void
+	lintRejectsDuplicateSequence        *Void
+	lintRejectsMissingBrunoJson         *Void
+	lintRejectsPlaintextSecret          *Void
+	lintRejectsUnknownEnvironment       *Void
+	lintRejectsUnresolvedVariable       *Void
+	lintWarnsOnRequestWithoutTests      *Void
 	passThroughFlagsAreAccepted         *Void
 	recursiveDefaultReachesSubfolders   *Void
 	reportEmitsJunitForFailingRun       *Void
@@ -75,7 +82,7 @@ func (r *BrunoTests) All(ctx context.Context, opts ...BrunoTestsAllOpts) error {
 // It also pins the reason the default diverges from upstream's. The
 // opencollection shape carries no bruno.json, so it is not something Collection
 // could run — which is why this module defaults to the other one.
-func (r *BrunoTests) GenerateHonoursOpenCollectionFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:581:1)
+func (r *BrunoTests) GenerateHonoursOpenCollectionFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:588:1)
 	if r.generateHonoursOpenCollectionFormat != nil {
 		return nil
 	}
@@ -97,7 +104,7 @@ func (r *BrunoTests) GenerateHonoursOpenCollectionFormat(ctx context.Context) er
 // The environment's name is read off the generated tree rather than hardcoded:
 // bru derives it from the server's description, which is the spec's business
 // and not this module's.
-func (r *BrunoTests) GenerateProducesRunnableCollection(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:503:1)
+func (r *BrunoTests) GenerateProducesRunnableCollection(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:510:1)
 	if r.generateProducesRunnableCollection != nil {
 		return nil
 	}
@@ -110,7 +117,7 @@ func (r *BrunoTests) GenerateProducesRunnableCollection(ctx context.Context) err
 // is refused by name. bru refuses one too, but by printing its whole help text
 // with the actual complaint on the last line — and only after a container has
 // been started to find out.
-func (r *BrunoTests) GenerateRejectsUnknownFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:601:1)
+func (r *BrunoTests) GenerateRejectsUnknownFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:608:1)
 	if r.generateRejectsUnknownFormat != nil {
 		return nil
 	}
@@ -173,11 +180,110 @@ func (r *BrunoTests) UnmarshalJSON(bs []byte) error {
 // that extension and not from the contents, so a JSON environment staged as
 // .bru dies inside the Bruno grammar — with a Node stack trace, several layers
 // away from anything the caller did.
-func (r *BrunoTests) JSONEnvFileKeepsItsExtension(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:465:1)
+func (r *BrunoTests) JSONEnvFileKeepsItsExtension(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:472:1)
 	if r.jsonEnvFileKeepsItsExtension != nil {
 		return nil
 	}
 	q := r.query.Select("jsonEnvFileKeepsItsExtension")
+
+	return q.Execute(ctx)
+}
+
+// LintAcceptsValidCollection checks that a collection this suite already runs
+// against a live service is also one the linter is happy with. The api fixture
+// is deliberately reused rather than a purpose-built clean one: a linter that
+// only accepts collections written for it is a linter nobody can adopt.
+//
+// It is checked under failOnWarnings=true as well, so the fixture has to be
+// free of warnings and not merely free of errors.
+func (r *BrunoTests) LintAcceptsValidCollection(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:633:1)
+	if r.lintAcceptsValidCollection != nil {
+		return nil
+	}
+	q := r.query.Select("lintAcceptsValidCollection")
+
+	return q.Execute(ctx)
+}
+
+// LintRejectsDuplicateSequence checks that two requests claiming the same seq
+// in one folder is a finding, and that the same seq in a different folder is
+// not — seq orders a folder's requests, so it is only ambiguous within one.
+func (r *BrunoTests) LintRejectsDuplicateSequence(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:740:1)
+	if r.lintRejectsDuplicateSequence != nil {
+		return nil
+	}
+	q := r.query.Select("lintRejectsDuplicateSequence")
+
+	return q.Execute(ctx)
+}
+
+// LintRejectsMissingBrunoJson checks the finding that stands in for bru's exit
+// 4. bru reports that one as "not a collection root", from inside a container,
+// without naming the file it wanted.
+func (r *BrunoTests) LintRejectsMissingBrunoJSON(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:652:1)
+	if r.lintRejectsMissingBrunoJson != nil {
+		return nil
+	}
+	q := r.query.Select("lintRejectsMissingBrunoJson")
+
+	return q.Execute(ctx)
+}
+
+// LintRejectsPlaintextSecret checks the rule that catches a leak rather than a
+// breakage: a credential-shaped variable carrying a literal in a file that is
+// committed.
+//
+// The fixture holds two controls beside the violation — a token whose value is
+// a {{process.env.*}} interpolation, and a name declared in a vars:secret
+// block — so this also pins that the rule accepts the shape it is asking for.
+func (r *BrunoTests) LintRejectsPlaintextSecret(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:716:1)
+	if r.lintRejectsPlaintextSecret != nil {
+		return nil
+	}
+	q := r.query.Select("lintRejectsPlaintextSecret")
+
+	return q.Execute(ctx)
+}
+
+// LintRejectsUnknownEnvironment checks that a mistyped --env name is caught
+// here rather than as bru's exit 6, and that the finding lists the names the
+// collection does ship.
+func (r *BrunoTests) LintRejectsUnknownEnvironment(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:668:1)
+	if r.lintRejectsUnknownEnvironment != nil {
+		return nil
+	}
+	q := r.query.Select("lintRejectsUnknownEnvironment")
+
+	return q.Execute(ctx)
+}
+
+// LintRejectsUnresolvedVariable checks the finding the whole function exists
+// for: a {{var}} that resolves nowhere, named along with the file it appears
+// in, before a request has been issued to discover it.
+//
+// The fixture also references two undeclared variables from its docs block,
+// which bru never interpolates — so this pins that prose is not linted as
+// though it were a request.
+func (r *BrunoTests) LintRejectsUnresolvedVariable(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:688:1)
+	if r.lintRejectsUnresolvedVariable != nil {
+		return nil
+	}
+	q := r.query.Select("lintRejectsUnresolvedVariable")
+
+	return q.Execute(ctx)
+}
+
+// LintWarnsOnRequestWithoutTests checks the one finding that is a warning: a
+// request that checks nothing passes whatever the API returns, which is worth
+// saying and not worth failing a pipeline over by default.
+//
+// The fixture's only assertion is disabled, which is the same as not having
+// written it — so this also pins that a commented-out assert does not count.
+func (r *BrunoTests) LintWarnsOnRequestWithoutTests(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:762:1)
+	if r.lintWarnsOnRequestWithoutTests != nil {
+		return nil
+	}
+	q := r.query.Select("lintWarnsOnRequestWithoutTests")
 
 	return q.Execute(ctx)
 }
@@ -191,7 +297,7 @@ func (r *BrunoTests) JSONEnvFileKeepsItsExtension(ctx context.Context) error { /
 // The api fixture tags its root request and leaves the nested one untagged, so
 // the tag filters also have to have selected the right request rather than
 // merely been tolerated.
-func (r *BrunoTests) PassThroughFlagsAreAccepted(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:426:1)
+func (r *BrunoTests) PassThroughFlagsAreAccepted(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:433:1)
 	if r.passThroughFlagsAreAccepted != nil {
 		return nil
 	}
@@ -209,7 +315,7 @@ func (r *BrunoTests) PassThroughFlagsAreAccepted(ctx context.Context) error { //
 // and the default wins — so `Recursive: false` would silently assert the
 // default all over again. It is reachable from the CLI as
 // `run --recursive=false`.
-func (r *BrunoTests) RecursiveDefaultReachesSubfolders(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:213:1)
+func (r *BrunoTests) RecursiveDefaultReachesSubfolders(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:220:1)
 	if r.recursiveDefaultReachesSubfolders != nil {
 		return nil
 	}
@@ -223,7 +329,7 @@ func (r *BrunoTests) RecursiveDefaultReachesSubfolders(ctx context.Context) erro
 // artifact, and the artifact says what failed. Run would have raised an error
 // here, and an error forfeits the value — which is why the two are separate
 // functions rather than one.
-func (r *BrunoTests) ReportEmitsJunitForFailingRun(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:246:1)
+func (r *BrunoTests) ReportEmitsJunitForFailingRun(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:253:1)
 	if r.reportEmitsJunitForFailingRun != nil {
 		return nil
 	}
@@ -235,7 +341,7 @@ func (r *BrunoTests) ReportEmitsJunitForFailingRun(ctx context.Context) error { 
 // ReportRejectsUnknownFormat checks that a format bru does not write is
 // refused by name, before a live collection has been run against a live
 // service to find out.
-func (r *BrunoTests) ReportRejectsUnknownFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:273:1)
+func (r *BrunoTests) ReportRejectsUnknownFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:280:1)
 	if r.reportRejectsUnknownFormat != nil {
 		return nil
 	}
@@ -247,7 +353,7 @@ func (r *BrunoTests) ReportRejectsUnknownFormat(ctx context.Context) error { // 
 // ReportShouldNotBeCached checks that two identical Reports each reach the
 // service. A report of a run that never happened describes an API nobody
 // asked about.
-func (r *BrunoTests) ReportShouldNotBeCached(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:295:1)
+func (r *BrunoTests) ReportShouldNotBeCached(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:302:1)
 	if r.reportShouldNotBeCached != nil {
 		return nil
 	}
@@ -259,7 +365,7 @@ func (r *BrunoTests) ReportShouldNotBeCached(ctx context.Context) error { // bru
 // RunFailsOnAssertionFailure checks that exit 1 — a failing request, test or
 // assertion — is an error, and that the error carries bru's own account of
 // what failed rather than just the exit code.
-func (r *BrunoTests) RunFailsOnAssertionFailure(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:120:1)
+func (r *BrunoTests) RunFailsOnAssertionFailure(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:127:1)
 	if r.runFailsOnAssertionFailure != nil {
 		return nil
 	}
@@ -270,7 +376,7 @@ func (r *BrunoTests) RunFailsOnAssertionFailure(ctx context.Context) error { // 
 
 // RunPassesAgainstBoundService checks the whole point of the module: a
 // collection whose environment names a bound service reaches it and passes.
-func (r *BrunoTests) RunPassesAgainstBoundService(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:88:1)
+func (r *BrunoTests) RunPassesAgainstBoundService(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:95:1)
 	if r.runPassesAgainstBoundService != nil {
 		return nil
 	}
@@ -282,7 +388,7 @@ func (r *BrunoTests) RunPassesAgainstBoundService(ctx context.Context) error { /
 // RunShouldNotBeCached checks that two identical Runs each reach the service.
 // A collection run hits a live API, so a cached pass would report a
 // now-broken API as green.
-func (r *BrunoTests) RunShouldNotBeCached(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:176:1)
+func (r *BrunoTests) RunShouldNotBeCached(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:183:1)
 	if r.runShouldNotBeCached != nil {
 		return nil
 	}
@@ -304,7 +410,7 @@ func (r *BrunoTests) RunShouldNotBeCached(ctx context.Context) error { // bruno-
 // command line" can actually be checked. That script needs the developer
 // sandbox — the safe one has no process — which is what makes WithSandbox
 // part of this test.
-func (r *BrunoTests) SecretVarIsNotOnArgv(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:372:1)
+func (r *BrunoTests) SecretVarIsNotOnArgv(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:379:1)
 	if r.secretVarIsNotOnArgv != nil {
 		return nil
 	}
@@ -317,7 +423,7 @@ func (r *BrunoTests) SecretVarIsNotOnArgv(ctx context.Context) error { // bruno-
 // bru exits 6 when the named environment does not exist; conflating that with
 // exit 1 would make "you typo'd the environment name" read as "your API is
 // broken".
-func (r *BrunoTests) UnknownEnvironmentIsRejected(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:150:1)
+func (r *BrunoTests) UnknownEnvironmentIsRejected(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:157:1)
 	if r.unknownEnvironmentIsRejected != nil {
 		return nil
 	}
@@ -330,7 +436,7 @@ func (r *BrunoTests) UnknownEnvironmentIsRejected(ctx context.Context) error { /
 // release the module pins. The Debian variant is not cosmetic — it is the
 // escape hatch for the Alpine image's musl/OpenSSL TLS failures — so it has
 // to be a tag that exists and ships the same CLI.
-func (r *BrunoTests) VersionReportsPinnedRelease(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:73:1)
+func (r *BrunoTests) VersionReportsPinnedRelease(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:80:1)
 	if r.versionReportsPinnedRelease != nil {
 		return nil
 	}
@@ -343,7 +449,7 @@ func (r *BrunoTests) VersionReportsPinnedRelease(ctx context.Context) error { //
 // selected environment declares. The fixture puts the variable in the request
 // path, so the responder records which of the two won rather than the module
 // having to trust bru's summary.
-func (r *BrunoTests) WithVarOverridesEnvironmentValue(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:332:1)
+func (r *BrunoTests) WithVarOverridesEnvironmentValue(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:339:1)
 	if r.withVarOverridesEnvironmentValue != nil {
 		return nil
 	}

--- a/daggerverse/bruno/README.md
+++ b/daggerverse/bruno/README.md
@@ -126,6 +126,64 @@ from the CLI.
 or workspace not found, or an unparseable collection file), 12 and 13 (global
 environment problems), and 255 for everything else.
 
+## Linting
+
+Bruno ships no linter, and the failure modes that leaves open are the expensive
+kind: a `{{baseUrl}}` that resolves nowhere fails at request time in CI rather
+than at review time, and an API key committed as a plaintext value under
+`environments/` is a leak nobody notices.
+
+`Lint` runs without issuing a single request — and without starting a
+container, since every rule is evaluated in pure Go over the source tree.
+
+```sh
+dagger -m github.com/z5labs/devex/daggerverse/bruno call \
+  collection --source=./api-tests with-environment --name=ci \
+  lint --fail-on-warnings
+```
+
+The rules:
+
+| Rule | Level |
+|---|---|
+| `bruno.json` exists at the collection root and declares `version`, `name` and `type` | error |
+| The environment `WithEnvironment` selected exists under `environments/` | error |
+| Every `{{var}}` resolves to a collection, folder or request variable, the selected environment, a `WithVar` override, a `WithEnvFile` file, a `bru.setVar` call, or `process.env` | error |
+| No credential-shaped name (`token`, `key`, `password`, `secret`) carries a literal value in a committed `environments/*.bru` `vars` block | error |
+| Every request declares `meta { name, seq }`, with `seq` unique within its folder | error |
+| A request declares neither `tests` nor `asserts` | warning |
+
+The first two are bru's exit 4 and exit 6, caught before a container starts and
+named against the file that is actually missing.
+
+Findings are folded into the returned error, following `kicad`'s `Drc` and
+`Erc`: Dagger drops a function's value when it also returns a non-nil error, so
+a `(findings, error)` signature would hide the findings on exactly the path
+that needs them. Warnings that fail nothing are written to stderr instead, so
+they still land in the run's logs.
+
+```
+bru lint found 2 errors and 1 warning:
+  error   environments/local.bru:3: "apiKey" is credential-shaped and carries a literal value in a committed file: move the name to a vars:secret block, or set the value to {{process.env.<NAME>}}
+  error   tenant.bru:8: {{tenantId}} resolves to nothing: declare it in the selected environment "local" or in a vars block, pass it with with-var, or read it from process.env
+  warning ping.bru: declares neither tests nor asserts: it passes whatever the API returns
+```
+
+Three things about the variable rule worth knowing. With **no** environment
+selected, every file under `environments/` contributes — otherwise linting a
+collection would force a choice the caller has not made, and report every
+`{{baseUrl}}` as broken. A `WithSecretVar` secret is deliberately *not* a bru
+variable, so `{{API_TOKEN}}` is a finding where `{{process.env.API_TOKEN}}` is
+not. And references inside `docs`, `tests` and `script:*` blocks are skipped:
+bru does not interpolate them, so linting them would invent findings out of
+prose.
+
+Scope limit: this reads the collection's block and reference structure, not a
+full `.bru` parse. Blocks are recognised by their opener at column 0, which is
+where Bruno's own writer puts them; everything indented under one — a JS
+script, a JSON body, an `example`'s nested request and response — is stepped
+over. A complete grammar is tracked separately.
+
 ## Generating a collection from OpenAPI
 
 A collection hand-maintained beside an OpenAPI document drifts. `Generate`
@@ -214,7 +272,7 @@ module or touch the filesystem needs `WithSandbox("developer")` — and fails at
 
 `Run` and `Report` carry `+cache="never"`: a collection run hits a live
 service, so a cached pass would report a now-broken API as green. `Container`,
-`Version` and `Generate` stay `+cache="session"` — those are pure.
+`Version`, `Generate` and `Lint` stay `+cache="session"` — those are pure.
 
 That directive governs the *function* result; the `WithExec` layer underneath
 is still content-addressed, so both terminals stamp a per-call nonce onto the
@@ -249,6 +307,7 @@ reachable through `Container()`.
 | `Collection.WithTestsOnly()` | `--tests-only`; skip requests with no test or assertion. |
 | `Collection.WithBail()` | `--bail`; stop at the first failure. |
 | `Collection.WithDelay(milliseconds)` | `--delay`; wait between requests. |
+| `Collection.Lint(failOnWarnings)` | Check the collection's structure in pure Go, issuing no requests. |
 | `Collection.Run(recursive)` | Run the collection; bru's output, failing on exit 1. |
 | `Collection.Report(format)` | Run it and return the `json`, `junit` or `html` artifact, failing only on usage errors. |
 
@@ -276,6 +335,17 @@ that same responder, which is what makes
 `GenerateProducesRunnableCollection` a real test — the generated collection is
 handed straight to `Collection` and run, rather than merely inspected for a
 `bruno.json`.
+
+The `fixtures/lint/` tree is the exception to all of that: one deliberately
+broken collection per rule, linted rather than run, so nothing there needs the
+responder at all. Each carries controls beside its violation — a
+`{{process.env.*}}` value beside the plaintext credential, a second folder
+reusing a `seq` beside the folder that duplicates one — because a rule that
+fires is only half of what needs pinning.
+
+`LintAcceptsValidCollection` deliberately reuses `fixtures/api`, the same
+collection the run tests drive against a live service: a linter that only
+accepts collections written for it is a linter nobody can adopt.
 
 `SecretVarIsNotOnArgv` is the one test that needs the collection's own
 scripting. Its fixture reports `process.argv` — bru's own command line — back

--- a/daggerverse/bruno/dagger.gen.go
+++ b/daggerverse/bruno/dagger.gen.go
@@ -379,6 +379,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 		}
 	case "Collection":
 		switch fnName {
+		case "Lint":
+			var parent Collection
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var failOnWarnings bool
+			if inputArgs["failOnWarnings"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["failOnWarnings"]), &failOnWarnings)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg failOnWarnings", err))
+				}
+			}
+			return nil, (*Collection).Lint(&parent, ctx, failOnWarnings)
 		case "Report":
 			var parent Collection
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/bruno/lint.go
+++ b/daggerverse/bruno/lint.go
@@ -1,0 +1,830 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+
+	"dagger/bruno/internal/dagger"
+)
+
+const (
+	// manifestFile is the file bru looks for to decide it is inside a
+	// collection root at all. Its absence is bru's exit 4 — a diagnostic that
+	// arrives only after a container has been started, and does not say which
+	// file it wanted.
+	manifestFile = "bruno.json"
+
+	// environmentsDir holds the per-environment variable files `--env` selects
+	// between, by file name without its extension.
+	environmentsDir = "environments"
+
+	// collectionSettingsFile and folderSettingsFile are the two .bru files that
+	// are not requests: they carry the auth, headers, scripts and variables
+	// that apply to a whole collection or a whole folder. Linting them as
+	// requests would demand a meta { seq } that neither has.
+	collectionSettingsFile = "collection.bru"
+	folderSettingsFile     = "folder.bru"
+
+	// rootFolder is the folder key for a request sitting at the collection
+	// root, matching what path.Dir returns for a bare file name. seq is unique
+	// per folder, so the root needs a key like any other folder.
+	rootFolder = "."
+
+	// processEnvPrefix is how a collection reaches an environment variable —
+	// the only shape a WithSecretVar secret is readable under, since a secret
+	// deliberately never becomes a bru variable.
+	processEnvPrefix = "process.env."
+)
+
+// credentialWords are the substrings that make a variable name
+// credential-shaped. A match is a name, not a value: the rule is that a
+// variable called something like apiKey has no business carrying a literal in
+// a file that is committed, whatever the literal happens to be.
+var credentialWords = []string{"token", "key", "password", "secret"}
+
+var (
+	// bruBlockHeader matches a top-level block opener. Anchored at column 0
+	// because that is where the Bruno writer puts them, and because it is what
+	// lets an indented brace inside a script, an example or a JSON body pass
+	// through untouched.
+	bruBlockHeader = regexp.MustCompile(`^([A-Za-z][A-Za-z0-9_:.-]*)\s*([{\[])\s*$`)
+
+	// bruReference matches one {{...}} interpolation. The body excludes braces
+	// so that a nested pair never swallows the rest of the line.
+	bruReference = regexp.MustCompile(`\{\{([^{}]*)\}\}`)
+
+	// bruIdentifier is a reference this linter is willing to have an opinion
+	// about: a plain variable name. Anything else inside {{ }} — an expression,
+	// a dotted path, a function call — is bru's runtime to resolve, and
+	// flagging it would be guessing.
+	bruIdentifier = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_-]*$`)
+
+	// bruSetVar matches a variable a script creates at runtime. Those names
+	// exist in no vars block anywhere, so without this every collection that
+	// chains a request onto a previous one's response would be reported as
+	// referencing something undefined.
+	bruSetVar = regexp.MustCompile(`\bbru\.set(?:Env|GlobalEnv)?Var\s*\(\s*['"]([^'"]+)`)
+)
+
+// Lint checks a collection's structure without issuing a single request.
+//
+// Bruno ships no linter, and the failure modes it leaves open are the
+// expensive kind: a {{baseUrl}} that resolves nowhere fails at request time in
+// CI rather than at review time, and an API key committed as a plaintext value
+// under environments/ is a leak nobody notices.
+//
+// Findings are folded into the returned error rather than returned as a value,
+// following kicad's Drc and Erc: Dagger drops a function's value when it also
+// returns a non-nil error, so a (findings, error) signature would hide the
+// findings on exactly the path that needs them. Warnings that do not fail the
+// call are written to stderr instead, so they are still visible in the run's
+// logs.
+//
+// Everything is evaluated in pure Go over the source tree — no container, per
+// the module's runtime-I/O convention — which is also why it is
+// +cache="session" rather than "never": the result is a function of the
+// directory's contents and nothing else.
+//
+// Scope limit: this reads the collection's block and reference structure, not
+// a full .bru parse. Blocks are recognised by their opener at column 0, which
+// is where Bruno's own writer puts them.
+//
+// +cache="session"
+func (c *Collection) Lint(
+	ctx context.Context,
+	// Treat warnings as failures.
+	// +default=false
+	failOnWarnings bool,
+) error {
+	if err := c.validate(); err != nil {
+		return err
+	}
+	parsed, err := c.loadTree(ctx)
+	if err != nil {
+		return err
+	}
+	findings := parsed.lint(strings.TrimSuffix(c.Environment, ".bru"), c.VarNames)
+	sortFindings(findings)
+
+	var errorCount, warningCount int
+	for _, f := range findings {
+		if f.Warning {
+			warningCount++
+			continue
+		}
+		errorCount++
+	}
+	if errorCount == 0 && warningCount == 0 {
+		return nil
+	}
+	report := fmt.Sprintf("bru lint found %s:\n%s",
+		countFindings(errorCount, warningCount), renderFindings(findings))
+	if errorCount > 0 || failOnWarnings {
+		return fmt.Errorf("%s", report)
+	}
+	// A warning that fails nothing still has to reach someone. Lint returns a
+	// bare error, so stderr is the only channel left — and module stderr shows
+	// up under the function's own span.
+	fmt.Fprintln(os.Stderr, report)
+	return nil
+}
+
+// ------------------------------------------------------------------ findings
+
+// finding is one lint result. File is empty when the finding is about the
+// collection rather than any one file, and Line is 0 when it is about a file
+// as a whole rather than a line within it.
+type finding struct {
+	File    string
+	Line    int
+	Warning bool
+	Message string
+}
+
+func (f finding) location() string {
+	switch {
+	case f.File == "":
+		return "<collection root>"
+	case f.Line > 0:
+		return fmt.Sprintf("%s:%d", f.File, f.Line)
+	default:
+		return f.File
+	}
+}
+
+// sortFindings orders findings by where they are rather than by severity, so
+// that everything about one file reads together. Collection-wide findings sort
+// first because they are the ones that explain the rest — a missing bruno.json
+// is why the environment could not be resolved either.
+func sortFindings(findings []finding) {
+	sort.SliceStable(findings, func(i, j int) bool {
+		a, b := findings[i], findings[j]
+		if a.File != b.File {
+			return a.File < b.File
+		}
+		if a.Line != b.Line {
+			return a.Line < b.Line
+		}
+		return a.Message < b.Message
+	})
+}
+
+func renderFindings(findings []finding) string {
+	var b strings.Builder
+	for _, f := range findings {
+		level := "error"
+		if f.Warning {
+			level = "warning"
+		}
+		fmt.Fprintf(&b, "  %-7s %s: %s\n", level, f.location(), f.Message)
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func countFindings(errors, warnings int) string {
+	switch {
+	case warnings == 0:
+		return plural(errors, "error")
+	case errors == 0:
+		return plural(warnings, "warning")
+	default:
+		return plural(errors, "error") + " and " + plural(warnings, "warning")
+	}
+}
+
+func plural(n int, noun string) string {
+	if n == 1 {
+		return fmt.Sprintf("1 %s", noun)
+	}
+	return fmt.Sprintf("%d %ss", n, noun)
+}
+
+// ---------------------------------------------------------------- .bru shapes
+
+// bruFile is one parsed .bru file: its path within the collection, its source,
+// and the top-level blocks found in it.
+type bruFile struct {
+	Path   string
+	Source string
+	Blocks []bruBlock
+}
+
+// bruBlock is one top-level `name { ... }` or `name [ ... ]` block. Bruno uses
+// both: dictionaries for vars, headers and asserts, arrays for the
+// name-only lists such as vars:secret.
+type bruBlock struct {
+	Name  string
+	Line  int
+	Array bool
+	Body  []bruEntry
+}
+
+// bruEntry is one line inside a block. Key is empty for a line that carries no
+// entry — a blank line, or the continuation of a multi-line value.
+type bruEntry struct {
+	Line     int
+	Key      string
+	Value    string
+	Disabled bool
+}
+
+// parseBru splits a .bru file into its top-level blocks.
+//
+// It is a structural scan, not a parse of the Bruno grammar: a block runs from
+// an opener at column 0 to its matching closer at column 0. That is enough to
+// find variable references, meta fields and assertion blocks, and it steps
+// over the parts of the grammar with no fixed shape — a JS script, a JSON
+// body, an example's nested request/response — because everything inside them
+// is indented.
+func parseBru(src string) []bruBlock {
+	var blocks []bruBlock
+	lines := strings.Split(src, "\n")
+	for i := 0; i < len(lines); i++ {
+		match := bruBlockHeader.FindStringSubmatch(lines[i])
+		if match == nil {
+			continue
+		}
+		block := bruBlock{Name: match[1], Line: i + 1, Array: match[2] == "["}
+		closer := "}"
+		if block.Array {
+			closer = "]"
+		}
+		for i++; i < len(lines); i++ {
+			if strings.TrimRight(lines[i], " \t\r") == closer {
+				break
+			}
+			block.Body = append(block.Body, parseBruEntry(lines[i], i+1, block.Array))
+		}
+		blocks = append(blocks, block)
+	}
+	return blocks
+}
+
+// parseBruEntry reads one line of a block body. A dictionary line is
+// `key: value`; an array line is a bare name. Either may be prefixed with ~,
+// which is how Bruno marks an entry as disabled — still committed, so still
+// this linter's business.
+func parseBruEntry(line string, number int, array bool) bruEntry {
+	entry := bruEntry{Line: number}
+	text := strings.TrimSpace(line)
+	if text == "" {
+		return entry
+	}
+	if strings.HasPrefix(text, "~") {
+		entry.Disabled = true
+		text = strings.TrimSpace(strings.TrimPrefix(text, "~"))
+	}
+	if array {
+		entry.Key = text
+		return entry
+	}
+	key, value, ok := strings.Cut(text, ":")
+	if !ok {
+		return entry
+	}
+	entry.Key = strings.TrimSpace(key)
+	entry.Value = strings.TrimSpace(value)
+	return entry
+}
+
+// block returns the first top-level block with the given name.
+func (f *bruFile) block(name string) *bruBlock {
+	for i := range f.Blocks {
+		if f.Blocks[i].Name == name {
+			return &f.Blocks[i]
+		}
+	}
+	return nil
+}
+
+// value returns the value of a key within a block.
+func (b *bruBlock) value(key string) (string, bool) {
+	if b == nil {
+		return "", false
+	}
+	for _, entry := range b.Body {
+		if entry.Key == key {
+			return entry.Value, true
+		}
+	}
+	return "", false
+}
+
+// entries returns the block's lines that actually carry an entry.
+func (b *bruBlock) entries() []bruEntry {
+	if b == nil {
+		return nil
+	}
+	var out []bruEntry
+	for _, entry := range b.Body {
+		if entry.Key != "" {
+			out = append(out, entry)
+		}
+	}
+	return out
+}
+
+// varNames collects every variable a file declares, across all of Bruno's
+// spellings: `vars` in an environment, `vars:secret`, and the
+// `vars:pre-request` / `vars:post-response` blocks a collection, folder or
+// request can carry.
+//
+// A disabled entry still counts as declared. bru would not resolve it, but
+// toggling one off in the Bruno app is a routine thing to do, and turning
+// every reference to it into an error would make the reference rule punish
+// ordinary editing.
+func (f *bruFile) varNames() []string {
+	var names []string
+	for i := range f.Blocks {
+		block := &f.Blocks[i]
+		if block.Name != "vars" && !strings.HasPrefix(block.Name, "vars:") {
+			continue
+		}
+		for _, entry := range block.entries() {
+			names = append(names, entry.Key)
+		}
+	}
+	return names
+}
+
+// ------------------------------------------------------------------- loading
+
+// tree is the collection as the linter sees it: the manifest, and every .bru
+// file sorted into the role its path gives it.
+type tree struct {
+	ManifestFound bool
+	Manifest      string
+
+	Environments []*bruFile
+	Settings     *bruFile
+	Folders      []*bruFile
+	Requests     []*bruFile
+
+	// SuppliedVars are the names a WithEnvFile file declares. They are
+	// variables the run will have and the committed tree cannot show, so
+	// without them a collection that gets its baseUrl from --env-file would be
+	// reported as referencing something undefined.
+	SuppliedVars []string
+}
+
+// loadTree reads the collection out of the engine. Reads are one file at a
+// time rather than through a container: a lint that needed the CLI image
+// pulled would cost more than the check it performs.
+func (c *Collection) loadTree(ctx context.Context) (*tree, error) {
+	out := &tree{}
+
+	found, err := c.Source.Exists(ctx, manifestFile)
+	if err != nil {
+		return nil, fmt.Errorf("Lint: look for %s in the collection: %v", manifestFile, err)
+	}
+	out.ManifestFound = found
+	if found {
+		contents, err := c.Source.File(manifestFile).Contents(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("Lint: read %s: %v", manifestFile, err)
+		}
+		out.Manifest = contents
+	}
+
+	paths, err := c.Source.Glob(ctx, "**/*.bru")
+	if err != nil {
+		return nil, fmt.Errorf("Lint: list the collection's .bru files: %v", err)
+	}
+	sort.Strings(paths)
+	for _, p := range paths {
+		contents, err := c.Source.File(p).Contents(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("Lint: read %s: %v", p, err)
+		}
+		file := &bruFile{Path: p, Source: contents, Blocks: parseBru(contents)}
+		switch {
+		case strings.HasPrefix(p, environmentsDir+"/"):
+			out.Environments = append(out.Environments, file)
+		case p == collectionSettingsFile:
+			out.Settings = file
+		case path.Base(p) == folderSettingsFile:
+			out.Folders = append(out.Folders, file)
+		default:
+			out.Requests = append(out.Requests, file)
+		}
+	}
+
+	if c.EnvFile != nil {
+		supplied, err := suppliedVarNames(ctx, c.EnvFile)
+		if err != nil {
+			return nil, err
+		}
+		out.SuppliedVars = supplied
+	}
+	return out, nil
+}
+
+// suppliedVarNames reads the variable names out of a WithEnvFile file. bru
+// picks its environment parser from the extension, so this does too — the two
+// shapes are not interchangeable, which is the same reason WithEnvFile mounts
+// the file under the extension it arrived with.
+func suppliedVarNames(ctx context.Context, file *dagger.File) ([]string, error) {
+	name, err := file.Name(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("Lint: read the environment file's name: %v", err)
+	}
+	contents, err := file.Contents(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("Lint: read the environment file %q: %v", name, err)
+	}
+	if strings.EqualFold(path.Ext(name), ".json") {
+		return jsonEnvVarNames(contents), nil
+	}
+	return (&bruFile{Source: contents, Blocks: parseBru(contents)}).varNames(), nil
+}
+
+// jsonEnvVarNames reads the names out of a JSON environment. Bruno writes the
+// `variables` array form; a flat object is accepted too, because it is what
+// anyone hand-writing one reaches for first.
+func jsonEnvVarNames(contents string) []string {
+	var structured struct {
+		Variables []struct {
+			Name string `json:"name"`
+		} `json:"variables"`
+	}
+	if err := json.Unmarshal([]byte(contents), &structured); err == nil && len(structured.Variables) > 0 {
+		names := make([]string, 0, len(structured.Variables))
+		for _, v := range structured.Variables {
+			names = append(names, v.Name)
+		}
+		return names
+	}
+	var flat map[string]any
+	if err := json.Unmarshal([]byte(contents), &flat); err != nil {
+		// A malformed environment file is bru's own error to raise, and it is
+		// not one of the rules this function owns. Contributing no names is the
+		// honest outcome: whatever the file was meant to declare, it declares
+		// nothing this linter can see.
+		return nil
+	}
+	names := make([]string, 0, len(flat))
+	for name := range flat {
+		names = append(names, name)
+	}
+	return names
+}
+
+// --------------------------------------------------------------------- rules
+
+// lint runs every rule and returns the findings, in no particular order.
+func (t *tree) lint(environment string, overrides []string) []finding {
+	var findings []finding
+	findings = append(findings, t.lintManifest()...)
+	findings = append(findings, t.lintEnvironment(environment)...)
+	findings = append(findings, t.lintPlaintextSecrets()...)
+	findings = append(findings, t.lintMeta()...)
+	findings = append(findings, t.lintAssertions()...)
+	findings = append(findings, t.lintReferences(environment, overrides)...)
+	return findings
+}
+
+// lintManifest checks that the collection has a root manifest declaring the
+// three fields bru reads out of it. This is bru's exit 4, caught with a
+// message that says which file is missing.
+func (t *tree) lintManifest() []finding {
+	if !t.ManifestFound {
+		return []finding{{Message: fmt.Sprintf(
+			"%s is missing from the collection root: bru exits 4 (\"not a collection root\") without it",
+			manifestFile)}}
+	}
+	var manifest map[string]any
+	if err := json.Unmarshal([]byte(t.Manifest), &manifest); err != nil {
+		return []finding{{File: manifestFile, Message: fmt.Sprintf("is not valid JSON: %v", err)}}
+	}
+	var findings []finding
+	for _, field := range []string{"version", "name", "type"} {
+		value, present := manifest[field]
+		text, isText := value.(string)
+		if !present || (isText && strings.TrimSpace(text) == "") {
+			findings = append(findings, finding{File: manifestFile, Message: fmt.Sprintf(
+				"declares no %q: a collection manifest needs version, name and type", field)})
+		}
+	}
+	if kind, ok := manifest["type"].(string); ok && kind != "" && kind != "collection" {
+		findings = append(findings, finding{File: manifestFile, Message: fmt.Sprintf(
+			"declares type %q: bru only reads %q", kind, "collection")})
+	}
+	return findings
+}
+
+// lintEnvironment checks that the environment WithEnvironment selected is one
+// the collection actually ships. bru spends exit 6 on this, after starting a
+// container to find out.
+func (t *tree) lintEnvironment(environment string) []finding {
+	if environment == "" {
+		return nil
+	}
+	var available []string
+	for _, env := range t.Environments {
+		name := strings.TrimSuffix(path.Base(env.Path), path.Ext(env.Path))
+		if name == environment {
+			return nil
+		}
+		available = append(available, name)
+	}
+	message := fmt.Sprintf("no environment named %q under %s/", environment, environmentsDir)
+	if len(available) == 0 {
+		return []finding{{Message: message + ": the collection ships none"}}
+	}
+	sort.Strings(available)
+	return []finding{{Message: fmt.Sprintf("%s: the collection ships %s",
+		message, strings.Join(quoteAll(available), ", "))}}
+}
+
+// lintPlaintextSecrets checks that no credential-shaped variable carries a
+// literal value in a committed environment file. Those belong in a
+// `vars:secret` block, which holds names rather than values.
+//
+// A value that is entirely interpolation — {{process.env.API_TOKEN}} — is not
+// a literal and is exactly the shape being asked for, so it passes. A disabled
+// entry does not: commenting a credential out does not uncommit it.
+func (t *tree) lintPlaintextSecrets() []finding {
+	var findings []finding
+	for _, env := range t.Environments {
+		for i := range env.Blocks {
+			block := &env.Blocks[i]
+			// vars:secret is the destination, not a violation of the rule, and
+			// carries no values to leak in the first place.
+			if block.Name != "vars" {
+				continue
+			}
+			for _, entry := range block.entries() {
+				if !credentialShaped(entry.Key) || !literalValue(entry.Value) {
+					continue
+				}
+				findings = append(findings, finding{File: env.Path, Line: entry.Line, Message: fmt.Sprintf(
+					"%q is credential-shaped and carries a literal value in a committed file: move the name to a vars:secret block, or set the value to {{%s<NAME>}}",
+					entry.Key, processEnvPrefix)})
+			}
+		}
+	}
+	return findings
+}
+
+// credentialShaped reports whether a variable name reads like a credential.
+func credentialShaped(name string) bool {
+	lower := strings.ToLower(name)
+	for _, word := range credentialWords {
+		if strings.Contains(lower, word) {
+			return true
+		}
+	}
+	return false
+}
+
+// literalValue reports whether a value is a committed constant rather than an
+// interpolation. Anything holding a {{...}} is resolved elsewhere, so there is
+// nothing committed to leak.
+func literalValue(value string) bool {
+	if strings.TrimSpace(value) == "" {
+		return false
+	}
+	return !bruReference.MatchString(value)
+}
+
+// lintMeta checks that every request declares meta { name } and a seq that is
+// unique within its folder. seq is what orders a run; two requests sharing one
+// order arbitrarily, and a request with none is ordered arbitrarily against
+// every other.
+func (t *tree) lintMeta() []finding {
+	var findings []finding
+	// seq is scoped to a folder, so the map is keyed by both.
+	seen := map[string]map[string]string{}
+	for _, request := range t.Requests {
+		meta := request.block("meta")
+		if meta == nil {
+			findings = append(findings, finding{File: request.Path,
+				Message: "declares no meta block: every request needs meta { name, seq }"})
+			continue
+		}
+		if name, ok := meta.value("name"); !ok || strings.TrimSpace(name) == "" {
+			findings = append(findings, finding{File: request.Path, Line: meta.Line,
+				Message: "declares no name in its meta block"})
+		}
+		seq, ok := meta.value("seq")
+		if !ok || strings.TrimSpace(seq) == "" {
+			findings = append(findings, finding{File: request.Path, Line: meta.Line,
+				Message: "declares no seq in its meta block: seq is what orders the run"})
+			continue
+		}
+		folder := path.Dir(request.Path)
+		if seen[folder] == nil {
+			seen[folder] = map[string]string{}
+		}
+		if first, clash := seen[folder][seq]; clash {
+			findings = append(findings, finding{File: request.Path, Line: meta.Line, Message: fmt.Sprintf(
+				"seq %s is already used by %s in the same folder: seq must be unique per folder",
+				seq, path.Base(first))})
+			continue
+		}
+		seen[folder][seq] = request.Path
+	}
+	return findings
+}
+
+// lintAssertions warns about a request that checks nothing. It runs, it
+// reports a pass, and it would report a pass against an API returning
+// anything at all.
+func (t *tree) lintAssertions() []finding {
+	var findings []finding
+	for _, request := range t.Requests {
+		if hasChecks(request) {
+			continue
+		}
+		findings = append(findings, finding{File: request.Path, Warning: true,
+			Message: "declares neither tests nor asserts: it passes whatever the API returns"})
+	}
+	return findings
+}
+
+// hasChecks reports whether a request declares anything that can fail. A
+// disabled assertion does not count — it is the same as not having written it
+// — and neither does an empty tests block.
+func hasChecks(request *bruFile) bool {
+	for i := range request.Blocks {
+		block := &request.Blocks[i]
+		switch block.Name {
+		case "tests":
+			for _, line := range block.Body {
+				if strings.TrimSpace(line.Key) != "" || strings.TrimSpace(line.Value) != "" {
+					return true
+				}
+			}
+		case "assert", "asserts":
+			for _, entry := range block.entries() {
+				if !entry.Disabled {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// lintReferences checks that every {{var}} the collection interpolates
+// resolves to something the run will have.
+//
+// The sources are the ones bru itself resolves from: the collection's own
+// vars, the folder's, the request's, the selected environment's, a WithVar
+// override, a WithEnvFile file, and process.env. Variables a script creates
+// with bru.setVar count too — they exist in no vars block anywhere, and
+// without them every chained request would read as broken.
+//
+// With no environment selected, every file under environments/ contributes.
+// The alternative would report {{baseUrl}} as unresolved for the common case
+// of linting a collection without committing to one of its environments.
+func (t *tree) lintReferences(environment string, overrides []string) []finding {
+	global := map[string]bool{}
+	addAll(global, overrides)
+	addAll(global, t.SuppliedVars)
+	if t.Settings != nil {
+		addAll(global, t.Settings.varNames())
+	}
+	for _, env := range t.Environments {
+		name := strings.TrimSuffix(path.Base(env.Path), path.Ext(env.Path))
+		if environment == "" || name == environment {
+			addAll(global, env.varNames())
+		}
+	}
+	// A script can set a variable one request consumes and another produces,
+	// in either order, so the names it creates are collected across the whole
+	// collection rather than per file.
+	for _, file := range t.everyFile() {
+		for _, match := range bruSetVar.FindAllStringSubmatch(file.Source, -1) {
+			global[match[1]] = true
+		}
+	}
+
+	// Folder-scoped variables reach the requests beneath that folder and
+	// nothing else.
+	folderVars := map[string]map[string]bool{}
+	for _, folder := range t.Folders {
+		scope := path.Dir(folder.Path)
+		if folderVars[scope] == nil {
+			folderVars[scope] = map[string]bool{}
+		}
+		addAll(folderVars[scope], folder.varNames())
+	}
+
+	var findings []finding
+	for _, request := range t.Requests {
+		defined := map[string]bool{}
+		for name := range global {
+			defined[name] = true
+		}
+		for scope, names := range folderVars {
+			if scope == rootFolder || strings.HasPrefix(request.Path, scope+"/") {
+				for name := range names {
+					defined[name] = true
+				}
+			}
+		}
+		addAll(defined, request.varNames())
+
+		for _, ref := range references(request) {
+			if defined[ref.Name] {
+				continue
+			}
+			findings = append(findings, finding{File: request.Path, Line: ref.Line, Message: fmt.Sprintf(
+				"{{%s}} resolves to nothing: %s", ref.Name, resolutionHint(environment))})
+		}
+	}
+	return findings
+}
+
+// resolutionHint says what would satisfy an unresolved reference, so the
+// finding is actionable without re-running the lint to find out.
+func resolutionHint(environment string) string {
+	source := "any environment under " + environmentsDir + "/"
+	if environment != "" {
+		source = fmt.Sprintf("the selected environment %q", environment)
+	}
+	return fmt.Sprintf("declare it in %s or in a vars block, pass it with with-var, or read it from %s",
+		source, strings.TrimSuffix(processEnvPrefix, "."))
+}
+
+// reference is one {{name}} interpolation and the line it sits on.
+type reference struct {
+	Name string
+	Line int
+}
+
+// references collects the variable references a request interpolates.
+//
+// Scripts, tests and docs are skipped. A {{...}} there is not interpolated by
+// bru at all — scripts reach variables through bru.getVar, and docs are prose
+// — so reading them would invent findings out of documentation.
+func references(file *bruFile) []reference {
+	var out []reference
+	seen := map[string]bool{}
+	for i := range file.Blocks {
+		block := &file.Blocks[i]
+		if block.Name == "docs" || block.Name == "tests" || strings.HasPrefix(block.Name, "script") {
+			continue
+		}
+		for _, entry := range block.Body {
+			for _, match := range bruReference.FindAllStringSubmatch(entry.Value, -1) {
+				name := strings.TrimSpace(match[1])
+				switch {
+				case strings.HasPrefix(name, "$"):
+					// A Bruno dynamic variable: {{$guid}}, {{$timestamp}}.
+					// Always available, never declared.
+					continue
+				case strings.HasPrefix(name, processEnvPrefix):
+					continue
+				case !bruIdentifier.MatchString(name):
+					// An expression rather than a name. Out of scope, and
+					// guessing at it would produce findings nobody can act on.
+					continue
+				}
+				// One finding per variable per file: a baseUrl referenced by
+				// six requests is one thing to fix, not six.
+				if seen[name] {
+					continue
+				}
+				seen[name] = true
+				out = append(out, reference{Name: name, Line: entry.Line})
+			}
+		}
+	}
+	return out
+}
+
+// everyFile returns every .bru file in the collection, whatever its role.
+func (t *tree) everyFile() []*bruFile {
+	files := make([]*bruFile, 0, len(t.Environments)+len(t.Folders)+len(t.Requests)+1)
+	files = append(files, t.Environments...)
+	files = append(files, t.Folders...)
+	files = append(files, t.Requests...)
+	if t.Settings != nil {
+		files = append(files, t.Settings)
+	}
+	return files
+}
+
+func addAll(set map[string]bool, names []string) {
+	for _, name := range names {
+		if name = strings.TrimSpace(name); name != "" {
+			set[name] = true
+		}
+	}
+}
+
+func quoteAll(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		out = append(out, fmt.Sprintf("%q", v))
+	}
+	return out
+}

--- a/daggerverse/bruno/tests/dagger.gen.go
+++ b/daggerverse/bruno/tests/dagger.gen.go
@@ -234,6 +234,55 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).JsonEnvFileKeepsItsExtension(&parent, ctx)
+		case "LintAcceptsValidCollection":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).LintAcceptsValidCollection(&parent, ctx)
+		case "LintRejectsDuplicateSequence":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).LintRejectsDuplicateSequence(&parent, ctx)
+		case "LintRejectsMissingBrunoJson":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).LintRejectsMissingBrunoJson(&parent, ctx)
+		case "LintRejectsPlaintextSecret":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).LintRejectsPlaintextSecret(&parent, ctx)
+		case "LintRejectsUnknownEnvironment":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).LintRejectsUnknownEnvironment(&parent, ctx)
+		case "LintRejectsUnresolvedVariable":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).LintRejectsUnresolvedVariable(&parent, ctx)
+		case "LintWarnsOnRequestWithoutTests":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).LintWarnsOnRequestWithoutTests(&parent, ctx)
 		case "PassThroughFlagsAreAccepted":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/bruno/tests/fixtures/lint/duplicate-seq/bruno.json
+++ b/daggerverse/bruno/tests/fixtures/lint/duplicate-seq/bruno.json
@@ -1,0 +1,5 @@
+{
+  "version": "1",
+  "name": "duplicate-seq",
+  "type": "collection"
+}

--- a/daggerverse/bruno/tests/fixtures/lint/duplicate-seq/environments/local.bru
+++ b/daggerverse/bruno/tests/fixtures/lint/duplicate-seq/environments/local.bru
@@ -1,0 +1,3 @@
+vars {
+  baseUrl: http://api:8080
+}

--- a/daggerverse/bruno/tests/fixtures/lint/duplicate-seq/first.bru
+++ b/daggerverse/bruno/tests/fixtures/lint/duplicate-seq/first.bru
@@ -1,0 +1,15 @@
+meta {
+  name: first
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/health
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+}

--- a/daggerverse/bruno/tests/fixtures/lint/duplicate-seq/nested/also-first.bru
+++ b/daggerverse/bruno/tests/fixtures/lint/duplicate-seq/nested/also-first.bru
@@ -1,0 +1,15 @@
+meta {
+  name: also-first
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/nested/deep
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+}

--- a/daggerverse/bruno/tests/fixtures/lint/duplicate-seq/second.bru
+++ b/daggerverse/bruno/tests/fixtures/lint/duplicate-seq/second.bru
@@ -1,0 +1,15 @@
+meta {
+  name: second
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/health
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+}

--- a/daggerverse/bruno/tests/fixtures/lint/missing-manifest/environments/local.bru
+++ b/daggerverse/bruno/tests/fixtures/lint/missing-manifest/environments/local.bru
@@ -1,0 +1,3 @@
+vars {
+  baseUrl: http://api:8080
+}

--- a/daggerverse/bruno/tests/fixtures/lint/missing-manifest/health.bru
+++ b/daggerverse/bruno/tests/fixtures/lint/missing-manifest/health.bru
@@ -1,0 +1,15 @@
+meta {
+  name: health
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/health
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+}

--- a/daggerverse/bruno/tests/fixtures/lint/no-tests/bruno.json
+++ b/daggerverse/bruno/tests/fixtures/lint/no-tests/bruno.json
@@ -1,0 +1,5 @@
+{
+  "version": "1",
+  "name": "no-tests",
+  "type": "collection"
+}

--- a/daggerverse/bruno/tests/fixtures/lint/no-tests/environments/local.bru
+++ b/daggerverse/bruno/tests/fixtures/lint/no-tests/environments/local.bru
@@ -1,0 +1,3 @@
+vars {
+  baseUrl: http://api:8080
+}

--- a/daggerverse/bruno/tests/fixtures/lint/no-tests/ping.bru
+++ b/daggerverse/bruno/tests/fixtures/lint/no-tests/ping.bru
@@ -1,0 +1,15 @@
+meta {
+  name: ping
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/health
+  body: none
+  auth: none
+}
+
+assert {
+  ~res.status: eq 200
+}

--- a/daggerverse/bruno/tests/fixtures/lint/plaintext-secret/bruno.json
+++ b/daggerverse/bruno/tests/fixtures/lint/plaintext-secret/bruno.json
@@ -1,0 +1,5 @@
+{
+  "version": "1",
+  "name": "plaintext-secret",
+  "type": "collection"
+}

--- a/daggerverse/bruno/tests/fixtures/lint/plaintext-secret/environments/local.bru
+++ b/daggerverse/bruno/tests/fixtures/lint/plaintext-secret/environments/local.bru
@@ -1,0 +1,9 @@
+vars {
+  baseUrl: http://api:8080
+  apiKey: replace-me-this-is-not-a-real-credential
+  sessionToken: {{process.env.SESSION_TOKEN}}
+}
+
+vars:secret [
+  refreshToken
+]

--- a/daggerverse/bruno/tests/fixtures/lint/plaintext-secret/token.bru
+++ b/daggerverse/bruno/tests/fixtures/lint/plaintext-secret/token.bru
@@ -1,0 +1,21 @@
+meta {
+  name: token
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/token
+  body: none
+  auth: none
+}
+
+headers {
+  X-Api-Key: {{apiKey}}
+  X-Session-Token: {{sessionToken}}
+  X-Refresh-Token: {{refreshToken}}
+}
+
+assert {
+  res.status: eq 200
+}

--- a/daggerverse/bruno/tests/fixtures/lint/unresolved/bruno.json
+++ b/daggerverse/bruno/tests/fixtures/lint/unresolved/bruno.json
@@ -1,0 +1,5 @@
+{
+  "version": "1",
+  "name": "unresolved",
+  "type": "collection"
+}

--- a/daggerverse/bruno/tests/fixtures/lint/unresolved/environments/local.bru
+++ b/daggerverse/bruno/tests/fixtures/lint/unresolved/environments/local.bru
@@ -1,0 +1,3 @@
+vars {
+  baseUrl: http://api:8080
+}

--- a/daggerverse/bruno/tests/fixtures/lint/unresolved/tenant.bru
+++ b/daggerverse/bruno/tests/fixtures/lint/unresolved/tenant.bru
@@ -1,0 +1,24 @@
+meta {
+  name: tenant
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/tenants/{{tenantId}}
+  body: none
+  auth: none
+}
+
+docs {
+  The {{tenantId}} above is declared nowhere: not by an environment, not by a
+  vars block, not by process.env. bru resolves it to the literal string
+  "{{tenantId}}" and issues the request anyway.
+
+  This {{alsoUndeclared}} reference is here to pin the opposite behaviour --
+  docs are prose, so nothing in this block is a finding.
+}
+
+assert {
+  res.status: eq 200
+}

--- a/daggerverse/bruno/tests/internal/dagger/bruno.gen.go
+++ b/daggerverse/bruno/tests/internal/dagger/bruno.gen.go
@@ -200,8 +200,9 @@ func (r *Bruno) AsNode() Node {
 type BrunoCollection struct { // bruno (../../../../../daggerverse/bruno/collection.go:86:6)
 	query *querybuilder.Selection
 
-	id  *ID
-	run *string
+	id   *ID
+	lint *Void
+	run  *string
 }
 type WithBrunoCollectionFunc func(r *BrunoCollection) *BrunoCollection
 
@@ -265,6 +266,50 @@ func (r *BrunoCollection) UnmarshalJSON(bs []byte) error {
 	}
 	*r = BrunoCollection{query: selectNode(dag.query, id, "BrunoCollection")}
 	return nil
+}
+
+// BrunoCollectionLintOpts contains options for BrunoCollection.Lint
+type BrunoCollectionLintOpts struct {
+	//
+	// Treat warnings as failures.
+	//
+	FailOnWarnings bool // bruno (../../../../../daggerverse/bruno/lint.go:103:2)
+}
+
+// Lint checks a collection's structure without issuing a single request.
+//
+// Bruno ships no linter, and the failure modes it leaves open are the
+// expensive kind: a {{baseUrl}} that resolves nowhere fails at request time in
+// CI rather than at review time, and an API key committed as a plaintext value
+// under environments/ is a leak nobody notices.
+//
+// Findings are folded into the returned error rather than returned as a value,
+// following kicad's Drc and Erc: Dagger drops a function's value when it also
+// returns a non-nil error, so a (findings, error) signature would hide the
+// findings on exactly the path that needs them. Warnings that do not fail the
+// call are written to stderr instead, so they are still visible in the run's
+// logs.
+//
+// Everything is evaluated in pure Go over the source tree — no container, per
+// the module's runtime-I/O convention — which is also why it is
+// directory's contents and nothing else.
+//
+// Scope limit: this reads the collection's block and reference structure, not
+// a full .bru parse. Blocks are recognised by their opener at column 0, which
+// is where Bruno's own writer puts them.
+func (r *BrunoCollection) Lint(ctx context.Context, opts ...BrunoCollectionLintOpts) error { // bruno (../../../../../daggerverse/bruno/lint.go:99:1)
+	if r.lint != nil {
+		return nil
+	}
+	q := r.query.Select("lint")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `failOnWarnings` optional argument
+		if !querybuilder.IsZeroValue(opts[i].FailOnWarnings) {
+			q = q.Arg("failOnWarnings", opts[i].FailOnWarnings)
+		}
+	}
+
+	return q.Execute(ctx)
 }
 
 // Report executes the collection and returns the reporter's artifact.

--- a/daggerverse/bruno/tests/main.go
+++ b/daggerverse/bruno/tests/main.go
@@ -62,6 +62,13 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("GenerateProducesRunnableCollection", t.GenerateProducesRunnableCollection)
 	jobs = jobs.WithJob("GenerateHonoursOpenCollectionFormat", t.GenerateHonoursOpenCollectionFormat)
 	jobs = jobs.WithJob("GenerateRejectsUnknownFormat", t.GenerateRejectsUnknownFormat)
+	jobs = jobs.WithJob("LintAcceptsValidCollection", t.LintAcceptsValidCollection)
+	jobs = jobs.WithJob("LintRejectsMissingBrunoJson", t.LintRejectsMissingBrunoJson)
+	jobs = jobs.WithJob("LintRejectsUnknownEnvironment", t.LintRejectsUnknownEnvironment)
+	jobs = jobs.WithJob("LintRejectsUnresolvedVariable", t.LintRejectsUnresolvedVariable)
+	jobs = jobs.WithJob("LintRejectsPlaintextSecret", t.LintRejectsPlaintextSecret)
+	jobs = jobs.WithJob("LintRejectsDuplicateSequence", t.LintRejectsDuplicateSequence)
+	jobs = jobs.WithJob("LintWarnsOnRequestWithoutTests", t.LintWarnsOnRequestWithoutTests)
 
 	return jobs.Run(ctx)
 }
@@ -611,6 +618,159 @@ func (t *Tests) GenerateRejectsUnknownFormat(ctx context.Context) error {
 	for _, want := range []string{"postman", "bru", "opencollection"} {
 		if !strings.Contains(err.Error(), want) {
 			return fmt.Errorf("expected the error to mention %q, got: %s", want, err.Error())
+		}
+	}
+	return nil
+}
+
+// LintAcceptsValidCollection checks that a collection this suite already runs
+// against a live service is also one the linter is happy with. The api fixture
+// is deliberately reused rather than a purpose-built clean one: a linter that
+// only accepts collections written for it is a linter nobody can adopt.
+//
+// It is checked under failOnWarnings=true as well, so the fixture has to be
+// free of warnings and not merely free of errors.
+func (t *Tests) LintAcceptsValidCollection(ctx context.Context) error {
+	collection := dag.Bruno().Collection(fixture("api")).WithEnvironment("local")
+	for _, strict := range []bool{false, true} {
+		if err := collection.Lint(ctx, dagger.BrunoCollectionLintOpts{FailOnWarnings: strict}); err != nil {
+			return fmt.Errorf("expected a clean collection to lint (failOnWarnings=%t): %w", strict, err)
+		}
+	}
+	// The same collection with no environment selected still resolves
+	// {{baseUrl}}: with nothing selected every file under environments/ counts,
+	// so linting does not force a choice the caller has not made.
+	if err := dag.Bruno().Collection(fixture("api")).Lint(ctx); err != nil {
+		return fmt.Errorf("expected a clean collection to lint with no environment selected: %w", err)
+	}
+	return nil
+}
+
+// LintRejectsMissingBrunoJson checks the finding that stands in for bru's exit
+// 4. bru reports that one as "not a collection root", from inside a container,
+// without naming the file it wanted.
+func (t *Tests) LintRejectsMissingBrunoJson(ctx context.Context) error {
+	err := dag.Bruno().Collection(fixture("lint/missing-manifest")).WithEnvironment("local").Lint(ctx)
+	if err == nil {
+		return fmt.Errorf("expected a collection with no bruno.json to be an error")
+	}
+	for _, want := range []string{"bruno.json", "collection root"} {
+		if !strings.Contains(err.Error(), want) {
+			return fmt.Errorf("expected the error to mention %q, got:\n%s", want, head(err.Error()))
+		}
+	}
+	return nil
+}
+
+// LintRejectsUnknownEnvironment checks that a mistyped --env name is caught
+// here rather than as bru's exit 6, and that the finding lists the names the
+// collection does ship.
+func (t *Tests) LintRejectsUnknownEnvironment(ctx context.Context) error {
+	err := dag.Bruno().Collection(fixture("api")).WithEnvironment("nope").Lint(ctx)
+	if err == nil {
+		return fmt.Errorf("expected an unknown environment to be an error")
+	}
+	for _, want := range []string{`"nope"`, "environments/", `"local"`} {
+		if !strings.Contains(err.Error(), want) {
+			return fmt.Errorf("expected the error to mention %q, got:\n%s", want, head(err.Error()))
+		}
+	}
+	return nil
+}
+
+// LintRejectsUnresolvedVariable checks the finding the whole function exists
+// for: a {{var}} that resolves nowhere, named along with the file it appears
+// in, before a request has been issued to discover it.
+//
+// The fixture also references two undeclared variables from its docs block,
+// which bru never interpolates — so this pins that prose is not linted as
+// though it were a request.
+func (t *Tests) LintRejectsUnresolvedVariable(ctx context.Context) error {
+	err := dag.Bruno().Collection(fixture("lint/unresolved")).WithEnvironment("local").Lint(ctx)
+	if err == nil {
+		return fmt.Errorf("expected an unresolved variable to be an error")
+	}
+	for _, want := range []string{"tenantId", "tenant.bru"} {
+		if !strings.Contains(err.Error(), want) {
+			return fmt.Errorf("expected the error to name %q, got:\n%s", want, head(err.Error()))
+		}
+	}
+	// baseUrl is declared by the selected environment, and the docs block's
+	// references are prose. Either one showing up would mean the rule fires on
+	// things that resolve perfectly well.
+	for _, unwanted := range []string{"baseUrl", "alsoUndeclared"} {
+		if strings.Contains(err.Error(), unwanted) {
+			return fmt.Errorf("expected %q not to be reported, got:\n%s", unwanted, head(err.Error()))
+		}
+	}
+	return nil
+}
+
+// LintRejectsPlaintextSecret checks the rule that catches a leak rather than a
+// breakage: a credential-shaped variable carrying a literal in a file that is
+// committed.
+//
+// The fixture holds two controls beside the violation — a token whose value is
+// a {{process.env.*}} interpolation, and a name declared in a vars:secret
+// block — so this also pins that the rule accepts the shape it is asking for.
+func (t *Tests) LintRejectsPlaintextSecret(ctx context.Context) error {
+	err := dag.Bruno().Collection(fixture("lint/plaintext-secret")).WithEnvironment("local").Lint(ctx)
+	if err == nil {
+		return fmt.Errorf("expected a plaintext credential to be an error")
+	}
+	for _, want := range []string{"apiKey", "environments/local.bru", "vars:secret"} {
+		if !strings.Contains(err.Error(), want) {
+			return fmt.Errorf("expected the error to mention %q, got:\n%s", want, head(err.Error()))
+		}
+	}
+	if strings.Contains(err.Error(), "sessionToken") {
+		return fmt.Errorf("expected a {{process.env}} value not to be reported as a committed literal, got:\n%s",
+			head(err.Error()))
+	}
+	if strings.Contains(err.Error(), "refreshToken") {
+		return fmt.Errorf("expected a vars:secret name to satisfy the rule rather than trip it, got:\n%s",
+			head(err.Error()))
+	}
+	return nil
+}
+
+// LintRejectsDuplicateSequence checks that two requests claiming the same seq
+// in one folder is a finding, and that the same seq in a different folder is
+// not — seq orders a folder's requests, so it is only ambiguous within one.
+func (t *Tests) LintRejectsDuplicateSequence(ctx context.Context) error {
+	err := dag.Bruno().Collection(fixture("lint/duplicate-seq")).WithEnvironment("local").Lint(ctx)
+	if err == nil {
+		return fmt.Errorf("expected a duplicated seq to be an error")
+	}
+	for _, want := range []string{"second.bru", "first.bru", "seq 1"} {
+		if !strings.Contains(err.Error(), want) {
+			return fmt.Errorf("expected the error to mention %q, got:\n%s", want, head(err.Error()))
+		}
+	}
+	if strings.Contains(err.Error(), "also-first.bru") {
+		return fmt.Errorf("expected a seq reused in a different folder to be fine, got:\n%s", head(err.Error()))
+	}
+	return nil
+}
+
+// LintWarnsOnRequestWithoutTests checks the one finding that is a warning: a
+// request that checks nothing passes whatever the API returns, which is worth
+// saying and not worth failing a pipeline over by default.
+//
+// The fixture's only assertion is disabled, which is the same as not having
+// written it — so this also pins that a commented-out assert does not count.
+func (t *Tests) LintWarnsOnRequestWithoutTests(ctx context.Context) error {
+	collection := dag.Bruno().Collection(fixture("lint/no-tests")).WithEnvironment("local")
+	if err := collection.Lint(ctx); err != nil {
+		return fmt.Errorf("expected a warning not to fail by default: %w", err)
+	}
+	err := collection.Lint(ctx, dagger.BrunoCollectionLintOpts{FailOnWarnings: true})
+	if err == nil {
+		return fmt.Errorf("expected failOnWarnings to turn the warning into an error")
+	}
+	for _, want := range []string{"warning", "ping.bru", "tests"} {
+		if !strings.Contains(err.Error(), want) {
+			return fmt.Errorf("expected the error to mention %q, got:\n%s", want, head(err.Error()))
 		}
 	}
 	return nil


### PR DESCRIPTION
Closes #243.

Bruno ships no linter. A `{{baseUrl}}` that resolves nowhere fails at request
time in CI rather than at review time, and an API key committed as a plaintext
value in `environments/*.bru` is a leak nobody notices. `Collection.Lint`
checks both without issuing a single request.

Every rule runs in pure Go over the source tree — no helper container, per the
module's runtime-I/O convention — so the check costs a directory read rather
than an image pull.

| Rule | Level |
|---|---|
| `bruno.json` exists at the collection root and declares `version`, `name` and `type` | error |
| The environment `WithEnvironment` selected exists under `environments/` | error |
| Every `{{var}}` resolves to a collection, folder or request variable, the selected environment, a `WithVar` override, a `WithEnvFile` file, a `bru.setVar` call, or `process.env` | error |
| No credential-shaped name (`token`, `key`, `password`, `secret`) carries a literal value in a committed `environments/*.bru` `vars` block | error |
| Every request declares `meta { name, seq }`, with `seq` unique within its folder | error |
| A request declares neither `tests` nor `asserts` | warning |

The first two are bru's exit 4 and exit 6, caught before a container starts and
named against the file that is actually missing.

Findings are folded into the returned error, following `kicad`'s `Drc` and
`Erc`: Dagger drops a function's value when it also returns a non-nil error, so
a `(findings, error)` signature would hide the findings on exactly the path
that needs them. Warnings that fail nothing are written to stderr instead, so
they still land in the run's logs.

```
bru lint found 2 errors and 1 warning:
  error   environments/local.bru:3: "apiKey" is credential-shaped and carries a literal value in a committed file: move the name to a vars:secret block, or set the value to {{process.env.<NAME>}}
  error   tenant.bru:8: {{tenantId}} resolves to nothing: declare it in the selected environment "local" or in a vars block, pass it with with-var, or read it from process.env
  warning ping.bru: declares neither tests nor asserts: it passes whatever the API returns
```

## Judgment calls

- **With no environment selected, every file under `environments/` contributes.**
  The alternative reports every `{{baseUrl}}` as broken for a caller who has
  not committed to one of the collection's environments. A *selected*
  environment is the sharp check.
- **References inside `docs`, `tests` and `script:*` blocks are skipped.** bru
  does not interpolate them, so linting them would invent findings out of prose.
- **A `WithSecretVar` secret is deliberately not a bru variable**, so
  `{{API_TOKEN}}` is a finding where `{{process.env.API_TOKEN}}` is not.

Checked against a `bru import openapi` tree: it lints with warnings only, so
`Generate` piped into `Lint` does not hard-fail.

## Scope limit

This reads the collection's block and reference structure, not a full `.bru`
parse. Blocks are recognised by their opener at column 0, which is where
Bruno's own writer puts them; everything indented under one — a JS script, a
JSON body, an `example`'s nested request and response — is stepped over. The
complete grammar stays tracked in #247.

## Tests

Seven new jobs, green individually and under `all` (23/23):
`LintAcceptsValidCollection`, `LintRejectsMissingBrunoJson`,
`LintRejectsUnknownEnvironment`, `LintRejectsUnresolvedVariable`,
`LintRejectsPlaintextSecret`, `LintRejectsDuplicateSequence`,
`LintWarnsOnRequestWithoutTests`.

`LintAcceptsValidCollection` deliberately reuses `fixtures/api`, the collection
the run tests already drive against a live service: a linter that only accepts
collections written for it is a linter nobody can adopt. The broken fixtures
under `fixtures/lint/` each carry a control beside the violation — a
`{{process.env.*}}` value beside the plaintext credential, a `vars:secret`
name, a second folder reusing a `seq`, undeclared references inside a `docs`
block — so the negative half of every rule is pinned too. The plaintext-secret
fixture's value is an obvious placeholder, not a credential.

```sh
dagger -m daggerverse/bruno/tests call all   # green
dagger -m ci call generated                  # green
```

Bindings regenerated in `daggerverse/bruno`, `daggerverse/bruno/tests` and at
the repo root (`ci/internal/dagger/bruno-tests.gen.go`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)