### PR TITLE
story(issue-267): render PDFs to SVG, EPS, PostScript and HTML

### DIFF
--- a/ci/internal/dagger/pdf-tests.gen.go
+++ b/ci/internal/dagger/pdf-tests.gen.go
@@ -51,21 +51,27 @@ type PdfTests struct { // pdf-tests (../../../daggerverse/pdf/tests/main.go:120:
 	disablePageBreaksControlsFormFeeds           *Void
 	dpiDefaultsToOneFiftyAndScalesWithTheSetting *Void
 	encryptedDocumentNeedsThePassword            *Void
+	epsWritesEveryPageOfTheDocument              *Void
+	htmlCarriesPageMarkupAndItsImages            *Void
 	id                                           *ID
 	infoReportsPageCountAndSize                  *Void
 	jpegAndTiffFollowTheSameContract             *Void
 	layoutModesProduceDifferentOrderings         *Void
+	pageRangeNarrowsEveryPerPageFormat           *Void
 	pageRangeNarrowsText                         *Void
 	pageRangeOpenEndedRunsToTheLastPage          *Void
 	pageRangeRejectsInvalidBounds                *Void
 	pngNamesEveryPageWithFourDigits              *Void
 	pngNarrowedRangeKeepsFourDigitNames          *Void
 	pngSinglePageIsStillNumbered                 *Void
+	psHoldsEveryPageInOneFile                    *Void
 	renderSettingsRejectNonPositiveValues        *Void
 	scaleToOverridesDpi                          *Void
+	svgWritesOneVectorFilePerPage                *Void
 	textOnImageOnlyPdfReturnsNothing             *Void
 	textReproducesTextLayerExactly               *Void
 	txtMatchesText                               *Void
+	vectorFormatsIgnoreRasterOnlySettings        *Void
 	versionReportsPopplerRelease                 *Void
 	withFontsPutsFaceWhereFontconfigFindsIt      *Void
 	withoutAnnotationsRemovesTheAnnotationLayer  *Void
@@ -120,7 +126,7 @@ func (r *PdfTests) All(ctx context.Context, opts ...PdfTestsAllOpts) error { // 
 // The three properties are mutually exclusive by construction: colour keeps
 // chroma, grey drops chroma but keeps mid-tones, and mono drops both — flat tones
 // are dithered into black and white rather than averaged into grey.
-func (r *PdfTests) ColorModesProduceDifferentPixels(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:744:1)
+func (r *PdfTests) ColorModesProduceDifferentPixels(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1098:1)
 	if r.colorModesProduceDifferentPixels != nil {
 		return nil
 	}
@@ -137,7 +143,7 @@ func (r *PdfTests) ColorModesProduceDifferentPixels(ctx context.Context) error {
 // nothing to substitute for a PDF that names a base-14 face without embedding
 // it, and renders the page blank while exiting 0 — a silent wrong answer, which
 // is the failure mode this assertion exists to keep out.
-func (r *PdfTests) ContainerCarriesEveryPopplerBinaryAndTheFont(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:212:1)
+func (r *PdfTests) ContainerCarriesEveryPopplerBinaryAndTheFont(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:566:1)
 	if r.containerCarriesEveryPopplerBinaryAndTheFont != nil {
 		return nil
 	}
@@ -153,7 +159,7 @@ func (r *PdfTests) ContainerCarriesEveryPopplerBinaryAndTheFont(ctx context.Cont
 // defaulting to true because a `Go SDK — the zero value is dropped before it reaches the API — so the
 // affirmative spelling would have produced an option no caller could turn off.
 // That makes the second half of this test the one that would have caught it.
-func (r *PdfTests) DisablePageBreaksControlsFormFeeds(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:461:1)
+func (r *PdfTests) DisablePageBreaksControlsFormFeeds(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:815:1)
 	if r.disablePageBreaksControlsFormFeeds != nil {
 		return nil
 	}
@@ -169,7 +175,7 @@ func (r *PdfTests) DisablePageBreaksControlsFormFeeds(ctx context.Context) error
 // remembered pixel count, so the assertion says "150 dpi of a US Letter page"
 // rather than "1275 by 1650" — which is the claim the documentation actually
 // makes.
-func (r *PdfTests) DpiDefaultsToOneFiftyAndScalesWithTheSetting(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:643:1)
+func (r *PdfTests) DpiDefaultsToOneFiftyAndScalesWithTheSetting(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:997:1)
 	if r.dpiDefaultsToOneFiftyAndScalesWithTheSetting != nil {
 		return nil
 	}
@@ -193,11 +199,56 @@ func (r *PdfTests) DpiDefaultsToOneFiftyAndScalesWithTheSetting(ctx context.Cont
 // poppler alike through the environment rather than argv: a password in argv is
 // visible in every Dagger trace, which is exactly what the module's own posture
 // avoids.
-func (r *PdfTests) EncryptedDocumentNeedsThePassword(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:869:1)
+func (r *PdfTests) EncryptedDocumentNeedsThePassword(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1223:1)
 	if r.encryptedDocumentNeedsThePassword != nil {
 		return nil
 	}
 	q := r.query.Select("encryptedDocumentNeedsThePassword")
+
+	return q.Execute(ctx)
+}
+
+// EpsWritesEveryPageOfTheDocument asserts Eps turns a twelve-page
+// document into twelve EPS files rather than into a failure.
+//
+// This is the criterion that a multi-page source never silently loses pages, and
+// for EPS the failure it guards is not silent at all: `pdftocairo -eps` handed a
+// multi-page document writes nothing and exits 99 with `EPS files can only
+// contain one page.` A single invocation would make Eps unusable for every
+// document with a second page in it, so the page count here is the assertion
+// that the per-page loop is what runs.
+//
+// Each file is then checked to be an EPS in its own right — the EPSF version
+// header, and exactly one page in it — because a loop that wrote twelve copies
+// of page one would satisfy the names alone.
+func (r *PdfTests) EpsWritesEveryPageOfTheDocument(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:242:1)
+	if r.epsWritesEveryPageOfTheDocument != nil {
+		return nil
+	}
+	q := r.query.Select("epsWritesEveryPageOfTheDocument")
+
+	return q.Execute(ctx)
+}
+
+// HtmlCarriesPageMarkupAndItsImages asserts both halves of what Html promises:
+// the page's text as markup, and the images the page carries extracted beside it
+// and referenced by a path that resolves.
+//
+// The relative reference is the half that is easy to get wrong and impossible to
+// notice. pdftohtml writes the output name it was given straight into every `img
+// src`, so an absolute output base — the obvious way to write into a staging
+// directory — produces markup whose images resolve only on the machine that
+// rendered them, and which still passes every assertion about entry names. The
+// conversion runs with the output directory as its working directory for exactly
+// this reason, and the `src` check here is what holds it there.
+//
+// Two fixtures are needed because no one page is both: ledger.pdf is text and no
+// images, scan.pdf is one image and no text.
+func (r *PdfTests) HTMLCarriesPageMarkupAndItsImages(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:334:1)
+	if r.htmlCarriesPageMarkupAndItsImages != nil {
+		return nil
+	}
+	q := r.query.Select("htmlCarriesPageMarkupAndItsImages")
 
 	return q.Execute(ctx)
 }
@@ -258,7 +309,7 @@ func (r *PdfTests) UnmarshalJSON(bs []byte) error {
 // first: PageCount parses Info's `Pages:` line, so a change to how Info is
 // captured that broke the parse would otherwise show up only in whatever used
 // PageCount next.
-func (r *PdfTests) InfoReportsPageCountAndSize(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:276:1)
+func (r *PdfTests) InfoReportsPageCountAndSize(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:630:1)
 	if r.infoReportsPageCountAndSize != nil {
 		return nil
 	}
@@ -274,7 +325,7 @@ func (r *PdfTests) InfoReportsPageCountAndSize(ctx context.Context) error { // p
 // `-jpeg` writes `.jpg` and `-tiff` writes `.tif`, which are poppler's spellings
 // and not this module's: a caller building a path from the function's name would
 // get them wrong, so they are part of the documented contract.
-func (r *PdfTests) JpegAndTiffFollowTheSameContract(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:819:1)
+func (r *PdfTests) JpegAndTiffFollowTheSameContract(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1173:1)
 	if r.jpegAndTiffFollowTheSameContract != nil {
 		return nil
 	}
@@ -294,7 +345,7 @@ func (r *PdfTests) JpegAndTiffFollowTheSameContract(ctx context.Context) error {
 // physical layout puts the two columns side by side on one output line. A fixture
 // whose stream order matched its reading order would let two of these three pass
 // on the same output.
-func (r *PdfTests) LayoutModesProduceDifferentOrderings(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:498:1)
+func (r *PdfTests) LayoutModesProduceDifferentOrderings(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:852:1)
 	if r.layoutModesProduceDifferentOrderings != nil {
 		return nil
 	}
@@ -303,10 +354,33 @@ func (r *PdfTests) LayoutModesProduceDifferentOrderings(ctx context.Context) err
 	return q.Execute(ctx)
 }
 
+// PageRangeNarrowsEveryPerPageFormat asserts the page bounds reach Svg, Eps and
+// Html, in all three of the shapes a range comes in.
+//
+// The per-page loop resolves the bounds itself rather than handing poppler `-f`
+// and `-l`, so none of this follows from the raster path already honouring them.
+// The open-ended case is the one that exercises the resolution: a zero last is
+// the document's page count read inside the same exec that renders, and a loop
+// that mishandled it would render nothing at all and return an empty directory
+// rather than fail.
+//
+// The numbers are the source document's page numbers and not positions within
+// the range, which is why pages 4 through 6 come out `page-0004` through
+// `page-0006` — the same promise the raster contract makes, so a page stays
+// traceable to the page it came from whichever format it was rendered to.
+func (r *PdfTests) PageRangeNarrowsEveryPerPageFormat(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:411:1)
+	if r.pageRangeNarrowsEveryPerPageFormat != nil {
+		return nil
+	}
+	q := r.query.Select("pageRangeNarrowsEveryPerPageFormat")
+
+	return q.Execute(ctx)
+}
+
 // PageRangeNarrowsText asserts WithPageRange narrows extraction to the pages it
 // names, and that the bounds are the 1-based inclusive ones poppler uses rather
 // than an offset and a length.
-func (r *PdfTests) PageRangeNarrowsText(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:383:1)
+func (r *PdfTests) PageRangeNarrowsText(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:737:1)
 	if r.pageRangeNarrowsText != nil {
 		return nil
 	}
@@ -318,7 +392,7 @@ func (r *PdfTests) PageRangeNarrowsText(ctx context.Context) error { // pdf-test
 // PageRangeOpenEndedRunsToTheLastPage asserts a zero last means "to the end",
 // which is the only way to name an open-ended range without first asking how
 // many pages the document has.
-func (r *PdfTests) PageRangeOpenEndedRunsToTheLastPage(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:402:1)
+func (r *PdfTests) PageRangeOpenEndedRunsToTheLastPage(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:756:1)
 	if r.pageRangeOpenEndedRunsToTheLastPage != nil {
 		return nil
 	}
@@ -334,7 +408,7 @@ func (r *PdfTests) PageRangeOpenEndedRunsToTheLastPage(ctx context.Context) erro
 // renders nothing for them and exits 0, so a caller who asked for page 20 of a
 // 12-page document would otherwise get an empty result indistinguishable from a
 // document with no text in it.
-func (r *PdfTests) PageRangeRejectsInvalidBounds(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:425:1)
+func (r *PdfTests) PageRangeRejectsInvalidBounds(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:779:1)
 	if r.pageRangeRejectsInvalidBounds != nil {
 		return nil
 	}
@@ -354,7 +428,7 @@ func (r *PdfTests) PageRangeRejectsInvalidBounds(ctx context.Context) error { //
 // has no way to know which width it is holding. Asserting the full ordered list
 // covers both halves of the promise: the names, and that lexicographic order is
 // page order.
-func (r *PdfTests) PngNamesEveryPageWithFourDigits(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:570:1)
+func (r *PdfTests) PngNamesEveryPageWithFourDigits(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:924:1)
 	if r.pngNamesEveryPageWithFourDigits != nil {
 		return nil
 	}
@@ -374,7 +448,7 @@ func (r *PdfTests) PngNamesEveryPageWithFourDigits(ctx context.Context) error { 
 // The numbers are the source document's page numbers and not positions within
 // the range, which is why the second case starts at `page-0004.png`. That keeps a
 // rendered page traceable back to the page it came from.
-func (r *PdfTests) PngNarrowedRangeKeepsFourDigitNames(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:589:1)
+func (r *PdfTests) PngNarrowedRangeKeepsFourDigitNames(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:943:1)
 	if r.pngNarrowedRangeKeepsFourDigitNames != nil {
 		return nil
 	}
@@ -392,11 +466,28 @@ func (r *PdfTests) PngNarrowedRangeKeepsFourDigitNames(ctx context.Context) erro
 // document keeps the longer document's width. A consumer globbing for
 // `page-*.png` finds nothing in the first case and a caller indexing by name
 // finds the wrong file in the second.
-func (r *PdfTests) PngSinglePageIsStillNumbered(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:616:1)
+func (r *PdfTests) PngSinglePageIsStillNumbered(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:970:1)
 	if r.pngSinglePageIsStillNumbered != nil {
 		return nil
 	}
 	q := r.query.Select("pngSinglePageIsStillNumbered")
+
+	return q.Execute(ctx)
+}
+
+// PsHoldsEveryPageInOneFile asserts Ps returns one PostScript document carrying
+// every page, and that the page range narrows it.
+//
+// The return type is the claim under test. PostScript is a multi-page format
+// with a document-level `%%Pages:` count and a `%%Page:` marker per page, so a
+// directory of one-page fragments would be the wrong answer even though it would
+// look tidier beside Svg and Eps. Counting the markers is what says the pages
+// reached the file rather than only the header saying they did.
+func (r *PdfTests) PsHoldsEveryPageInOneFile(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:291:1)
+	if r.psHoldsEveryPageInOneFile != nil {
+		return nil
+	}
+	q := r.query.Select("psHoldsEveryPageInOneFile")
 
 	return q.Execute(ctx)
 }
@@ -406,7 +497,7 @@ func (r *PdfTests) PngSinglePageIsStillNumbered(ctx context.Context) error { // 
 //
 // Left to poppler these arrive much later as a complaint about `-r` or
 // `-scale-to`, which names a flag the caller never wrote.
-func (r *PdfTests) RenderSettingsRejectNonPositiveValues(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:706:1)
+func (r *PdfTests) RenderSettingsRejectNonPositiveValues(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1060:1)
 	if r.renderSettingsRejectNonPositiveValues != nil {
 		return nil
 	}
@@ -422,11 +513,35 @@ func (r *PdfTests) RenderSettingsRejectNonPositiveValues(ctx context.Context) er
 // resolution flag off the command line rather than by relying on poppler's own
 // precedence, so this is the assertion that would catch the two being emitted
 // together and whichever poppler happened to prefer winning silently.
-func (r *PdfTests) ScaleToOverridesDpi(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:675:1)
+func (r *PdfTests) ScaleToOverridesDpi(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1029:1)
 	if r.scaleToOverridesDpi != nil {
 		return nil
 	}
 	q := r.query.Select("scaleToOverridesDpi")
+
+	return q.Execute(ctx)
+}
+
+// SvgWritesOneVectorFilePerPage asserts Svg renders a multi-page document to one
+// SVG per page, named to the page contract, carrying vector geometry.
+//
+// The per-page invocation is the whole point. `pdftocairo -svg` run once over a
+// twelve-page document writes a single file — no page is dropped, but they are
+// wrapped in the SVG 1.2 `<pageSet>`/`<page>` elements that essentially no
+// renderer implements, so a browser, Inkscape or librsvg shows page one and
+// silently discards the other eleven. The `<pageSet>` assertion is what would
+// catch a return to the single invocation: it passes an entry-count check and
+// fails here.
+//
+// Vectorness is asserted as drawing operators present and no raster image
+// anywhere. Poppler converts text to glyph outlines rather than to `<text>`, so
+// the marker words are not in the file at all — a Contains check for one would
+// fail on a perfectly good SVG.
+func (r *PdfTests) SvgWritesOneVectorFilePerPage(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:199:1)
+	if r.svgWritesOneVectorFilePerPage != nil {
+		return nil
+	}
+	q := r.query.Select("svgWritesOneVectorFilePerPage")
 
 	return q.Execute(ctx)
 }
@@ -441,7 +556,7 @@ func (r *PdfTests) ScaleToOverridesDpi(ctx context.Context) error { // pdf-tests
 // a caller gets that this document needs rasterizing and handing to OCR. A
 // module that failed here instead would make the two paths impossible to choose
 // between programmatically.
-func (r *PdfTests) TextOnImageOnlyPdfReturnsNothing(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:333:1)
+func (r *PdfTests) TextOnImageOnlyPdfReturnsNothing(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:687:1)
 	if r.textOnImageOnlyPdfReturnsNothing != nil {
 		return nil
 	}
@@ -459,7 +574,7 @@ func (r *PdfTests) TextOnImageOnlyPdfReturnsNothing(ctx context.Context) error {
 // leading newline, pages in the wrong order — is a defect and not a recognition
 // error. A fixture whose content streams are readable is what makes an exact
 // expectation writable at all.
-func (r *PdfTests) TextReproducesTextLayerExactly(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:312:1)
+func (r *PdfTests) TextReproducesTextLayerExactly(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:666:1)
 	if r.textReproducesTextLayerExactly != nil {
 		return nil
 	}
@@ -475,11 +590,33 @@ func (r *PdfTests) TextReproducesTextLayerExactly(ctx context.Context) error { /
 // straight off the handle: the point of Txt is that the bytes reach a filesystem
 // intact, and File.Contents would confirm the engine's copy while saying nothing
 // about the export a real consumer performs.
-func (r *PdfTests) TxtMatchesText(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:356:1)
+func (r *PdfTests) TxtMatchesText(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:710:1)
 	if r.txtMatchesText != nil {
 		return nil
 	}
 	q := r.query.Select("txtMatchesText")
+
+	return q.Execute(ctx)
+}
+
+// VectorFormatsIgnoreRasterOnlySettings asserts a conversion configured for the
+// raster outputs still converts when it is asked for a vector one.
+//
+// Forwarding those flags is not a no-op, which is what makes this worth an
+// assertion of its own: pdftocairo rejects both of the ones it recognises —
+// `-mono may only be used with the -png, -jpeg, or -tiff output options` — and
+// exits 99 having written nothing, and `-hide-annotations` is not a pdftocairo
+// option at all. So the natural shape of "render this document as PNG for OCR
+// and as SVG for the web view" would fail on its second half unless the module
+// drops what it cannot honour.
+//
+// WithDpi is the one setting that does reach pdftocairo, and it is set here too
+// so this is not accidentally asserting that no flags are passed at all.
+func (r *PdfTests) VectorFormatsIgnoreRasterOnlySettings(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:461:1)
+	if r.vectorFormatsIgnoreRasterOnlySettings != nil {
+		return nil
+	}
+	q := r.query.Select("vectorFormatsIgnoreRasterOnlySettings")
 
 	return q.Execute(ctx)
 }
@@ -493,7 +630,7 @@ func (r *PdfTests) TxtMatchesText(ctx context.Context) error { // pdf-tests (../
 // exact patch: Alpine may rebuild poppler-utils within the v3.24 branch, and a
 // test that pins the patch level would fail on a change this module has no
 // opinion about.
-func (r *PdfTests) VersionReportsPopplerRelease(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:186:1)
+func (r *PdfTests) VersionReportsPopplerRelease(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:540:1)
 	if r.versionReportsPopplerRelease != nil {
 		return nil
 	}
@@ -511,7 +648,7 @@ func (r *PdfTests) VersionReportsPopplerRelease(ctx context.Context) error { // 
 // module installs, so the negative control is real — the plain image genuinely
 // cannot see it, and the assertion is not passing on something the base image
 // already had.
-func (r *PdfTests) WithFontsPutsFaceWhereFontconfigFindsIt(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:246:1)
+func (r *PdfTests) WithFontsPutsFaceWhereFontconfigFindsIt(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:600:1)
 	if r.withFontsPutsFaceWhereFontconfigFindsIt != nil {
 		return nil
 	}
@@ -527,7 +664,7 @@ func (r *PdfTests) WithFontsPutsFaceWhereFontconfigFindsIt(ctx context.Context) 
 // a render of it is the annotation's appearance stream and nothing else. Without
 // that separation the assertion could not tell an annotation that was not drawn
 // from one that was drawn somewhere else on the page.
-func (r *PdfTests) WithoutAnnotationsRemovesTheAnnotationLayer(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:786:1)
+func (r *PdfTests) WithoutAnnotationsRemovesTheAnnotationLayer(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1140:1)
 	if r.withoutAnnotationsRemovesTheAnnotationLayer != nil {
 		return nil
 	}

--- a/daggerverse/pdf/README.md
+++ b/daggerverse/pdf/README.md
@@ -4,9 +4,11 @@ Daggerverse module that reads and renders PDFs with
 [poppler](https://poppler.freedesktop.org/) as a `dagger call`. Bind a PDF and
 get back its text — exactly, in reading order, physical layout or content-stream
 order — or its pages as PNG, JPEG or TIFF images, at a resolution or a pixel
-size you choose, in colour, grayscale or bilevel. Ask it what the document is
-and it tells you: page count, page size, PDF version, whether it is encrypted
-and under which algorithm.
+size you choose, in colour, grayscale or bilevel. Keep the type outlines instead
+and it gives you SVG, EPS or PostScript; ask for markup and it gives you HTML
+with the page's images beside it. Ask it what the document is and it tells you:
+page count, page size, PDF version, whether it is encrypted and under which
+algorithm.
 
 **There is no official poppler container image**, so this module assembles its
 own the way `tesseract` and `qemu` do rather than pinning a vendor image the way
@@ -227,7 +229,7 @@ document with no text in it.
 | `WithPageRange(20, 0)` on 12 pages | `first (20) is past the end of the document, which has 12 pages` |
 | `WithPageRange(1, 13)` on 12 pages | `last (13) is past the end …` |
 
-## Convert — the render options and the five outputs
+## Convert — the render options and the nine outputs
 
 ```go
 Document.Convert() *Convert
@@ -242,17 +244,41 @@ Convert.Txt(ctx, layout LayoutMode, disablePageBreaks bool) (*dagger.File, error
 Convert.Png(ctx) (*dagger.Directory, error)
 Convert.Jpeg(ctx) (*dagger.Directory, error)
 Convert.Tiff(ctx) (*dagger.Directory, error)
+Convert.Svg(ctx) (*dagger.Directory, error)
+Convert.Eps(ctx) (*dagger.Directory, error)
+Convert.Ps(ctx) (*dagger.File, error)
+Convert.Html(ctx) (*dagger.Directory, error)
 ```
 
 The render options live on `Convert` rather than on `Document` because the three
 raster outputs share them and because they describe a *conversion* rather than
 the document being converted — `WithDpi` says nothing about the PDF.
 
-They are **documented no-ops** for `Text` and `Txt` rather than rejections.
-Unlike a page bound past the end of the document, which is always a mistake, a
-DPI set before asking for text is inapplicable rather than wrong — the natural
-shape of "render this at 300 and also give me the text" should not have to
-un-set an option to ask the second question.
+Which options an output actually reads depends on the renderer behind it:
+
+| output | renderer | reads |
+| --- | --- | --- |
+| `Text`, `Txt` | `pdftotext` | `layout`, `disablePageBreaks` |
+| `Png`, `Jpeg`, `Tiff` | `pdftoppm` | `WithDpi`, `WithColorMode`, `WithScaleTo`, `WithoutAnnotations` |
+| `Svg`, `Eps`, `Ps` | `pdftocairo` | `WithDpi` |
+| `Html` | `pdftohtml` | — |
+
+Everything an output does not read is a **documented no-op** rather than a
+rejection. Unlike a page bound past the end of the document, which is always a
+mistake, a DPI set before asking for text is inapplicable rather than wrong — the
+natural shape of "render this at 300 and also give me the text" should not have
+to un-set an option to ask the second question.
+
+> For the `pdftocairo` outputs that is a decision with teeth, because **poppler
+> does not ignore those flags — it refuses**: `-mono may only be used with the
+> -png, -jpeg, or -tiff output options`, exit 99, nothing written. And
+> `-hide-annotations` is not a `pdftocairo` option at all. So the flags are
+> dropped here rather than forwarded, and "render this as PNG for OCR and as SVG
+> for the web view" works off one `Convert`.
+
+`WithDpi` still reaches `pdftocairo`, where it governs the **rasterized regions**
+a vector output can still contain — an embedded photograph has no vector form to
+keep — and a non-positive value is still rejected by name.
 
 `Convert` is immutable too, so one configuration fans out into several formats:
 
@@ -341,19 +367,92 @@ Both reject a non-positive value by naming the argument (`WithDpi: dpi must be
 positive, got 0`). Left to poppler these arrive much later as a complaint about
 `-r` or `-scale-to`, which names a flag the caller never wrote.
 
+### `Svg`, `Eps` and `Ps` — keeping the outlines
+
+`Png` gives you pixels of the type. These give you the type: paths a browser, a
+plotter or a vector editor can scale, restyle and re-flow.
+
+Text arrives as **glyph outlines, not `<text>`** — poppler converts every glyph
+to a `<path>` and places it with `<use>` — so the page is faithful and is not
+searchable. `Text` is what to reach for when the words are what is wanted.
+
+**One SVG per page is this module's doing, and it matters.** `pdftocairo -svg`
+run once over a twelve-page document writes a single file holding all twelve,
+wrapped in the SVG 1.2 `<pageSet>`/`<page>` elements — which no browser, librsvg
+or Inkscape implements. The pages are in the file and invisible to everything
+that draws it. Rendering each page on its own invocation is what makes them
+reachable, and `SvgWritesOneVectorFilePerPage` asserts the absence of a
+`<pageSet>` for exactly that reason.
+
+**EPS refuses multi-page outright.** `pdftocairo -eps` handed a document with a
+second page writes nothing and exits 99 with `EPS files can only contain one
+page.` The per-page loop is what turns that refusal into the whole document.
+Note that an EPS's bounding box is the page's **ink**, not its media box —
+poppler crops to what is drawn, so a US Letter page with one line of text on it
+comes out a few inches wide. That is EPS's own convention (a figure carries its
+extent so the placing document can size it) and the one place these files
+disagree with the geometry `Png` reports.
+
+**`Ps` returns a `*dagger.File`, not a directory**, because PostScript is a
+multi-page format: one document with a `%%Pages:` count and a `%%Page:` marker
+per page. A directory of one-page fragments would look tidier beside `Svg` and
+`Eps` and be individually invalid.
+
+### `Html` — markup with the images beside it
+
+`Html` returns a directory of `page-0001.html`, `page-0002.html`, … **plus each
+page's extracted images**, which are the only entries in this module that do not
+follow the page contract:
+
+```
+page-0001.html
+page-0001-1_1.png   ← referenced from page-0001.html as src="page-0001-1_1.png"
+page-0002.html
+```
+
+Those image names are `pdftohtml`'s, and they are left alone precisely because
+they are written *into* the markup — renaming them to a contract would mean
+rewriting the HTML to match. **A consumer walking this directory should select
+`page-*.html` rather than assume every entry is a page.**
+
+The conversion runs with the output directory as its **working directory**, and
+that is load-bearing: `pdftohtml` writes the output name it was given straight
+into every `img src`, so an absolute output base — the obvious way to write into
+a staging directory — produces markup whose images resolve only on the machine
+that rendered them, while still passing every assertion about entry names.
+`HtmlCarriesPageMarkupAndItsImages` checks the `src` for that reason.
+
+`-noframes` is passed unconditionally. `pdftohtml`'s default is a three-file
+frameset — a frameset, an index and the content — of which only the last carries
+anything.
+
 ## Page naming — `page-0001.png`
 
-`Png`, `Jpeg` and `Tiff` return a directory of `page-0001.<ext>`,
-`page-0002.<ext>`, … zero-padded to at least four digits and uniform within a
-document. The extensions are **poppler's** spellings, not this module's:
+`Png`, `Jpeg`, `Tiff`, `Svg`, `Eps` and `Html` return a directory of
+`page-0001.<ext>`, `page-0002.<ext>`, … zero-padded to at least four digits and
+uniform within a document. The extensions are **poppler's** spellings, not this
+module's:
 
 | output | extension |
 | --- | --- |
 | `Png` | `page-0001.png` |
 | `Jpeg` | `page-0001.jpg` |
 | `Tiff` | `page-0001.tif` |
+| `Svg` | `page-0001.svg` |
+| `Eps` | `page-0001.eps` |
+| `Html` | `page-0001.html` (+ its images, see above) |
 
-**This is a normalization, not `pdftoppm`'s own behaviour.** `pdftoppm` pads a
+The raster family and the per-page family reach that contract from opposite
+directions. `pdftoppm` names the files and this module **renames** them; for
+`Svg`, `Eps` and `Html` the module drives the page loop itself and **names them
+outright**, one invocation per page, because neither `pdftocairo` nor
+`pdftohtml` will produce a usable page-per-file set on its own. The upper bound
+of that loop — a `WithPageRange` open-ended `last`, or no range at all — is
+resolved from `pdfinfo` **inside the same exec** that renders, so the whole
+conversion stays one exec either way.
+
+For the raster family in particular, **this is a normalization, not
+`pdftoppm`'s own behaviour.** `pdftoppm` pads a
 page number to the width of the *document's* page count, so a 9-page document
 yields `page-1.png` and a 10-page one `page-01.png` — and a 9-page *range* of a
 12-page document yields `page-01.png` too, because the width follows the
@@ -375,19 +474,24 @@ Page numbers are the **source document's**, not positions within a range, so
 `WithPageRange(4, 6)` yields `page-0004`…`page-0006`. That keeps a rendered page
 traceable back to the page it came from.
 
-`-forcenum` is passed unconditionally. On poppler 25.12 — what the pinned tag
-ships — it changes nothing, because a page number is always appended. It is
-there for a caller who overrode `alpineTag` onto an older release, where a
+`-forcenum` is passed unconditionally to `pdftoppm`. On poppler 25.12 — what the
+pinned tag ships — it changes nothing, because a page number is always appended.
+It is there for a caller who overrode `alpineTag` onto an older release, where a
 single-page render was named `page.png` with no number at all, breaking the
-contract for exactly the documents most likely to be one page.
+contract for exactly the documents most likely to be one page. The per-page
+family needs no equivalent, naming its own output.
 
-### Why `pdftoppm` and not `pdftocairo`
+### Why `pdftoppm` for raster and `pdftocairo` for vector
 
-Both render PNG, JPEG and TIFF. Only `pdftoppm` offers `-mono` and `-gray`, and
-binarized or grayscale input is exactly what OCR preprocessing wants. A
-`pdftocairo` backend would be a second renderer with different fidelity
-characteristics rather than a drop-in, which is why it is a follow-up (#277)
-rather than an implementation detail.
+Both render PNG, JPEG and TIFF, and both are now in this module — but for
+disjoint formats, not as alternatives.
+
+Only `pdftoppm` offers `-mono` and `-gray`, and binarized or grayscale input is
+exactly what OCR preprocessing wants, so the raster family is its. Only
+`pdftocairo` emits SVG, EPS and PostScript, so the vector family is its. Neither
+is a drop-in for the other: they are separate rasterizers with different fidelity
+characteristics, which is why *choosing* between them for a format both can
+produce is still a follow-up (#277) rather than something this module does.
 
 ## Caching
 
@@ -398,8 +502,7 @@ about. Same posture as `tesseract`'s outputs and `kicad`.
 
 ## Follow-ups
 
-Other renderers — SVG, PostScript, HTML via `pdftocairo`/`pdftops`/`pdftohtml`
-(#267); reporting a document's fonts, metadata and signatures (#268);
+Reporting a document's fonts, metadata and signatures (#268);
 text-layer geometry as bbox HTML and TSV (#269); splitting and merging pages
 (#270); extracting embedded images and attachments (#271); cropping the render
 window and selecting odd or even pages (#272); the chained `Ci` builder (#273);

--- a/daggerverse/pdf/convert.go
+++ b/daggerverse/pdf/convert.go
@@ -274,6 +274,114 @@ func (c *Convert) Tiff(ctx context.Context) (*dagger.Directory, error) {
 	return c.raster(ctx, "Tiff", formatTiff)
 }
 
+// Svg renders each page in range to its own SVG and returns the directory
+// holding them, named `page-0001.svg`, `page-0002.svg`, and so on.
+//
+// This is the output for a caller who wants to keep the type outlines rather
+// than pixels of them: embedding a page in a web view, feeding a plotter,
+// re-flowing it in a vector editor. Text arrives as glyph outlines and not as
+// `<text>` — poppler converts every glyph to a `<path>` and references it with
+// `<use>` — so the page is faithful and is not searchable. Reach for Text when
+// the words are what is wanted.
+//
+// One SVG per page is this module's doing and matters. `pdftocairo -svg` run
+// once over a multi-page document writes a single file holding every page,
+// wrapped in the SVG 1.2 `pageSet` and `page` elements — which no browser,
+// librsvg or Inkscape implements, so the file draws page one and silently
+// discards the rest. Rendering each page on its own invocation is what makes
+// every page reachable.
+//
+// WithDpi governs the rasterized regions a page can still contain — an embedded
+// photograph has no vector form to keep. WithColorMode, WithScaleTo and
+// WithoutAnnotations are ignored: see the note on Ps.
+func (c *Convert) Svg(ctx context.Context) (*dagger.Directory, error) {
+	return c.pageRender(ctx, "Svg", formatSvg)
+}
+
+// Eps renders each page in range to its own Encapsulated PostScript file and
+// returns the directory holding them, named `page-0001.eps`, `page-0002.eps`,
+// and so on.
+//
+// EPS is the format for placing one page inside another document — a figure in
+// a LaTeX paper, artwork in a layout program — which is why it is one page per
+// file by definition and not by this module's choice: `pdftocairo -eps` handed a
+// multi-page document refuses to write anything at all and exits non-zero. The
+// per-page loop is what turns that refusal into the whole document.
+//
+// The bounding box is the page's *ink*, not its media box: poppler crops an EPS
+// to what is drawn, so a page of a US Letter document with a single line of text
+// on it comes out a few inches wide. That is EPS's own convention — a figure
+// carries its extent so the placing document can size it — and it is the one
+// place these files do not agree with the page geometry Png reports.
+//
+// WithDpi governs rasterized regions; WithColorMode, WithScaleTo and
+// WithoutAnnotations are ignored: see the note on Ps.
+func (c *Convert) Eps(ctx context.Context) (*dagger.Directory, error) {
+	return c.pageRender(ctx, "Eps", formatEps)
+}
+
+// Ps renders the pages in range to a single PostScript file.
+//
+// It returns a file rather than a directory because PostScript is a multi-page
+// format: one document with a `%%Pages:` count and a `%%Page:` marker per page,
+// which is what a printer queue and every downstream PostScript tool expect.
+// Splitting it into a page-per-file directory would produce fragments that are
+// each individually invalid.
+//
+// WithDpi governs the rasterized regions the output can still contain.
+// WithColorMode, WithScaleTo and WithoutAnnotations are ignored here and by Svg,
+// Eps and Html, and are documented no-ops rather than rejections for the same
+// reason they are on Text: a conversion configured for the raster outputs should
+// fan out into a vector one without having to un-set an option first. The flags
+// are dropped rather than forwarded because poppler does not ignore them — it
+// exits non-zero with `-mono may only be used with the -png, -jpeg, or -tiff
+// output options`, and `-hide-annotations` is not a pdftocairo option at all.
+func (c *Convert) Ps(ctx context.Context) (*dagger.File, error) {
+	flags, err := c.cairoFlags(formatPs)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.Document.validateRange(ctx); err != nil {
+		return nil, err
+	}
+	flags = append(flags, c.Document.rangeArgs()...)
+
+	script := strings.Join([]string{
+		"set -e",
+		"mkdir -p " + outputDir,
+		c.Document.command(formatPs.tool, flags, sourcePath, psOutputPath),
+	}, "\n")
+
+	res, err := c.Document.runScript(ctx, "Ps", script)
+	if err != nil {
+		return nil, err
+	}
+	return res.container.File(psOutputPath), nil
+}
+
+// Html converts each page in range to its own HTML file and returns the
+// directory holding them, named `page-0001.html`, `page-0002.html`, and so on,
+// with each page's extracted images beside them.
+//
+// The directory therefore holds more than the pages: a page carrying images gets
+// `page-0001-1_1.png` and so on next to `page-0001.html`, referenced from the
+// markup by a relative path. Those names are pdftohtml's, not this module's, and
+// are left alone precisely because they are written *into* the HTML — renaming
+// them to a contract would mean rewriting the markup to match. A consumer
+// walking this directory should select `page-*.html`, not assume every entry is
+// a page.
+//
+// The relative reference is the reason the conversion runs with the output
+// directory as its working directory: handed an absolute output base, pdftohtml
+// writes that absolute path into every `img src`, and the markup then only
+// resolves on the machine that produced it.
+//
+// Every render option is ignored, pdftohtml having no resolution, colour or
+// annotation switch of any kind. WithPageRange narrows it like everything else.
+func (c *Convert) Html(ctx context.Context) (*dagger.Directory, error) {
+	return c.pageRender(ctx, "Html", formatHtml)
+}
+
 // clone copies the conversion for a builder method. Every field is a value or a
 // handle, so the shallow copy is the deep one.
 func (c *Convert) clone() *Convert {
@@ -344,6 +452,115 @@ func (c *Convert) dpi() int {
 		return c.Dpi
 	}
 	return defaultDpi
+}
+
+// cairoFlags renders everything a pdftocairo invocation needs that is not the
+// document, the page bounds or the output name.
+//
+// Only the resolution reaches the command line. The colour modes, the pixel
+// bound and the annotation switch are dropped rather than translated, because
+// pdftocairo has no equivalent for any of them and rejects the two it recognises
+// by name — see the note on Ps for why that is a silent no-op here rather than a
+// rejection.
+func (c *Convert) cairoFlags(format pageFormat) ([]string, error) {
+	if c.HasDpi && c.Dpi <= 0 {
+		return nil, fmt.Errorf(
+			"WithDpi: dpi must be positive, got %d", c.Dpi)
+	}
+	args := append([]string(nil), format.flags...)
+	if format.takesResolution {
+		args = append(args, "-r", strconv.Itoa(c.dpi()))
+	}
+	return args, nil
+}
+
+// pageRender writes one file per page and returns the directory holding them.
+//
+// The page loop runs in the container rather than here because its upper bound
+// is the document's page count, and reading that from Go would mean a second
+// round trip to fetch what the very next exec is about to open anyway. Resolving
+// it in the same shell keeps the whole conversion one exec, the way the raster
+// path's rename pass does.
+func (c *Convert) pageRender(ctx context.Context, label string, format pageFormat) (*dagger.Directory, error) {
+	flags, err := c.cairoFlags(format)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.Document.validateRange(ctx); err != nil {
+		return nil, err
+	}
+
+	name := pageNamePrefix + `$padded`
+	if format.namesExtension {
+		name += "." + format.ext
+	}
+	// The bounds are the loop variable, so the document's own range flags are
+	// deliberately not appended: this invocation renders exactly one page.
+	render := c.Document.command(format.tool, flags,
+		"-f", `"$p"`, "-l", `"$p"`, sourcePath, name)
+
+	res, err := c.Document.runScript(ctx, label, c.pageLoop(render))
+	if err != nil {
+		return nil, err
+	}
+	return res.container.Directory(outputDir), nil
+}
+
+// pageLoop is the script that runs a per-page conversion once for every page in
+// range, with `$padded` set to the page's zero-padded number.
+//
+// It works the output directory from the inside — `cd` rather than an absolute
+// output path — because pdftohtml writes the output name it was given into every
+// `img src` in the markup it produces. Named absolutely, it emits markup whose
+// images only resolve on the machine that rendered them.
+func (c *Convert) pageLoop(render string) string {
+	first := 1
+	if c.Document.HasRange && c.Document.FirstPage > 0 {
+		first = c.Document.FirstPage
+	}
+	last := endOfDocument
+	if c.Document.HasRange {
+		last = c.Document.LastPage
+	}
+
+	return strings.Join([]string{
+		// set -e is what makes a page poppler cannot write stop the loop
+		// carrying its own message, rather than leaving a directory that is
+		// short a page and says nothing about it.
+		`set -e`,
+		`mkdir -p ` + outputDir,
+		`cd ` + outputDir,
+		`first=` + strconv.Itoa(first),
+		`last=` + strconv.Itoa(last),
+		// An open-ended range is resolved here rather than in Go so the page
+		// count and the render share one exec.
+		//
+		// The report is captured and parsed in two steps rather than piped
+		// straight into sed, because set -e reads the exit status of the *last*
+		// command in a pipeline. Piped, a document pdfinfo cannot open leaves
+		// sed succeeding on nothing, and the run gets as far as the page-count
+		// check below and fails there — with poppler's diagnostic still on
+		// stderr, but joined by a second message about a page count that was
+		// never the problem. Split, the script stops on pdfinfo's own status.
+		`if [ "$last" -eq ` + strconv.Itoa(endOfDocument) + ` ]; then`,
+		`	info=$(` + c.Document.command("pdfinfo", nil, sourcePath) + `)`,
+		`	last=$(printf '%s\n' "$info" | sed -n 's/^Pages:[[:space:]]*//p')`,
+		`fi`,
+		`case "$last" in`,
+		`	''|*[!0-9]*) echo "could not read the page count: $last" >&2; exit 1;;`,
+		`esac`,
+		// The width is the greater of the module's minimum and what the last
+		// page number needs, so a document longer than the minimum can express
+		// stays uniform. Same contract the raster path normalizes to.
+		`width=` + strconv.Itoa(minPageNumberWidth),
+		`if [ ${#last} -gt "$width" ]; then width=${#last}; fi`,
+		`p="$first"`,
+		`while [ "$p" -le "$last" ]; do`,
+		`	padded=$(printf "%0${width}d" "$p")`,
+		`	` + render,
+		`	p=$((p + 1))`,
+		`done`,
+	}, "\n")
 }
 
 // raster renders the pages and returns the directory holding them, with every

--- a/daggerverse/pdf/dagger.gen.go
+++ b/daggerverse/pdf/dagger.gen.go
@@ -406,6 +406,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 	switch parentName {
 	case "Convert":
 		switch fnName {
+		case "Eps":
+			var parent Convert
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Convert).Eps(&parent, ctx)
+		case "Html":
+			var parent Convert
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Convert).Html(&parent, ctx)
 		case "Jpeg":
 			var parent Convert
 			err = json.Unmarshal(parentJSON, &parent)
@@ -420,6 +434,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return (*Convert).Png(&parent, ctx)
+		case "Ps":
+			var parent Convert
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Convert).Ps(&parent, ctx)
+		case "Svg":
+			var parent Convert
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Convert).Svg(&parent, ctx)
 		case "Text":
 			var parent Convert
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/pdf/enums.go
+++ b/daggerverse/pdf/enums.go
@@ -113,6 +113,60 @@ var (
 	formatTiff = rasterFormat{flag: "-tiff", ext: "tif"}
 )
 
+// pageFormat is an output written one file per page, by one invocation per
+// page. It is not a Dagger enum for the same reason rasterFormat is not: Svg,
+// Eps and Html are named functions, so a caller never spells a format.
+//
+// One invocation per page is not an implementation preference, it is what these
+// tools do. `pdftocairo -eps` refuses a multi-page document outright, and
+// `pdftocairo -svg` writes every page into one file wrapped in the SVG 1.2
+// `pageSet` elements that essentially no renderer implements — so the pages are
+// present in the file and absent from anything that draws it. Driving the page
+// loop here is what makes both of them honour the page-naming contract.
+type pageFormat struct {
+	// tool is the poppler binary that writes this format.
+	tool string
+	// flags select the format, and are everything the tool needs that is not
+	// the page bounds, the document or the output name.
+	flags []string
+	// ext is the extension a page of this format carries.
+	ext string
+	// namesExtension is whether the tool is handed the output path with the
+	// extension already on it. pdftocairo writes exactly the file it is named;
+	// pdftohtml is handed a base and appends `.html` to it itself.
+	namesExtension bool
+	// takesResolution is whether the tool accepts `-r`. It is pdftocairo's, and
+	// governs the rasterized regions a vector output can still contain; pdftohtml
+	// has no resolution option at all.
+	takesResolution bool
+}
+
+var (
+	formatSvg = pageFormat{
+		tool: "pdftocairo", flags: []string{"-svg"}, ext: "svg",
+		namesExtension: true, takesResolution: true,
+	}
+	formatEps = pageFormat{
+		tool: "pdftocairo", flags: []string{"-eps"}, ext: "eps",
+		namesExtension: true, takesResolution: true,
+	}
+	// -noframes is what makes pdftohtml write one self-contained page instead of
+	// the three-file frameset it emits by default: a frameset, an index and the
+	// content, of which only the last carries anything.
+	formatHtml = pageFormat{
+		tool: "pdftohtml", flags: []string{"-noframes"}, ext: "html",
+	}
+
+	// formatPs is the odd one out and is not driven by the page loop: PostScript
+	// holds a whole document, so Ps writes one file in one invocation. It is
+	// spelled as a pageFormat anyway so the resolution flag is assembled the same
+	// way for all three pdftocairo outputs.
+	formatPs = pageFormat{
+		tool: "pdftocairo", flags: []string{"-ps"}, ext: "ps",
+		namesExtension: true, takesResolution: true,
+	}
+)
+
 // colorNames lists every legal ColorMode, for the message a rejection carries.
 func colorNames() string {
 	names := make([]string, 0, len(colorOrder))

--- a/daggerverse/pdf/main.go
+++ b/daggerverse/pdf/main.go
@@ -34,13 +34,20 @@
 // out here: a `+key="value"` in doc-comment prose is stripped as a directive
 // and mangles the generated description.)
 //
+// Three renderers sit behind the outputs, chosen per format rather than
+// uniformly. The raster family stays on pdftoppm because it alone offers -mono
+// and -gray, which is what the OCR path wants. The vector family — SVG, EPS and
+// PostScript — is pdftocairo's, that being the only one of the two that emits
+// them. HTML is pdftohtml's, which is not a renderer at all so much as a
+// re-layout, and shares no options with either.
+//
 // File map (all `package main`, surfaced as one Dagger module):
 //
 //   - enums.go    — ColorMode and LayoutMode plus the tables mapping them onto
-//     poppler's flags, and the internal raster-format table.
+//     poppler's flags, and the internal raster- and per-page-format tables.
 //   - document.go — *Document, one bound PDF: its passwords, its page range,
 //     and what pdfinfo reports about it.
-//   - convert.go  — *Convert, the render options and the five outputs that
+//   - convert.go  — *Convert, the render options and the nine outputs that
 //     read them.
 package main
 
@@ -66,8 +73,8 @@ const (
 	defaultAlpineTag = "3.24"
 
 	// popplerPkg carries all thirteen pdf* binaries this module reaches
-	// through Container, of which three are wrapped: pdftotext, pdftoppm and
-	// pdfinfo.
+	// through Container, of which five are wrapped: pdftotext, pdftoppm,
+	// pdfinfo, pdftocairo and pdftohtml.
 	popplerPkg = "poppler-utils"
 
 	// fontPkg is the substitute font family poppler draws with when a PDF
@@ -112,10 +119,11 @@ const (
 	sourcePath = workDir + "/source.pdf"
 	outputDir  = "/out"
 
-	// textOutputPath is the file Convert.Txt writes, and pageBase the
-	// OUTPUTBASE handed to pdftoppm — which appends a page number and the
-	// format's extension to it.
+	// textOutputPath is the file Convert.Txt writes, psOutputPath the one
+	// Convert.Ps writes, and pageBase the OUTPUTBASE handed to pdftoppm — which
+	// appends a page number and the format's extension to it.
 	textOutputPath = outputDir + "/document.txt"
+	psOutputPath   = outputDir + "/document.ps"
 	pageBase       = outputDir + "/page"
 
 	// pageNamePrefix is the leading part of a rendered page's file name, and
@@ -299,8 +307,8 @@ func (p *Pdf) WithFonts(
 
 // Container returns the assembled toolchain image. This is the escape hatch
 // for everything this module does not wrap: poppler-utils ships thirteen
-// binaries and three of them are wrapped here, so pdfimages, pdfseparate,
-// pdfunite, pdfsig, pdffonts, pdftocairo and the rest stay reachable via
+// binaries and five of them are wrapped here, so pdfimages, pdfseparate,
+// pdfunite, pdfsig, pdffonts and the rest stay reachable via
 // `container with-exec`.
 func (p *Pdf) Container() *dagger.Container {
 	ctr := p.base().WithExec([]string{"apk", "add", "--no-cache", popplerPkg, fontPkg})

--- a/daggerverse/pdf/tests/dagger.gen.go
+++ b/daggerverse/pdf/tests/dagger.gen.go
@@ -241,6 +241,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).EncryptedDocumentNeedsThePassword(&parent, ctx)
+		case "EpsWritesEveryPageOfTheDocument":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).EpsWritesEveryPageOfTheDocument(&parent, ctx)
+		case "HtmlCarriesPageMarkupAndItsImages":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).HtmlCarriesPageMarkupAndItsImages(&parent, ctx)
 		case "InfoReportsPageCountAndSize":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -262,6 +276,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).LayoutModesProduceDifferentOrderings(&parent, ctx)
+		case "PageRangeNarrowsEveryPerPageFormat":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).PageRangeNarrowsEveryPerPageFormat(&parent, ctx)
 		case "PageRangeNarrowsText":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -304,6 +325,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).PngSinglePageIsStillNumbered(&parent, ctx)
+		case "PsHoldsEveryPageInOneFile":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).PsHoldsEveryPageInOneFile(&parent, ctx)
 		case "RenderSettingsRejectNonPositiveValues":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -318,6 +346,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).ScaleToOverridesDpi(&parent, ctx)
+		case "SvgWritesOneVectorFilePerPage":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).SvgWritesOneVectorFilePerPage(&parent, ctx)
 		case "TextOnImageOnlyPdfReturnsNothing":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -339,6 +374,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).TxtMatchesText(&parent, ctx)
+		case "VectorFormatsIgnoreRasterOnlySettings":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).VectorFormatsIgnoreRasterOnlySettings(&parent, ctx)
 		case "VersionReportsPopplerRelease":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/pdf/tests/internal/dagger/pdf.gen.go
+++ b/daggerverse/pdf/tests/internal/dagger/pdf.gen.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Retrieve the binding value, as type Pdf
-func (r *Binding) AsPdf() *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:160:6)
+func (r *Binding) AsPdf() *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:168:6)
 	q := r.query.Select("asPdf")
 
 	return &Pdf{
@@ -86,7 +86,7 @@ func (r *Env) WithPdfDocumentOutput(name string, description string) *Env { // p
 }
 
 // Create or update a binding of type Pdf in the environment
-func (r *Env) WithPdfInput(name string, value *Pdf, description string) *Env { // pdf (../../../../../daggerverse/pdf/main.go:160:6)
+func (r *Env) WithPdfInput(name string, value *Pdf, description string) *Env { // pdf (../../../../../daggerverse/pdf/main.go:168:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withPdfInput")
 	q = q.Arg("name", name)
@@ -99,7 +99,7 @@ func (r *Env) WithPdfInput(name string, value *Pdf, description string) *Env { /
 }
 
 // Declare a desired Pdf output to be assigned in the environment
-func (r *Env) WithPdfOutput(name string, description string) *Env { // pdf (../../../../../daggerverse/pdf/main.go:160:6)
+func (r *Env) WithPdfOutput(name string, description string) *Env { // pdf (../../../../../daggerverse/pdf/main.go:168:6)
 	q := r.query.Select("withPdfOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -113,7 +113,7 @@ func (r *Env) WithPdfOutput(name string, description string) *Env { // pdf (../.
 // carries the image coordinates and the fonts the image is built with;
 // Document hangs off it so the generated SDK surfaces conversion under
 // `dag.Pdf().Document(...)`.
-type Pdf struct { // pdf (../../../../../daggerverse/pdf/main.go:160:6)
+type Pdf struct { // pdf (../../../../../daggerverse/pdf/main.go:168:6)
 	query *querybuilder.Selection
 
 	id      *ID
@@ -136,10 +136,10 @@ func (r *Pdf) WithGraphQLQuery(q *querybuilder.Selection) *Pdf {
 
 // Container returns the assembled toolchain image. This is the escape hatch
 // for everything this module does not wrap: poppler-utils ships thirteen
-// binaries and three of them are wrapped here, so pdfimages, pdfseparate,
-// pdfunite, pdfsig, pdffonts, pdftocairo and the rest stay reachable via
+// binaries and five of them are wrapped here, so pdfimages, pdfseparate,
+// pdfunite, pdfsig, pdffonts and the rest stay reachable via
 // `container with-exec`.
-func (r *Pdf) Container() *Container { // pdf (../../../../../daggerverse/pdf/main.go:305:1)
+func (r *Pdf) Container() *Container { // pdf (../../../../../daggerverse/pdf/main.go:313:1)
 	q := r.query.Select("container")
 
 	return &Container{
@@ -152,7 +152,7 @@ func (r *Pdf) Container() *Container { // pdf (../../../../../daggerverse/pdf/ma
 // The boundary input is a *dagger.File rather than a *dagger.Directory: a PDF
 // resolves nothing relative to its own location, so one file is the whole unit
 // of work however many pages it carries.
-func (r *Pdf) Document(source *File) *PdfDocument { // pdf (../../../../../daggerverse/pdf/main.go:338:1)
+func (r *Pdf) Document(source *File) *PdfDocument { // pdf (../../../../../daggerverse/pdf/main.go:346:1)
 	assertNotNil("source", source)
 	q := r.query.Select("document")
 	q = q.Arg("source", source)
@@ -213,7 +213,7 @@ func (r *Pdf) UnmarshalJSON(bs []byte) error {
 
 // Version returns the poppler release the assembled image ships, as the bare
 // version number reported by `pdftotext -v`.
-func (r *Pdf) Version(ctx context.Context) (string, error) { // pdf (../../../../../daggerverse/pdf/main.go:318:1)
+func (r *Pdf) Version(ctx context.Context) (string, error) { // pdf (../../../../../daggerverse/pdf/main.go:326:1)
 	if r.version != nil {
 		return *r.version, nil
 	}
@@ -239,7 +239,7 @@ func (r *Pdf) Version(ctx context.Context) (string, error) { // pdf (../../../..
 // why the credentials are not simply userinfo in the WithApkRepository URL,
 // which would put them in /etc/apk/repositories and in every apk error
 // message that quotes it.
-func (r *Pdf) WithApkAuth(credentials *Secret) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:267:1)
+func (r *Pdf) WithApkAuth(credentials *Secret) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:275:1)
 	assertNotNil("credentials", credentials)
 	q := r.query.Select("withApkAuth")
 	q = q.Arg("credentials", credentials)
@@ -262,7 +262,7 @@ func (r *Pdf) WithApkAuth(credentials *Secret) *Pdf { // pdf (../../../../../dag
 // Repeatable, for a mirror set signed by more than one key. It is a *File
 // rather than a *Secret because a public key is not a credential: it is meant
 // to be in the image, and WithApkAuth is the option for the part that is not.
-func (r *Pdf) WithApkKey(key *File) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:244:1)
+func (r *Pdf) WithApkKey(key *File) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:252:1)
 	assertNotNil("key", key)
 	q := r.query.Select("withApkKey")
 	q = q.Arg("key", key)
@@ -292,7 +292,7 @@ func (r *Pdf) WithApkKey(key *File) *Pdf { // pdf (../../../../../daggerverse/pd
 // call per component. A repository's index is signed, so pair this with
 // WithApkKey unless the mirror is signed by a key the base image already
 // trusts.
-func (r *Pdf) WithApkRepository(url string) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:216:1)
+func (r *Pdf) WithApkRepository(url string) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:224:1)
 	q := r.query.Select("withApkRepository")
 	q = q.Arg("url", url)
 
@@ -316,7 +316,7 @@ func (r *Pdf) WithApkRepository(url string) *Pdf { // pdf (../../../../../dagger
 // /etc/fonts/fonts.conf tells fontconfig to scan, so the faces in it are
 // indistinguishable from packaged ones as far as poppler is concerned. It is
 // mounted rather than copied so a large family does not become an image layer.
-func (r *Pdf) WithFonts(dir *Directory) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:291:1)
+func (r *Pdf) WithFonts(dir *Directory) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:299:1)
 	assertNotNil("dir", dir)
 	q := r.query.Select("withFonts")
 	q = q.Arg("dir", dir)
@@ -364,6 +364,59 @@ func (r *PdfConvert) With(f WithPdfConvertFunc) *PdfConvert {
 
 func (r *PdfConvert) WithGraphQLQuery(q *querybuilder.Selection) *PdfConvert {
 	return &PdfConvert{
+		query: q,
+	}
+}
+
+// Eps renders each page in range to its own Encapsulated PostScript file and
+// returns the directory holding them, named `page-0001.eps`, `page-0002.eps`,
+// and so on.
+//
+// EPS is the format for placing one page inside another document — a figure in
+// a LaTeX paper, artwork in a layout program — which is why it is one page per
+// file by definition and not by this module's choice: `pdftocairo -eps` handed a
+// multi-page document refuses to write anything at all and exits non-zero. The
+// per-page loop is what turns that refusal into the whole document.
+//
+// The bounding box is the page's *ink*, not its media box: poppler crops an EPS
+// to what is drawn, so a page of a US Letter document with a single line of text
+// on it comes out a few inches wide. That is EPS's own convention — a figure
+// carries its extent so the placing document can size it — and it is the one
+// place these files do not agree with the page geometry Png reports.
+//
+// WithDpi governs rasterized regions; WithColorMode, WithScaleTo and
+// WithoutAnnotations are ignored: see the note on Ps.
+func (r *PdfConvert) Eps() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:319:1)
+	q := r.query.Select("eps")
+
+	return &Directory{
+		query: q,
+	}
+}
+
+// Html converts each page in range to its own HTML file and returns the
+// directory holding them, named `page-0001.html`, `page-0002.html`, and so on,
+// with each page's extracted images beside them.
+//
+// The directory therefore holds more than the pages: a page carrying images gets
+// `page-0001-1_1.png` and so on next to `page-0001.html`, referenced from the
+// markup by a relative path. Those names are pdftohtml's, not this module's, and
+// are left alone precisely because they are written *into* the HTML — renaming
+// them to a contract would mean rewriting the markup to match. A consumer
+// walking this directory should select `page-*.html`, not assume every entry is
+// a page.
+//
+// The relative reference is the reason the conversion runs with the output
+// directory as its working directory: handed an absolute output base, pdftohtml
+// writes that absolute path into every `img src`, and the markup then only
+// resolves on the machine that produced it.
+//
+// Every render option is ignored, pdftohtml having no resolution, colour or
+// annotation switch of any kind. WithPageRange narrows it like everything else.
+func (r *PdfConvert) HTML() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:381:1)
+	q := r.query.Select("html")
+
+	return &Directory{
 		query: q,
 	}
 }
@@ -440,6 +493,58 @@ func (r *PdfConvert) Jpeg() *Directory { // pdf (../../../../../daggerverse/pdf/
 // every image library reads without a codec question.
 func (r *PdfConvert) Png() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:251:1)
 	q := r.query.Select("png")
+
+	return &Directory{
+		query: q,
+	}
+}
+
+// Ps renders the pages in range to a single PostScript file.
+//
+// It returns a file rather than a directory because PostScript is a multi-page
+// format: one document with a `%%Pages:` count and a `%%Page:` marker per page,
+// which is what a printer queue and every downstream PostScript tool expect.
+// Splitting it into a page-per-file directory would produce fragments that are
+// each individually invalid.
+//
+// WithDpi governs the rasterized regions the output can still contain.
+// WithColorMode, WithScaleTo and WithoutAnnotations are ignored here and by Svg,
+// Eps and Html, and are documented no-ops rather than rejections for the same
+// reason they are on Text: a conversion configured for the raster outputs should
+// fan out into a vector one without having to un-set an option first. The flags
+// are dropped rather than forwarded because poppler does not ignore them — it
+// exits non-zero with `-mono may only be used with the -png, -jpeg, or -tiff
+// output options`, and `-hide-annotations` is not a pdftocairo option at all.
+func (r *PdfConvert) Ps() *File { // pdf (../../../../../daggerverse/pdf/convert.go:339:1)
+	q := r.query.Select("ps")
+
+	return &File{
+		query: q,
+	}
+}
+
+// Svg renders each page in range to its own SVG and returns the directory
+// holding them, named `page-0001.svg`, `page-0002.svg`, and so on.
+//
+// This is the output for a caller who wants to keep the type outlines rather
+// than pixels of them: embedding a page in a web view, feeding a plotter,
+// re-flowing it in a vector editor. Text arrives as glyph outlines and not as
+// `<text>` — poppler converts every glyph to a `<path>` and references it with
+// `<use>` — so the page is faithful and is not searchable. Reach for Text when
+// the words are what is wanted.
+//
+// One SVG per page is this module's doing and matters. `pdftocairo -svg` run
+// once over a multi-page document writes a single file holding every page,
+// wrapped in the SVG 1.2 `pageSet` and `page` elements — which no browser,
+// librsvg or Inkscape implements, so the file draws page one and silently
+// discards the rest. Rendering each page on its own invocation is what makes
+// every page reachable.
+//
+// WithDpi governs the rasterized regions a page can still contain — an embedded
+// photograph has no vector form to keep. WithColorMode, WithScaleTo and
+// WithoutAnnotations are ignored: see the note on Ps.
+func (r *PdfConvert) Svg() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:297:1)
+	q := r.query.Select("svg")
 
 	return &Directory{
 		query: q,
@@ -858,18 +963,18 @@ type PdfOpts struct {
 	//
 	//
 	// Default: "docker.io"
-	Registry string // pdf (../../../../../daggerverse/pdf/main.go:182:2)
+	Registry string // pdf (../../../../../daggerverse/pdf/main.go:190:2)
 	//
 	// Tag of the alpine image the toolchain is assembled on.
 	//
 	//
 	// Default: "3.24"
-	AlpineTag string // pdf (../../../../../daggerverse/pdf/main.go:185:2)
+	AlpineTag string // pdf (../../../../../daggerverse/pdf/main.go:193:2)
 }
 
 // New returns a Pdf module backed by <registry>/library/alpine:<tag> with
 // poppler-utils and a substitute font family installed.
-func (r *Query) Pdf(opts ...PdfOpts) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:177:1)
+func (r *Query) Pdf(opts ...PdfOpts) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:185:1)
 	q := r.query.Select("pdf")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `registry` optional argument

--- a/daggerverse/pdf/tests/main.go
+++ b/daggerverse/pdf/tests/main.go
@@ -169,9 +169,363 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("ColorModesProduceDifferentPixels", t.ColorModesProduceDifferentPixels)
 	jobs = jobs.WithJob("WithoutAnnotationsRemovesTheAnnotationLayer", t.WithoutAnnotationsRemovesTheAnnotationLayer)
 
+	jobs = jobs.WithJob("SvgWritesOneVectorFilePerPage", t.SvgWritesOneVectorFilePerPage)
+	jobs = jobs.WithJob("EpsWritesEveryPageOfTheDocument", t.EpsWritesEveryPageOfTheDocument)
+	jobs = jobs.WithJob("PsHoldsEveryPageInOneFile", t.PsHoldsEveryPageInOneFile)
+	jobs = jobs.WithJob("HtmlCarriesPageMarkupAndItsImages", t.HtmlCarriesPageMarkupAndItsImages)
+	jobs = jobs.WithJob("PageRangeNarrowsEveryPerPageFormat", t.PageRangeNarrowsEveryPerPageFormat)
+	jobs = jobs.WithJob("VectorFormatsIgnoreRasterOnlySettings", t.VectorFormatsIgnoreRasterOnlySettings)
+
 	jobs = jobs.WithJob("EncryptedDocumentNeedsThePassword", t.EncryptedDocumentNeedsThePassword)
 
 	return jobs.Run(ctx)
+}
+
+// SvgWritesOneVectorFilePerPage asserts Svg renders a multi-page document to one
+// SVG per page, named to the page contract, carrying vector geometry.
+//
+// The per-page invocation is the whole point. `pdftocairo -svg` run once over a
+// twelve-page document writes a single file — no page is dropped, but they are
+// wrapped in the SVG 1.2 `<pageSet>`/`<page>` elements that essentially no
+// renderer implements, so a browser, Inkscape or librsvg shows page one and
+// silently discards the other eleven. The `<pageSet>` assertion is what would
+// catch a return to the single invocation: it passes an entry-count check and
+// fails here.
+//
+// Vectorness is asserted as drawing operators present and no raster image
+// anywhere. Poppler converts text to glyph outlines rather than to `<text>`, so
+// the marker words are not in the file at all — a Contains check for one would
+// fail on a perfectly good SVG.
+func (t *Tests) SvgWritesOneVectorFilePerPage(ctx context.Context) error {
+	dir := pdf().Document(fixture(ledgerPdf)).Convert().Svg()
+
+	entries, err := dir.Entries(ctx)
+	if err != nil {
+		return fmt.Errorf("Svg: %w", err)
+	}
+	if err := assertPageNames(entries, pageNames("svg", 1, ledgerPages)); err != nil {
+		return err
+	}
+
+	for _, page := range []int{1, ledgerPages} {
+		name := fmt.Sprintf("page-%04d.svg", page)
+		got, err := dir.File(name).Contents(ctx)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", name, err)
+		}
+		if !strings.Contains(got, "<path") {
+			return fmt.Errorf("expected %s to carry vector path data, got:\n%s", name, head(got))
+		}
+		if strings.Contains(got, "<image") {
+			return fmt.Errorf("expected %s to carry no embedded raster image, got:\n%s", name, head(got))
+		}
+		if strings.Contains(got, "<pageSet") {
+			return fmt.Errorf("expected %s to be a single-page SVG, got a pageSet:\n%s", name, head(got))
+		}
+	}
+	return nil
+}
+
+// EpsWritesEveryPageOfTheDocument asserts Eps turns a twelve-page
+// document into twelve EPS files rather than into a failure.
+//
+// This is the criterion that a multi-page source never silently loses pages, and
+// for EPS the failure it guards is not silent at all: `pdftocairo -eps` handed a
+// multi-page document writes nothing and exits 99 with `EPS files can only
+// contain one page.` A single invocation would make Eps unusable for every
+// document with a second page in it, so the page count here is the assertion
+// that the per-page loop is what runs.
+//
+// Each file is then checked to be an EPS in its own right — the EPSF version
+// header, and exactly one page in it — because a loop that wrote twelve copies
+// of page one would satisfy the names alone.
+func (t *Tests) EpsWritesEveryPageOfTheDocument(ctx context.Context) error {
+	dir := pdf().Document(fixture(ledgerPdf)).Convert().Eps()
+
+	entries, err := dir.Entries(ctx)
+	if err != nil {
+		return fmt.Errorf("Eps: %w", err)
+	}
+	if err := assertPageNames(entries, pageNames("eps", 1, ledgerPages)); err != nil {
+		return err
+	}
+
+	for _, page := range []int{1, ledgerPages} {
+		name := fmt.Sprintf("page-%04d.eps", page)
+		got, err := dir.File(name).Contents(ctx)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", name, err)
+		}
+		if !strings.HasPrefix(got, "%!PS-Adobe-3.0 EPSF-3.0") {
+			return fmt.Errorf("expected %s to open with an EPSF header, got:\n%s", name, head(got))
+		}
+		if n := strings.Count(got, "\n%%Page: "); n != 1 {
+			return fmt.Errorf("expected %s to hold exactly one page, got %d", name, n)
+		}
+	}
+
+	// The pages differ from one another, which is what says the loop advanced
+	// rather than rendering the same page twelve times under twelve names.
+	first, err := dir.File("page-0001.eps").Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("read page-0001.eps: %w", err)
+	}
+	last, err := dir.File(fmt.Sprintf("page-%04d.eps", ledgerPages)).Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("read the last page: %w", err)
+	}
+	if first == last {
+		return fmt.Errorf("expected the first and last page to differ, got identical EPS")
+	}
+	return nil
+}
+
+// PsHoldsEveryPageInOneFile asserts Ps returns one PostScript document carrying
+// every page, and that the page range narrows it.
+//
+// The return type is the claim under test. PostScript is a multi-page format
+// with a document-level `%%Pages:` count and a `%%Page:` marker per page, so a
+// directory of one-page fragments would be the wrong answer even though it would
+// look tidier beside Svg and Eps. Counting the markers is what says the pages
+// reached the file rather than only the header saying they did.
+func (t *Tests) PsHoldsEveryPageInOneFile(ctx context.Context) error {
+	doc := pdf().Document(fixture(ledgerPdf))
+
+	whole, err := doc.Convert().Ps().Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("Ps: %w", err)
+	}
+	if !strings.HasPrefix(whole, "%!PS-Adobe-") {
+		return fmt.Errorf("expected a PostScript header, got:\n%s", head(whole))
+	}
+	if want := fmt.Sprintf("%%%%Pages: %d", ledgerPages); !strings.Contains(whole, want) {
+		return fmt.Errorf("expected %q in the document header, got:\n%s", want, head(whole))
+	}
+	if got := strings.Count(whole, "\n%%Page: "); got != ledgerPages {
+		return fmt.Errorf("expected %d page markers, got %d", ledgerPages, got)
+	}
+
+	const first, last = 4, 6
+	narrowed, err := doc.WithPageRange(first, last).Convert().Ps().Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("Ps for pages %d-%d: %w", first, last, err)
+	}
+	if got := strings.Count(narrowed, "\n%%Page: "); got != last-first+1 {
+		return fmt.Errorf("expected %d page markers for pages %d-%d, got %d",
+			last-first+1, first, last, got)
+	}
+	return nil
+}
+
+// HtmlCarriesPageMarkupAndItsImages asserts both halves of what Html promises:
+// the page's text as markup, and the images the page carries extracted beside it
+// and referenced by a path that resolves.
+//
+// The relative reference is the half that is easy to get wrong and impossible to
+// notice. pdftohtml writes the output name it was given straight into every `img
+// src`, so an absolute output base — the obvious way to write into a staging
+// directory — produces markup whose images resolve only on the machine that
+// rendered them, and which still passes every assertion about entry names. The
+// conversion runs with the output directory as its working directory for exactly
+// this reason, and the `src` check here is what holds it there.
+//
+// Two fixtures are needed because no one page is both: ledger.pdf is text and no
+// images, scan.pdf is one image and no text.
+func (t *Tests) HtmlCarriesPageMarkupAndItsImages(ctx context.Context) error {
+	const page = 3
+
+	text := pdf().Document(fixture(ledgerPdf)).Convert().HTML()
+	entries, err := text.Entries(ctx)
+	if err != nil {
+		return fmt.Errorf("Html: %w", err)
+	}
+	// A document with no images produces the pages and nothing else, so this is
+	// the fixture the page-naming contract is asserted on.
+	if err := assertPageNames(entries, pageNames("html", 1, ledgerPages)); err != nil {
+		return err
+	}
+
+	markup, err := text.File(fmt.Sprintf("page-%04d.html", page)).Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("read page %d: %w", page, err)
+	}
+	for _, want := range []string{
+		"<html", fmt.Sprintf("Page %d of the ledger.", page), ledgerMarkers[page-1],
+	} {
+		if !strings.Contains(markup, want) {
+			return fmt.Errorf("expected page %d's markup to contain %q, got:\n%s", page, want, head(markup))
+		}
+	}
+	// The pages are separate documents, so page 3 carries page 3 and nothing
+	// from its neighbours.
+	if other := ledgerMarkers[page]; strings.Contains(markup, other) {
+		return fmt.Errorf("expected page %d's markup to carry only its own page, found %q", page, other)
+	}
+
+	scan := pdf().Document(fixture(scanPdf)).Convert().HTML()
+	scanEntries, err := scan.Entries(ctx)
+	if err != nil {
+		return fmt.Errorf("Html of a scan: %w", err)
+	}
+	if !slices.Contains(scanEntries, "page-0001.html") {
+		return fmt.Errorf("expected page-0001.html, got %v", scanEntries)
+	}
+	images := imageEntries(scanEntries)
+	if len(images) == 0 {
+		return fmt.Errorf("expected the page's image to be extracted beside it, got %v", scanEntries)
+	}
+
+	scanMarkup, err := scan.File("page-0001.html").Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("read the scan's markup: %w", err)
+	}
+	for _, img := range images {
+		want := `src="` + img + `"`
+		if !strings.Contains(scanMarkup, want) {
+			return fmt.Errorf("expected the markup to reference %s relatively as %s, got:\n%s",
+				img, want, head(scanMarkup))
+		}
+	}
+	// An absolute reference is the failure this test exists for: it resolves on
+	// the machine that rendered the page and nowhere else.
+	if strings.Contains(scanMarkup, `src="/`) {
+		return fmt.Errorf("expected no absolute image path in the markup, got:\n%s", head(scanMarkup))
+	}
+	return nil
+}
+
+// PageRangeNarrowsEveryPerPageFormat asserts the page bounds reach Svg, Eps and
+// Html, in all three of the shapes a range comes in.
+//
+// The per-page loop resolves the bounds itself rather than handing poppler `-f`
+// and `-l`, so none of this follows from the raster path already honouring them.
+// The open-ended case is the one that exercises the resolution: a zero last is
+// the document's page count read inside the same exec that renders, and a loop
+// that mishandled it would render nothing at all and return an empty directory
+// rather than fail.
+//
+// The numbers are the source document's page numbers and not positions within
+// the range, which is why pages 4 through 6 come out `page-0004` through
+// `page-0006` — the same promise the raster contract makes, so a page stays
+// traceable to the page it came from whichever format it was rendered to.
+func (t *Tests) PageRangeNarrowsEveryPerPageFormat(ctx context.Context) error {
+	doc := pdf().Document(fixture(ledgerPdf))
+
+	for _, rng := range []struct {
+		name        string
+		first, last int
+		wantFirst   int
+		wantLast    int
+	}{
+		{"a span", 4, 6, 4, 6},
+		{"one page", 2, 2, 2, 2},
+		{"open ended", 10, 0, 10, ledgerPages},
+	} {
+		conv := doc.WithPageRange(rng.first, rng.last).Convert()
+
+		for _, format := range []struct {
+			name string
+			ext  string
+			dir  *dagger.Directory
+		}{
+			{"Svg", "svg", conv.Svg()},
+			{"Eps", "eps", conv.Eps()},
+			{"Html", "html", conv.HTML()},
+		} {
+			got, err := format.dir.Entries(ctx)
+			if err != nil {
+				return fmt.Errorf("%s: %s: %w", rng.name, format.name, err)
+			}
+			want := pageNames(format.ext, rng.wantFirst, rng.wantLast)
+			if err := assertPageNames(got, want); err != nil {
+				return fmt.Errorf("%s: %s: %s", rng.name, format.name, err.Error())
+			}
+		}
+	}
+	return nil
+}
+
+// VectorFormatsIgnoreRasterOnlySettings asserts a conversion configured for the
+// raster outputs still converts when it is asked for a vector one.
+//
+// Forwarding those flags is not a no-op, which is what makes this worth an
+// assertion of its own: pdftocairo rejects both of the ones it recognises —
+// `-mono may only be used with the -png, -jpeg, or -tiff output options` — and
+// exits 99 having written nothing, and `-hide-annotations` is not a pdftocairo
+// option at all. So the natural shape of "render this document as PNG for OCR
+// and as SVG for the web view" would fail on its second half unless the module
+// drops what it cannot honour.
+//
+// WithDpi is the one setting that does reach pdftocairo, and it is set here too
+// so this is not accidentally asserting that no flags are passed at all.
+func (t *Tests) VectorFormatsIgnoreRasterOnlySettings(ctx context.Context) error {
+	conv := pdf().Document(fixture(annotatedPdf)).
+		Convert().
+		WithDpi(300).
+		WithColorMode(dagger.PdfColorModeMono).
+		WithScaleTo(500).
+		WithoutAnnotations()
+
+	for _, format := range []struct {
+		name string
+		ext  string
+		dir  *dagger.Directory
+	}{
+		{"Svg", "svg", conv.Svg()},
+		{"Eps", "eps", conv.Eps()},
+		{"Html", "html", conv.HTML()},
+	} {
+		got, err := format.dir.Entries(ctx)
+		if err != nil {
+			return fmt.Errorf("%s with raster-only settings: %w", format.name, err)
+		}
+		if !slices.Contains(got, "page-0001."+format.ext) {
+			return fmt.Errorf("%s: expected page-0001.%s, got %v", format.name, format.ext, got)
+		}
+	}
+
+	if _, err := conv.Ps().Contents(ctx); err != nil {
+		return fmt.Errorf("Ps with raster-only settings: %w", err)
+	}
+
+	// A resolution that cannot mean anything is still refused, because that one
+	// does reach the tool. Left to poppler it arrives as a complaint about `-r`,
+	// which names a flag the caller never wrote.
+	if _, err := conv.WithDpi(0).Svg().Entries(ctx); err == nil {
+		return fmt.Errorf("expected Svg to reject a zero dpi")
+	} else {
+		for _, want := range []string{"WithDpi", "dpi", "positive"} {
+			if !strings.Contains(err.Error(), want) {
+				return fmt.Errorf("expected the rejection to mention %q, got: %v", want, err)
+			}
+		}
+	}
+	return nil
+}
+
+// imageEntries picks the extracted images out of an Html directory's listing.
+//
+// They are everything that is not a page, and they keep pdftohtml's own names
+// rather than the page contract's: the names are written into the markup that
+// references them, so renaming them would mean rewriting the markup.
+func imageEntries(entries []string) []string {
+	var images []string
+	for _, e := range entries {
+		if !strings.HasSuffix(e, ".html") {
+			images = append(images, e)
+		}
+	}
+	return images
+}
+
+// head is the first part of a file, for an error message that has to quote what
+// it read without pasting a whole rendered page into the log.
+func head(s string) string {
+	const limit = 400
+	if len(s) <= limit {
+		return s
+	}
+	return s[:limit] + "…"
 }
 
 // VersionReportsPopplerRelease asserts Version reports the poppler release the
@@ -894,6 +1248,22 @@ func (t *Tests) EncryptedDocumentNeedsThePassword(ctx context.Context) error {
 	for _, want := range []string{"encrypted", "no password was supplied", "WithUserPassword"} {
 		if !strings.Contains(err.Error(), want) {
 			return fmt.Errorf("expected the refusal to mention %q, got: %v", want, err)
+		}
+	}
+
+	// The per-page formats reach poppler by a different route than PageCount
+	// does — they resolve the document's page count inside the same exec that
+	// renders, from a shell rather than from Go — and an encrypted document has
+	// to be refused just as clearly along it. Without this the whole per-page
+	// family's encryption behaviour would rest on the raster path's assertion,
+	// which does not exercise that shell at all.
+	_, err = pdf().Document(encrypted).Convert().Svg().Entries(ctx)
+	if err == nil {
+		return fmt.Errorf("expected Svg on an encrypted document to be refused without a password")
+	}
+	for _, want := range []string{"encrypted", "no password was supplied"} {
+		if !strings.Contains(err.Error(), want) {
+			return fmt.Errorf("expected Svg's refusal to mention %q, got: %v", want, err)
 		}
 	}
 


### PR DESCRIPTION
Brings `pdftocairo` and `pdftohtml` into the `pdf` module alongside the
`pdftoppm` raster family, as four new outputs on `Convert`:

```go
Convert.Svg(ctx)  (*dagger.Directory, error)  // page-NNNN.svg
Convert.Eps(ctx)  (*dagger.Directory, error)  // page-NNNN.eps
Convert.Ps(ctx)   (*dagger.File, error)
Convert.Html(ctx) (*dagger.Directory, error)  // page-NNNN.html + its images
```

## What the probes found

The issue asked for `pdftocairo`'s multi-page behaviour to be confirmed rather
than assumed. Measured against poppler 25.12 (what the pinned Alpine tag ships):

| invocation | result |
| --- | --- |
| `pdftocairo -eps` multi-page | writes **nothing**, exit 99: `EPS files can only contain one page.` |
| `pdftocairo -svg` multi-page | **one** file wrapping every page in the SVG 1.2 `<pageSet>`/`<page>` elements — no page lost, but no browser, librsvg or Inkscape implements them, so it draws page one and discards the rest |
| `pdftocairo -ps` multi-page | one document, `%%Pages: 12` + a `%%Page:` per page |
| `-scale-to` / `-mono` / `-gray` on `-svg` | exit 99, `may only be used with the -png, -jpeg, or -tiff output options` |
| `-hide-annotations` on `pdftocairo` | does not exist |
| `pdftohtml` | writes the **output path it was given** into every `<img src>` |

So `Svg`, `Eps` and `Html` drive the page loop themselves — one invocation per
page, naming their own output to the `page-NNNN.<ext>` contract. `Ps` alone
returns a `*dagger.File`, PostScript being a multi-page format whose one-page
fragments would each be invalid.

The loop's upper bound (an open-ended `WithPageRange`, or no range at all) is
resolved from `pdfinfo` **inside the same exec** that renders, so a conversion
stays one exec the way the raster path's rename pass does.

## Two decisions worth reviewing

**`Html` runs with the output directory as its working directory.** Handed an
absolute output base — the obvious way to write into a staging directory —
`pdftohtml` emits markup whose images resolve only on the machine that rendered
them, while still passing every assertion about entry names. Its extracted
images keep `pdftohtml`'s own names (`page-0001-1_1.png`), because those names
are written *into* the markup that references them; renaming them to the page
contract would mean rewriting the HTML. The directory therefore holds more than
pages, and that is documented on the function and in the README.

**`WithColorMode`, `WithScaleTo` and `WithoutAnnotations` are documented no-ops
for all four**, matching the existing posture on `Text`/`Txt`. That is
load-bearing rather than tidy: poppler does not ignore those flags, it exits 99
having written nothing — so forwarding them would break "render this as PNG for
OCR and as SVG for the web view" off one `Convert`. `WithDpi` does reach
`pdftocairo` (it governs rasterized regions a vector output can still contain)
and is still rejected when non-positive.

## Acceptance criteria

- [x] `Svg`, `Eps`, `Ps` and `Html` exist on `Convert` and appear in `dagger functions`
- [x] Multi-page behaviour confirmed and return types match it; asserted by page count and by the absence of a `<pageSet>`
- [x] Directory-returning formats honour `page-NNNN.<ext>`
- [x] `Svg` output carries `<path>` and no `<image>`
- [x] `Html` output carries the page markup and its extracted images, referenced relatively
- [x] `WithPageRange` narrows every new format — span, single page and open-ended
- [x] No `+cache=` directive added

## Tests

Six new tests, plus an encryption assertion along the new page-count path (the
per-page family reaches poppler from a shell rather than from Go, so it does not
inherit the raster path's coverage). `dagger -m daggerverse/pdf/tests call all`
is green at 26 tests; `dagger -m ci call generated` is green.

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)