### PR TITLE
story(issue-244): add the chained Ci builder to bruno

### DIFF
--- a/ci/internal/dagger/bruno-tests.gen.go
+++ b/ci/internal/dagger/bruno-tests.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type BrunoTests
-func (r *Binding) AsBrunoTests() *BrunoTests { // bruno-tests (../../../daggerverse/bruno/tests/main.go:31:6)
+func (r *Binding) AsBrunoTests() *BrunoTests { // bruno-tests (../../../daggerverse/bruno/tests/main.go:32:6)
 	q := r.query.Select("asBrunoTests")
 
 	return &BrunoTests{
@@ -18,34 +18,41 @@ func (r *Binding) AsBrunoTests() *BrunoTests { // bruno-tests (../../../daggerve
 	}
 }
 
-type BrunoTests struct { // bruno-tests (../../../daggerverse/bruno/tests/main.go:31:6)
+type BrunoTests struct { // bruno-tests (../../../daggerverse/bruno/tests/main.go:32:6)
 	query *querybuilder.Selection
 
-	all                                 *Void
-	generateHonoursOpenCollectionFormat *Void
-	generateProducesRunnableCollection  *Void
-	generateRejectsUnknownFormat        *Void
-	id                                  *ID
-	jsonEnvFileKeepsItsExtension        *Void
-	lintAcceptsValidCollection          *Void
-	lintRejectsDuplicateSequence        *Void
-	lintRejectsMissingBrunoJson         *Void
-	lintRejectsPlaintextSecret          *Void
-	lintRejectsUnknownEnvironment       *Void
-	lintRejectsUnresolvedVariable       *Void
-	lintWarnsOnRequestWithoutTests      *Void
-	passThroughFlagsAreAccepted         *Void
-	recursiveDefaultReachesSubfolders   *Void
-	reportEmitsJunitForFailingRun       *Void
-	reportRejectsUnknownFormat          *Void
-	reportShouldNotBeCached             *Void
-	runFailsOnAssertionFailure          *Void
-	runPassesAgainstBoundService        *Void
-	runShouldNotBeCached                *Void
-	secretVarIsNotOnArgv                *Void
-	unknownEnvironmentIsRejected        *Void
-	versionReportsPinnedRelease         *Void
-	withVarOverridesEnvironmentValue    *Void
+	all                                     *Void
+	ciCheckGatesOnFailingAssertion          *Void
+	ciLintFailsBeforeAnyRequest             *Void
+	ciRejectsUnknownReportFormat            *Void
+	ciRunProducesEveryRequestedReport       *Void
+	ciRunStillReportsWhenTheCollectionFails *Void
+	ciSecretVarReachesTheCollection         *Void
+	ciShouldNotBeCached                     *Void
+	generateHonoursOpenCollectionFormat     *Void
+	generateProducesRunnableCollection      *Void
+	generateRejectsUnknownFormat            *Void
+	id                                      *ID
+	jsonEnvFileKeepsItsExtension            *Void
+	lintAcceptsValidCollection              *Void
+	lintRejectsDuplicateSequence            *Void
+	lintRejectsMissingBrunoJson             *Void
+	lintRejectsPlaintextSecret              *Void
+	lintRejectsUnknownEnvironment           *Void
+	lintRejectsUnresolvedVariable           *Void
+	lintWarnsOnRequestWithoutTests          *Void
+	passThroughFlagsAreAccepted             *Void
+	recursiveDefaultReachesSubfolders       *Void
+	reportEmitsJunitForFailingRun           *Void
+	reportRejectsUnknownFormat              *Void
+	reportShouldNotBeCached                 *Void
+	runFailsOnAssertionFailure              *Void
+	runPassesAgainstBoundService            *Void
+	runShouldNotBeCached                    *Void
+	secretVarIsNotOnArgv                    *Void
+	unknownEnvironmentIsRejected            *Void
+	versionReportsPinnedRelease             *Void
+	withVarOverridesEnvironmentValue        *Void
 }
 
 func (r *BrunoTests) WithGraphQLQuery(q *querybuilder.Selection) *BrunoTests {
@@ -56,11 +63,11 @@ func (r *BrunoTests) WithGraphQLQuery(q *querybuilder.Selection) *BrunoTests {
 
 // BrunoTestsAllOpts contains options for BrunoTests.All
 type BrunoTestsAllOpts struct {
-	Parallel int // bruno-tests (../../../daggerverse/bruno/tests/main.go:40:2)
+	Parallel int // bruno-tests (../../../daggerverse/bruno/tests/main.go:41:2)
 }
 
 // All runs every bruno-module test in parallel.
-func (r *BrunoTests) All(ctx context.Context, opts ...BrunoTestsAllOpts) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:37:1)
+func (r *BrunoTests) All(ctx context.Context, opts ...BrunoTestsAllOpts) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:38:1)
 	if r.all != nil {
 		return nil
 	}
@@ -75,6 +82,128 @@ func (r *BrunoTests) All(ctx context.Context, opts ...BrunoTestsAllOpts) error {
 	return q.Execute(ctx)
 }
 
+// CiCheckGatesOnFailingAssertion checks the other half of the gate: a
+// collection that lints clean and then fails a request, test or assertion fails
+// the pipeline, carrying bru's own account of what failed.
+//
+// The lint stage is enabled deliberately, so the failure has to be the
+// assertion and not the linter having an opinion about the fixture.
+func (r *BrunoTests) CiCheckGatesOnFailingAssertion(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:882:1)
+	if r.ciCheckGatesOnFailingAssertion != nil {
+		return nil
+	}
+	q := r.query.Select("ciCheckGatesOnFailingAssertion")
+
+	return q.Execute(ctx)
+}
+
+// CiLintFailsBeforeAnyRequest checks the ordering that is the builder's own
+// contribution: the lint stage runs ahead of the collection, so a structural
+// error is reported without spending a request on discovering it.
+//
+// The fixture is the one whose {{tenantId}} resolves nowhere — and which bru
+// runs perfectly happily, interpolating the literal string and getting a 200
+// back. That is what makes the assertion mean something: the un-linted pipeline
+// is checked afterwards and passes, so a request count of zero on the first
+// pass is the lint stage short-circuiting rather than the collection being
+// unrunnable.
+func (r *BrunoTests) CiLintFailsBeforeAnyRequest(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:832:1)
+	if r.ciLintFailsBeforeAnyRequest != nil {
+		return nil
+	}
+	q := r.query.Select("ciLintFailsBeforeAnyRequest")
+
+	return q.Execute(ctx)
+}
+
+// CiRejectsUnknownReportFormat checks that a reporter format bru has no writer
+// for is caught before anything is started. WithReport has no error return, so
+// the finding belongs to the terminal — and it belongs to Check as much as to
+// Run, because a pipeline whose declared artifact cannot be produced is broken
+// whichever terminal is invoked first.
+func (r *BrunoTests) CiRejectsUnknownReportFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:792:1)
+	if r.ciRejectsUnknownReportFormat != nil {
+		return nil
+	}
+	q := r.query.Select("ciRejectsUnknownReportFormat")
+
+	return q.Execute(ctx)
+}
+
+// CiRunProducesEveryRequestedReport checks the artifact terminal: each format
+// WithReport asked for comes back as its own file in the returned directory.
+//
+// It also pins that all of them come out of one collection pass. The api
+// fixture makes two requests, so a service that served exactly two after a
+// two-format Run is a pipeline that ran the collection once — and therefore two
+// reports describing the same set of responses, rather than two runs of the same
+// collection reporting on different ones.
+func (r *BrunoTests) CiRunProducesEveryRequestedReport(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:921:1)
+	if r.ciRunProducesEveryRequestedReport != nil {
+		return nil
+	}
+	q := r.query.Select("ciRunProducesEveryRequestedReport")
+
+	return q.Execute(ctx)
+}
+
+// CiRunStillReportsWhenTheCollectionFails pins the split between the two terminals: Run
+// hands back the artifact for a run whose assertions failed, and does not fail
+// itself.
+//
+// This is the whole reason the gate is Check's job. Dagger drops a function's
+// value when it also returns an error, so a Run that gated would return nothing
+// on exactly the runs whose report a pipeline needs — the JUnit file a CI system
+// turns into a test report names which assertion failed, and it is worthless if
+// it only arrives when nothing did.
+func (r *BrunoTests) CiRunStillReportsWhenTheCollectionFails(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:991:1)
+	if r.ciRunStillReportsWhenTheCollectionFails != nil {
+		return nil
+	}
+	q := r.query.Select("ciRunStillReportsWhenTheCollectionFails")
+
+	return q.Execute(ctx)
+}
+
+// CiSecretVarReachesTheCollection checks that the pipeline's one secret-passing
+// method actually delegates: a WithSecretVar secret is readable from the
+// collection as {{process.env.NAME}} and arrives at the service.
+//
+// A builder that silently dropped the secret would look identical from the
+// outside — the collection would send an empty header and the responder would
+// answer 200 either way — so the value is read back off the request rather than
+// inferred from the run passing.
+//
+// It runs against its own fixture rather than the one SecretVarIsNotOnArgv
+// uses, because that one records bru's command line from a pre-request script
+// and reading process.argv needs the developer sandbox. The pipeline builder
+// wraps no sandbox switch — a collection needing one is assembled through
+// Collection — so it gets the same request without the script.
+func (r *BrunoTests) CiSecretVarReachesTheCollection(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1088:1)
+	if r.ciSecretVarReachesTheCollection != nil {
+		return nil
+	}
+	q := r.query.Select("ciSecretVarReachesTheCollection")
+
+	return q.Execute(ctx)
+}
+
+// CiShouldNotBeCached checks that both terminals re-run within one session.
+// A pipeline hits a live API, so a cached pass would report a now-broken API as
+// green — and it is the second call in a session, not the first, that a CI
+// system makes when somebody re-runs a failed job.
+//
+// Counted at the service rather than read out of bru's summary: a replayed run
+// prints a perfectly convincing "1 request, 1 passed".
+func (r *BrunoTests) CiShouldNotBeCached(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1032:1)
+	if r.ciShouldNotBeCached != nil {
+		return nil
+	}
+	q := r.query.Select("ciShouldNotBeCached")
+
+	return q.Execute(ctx)
+}
+
 // GenerateHonoursOpenCollectionFormat checks that the format argument reaches
 // bru at all: every other assertion in this suite would pass just as well
 // against a Generate that had "bru" hardcoded.
@@ -82,7 +211,7 @@ func (r *BrunoTests) All(ctx context.Context, opts ...BrunoTestsAllOpts) error {
 // It also pins the reason the default diverges from upstream's. The
 // opencollection shape carries no bruno.json, so it is not something Collection
 // could run — which is why this module defaults to the other one.
-func (r *BrunoTests) GenerateHonoursOpenCollectionFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:588:1)
+func (r *BrunoTests) GenerateHonoursOpenCollectionFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:596:1)
 	if r.generateHonoursOpenCollectionFormat != nil {
 		return nil
 	}
@@ -104,7 +233,7 @@ func (r *BrunoTests) GenerateHonoursOpenCollectionFormat(ctx context.Context) er
 // The environment's name is read off the generated tree rather than hardcoded:
 // bru derives it from the server's description, which is the spec's business
 // and not this module's.
-func (r *BrunoTests) GenerateProducesRunnableCollection(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:510:1)
+func (r *BrunoTests) GenerateProducesRunnableCollection(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:518:1)
 	if r.generateProducesRunnableCollection != nil {
 		return nil
 	}
@@ -117,7 +246,7 @@ func (r *BrunoTests) GenerateProducesRunnableCollection(ctx context.Context) err
 // is refused by name. bru refuses one too, but by printing its whole help text
 // with the actual complaint on the last line — and only after a container has
 // been started to find out.
-func (r *BrunoTests) GenerateRejectsUnknownFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:608:1)
+func (r *BrunoTests) GenerateRejectsUnknownFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:616:1)
 	if r.generateRejectsUnknownFormat != nil {
 		return nil
 	}
@@ -180,7 +309,7 @@ func (r *BrunoTests) UnmarshalJSON(bs []byte) error {
 // that extension and not from the contents, so a JSON environment staged as
 // .bru dies inside the Bruno grammar — with a Node stack trace, several layers
 // away from anything the caller did.
-func (r *BrunoTests) JSONEnvFileKeepsItsExtension(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:472:1)
+func (r *BrunoTests) JSONEnvFileKeepsItsExtension(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:480:1)
 	if r.jsonEnvFileKeepsItsExtension != nil {
 		return nil
 	}
@@ -196,7 +325,7 @@ func (r *BrunoTests) JSONEnvFileKeepsItsExtension(ctx context.Context) error { /
 //
 // It is checked under failOnWarnings=true as well, so the fixture has to be
 // free of warnings and not merely free of errors.
-func (r *BrunoTests) LintAcceptsValidCollection(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:633:1)
+func (r *BrunoTests) LintAcceptsValidCollection(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:641:1)
 	if r.lintAcceptsValidCollection != nil {
 		return nil
 	}
@@ -208,7 +337,7 @@ func (r *BrunoTests) LintAcceptsValidCollection(ctx context.Context) error { // 
 // LintRejectsDuplicateSequence checks that two requests claiming the same seq
 // in one folder is a finding, and that the same seq in a different folder is
 // not — seq orders a folder's requests, so it is only ambiguous within one.
-func (r *BrunoTests) LintRejectsDuplicateSequence(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:740:1)
+func (r *BrunoTests) LintRejectsDuplicateSequence(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:748:1)
 	if r.lintRejectsDuplicateSequence != nil {
 		return nil
 	}
@@ -220,7 +349,7 @@ func (r *BrunoTests) LintRejectsDuplicateSequence(ctx context.Context) error { /
 // LintRejectsMissingBrunoJson checks the finding that stands in for bru's exit
 // 4. bru reports that one as "not a collection root", from inside a container,
 // without naming the file it wanted.
-func (r *BrunoTests) LintRejectsMissingBrunoJSON(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:652:1)
+func (r *BrunoTests) LintRejectsMissingBrunoJSON(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:660:1)
 	if r.lintRejectsMissingBrunoJson != nil {
 		return nil
 	}
@@ -236,7 +365,7 @@ func (r *BrunoTests) LintRejectsMissingBrunoJSON(ctx context.Context) error { //
 // The fixture holds two controls beside the violation — a token whose value is
 // a {{process.env.*}} interpolation, and a name declared in a vars:secret
 // block — so this also pins that the rule accepts the shape it is asking for.
-func (r *BrunoTests) LintRejectsPlaintextSecret(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:716:1)
+func (r *BrunoTests) LintRejectsPlaintextSecret(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:724:1)
 	if r.lintRejectsPlaintextSecret != nil {
 		return nil
 	}
@@ -248,7 +377,7 @@ func (r *BrunoTests) LintRejectsPlaintextSecret(ctx context.Context) error { // 
 // LintRejectsUnknownEnvironment checks that a mistyped --env name is caught
 // here rather than as bru's exit 6, and that the finding lists the names the
 // collection does ship.
-func (r *BrunoTests) LintRejectsUnknownEnvironment(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:668:1)
+func (r *BrunoTests) LintRejectsUnknownEnvironment(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:676:1)
 	if r.lintRejectsUnknownEnvironment != nil {
 		return nil
 	}
@@ -264,7 +393,7 @@ func (r *BrunoTests) LintRejectsUnknownEnvironment(ctx context.Context) error { 
 // The fixture also references two undeclared variables from its docs block,
 // which bru never interpolates — so this pins that prose is not linted as
 // though it were a request.
-func (r *BrunoTests) LintRejectsUnresolvedVariable(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:688:1)
+func (r *BrunoTests) LintRejectsUnresolvedVariable(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:696:1)
 	if r.lintRejectsUnresolvedVariable != nil {
 		return nil
 	}
@@ -279,7 +408,7 @@ func (r *BrunoTests) LintRejectsUnresolvedVariable(ctx context.Context) error { 
 //
 // The fixture's only assertion is disabled, which is the same as not having
 // written it — so this also pins that a commented-out assert does not count.
-func (r *BrunoTests) LintWarnsOnRequestWithoutTests(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:762:1)
+func (r *BrunoTests) LintWarnsOnRequestWithoutTests(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:770:1)
 	if r.lintWarnsOnRequestWithoutTests != nil {
 		return nil
 	}
@@ -297,7 +426,7 @@ func (r *BrunoTests) LintWarnsOnRequestWithoutTests(ctx context.Context) error {
 // The api fixture tags its root request and leaves the nested one untagged, so
 // the tag filters also have to have selected the right request rather than
 // merely been tolerated.
-func (r *BrunoTests) PassThroughFlagsAreAccepted(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:433:1)
+func (r *BrunoTests) PassThroughFlagsAreAccepted(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:441:1)
 	if r.passThroughFlagsAreAccepted != nil {
 		return nil
 	}
@@ -315,7 +444,7 @@ func (r *BrunoTests) PassThroughFlagsAreAccepted(ctx context.Context) error { //
 // and the default wins — so `Recursive: false` would silently assert the
 // default all over again. It is reachable from the CLI as
 // `run --recursive=false`.
-func (r *BrunoTests) RecursiveDefaultReachesSubfolders(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:220:1)
+func (r *BrunoTests) RecursiveDefaultReachesSubfolders(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:228:1)
 	if r.recursiveDefaultReachesSubfolders != nil {
 		return nil
 	}
@@ -329,7 +458,7 @@ func (r *BrunoTests) RecursiveDefaultReachesSubfolders(ctx context.Context) erro
 // artifact, and the artifact says what failed. Run would have raised an error
 // here, and an error forfeits the value — which is why the two are separate
 // functions rather than one.
-func (r *BrunoTests) ReportEmitsJunitForFailingRun(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:253:1)
+func (r *BrunoTests) ReportEmitsJunitForFailingRun(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:261:1)
 	if r.reportEmitsJunitForFailingRun != nil {
 		return nil
 	}
@@ -341,7 +470,7 @@ func (r *BrunoTests) ReportEmitsJunitForFailingRun(ctx context.Context) error { 
 // ReportRejectsUnknownFormat checks that a format bru does not write is
 // refused by name, before a live collection has been run against a live
 // service to find out.
-func (r *BrunoTests) ReportRejectsUnknownFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:280:1)
+func (r *BrunoTests) ReportRejectsUnknownFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:288:1)
 	if r.reportRejectsUnknownFormat != nil {
 		return nil
 	}
@@ -353,7 +482,7 @@ func (r *BrunoTests) ReportRejectsUnknownFormat(ctx context.Context) error { // 
 // ReportShouldNotBeCached checks that two identical Reports each reach the
 // service. A report of a run that never happened describes an API nobody
 // asked about.
-func (r *BrunoTests) ReportShouldNotBeCached(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:302:1)
+func (r *BrunoTests) ReportShouldNotBeCached(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:310:1)
 	if r.reportShouldNotBeCached != nil {
 		return nil
 	}
@@ -365,7 +494,7 @@ func (r *BrunoTests) ReportShouldNotBeCached(ctx context.Context) error { // bru
 // RunFailsOnAssertionFailure checks that exit 1 — a failing request, test or
 // assertion — is an error, and that the error carries bru's own account of
 // what failed rather than just the exit code.
-func (r *BrunoTests) RunFailsOnAssertionFailure(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:127:1)
+func (r *BrunoTests) RunFailsOnAssertionFailure(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:135:1)
 	if r.runFailsOnAssertionFailure != nil {
 		return nil
 	}
@@ -376,7 +505,7 @@ func (r *BrunoTests) RunFailsOnAssertionFailure(ctx context.Context) error { // 
 
 // RunPassesAgainstBoundService checks the whole point of the module: a
 // collection whose environment names a bound service reaches it and passes.
-func (r *BrunoTests) RunPassesAgainstBoundService(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:95:1)
+func (r *BrunoTests) RunPassesAgainstBoundService(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:103:1)
 	if r.runPassesAgainstBoundService != nil {
 		return nil
 	}
@@ -388,7 +517,7 @@ func (r *BrunoTests) RunPassesAgainstBoundService(ctx context.Context) error { /
 // RunShouldNotBeCached checks that two identical Runs each reach the service.
 // A collection run hits a live API, so a cached pass would report a
 // now-broken API as green.
-func (r *BrunoTests) RunShouldNotBeCached(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:183:1)
+func (r *BrunoTests) RunShouldNotBeCached(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:191:1)
 	if r.runShouldNotBeCached != nil {
 		return nil
 	}
@@ -410,7 +539,7 @@ func (r *BrunoTests) RunShouldNotBeCached(ctx context.Context) error { // bruno-
 // command line" can actually be checked. That script needs the developer
 // sandbox — the safe one has no process — which is what makes WithSandbox
 // part of this test.
-func (r *BrunoTests) SecretVarIsNotOnArgv(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:379:1)
+func (r *BrunoTests) SecretVarIsNotOnArgv(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:387:1)
 	if r.secretVarIsNotOnArgv != nil {
 		return nil
 	}
@@ -423,7 +552,7 @@ func (r *BrunoTests) SecretVarIsNotOnArgv(ctx context.Context) error { // bruno-
 // bru exits 6 when the named environment does not exist; conflating that with
 // exit 1 would make "you typo'd the environment name" read as "your API is
 // broken".
-func (r *BrunoTests) UnknownEnvironmentIsRejected(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:157:1)
+func (r *BrunoTests) UnknownEnvironmentIsRejected(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:165:1)
 	if r.unknownEnvironmentIsRejected != nil {
 		return nil
 	}
@@ -436,7 +565,7 @@ func (r *BrunoTests) UnknownEnvironmentIsRejected(ctx context.Context) error { /
 // release the module pins. The Debian variant is not cosmetic — it is the
 // escape hatch for the Alpine image's musl/OpenSSL TLS failures — so it has
 // to be a tag that exists and ships the same CLI.
-func (r *BrunoTests) VersionReportsPinnedRelease(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:80:1)
+func (r *BrunoTests) VersionReportsPinnedRelease(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:88:1)
 	if r.versionReportsPinnedRelease != nil {
 		return nil
 	}
@@ -449,7 +578,7 @@ func (r *BrunoTests) VersionReportsPinnedRelease(ctx context.Context) error { //
 // selected environment declares. The fixture puts the variable in the request
 // path, so the responder records which of the two won rather than the module
 // having to trust bru's summary.
-func (r *BrunoTests) WithVarOverridesEnvironmentValue(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:339:1)
+func (r *BrunoTests) WithVarOverridesEnvironmentValue(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:347:1)
 	if r.withVarOverridesEnvironmentValue != nil {
 		return nil
 	}
@@ -467,7 +596,7 @@ func (r *BrunoTests) AsNode() Node {
 }
 
 // Create or update a binding of type BrunoTests in the environment
-func (r *Env) WithBrunoTestsInput(name string, value *BrunoTests, description string) *Env { // bruno-tests (../../../daggerverse/bruno/tests/main.go:31:6)
+func (r *Env) WithBrunoTestsInput(name string, value *BrunoTests, description string) *Env { // bruno-tests (../../../daggerverse/bruno/tests/main.go:32:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withBrunoTestsInput")
 	q = q.Arg("name", name)
@@ -480,7 +609,7 @@ func (r *Env) WithBrunoTestsInput(name string, value *BrunoTests, description st
 }
 
 // Declare a desired BrunoTests output to be assigned in the environment
-func (r *Env) WithBrunoTestsOutput(name string, description string) *Env { // bruno-tests (../../../daggerverse/bruno/tests/main.go:31:6)
+func (r *Env) WithBrunoTestsOutput(name string, description string) *Env { // bruno-tests (../../../daggerverse/bruno/tests/main.go:32:6)
 	q := r.query.Select("withBrunoTestsOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -494,7 +623,7 @@ func (r *Env) WithBrunoTestsOutput(name string, description string) *Env { // br
 // test is exposed as a standalone dagger function so it can be invoked
 // individually during TDD; All wires them up for parallel execution under
 // `dagger call all`.
-func (r *Query) BrunoTests() *BrunoTests { // bruno-tests (../../../daggerverse/bruno/tests/main.go:31:6)
+func (r *Query) BrunoTests() *BrunoTests { // bruno-tests (../../../daggerverse/bruno/tests/main.go:32:6)
 	q := r.query.Select("brunoTests")
 
 	return &BrunoTests{

--- a/daggerverse/bruno/README.md
+++ b/daggerverse/bruno/README.md
@@ -236,6 +236,76 @@ of the document and touches no live service.
 `--group-by path` (the alternative to grouping by tag) and `bru import wsdl`
 are not wrapped; both are reachable through `Container()`.
 
+## The Ci pipeline
+
+Lint, run and report are three calls plus the glue that decides what fails the
+build. `Ci` bundles them, so an API repo's pipeline is one declarative
+`dagger call`.
+
+```sh
+dagger -m github.com/z5labs/devex/daggerverse/bruno call \
+  ci --source=./api-tests \
+  with-environment --name=ci \
+  with-lint \
+  with-report --format=junit \
+  check
+```
+
+```go
+ci := dag.Bruno().Ci(source).
+    WithEnvironment("ci").
+    WithService("api", api).
+    WithSecretVar("API_TOKEN", token).
+    WithLint().
+    WithReport("junit")
+
+err := ci.Check(ctx)   // the gate
+reports := ci.Run()    // the artifacts: reports/report.xml
+```
+
+It composes `Collection` without adding capability — every stage is a call the
+caller could make by hand. What it adds is the *ordering*: lint runs before the
+collection, so a `{{baseUrl}}` that resolves nowhere or a credential committed
+in plaintext is reported without spending a request on discovering it.
+
+| Stage | What it does |
+|---|---|
+| `WithEnvironment(name)` | `--env`, and the environment lint resolves references against. |
+| `WithService(alias, service)` | Put a Dagger service on the pipeline's network. |
+| `WithSecretVar(name, secret)` | A credential readable as `{{process.env.NAME}}`, never on argv. |
+| `WithLint(failOnWarnings)` | Add the lint stage, ahead of the collection. |
+| `WithReport(format)` | Add `json`, `junit` or `html` to the set `Run` returns. Call it more than once. |
+| `Check()` | The gate: fails on a lint error, on a failing request/test/assertion, and on a usage error. |
+| `Run()` | The artifacts: `report.json`, `report.xml` (junit), `report.html`. |
+
+`Check` gates and `Run` does not, which is the same split as `Collection`'s
+`Run` and `Report` and for the same reason: a Dagger function that returns an
+error forfeits its value, so a gating `Run` would hand back nothing on exactly
+the runs whose report a pipeline needs. Pair them — `Run` for the artifacts,
+`Check` for the gate. A lint error and a usage error still fail `Run`, because
+then the collection never ran and there is no report to return.
+
+Every requested format comes out of **one** collection pass: `bru` accepts all
+of its `--reporter-*` flags at once, so asking for both JUnit and HTML costs one
+run and the two artifacts describe the same set of responses.
+
+`Run` with no `WithReport` is an error rather than an empty directory: running
+the collection to hand back nothing reads as a pass, and a pipeline that only
+wants to gate wants `Check`.
+
+Lint is opt-in rather than always-on because it is an opinion about how a
+collection is written, and a pipeline should not start failing on one the day it
+adopts the builder.
+
+The pipeline deliberately wraps a subset of `Collection`'s surface: secrets but
+not plain `WithVar` overrides (a value passed into CI by hand is usually a
+credential, and `--env-var` would put it on the command line), and no sandbox,
+tag, bail or delay switches. A collection that needs those is assembled through
+`Collection` directly.
+
+Both terminals are `+cache="never"`, and the suite proves the second `Check` in
+one session really re-runs by counting requests at the service.
+
 ## Secrets
 
 `WithSecretVar(name, secret)` is a separate function from `WithVar` rather than
@@ -270,14 +340,20 @@ module or touch the filesystem needs `WithSandbox("developer")` — and fails at
 
 ## Caching
 
-`Run` and `Report` carry `+cache="never"`: a collection run hits a live
-service, so a cached pass would report a now-broken API as green. `Container`,
-`Version`, `Generate` and `Lint` stay `+cache="session"` — those are pure.
+`Run`, `Report`, `Ci.Check` and `Ci.Run` carry `+cache="never"`: a collection
+run hits a live service, so a cached pass would report a now-broken API as
+green. `Container`, `Version`, `Generate` and `Lint` stay `+cache="session"` —
+those are pure.
 
 That directive governs the *function* result; the `WithExec` layer underneath
-is still content-addressed, so both terminals stamp a per-call nonce onto the
+is still content-addressed, so every terminal stamps a per-call nonce onto the
 run. Without it, a second `Run` of the same collection against the same service
 would be a build-cache hit and never leave the engine.
+
+`Ci.Run` returns a directory, and a never-cached function is re-invoked by each
+selection off its result — so reading two reports out of one `Run` would be two
+runs of the collection. Resolve the directory's `ID` once and load it back
+before fanning out, as `tests/main.go`'s `pin` does.
 
 ## Security posture
 
@@ -310,6 +386,14 @@ reachable through `Container()`.
 | `Collection.Lint(failOnWarnings)` | Check the collection's structure in pure Go, issuing no requests. |
 | `Collection.Run(recursive)` | Run the collection; bru's output, failing on exit 1. |
 | `Collection.Report(format)` | Run it and return the `json`, `junit` or `html` artifact, failing only on usage errors. |
+| `Ci(source)` | Bind a collection to the standardized pipeline builder. |
+| `Ci.WithEnvironment(name)` | `--env`, and the environment lint resolves against. |
+| `Ci.WithService(alias, service)` | Put a Dagger service on the pipeline's network. |
+| `Ci.WithSecretVar(name, secret)` | A credential readable as `{{process.env.NAME}}`. |
+| `Ci.WithLint(failOnWarnings)` | Add the lint stage, ahead of the collection. |
+| `Ci.WithReport(format)` | Add a reporter format to the set `Ci.Run` returns. |
+| `Ci.Check()` | The pipeline as a gate: lint, then the collection. Produces nothing. |
+| `Ci.Run()` | The pipeline's reports as a directory. Does not gate. |
 
 ## Tests
 
@@ -351,4 +435,15 @@ accepts collections written for it is a linter nobody can adopt.
 scripting. Its fixture reports `process.argv` — bru's own command line — back
 to the responder in a header, which is the only vantage point from which "the
 secret never reached argv" can be checked at all. That script needs the
-developer sandbox, since the safe one has no `process`.
+developer sandbox, since the safe one has no `process` — which is why
+`fixtures/ci-secret/` exists as a script-free copy of the same request: the
+pipeline builder wraps no sandbox switch.
+
+The `Ci` tests lean on the request counter for the two things the builder itself
+adds. `CiLintFailsBeforeAnyRequest` runs the `fixtures/lint/unresolved`
+collection, which bru is perfectly happy to execute — it interpolates the
+literal `{{tenantId}}` and gets a 200 — so a count of zero is the lint stage
+short-circuiting and not an unrunnable fixture, and the same pipeline without
+`WithLint` is checked afterwards to prove it. And
+`CiRunProducesEveryRequestedReport` asks for two formats over the 2-request
+`fixtures/api`: a count of two says both reports came out of one pass.

--- a/daggerverse/bruno/ci.go
+++ b/daggerverse/bruno/ci.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"dagger/bruno/internal/dagger"
+)
+
+// reportFileName is the base name a report carries inside the directory Run
+// returns. The extension comes from the format, so json, junit and html land
+// beside one another as report.json, report.xml and report.html rather than
+// colliding.
+const reportFileName = "report"
+
+// Ci is a chained builder for a standardized Bruno CI pipeline: a collection
+// in, a gate and the reports out.
+//
+// Lint, run and report are three calls plus the glue that decides what fails
+// the build, which is the shape every API repo ends up hand-rolling. This
+// bundles them so that CI is one declarative `dagger call`.
+//
+// It composes Collection without adding capability of its own — every stage is
+// a call the caller could make by hand. What it adds is the ordering: lint runs
+// before the collection, so a {{baseUrl}} that resolves nowhere or a
+// credential committed in plaintext is reported without spending a request on
+// discovering it, and a collection that could never have passed does not start
+// a container's worth of work to say so.
+//
+// The two terminals split the way Collection's own Run and Report do, and for
+// the same reason. Check is the gate: it fails on a lint error, on a failing
+// request, test or assertion, and on any of bru's usage errors. Run is the
+// artifact: it returns the reports directory, and does not fail a run whose
+// requests failed — Dagger drops a function's value when it also returns an
+// error, so a gating Run could never hand back the report describing the
+// failure, which is exactly when the report matters. CI pairs them.
+type Ci struct {
+	// +private
+	Collection *Collection
+	// +private
+	LintEnabled bool
+	// +private
+	LintFailOnWarnings bool
+	// +private
+	Formats []string
+}
+
+// Ci returns a new pipeline builder bound to the supplied collection source.
+// The input is the collection root, exactly as a bare Collection(source) call
+// would take it.
+func (b *Bruno) Ci(source *dagger.Directory) *Ci {
+	return &Ci{Collection: b.Collection(source)}
+}
+
+// WithEnvironment selects the environment the pipeline resolves variables from,
+// by the name of the file under environments/ without its extension. See
+// Collection.WithEnvironment.
+//
+// It is also what the lint stage checks references against, so the environment
+// a pipeline runs under is the one its variables are required to resolve in.
+func (c *Ci) WithEnvironment(name string) *Ci {
+	out := *c
+	out.Collection = c.Collection.WithEnvironment(name)
+	return &out
+}
+
+// WithService binds a service into the pipeline's network under alias, so the
+// collection can reach it by that hostname. A collection is inert without a
+// target. See Collection.WithService.
+func (c *Ci) WithService(alias string, service *dagger.Service) *Ci {
+	out := *c
+	out.Collection = c.Collection.WithService(alias, service)
+	return &out
+}
+
+// WithSecretVar makes a secret readable from the collection as
+// {{process.env.NAME}}, without it ever reaching argv. See
+// Collection.WithSecretVar.
+//
+// A pipeline takes secrets and not plain overrides on purpose: a value worth
+// passing into CI by hand is usually a credential, and WithVar would put it on
+// the command line. A collection that needs a non-secret override can still be
+// assembled through Collection.
+func (c *Ci) WithSecretVar(name string, value *dagger.Secret) *Ci {
+	out := *c
+	out.Collection = c.Collection.WithSecretVar(name, value)
+	return &out
+}
+
+// WithLint adds the lint stage, which runs before the collection and fails the
+// pipeline on a structural error without issuing a request. See
+// Collection.Lint for the rules.
+//
+// It is opt-in rather than always-on because linting is an opinion about how a
+// collection is written, and a pipeline should not start failing on one the day
+// it adopts the builder.
+func (c *Ci) WithLint(
+	// Treat lint warnings as failures.
+	// +default=false
+	failOnWarnings bool,
+) *Ci {
+	out := *c
+	out.LintEnabled = true
+	out.LintFailOnWarnings = failOnWarnings
+	return &out
+}
+
+// WithReport adds a reporter format — json, junit or html — to the set Run
+// returns. Call it more than once for more than one format.
+//
+// Every requested format comes out of a single collection pass: bru accepts all
+// of its `--reporter-*` flags at once, so asking for both JUnit and HTML costs
+// one run and the two artifacts describe the same set of responses rather than
+// two different ones.
+//
+// Like the rest of the builder it has no error return, so an unknown format is
+// reported by the terminal that would have written it.
+func (c *Ci) WithReport(
+	// Reporter format: json, junit or html.
+	format string,
+) *Ci {
+	out := *c
+	out.Formats = append(append([]string(nil), c.Formats...), format)
+	return &out
+}
+
+// Check runs the pipeline as a gate and produces nothing, for the PR that wants
+// to know whether the API is behaving.
+//
+// The stages are the enabled lint followed by the collection itself. Lint comes
+// first so that a structural error costs no request: a collection whose
+// variables resolve nowhere fails here rather than against a live service,
+// naming the file instead of the response. The collection then fails on bru's
+// exit 1 — a failing request, test or assertion — and reports every other
+// non-zero exit as the usage error it is.
+//
+// No report is produced, because a gate that returns nothing can gate: see Run
+// for why the terminal that hands back artifacts cannot also be the one that
+// fails.
+//
+// +cache="never"
+func (c *Ci) Check(ctx context.Context) error {
+	if err := c.validate(); err != nil {
+		return err
+	}
+	if err := c.lint(ctx); err != nil {
+		return err
+	}
+	_, err := c.Collection.Run(ctx, true)
+	return err
+}
+
+// Run executes the pipeline and returns the requested reports as a directory,
+// one file per format: report.json, report.xml for junit, report.html.
+//
+// It does not fail on a failing request, test or assertion. That is deliberate
+// and it is the same reasoning as Collection.Report: a Dagger function that
+// returns an error forfeits its value, so a Run that gated would hand back
+// nothing on exactly the runs whose reports a pipeline needs — the JUnit file a
+// CI system turns into a test report, the HTML page somebody opens to see which
+// assertion failed. Pair the two: Run for the artifacts, Check for the gate.
+//
+// A lint error is still an error here, because then the collection never ran
+// and there is no report to return. So is a usage error, for the same reason.
+//
+// +cache="never"
+func (c *Ci) Run(ctx context.Context) (*dagger.Directory, error) {
+	if err := c.validate(); err != nil {
+		return nil, err
+	}
+	// A pipeline with no reporter has nothing for this terminal to return, and
+	// running the collection to hand back an empty directory would look like a
+	// pass. The caller wanted Check.
+	if len(c.Formats) == 0 {
+		return nil, fmt.Errorf(
+			"Ci: run has no reports to return: add one with with-report (%s, %s or %s), or use check for a pipeline that only gates",
+			formatJSON, formatJUnit, formatHTML)
+	}
+	if err := c.lint(ctx); err != nil {
+		return nil, err
+	}
+	exec, err := c.Collection.exec(ctx, true, c.Formats)
+	if err != nil {
+		return nil, err
+	}
+	code, err := exec.ExitCode(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if code != 0 && code != exitCollectionFailed {
+		return nil, usageError(code, combinedOutput(ctx, exec))
+	}
+	out := dag.Directory()
+	for _, format := range c.Formats {
+		path, err := reportPath(format)
+		if err != nil {
+			return nil, err
+		}
+		ext, err := reportExtension(format)
+		if err != nil {
+			return nil, err
+		}
+		out = out.WithFile(reportFileName+"."+ext, exec.File(path))
+	}
+	return out, nil
+}
+
+// validate reports the deferred builder checks, which live here because a
+// builder has no error return. The report formats are checked by both terminals
+// rather than only by Run: a pipeline whose declared artifact cannot be written
+// is misconfigured whichever terminal discovers it, and finding out from Check
+// costs nothing.
+func (c *Ci) validate() error {
+	for _, format := range c.Formats {
+		if _, err := reportExtension(format); err != nil {
+			return fmt.Errorf("WithReport: %w", err)
+		}
+	}
+	return nil
+}
+
+// lint runs the enabled lint stage. Nothing here is a container: every rule is
+// evaluated in pure Go over the source tree, which is what makes running it
+// ahead of the collection free.
+func (c *Ci) lint(ctx context.Context) error {
+	if !c.LintEnabled {
+		return nil
+	}
+	return c.Collection.Lint(ctx, c.LintFailOnWarnings)
+}

--- a/daggerverse/bruno/collection.go
+++ b/daggerverse/bruno/collection.go
@@ -272,7 +272,7 @@ func (c *Collection) Run(
 	// +default=true
 	recursive bool,
 ) (string, error) {
-	exec, err := c.exec(ctx, recursive, "")
+	exec, err := c.exec(ctx, recursive, nil)
 	if err != nil {
 		return "", err
 	}
@@ -308,12 +308,11 @@ func (c *Collection) Report(
 	// Reporter format: json, junit or html.
 	format string,
 ) (*dagger.File, error) {
-	ext, err := reportExtension(format)
+	path, err := reportPath(format)
 	if err != nil {
 		return nil, err
 	}
-	path := reportPathPrefix + "." + ext
-	exec, err := c.exec(ctx, true, format)
+	exec, err := c.exec(ctx, true, []string{format})
 	if err != nil {
 		return nil, err
 	}
@@ -340,13 +339,16 @@ func (c *Collection) clone() *Collection {
 	return &out
 }
 
-// exec assembles the container and stages the `bru run`. reportFormat is empty
-// for a plain run.
+// exec assembles the container and stages the `bru run`. reportFormats is empty
+// for a plain run, and may name more than one reporter: bru accepts every
+// `--reporter-*` flag at once, so a pipeline that wants both a JUnit file and an
+// HTML page gets them out of the same pass rather than out of two runs that
+// describe two different sets of responses.
 //
 // Expect=ReturnTypeAny keeps a non-zero exit on the value path: both terminals
 // have to read the exit code and the output to say anything useful about it,
 // and Report has to reach the artifact of a run that failed.
-func (c *Collection) exec(ctx context.Context, recursive bool, reportFormat string) (*dagger.Container, error) {
+func (c *Collection) exec(ctx context.Context, recursive bool, reportFormats []string) (*dagger.Container, error) {
 	if err := c.validate(); err != nil {
 		return nil, err
 	}
@@ -354,7 +356,7 @@ func (c *Collection) exec(ctx context.Context, recursive bool, reportFormat stri
 	if err != nil {
 		return nil, err
 	}
-	args, err := c.args(recursive, reportFormat, envFile)
+	args, err := c.args(recursive, reportFormats, envFile)
 	if err != nil {
 		return nil, err
 	}
@@ -408,7 +410,7 @@ func (c *Collection) container(envFile string) *dagger.Container {
 }
 
 // args renders the `bru run` command line.
-func (c *Collection) args(recursive bool, reportFormat string, envFile string) ([]string, error) {
+func (c *Collection) args(recursive bool, reportFormats []string, envFile string) ([]string, error) {
 	// The collection root is named explicitly rather than left implicit:
 	// `bru run` with no path descends into every folder whatever -r says, so
 	// without the "." the recursive parameter would only ever mean "true".
@@ -446,12 +448,12 @@ func (c *Collection) args(recursive bool, reportFormat string, envFile string) (
 	if c.Delay > 0 {
 		args = append(args, "--delay", strconv.Itoa(c.Delay))
 	}
-	if reportFormat != "" {
-		ext, err := reportExtension(reportFormat)
+	for _, format := range reportFormats {
+		path, err := reportPath(format)
 		if err != nil {
 			return nil, err
 		}
-		args = append(args, "--reporter-"+reportFormat, reportPathPrefix+"."+ext)
+		args = append(args, "--reporter-"+format, path)
 	}
 	return args, nil
 }
@@ -515,6 +517,17 @@ func reportExtension(format string) (string, error) {
 		return "", fmt.Errorf("invalid format %q: must be one of %s, %s, %s",
 			format, formatJSON, formatJUnit, formatHTML)
 	}
+}
+
+// reportPath is where a reporter writes its artifact inside the container. One
+// path per format, so every reporter can be asked for in the same pass without
+// two of them writing over each other.
+func reportPath(format string) (string, error) {
+	ext, err := reportExtension(format)
+	if err != nil {
+		return "", err
+	}
+	return reportPathPrefix + "." + ext, nil
 }
 
 // usageError turns one of bru's non-1 exits into an error that says what the

--- a/daggerverse/bruno/dagger.gen.go
+++ b/daggerverse/bruno/dagger.gen.go
@@ -87,6 +87,38 @@ func (r *Bruno) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
+func (r Ci) MarshalJSON() ([]byte, error) {
+	var concrete struct {
+		Collection         *Collection
+		LintEnabled        bool
+		LintFailOnWarnings bool
+		Formats            []string
+	}
+	concrete.Collection = r.Collection
+	concrete.LintEnabled = r.LintEnabled
+	concrete.LintFailOnWarnings = r.LintFailOnWarnings
+	concrete.Formats = r.Formats
+	return json.Marshal(&concrete)
+}
+
+func (r *Ci) UnmarshalJSON(bs []byte) error {
+	var concrete struct {
+		Collection         *Collection
+		LintEnabled        bool
+		LintFailOnWarnings bool
+		Formats            []string
+	}
+	err := json.Unmarshal(bs, &concrete)
+	if err != nil {
+		return err
+	}
+	r.Collection = concrete.Collection
+	r.LintEnabled = concrete.LintEnabled
+	r.LintFailOnWarnings = concrete.LintFailOnWarnings
+	r.Formats = concrete.Formats
+	return nil
+}
+
 func (r Collection) MarshalJSON() ([]byte, error) {
 	var concrete struct {
 		Bruno           *Bruno
@@ -290,6 +322,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 	switch parentName {
 	case "Bruno":
 		switch fnName {
+		case "Ci":
+			var parent Bruno
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var source *dagger.Directory
+			if inputArgs["source"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["source"]), &source)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg source", err))
+				}
+			}
+			return (*Bruno).Ci(&parent, source), nil
 		case "Collection":
 			var parent Bruno
 			err = json.Unmarshal(parentJSON, &parent)
@@ -374,6 +420,109 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return New(registry, version, debian), nil
+		default:
+			return nil, fmt.Errorf("unknown function %s", fnName)
+		}
+	case "Ci":
+		switch fnName {
+		case "Check":
+			var parent Ci
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Ci).Check(&parent, ctx)
+		case "Run":
+			var parent Ci
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Ci).Run(&parent, ctx)
+		case "WithEnvironment":
+			var parent Ci
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var name string
+			if inputArgs["name"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["name"]), &name)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg name", err))
+				}
+			}
+			return (*Ci).WithEnvironment(&parent, name), nil
+		case "WithLint":
+			var parent Ci
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var failOnWarnings bool
+			if inputArgs["failOnWarnings"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["failOnWarnings"]), &failOnWarnings)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg failOnWarnings", err))
+				}
+			}
+			return (*Ci).WithLint(&parent, failOnWarnings), nil
+		case "WithReport":
+			var parent Ci
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var format string
+			if inputArgs["format"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["format"]), &format)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg format", err))
+				}
+			}
+			return (*Ci).WithReport(&parent, format), nil
+		case "WithSecretVar":
+			var parent Ci
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var name string
+			if inputArgs["name"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["name"]), &name)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg name", err))
+				}
+			}
+			var value *dagger.Secret
+			if inputArgs["value"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["value"]), &value)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg value", err))
+				}
+			}
+			return (*Ci).WithSecretVar(&parent, name, value), nil
+		case "WithService":
+			var parent Ci
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var alias string
+			if inputArgs["alias"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["alias"]), &alias)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg alias", err))
+				}
+			}
+			var service *dagger.Service
+			if inputArgs["service"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["service"]), &service)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg service", err))
+				}
+			}
+			return (*Ci).WithService(&parent, alias, service), nil
 		default:
 			return nil, fmt.Errorf("unknown function %s", fnName)
 		}

--- a/daggerverse/bruno/tests/dagger.gen.go
+++ b/daggerverse/bruno/tests/dagger.gen.go
@@ -206,6 +206,55 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Tests).All(&parent, ctx, parallel)
+		case "CiCheckGatesOnFailingAssertion":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).CiCheckGatesOnFailingAssertion(&parent, ctx)
+		case "CiLintFailsBeforeAnyRequest":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).CiLintFailsBeforeAnyRequest(&parent, ctx)
+		case "CiRejectsUnknownReportFormat":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).CiRejectsUnknownReportFormat(&parent, ctx)
+		case "CiRunProducesEveryRequestedReport":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).CiRunProducesEveryRequestedReport(&parent, ctx)
+		case "CiRunStillReportsWhenTheCollectionFails":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).CiRunStillReportsWhenTheCollectionFails(&parent, ctx)
+		case "CiSecretVarReachesTheCollection":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).CiSecretVarReachesTheCollection(&parent, ctx)
+		case "CiShouldNotBeCached":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).CiShouldNotBeCached(&parent, ctx)
 		case "GenerateHonoursOpenCollectionFormat":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/bruno/tests/fixtures/ci-secret/bruno.json
+++ b/daggerverse/bruno/tests/fixtures/ci-secret/bruno.json
@@ -1,0 +1,5 @@
+{
+  "version": "1",
+  "name": "ci-secret",
+  "type": "collection"
+}

--- a/daggerverse/bruno/tests/fixtures/ci-secret/environments/local.bru
+++ b/daggerverse/bruno/tests/fixtures/ci-secret/environments/local.bru
@@ -1,0 +1,3 @@
+vars {
+  baseUrl: http://api:8080
+}

--- a/daggerverse/bruno/tests/fixtures/ci-secret/token.bru
+++ b/daggerverse/bruno/tests/fixtures/ci-secret/token.bru
@@ -1,0 +1,19 @@
+meta {
+  name: token
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/token
+  body: none
+  auth: none
+}
+
+headers {
+  X-Token: {{process.env.API_TOKEN}}
+}
+
+assert {
+  res.status: eq 200
+}

--- a/daggerverse/bruno/tests/internal/dagger/bruno.gen.go
+++ b/daggerverse/bruno/tests/internal/dagger/bruno.gen.go
@@ -18,6 +18,15 @@ func (r *Binding) AsBruno() *Bruno { // bruno (../../../../../daggerverse/bruno/
 	}
 }
 
+// Retrieve the binding value, as type BrunoCi
+func (r *Binding) AsBrunoCi() *BrunoCi { // bruno (../../../../../daggerverse/bruno/ci.go:37:6)
+	q := r.query.Select("asBrunoCi")
+
+	return &BrunoCi{
+		query: q,
+	}
+}
+
 // Retrieve the binding value, as type BrunoCollection
 func (r *Binding) AsBrunoCollection() *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:86:6)
 	q := r.query.Select("asBrunoCollection")
@@ -39,6 +48,19 @@ type Bruno struct { // bruno (../../../../../daggerverse/bruno/main.go:47:6)
 
 func (r *Bruno) WithGraphQLQuery(q *querybuilder.Selection) *Bruno {
 	return &Bruno{
+		query: q,
+	}
+}
+
+// Ci returns a new pipeline builder bound to the supplied collection source.
+// The input is the collection root, exactly as a bare Collection(source) call
+// would take it.
+func (r *Bruno) Ci(source *Directory) *BrunoCi { // bruno (../../../../../daggerverse/bruno/ci.go:51:1)
+	assertNotNil("source", source)
+	q := r.query.Select("ci")
+	q = q.Arg("source", source)
+
+	return &BrunoCi{
 		query: q,
 	}
 }
@@ -186,6 +208,243 @@ func (r *Bruno) Version(ctx context.Context) (string, error) { // bruno (../../.
 // AsNode returns this Bruno as a Node.
 // This is a local type conversion — no GraphQL call.
 func (r *Bruno) AsNode() Node {
+	return &NodeClient{
+		query: r.query,
+	}
+}
+
+// Ci is a chained builder for a standardized Bruno CI pipeline: a collection
+// in, a gate and the reports out.
+//
+// Lint, run and report are three calls plus the glue that decides what fails
+// the build, which is the shape every API repo ends up hand-rolling. This
+// bundles them so that CI is one declarative `dagger call`.
+//
+// It composes Collection without adding capability of its own — every stage is
+// a call the caller could make by hand. What it adds is the ordering: lint runs
+// before the collection, so a {{baseUrl}} that resolves nowhere or a
+// credential committed in plaintext is reported without spending a request on
+// discovering it, and a collection that could never have passed does not start
+// a container's worth of work to say so.
+//
+// The two terminals split the way Collection's own Run and Report do, and for
+// the same reason. Check is the gate: it fails on a lint error, on a failing
+// request, test or assertion, and on any of bru's usage errors. Run is the
+// artifact: it returns the reports directory, and does not fail a run whose
+// requests failed — Dagger drops a function's value when it also returns an
+// error, so a gating Run could never hand back the report describing the
+// failure, which is exactly when the report matters. CI pairs them.
+type BrunoCi struct { // bruno (../../../../../daggerverse/bruno/ci.go:37:6)
+	query *querybuilder.Selection
+
+	check *Void
+	id    *ID
+}
+type WithBrunoCiFunc func(r *BrunoCi) *BrunoCi
+
+// With calls the provided function with current BrunoCi.
+//
+// This is useful for reusability and readability by not breaking the calling chain.
+func (r *BrunoCi) With(f WithBrunoCiFunc) *BrunoCi {
+	return f(r)
+}
+
+func (r *BrunoCi) WithGraphQLQuery(q *querybuilder.Selection) *BrunoCi {
+	return &BrunoCi{
+		query: q,
+	}
+}
+
+// Check runs the pipeline as a gate and produces nothing, for the PR that wants
+// to know whether the API is behaving.
+//
+// The stages are the enabled lint followed by the collection itself. Lint comes
+// first so that a structural error costs no request: a collection whose
+// variables resolve nowhere fails here rather than against a live service,
+// naming the file instead of the response. The collection then fails on bru's
+// exit 1 — a failing request, test or assertion — and reports every other
+// non-zero exit as the usage error it is.
+//
+// No report is produced, because a gate that returns nothing can gate: see Run
+// for why the terminal that hands back artifacts cannot also be the one that
+// fails.
+func (r *BrunoCi) Check(ctx context.Context) error { // bruno (../../../../../daggerverse/bruno/ci.go:142:1)
+	if r.check != nil {
+		return nil
+	}
+	q := r.query.Select("check")
+
+	return q.Execute(ctx)
+}
+
+// A unique identifier for this BrunoCi.
+func (r *BrunoCi) ID(ctx context.Context) (ID, error) {
+	if r.id != nil {
+		return *r.id, nil
+	}
+	q := r.query.Select("id")
+
+	var response ID
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// XXX_GraphQLType is an internal function. It returns the native GraphQL type name
+func (r *BrunoCi) XXX_GraphQLType() string {
+	return "BrunoCi"
+}
+
+// XXX_GraphQLIDType is an internal function. It returns the native GraphQL type name for the ID of this object
+func (r *BrunoCi) XXX_GraphQLIDType() string {
+	return "ID"
+}
+
+// XXX_GraphQLID is an internal function. It returns the underlying type ID
+func (r *BrunoCi) XXX_GraphQLID(ctx context.Context) (string, error) {
+	id, err := r.ID(ctx)
+	if err != nil {
+		return "", err
+	}
+	return string(id), nil
+}
+
+func (r *BrunoCi) MarshalJSON() ([]byte, error) {
+	id, err := r.ID(marshalCtx)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(id)
+}
+func (r *BrunoCi) UnmarshalJSON(bs []byte) error {
+	var id string
+	err := json.Unmarshal(bs, &id)
+	if err != nil {
+		return err
+	}
+	*r = BrunoCi{query: selectNode(dag.query, id, "BrunoCi")}
+	return nil
+}
+
+// Run executes the pipeline and returns the requested reports as a directory,
+// one file per format: report.json, report.xml for junit, report.html.
+//
+// It does not fail on a failing request, test or assertion. That is deliberate
+// and it is the same reasoning as Collection.Report: a Dagger function that
+// returns an error forfeits its value, so a Run that gated would hand back
+// nothing on exactly the runs whose reports a pipeline needs — the JUnit file a
+// CI system turns into a test report, the HTML page somebody opens to see which
+// assertion failed. Pair the two: Run for the artifacts, Check for the gate.
+//
+// A lint error is still an error here, because then the collection never ran
+// and there is no report to return. So is a usage error, for the same reason.
+func (r *BrunoCi) Run() *Directory { // bruno (../../../../../daggerverse/bruno/ci.go:167:1)
+	q := r.query.Select("run")
+
+	return &Directory{
+		query: q,
+	}
+}
+
+// WithEnvironment selects the environment the pipeline resolves variables from,
+// by the name of the file under environments/ without its extension. See
+// Collection.WithEnvironment.
+//
+// It is also what the lint stage checks references against, so the environment
+// a pipeline runs under is the one its variables are required to resolve in.
+func (r *BrunoCi) WithEnvironment(name string) *BrunoCi { // bruno (../../../../../daggerverse/bruno/ci.go:61:1)
+	q := r.query.Select("withEnvironment")
+	q = q.Arg("name", name)
+
+	return &BrunoCi{
+		query: q,
+	}
+}
+
+// BrunoCiWithLintOpts contains options for BrunoCi.WithLint
+type BrunoCiWithLintOpts struct {
+	//
+	// Treat lint warnings as failures.
+	//
+	FailOnWarnings bool // bruno (../../../../../daggerverse/bruno/ci.go:100:2)
+}
+
+// WithLint adds the lint stage, which runs before the collection and fails the
+// pipeline on a structural error without issuing a request. See
+// Collection.Lint for the rules.
+//
+// It is opt-in rather than always-on because linting is an opinion about how a
+// collection is written, and a pipeline should not start failing on one the day
+// it adopts the builder.
+func (r *BrunoCi) WithLint(opts ...BrunoCiWithLintOpts) *BrunoCi { // bruno (../../../../../daggerverse/bruno/ci.go:97:1)
+	q := r.query.Select("withLint")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `failOnWarnings` optional argument
+		if !querybuilder.IsZeroValue(opts[i].FailOnWarnings) {
+			q = q.Arg("failOnWarnings", opts[i].FailOnWarnings)
+		}
+	}
+
+	return &BrunoCi{
+		query: q,
+	}
+}
+
+// WithReport adds a reporter format — json, junit or html — to the set Run
+// returns. Call it more than once for more than one format.
+//
+// Every requested format comes out of a single collection pass: bru accepts all
+// of its `--reporter-*` flags at once, so asking for both JUnit and HTML costs
+// one run and the two artifacts describe the same set of responses rather than
+// two different ones.
+//
+// Like the rest of the builder it has no error return, so an unknown format is
+// reported by the terminal that would have written it.
+func (r *BrunoCi) WithReport(format string) *BrunoCi { // bruno (../../../../../daggerverse/bruno/ci.go:118:1)
+	q := r.query.Select("withReport")
+	q = q.Arg("format", format)
+
+	return &BrunoCi{
+		query: q,
+	}
+}
+
+// WithSecretVar makes a secret readable from the collection as
+// {{process.env.NAME}}, without it ever reaching argv. See
+// Collection.WithSecretVar.
+//
+// A pipeline takes secrets and not plain overrides on purpose: a value worth
+// passing into CI by hand is usually a credential, and WithVar would put it on
+// the command line. A collection that needs a non-secret override can still be
+// assembled through Collection.
+func (r *BrunoCi) WithSecretVar(name string, value *Secret) *BrunoCi { // bruno (../../../../../daggerverse/bruno/ci.go:84:1)
+	assertNotNil("value", value)
+	q := r.query.Select("withSecretVar")
+	q = q.Arg("name", name)
+	q = q.Arg("value", value)
+
+	return &BrunoCi{
+		query: q,
+	}
+}
+
+// WithService binds a service into the pipeline's network under alias, so the
+// collection can reach it by that hostname. A collection is inert without a
+// target. See Collection.WithService.
+func (r *BrunoCi) WithService(alias string, service *Service) *BrunoCi { // bruno (../../../../../daggerverse/bruno/ci.go:70:1)
+	assertNotNil("service", service)
+	q := r.query.Select("withService")
+	q = q.Arg("alias", alias)
+	q = q.Arg("service", service)
+
+	return &BrunoCi{
+		query: q,
+	}
+}
+
+// AsNode returns this BrunoCi as a Node.
+// This is a local type conversion — no GraphQL call.
+func (r *BrunoCi) AsNode() Node {
 	return &NodeClient{
 		query: r.query,
 	}
@@ -539,6 +798,30 @@ func (r *BrunoCollection) WithoutTags(tags []string) *BrunoCollection { // bruno
 func (r *BrunoCollection) AsNode() Node {
 	return &NodeClient{
 		query: r.query,
+	}
+}
+
+// Create or update a binding of type BrunoCi in the environment
+func (r *Env) WithBrunoCiInput(name string, value *BrunoCi, description string) *Env { // bruno (../../../../../daggerverse/bruno/ci.go:37:6)
+	assertNotNil("value", value)
+	q := r.query.Select("withBrunoCiInput")
+	q = q.Arg("name", name)
+	q = q.Arg("value", value)
+	q = q.Arg("description", description)
+
+	return &Env{
+		query: q,
+	}
+}
+
+// Declare a desired BrunoCi output to be assigned in the environment
+func (r *Env) WithBrunoCiOutput(name string, description string) *Env { // bruno (../../../../../daggerverse/bruno/ci.go:37:6)
+	q := r.query.Select("withBrunoCiOutput")
+	q = q.Arg("name", name)
+	q = q.Arg("description", description)
+
+	return &Env{
+		query: q,
 	}
 }
 

--- a/daggerverse/bruno/tests/internal/dagger/dagger.gen.go
+++ b/daggerverse/bruno/tests/internal/dagger/dagger.gen.go
@@ -155,6 +155,9 @@ type AddressID string
 type BindingID string
 
 // A unique identifier for an object.
+type BrunoCiID string
+
+// A unique identifier for an object.
 type BrunoCollectionID string
 
 // A unique identifier for an object.
@@ -12805,6 +12808,16 @@ func (r *Query) LoadBindingFromID(id BindingID) *Binding {
 	q = q.Arg("id", id)
 
 	return &Binding{
+		query: q,
+	}
+}
+
+// Load a BrunoCi from its ID.
+func (r *Query) LoadBrunoCiFromID(id BrunoCiID) *BrunoCi {
+	q := r.query.Select("loadBrunoCiFromID")
+	q = q.Arg("id", id)
+
+	return &BrunoCi{
 		query: q,
 	}
 }

--- a/daggerverse/bruno/tests/main.go
+++ b/daggerverse/bruno/tests/main.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"path"
 	"slices"
@@ -69,6 +70,13 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("LintRejectsPlaintextSecret", t.LintRejectsPlaintextSecret)
 	jobs = jobs.WithJob("LintRejectsDuplicateSequence", t.LintRejectsDuplicateSequence)
 	jobs = jobs.WithJob("LintWarnsOnRequestWithoutTests", t.LintWarnsOnRequestWithoutTests)
+	jobs = jobs.WithJob("CiRejectsUnknownReportFormat", t.CiRejectsUnknownReportFormat)
+	jobs = jobs.WithJob("CiLintFailsBeforeAnyRequest", t.CiLintFailsBeforeAnyRequest)
+	jobs = jobs.WithJob("CiCheckGatesOnFailingAssertion", t.CiCheckGatesOnFailingAssertion)
+	jobs = jobs.WithJob("CiRunProducesEveryRequestedReport", t.CiRunProducesEveryRequestedReport)
+	jobs = jobs.WithJob("CiRunStillReportsWhenTheCollectionFails", t.CiRunStillReportsWhenTheCollectionFails)
+	jobs = jobs.WithJob("CiShouldNotBeCached", t.CiShouldNotBeCached)
+	jobs = jobs.WithJob("CiSecretVarReachesTheCollection", t.CiSecretVarReachesTheCollection)
 
 	return jobs.Run(ctx)
 }
@@ -776,11 +784,360 @@ func (t *Tests) LintWarnsOnRequestWithoutTests(ctx context.Context) error {
 	return nil
 }
 
+// CiRejectsUnknownReportFormat checks that a reporter format bru has no writer
+// for is caught before anything is started. WithReport has no error return, so
+// the finding belongs to the terminal — and it belongs to Check as much as to
+// Run, because a pipeline whose declared artifact cannot be produced is broken
+// whichever terminal is invoked first.
+func (t *Tests) CiRejectsUnknownReportFormat(ctx context.Context) error {
+	ci := dag.Bruno().Ci(fixture("single")).WithEnvironment("local").WithReport("tap")
+	err := ci.Check(ctx)
+	if err == nil {
+		return fmt.Errorf("expected an unknown reporter format to be an error")
+	}
+	for _, want := range []string{`"tap"`, "json", "junit", "html"} {
+		if !strings.Contains(err.Error(), want) {
+			return fmt.Errorf("expected the error to mention %q, got:\n%s", want, head(err.Error()))
+		}
+	}
+	if _, err := ci.Run().Entries(ctx); err == nil {
+		return fmt.Errorf("expected Run to reject the format as well")
+	}
+
+	// The other unusable report set is the empty one. Run would otherwise run
+	// the collection and hand back an empty directory, which reads as a pass;
+	// the caller who wants that wants Check.
+	_, err = dag.Bruno().Ci(fixture("single")).WithEnvironment("local").Run().Entries(ctx)
+	if err == nil {
+		return fmt.Errorf("expected Run with no requested report to be an error")
+	}
+	for _, want := range []string{"with-report", "check"} {
+		if !strings.Contains(err.Error(), want) {
+			return fmt.Errorf("expected the error to point at %q, got:\n%s", want, head(err.Error()))
+		}
+	}
+	return nil
+}
+
+// CiLintFailsBeforeAnyRequest checks the ordering that is the builder's own
+// contribution: the lint stage runs ahead of the collection, so a structural
+// error is reported without spending a request on discovering it.
+//
+// The fixture is the one whose {{tenantId}} resolves nowhere — and which bru
+// runs perfectly happily, interpolating the literal string and getting a 200
+// back. That is what makes the assertion mean something: the un-linted pipeline
+// is checked afterwards and passes, so a request count of zero on the first
+// pass is the lint stage short-circuiting rather than the collection being
+// unrunnable.
+func (t *Tests) CiLintFailsBeforeAnyRequest(ctx context.Context) error {
+	rsp, err := newResponder(ctx)
+	if err != nil {
+		return err
+	}
+	defer rsp.stop(ctx)
+
+	ci := dag.Bruno().Ci(fixture("lint/unresolved")).
+		WithEnvironment("local").
+		WithService(responderAlias, rsp.Svc)
+
+	err = ci.WithLint().Check(ctx)
+	if err == nil {
+		return fmt.Errorf("expected a lint error to fail the pipeline")
+	}
+	for _, want := range []string{"bru lint found", "tenantId", "tenant.bru"} {
+		if !strings.Contains(err.Error(), want) {
+			return fmt.Errorf("expected the error to carry the lint finding %q, got:\n%s", want, head(err.Error()))
+		}
+	}
+	got, err := rsp.stats(ctx, "after-lint-failure")
+	if err != nil {
+		return err
+	}
+	if got.Count != 0 {
+		return fmt.Errorf("expected the lint stage to fail before a request was issued, but the service served %d",
+			got.Count)
+	}
+
+	// The control: the same collection with no lint stage runs, so the zero
+	// above was the ordering and not an unrunnable fixture.
+	if err := ci.Check(ctx); err != nil {
+		return fmt.Errorf("expected the un-linted pipeline to pass: %w", err)
+	}
+	got, err = rsp.stats(ctx, "after-unlinted-check")
+	if err != nil {
+		return err
+	}
+	if got.Count != 1 {
+		return fmt.Errorf("expected the un-linted pipeline to issue 1 request, got %d", got.Count)
+	}
+	return nil
+}
+
+// CiCheckGatesOnFailingAssertion checks the other half of the gate: a
+// collection that lints clean and then fails a request, test or assertion fails
+// the pipeline, carrying bru's own account of what failed.
+//
+// The lint stage is enabled deliberately, so the failure has to be the
+// assertion and not the linter having an opinion about the fixture.
+func (t *Tests) CiCheckGatesOnFailingAssertion(ctx context.Context) error {
+	rsp, err := newResponder(ctx)
+	if err != nil {
+		return err
+	}
+	defer rsp.stop(ctx)
+
+	err = dag.Bruno().Ci(fixture("failing")).
+		WithEnvironment("local").
+		WithService(responderAlias, rsp.Svc).
+		WithLint().
+		Check(ctx)
+	if err == nil {
+		return fmt.Errorf("expected a failing assertion to fail the pipeline")
+	}
+	if !strings.Contains(err.Error(), "expected 200 to equal 418") {
+		return fmt.Errorf("expected the error to carry bru's failure output, got:\n%s", head(err.Error()))
+	}
+	if strings.Contains(err.Error(), "bru lint found") {
+		return fmt.Errorf("expected the gate to fail on the assertion, not on lint, got:\n%s", head(err.Error()))
+	}
+	got, err := rsp.stats(ctx, "after-failing-check")
+	if err != nil {
+		return err
+	}
+	if got.Count != 1 {
+		return fmt.Errorf("expected the collection to reach the service once, got %d", got.Count)
+	}
+	return nil
+}
+
+// CiRunProducesEveryRequestedReport checks the artifact terminal: each format
+// WithReport asked for comes back as its own file in the returned directory.
+//
+// It also pins that all of them come out of one collection pass. The api
+// fixture makes two requests, so a service that served exactly two after a
+// two-format Run is a pipeline that ran the collection once — and therefore two
+// reports describing the same set of responses, rather than two runs of the same
+// collection reporting on different ones.
+func (t *Tests) CiRunProducesEveryRequestedReport(ctx context.Context) error {
+	rsp, err := newResponder(ctx)
+	if err != nil {
+		return err
+	}
+	defer rsp.stop(ctx)
+
+	reports, err := pin(ctx, dag.Bruno().Ci(fixture("api")).
+		WithEnvironment("local").
+		WithService(responderAlias, rsp.Svc).
+		WithLint().
+		WithReport("json").
+		WithReport("junit").
+		Run())
+	if err != nil {
+		return fmt.Errorf("run: %w", err)
+	}
+	entries, err := reports.Entries(ctx)
+	if err != nil {
+		return fmt.Errorf("list the reports directory: %w", err)
+	}
+	slices.Sort(entries)
+	if want := []string{"report.json", "report.xml"}; !slices.Equal(entries, want) {
+		return fmt.Errorf("expected the reports directory to hold %v, got %v", want, entries)
+	}
+
+	// The junit artifact carries the .xml extension its reporter writes, so the
+	// name has to be checked against what it is rather than what it was asked
+	// for.
+	jsonReport, err := exportContents(ctx, reports.File("report.json"), "ci-report.json")
+	if err != nil {
+		return err
+	}
+	var results []any
+	if err := json.Unmarshal([]byte(jsonReport), &results); err != nil {
+		return fmt.Errorf("expected the json report to be a JSON array, got:\n%s", head(jsonReport))
+	}
+	if !strings.Contains(jsonReport, "health") {
+		return fmt.Errorf("expected the json report to name the health request, got:\n%s", head(jsonReport))
+	}
+	junitReport, err := exportContents(ctx, reports.File("report.xml"), "ci-report.xml")
+	if err != nil {
+		return err
+	}
+	for _, want := range []string{"<testsuite", "health"} {
+		if !strings.Contains(junitReport, want) {
+			return fmt.Errorf("expected the junit report to contain %q, got:\n%s", want, head(junitReport))
+		}
+	}
+
+	got, err := rsp.stats(ctx, "after-report-run")
+	if err != nil {
+		return err
+	}
+	if got.Count != 2 {
+		return fmt.Errorf("expected two formats to come out of one pass over the 2-request fixture, but the service served %d requests",
+			got.Count)
+	}
+	return nil
+}
+
+// CiRunStillReportsWhenTheCollectionFails pins the split between the two terminals: Run
+// hands back the artifact for a run whose assertions failed, and does not fail
+// itself.
+//
+// This is the whole reason the gate is Check's job. Dagger drops a function's
+// value when it also returns an error, so a Run that gated would return nothing
+// on exactly the runs whose report a pipeline needs — the JUnit file a CI system
+// turns into a test report names which assertion failed, and it is worthless if
+// it only arrives when nothing did.
+func (t *Tests) CiRunStillReportsWhenTheCollectionFails(ctx context.Context) error {
+	rsp, err := newResponder(ctx)
+	if err != nil {
+		return err
+	}
+	defer rsp.stop(ctx)
+
+	ci := dag.Bruno().Ci(fixture("failing")).
+		WithEnvironment("local").
+		WithService(responderAlias, rsp.Svc).
+		WithReport("junit")
+
+	reports, err := pin(ctx, ci.Run())
+	if err != nil {
+		return fmt.Errorf("expected a failing collection still to produce its report: %w", err)
+	}
+	report, err := exportContents(ctx, reports.File("report.xml"), "ci-failing-report.xml")
+	if err != nil {
+		return err
+	}
+	for _, want := range []string{"teapot", "<failure"} {
+		if !strings.Contains(report, want) {
+			return fmt.Errorf("expected the junit report to record the failure with %q, got:\n%s", want, head(report))
+		}
+	}
+
+	// The same pipeline through the gate does fail, so Run's silence is the
+	// split between the terminals and not a failure nobody notices.
+	if err := ci.Check(ctx); err == nil {
+		return fmt.Errorf("expected Check to gate the same pipeline Run reported on")
+	}
+	return nil
+}
+
+// CiShouldNotBeCached checks that both terminals re-run within one session.
+// A pipeline hits a live API, so a cached pass would report a now-broken API as
+// green — and it is the second call in a session, not the first, that a CI
+// system makes when somebody re-runs a failed job.
+//
+// Counted at the service rather than read out of bru's summary: a replayed run
+// prints a perfectly convincing "1 request, 1 passed".
+func (t *Tests) CiShouldNotBeCached(ctx context.Context) error {
+	rsp, err := newResponder(ctx)
+	if err != nil {
+		return err
+	}
+	defer rsp.stop(ctx)
+
+	ci := dag.Bruno().Ci(fixture("single")).
+		WithEnvironment("local").
+		WithService(responderAlias, rsp.Svc).
+		WithReport("json")
+
+	served := 0
+	for i := 1; i <= 2; i++ {
+		if err := ci.Check(ctx); err != nil {
+			return fmt.Errorf("check %d: %w", i, err)
+		}
+		served++
+		got, err := rsp.stats(ctx, fmt.Sprintf("after-check-%d", i))
+		if err != nil {
+			return err
+		}
+		if got.Count != served {
+			return fmt.Errorf("expected %d request(s) after %d check(s), got %d", served, i, got.Count)
+		}
+	}
+	for i := 1; i <= 2; i++ {
+		if _, err := pin(ctx, ci.Run()); err != nil {
+			return fmt.Errorf("run %d: %w", i, err)
+		}
+		served++
+		got, err := rsp.stats(ctx, fmt.Sprintf("after-run-%d", i))
+		if err != nil {
+			return err
+		}
+		if got.Count != served {
+			return fmt.Errorf("expected %d request(s) after %d run(s), got %d", served, i, got.Count)
+		}
+	}
+	return nil
+}
+
+// CiSecretVarReachesTheCollection checks that the pipeline's one secret-passing
+// method actually delegates: a WithSecretVar secret is readable from the
+// collection as {{process.env.NAME}} and arrives at the service.
+//
+// A builder that silently dropped the secret would look identical from the
+// outside — the collection would send an empty header and the responder would
+// answer 200 either way — so the value is read back off the request rather than
+// inferred from the run passing.
+//
+// It runs against its own fixture rather than the one SecretVarIsNotOnArgv
+// uses, because that one records bru's command line from a pre-request script
+// and reading process.argv needs the developer sandbox. The pipeline builder
+// wraps no sandbox switch — a collection needing one is assembled through
+// Collection — so it gets the same request without the script.
+func (t *Tests) CiSecretVarReachesTheCollection(ctx context.Context) error {
+	rsp, err := newResponder(ctx)
+	if err != nil {
+		return err
+	}
+	defer rsp.stop(ctx)
+
+	// No credential is ever a literal in this repo, not even a throwaway one
+	// for a service that exists for four seconds.
+	value, err := dag.Random().Sha256(ctx)
+	if err != nil {
+		return fmt.Errorf("mint the test token: %w", err)
+	}
+
+	err = dag.Bruno().Ci(fixture("ci-secret")).
+		WithEnvironment("local").
+		WithSecretVar("API_TOKEN", dag.SetSecret("bruno-ci-api-token", value)).
+		WithService(responderAlias, rsp.Svc).
+		WithLint().
+		Check(ctx)
+	if err != nil {
+		return fmt.Errorf("check: %w", err)
+	}
+	got, err := rsp.stats(ctx, "after-ci-secret")
+	if err != nil {
+		return err
+	}
+	if got.Token != value {
+		return fmt.Errorf("expected the secret to reach the request as its X-Token header, got %q", got.Token)
+	}
+	return nil
+}
+
 // ------------------------------------------------------------------ helpers
 
 // fixture returns the named hand-authored Bruno collection under fixtures/.
 func fixture(name string) *dagger.Directory {
 	return dag.CurrentModule().Source().Directory("fixtures/" + name)
+}
+
+// pin resolves a lazily-returned directory once and hands back a handle to that
+// exact result.
+//
+// Ci.Run is +cache="never", so every selection off the directory it returns
+// would otherwise re-invoke it — reading two reports out of one Run would be two
+// runs of the collection, each reporting on its own set of responses. Resolving
+// to an ID first pins the result.
+func pin(ctx context.Context, dir *dagger.Directory) (*dagger.Directory, error) {
+	id, err := dir.ID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return dag.LoadDirectoryFromID(dagger.DirectoryID(id)), nil
 }
 
 // exportContents round-trips an artifact through the module's own workdir and


### PR DESCRIPTION
Closes #244.

Lint, run and report are three calls plus the glue that decides what fails the
build. `Ci` bundles them, so an API repo's pipeline is one declarative
`dagger call`.

```sh
dagger -m github.com/z5labs/devex/daggerverse/bruno call \
  ci --source=./api-tests \
  with-environment --name=ci \
  with-lint \
  with-report --format=junit \
  check
```

It composes `Collection` without adding capability — every stage is a call the
caller could make by hand. What it adds is the **ordering**: lint runs before
the collection, so a `{{baseUrl}}` that resolves nowhere or a credential
committed in plaintext is reported without spending a request on discovering
it.

## Two judgement calls

**`Run` does not gate.** The issue assigns the gate to `Check`, and the module's
existing `Report` already documents why: Dagger forfeits a function's value when
it also returns an error, so a gating `Run` would hand back nothing on exactly
the runs whose JUnit file CI needs. `Run` still fails on a lint error and on a
usage error, because then the collection never ran and there is no report to
return.

**`Run` with no `WithReport` is an error**, not an empty directory — one line
beyond the issue's text, because running the collection to return nothing reads
as a pass. The caller who wants that wants `Check`.

## Multi-format in one pass

`Collection.exec`/`args` now take a *set* of reporter formats. `bru` accepts
every `--reporter-*` flag at once, so asking for both JUnit and HTML costs one
run and the two artifacts describe the same set of responses rather than two
different ones. `CiRunProducesEveryRequestedReport` asks for two formats over
the 2-request `fixtures/api` and asserts the service served exactly two.

## Acceptance criteria

- [x] `Ci` and its builder methods exist and are listed by `dagger functions`
- [x] `Check` fails when lint finds an error, before any request is issued
- [x] `Check` fails when a request, test or assertion fails
- [x] `Run` returns a directory containing each requested report format
- [x] `+cache="never"` on every terminal, with a test proving the second
      `Check` in one session re-runs
- [x] Bindings regenerated in `daggerverse/bruno` and `daggerverse/bruno/tests`
      (and the root `ci` aggregator)
- [x] `dagger -m daggerverse/bruno/tests call all` is green

## Tests

Eight new tests, each driven green individually before `all`. Both caching and
ordering are proved by **counting requests at the recording responder** rather
than reading bru's summary — a replayed run prints a convincing
"1 request, 1 passed".

`CiLintFailsBeforeAnyRequest` runs `fixtures/lint/unresolved`, which bru
executes perfectly happily (it interpolates the literal `{{tenantId}}` and gets
a 200), so a count of zero is the lint stage short-circuiting and not an
unrunnable fixture — and the same pipeline without `WithLint` is checked
afterwards to prove it.

`fixtures/ci-secret/` is new: a script-free copy of the secret request. The
existing one records `process.argv`, which needs the developer sandbox, and the
pipeline builder wraps no sandbox switch (a collection needing one is assembled
through `Collection`).

| | |
|---|---|
| `dagger -m daggerverse/bruno/tests call all` | green, 31 tests |
| `dagger -m ci call generated` | green |

🤖 Generated with [Claude Code](https://claude.com/claude-code)