### PR TITLE
story(issue-268): report a PDF's fonts, metadata and signatures

### DIFF
--- a/ci/internal/dagger/pdf-tests.gen.go
+++ b/ci/internal/dagger/pdf-tests.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type PdfTests
-func (r *Binding) AsPdfTests() *PdfTests { // pdf-tests (../../../daggerverse/pdf/tests/main.go:120:6)
+func (r *Binding) AsPdfTests() *PdfTests { // pdf-tests (../../../daggerverse/pdf/tests/main.go:150:6)
 	q := r.query.Select("asPdfTests")
 
 	return &PdfTests{
@@ -19,7 +19,7 @@ func (r *Binding) AsPdfTests() *PdfTests { // pdf-tests (../../../daggerverse/pd
 }
 
 // Create or update a binding of type PdfTests in the environment
-func (r *Env) WithPdfTestsInput(name string, value *PdfTests, description string) *Env { // pdf-tests (../../../daggerverse/pdf/tests/main.go:120:6)
+func (r *Env) WithPdfTestsInput(name string, value *PdfTests, description string) *Env { // pdf-tests (../../../daggerverse/pdf/tests/main.go:150:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withPdfTestsInput")
 	q = q.Arg("name", name)
@@ -32,7 +32,7 @@ func (r *Env) WithPdfTestsInput(name string, value *PdfTests, description string
 }
 
 // Declare a desired PdfTests output to be assigned in the environment
-func (r *Env) WithPdfTestsOutput(name string, description string) *Env { // pdf-tests (../../../daggerverse/pdf/tests/main.go:120:6)
+func (r *Env) WithPdfTestsOutput(name string, description string) *Env { // pdf-tests (../../../daggerverse/pdf/tests/main.go:150:6)
 	q := r.query.Select("withPdfTestsOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -42,39 +42,44 @@ func (r *Env) WithPdfTestsOutput(name string, description string) *Env { // pdf-
 	}
 }
 
-type PdfTests struct { // pdf-tests (../../../daggerverse/pdf/tests/main.go:120:6)
+type PdfTests struct { // pdf-tests (../../../daggerverse/pdf/tests/main.go:150:6)
 	query *querybuilder.Selection
 
-	all                                          *Void
-	colorModesProduceDifferentPixels             *Void
-	containerCarriesEveryPopplerBinaryAndTheFont *Void
-	disablePageBreaksControlsFormFeeds           *Void
-	dpiDefaultsToOneFiftyAndScalesWithTheSetting *Void
-	encryptedDocumentNeedsThePassword            *Void
-	epsWritesEveryPageOfTheDocument              *Void
-	htmlCarriesPageMarkupAndItsImages            *Void
-	id                                           *ID
-	infoReportsPageCountAndSize                  *Void
-	jpegAndTiffFollowTheSameContract             *Void
-	layoutModesProduceDifferentOrderings         *Void
-	pageRangeNarrowsEveryPerPageFormat           *Void
-	pageRangeNarrowsText                         *Void
-	pageRangeOpenEndedRunsToTheLastPage          *Void
-	pageRangeRejectsInvalidBounds                *Void
-	pngNamesEveryPageWithFourDigits              *Void
-	pngNarrowedRangeKeepsFourDigitNames          *Void
-	pngSinglePageIsStillNumbered                 *Void
-	psHoldsEveryPageInOneFile                    *Void
-	renderSettingsRejectNonPositiveValues        *Void
-	scaleToOverridesDpi                          *Void
-	svgWritesOneVectorFilePerPage                *Void
-	textOnImageOnlyPdfReturnsNothing             *Void
-	textReproducesTextLayerExactly               *Void
-	txtMatchesText                               *Void
-	vectorFormatsIgnoreRasterOnlySettings        *Void
-	versionReportsPopplerRelease                 *Void
-	withFontsPutsFaceWhereFontconfigFindsIt      *Void
-	withoutAnnotationsRemovesTheAnnotationLayer  *Void
+	all                                                 *Void
+	colorModesProduceDifferentPixels                    *Void
+	containerCarriesEveryPopplerBinaryAndTheFont        *Void
+	disablePageBreaksControlsFormFeeds                  *Void
+	dpiDefaultsToOneFiftyAndScalesWithTheSetting        *Void
+	encryptedDocumentNeedsThePassword                   *Void
+	epsWritesEveryPageOfTheDocument                     *Void
+	fontsNarrowsToThePageRange                          *Void
+	fontsReportsWhetherEachFaceIsEmbedded               *Void
+	htmlCarriesPageMarkupAndItsImages                   *Void
+	id                                                  *ID
+	infoReportsPageCountAndSize                         *Void
+	jpegAndTiffFollowTheSameContract                    *Void
+	layoutModesProduceDifferentOrderings                *Void
+	metadataReturnsTheXmpPacketOrSaysThereIsNone        *Void
+	pageRangeNarrowsEveryPerPageFormat                  *Void
+	pageRangeNarrowsText                                *Void
+	pageRangeOpenEndedRunsToTheLastPage                 *Void
+	pageRangeRejectsInvalidBounds                       *Void
+	pngNamesEveryPageWithFourDigits                     *Void
+	pngNarrowedRangeKeepsFourDigitNames                 *Void
+	pngSinglePageIsStillNumbered                        *Void
+	psHoldsEveryPageInOneFile                           *Void
+	renderSettingsRejectNonPositiveValues               *Void
+	reportsOpenAnEncryptedDocumentWithThePassword       *Void
+	scaleToOverridesDpi                                 *Void
+	signaturesReportsAnUnsignedDocumentInsteadOfFailing *Void
+	svgWritesOneVectorFilePerPage                       *Void
+	textOnImageOnlyPdfReturnsNothing                    *Void
+	textReproducesTextLayerExactly                      *Void
+	txtMatchesText                                      *Void
+	vectorFormatsIgnoreRasterOnlySettings               *Void
+	versionReportsPopplerRelease                        *Void
+	withFontsPutsFaceWhereFontconfigFindsIt             *Void
+	withoutAnnotationsRemovesTheAnnotationLayer         *Void
 }
 
 func (r *PdfTests) WithGraphQLQuery(q *querybuilder.Selection) *PdfTests {
@@ -88,7 +93,7 @@ type PdfTestsAllOpts struct {
 	//
 	// Maximum number of tests to run concurrently. Zero fans out unbounded.
 	//
-	Parallel int // pdf-tests (../../../daggerverse/pdf/tests/main.go:136:2)
+	Parallel int // pdf-tests (../../../daggerverse/pdf/tests/main.go:166:2)
 }
 
 // All runs every pdf-module test in parallel.
@@ -99,7 +104,7 @@ type PdfTestsAllOpts struct {
 // are single-threaded: twenty of them contend for cores the way any other
 // oversubscribed workload does. The cap stays available for a host that wants a
 // narrower slice.
-func (r *PdfTests) All(ctx context.Context, opts ...PdfTestsAllOpts) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:132:1)
+func (r *PdfTests) All(ctx context.Context, opts ...PdfTestsAllOpts) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:162:1)
 	if r.all != nil {
 		return nil
 	}
@@ -126,7 +131,7 @@ func (r *PdfTests) All(ctx context.Context, opts ...PdfTestsAllOpts) error { // 
 // The three properties are mutually exclusive by construction: colour keeps
 // chroma, grey drops chroma but keeps mid-tones, and mono drops both — flat tones
 // are dithered into black and white rather than averaged into grey.
-func (r *PdfTests) ColorModesProduceDifferentPixels(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1098:1)
+func (r *PdfTests) ColorModesProduceDifferentPixels(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1419:1)
 	if r.colorModesProduceDifferentPixels != nil {
 		return nil
 	}
@@ -143,7 +148,7 @@ func (r *PdfTests) ColorModesProduceDifferentPixels(ctx context.Context) error {
 // nothing to substitute for a PDF that names a base-14 face without embedding
 // it, and renders the page blank while exiting 0 — a silent wrong answer, which
 // is the failure mode this assertion exists to keep out.
-func (r *PdfTests) ContainerCarriesEveryPopplerBinaryAndTheFont(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:566:1)
+func (r *PdfTests) ContainerCarriesEveryPopplerBinaryAndTheFont(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:601:1)
 	if r.containerCarriesEveryPopplerBinaryAndTheFont != nil {
 		return nil
 	}
@@ -159,7 +164,7 @@ func (r *PdfTests) ContainerCarriesEveryPopplerBinaryAndTheFont(ctx context.Cont
 // defaulting to true because a `Go SDK — the zero value is dropped before it reaches the API — so the
 // affirmative spelling would have produced an option no caller could turn off.
 // That makes the second half of this test the one that would have caught it.
-func (r *PdfTests) DisablePageBreaksControlsFormFeeds(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:815:1)
+func (r *PdfTests) DisablePageBreaksControlsFormFeeds(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1136:1)
 	if r.disablePageBreaksControlsFormFeeds != nil {
 		return nil
 	}
@@ -175,7 +180,7 @@ func (r *PdfTests) DisablePageBreaksControlsFormFeeds(ctx context.Context) error
 // remembered pixel count, so the assertion says "150 dpi of a US Letter page"
 // rather than "1275 by 1650" — which is the claim the documentation actually
 // makes.
-func (r *PdfTests) DpiDefaultsToOneFiftyAndScalesWithTheSetting(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:997:1)
+func (r *PdfTests) DpiDefaultsToOneFiftyAndScalesWithTheSetting(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1318:1)
 	if r.dpiDefaultsToOneFiftyAndScalesWithTheSetting != nil {
 		return nil
 	}
@@ -199,7 +204,7 @@ func (r *PdfTests) DpiDefaultsToOneFiftyAndScalesWithTheSetting(ctx context.Cont
 // poppler alike through the environment rather than argv: a password in argv is
 // visible in every Dagger trace, which is exactly what the module's own posture
 // avoids.
-func (r *PdfTests) EncryptedDocumentNeedsThePassword(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1223:1)
+func (r *PdfTests) EncryptedDocumentNeedsThePassword(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1544:1)
 	if r.encryptedDocumentNeedsThePassword != nil {
 		return nil
 	}
@@ -221,11 +226,53 @@ func (r *PdfTests) EncryptedDocumentNeedsThePassword(ctx context.Context) error 
 // Each file is then checked to be an EPS in its own right — the EPSF version
 // header, and exactly one page in it — because a loop that wrote twelve copies
 // of page one would satisfy the names alone.
-func (r *PdfTests) EpsWritesEveryPageOfTheDocument(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:242:1)
+func (r *PdfTests) EpsWritesEveryPageOfTheDocument(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:277:1)
 	if r.epsWritesEveryPageOfTheDocument != nil {
 		return nil
 	}
 	q := r.query.Select("epsWritesEveryPageOfTheDocument")
+
+	return q.Execute(ctx)
+}
+
+// FontsNarrowsToThePageRange asserts WithPageRange reaches pdffonts, and that a
+// range it cannot honour is refused the way every other one is.
+//
+// Which faces a document needs is a question about pages, so this is not a
+// cosmetic option: a report of pages 1 through 3 that listed a face used only on
+// page 40 would say the render depends on a font it does not, and one that
+// dropped a face used on page 2 would say the opposite. fontsPdf is built for
+// it, its two pages naming different faces, because narrowing a report of
+// ledgerPdf — every page of which names the same Helvetica — changes nothing at
+// all and would pass against a module that ignored the bounds entirely.
+func (r *PdfTests) FontsNarrowsToThePageRange(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:761:1)
+	if r.fontsNarrowsToThePageRange != nil {
+		return nil
+	}
+	q := r.query.Select("fontsNarrowsToThePageRange")
+
+	return q.Execute(ctx)
+}
+
+// FontsReportsWhetherEachFaceIsEmbedded asserts Fonts surfaces pdffonts' table
+// and that the `emb` column in it says what it is supposed to say.
+//
+// ledgerPdf is the shape the module's font install exists for: its pages name
+// Helvetica without embedding it, so poppler has to ask fontconfig for a
+// substitute, and with no font installed there is nothing to substitute — the
+// page renders blank and the command exits 0. `Helvetica … no` is what that
+// silent failure looks like before it happens, which is the whole reason a
+// pipeline asks for this report.
+//
+// fontsPdf carries the other half of the column. Its Type 3 font is embedded by
+// construction, so the report has to read `yes` for it; without that contrast
+// the assertion would pass just as well on a report that said `no` about
+// everything, including one produced by a module that had hardcoded the answer.
+func (r *PdfTests) FontsReportsWhetherEachFaceIsEmbedded(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:706:1)
+	if r.fontsReportsWhetherEachFaceIsEmbedded != nil {
+		return nil
+	}
+	q := r.query.Select("fontsReportsWhetherEachFaceIsEmbedded")
 
 	return q.Execute(ctx)
 }
@@ -244,7 +291,7 @@ func (r *PdfTests) EpsWritesEveryPageOfTheDocument(ctx context.Context) error { 
 //
 // Two fixtures are needed because no one page is both: ledger.pdf is text and no
 // images, scan.pdf is one image and no text.
-func (r *PdfTests) HTMLCarriesPageMarkupAndItsImages(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:334:1)
+func (r *PdfTests) HTMLCarriesPageMarkupAndItsImages(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:369:1)
 	if r.htmlCarriesPageMarkupAndItsImages != nil {
 		return nil
 	}
@@ -309,7 +356,7 @@ func (r *PdfTests) UnmarshalJSON(bs []byte) error {
 // first: PageCount parses Info's `Pages:` line, so a change to how Info is
 // captured that broke the parse would otherwise show up only in whatever used
 // PageCount next.
-func (r *PdfTests) InfoReportsPageCountAndSize(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:630:1)
+func (r *PdfTests) InfoReportsPageCountAndSize(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:665:1)
 	if r.infoReportsPageCountAndSize != nil {
 		return nil
 	}
@@ -325,7 +372,7 @@ func (r *PdfTests) InfoReportsPageCountAndSize(ctx context.Context) error { // p
 // `-jpeg` writes `.jpg` and `-tiff` writes `.tif`, which are poppler's spellings
 // and not this module's: a caller building a path from the function's name would
 // get them wrong, so they are part of the documented contract.
-func (r *PdfTests) JpegAndTiffFollowTheSameContract(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1173:1)
+func (r *PdfTests) JpegAndTiffFollowTheSameContract(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1494:1)
 	if r.jpegAndTiffFollowTheSameContract != nil {
 		return nil
 	}
@@ -345,11 +392,35 @@ func (r *PdfTests) JpegAndTiffFollowTheSameContract(ctx context.Context) error {
 // physical layout puts the two columns side by side on one output line. A fixture
 // whose stream order matched its reading order would let two of these three pass
 // on the same output.
-func (r *PdfTests) LayoutModesProduceDifferentOrderings(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:852:1)
+func (r *PdfTests) LayoutModesProduceDifferentOrderings(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1173:1)
 	if r.layoutModesProduceDifferentOrderings != nil {
 		return nil
 	}
 	q := r.query.Select("layoutModesProduceDifferentOrderings")
+
+	return q.Execute(ctx)
+}
+
+// MetadataReturnsTheXmpPacketOrSaysThereIsNone asserts both halves of what
+// Metadata answers, because the interesting one is the absence.
+//
+// The packet is asserted to be the packet and not pdfinfo's ordinary report of
+// the same document: `pdfinfo -meta` prints the XMP alone, so a module that
+// dropped the flag would return a report that still mentions a title and still
+// looks like metadata. metadataPdf's Info dictionary carries a deliberately
+// different title for exactly that reason — the wrong one showing up is what
+// makes the substitution visible.
+//
+// The absence is the half that needs a decision. poppler prints nothing at all
+// and exits 0 for a document with no XMP, and an empty string is
+// indistinguishable from a function that did not run, so the module answers with
+// a line naming the absence and pointing at the report that does carry the
+// document's metadata.
+func (r *PdfTests) MetadataReturnsTheXmpPacketOrSaysThereIsNone(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:823:1)
+	if r.metadataReturnsTheXmpPacketOrSaysThereIsNone != nil {
+		return nil
+	}
+	q := r.query.Select("metadataReturnsTheXmpPacketOrSaysThereIsNone")
 
 	return q.Execute(ctx)
 }
@@ -368,7 +439,7 @@ func (r *PdfTests) LayoutModesProduceDifferentOrderings(ctx context.Context) err
 // the range, which is why pages 4 through 6 come out `page-0004` through
 // `page-0006` — the same promise the raster contract makes, so a page stays
 // traceable to the page it came from whichever format it was rendered to.
-func (r *PdfTests) PageRangeNarrowsEveryPerPageFormat(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:411:1)
+func (r *PdfTests) PageRangeNarrowsEveryPerPageFormat(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:446:1)
 	if r.pageRangeNarrowsEveryPerPageFormat != nil {
 		return nil
 	}
@@ -380,7 +451,7 @@ func (r *PdfTests) PageRangeNarrowsEveryPerPageFormat(ctx context.Context) error
 // PageRangeNarrowsText asserts WithPageRange narrows extraction to the pages it
 // names, and that the bounds are the 1-based inclusive ones poppler uses rather
 // than an offset and a length.
-func (r *PdfTests) PageRangeNarrowsText(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:737:1)
+func (r *PdfTests) PageRangeNarrowsText(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1058:1)
 	if r.pageRangeNarrowsText != nil {
 		return nil
 	}
@@ -392,7 +463,7 @@ func (r *PdfTests) PageRangeNarrowsText(ctx context.Context) error { // pdf-test
 // PageRangeOpenEndedRunsToTheLastPage asserts a zero last means "to the end",
 // which is the only way to name an open-ended range without first asking how
 // many pages the document has.
-func (r *PdfTests) PageRangeOpenEndedRunsToTheLastPage(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:756:1)
+func (r *PdfTests) PageRangeOpenEndedRunsToTheLastPage(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1077:1)
 	if r.pageRangeOpenEndedRunsToTheLastPage != nil {
 		return nil
 	}
@@ -408,7 +479,7 @@ func (r *PdfTests) PageRangeOpenEndedRunsToTheLastPage(ctx context.Context) erro
 // renders nothing for them and exits 0, so a caller who asked for page 20 of a
 // 12-page document would otherwise get an empty result indistinguishable from a
 // document with no text in it.
-func (r *PdfTests) PageRangeRejectsInvalidBounds(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:779:1)
+func (r *PdfTests) PageRangeRejectsInvalidBounds(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1100:1)
 	if r.pageRangeRejectsInvalidBounds != nil {
 		return nil
 	}
@@ -428,7 +499,7 @@ func (r *PdfTests) PageRangeRejectsInvalidBounds(ctx context.Context) error { //
 // has no way to know which width it is holding. Asserting the full ordered list
 // covers both halves of the promise: the names, and that lexicographic order is
 // page order.
-func (r *PdfTests) PngNamesEveryPageWithFourDigits(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:924:1)
+func (r *PdfTests) PngNamesEveryPageWithFourDigits(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1245:1)
 	if r.pngNamesEveryPageWithFourDigits != nil {
 		return nil
 	}
@@ -448,7 +519,7 @@ func (r *PdfTests) PngNamesEveryPageWithFourDigits(ctx context.Context) error { 
 // The numbers are the source document's page numbers and not positions within
 // the range, which is why the second case starts at `page-0004.png`. That keeps a
 // rendered page traceable back to the page it came from.
-func (r *PdfTests) PngNarrowedRangeKeepsFourDigitNames(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:943:1)
+func (r *PdfTests) PngNarrowedRangeKeepsFourDigitNames(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1264:1)
 	if r.pngNarrowedRangeKeepsFourDigitNames != nil {
 		return nil
 	}
@@ -466,7 +537,7 @@ func (r *PdfTests) PngNarrowedRangeKeepsFourDigitNames(ctx context.Context) erro
 // document keeps the longer document's width. A consumer globbing for
 // `page-*.png` finds nothing in the first case and a caller indexing by name
 // finds the wrong file in the second.
-func (r *PdfTests) PngSinglePageIsStillNumbered(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:970:1)
+func (r *PdfTests) PngSinglePageIsStillNumbered(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1291:1)
 	if r.pngSinglePageIsStillNumbered != nil {
 		return nil
 	}
@@ -483,7 +554,7 @@ func (r *PdfTests) PngSinglePageIsStillNumbered(ctx context.Context) error { // 
 // directory of one-page fragments would be the wrong answer even though it would
 // look tidier beside Svg and Eps. Counting the markers is what says the pages
 // reached the file rather than only the header saying they did.
-func (r *PdfTests) PsHoldsEveryPageInOneFile(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:291:1)
+func (r *PdfTests) PsHoldsEveryPageInOneFile(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:326:1)
 	if r.psHoldsEveryPageInOneFile != nil {
 		return nil
 	}
@@ -497,11 +568,32 @@ func (r *PdfTests) PsHoldsEveryPageInOneFile(ctx context.Context) error { // pdf
 //
 // Left to poppler these arrive much later as a complaint about `-r` or
 // `-scale-to`, which names a flag the caller never wrote.
-func (r *PdfTests) RenderSettingsRejectNonPositiveValues(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1060:1)
+func (r *PdfTests) RenderSettingsRejectNonPositiveValues(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1381:1)
 	if r.renderSettingsRejectNonPositiveValues != nil {
 		return nil
 	}
 	q := r.query.Select("renderSettingsRejectNonPositiveValues")
+
+	return q.Execute(ctx)
+}
+
+// ReportsOpenAnEncryptedDocumentWithThePassword asserts the document's password
+// reaches all three reporting tools, and that each says the same thing without
+// one.
+//
+// Each tool opens the document itself, so none of this follows from extraction
+// or rendering already working: a password threaded into pdftotext's invocation
+// and not into pdffonts' produces a module where a report on an encrypted
+// document fails while everything else about it succeeds. Both branches are
+// asserted for each, because the refusal is the half a caller reads — poppler
+// reports every wrong password as `Incorrect password` whether one was supplied
+// or not, so the message has to distinguish what the module knows and poppler
+// does not.
+func (r *PdfTests) ReportsOpenAnEncryptedDocumentWithThePassword(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:899:1)
+	if r.reportsOpenAnEncryptedDocumentWithThePassword != nil {
+		return nil
+	}
+	q := r.query.Select("reportsOpenAnEncryptedDocumentWithThePassword")
 
 	return q.Execute(ctx)
 }
@@ -513,11 +605,34 @@ func (r *PdfTests) RenderSettingsRejectNonPositiveValues(ctx context.Context) er
 // resolution flag off the command line rather than by relying on poppler's own
 // precedence, so this is the assertion that would catch the two being emitted
 // together and whichever poppler happened to prefer winning silently.
-func (r *PdfTests) ScaleToOverridesDpi(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1029:1)
+func (r *PdfTests) ScaleToOverridesDpi(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1350:1)
 	if r.scaleToOverridesDpi != nil {
 		return nil
 	}
 	q := r.query.Select("scaleToOverridesDpi")
+
+	return q.Execute(ctx)
+}
+
+// SignaturesReportsAnUnsignedDocumentInsteadOfFailing asserts the case almost
+// every document is: no signatures, reported as a result.
+//
+// It is the assertion the function's exit-code handling exists for. pdfsig exits
+// 2 for a document carrying no signatures, having printed exactly what it found,
+// and the module's usual treatment of a non-zero exit — an error naming the
+// failure — would turn the ordinary answer to an ordinary question into a broken
+// pipeline. Reserving failure for the runs that failed is what makes this
+// callable on documents whose signing status is what the caller is asking about.
+//
+// The NSS check is the other half. pdfsig writes `NSS_Init failed` to stderr in
+// an image carrying no certificate database, which is every image this module
+// builds, and a report assembled from both streams would carry that line into
+// every caller's output as though it were something the document said.
+func (r *PdfTests) SignaturesReportsAnUnsignedDocumentInsteadOfFailing(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:873:1)
+	if r.signaturesReportsAnUnsignedDocumentInsteadOfFailing != nil {
+		return nil
+	}
+	q := r.query.Select("signaturesReportsAnUnsignedDocumentInsteadOfFailing")
 
 	return q.Execute(ctx)
 }
@@ -537,7 +652,7 @@ func (r *PdfTests) ScaleToOverridesDpi(ctx context.Context) error { // pdf-tests
 // anywhere. Poppler converts text to glyph outlines rather than to `<text>`, so
 // the marker words are not in the file at all — a Contains check for one would
 // fail on a perfectly good SVG.
-func (r *PdfTests) SvgWritesOneVectorFilePerPage(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:199:1)
+func (r *PdfTests) SvgWritesOneVectorFilePerPage(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:234:1)
 	if r.svgWritesOneVectorFilePerPage != nil {
 		return nil
 	}
@@ -556,7 +671,7 @@ func (r *PdfTests) SvgWritesOneVectorFilePerPage(ctx context.Context) error { //
 // a caller gets that this document needs rasterizing and handing to OCR. A
 // module that failed here instead would make the two paths impossible to choose
 // between programmatically.
-func (r *PdfTests) TextOnImageOnlyPdfReturnsNothing(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:687:1)
+func (r *PdfTests) TextOnImageOnlyPdfReturnsNothing(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1008:1)
 	if r.textOnImageOnlyPdfReturnsNothing != nil {
 		return nil
 	}
@@ -574,7 +689,7 @@ func (r *PdfTests) TextOnImageOnlyPdfReturnsNothing(ctx context.Context) error {
 // leading newline, pages in the wrong order — is a defect and not a recognition
 // error. A fixture whose content streams are readable is what makes an exact
 // expectation writable at all.
-func (r *PdfTests) TextReproducesTextLayerExactly(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:666:1)
+func (r *PdfTests) TextReproducesTextLayerExactly(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:987:1)
 	if r.textReproducesTextLayerExactly != nil {
 		return nil
 	}
@@ -590,7 +705,7 @@ func (r *PdfTests) TextReproducesTextLayerExactly(ctx context.Context) error { /
 // straight off the handle: the point of Txt is that the bytes reach a filesystem
 // intact, and File.Contents would confirm the engine's copy while saying nothing
 // about the export a real consumer performs.
-func (r *PdfTests) TxtMatchesText(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:710:1)
+func (r *PdfTests) TxtMatchesText(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1031:1)
 	if r.txtMatchesText != nil {
 		return nil
 	}
@@ -612,7 +727,7 @@ func (r *PdfTests) TxtMatchesText(ctx context.Context) error { // pdf-tests (../
 //
 // WithDpi is the one setting that does reach pdftocairo, and it is set here too
 // so this is not accidentally asserting that no flags are passed at all.
-func (r *PdfTests) VectorFormatsIgnoreRasterOnlySettings(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:461:1)
+func (r *PdfTests) VectorFormatsIgnoreRasterOnlySettings(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:496:1)
 	if r.vectorFormatsIgnoreRasterOnlySettings != nil {
 		return nil
 	}
@@ -630,7 +745,7 @@ func (r *PdfTests) VectorFormatsIgnoreRasterOnlySettings(ctx context.Context) er
 // exact patch: Alpine may rebuild poppler-utils within the v3.24 branch, and a
 // test that pins the patch level would fail on a change this module has no
 // opinion about.
-func (r *PdfTests) VersionReportsPopplerRelease(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:540:1)
+func (r *PdfTests) VersionReportsPopplerRelease(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:575:1)
 	if r.versionReportsPopplerRelease != nil {
 		return nil
 	}
@@ -648,7 +763,7 @@ func (r *PdfTests) VersionReportsPopplerRelease(ctx context.Context) error { // 
 // module installs, so the negative control is real — the plain image genuinely
 // cannot see it, and the assertion is not passing on something the base image
 // already had.
-func (r *PdfTests) WithFontsPutsFaceWhereFontconfigFindsIt(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:600:1)
+func (r *PdfTests) WithFontsPutsFaceWhereFontconfigFindsIt(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:635:1)
 	if r.withFontsPutsFaceWhereFontconfigFindsIt != nil {
 		return nil
 	}
@@ -664,7 +779,7 @@ func (r *PdfTests) WithFontsPutsFaceWhereFontconfigFindsIt(ctx context.Context) 
 // a render of it is the annotation's appearance stream and nothing else. Without
 // that separation the assertion could not tell an annotation that was not drawn
 // from one that was drawn somewhere else on the page.
-func (r *PdfTests) WithoutAnnotationsRemovesTheAnnotationLayer(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1140:1)
+func (r *PdfTests) WithoutAnnotationsRemovesTheAnnotationLayer(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1461:1)
 	if r.withoutAnnotationsRemovesTheAnnotationLayer != nil {
 		return nil
 	}
@@ -689,7 +804,7 @@ func (r *PdfTests) AsNode() Node {
 // streams are uncompressed, so the text a page is supposed to render is readable
 // in the fixture itself and an assertion about it can be checked against the
 // PDF rather than against another tool's opinion of the PDF.
-func (r *Query) PdfTests() *PdfTests { // pdf-tests (../../../daggerverse/pdf/tests/main.go:120:6)
+func (r *Query) PdfTests() *PdfTests { // pdf-tests (../../../daggerverse/pdf/tests/main.go:150:6)
 	q := r.query.Select("pdfTests")
 
 	return &PdfTests{

--- a/daggerverse/pdf/README.md
+++ b/daggerverse/pdf/README.md
@@ -8,7 +8,8 @@ size you choose, in colour, grayscale or bilevel. Keep the type outlines instead
 and it gives you SVG, EPS or PostScript; ask for markup and it gives you HTML
 with the page's images beside it. Ask it what the document is and it tells you:
 page count, page size, PDF version, whether it is encrypted and under which
-algorithm.
+algorithm, which fonts it needs and whether they are embedded, what its XMP
+metadata says, and whether its signatures check out.
 
 **There is no official poppler container image**, so this module assembles its
 own the way `tesseract` and `qemu` do rather than pinning a vendor image the way
@@ -137,11 +138,12 @@ Pdf.Version(ctx) (string, error)
 ```
 
 `Container` is the escape hatch. poppler-utils ships **thirteen** binaries and
-this module wraps three of them — `pdftotext`, `pdftoppm` and `pdfinfo` — so
-`pdfimages`, `pdfseparate`, `pdfunite`, `pdfsig`, `pdffonts`, `pdftocairo`,
-`pdftohtml`, `pdftops`, `pdfattach` and `pdfdetach` stay reachable via
-`container with-exec` until they get wrapped too (see
-[Follow-ups](#follow-ups)).
+this module wraps seven of them — `pdftotext`, `pdftoppm`, `pdfinfo`,
+`pdftocairo`, `pdftohtml`, `pdffonts` and `pdfsig` — so `pdfimages`,
+`pdfseparate`, `pdfunite`, `pdftops`, `pdfattach` and `pdfdetach` stay reachable
+via `container with-exec` until they get wrapped too (see
+[Follow-ups](#follow-ups)). So do the flags of a wrapped tool that this module
+does not surface, `pdffonts -subst` among them.
 
 `Version` reads **stderr**, not stdout: poppler's tools print their version
 banner on stderr and still exit 0, so a module reading stdout would report the
@@ -157,6 +159,9 @@ Document.WithOwnerPassword(password *dagger.Secret) *Document
 Document.WithPageRange(first int, last int) *Document
 Document.Info(ctx) (string, error)
 Document.PageCount(ctx) (int, error)
+Document.Fonts(ctx) (string, error)
+Document.Metadata(ctx) (string, error)
+Document.Signatures(ctx) (string, error)
 Document.Convert() *Convert
 ```
 
@@ -177,7 +182,8 @@ body  := doc.WithPageRange(2, 0).Convert().WithDpi(300).Png()
 
 `Info` and `PageCount` describe the **document**, not a conversion of it, so
 `WithPageRange` does not narrow them. That is also what makes `PageCount` usable
-as the bound a range is validated against.
+as the bound a range is validated against. `Fonts`, `Metadata` and `Signatures`
+are the other three reports — see [The four reports](#the-four-reports).
 
 ### Passwords
 
@@ -228,6 +234,98 @@ document with no text in it.
 | `WithPageRange(5, 3)` | `last (3) must not precede first (5)` |
 | `WithPageRange(20, 0)` on 12 pages | `first (20) is past the end of the document, which has 12 pages` |
 | `WithPageRange(1, 13)` on 12 pages | `last (13) is past the end …` |
+
+## The four reports
+
+Four functions describe the document instead of converting it, one per poppler
+tool. Each returns its tool's report as text.
+
+| function | tool | page range | passwords |
+| --- | --- | --- | --- |
+| `Info` | `pdfinfo` | no — describes the document | yes |
+| `Fonts` | `pdffonts` | **yes** — which faces a document needs is a question about pages | yes |
+| `Metadata` | `pdfinfo -meta` | no — the packet is document-level | yes |
+| `Signatures` | `pdfsig` | no — a signature covers byte ranges, and the tool has no page bounds | yes |
+
+**They are not parsed, deliberately.** The formats are stable but wide, and a
+caller who wants one field can grep it out of these lines more cheaply than this
+module can model all of them. Structured values would mean four schemas to keep
+in step with poppler's output for no capability that grepping does not already
+have.
+
+### `Fonts` — the blank-page diagnostic, before the blank page
+
+```
+name                                 type              encoding         emb sub uni object ID
+------------------------------------ ----------------- ---------------- --- --- --- ---------
+Helvetica                            Type 1            WinAnsi          no  no  no       3  0
+```
+
+The `emb` column is the one to read, and it is the direct diagnostic for the
+failure [the font install](#the-font-is-not-decoration) exists to prevent: `no`
+means the file names that face without carrying it, so the render depends on the
+image's own fonts — the packaged family, or one supplied through `WithFonts`. Get
+that wrong and the page renders **blank while exiting 0**. This report is what
+that looks like beforehand.
+
+`WithPageRange` narrows it, because a face used only on page 40 is genuinely
+absent from a report of pages 1 through 3. Out-of-document bounds are rejected
+here the same way they are everywhere else — poppler would print the header and
+exit 0, which reads as a document that needs no fonts at all.
+
+Which substitute poppler would *actually* pick for an unembedded face is a
+different question, answered by `pdffonts -subst` through
+[`Container`](#toolchain).
+
+### `Metadata` — the XMP packet, not the Info dictionary
+
+`Metadata` returns the RDF/XML block a producer writes its own record of the
+document into, exactly as it sits in the file, ready for an XML parser. It is
+worth having next to `Info` because the two carry different things and disagree
+in the wild: `Info` reports the PDF's Info **dictionary**, whose handful of keys a
+producer may have left behind when it rewrote the XMP, and the packet is the
+record a downstream asset system reads.
+
+A document carrying **no** packet is not an error and does not come back empty.
+poppler prints nothing at all and exits 0 for that, and an empty string is
+indistinguishable from a function that never ran, so the module answers:
+
+```
+No XMP metadata: this document carries no XMP packet. Info reports the metadata in its Info dictionary.
+```
+
+### `Signatures` — reports, and does not gate
+
+An unsigned document — which is nearly every document — gets the report saying
+so, not a failure:
+
+```
+File '/work/source.pdf' does not contain any signatures
+```
+
+The path in it is where the module mounts the bound file, poppler naming the file
+it was handed; the report is otherwise `pdfsig`'s own, verbatim.
+
+That is the whole point of the function being callable on an arbitrary PDF: "is
+this signed, and does it check out" is asked *before* the answer is known, so the
+unsigned answer has to arrive as a result. It is also the one place this module
+reads a non-zero exit as a report — `pdfsig` exits **2** for it.
+
+It reports rather than gates. A signature that fails to validate comes back as a
+report saying `Signature Validation: Signature is Invalid.`, not as an error, and
+a caller that wants to stop on a bad signature reads the verdict out of the
+report. Only a run that produced no report at all — an unreadable file, a missing
+or wrong password — fails.
+
+> `pdfsig` overloads its exit codes: **1** is both "a signature did not validate",
+> having printed the whole report, and "could not open the document", having
+> printed nothing. The module therefore decides on what was *printed*, not on the
+> code.
+
+What the report can say about a signer's **certificate** is limited by the image
+and not by the document: chain validation needs a trust database, this image
+carries none, and `pdfsig` says so on stderr — which is not part of the report.
+Supply one with `-nssdir` through [`Container`](#toolchain).
 
 ## Convert — the render options and the nine outputs
 
@@ -502,8 +600,7 @@ about. Same posture as `tesseract`'s outputs and `kicad`.
 
 ## Follow-ups
 
-Reporting a document's fonts, metadata and signatures (#268);
-text-layer geometry as bbox HTML and TSV (#269); splitting and merging pages
+Text-layer geometry as bbox HTML and TSV (#269); splitting and merging pages
 (#270); extracting embedded images and attachments (#271); cropping the render
 window and selecting odd or even pages (#272); the chained `Ci` builder (#273);
 linearize, encrypt and repair via qpdf (#274); testing package assembly off a

--- a/daggerverse/pdf/dagger.gen.go
+++ b/daggerverse/pdf/dagger.gen.go
@@ -558,6 +558,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return (*Document).Convert(&parent), nil
+		case "Fonts":
+			var parent Document
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Document).Fonts(&parent, ctx)
 		case "Info":
 			var parent Document
 			err = json.Unmarshal(parentJSON, &parent)
@@ -565,6 +572,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return (*Document).Info(&parent, ctx)
+		case "Metadata":
+			var parent Document
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Document).Metadata(&parent, ctx)
 		case "PageCount":
 			var parent Document
 			err = json.Unmarshal(parentJSON, &parent)
@@ -572,6 +586,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return (*Document).PageCount(&parent, ctx)
+		case "Signatures":
+			var parent Document
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Document).Signatures(&parent, ctx)
 		case "WithOwnerPassword":
 			var parent Document
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/pdf/document.go
+++ b/daggerverse/pdf/document.go
@@ -147,6 +147,129 @@ func (d *Document) PageCount(ctx context.Context) (int, error) {
 	return count, nil
 }
 
+// Fonts returns what pdffonts reports about every face the document's pages
+// name: the face's name, its type, its encoding, whether it is embedded in the
+// file, whether it is a subset, whether it carries a ToUnicode map, and the
+// object it lives in.
+//
+// The `emb` column is the one to read. A PDF that names a font without
+// embedding one — the usual shape for anything not born as a scan — is drawn by
+// asking fontconfig for a substitute, and a substitute poppler cannot find is
+// not an error: the glyphs are simply absent from the rendered page and the
+// command exits 0. This report is what that failure looks like before it
+// happens, which makes it the diagnostic to reach for when a render comes out
+// blank or a face comes out wrong. `no` in that column means the render depends
+// on the image's own fonts — the packaged family, or one supplied through
+// WithFonts.
+//
+// The report is pdffonts' own table, verbatim. Parsing it into structured
+// values is deliberately not this module's job: the format is stable but wide,
+// and a caller who wants one column can read it out of these lines more cheaply
+// than this module can model all of them.
+//
+// WithPageRange narrows it, because which faces a document needs is a question
+// about pages: a face used only on page 40 is absent from a report of pages 1
+// through 3. Which substitute poppler would actually choose for an unembedded
+// face is a different question, answered by `pdffonts -subst`, and reachable
+// through Container.
+func (d *Document) Fonts(ctx context.Context) (string, error) {
+	if err := d.validateRange(ctx); err != nil {
+		return "", err
+	}
+	out, err := d.run(ctx, "Fonts", d.command("pdffonts", d.rangeArgs(), sourcePath))
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(out.stdout, "\n"), nil
+}
+
+// Metadata returns the document's XMP packet: the RDF/XML block a producer
+// writes its own record of the document into — title, creator tool, rights,
+// modification history — and the one place a workflow's own custom properties
+// can live inside a PDF.
+//
+// It is the packet and nothing else, which is what makes it worth having next to
+// Info. The two carry different things and disagree in the wild: Info reports the
+// PDF's Info dictionary, whose handful of keys a producer may have left behind
+// when it rewrote the XMP, and the packet is the record a downstream asset
+// system actually reads. The packet is returned exactly as it sits in the file,
+// so a caller can hand it to an XML parser or grep a property out of it.
+//
+// A document carrying no packet is not an error and does not return nothing:
+// poppler prints nothing at all and exits 0, and an empty string is
+// indistinguishable from a function that never ran. It returns a line saying
+// there is no XMP and naming Info as the report that does carry this document's
+// metadata.
+//
+// WithPageRange does not narrow it, the packet being a property of the document
+// rather than of any page — the same reason it does not narrow Info.
+func (d *Document) Metadata(ctx context.Context) (string, error) {
+	out, err := d.run(ctx, "Metadata", d.command("pdfinfo", []string{metadataFlag}, sourcePath))
+	if err != nil {
+		return "", err
+	}
+	packet := strings.TrimRight(out.stdout, "\n")
+	if strings.TrimSpace(packet) == "" {
+		return noMetadataReport, nil
+	}
+	return packet, nil
+}
+
+// Signatures returns what pdfsig reports about the document's digital
+// signatures: one block per signature naming its field, its signer, when it was
+// signed, which algorithm signed it, how much of the document it covers, and
+// whether the signature validates.
+//
+// A document with no signatures — which is nearly every document — gets the
+// report saying so rather than an error. That is the point of the function
+// being callable on an arbitrary PDF: "is this signed, and does it check out" is
+// a question asked *before* the answer is known, so the unsigned answer has to
+// come back as a result. poppler exits 2 for it, and this is the one place the
+// module reads a non-zero exit as a report rather than a failure.
+//
+// It reports and does not gate. A signature that fails to validate is a report
+// saying so — `Signature Validation: Signature is Invalid.` — and not an error,
+// for the same reason: a caller asking whether the signatures hold needs the
+// answer, and one that wants to stop on a bad signature reads the verdict out of
+// the report. Only a run that got no report at all — an unreadable file, a
+// document whose password is missing or wrong — fails.
+//
+// What the report can say about a signer's *certificate* is limited by the image
+// rather than by the document. Certificate validation needs a trust database,
+// this image carries none, and pdfsig says so on stderr — which is not part of
+// this report. A caller who needs a validated chain supplies one with
+// `-nssdir`, through Container.
+//
+// Neither WithPageRange nor anything else narrows it: a signature covers byte
+// ranges of the file rather than pages, and pdfsig has no page bounds at all.
+// The passwords do reach it, an encrypted document being one it has to open like
+// any other.
+func (d *Document) Signatures(ctx context.Context) (string, error) {
+	res, code, err := d.capture(ctx, d.command("pdfsig", nil, sourcePath))
+	if err != nil {
+		return "", err
+	}
+	report := strings.TrimRight(res.stdout, "\n")
+	// A non-zero exit that printed a report is an answer about the document —
+	// unsigned, or signed by something that did not validate — and only a
+	// non-zero exit that printed nothing is a failed run.
+	if code != 0 && !isSignatureReport(report) {
+		return "", d.failure("Signatures", code, res.stdout, res.stderr)
+	}
+	return report, nil
+}
+
+// isSignatureReport reports whether pdfsig got far enough to say something about
+// the document, which is what separates its two meanings of a non-zero exit.
+//
+// It matches on what was printed rather than on the code, because the codes are
+// ambiguous where the output is not: pdfsig exits 1 both for a document it could
+// not open — nothing on stdout — and for one whose signature did not validate,
+// having printed the whole report first.
+func isSignatureReport(out string) bool {
+	return strings.Contains(out, noSignaturesMarker) || strings.Contains(out, signatureInfoMarker)
+}
+
 // Convert opens the conversion namespace: the render options, and the five
 // outputs that read them.
 //
@@ -298,31 +421,43 @@ func (d *Document) run(ctx context.Context, label string, command string) (*popp
 // non-zero exit into an error that says what actually went wrong. Anything
 // after the script becomes `$0`, `$1` and so on, which is how a value the
 // script needs reaches it without being interpolated into the script text.
-//
-// Expect=ReturnTypeAny keeps a failed run on the value path so its stderr is
-// still readable; without it the exit code is the error and poppler's own
-// message about the document is lost inside Dagger's.
 func (d *Document) runScript(ctx context.Context, label string, script string, args ...string) (*popplerResult, error) {
+	res, code, err := d.capture(ctx, script, args...)
+	if err != nil {
+		return nil, err
+	}
+	if code != 0 {
+		return nil, d.failure(label, code, res.stdout, res.stderr)
+	}
+	return res, nil
+}
+
+// capture runs a shell script against the bound document and returns its output
+// and its exit code without judging either, which is what Signatures needs: for
+// pdfsig a non-zero exit is as often an answer about the document as it is a
+// failure to read it.
+//
+// Expect=ReturnTypeAny is what keeps a failed run on the value path so its
+// output is still readable; without it the exit code is the error and poppler's
+// own message about the document is lost inside Dagger's.
+func (d *Document) capture(ctx context.Context, script string, args ...string) (*popplerResult, int, error) {
 	exec := d.container().WithExec(
 		append([]string{"sh", "-c", script}, args...),
 		dagger.ContainerWithExecOpts{Expect: dagger.ReturnTypeAny})
 
 	code, err := exec.ExitCode(ctx)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	stdout, err := exec.Stdout(ctx)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	stderr, err := exec.Stderr(ctx)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	if code != 0 {
-		return nil, d.failure(label, code, stdout, stderr)
-	}
-	return &popplerResult{container: exec, stdout: stdout, stderr: stderr}, nil
+	return &popplerResult{container: exec, stdout: stdout, stderr: stderr}, code, nil
 }
 
 // failure builds the error a non-zero exit becomes.

--- a/daggerverse/pdf/main.go
+++ b/daggerverse/pdf/main.go
@@ -1,7 +1,7 @@
-// Package main implements the pdf Dagger module: reading a PDF's text and
-// rendering its pages as images, as a `dagger call` instead of the usual
-// hand-rolled Dockerfile with poppler-utils in it plus a shell script to
-// rescue the output.
+// Package main implements the pdf Dagger module: reading a PDF's text,
+// rendering its pages, and reporting what it is made of, as a `dagger call`
+// instead of the usual hand-rolled Dockerfile with poppler-utils in it plus a
+// shell script to rescue the output.
 //
 // The text path and the OCR path are different tools for different documents,
 // and this module is the one to try first. pdftotext reads the text layer a
@@ -41,12 +41,20 @@
 // them. HTML is pdftohtml's, which is not a renderer at all so much as a
 // re-layout, and shares no options with either.
 //
+// Four reports describe the document instead of converting it, one per tool:
+// Info is pdfinfo, Fonts is pdffonts, Metadata is `pdfinfo -meta` and Signatures
+// is pdfsig. Each returns its tool's own report as text. Parsing those into
+// structured values is deliberately out of scope — the formats are stable but
+// wide, and a caller who wants one field can read it out of these lines more
+// cheaply than this module can model all of them.
+//
 // File map (all `package main`, surfaced as one Dagger module):
 //
 //   - enums.go    — ColorMode and LayoutMode plus the tables mapping them onto
 //     poppler's flags, and the internal raster- and per-page-format tables.
 //   - document.go — *Document, one bound PDF: its passwords, its page range,
-//     and what pdfinfo reports about it.
+//     and the four reports about it — what pdfinfo says, which fonts it needs,
+//     its XMP metadata, and its signatures.
 //   - convert.go  — *Convert, the render options and the nine outputs that
 //     read them.
 package main
@@ -73,8 +81,8 @@ const (
 	defaultAlpineTag = "3.24"
 
 	// popplerPkg carries all thirteen pdf* binaries this module reaches
-	// through Container, of which five are wrapped: pdftotext, pdftoppm,
-	// pdfinfo, pdftocairo and pdftohtml.
+	// through Container, of which seven are wrapped: pdftotext, pdftoppm,
+	// pdfinfo, pdftocairo, pdftohtml, pdffonts and pdfsig.
 	popplerPkg = "poppler-utils"
 
 	// fontPkg is the substitute font family poppler draws with when a PDF
@@ -152,6 +160,27 @@ const (
 	// endOfDocument is the WithPageRange `last` that means "to the last page",
 	// and the zero value a Document that was never given a range carries.
 	endOfDocument = 0
+
+	// metadataFlag is what makes pdfinfo print the document's XMP packet, and
+	// only the packet: the ordinary report is suppressed, so a document with no
+	// XMP produces no output at all.
+	metadataFlag = "-meta"
+
+	// noMetadataReport is what Metadata answers for a document carrying no XMP
+	// packet. It is a report and not an error, that document being a perfectly
+	// good one, and it is not the empty string poppler produces because an empty
+	// string is indistinguishable from a function that never ran.
+	noMetadataReport = "No XMP metadata: this document carries no XMP packet. " +
+		"Info reports the metadata in its Info dictionary."
+
+	// noSignaturesMarker and signatureInfoMarker are the two openings pdfsig's
+	// report comes in — one for a document carrying no signatures, one for a
+	// document carrying some — and recognising either is what lets Signatures
+	// tell a report from a failed run. pdfsig exits non-zero for both an
+	// unsigned document (2) and a signature that did not validate (1), and 1 is
+	// also what it exits for a document it could not open at all.
+	noSignaturesMarker  = "does not contain any signatures"
+	signatureInfoMarker = "Digital Signature Info of:"
 
 	// incorrectPasswordMarker is the text poppler's own message carries when a
 	// document is encrypted and the password it was given — including the
@@ -307,9 +336,10 @@ func (p *Pdf) WithFonts(
 
 // Container returns the assembled toolchain image. This is the escape hatch
 // for everything this module does not wrap: poppler-utils ships thirteen
-// binaries and five of them are wrapped here, so pdfimages, pdfseparate,
-// pdfunite, pdfsig, pdffonts and the rest stay reachable via
-// `container with-exec`.
+// binaries and seven of them are wrapped here, so pdfimages, pdfseparate,
+// pdfunite, pdfattach, pdfdetach and pdftops stay reachable via
+// `container with-exec` — as do the flags of a wrapped tool that this module
+// does not surface, `pdffonts -subst` among them.
 func (p *Pdf) Container() *dagger.Container {
 	ctr := p.base().WithExec([]string{"apk", "add", "--no-cache", popplerPkg, fontPkg})
 	// Mounted after the install because the install is what brings

--- a/daggerverse/pdf/tests/dagger.gen.go
+++ b/daggerverse/pdf/tests/dagger.gen.go
@@ -248,6 +248,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).EpsWritesEveryPageOfTheDocument(&parent, ctx)
+		case "FontsNarrowsToThePageRange":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).FontsNarrowsToThePageRange(&parent, ctx)
+		case "FontsReportsWhetherEachFaceIsEmbedded":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).FontsReportsWhetherEachFaceIsEmbedded(&parent, ctx)
 		case "HtmlCarriesPageMarkupAndItsImages":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -276,6 +290,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).LayoutModesProduceDifferentOrderings(&parent, ctx)
+		case "MetadataReturnsTheXmpPacketOrSaysThereIsNone":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).MetadataReturnsTheXmpPacketOrSaysThereIsNone(&parent, ctx)
 		case "PageRangeNarrowsEveryPerPageFormat":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -339,6 +360,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).RenderSettingsRejectNonPositiveValues(&parent, ctx)
+		case "ReportsOpenAnEncryptedDocumentWithThePassword":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ReportsOpenAnEncryptedDocumentWithThePassword(&parent, ctx)
 		case "ScaleToOverridesDpi":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -346,6 +374,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).ScaleToOverridesDpi(&parent, ctx)
+		case "SignaturesReportsAnUnsignedDocumentInsteadOfFailing":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).SignaturesReportsAnUnsignedDocumentInsteadOfFailing(&parent, ctx)
 		case "SvgWritesOneVectorFilePerPage":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/pdf/tests/fixtures/fonts.pdf
+++ b/daggerverse/pdf/tests/fixtures/fonts.pdf
@@ -1,0 +1,81 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 2 /Kids [3 0 R 4 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 7 0 R >> >> /Contents 5 0 R >>
+endobj
+4 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F2 8 0 R /F3 9 0 R >> >> /Contents 6 0 R >>
+endobj
+5 0 obj
+<<  /Length 77 >>
+stream
+BT
+/F1 12 Tf
+72 700 Td
+(HELVETICAPAGE set in an unembedded Helvetica.) Tj
+ET
+
+endstream
+endobj
+6 0 obj
+<<  /Length 108 >>
+stream
+BT
+/F2 12 Tf
+72 700 Td
+(COURIERPAGE set in an unembedded Courier.) Tj
+ET
+BT
+/F3 48 Tf
+72 600 Td
+(aaa) Tj
+ET
+
+endstream
+endobj
+7 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>
+endobj
+8 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Courier /Encoding /WinAnsiEncoding >>
+endobj
+9 0 obj
+<< /Type /Font /Subtype /Type3 /Name /SquareGlyphs /FontBBox [0 0 750 750] /FontMatrix [0.001 0 0 0.001 0 0] /CharProcs 10 0 R /Encoding << /Type /Encoding /Differences [97 /square] >> /FirstChar 97 /LastChar 97 /Widths [750] >>
+endobj
+10 0 obj
+<< /square 11 0 R >>
+endobj
+11 0 obj
+<<  /Length 38 >>
+stream
+750 0 0 0 750 750 d1
+0 0 750 750 re
+f
+
+endstream
+endobj
+xref
+0 12
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000127 00000 n 
+0000000253 00000 n 
+0000000389 00000 n 
+0000000517 00000 n 
+0000000677 00000 n 
+0000000774 00000 n 
+0000000869 00000 n 
+0000001113 00000 n 
+0000001150 00000 n 
+trailer
+<< /Size 12 /Root 1 0 R >>
+startxref
+1240
+%%EOF

--- a/daggerverse/pdf/tests/fixtures/metadata.pdf
+++ b/daggerverse/pdf/tests/fixtures/metadata.pdf
@@ -1,0 +1,65 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R /Metadata 5 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [4 0 R] >>
+endobj
+3 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>
+endobj
+4 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R >> >> /Contents 6 0 R >>
+endobj
+5 0 obj
+<< /Type /Metadata /Subtype /XML /Length 543 >>
+stream
+<?xpacket begin="" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/">
+ <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <rdf:Description rdf:about=""
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:xmp="http://ns.adobe.com/xap/1.0/">
+   <dc:title>
+    <rdf:Alt>
+     <rdf:li xml:lang="x-default">XMPTITLE the packet's own title</rdf:li>
+    </rdf:Alt>
+   </dc:title>
+   <xmp:CreatorTool>devex pdf module fixture</xmp:CreatorTool>
+  </rdf:Description>
+ </rdf:RDF>
+</x:xmpmeta>
+<?xpacket end="w"?>
+
+endstream
+endobj
+6 0 obj
+<<  /Length 73 >>
+stream
+BT
+/F1 12 Tf
+72 700 Td
+(This page carries an XMP metadata packet.) Tj
+ET
+
+endstream
+endobj
+7 0 obj
+<< /Title (INFOTITLE the info dictionary's title) >>
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000015 00000 n 
+0000000080 00000 n 
+0000000137 00000 n 
+0000000234 00000 n 
+0000000360 00000 n 
+0000000984 00000 n 
+0000001108 00000 n 
+trailer
+<< /Size 8 /Root 1 0 R /Info 7 0 R >>
+startxref
+1176
+%%EOF

--- a/daggerverse/pdf/tests/internal/dagger/pdf.gen.go
+++ b/daggerverse/pdf/tests/internal/dagger/pdf.gen.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Retrieve the binding value, as type Pdf
-func (r *Binding) AsPdf() *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:168:6)
+func (r *Binding) AsPdf() *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:197:6)
 	q := r.query.Select("asPdf")
 
 	return &Pdf{
@@ -86,7 +86,7 @@ func (r *Env) WithPdfDocumentOutput(name string, description string) *Env { // p
 }
 
 // Create or update a binding of type Pdf in the environment
-func (r *Env) WithPdfInput(name string, value *Pdf, description string) *Env { // pdf (../../../../../daggerverse/pdf/main.go:168:6)
+func (r *Env) WithPdfInput(name string, value *Pdf, description string) *Env { // pdf (../../../../../daggerverse/pdf/main.go:197:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withPdfInput")
 	q = q.Arg("name", name)
@@ -99,7 +99,7 @@ func (r *Env) WithPdfInput(name string, value *Pdf, description string) *Env { /
 }
 
 // Declare a desired Pdf output to be assigned in the environment
-func (r *Env) WithPdfOutput(name string, description string) *Env { // pdf (../../../../../daggerverse/pdf/main.go:168:6)
+func (r *Env) WithPdfOutput(name string, description string) *Env { // pdf (../../../../../daggerverse/pdf/main.go:197:6)
 	q := r.query.Select("withPdfOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -113,7 +113,7 @@ func (r *Env) WithPdfOutput(name string, description string) *Env { // pdf (../.
 // carries the image coordinates and the fonts the image is built with;
 // Document hangs off it so the generated SDK surfaces conversion under
 // `dag.Pdf().Document(...)`.
-type Pdf struct { // pdf (../../../../../daggerverse/pdf/main.go:168:6)
+type Pdf struct { // pdf (../../../../../daggerverse/pdf/main.go:197:6)
 	query *querybuilder.Selection
 
 	id      *ID
@@ -136,10 +136,11 @@ func (r *Pdf) WithGraphQLQuery(q *querybuilder.Selection) *Pdf {
 
 // Container returns the assembled toolchain image. This is the escape hatch
 // for everything this module does not wrap: poppler-utils ships thirteen
-// binaries and five of them are wrapped here, so pdfimages, pdfseparate,
-// pdfunite, pdfsig, pdffonts and the rest stay reachable via
-// `container with-exec`.
-func (r *Pdf) Container() *Container { // pdf (../../../../../daggerverse/pdf/main.go:313:1)
+// binaries and seven of them are wrapped here, so pdfimages, pdfseparate,
+// pdfunite, pdfattach, pdfdetach and pdftops stay reachable via
+// `container with-exec` — as do the flags of a wrapped tool that this module
+// does not surface, `pdffonts -subst` among them.
+func (r *Pdf) Container() *Container { // pdf (../../../../../daggerverse/pdf/main.go:343:1)
 	q := r.query.Select("container")
 
 	return &Container{
@@ -152,7 +153,7 @@ func (r *Pdf) Container() *Container { // pdf (../../../../../daggerverse/pdf/ma
 // The boundary input is a *dagger.File rather than a *dagger.Directory: a PDF
 // resolves nothing relative to its own location, so one file is the whole unit
 // of work however many pages it carries.
-func (r *Pdf) Document(source *File) *PdfDocument { // pdf (../../../../../daggerverse/pdf/main.go:346:1)
+func (r *Pdf) Document(source *File) *PdfDocument { // pdf (../../../../../daggerverse/pdf/main.go:376:1)
 	assertNotNil("source", source)
 	q := r.query.Select("document")
 	q = q.Arg("source", source)
@@ -213,7 +214,7 @@ func (r *Pdf) UnmarshalJSON(bs []byte) error {
 
 // Version returns the poppler release the assembled image ships, as the bare
 // version number reported by `pdftotext -v`.
-func (r *Pdf) Version(ctx context.Context) (string, error) { // pdf (../../../../../daggerverse/pdf/main.go:326:1)
+func (r *Pdf) Version(ctx context.Context) (string, error) { // pdf (../../../../../daggerverse/pdf/main.go:356:1)
 	if r.version != nil {
 		return *r.version, nil
 	}
@@ -239,7 +240,7 @@ func (r *Pdf) Version(ctx context.Context) (string, error) { // pdf (../../../..
 // why the credentials are not simply userinfo in the WithApkRepository URL,
 // which would put them in /etc/apk/repositories and in every apk error
 // message that quotes it.
-func (r *Pdf) WithApkAuth(credentials *Secret) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:275:1)
+func (r *Pdf) WithApkAuth(credentials *Secret) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:304:1)
 	assertNotNil("credentials", credentials)
 	q := r.query.Select("withApkAuth")
 	q = q.Arg("credentials", credentials)
@@ -262,7 +263,7 @@ func (r *Pdf) WithApkAuth(credentials *Secret) *Pdf { // pdf (../../../../../dag
 // Repeatable, for a mirror set signed by more than one key. It is a *File
 // rather than a *Secret because a public key is not a credential: it is meant
 // to be in the image, and WithApkAuth is the option for the part that is not.
-func (r *Pdf) WithApkKey(key *File) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:252:1)
+func (r *Pdf) WithApkKey(key *File) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:281:1)
 	assertNotNil("key", key)
 	q := r.query.Select("withApkKey")
 	q = q.Arg("key", key)
@@ -292,7 +293,7 @@ func (r *Pdf) WithApkKey(key *File) *Pdf { // pdf (../../../../../daggerverse/pd
 // call per component. A repository's index is signed, so pair this with
 // WithApkKey unless the mirror is signed by a key the base image already
 // trusts.
-func (r *Pdf) WithApkRepository(url string) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:224:1)
+func (r *Pdf) WithApkRepository(url string) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:253:1)
 	q := r.query.Select("withApkRepository")
 	q = q.Arg("url", url)
 
@@ -316,7 +317,7 @@ func (r *Pdf) WithApkRepository(url string) *Pdf { // pdf (../../../../../dagger
 // /etc/fonts/fonts.conf tells fontconfig to scan, so the faces in it are
 // indistinguishable from packaged ones as far as poppler is concerned. It is
 // mounted rather than copied so a large family does not become an image layer.
-func (r *Pdf) WithFonts(dir *Directory) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:299:1)
+func (r *Pdf) WithFonts(dir *Directory) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:328:1)
 	assertNotNil("dir", dir)
 	q := r.query.Select("withFonts")
 	q = q.Arg("dir", dir)
@@ -748,9 +749,12 @@ func (r *PdfConvert) AsNode() Node {
 type PdfDocument struct { // pdf (../../../../../daggerverse/pdf/document.go:18:6)
 	query *querybuilder.Selection
 
-	id        *ID
-	info      *string
-	pageCount *int
+	fonts      *string
+	id         *ID
+	info       *string
+	metadata   *string
+	pageCount  *int
+	signatures *string
 }
 type WithPdfDocumentFunc func(r *PdfDocument) *PdfDocument
 
@@ -775,12 +779,49 @@ func (r *PdfDocument) WithGraphQLQuery(q *querybuilder.Selection) *PdfDocument {
 // nothing about the PDF — and because it is what lets one bound document, with
 // its passwords and its page range settled, fan out into several differently
 // configured conversions.
-func (r *PdfDocument) Convert() *PdfConvert { // pdf (../../../../../daggerverse/pdf/document.go:158:1)
+func (r *PdfDocument) Convert() *PdfConvert { // pdf (../../../../../daggerverse/pdf/document.go:281:1)
 	q := r.query.Select("convert")
 
 	return &PdfConvert{
 		query: q,
 	}
+}
+
+// Fonts returns what pdffonts reports about every face the document's pages
+// name: the face's name, its type, its encoding, whether it is embedded in the
+// file, whether it is a subset, whether it carries a ToUnicode map, and the
+// object it lives in.
+//
+// The `emb` column is the one to read. A PDF that names a font without
+// embedding one — the usual shape for anything not born as a scan — is drawn by
+// asking fontconfig for a substitute, and a substitute poppler cannot find is
+// not an error: the glyphs are simply absent from the rendered page and the
+// command exits 0. This report is what that failure looks like before it
+// happens, which makes it the diagnostic to reach for when a render comes out
+// blank or a face comes out wrong. `no` in that column means the render depends
+// on the image's own fonts — the packaged family, or one supplied through
+// WithFonts.
+//
+// The report is pdffonts' own table, verbatim. Parsing it into structured
+// values is deliberately not this module's job: the format is stable but wide,
+// and a caller who wants one column can read it out of these lines more cheaply
+// than this module can model all of them.
+//
+// WithPageRange narrows it, because which faces a document needs is a question
+// about pages: a face used only on page 40 is absent from a report of pages 1
+// through 3. Which substitute poppler would actually choose for an unembedded
+// face is a different question, answered by `pdffonts -subst`, and reachable
+// through Container.
+func (r *PdfDocument) Fonts(ctx context.Context) (string, error) { // pdf (../../../../../daggerverse/pdf/document.go:175:1)
+	if r.fonts != nil {
+		return *r.fonts, nil
+	}
+	q := r.query.Select("fonts")
+
+	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
 }
 
 // A unique identifier for this PdfDocument.
@@ -850,6 +891,38 @@ func (r *PdfDocument) Info(ctx context.Context) (string, error) { // pdf (../../
 	return response, q.Execute(ctx)
 }
 
+// Metadata returns the document's XMP packet: the RDF/XML block a producer
+// writes its own record of the document into — title, creator tool, rights,
+// modification history — and the one place a workflow's own custom properties
+// can live inside a PDF.
+//
+// It is the packet and nothing else, which is what makes it worth having next to
+// Info. The two carry different things and disagree in the wild: Info reports the
+// PDF's Info dictionary, whose handful of keys a producer may have left behind
+// when it rewrote the XMP, and the packet is the record a downstream asset
+// system actually reads. The packet is returned exactly as it sits in the file,
+// so a caller can hand it to an XML parser or grep a property out of it.
+//
+// A document carrying no packet is not an error and does not return nothing:
+// poppler prints nothing at all and exits 0, and an empty string is
+// indistinguishable from a function that never ran. It returns a line saying
+// there is no XMP and naming Info as the report that does carry this document's
+// metadata.
+//
+// WithPageRange does not narrow it, the packet being a property of the document
+// rather than of any page — the same reason it does not narrow Info.
+func (r *PdfDocument) Metadata(ctx context.Context) (string, error) { // pdf (../../../../../daggerverse/pdf/document.go:206:1)
+	if r.metadata != nil {
+		return *r.metadata, nil
+	}
+	q := r.query.Select("metadata")
+
+	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
 // PageCount returns how many pages the document has, by reading the `Pages:`
 // line out of what Info reports.
 //
@@ -862,6 +935,47 @@ func (r *PdfDocument) PageCount(ctx context.Context) (int, error) { // pdf (../.
 	q := r.query.Select("pageCount")
 
 	var response int
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// Signatures returns what pdfsig reports about the document's digital
+// signatures: one block per signature naming its field, its signer, when it was
+// signed, which algorithm signed it, how much of the document it covers, and
+// whether the signature validates.
+//
+// A document with no signatures — which is nearly every document — gets the
+// report saying so rather than an error. That is the point of the function
+// being callable on an arbitrary PDF: "is this signed, and does it check out" is
+// a question asked *before* the answer is known, so the unsigned answer has to
+// come back as a result. poppler exits 2 for it, and this is the one place the
+// module reads a non-zero exit as a report rather than a failure.
+//
+// It reports and does not gate. A signature that fails to validate is a report
+// saying so — `Signature Validation: Signature is Invalid.` — and not an error,
+// for the same reason: a caller asking whether the signatures hold needs the
+// answer, and one that wants to stop on a bad signature reads the verdict out of
+// the report. Only a run that got no report at all — an unreadable file, a
+// document whose password is missing or wrong — fails.
+//
+// What the report can say about a signer's *certificate* is limited by the image
+// rather than by the document. Certificate validation needs a trust database,
+// this image carries none, and pdfsig says so on stderr — which is not part of
+// this report. A caller who needs a validated chain supplies one with
+// `-nssdir`, through Container.
+//
+// Neither WithPageRange nor anything else narrows it: a signature covers byte
+// ranges of the file rather than pages, and pdfsig has no page bounds at all.
+// The passwords do reach it, an encrypted document being one it has to open like
+// any other.
+func (r *PdfDocument) Signatures(ctx context.Context) (string, error) { // pdf (../../../../../daggerverse/pdf/document.go:247:1)
+	if r.signatures != nil {
+		return *r.signatures, nil
+	}
+	q := r.query.Select("signatures")
+
+	var response string
 
 	q = q.Bind(&response)
 	return response, q.Execute(ctx)
@@ -963,18 +1077,18 @@ type PdfOpts struct {
 	//
 	//
 	// Default: "docker.io"
-	Registry string // pdf (../../../../../daggerverse/pdf/main.go:190:2)
+	Registry string // pdf (../../../../../daggerverse/pdf/main.go:219:2)
 	//
 	// Tag of the alpine image the toolchain is assembled on.
 	//
 	//
 	// Default: "3.24"
-	AlpineTag string // pdf (../../../../../daggerverse/pdf/main.go:193:2)
+	AlpineTag string // pdf (../../../../../daggerverse/pdf/main.go:222:2)
 }
 
 // New returns a Pdf module backed by <registry>/library/alpine:<tag> with
 // poppler-utils and a substitute font family installed.
-func (r *Query) Pdf(opts ...PdfOpts) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:185:1)
+func (r *Query) Pdf(opts ...PdfOpts) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:214:1)
 	q := r.query.Select("pdf")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `registry` optional argument

--- a/daggerverse/pdf/tests/main.go
+++ b/daggerverse/pdf/tests/main.go
@@ -62,6 +62,36 @@ const (
 	// be handed to the tesseract module.
 	scanPdf = "scan.pdf"
 
+	// fontsPdf is a two-page PDF whose pages name different faces: page one an
+	// unembedded Helvetica, page two an unembedded Courier alongside a Type 3
+	// font.
+	//
+	// Both halves of that are deliberate. The faces differ per page, which is
+	// the only way a page range is observable in a font report at all — every
+	// page of ledgerPdf names the same face, so narrowing it changes nothing.
+	// And the Type 3 font is embedded by construction, its glyph procedures
+	// being in the file itself, which is what gives the `emb` column something
+	// to say `yes` about.
+	fontsPdf = "fonts.pdf"
+
+	// fontsHelvetica, fontsCourier and fontsEmbedded are the face names
+	// pdffonts reports for fontsPdf: the first on page one, the other two on
+	// page two.
+	fontsHelvetica = "Helvetica"
+	fontsCourier   = "Courier"
+	fontsEmbedded  = "SquareGlyphs"
+
+	// metadataPdf is a one-page PDF carrying an XMP packet in a /Metadata
+	// stream, plus an Info dictionary. The two carry deliberately different
+	// titles, which is what lets an assertion tell the packet apart from
+	// pdfinfo's ordinary report of the same document.
+	metadataPdf = "metadata.pdf"
+
+	// xmpTitleMarker occurs in metadataPdf's XMP packet and infoTitleMarker in
+	// its Info dictionary, and neither occurs anywhere else in the fixture.
+	xmpTitleMarker  = "XMPTITLE"
+	infoTitleMarker = "INFOTITLE"
+
 	// swatchPdf is a one-page PDF of saturated colour patches and one mid grey.
 	// It exists because a colour mode is not observable in a PNG's header:
 	// poppler's writer emits 8-bit RGB whatever was asked for, so the only place
@@ -108,9 +138,9 @@ var ledgerMarkers = []string{
 }
 
 // popplerBinaries is every executable poppler-utils installs. Container's
-// promise is that all of them are reachable, not just the three this module
-// wraps: the module wraps pdftotext, pdftoppm and pdfinfo, and the escape hatch
-// is the whole point of the other ten.
+// promise is that all of them are reachable, not just the seven this module
+// wraps: the module wraps pdftotext, pdftoppm, pdfinfo, pdftocairo, pdftohtml,
+// pdffonts and pdfsig, and the escape hatch is the whole point of the other six.
 var popplerBinaries = []string{
 	"pdfattach", "pdfdetach", "pdffonts", "pdfimages", "pdfinfo",
 	"pdfseparate", "pdfsig", "pdftocairo", "pdftohtml", "pdftoppm",
@@ -147,6 +177,11 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("WithFontsPutsFaceWhereFontconfigFindsIt", t.WithFontsPutsFaceWhereFontconfigFindsIt)
 
 	jobs = jobs.WithJob("InfoReportsPageCountAndSize", t.InfoReportsPageCountAndSize)
+	jobs = jobs.WithJob("FontsReportsWhetherEachFaceIsEmbedded", t.FontsReportsWhetherEachFaceIsEmbedded)
+	jobs = jobs.WithJob("FontsNarrowsToThePageRange", t.FontsNarrowsToThePageRange)
+	jobs = jobs.WithJob("MetadataReturnsTheXmpPacketOrSaysThereIsNone", t.MetadataReturnsTheXmpPacketOrSaysThereIsNone)
+	jobs = jobs.WithJob("SignaturesReportsAnUnsignedDocumentInsteadOfFailing", t.SignaturesReportsAnUnsignedDocumentInsteadOfFailing)
+	jobs = jobs.WithJob("ReportsOpenAnEncryptedDocumentWithThePassword", t.ReportsOpenAnEncryptedDocumentWithThePassword)
 
 	jobs = jobs.WithJob("TextReproducesTextLayerExactly", t.TextReproducesTextLayerExactly)
 	jobs = jobs.WithJob("TextOnImageOnlyPdfReturnsNothing", t.TextOnImageOnlyPdfReturnsNothing)
@@ -652,6 +687,292 @@ func (t *Tests) InfoReportsPageCountAndSize(ctx context.Context) error {
 		return fmt.Errorf("expected PageCount %d, got %d", ledgerPages, count)
 	}
 	return nil
+}
+
+// FontsReportsWhetherEachFaceIsEmbedded asserts Fonts surfaces pdffonts' table
+// and that the `emb` column in it says what it is supposed to say.
+//
+// ledgerPdf is the shape the module's font install exists for: its pages name
+// Helvetica without embedding it, so poppler has to ask fontconfig for a
+// substitute, and with no font installed there is nothing to substitute — the
+// page renders blank and the command exits 0. `Helvetica … no` is what that
+// silent failure looks like before it happens, which is the whole reason a
+// pipeline asks for this report.
+//
+// fontsPdf carries the other half of the column. Its Type 3 font is embedded by
+// construction, so the report has to read `yes` for it; without that contrast
+// the assertion would pass just as well on a report that said `no` about
+// everything, including one produced by a module that had hardcoded the answer.
+func (t *Tests) FontsReportsWhetherEachFaceIsEmbedded(ctx context.Context) error {
+	report, err := pdf().Document(fixture(ledgerPdf)).Fonts(ctx)
+	if err != nil {
+		return fmt.Errorf("Fonts: %w", err)
+	}
+	// The header is part of the report and is what makes it readable as a table
+	// rather than as a list of names.
+	for _, want := range []string{"name", "type", "encoding", "emb"} {
+		if !strings.Contains(report, want) {
+			return fmt.Errorf("expected the report's header to name the %q column, got:\n%s", want, report)
+		}
+	}
+	row, err := fontRow(report, fontsHelvetica)
+	if err != nil {
+		return fmt.Errorf("%s: %s", ledgerPdf, err.Error())
+	}
+	if got := fontEmbedded(row); got != "no" {
+		return fmt.Errorf("expected %s to be reported unembedded, got %q in:\n%s",
+			fontsHelvetica, got, report)
+	}
+
+	report, err = pdf().Document(fixture(fontsPdf)).Fonts(ctx)
+	if err != nil {
+		return fmt.Errorf("Fonts of %s: %w", fontsPdf, err)
+	}
+	for _, tc := range []struct {
+		face string
+		emb  string
+	}{
+		{fontsHelvetica, "no"},
+		{fontsCourier, "no"},
+		{fontsEmbedded, "yes"},
+	} {
+		row, err := fontRow(report, tc.face)
+		if err != nil {
+			return fmt.Errorf("%s: %s", fontsPdf, err.Error())
+		}
+		if got := fontEmbedded(row); got != tc.emb {
+			return fmt.Errorf("expected %s's emb column to read %q, got %q in:\n%s",
+				tc.face, tc.emb, got, report)
+		}
+	}
+	return nil
+}
+
+// FontsNarrowsToThePageRange asserts WithPageRange reaches pdffonts, and that a
+// range it cannot honour is refused the way every other one is.
+//
+// Which faces a document needs is a question about pages, so this is not a
+// cosmetic option: a report of pages 1 through 3 that listed a face used only on
+// page 40 would say the render depends on a font it does not, and one that
+// dropped a face used on page 2 would say the opposite. fontsPdf is built for
+// it, its two pages naming different faces, because narrowing a report of
+// ledgerPdf — every page of which names the same Helvetica — changes nothing at
+// all and would pass against a module that ignored the bounds entirely.
+func (t *Tests) FontsNarrowsToThePageRange(ctx context.Context) error {
+	doc := pdf().Document(fixture(fontsPdf))
+
+	for _, tc := range []struct {
+		first, last int
+		want        []string
+		absent      []string
+	}{
+		{1, 1, []string{fontsHelvetica}, []string{fontsCourier, fontsEmbedded}},
+		{2, 2, []string{fontsCourier, fontsEmbedded}, []string{fontsHelvetica}},
+		// An open-ended range is the whole document from page one, so both
+		// pages' faces are back.
+		{1, 0, []string{fontsHelvetica, fontsCourier, fontsEmbedded}, nil},
+	} {
+		report, err := doc.WithPageRange(tc.first, tc.last).Fonts(ctx)
+		if err != nil {
+			return fmt.Errorf("Fonts for pages %d-%d: %w", tc.first, tc.last, err)
+		}
+		for _, face := range tc.want {
+			if _, err := fontRow(report, face); err != nil {
+				return fmt.Errorf("pages %d-%d: %s", tc.first, tc.last, err.Error())
+			}
+		}
+		for _, face := range tc.absent {
+			if strings.Contains(report, face) {
+				return fmt.Errorf("pages %d-%d: expected no %s in the report, got:\n%s",
+					tc.first, tc.last, face, report)
+			}
+		}
+	}
+
+	// The bounds are checked against the document rather than handed to poppler,
+	// which for pdffonts is the difference between a named refusal and a report
+	// of no fonts at all — it prints the header and exits 0 for a range past the
+	// end of the document.
+	_, err := doc.WithPageRange(9, 0).Fonts(ctx)
+	if err == nil {
+		return fmt.Errorf("expected a range past the end of the document to be rejected")
+	}
+	for _, want := range []string{"first (9)", "2 pages"} {
+		if !strings.Contains(err.Error(), want) {
+			return fmt.Errorf("expected the rejection to mention %q, got: %v", want, err)
+		}
+	}
+	return nil
+}
+
+// MetadataReturnsTheXmpPacketOrSaysThereIsNone asserts both halves of what
+// Metadata answers, because the interesting one is the absence.
+//
+// The packet is asserted to be the packet and not pdfinfo's ordinary report of
+// the same document: `pdfinfo -meta` prints the XMP alone, so a module that
+// dropped the flag would return a report that still mentions a title and still
+// looks like metadata. metadataPdf's Info dictionary carries a deliberately
+// different title for exactly that reason — the wrong one showing up is what
+// makes the substitution visible.
+//
+// The absence is the half that needs a decision. poppler prints nothing at all
+// and exits 0 for a document with no XMP, and an empty string is
+// indistinguishable from a function that did not run, so the module answers with
+// a line naming the absence and pointing at the report that does carry the
+// document's metadata.
+func (t *Tests) MetadataReturnsTheXmpPacketOrSaysThereIsNone(ctx context.Context) error {
+	packet, err := pdf().Document(fixture(metadataPdf)).Metadata(ctx)
+	if err != nil {
+		return fmt.Errorf("Metadata: %w", err)
+	}
+	for _, want := range []string{"<?xpacket", "x:xmpmeta", "dc:title", xmpTitleMarker} {
+		if !strings.Contains(packet, want) {
+			return fmt.Errorf("expected the packet to contain %q, got:\n%s", want, packet)
+		}
+	}
+	// The Info dictionary's title is what pdfinfo prints without -meta, so its
+	// presence would mean the ordinary report came back under this name.
+	if strings.Contains(packet, infoTitleMarker) {
+		return fmt.Errorf("expected the XMP packet rather than pdfinfo's ordinary report, got:\n%s", packet)
+	}
+
+	absent, err := pdf().Document(fixture(ledgerPdf)).Metadata(ctx)
+	if err != nil {
+		return fmt.Errorf("Metadata of a document without XMP: %w", err)
+	}
+	// A document with no XMP is a perfectly good document, so this is a result
+	// and not a failure — and it has to say something, an empty string being what
+	// poppler returns and what a caller cannot act on.
+	for _, want := range []string{"No XMP metadata", "Info"} {
+		if !strings.Contains(absent, want) {
+			return fmt.Errorf("expected the absence to be reported with %q, got:\n%s", want, absent)
+		}
+	}
+	// Whatever it says, it must not read as a packet: a caller looking for XMP
+	// has to be able to tell there is none.
+	if strings.Contains(absent, "<?xpacket") {
+		return fmt.Errorf("expected no XMP packet, got:\n%s", absent)
+	}
+	return nil
+}
+
+// SignaturesReportsAnUnsignedDocumentInsteadOfFailing asserts the case almost
+// every document is: no signatures, reported as a result.
+//
+// It is the assertion the function's exit-code handling exists for. pdfsig exits
+// 2 for a document carrying no signatures, having printed exactly what it found,
+// and the module's usual treatment of a non-zero exit — an error naming the
+// failure — would turn the ordinary answer to an ordinary question into a broken
+// pipeline. Reserving failure for the runs that failed is what makes this
+// callable on documents whose signing status is what the caller is asking about.
+//
+// The NSS check is the other half. pdfsig writes `NSS_Init failed` to stderr in
+// an image carrying no certificate database, which is every image this module
+// builds, and a report assembled from both streams would carry that line into
+// every caller's output as though it were something the document said.
+func (t *Tests) SignaturesReportsAnUnsignedDocumentInsteadOfFailing(ctx context.Context) error {
+	report, err := pdf().Document(fixture(ledgerPdf)).Signatures(ctx)
+	if err != nil {
+		return fmt.Errorf("Signatures: %w", err)
+	}
+	if !strings.Contains(report, "does not contain any signatures") {
+		return fmt.Errorf("expected the report to say the document carries no signatures, got:\n%s", report)
+	}
+	if strings.Contains(report, "NSS") {
+		return fmt.Errorf("expected the report to carry the document's own report and not poppler's diagnostics, got:\n%s", report)
+	}
+	return nil
+}
+
+// ReportsOpenAnEncryptedDocumentWithThePassword asserts the document's password
+// reaches all three reporting tools, and that each says the same thing without
+// one.
+//
+// Each tool opens the document itself, so none of this follows from extraction
+// or rendering already working: a password threaded into pdftotext's invocation
+// and not into pdffonts' produces a module where a report on an encrypted
+// document fails while everything else about it succeeds. Both branches are
+// asserted for each, because the refusal is the half a caller reads — poppler
+// reports every wrong password as `Incorrect password` whether one was supplied
+// or not, so the message has to distinguish what the module knows and poppler
+// does not.
+func (t *Tests) ReportsOpenAnEncryptedDocumentWithThePassword(ctx context.Context) error {
+	userPw, err := generatedPassword(ctx)
+	if err != nil {
+		return fmt.Errorf("generating the user password: %w", err)
+	}
+	ownerPw, err := generatedPassword(ctx)
+	if err != nil {
+		return fmt.Errorf("generating the owner password: %w", err)
+	}
+	user := dag.SetSecret("pdf-tests-reports-user-password", userPw)
+	owner := dag.SetSecret("pdf-tests-reports-owner-password", ownerPw)
+	encrypted := encryptedLedger(user, owner)
+
+	reports := []struct {
+		name string
+		read func(doc *dagger.PdfDocument) (string, error)
+		want string
+	}{
+		{"Fonts", func(doc *dagger.PdfDocument) (string, error) { return doc.Fonts(ctx) }, fontsHelvetica},
+		// The encrypted fixture is ledgerPdf, which carries no XMP packet, so the
+		// opened document's answer here is the absence — reported, not failed.
+		{"Metadata", func(doc *dagger.PdfDocument) (string, error) { return doc.Metadata(ctx) }, "No XMP metadata"},
+		{"Signatures", func(doc *dagger.PdfDocument) (string, error) { return doc.Signatures(ctx) }, "does not contain any signatures"},
+	}
+
+	for _, report := range reports {
+		if _, err := report.read(pdf().Document(encrypted)); err == nil {
+			return fmt.Errorf("%s: expected an encrypted document to be refused without a password", report.name)
+		} else {
+			for _, want := range []string{"encrypted", "no password was supplied", "WithUserPassword"} {
+				if !strings.Contains(err.Error(), want) {
+					return fmt.Errorf("%s: expected the refusal to mention %q, got: %v", report.name, want, err)
+				}
+			}
+		}
+
+		for _, opened := range []struct {
+			name string
+			doc  *dagger.PdfDocument
+		}{
+			{"WithUserPassword", pdf().Document(encrypted).WithUserPassword(user)},
+			{"WithOwnerPassword", pdf().Document(encrypted).WithOwnerPassword(owner)},
+		} {
+			got, err := report.read(opened.doc)
+			if err != nil {
+				return fmt.Errorf("%s with %s: %w", report.name, opened.name, err)
+			}
+			if !strings.Contains(got, report.want) {
+				return fmt.Errorf("%s with %s: expected the report to contain %q, got:\n%s",
+					report.name, opened.name, report.want, got)
+			}
+		}
+	}
+	return nil
+}
+
+// fontRow picks one face's row out of pdffonts' table and splits it into fields.
+func fontRow(report, face string) ([]string, error) {
+	for _, line := range strings.Split(report, "\n") {
+		if strings.HasPrefix(line, face) {
+			return strings.Fields(line), nil
+		}
+	}
+	return nil, fmt.Errorf("expected a row for %s, got:\n%s", face, report)
+}
+
+// fontEmbedded reads the `emb` column out of a row of pdffonts' table.
+//
+// It counts from the end because the columns before it can each carry a space —
+// `Type 1` is one column, and a font name may hold one too — while the five that
+// follow never do: emb, sub, uni, and the two halves of the object reference.
+func fontEmbedded(fields []string) string {
+	const embFromEnd = 5
+	if len(fields) < embFromEnd {
+		return ""
+	}
+	return fields[len(fields)-embFromEnd]
 }
 
 // TextReproducesTextLayerExactly asserts Text returns the document's text


### PR DESCRIPTION
Closes #268.

Three reports on `Document`, each returning its poppler tool's report as text —
parsing them into structured values stays deliberately out of scope.

| function | tool | page range |
| --- | --- | --- |
| `Fonts` | `pdffonts` | **yes** |
| `Metadata` | `pdfinfo -meta` | no — document-level |
| `Signatures` | `pdfsig` | no — the tool has no page bounds |

`Fonts`' `emb` column is the direct diagnostic for the blank-page failure the
module's font install exists to prevent, and the page range reaches it because a
face used only on page 40 is genuinely absent from a report of pages 1–3.

`Metadata` returns the XMP packet alone. A document carrying none gets a line
naming the absence rather than the empty string poppler produces, which is
indistinguishable from a function that never ran.

`Signatures` is the one place this module reads a non-zero exit as a report
rather than a failure — `pdfsig` exits 2 for an unsigned document, which is
nearly every document. It decides on what was *printed*, not on the code:
`pdfsig` exits 1 both for "a signature did not validate", with the report on
stdout, and for "could not open the document", with nothing on it. Only a run
that produced no report fails, so a bad signature comes back as the report
saying so rather than as an error.

Passwords reach all three; without one, each refuses by naming the encryption.

## Fixtures

Two hand-authored, uncompressed PDFs, for shapes the existing fixtures cannot
express:

- `fonts.pdf` — two pages naming different faces (unembedded Helvetica, then
  unembedded Courier plus a Type 3 font that is embedded by construction). Every
  page of `ledger.pdf` names the same face, so narrowing a report of it changes
  nothing and would pass against a module that ignored the bounds.
- `metadata.pdf` — an XMP packet in a `/Metadata` stream, with an Info
  dictionary whose title deliberately differs, so an assertion can tell the
  packet apart from `pdfinfo`'s ordinary report of the same document.

## Tests

`dagger -m daggerverse/pdf/tests call all` is green. Five new tests:
`FontsReportsWhetherEachFaceIsEmbedded`, `FontsNarrowsToThePageRange`,
`MetadataReturnsTheXmpPacketOrSaysThereIsNone`,
`SignaturesReportsAnUnsignedDocumentInsteadOfFailing` and
`ReportsOpenAnEncryptedDocumentWithThePassword`.

No `+cache=` directive was added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)