### PR TITLE
story(issue-246): gate collection drift against its OpenAPI source

### DIFF
--- a/ci/internal/dagger/bruno-tests.gen.go
+++ b/ci/internal/dagger/bruno-tests.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type BrunoTests
-func (r *Binding) AsBrunoTests() *BrunoTests { // bruno-tests (../../../daggerverse/bruno/tests/main.go:32:6)
+func (r *Binding) AsBrunoTests() *BrunoTests { // bruno-tests (../../../daggerverse/bruno/tests/main.go:33:6)
 	q := r.query.Select("asBrunoTests")
 
 	return &BrunoTests{
@@ -18,11 +18,13 @@ func (r *Binding) AsBrunoTests() *BrunoTests { // bruno-tests (../../../daggerve
 	}
 }
 
-type BrunoTests struct { // bruno-tests (../../../daggerverse/bruno/tests/main.go:32:6)
+type BrunoTests struct { // bruno-tests (../../../daggerverse/bruno/tests/main.go:33:6)
 	query *querybuilder.Selection
 
 	all                                       *Void
 	caCertReachesPrivateCaService             *Void
+	checkDriftFailsOnAnEndpointAddedToTheSpec *Void
+	checkDriftFailsOnBothSidesOfTheRequestSet *Void
 	ciCheckGatesOnFailingAssertion            *Void
 	ciLintFailsBeforeAnyRequest               *Void
 	ciReachesMtlsServiceBehindPrivateCa       *Void
@@ -34,6 +36,7 @@ type BrunoTests struct { // bruno-tests (../../../daggerverse/bruno/tests/main.g
 	clientCertAuthenticatesToMtlsService      *Void
 	clientCertMaterialStaysOutOfTheCollection *Void
 	clientCertPassphraseUnlocksTheKey         *Void
+	driftIgnoresHandWrittenTests              *Void
 	generateHonoursOpenCollectionFormat       *Void
 	generateProducesRunnableCollection        *Void
 	generateRejectsUnknownFormat              *Void
@@ -69,11 +72,11 @@ func (r *BrunoTests) WithGraphQLQuery(q *querybuilder.Selection) *BrunoTests {
 
 // BrunoTestsAllOpts contains options for BrunoTests.All
 type BrunoTestsAllOpts struct {
-	Parallel int // bruno-tests (../../../daggerverse/bruno/tests/main.go:41:2)
+	Parallel int // bruno-tests (../../../daggerverse/bruno/tests/main.go:42:2)
 }
 
 // All runs every bruno-module test in parallel.
-func (r *BrunoTests) All(ctx context.Context, opts ...BrunoTestsAllOpts) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:38:1)
+func (r *BrunoTests) All(ctx context.Context, opts ...BrunoTestsAllOpts) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:39:1)
 	if r.all != nil {
 		return nil
 	}
@@ -101,11 +104,44 @@ func (r *BrunoTests) All(ctx context.Context, opts ...BrunoTestsAllOpts) error {
 // alone. It has to still pass: the flag is a no-op that is easy to render into a
 // run that was going to pass anyway, and easy to get wrong in a way that severs
 // the connection.
-func (r *BrunoTests) CaCertReachesPrivateCaService(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1186:1)
+func (r *BrunoTests) CaCertReachesPrivateCaService(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1339:1)
 	if r.caCertReachesPrivateCaService != nil {
 		return nil
 	}
 	q := r.query.Select("caCertReachesPrivateCaService")
+
+	return q.Execute(ctx)
+}
+
+// CheckDriftFailsOnAnEndpointAddedToTheSpec checks the case the whole story
+// exists for: the document grew an operation and nobody added a request for it,
+// so the endpoint is untested and nothing says so.
+//
+// The failure has to name the missing request rather than only report that
+// something differs — an endpoint nobody noticed is not made findable by being
+// told a count changed.
+func (r *BrunoTests) CheckDriftFailsOnAnEndpointAddedToTheSpec(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:710:1)
+	if r.checkDriftFailsOnAnEndpointAddedToTheSpec != nil {
+		return nil
+	}
+	q := r.query.Select("checkDriftFailsOnAnEndpointAddedToTheSpec")
+
+	return q.Execute(ctx)
+}
+
+// CheckDriftFailsOnBothSidesOfTheRequestSet checks the other direction, and
+// that the two are distinguished.
+//
+// A request deleted from the collection leaves an endpoint the document declares
+// with nothing testing it. A request the document has no operation for is the
+// opposite problem — an endpoint that was renamed or retired upstream, still
+// being exercised — and it has to read as its own thing rather than as the same
+// finding, because the fix is the opposite one.
+func (r *BrunoTests) CheckDriftFailsOnBothSidesOfTheRequestSet(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:754:1)
+	if r.checkDriftFailsOnBothSidesOfTheRequestSet != nil {
+		return nil
+	}
+	q := r.query.Select("checkDriftFailsOnBothSidesOfTheRequestSet")
 
 	return q.Execute(ctx)
 }
@@ -116,7 +152,7 @@ func (r *BrunoTests) CaCertReachesPrivateCaService(ctx context.Context) error { 
 //
 // The lint stage is enabled deliberately, so the failure has to be the
 // assertion and not the linter having an opinion about the fixture.
-func (r *BrunoTests) CiCheckGatesOnFailingAssertion(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:888:1)
+func (r *BrunoTests) CiCheckGatesOnFailingAssertion(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1041:1)
 	if r.ciCheckGatesOnFailingAssertion != nil {
 		return nil
 	}
@@ -135,7 +171,7 @@ func (r *BrunoTests) CiCheckGatesOnFailingAssertion(ctx context.Context) error {
 // is checked afterwards and passes, so a request count of zero on the first
 // pass is the lint stage short-circuiting rather than the collection being
 // unrunnable.
-func (r *BrunoTests) CiLintFailsBeforeAnyRequest(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:838:1)
+func (r *BrunoTests) CiLintFailsBeforeAnyRequest(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:991:1)
 	if r.ciLintFailsBeforeAnyRequest != nil {
 		return nil
 	}
@@ -158,7 +194,7 @@ func (r *BrunoTests) CiLintFailsBeforeAnyRequest(ctx context.Context) error { //
 // Both terminals are exercised, since a report of a run that never connected is
 // the failure this would otherwise hide, and the lint stage is enabled so the
 // TLS material has to survive being validated ahead of the run.
-func (r *BrunoTests) CiReachesMtlsServiceBehindPrivateCa(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1492:1)
+func (r *BrunoTests) CiReachesMtlsServiceBehindPrivateCa(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1645:1)
 	if r.ciReachesMtlsServiceBehindPrivateCa != nil {
 		return nil
 	}
@@ -172,7 +208,7 @@ func (r *BrunoTests) CiReachesMtlsServiceBehindPrivateCa(ctx context.Context) er
 // the finding belongs to the terminal — and it belongs to Check as much as to
 // Run, because a pipeline whose declared artifact cannot be produced is broken
 // whichever terminal is invoked first.
-func (r *BrunoTests) CiRejectsUnknownReportFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:798:1)
+func (r *BrunoTests) CiRejectsUnknownReportFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:951:1)
 	if r.ciRejectsUnknownReportFormat != nil {
 		return nil
 	}
@@ -189,7 +225,7 @@ func (r *BrunoTests) CiRejectsUnknownReportFormat(ctx context.Context) error { /
 // two-format Run is a pipeline that ran the collection once — and therefore two
 // reports describing the same set of responses, rather than two runs of the same
 // collection reporting on different ones.
-func (r *BrunoTests) CiRunProducesEveryRequestedReport(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:927:1)
+func (r *BrunoTests) CiRunProducesEveryRequestedReport(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1080:1)
 	if r.ciRunProducesEveryRequestedReport != nil {
 		return nil
 	}
@@ -207,7 +243,7 @@ func (r *BrunoTests) CiRunProducesEveryRequestedReport(ctx context.Context) erro
 // on exactly the runs whose report a pipeline needs — the JUnit file a CI system
 // turns into a test report names which assertion failed, and it is worthless if
 // it only arrives when nothing did.
-func (r *BrunoTests) CiRunStillReportsWhenTheCollectionFails(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:997:1)
+func (r *BrunoTests) CiRunStillReportsWhenTheCollectionFails(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1150:1)
 	if r.ciRunStillReportsWhenTheCollectionFails != nil {
 		return nil
 	}
@@ -230,7 +266,7 @@ func (r *BrunoTests) CiRunStillReportsWhenTheCollectionFails(ctx context.Context
 // and reading process.argv needs the developer sandbox. The pipeline builder
 // wraps no sandbox switch — a collection needing one is assembled through
 // Collection — so it gets the same request without the script.
-func (r *BrunoTests) CiSecretVarReachesTheCollection(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1094:1)
+func (r *BrunoTests) CiSecretVarReachesTheCollection(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1247:1)
 	if r.ciSecretVarReachesTheCollection != nil {
 		return nil
 	}
@@ -246,7 +282,7 @@ func (r *BrunoTests) CiSecretVarReachesTheCollection(ctx context.Context) error 
 //
 // Counted at the service rather than read out of bru's summary: a replayed run
 // prints a perfectly convincing "1 request, 1 passed".
-func (r *BrunoTests) CiShouldNotBeCached(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1038:1)
+func (r *BrunoTests) CiShouldNotBeCached(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1191:1)
 	if r.ciShouldNotBeCached != nil {
 		return nil
 	}
@@ -267,7 +303,7 @@ func (r *BrunoTests) CiShouldNotBeCached(ctx context.Context) error { // bruno-t
 // The first pass is the control: the same collection, verifying the same server,
 // with no client certificate configured. It has to fail, or the second pass says
 // nothing about the certificate having been needed.
-func (r *BrunoTests) ClientCertAuthenticatesToMtlsService(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1255:1)
+func (r *BrunoTests) ClientCertAuthenticatesToMtlsService(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1408:1)
 	if r.clientCertAuthenticatesToMtlsService != nil {
 		return nil
 	}
@@ -290,7 +326,7 @@ func (r *BrunoTests) ClientCertAuthenticatesToMtlsService(ctx context.Context) e
 // The responder demands the certificate, so this is not a run that skipped the
 // key: it reports the peer's Common Name back, and the key was necessary to
 // produce it.
-func (r *BrunoTests) ClientCertMaterialStaysOutOfTheCollection(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1341:1)
+func (r *BrunoTests) ClientCertMaterialStaysOutOfTheCollection(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1494:1)
 	if r.clientCertMaterialStaysOutOfTheCollection != nil {
 		return nil
 	}
@@ -310,11 +346,28 @@ func (r *BrunoTests) ClientCertMaterialStaysOutOfTheCollection(ctx context.Conte
 // So the same encrypted key is run twice. Without the passphrase the key cannot
 // be loaded and the run fails; with it, the run authenticates to the mTLS
 // endpoint and the responder reports the certificate back.
-func (r *BrunoTests) ClientCertPassphraseUnlocksTheKey(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1418:1)
+func (r *BrunoTests) ClientCertPassphraseUnlocksTheKey(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1571:1)
 	if r.clientCertPassphraseUnlocksTheKey != nil {
 		return nil
 	}
 	q := r.query.Select("clientCertPassphraseUnlocksTheKey")
+
+	return q.Execute(ctx)
+}
+
+// DriftIgnoresHandWrittenTests checks the scoping the comparison exists for. A
+// collection generated from the spec matches it — and still matches once one of
+// its requests carries a test the document never described.
+//
+// The second half is the whole reason the comparison is not a tree diff: a
+// generated request is where anyone would put the assertions that make the
+// collection worth running, and a check that called that drift would be a check
+// nobody could leave switched on.
+func (r *BrunoTests) DriftIgnoresHandWrittenTests(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:652:1)
+	if r.driftIgnoresHandWrittenTests != nil {
+		return nil
+	}
+	q := r.query.Select("driftIgnoresHandWrittenTests")
 
 	return q.Execute(ctx)
 }
@@ -326,7 +379,7 @@ func (r *BrunoTests) ClientCertPassphraseUnlocksTheKey(ctx context.Context) erro
 // It also pins the reason the default diverges from upstream's. The
 // opencollection shape carries no bruno.json, so it is not something Collection
 // could run — which is why this module defaults to the other one.
-func (r *BrunoTests) GenerateHonoursOpenCollectionFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:602:1)
+func (r *BrunoTests) GenerateHonoursOpenCollectionFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:606:1)
 	if r.generateHonoursOpenCollectionFormat != nil {
 		return nil
 	}
@@ -348,7 +401,7 @@ func (r *BrunoTests) GenerateHonoursOpenCollectionFormat(ctx context.Context) er
 // The environment's name is read off the generated tree rather than hardcoded:
 // bru derives it from the server's description, which is the spec's business
 // and not this module's.
-func (r *BrunoTests) GenerateProducesRunnableCollection(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:524:1)
+func (r *BrunoTests) GenerateProducesRunnableCollection(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:528:1)
 	if r.generateProducesRunnableCollection != nil {
 		return nil
 	}
@@ -361,7 +414,7 @@ func (r *BrunoTests) GenerateProducesRunnableCollection(ctx context.Context) err
 // is refused by name. bru refuses one too, but by printing its whole help text
 // with the actual complaint on the last line — and only after a container has
 // been started to find out.
-func (r *BrunoTests) GenerateRejectsUnknownFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:622:1)
+func (r *BrunoTests) GenerateRejectsUnknownFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:626:1)
 	if r.generateRejectsUnknownFormat != nil {
 		return nil
 	}
@@ -424,7 +477,7 @@ func (r *BrunoTests) UnmarshalJSON(bs []byte) error {
 // that extension and not from the contents, so a JSON environment staged as
 // .bru dies inside the Bruno grammar — with a Node stack trace, several layers
 // away from anything the caller did.
-func (r *BrunoTests) JSONEnvFileKeepsItsExtension(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:486:1)
+func (r *BrunoTests) JSONEnvFileKeepsItsExtension(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:490:1)
 	if r.jsonEnvFileKeepsItsExtension != nil {
 		return nil
 	}
@@ -440,7 +493,7 @@ func (r *BrunoTests) JSONEnvFileKeepsItsExtension(ctx context.Context) error { /
 //
 // It is checked under failOnWarnings=true as well, so the fixture has to be
 // free of warnings and not merely free of errors.
-func (r *BrunoTests) LintAcceptsValidCollection(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:647:1)
+func (r *BrunoTests) LintAcceptsValidCollection(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:800:1)
 	if r.lintAcceptsValidCollection != nil {
 		return nil
 	}
@@ -452,7 +505,7 @@ func (r *BrunoTests) LintAcceptsValidCollection(ctx context.Context) error { // 
 // LintRejectsDuplicateSequence checks that two requests claiming the same seq
 // in one folder is a finding, and that the same seq in a different folder is
 // not — seq orders a folder's requests, so it is only ambiguous within one.
-func (r *BrunoTests) LintRejectsDuplicateSequence(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:754:1)
+func (r *BrunoTests) LintRejectsDuplicateSequence(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:907:1)
 	if r.lintRejectsDuplicateSequence != nil {
 		return nil
 	}
@@ -464,7 +517,7 @@ func (r *BrunoTests) LintRejectsDuplicateSequence(ctx context.Context) error { /
 // LintRejectsMissingBrunoJson checks the finding that stands in for bru's exit
 // 4. bru reports that one as "not a collection root", from inside a container,
 // without naming the file it wanted.
-func (r *BrunoTests) LintRejectsMissingBrunoJSON(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:666:1)
+func (r *BrunoTests) LintRejectsMissingBrunoJSON(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:819:1)
 	if r.lintRejectsMissingBrunoJson != nil {
 		return nil
 	}
@@ -480,7 +533,7 @@ func (r *BrunoTests) LintRejectsMissingBrunoJSON(ctx context.Context) error { //
 // The fixture holds two controls beside the violation — a token whose value is
 // a {{process.env.*}} interpolation, and a name declared in a vars:secret
 // block — so this also pins that the rule accepts the shape it is asking for.
-func (r *BrunoTests) LintRejectsPlaintextSecret(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:730:1)
+func (r *BrunoTests) LintRejectsPlaintextSecret(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:883:1)
 	if r.lintRejectsPlaintextSecret != nil {
 		return nil
 	}
@@ -492,7 +545,7 @@ func (r *BrunoTests) LintRejectsPlaintextSecret(ctx context.Context) error { // 
 // LintRejectsUnknownEnvironment checks that a mistyped --env name is caught
 // here rather than as bru's exit 6, and that the finding lists the names the
 // collection does ship.
-func (r *BrunoTests) LintRejectsUnknownEnvironment(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:682:1)
+func (r *BrunoTests) LintRejectsUnknownEnvironment(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:835:1)
 	if r.lintRejectsUnknownEnvironment != nil {
 		return nil
 	}
@@ -508,7 +561,7 @@ func (r *BrunoTests) LintRejectsUnknownEnvironment(ctx context.Context) error { 
 // The fixture also references two undeclared variables from its docs block,
 // which bru never interpolates — so this pins that prose is not linted as
 // though it were a request.
-func (r *BrunoTests) LintRejectsUnresolvedVariable(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:702:1)
+func (r *BrunoTests) LintRejectsUnresolvedVariable(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:855:1)
 	if r.lintRejectsUnresolvedVariable != nil {
 		return nil
 	}
@@ -523,7 +576,7 @@ func (r *BrunoTests) LintRejectsUnresolvedVariable(ctx context.Context) error { 
 //
 // The fixture's only assertion is disabled, which is the same as not having
 // written it — so this also pins that a commented-out assert does not count.
-func (r *BrunoTests) LintWarnsOnRequestWithoutTests(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:776:1)
+func (r *BrunoTests) LintWarnsOnRequestWithoutTests(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:929:1)
 	if r.lintWarnsOnRequestWithoutTests != nil {
 		return nil
 	}
@@ -541,7 +594,7 @@ func (r *BrunoTests) LintWarnsOnRequestWithoutTests(ctx context.Context) error {
 // The api fixture tags its root request and leaves the nested one untagged, so
 // the tag filters also have to have selected the right request rather than
 // merely been tolerated.
-func (r *BrunoTests) PassThroughFlagsAreAccepted(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:447:1)
+func (r *BrunoTests) PassThroughFlagsAreAccepted(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:451:1)
 	if r.passThroughFlagsAreAccepted != nil {
 		return nil
 	}
@@ -559,7 +612,7 @@ func (r *BrunoTests) PassThroughFlagsAreAccepted(ctx context.Context) error { //
 // and the default wins — so `Recursive: false` would silently assert the
 // default all over again. It is reachable from the CLI as
 // `run --recursive=false`.
-func (r *BrunoTests) RecursiveDefaultReachesSubfolders(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:234:1)
+func (r *BrunoTests) RecursiveDefaultReachesSubfolders(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:238:1)
 	if r.recursiveDefaultReachesSubfolders != nil {
 		return nil
 	}
@@ -573,7 +626,7 @@ func (r *BrunoTests) RecursiveDefaultReachesSubfolders(ctx context.Context) erro
 // artifact, and the artifact says what failed. Run would have raised an error
 // here, and an error forfeits the value — which is why the two are separate
 // functions rather than one.
-func (r *BrunoTests) ReportEmitsJunitForFailingRun(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:267:1)
+func (r *BrunoTests) ReportEmitsJunitForFailingRun(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:271:1)
 	if r.reportEmitsJunitForFailingRun != nil {
 		return nil
 	}
@@ -585,7 +638,7 @@ func (r *BrunoTests) ReportEmitsJunitForFailingRun(ctx context.Context) error { 
 // ReportRejectsUnknownFormat checks that a format bru does not write is
 // refused by name, before a live collection has been run against a live
 // service to find out.
-func (r *BrunoTests) ReportRejectsUnknownFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:294:1)
+func (r *BrunoTests) ReportRejectsUnknownFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:298:1)
 	if r.reportRejectsUnknownFormat != nil {
 		return nil
 	}
@@ -597,7 +650,7 @@ func (r *BrunoTests) ReportRejectsUnknownFormat(ctx context.Context) error { // 
 // ReportShouldNotBeCached checks that two identical Reports each reach the
 // service. A report of a run that never happened describes an API nobody
 // asked about.
-func (r *BrunoTests) ReportShouldNotBeCached(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:316:1)
+func (r *BrunoTests) ReportShouldNotBeCached(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:320:1)
 	if r.reportShouldNotBeCached != nil {
 		return nil
 	}
@@ -609,7 +662,7 @@ func (r *BrunoTests) ReportShouldNotBeCached(ctx context.Context) error { // bru
 // RunFailsOnAssertionFailure checks that exit 1 — a failing request, test or
 // assertion — is an error, and that the error carries bru's own account of
 // what failed rather than just the exit code.
-func (r *BrunoTests) RunFailsOnAssertionFailure(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:141:1)
+func (r *BrunoTests) RunFailsOnAssertionFailure(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:145:1)
 	if r.runFailsOnAssertionFailure != nil {
 		return nil
 	}
@@ -620,7 +673,7 @@ func (r *BrunoTests) RunFailsOnAssertionFailure(ctx context.Context) error { // 
 
 // RunPassesAgainstBoundService checks the whole point of the module: a
 // collection whose environment names a bound service reaches it and passes.
-func (r *BrunoTests) RunPassesAgainstBoundService(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:109:1)
+func (r *BrunoTests) RunPassesAgainstBoundService(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:113:1)
 	if r.runPassesAgainstBoundService != nil {
 		return nil
 	}
@@ -632,7 +685,7 @@ func (r *BrunoTests) RunPassesAgainstBoundService(ctx context.Context) error { /
 // RunShouldNotBeCached checks that two identical Runs each reach the service.
 // A collection run hits a live API, so a cached pass would report a
 // now-broken API as green.
-func (r *BrunoTests) RunShouldNotBeCached(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:197:1)
+func (r *BrunoTests) RunShouldNotBeCached(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:201:1)
 	if r.runShouldNotBeCached != nil {
 		return nil
 	}
@@ -654,7 +707,7 @@ func (r *BrunoTests) RunShouldNotBeCached(ctx context.Context) error { // bruno-
 // command line" can actually be checked. That script needs the developer
 // sandbox — the safe one has no process — which is what makes WithSandbox
 // part of this test.
-func (r *BrunoTests) SecretVarIsNotOnArgv(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:393:1)
+func (r *BrunoTests) SecretVarIsNotOnArgv(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:397:1)
 	if r.secretVarIsNotOnArgv != nil {
 		return nil
 	}
@@ -671,7 +724,7 @@ func (r *BrunoTests) SecretVarIsNotOnArgv(ctx context.Context) error { // bruno-
 // against a named CA. `--ignore-truststore` is evaluated in combination with
 // `--cacert` only, so on its own it is a flag that does nothing. Neither is a
 // non-zero exit, which is why they are the module's to catch.
-func (r *BrunoTests) TLSControlsAreValidated(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1135:1)
+func (r *BrunoTests) TLSControlsAreValidated(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1288:1)
 	if r.tlsControlsAreValidated != nil {
 		return nil
 	}
@@ -684,7 +737,7 @@ func (r *BrunoTests) TLSControlsAreValidated(ctx context.Context) error { // bru
 // bru exits 6 when the named environment does not exist; conflating that with
 // exit 1 would make "you typo'd the environment name" read as "your API is
 // broken".
-func (r *BrunoTests) UnknownEnvironmentIsRejected(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:171:1)
+func (r *BrunoTests) UnknownEnvironmentIsRejected(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:175:1)
 	if r.unknownEnvironmentIsRejected != nil {
 		return nil
 	}
@@ -697,7 +750,7 @@ func (r *BrunoTests) UnknownEnvironmentIsRejected(ctx context.Context) error { /
 // release the module pins. The Debian variant is not cosmetic — it is the
 // escape hatch for the Alpine image's musl/OpenSSL TLS failures — so it has
 // to be a tag that exists and ships the same CLI.
-func (r *BrunoTests) VersionReportsPinnedRelease(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:94:1)
+func (r *BrunoTests) VersionReportsPinnedRelease(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:98:1)
 	if r.versionReportsPinnedRelease != nil {
 		return nil
 	}
@@ -710,7 +763,7 @@ func (r *BrunoTests) VersionReportsPinnedRelease(ctx context.Context) error { //
 // selected environment declares. The fixture puts the variable in the request
 // path, so the responder records which of the two won rather than the module
 // having to trust bru's summary.
-func (r *BrunoTests) WithVarOverridesEnvironmentValue(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:353:1)
+func (r *BrunoTests) WithVarOverridesEnvironmentValue(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:357:1)
 	if r.withVarOverridesEnvironmentValue != nil {
 		return nil
 	}
@@ -728,7 +781,7 @@ func (r *BrunoTests) AsNode() Node {
 }
 
 // Create or update a binding of type BrunoTests in the environment
-func (r *Env) WithBrunoTestsInput(name string, value *BrunoTests, description string) *Env { // bruno-tests (../../../daggerverse/bruno/tests/main.go:32:6)
+func (r *Env) WithBrunoTestsInput(name string, value *BrunoTests, description string) *Env { // bruno-tests (../../../daggerverse/bruno/tests/main.go:33:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withBrunoTestsInput")
 	q = q.Arg("name", name)
@@ -741,7 +794,7 @@ func (r *Env) WithBrunoTestsInput(name string, value *BrunoTests, description st
 }
 
 // Declare a desired BrunoTests output to be assigned in the environment
-func (r *Env) WithBrunoTestsOutput(name string, description string) *Env { // bruno-tests (../../../daggerverse/bruno/tests/main.go:32:6)
+func (r *Env) WithBrunoTestsOutput(name string, description string) *Env { // bruno-tests (../../../daggerverse/bruno/tests/main.go:33:6)
 	q := r.query.Select("withBrunoTestsOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -755,7 +808,7 @@ func (r *Env) WithBrunoTestsOutput(name string, description string) *Env { // br
 // test is exposed as a standalone dagger function so it can be invoked
 // individually during TDD; All wires them up for parallel execution under
 // `dagger call all`.
-func (r *Query) BrunoTests() *BrunoTests { // bruno-tests (../../../daggerverse/bruno/tests/main.go:32:6)
+func (r *Query) BrunoTests() *BrunoTests { // bruno-tests (../../../daggerverse/bruno/tests/main.go:33:6)
 	q := r.query.Select("brunoTests")
 
 	return &BrunoTests{

--- a/daggerverse/bruno/README.md
+++ b/daggerverse/bruno/README.md
@@ -236,6 +236,79 @@ of the document and touches no live service.
 `--group-by path` (the alternative to grouping by tag) and `bru import wsdl`
 are not wrapped; both are reachable through `Container()`.
 
+## Gating drift against the spec
+
+Generating a collection is the easy half. Once it is committed and someone has
+written the assertions that make it worth running, the interesting question is
+whether it still matches the document. An operation added to the spec that
+nobody added a request for is a silently untested endpoint: nothing fails,
+because nothing asks.
+
+`Drift` regenerates the collection from the document and reports the difference;
+`CheckDrift` is the same comparison as a gate.
+
+```go
+report, err := dag.Bruno().Collection(source).Drift(ctx, spec)   // tells you
+err = dag.Bruno().Collection(source).CheckDrift(ctx, spec)       // fails on it
+```
+
+```sh
+dagger -m github.com/z5labs/devex/daggerverse/bruno call \
+  collection --source=./api-tests \
+  check-drift --spec=./openapi.yaml
+```
+
+```
+bru drift: the collection does not match the OpenAPI document.
+  a/requests is the request set the collection commits; b/requests is the one the document declares.
+  + is an operation the document declares that the collection has no request for;
+  - is a request the collection commits that the document does not declare.
+
+diff --git a/requests b/requests
+--- a/requests
++++ b/requests
+@@ -2,3 +2,4 @@ GET /health
+ GET /pets
+ POST /pets
+ GET /pets/:petId
++GET /pets/:petId/toys
+```
+
+**The comparison is scoped to the request set — each request's method and path —
+and not to the two trees.** A generated request carries detail the document
+never described: the tests and assertions somebody added, the ordering, the
+scripts. A byte-for-byte tree diff would call every one of those drift, which
+would make the check useless on any collection anyone has actually worked on —
+and a check nobody can leave switched on catches nothing.
+
+So the listing each side is reduced to drops what the document has no opinion
+about:
+
+| | |
+|---|---|
+| The server | `{{baseUrl}}/pets` and `https://api.example.com/pets` are both `/pets`. Which host the collection points at is the environment's business. |
+| The query string | OpenAPI describes query parameters beside the path, and `bru import` writes them into a `params:query` block, so a url carrying one was hand-edited and is still the same endpoint. |
+| Path-parameter spelling | The document's `{petId}` and Bruno's `:petId` are the same segment; both normalise onto `:petId`, which is how the report spells it. |
+| Duplicate requests | A collection may hold two requests against one endpoint, the second asserting what the first set up. Neither the document nor this comparison has anything to say about how many there are. |
+
+The expected set comes from `bru import` rather than from a second reading of
+the document. Drift means "what `bru` would generate from this spec versus what
+is committed", and an independent OpenAPI parser here could disagree with `bru`
+about a document and report a difference nobody could act on.
+
+The diff itself is `Directory.Changes` and the `Changeset` it returns —
+`IsEmpty` is the verdict, `AsPatch` is the report — so nothing about it is
+hand-rolled. What this module owns is only the normalisation above, which is why
+the patch names a synthetic `requests` file rather than any file on disk.
+
+`Drift` never fails on drift and `CheckDrift` carries the report inside its
+error, for the same reason `Report` does not gate and `Lint` folds its findings
+into one: Dagger drops a function's value when it also returns an error, so a
+gating `Drift` could not hand back the report that says what to fix.
+
+Unlike `Lint`, this one runs a container — regenerating means running `bru
+import` — so it is not the free check that `Lint` is.
+
 ## The Ci pipeline
 
 Lint, run and report are three calls plus the glue that decides what fails the
@@ -347,8 +420,8 @@ module or touch the filesystem needs `WithSandbox("developer")` — and fails at
 
 `Run`, `Report`, `Ci.Check` and `Ci.Run` carry `+cache="never"`: a collection
 run hits a live service, so a cached pass would report a now-broken API as
-green. `Container`, `Version`, `Generate` and `Lint` stay `+cache="session"` —
-those are pure.
+green. `Container`, `Version`, `Generate`, `Lint`, `Drift` and `CheckDrift` stay
+`+cache="session"` — those are pure functions of a document and a tree.
 
 That directive governs the *function* result; the `WithExec` layer underneath
 is still content-addressed, so every terminal stamps a per-call nonce onto the
@@ -440,6 +513,8 @@ tail.
 | `Collection.WithBail()` | `--bail`; stop at the first failure. |
 | `Collection.WithDelay(milliseconds)` | `--delay`; wait between requests. |
 | `Collection.Lint(failOnWarnings)` | Check the collection's structure in pure Go, issuing no requests. |
+| `Collection.Drift(spec)` | Report how the committed request set differs from the OpenAPI document. |
+| `Collection.CheckDrift(spec)` | The same comparison as a gate; the report travels in the error. |
 | `Collection.Run(recursive)` | Run the collection; bru's output, failing on exit 1. |
 | `Collection.Report(format)` | Run it and return the `json`, `junit` or `html` artifact, failing only on usage errors. |
 | `Ci(source)` | Bind a collection to the standardized pipeline builder. |

--- a/daggerverse/bruno/dagger.gen.go
+++ b/daggerverse/bruno/dagger.gen.go
@@ -608,6 +608,34 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 		}
 	case "Collection":
 		switch fnName {
+		case "CheckDrift":
+			var parent Collection
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var spec *dagger.File
+			if inputArgs["spec"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["spec"]), &spec)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg spec", err))
+				}
+			}
+			return nil, (*Collection).CheckDrift(&parent, ctx, spec)
+		case "Drift":
+			var parent Collection
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var spec *dagger.File
+			if inputArgs["spec"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["spec"]), &spec)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg spec", err))
+				}
+			}
+			return (*Collection).Drift(&parent, ctx, spec)
 		case "Lint":
 			var parent Collection
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/bruno/drift.go
+++ b/daggerverse/bruno/drift.go
@@ -1,0 +1,300 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"dagger/bruno/internal/dagger"
+)
+
+const (
+	// requestListingFile is the name the canonical request listing is written
+	// under on both sides of the comparison. It is the path that shows up in
+	// the patch's own `a/` and `b/` headers, so it is named for what it holds
+	// rather than for either side of the diff.
+	requestListingFile = "requests"
+)
+
+// requestMethodBlocks maps a request's verb block onto the method it stands
+// for. In a .bru file the verb is the block's name — `get { url: ... }` — so
+// this is also the set of blocks that make a .bru file a request rather than a
+// folder or collection settings file.
+var requestMethodBlocks = map[string]string{
+	"get":     "GET",
+	"post":    "POST",
+	"put":     "PUT",
+	"patch":   "PATCH",
+	"delete":  "DELETE",
+	"head":    "HEAD",
+	"options": "OPTIONS",
+	"trace":   "TRACE",
+}
+
+var (
+	// urlBaseVariable matches the interpolation a generated request's url opens
+	// with — `{{baseUrl}}/pets`. It names the server, which is the spec's
+	// business and not the request set's, so it comes off before comparing.
+	urlBaseVariable = regexp.MustCompile(`^\{\{[^{}]*\}\}`)
+
+	// urlOrigin matches the scheme://host[:port] prefix of a url written out in
+	// full, for the collection that hardcodes its target instead of resolving
+	// one from an environment.
+	urlOrigin = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9+.\-]*://[^/]*`)
+
+	// bracedPathParam matches OpenAPI's `{petId}` spelling of a path parameter.
+	// `bru import` rewrites it to Bruno's `:petId`, so the two are the same
+	// segment and normalising one onto the other keeps a hand-written request
+	// comparable with a generated one.
+	bracedPathParam = regexp.MustCompile(`^\{([^{}]+)\}$`)
+)
+
+// Drift reports how the committed collection differs from the OpenAPI document
+// it was generated from.
+//
+// A new operation in the spec that nobody added to the collection is a silently
+// untested endpoint: nothing fails, because nothing asks. This is the check that
+// notices — it regenerates the collection from the document and compares the
+// result against what is committed.
+//
+// The comparison is scoped to the request set — each request's method and path,
+// deduplicated and sorted — rather than being a diff of the two trees. A
+// generated request carries detail the document never described (the tests and
+// assertions that make the collection worth running, the ordering, the scripts),
+// and a byte-for-byte comparison would call every one of those drift. Query
+// strings are dropped and path parameters are normalised onto Bruno's `:name`
+// spelling, so the same endpoint written either way reads as the same endpoint.
+//
+// It returns the difference rather than failing on it, and never fails on drift
+// alone: Dagger drops a function's value when it also returns an error, so a
+// gating Drift could not hand back the report that says what drifted. CheckDrift
+// is the gate; this is the one that tells you what to fix.
+//
+// +cache="session"
+func (c *Collection) Drift(
+	ctx context.Context,
+	// The OpenAPI document the collection is generated from. YAML or JSON —
+	// bru reads the contents, not the file name.
+	spec *dagger.File,
+) (string, error) {
+	result, err := c.drift(ctx, spec)
+	if err != nil {
+		return "", err
+	}
+	return result.report(), nil
+}
+
+// CheckDrift fails when the committed collection no longer matches the OpenAPI
+// document it was generated from, so a pipeline can hang a check on the two
+// staying in step.
+//
+// The report travels in the error rather than alongside it, following Lint: a
+// Dagger function that returns an error forfeits its value, so a (report, error)
+// signature would hide the report on the one path that needs it.
+//
+// +cache="session"
+func (c *Collection) CheckDrift(
+	ctx context.Context,
+	// The OpenAPI document the collection is generated from.
+	spec *dagger.File,
+) error {
+	result, err := c.drift(ctx, spec)
+	if err != nil {
+		return err
+	}
+	if !result.Drifted {
+		return nil
+	}
+	return fmt.Errorf("%s", result.report())
+}
+
+// driftResult is the outcome of one comparison: whether the two request sets
+// differ, the patch describing how, and how many requests the spec accounts
+// for.
+type driftResult struct {
+	Drifted  bool
+	Patch    string
+	Declared int
+}
+
+// report renders the outcome for a human. The clean case names the number of
+// requests it accounted for, because a comparison that read no requests at all
+// would otherwise "match" every document it was handed.
+func (r driftResult) report() string {
+	if !r.Drifted {
+		return fmt.Sprintf("bru drift: the collection matches the OpenAPI document (%s).",
+			plural(r.Declared, "request"))
+	}
+	return strings.Join([]string{
+		"bru drift: the collection does not match the OpenAPI document.",
+		fmt.Sprintf("  a/%s is the request set the collection commits; b/%s is the one the document declares.",
+			requestListingFile, requestListingFile),
+		"  + is an operation the document declares that the collection has no request for;",
+		"  - is a request the collection commits that the document does not declare.",
+		"",
+		r.Patch,
+	}, "\n")
+}
+
+// drift regenerates the collection from the document and compares the two
+// request sets.
+//
+// The expected set comes from `bru import` rather than from a second reading of
+// the OpenAPI document: drift is "what bru would generate from this spec versus
+// what is committed", and an independent parser here could disagree with bru
+// about a document and report a difference nobody could act on.
+//
+// The two sets are compared through Directory.Changes and the Changeset it
+// returns — IsEmpty is the verdict, AsPatch is the report — so the diff itself is
+// the engine's rather than something hand-rolled. What this function owns is
+// only the normalisation that decides what goes into the listing.
+func (c *Collection) drift(ctx context.Context, spec *dagger.File) (driftResult, error) {
+	var out driftResult
+	if err := c.validate(); err != nil {
+		return out, err
+	}
+
+	committed, err := c.loadTree(ctx, "Drift")
+	if err != nil {
+		return out, err
+	}
+
+	// The collection name is stamped into the generated bruno.json, which the
+	// request set does not include — so the default is as good as reading the
+	// committed manifest to match it.
+	generatedDir, err := c.Bruno.Generate(ctx, spec, defaultCollectionName, formatBru)
+	if err != nil {
+		return out, err
+	}
+	generated, err := (&Collection{Bruno: c.Bruno, Source: generatedDir}).loadTree(ctx, "Drift")
+	if err != nil {
+		return out, err
+	}
+
+	declared := requestSet(generated)
+	out.Declared = len(declared)
+
+	changes := listingDirectory(declared).
+		Changes(listingDirectory(requestSet(committed)))
+	empty, err := changes.IsEmpty(ctx)
+	if err != nil {
+		return out, fmt.Errorf("Drift: compare the two request sets: %v", err)
+	}
+	if empty {
+		return out, nil
+	}
+
+	patch, err := changes.AsPatch().Contents(ctx)
+	if err != nil {
+		return out, fmt.Errorf("Drift: read the difference between the two request sets: %v", err)
+	}
+	out.Drifted = true
+	out.Patch = strings.TrimRight(patch, "\n")
+	return out, nil
+}
+
+// listingDirectory stages a request set as the single file the comparison is
+// made over. Both sides are staged the same way, so the patch Changes produces
+// is a diff of the two listings and nothing else.
+func listingDirectory(routes []route) *dagger.Directory {
+	var listing strings.Builder
+	for _, r := range routes {
+		listing.WriteString(r.String())
+		listing.WriteString("\n")
+	}
+	return dag.Directory().WithNewFile(requestListingFile, listing.String())
+}
+
+// route is one request reduced to what the OpenAPI document describes about it.
+type route struct {
+	Method string
+	Path   string
+}
+
+func (r route) String() string {
+	return r.Method + " " + r.Path
+}
+
+// requestSet reduces a collection to its routes: deduplicated, and ordered by
+// path so that every method on one endpoint reads together and a change to one
+// endpoint stays in one hunk of the patch.
+//
+// Duplicates are folded because a collection may hold more than one request
+// against the same endpoint — the second one asserting what the first set up —
+// and neither the spec nor this comparison has anything to say about how many
+// there are.
+func requestSet(t *tree) []route {
+	seen := map[string]bool{}
+	var routes []route
+	for _, request := range t.Requests {
+		r, ok := requestRoute(request)
+		if !ok {
+			continue
+		}
+		if seen[r.String()] {
+			continue
+		}
+		seen[r.String()] = true
+		routes = append(routes, r)
+	}
+	sort.Slice(routes, func(i, j int) bool {
+		if routes[i].Path != routes[j].Path {
+			return routes[i].Path < routes[j].Path
+		}
+		return routes[i].Method < routes[j].Method
+	})
+	return routes
+}
+
+// requestRoute reads a request's method and path out of its verb block.
+//
+// A .bru file carrying no verb block contributes nothing: it is not a request
+// bru could issue, which is a structural problem Lint owns and not a difference
+// against the document.
+func requestRoute(request *bruFile) (route, bool) {
+	for i := range request.Blocks {
+		block := &request.Blocks[i]
+		method, ok := requestMethodBlocks[block.Name]
+		if !ok {
+			continue
+		}
+		url, _ := block.value("url")
+		return route{Method: method, Path: routePath(url)}, true
+	}
+	return route{}, false
+}
+
+// routePath reduces a request's url to the path the document describes.
+//
+// The server comes off — whether it arrived as the `{{baseUrl}}` a generated
+// request interpolates or as a hardcoded origin — because which host the
+// collection points at is the environment's business. So does the query string:
+// OpenAPI describes query parameters beside the path rather than in it, and
+// `bru import` writes them into a params:query block, so a url that carries one
+// was hand-edited and is still the same endpoint.
+func routePath(url string) string {
+	text := strings.TrimSpace(url)
+	if cut := strings.IndexAny(text, "?#"); cut >= 0 {
+		text = text[:cut]
+	}
+	if urlBaseVariable.MatchString(text) {
+		text = urlBaseVariable.ReplaceAllString(text, "")
+	} else {
+		text = urlOrigin.ReplaceAllString(text, "")
+	}
+
+	segments := strings.Split(text, "/")
+	kept := make([]string, 0, len(segments))
+	for _, segment := range segments {
+		if segment == "" {
+			continue
+		}
+		if match := bracedPathParam.FindStringSubmatch(segment); match != nil {
+			segment = ":" + match[1]
+		}
+		kept = append(kept, segment)
+	}
+	return "/" + strings.Join(kept, "/")
+}

--- a/daggerverse/bruno/lint.go
+++ b/daggerverse/bruno/lint.go
@@ -105,7 +105,7 @@ func (c *Collection) Lint(
 	if err := c.validate(); err != nil {
 		return err
 	}
-	parsed, err := c.loadTree(ctx)
+	parsed, err := c.loadTree(ctx, "Lint")
 	if err != nil {
 		return err
 	}
@@ -376,31 +376,35 @@ type tree struct {
 // loadTree reads the collection out of the engine. Reads are one file at a
 // time rather than through a container: a lint that needed the CLI image
 // pulled would cost more than the check it performs.
-func (c *Collection) loadTree(ctx context.Context) (*tree, error) {
+//
+// fn names the caller in the diagnostics, because more than one function reads
+// a collection this way and "read bruno.json" is not much of a message without
+// saying which call wanted it.
+func (c *Collection) loadTree(ctx context.Context, fn string) (*tree, error) {
 	out := &tree{}
 
 	found, err := c.Source.Exists(ctx, manifestFile)
 	if err != nil {
-		return nil, fmt.Errorf("Lint: look for %s in the collection: %v", manifestFile, err)
+		return nil, fmt.Errorf(fn+": look for %s in the collection: %v", manifestFile, err)
 	}
 	out.ManifestFound = found
 	if found {
 		contents, err := c.Source.File(manifestFile).Contents(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("Lint: read %s: %v", manifestFile, err)
+			return nil, fmt.Errorf(fn+": read %s: %v", manifestFile, err)
 		}
 		out.Manifest = contents
 	}
 
 	paths, err := c.Source.Glob(ctx, "**/*.bru")
 	if err != nil {
-		return nil, fmt.Errorf("Lint: list the collection's .bru files: %v", err)
+		return nil, fmt.Errorf(fn+": list the collection's .bru files: %v", err)
 	}
 	sort.Strings(paths)
 	for _, p := range paths {
 		contents, err := c.Source.File(p).Contents(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("Lint: read %s: %v", p, err)
+			return nil, fmt.Errorf(fn+": read %s: %v", p, err)
 		}
 		file := &bruFile{Path: p, Source: contents, Blocks: parseBru(contents)}
 		switch {
@@ -416,7 +420,7 @@ func (c *Collection) loadTree(ctx context.Context) (*tree, error) {
 	}
 
 	if c.EnvFile != nil {
-		supplied, err := suppliedVarNames(ctx, c.EnvFile)
+		supplied, err := suppliedVarNames(ctx, fn, c.EnvFile)
 		if err != nil {
 			return nil, err
 		}
@@ -429,14 +433,14 @@ func (c *Collection) loadTree(ctx context.Context) (*tree, error) {
 // picks its environment parser from the extension, so this does too — the two
 // shapes are not interchangeable, which is the same reason WithEnvFile mounts
 // the file under the extension it arrived with.
-func suppliedVarNames(ctx context.Context, file *dagger.File) ([]string, error) {
+func suppliedVarNames(ctx context.Context, fn string, file *dagger.File) ([]string, error) {
 	name, err := file.Name(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("Lint: read the environment file's name: %v", err)
+		return nil, fmt.Errorf(fn+": read the environment file's name: %v", err)
 	}
 	contents, err := file.Contents(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("Lint: read the environment file %q: %v", name, err)
+		return nil, fmt.Errorf(fn+": read the environment file %q: %v", name, err)
 	}
 	if strings.EqualFold(path.Ext(name), ".json") {
 		return jsonEnvVarNames(contents), nil

--- a/daggerverse/bruno/tests/dagger.gen.go
+++ b/daggerverse/bruno/tests/dagger.gen.go
@@ -213,6 +213,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).CaCertReachesPrivateCaService(&parent, ctx)
+		case "CheckDriftFailsOnAnEndpointAddedToTheSpec":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).CheckDriftFailsOnAnEndpointAddedToTheSpec(&parent, ctx)
+		case "CheckDriftFailsOnBothSidesOfTheRequestSet":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).CheckDriftFailsOnBothSidesOfTheRequestSet(&parent, ctx)
 		case "CiCheckGatesOnFailingAssertion":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -290,6 +304,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).ClientCertPassphraseUnlocksTheKey(&parent, ctx)
+		case "DriftIgnoresHandWrittenTests":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).DriftIgnoresHandWrittenTests(&parent, ctx)
 		case "GenerateHonoursOpenCollectionFormat":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/bruno/tests/fixtures/petstore-extended.yaml
+++ b/daggerverse/bruno/tests/fixtures/petstore-extended.yaml
@@ -1,0 +1,123 @@
+# fixtures/petstore.yaml plus one operation, for the drift tests.
+#
+# The addition is a new path carrying a path parameter — GET /pets/{petId}/toys
+# — so a collection generated from petstore.yaml is one request short of this
+# document, and the request it is short of is one whose parameter has to survive
+# normalisation to be named in the report.
+#
+# Everything else is copied verbatim: a spec that dropped the schemas would make
+# every other request read as drifted too, and the test would pass for the wrong
+# reason.
+openapi: 3.0.3
+info:
+  title: Petstore
+  description: A very small store, for a test that has to run what it generates.
+  version: 1.0.0
+servers:
+  - url: http://api:8080
+    description: recording responder
+paths:
+  /health:
+    get:
+      operationId: getHealth
+      tags:
+        - status
+      summary: Report service health
+      responses:
+        "200":
+          description: The service is up.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+  /pets:
+    get:
+      operationId: listPets
+      tags:
+        - pets
+      summary: List every pet
+      responses:
+        "200":
+          description: A list of pets.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+    post:
+      operationId: createPet
+      tags:
+        - pets
+      summary: Add a pet to the store
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        "200":
+          description: The pet that was stored.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+  /pets/{petId}:
+    get:
+      operationId: showPetById
+      tags:
+        - pets
+      summary: Fetch one pet
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The pet's identifier.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The requested pet.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+  /pets/{petId}/toys:
+    get:
+      operationId: listPetToys
+      tags:
+        - pets
+      summary: List one pet's toys
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The pet's identifier.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The pet's toys.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - name
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        tag:
+          type: string

--- a/daggerverse/bruno/tests/internal/dagger/bruno.gen.go
+++ b/daggerverse/bruno/tests/internal/dagger/bruno.gen.go
@@ -517,9 +517,11 @@ func (r *BrunoCi) AsNode() Node {
 type BrunoCollection struct { // bruno (../../../../../daggerverse/bruno/collection.go:86:6)
 	query *querybuilder.Selection
 
-	id   *ID
-	lint *Void
-	run  *string
+	checkDrift *Void
+	drift      *string
+	id         *ID
+	lint       *Void
+	run        *string
 }
 type WithBrunoCollectionFunc func(r *BrunoCollection) *BrunoCollection
 
@@ -534,6 +536,58 @@ func (r *BrunoCollection) WithGraphQLQuery(q *querybuilder.Selection) *BrunoColl
 	return &BrunoCollection{
 		query: q,
 	}
+}
+
+// CheckDrift fails when the committed collection no longer matches the OpenAPI
+// document it was generated from, so a pipeline can hang a check on the two
+// staying in step.
+//
+// The report travels in the error rather than alongside it, following Lint: a
+// Dagger function that returns an error forfeits its value, so a (report, error)
+// signature would hide the report on the one path that needs it.
+func (r *BrunoCollection) CheckDrift(ctx context.Context, spec *File) error { // bruno (../../../../../daggerverse/bruno/drift.go:98:1)
+	assertNotNil("spec", spec)
+	if r.checkDrift != nil {
+		return nil
+	}
+	q := r.query.Select("checkDrift")
+	q = q.Arg("spec", spec)
+
+	return q.Execute(ctx)
+}
+
+// Drift reports how the committed collection differs from the OpenAPI document
+// it was generated from.
+//
+// A new operation in the spec that nobody added to the collection is a silently
+// untested endpoint: nothing fails, because nothing asks. This is the check that
+// notices — it regenerates the collection from the document and compares the
+// result against what is committed.
+//
+// The comparison is scoped to the request set — each request's method and path,
+// deduplicated and sorted — rather than being a diff of the two trees. A
+// generated request carries detail the document never described (the tests and
+// assertions that make the collection worth running, the ordering, the scripts),
+// and a byte-for-byte comparison would call every one of those drift. Query
+// strings are dropped and path parameters are normalised onto Bruno's `:name`
+// spelling, so the same endpoint written either way reads as the same endpoint.
+//
+// It returns the difference rather than failing on it, and never fails on drift
+// alone: Dagger drops a function's value when it also returns an error, so a
+// gating Drift could not hand back the report that says what drifted. CheckDrift
+// is the gate; this is the one that tells you what to fix.
+func (r *BrunoCollection) Drift(ctx context.Context, spec *File) (string, error) { // bruno (../../../../../daggerverse/bruno/drift.go:76:1)
+	assertNotNil("spec", spec)
+	if r.drift != nil {
+		return *r.drift, nil
+	}
+	q := r.query.Select("drift")
+	q = q.Arg("spec", spec)
+
+	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
 }
 
 // A unique identifier for this BrunoCollection.

--- a/daggerverse/bruno/tests/main.go
+++ b/daggerverse/bruno/tests/main.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path"
+	"regexp"
 	"slices"
 	"strings"
 
@@ -69,6 +70,9 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("GenerateProducesRunnableCollection", t.GenerateProducesRunnableCollection)
 	jobs = jobs.WithJob("GenerateHonoursOpenCollectionFormat", t.GenerateHonoursOpenCollectionFormat)
 	jobs = jobs.WithJob("GenerateRejectsUnknownFormat", t.GenerateRejectsUnknownFormat)
+	jobs = jobs.WithJob("DriftIgnoresHandWrittenTests", t.DriftIgnoresHandWrittenTests)
+	jobs = jobs.WithJob("CheckDriftFailsOnAnEndpointAddedToTheSpec", t.CheckDriftFailsOnAnEndpointAddedToTheSpec)
+	jobs = jobs.WithJob("CheckDriftFailsOnBothSidesOfTheRequestSet", t.CheckDriftFailsOnBothSidesOfTheRequestSet)
 	jobs = jobs.WithJob("LintAcceptsValidCollection", t.LintAcceptsValidCollection)
 	jobs = jobs.WithJob("LintRejectsMissingBrunoJson", t.LintRejectsMissingBrunoJson)
 	jobs = jobs.WithJob("LintRejectsUnknownEnvironment", t.LintRejectsUnknownEnvironment)
@@ -632,6 +636,155 @@ func (t *Tests) GenerateRejectsUnknownFormat(ctx context.Context) error {
 	for _, want := range []string{"postman", "bru", "opencollection"} {
 		if !strings.Contains(err.Error(), want) {
 			return fmt.Errorf("expected the error to mention %q, got: %s", want, err.Error())
+		}
+	}
+	return nil
+}
+
+// DriftIgnoresHandWrittenTests checks the scoping the comparison exists for. A
+// collection generated from the spec matches it — and still matches once one of
+// its requests carries a test the document never described.
+//
+// The second half is the whole reason the comparison is not a tree diff: a
+// generated request is where anyone would put the assertions that make the
+// collection worth running, and a check that called that drift would be a check
+// nobody could leave switched on.
+func (t *Tests) DriftIgnoresHandWrittenTests(ctx context.Context) error {
+	spec := fixtureFile("petstore.yaml")
+	generated, err := pin(ctx, dag.Bruno().Generate(spec, dagger.BrunoGenerateOpts{Name: "petstore"}))
+	if err != nil {
+		return fmt.Errorf("generate: %w", err)
+	}
+
+	// The test is appended to a request the spec does describe, so the request
+	// set is untouched and only the file's bytes move.
+	const request = "pets/List every pet.bru"
+	body, err := generated.File(request).Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("read %q from the generated collection: %w", request, err)
+	}
+	edited := generated.WithNewFile(request, body+`
+tests {
+  test("responds", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+}
+`)
+
+	for _, tc := range []struct {
+		name       string
+		collection *dagger.Directory
+	}{
+		{"as generated", generated},
+		{"with a hand-written test", edited},
+	} {
+		collection := dag.Bruno().Collection(tc.collection)
+
+		report, err := collection.Drift(ctx, spec)
+		if err != nil {
+			return fmt.Errorf("drift (%s): %w", tc.name, err)
+		}
+		if !strings.Contains(report, "matches") {
+			return fmt.Errorf("expected drift (%s) to report a match, got:\n%s", tc.name, head(report))
+		}
+		// The count is the claim that the comparison read the requests at all:
+		// a report of zero requests would "match" any spec.
+		if !strings.Contains(report, fmt.Sprintf("%d requests", specOperations)) {
+			return fmt.Errorf("expected drift (%s) to account for %d requests, got:\n%s",
+				tc.name, specOperations, head(report))
+		}
+		if err := collection.CheckDrift(ctx, spec); err != nil {
+			return fmt.Errorf("expected the collection (%s) to gate clean against its own spec: %w", tc.name, err)
+		}
+	}
+	return nil
+}
+
+// CheckDriftFailsOnAnEndpointAddedToTheSpec checks the case the whole story
+// exists for: the document grew an operation and nobody added a request for it,
+// so the endpoint is untested and nothing says so.
+//
+// The failure has to name the missing request rather than only report that
+// something differs — an endpoint nobody noticed is not made findable by being
+// told a count changed.
+func (t *Tests) CheckDriftFailsOnAnEndpointAddedToTheSpec(ctx context.Context) error {
+	collection := dag.Bruno().Collection(
+		dag.Bruno().Generate(fixtureFile("petstore.yaml"), dagger.BrunoGenerateOpts{Name: "petstore"}))
+	extended := fixtureFile("petstore-extended.yaml")
+
+	err := collection.CheckDrift(ctx, extended)
+	if err == nil {
+		return fmt.Errorf("expected an endpoint added to the spec to fail the drift check")
+	}
+	// The route is spelled with Bruno's `:petId`, not the document's {petId}:
+	// the two are the same segment, and the report is read beside the
+	// collection.
+	if !hasReportLine(err.Error(), "+GET /pets/:petId/toys") {
+		return fmt.Errorf("expected the error to name the missing request, got:\n%s", head(err.Error()))
+	}
+	// The requests that did not change must not be reported as differences, or
+	// the report buries the one endpoint that needs adding.
+	for _, unchanged := range []string{"+GET /health", "+GET /pets", "+POST /pets", "+GET /pets/:petId", "-GET /pets"} {
+		if hasReportLine(err.Error(), unchanged) {
+			return fmt.Errorf("expected only the added endpoint to be reported, but the report carries %q:\n%s",
+				unchanged, head(err.Error()))
+		}
+	}
+
+	// Drift describes the same difference without failing on it, so the report
+	// is reachable from a step that is not the gate.
+	report, err := collection.Drift(ctx, extended)
+	if err != nil {
+		return fmt.Errorf("drift: %w", err)
+	}
+	if !strings.Contains(report, "+GET /pets/:petId/toys") {
+		return fmt.Errorf("expected drift to report the missing request without failing, got:\n%s", head(report))
+	}
+	return nil
+}
+
+// CheckDriftFailsOnBothSidesOfTheRequestSet checks the other direction, and
+// that the two are distinguished.
+//
+// A request deleted from the collection leaves an endpoint the document declares
+// with nothing testing it. A request the document has no operation for is the
+// opposite problem — an endpoint that was renamed or retired upstream, still
+// being exercised — and it has to read as its own thing rather than as the same
+// finding, because the fix is the opposite one.
+func (t *Tests) CheckDriftFailsOnBothSidesOfTheRequestSet(ctx context.Context) error {
+	spec := fixtureFile("petstore.yaml")
+	generated, err := pin(ctx, dag.Bruno().Generate(spec, dagger.BrunoGenerateOpts{Name: "petstore"}))
+	if err != nil {
+		return fmt.Errorf("generate: %w", err)
+	}
+
+	edited := generated.
+		WithoutFile("pets/Fetch one pet.bru").
+		WithNewFile("pets/Retire a pet.bru", `meta {
+  name: Retire a pet
+  type: http
+  seq: 4
+}
+
+delete {
+  url: {{baseUrl}}/pets/:petId/retire
+  body: none
+  auth: inherit
+}
+`)
+
+	err = dag.Bruno().Collection(edited).CheckDrift(ctx, spec)
+	if err == nil {
+		return fmt.Errorf("expected a collection missing one request and carrying an undeclared one to fail the drift check")
+	}
+	for _, want := range []string{
+		// The document declares it; the collection no longer has it.
+		"+GET /pets/:petId",
+		// The collection has it; the document declares no such operation.
+		"-DELETE /pets/:petId/retire",
+	} {
+		if !hasReportLine(err.Error(), want) {
+			return fmt.Errorf("expected the error to carry %q, got:\n%s", want, head(err.Error()))
 		}
 	}
 	return nil
@@ -1636,6 +1789,26 @@ func generatedRequests(ctx context.Context, collection *dagger.Directory) ([]str
 func fixtureFile(path string) *dagger.File {
 	return dag.CurrentModule().Source().File("fixtures/" + path)
 }
+
+// hasReportLine reports whether a drift report carries a line exactly.
+//
+// The comparison is per line rather than a substring match because every line of
+// the patch is prefixed with a space, a + or a -, and one route is a prefix of
+// another: "+GET /pets/:petId" would otherwise be satisfied by
+// "+GET /pets/:petId/toys", which is the difference between the check naming the
+// endpoint that drifted and naming a longer one.
+//
+// The traceparent comes off first. Dagger appends one to the end of a module
+// error's message, so the report's last line — which for a patch is a route —
+// arrives carrying a span id that is nothing to do with what drifted.
+func hasReportLine(report string, line string) bool {
+	report = traceparentSuffix.ReplaceAllString(report, "")
+	return slices.Contains(strings.Split(report, "\n"), line)
+}
+
+// traceparentSuffix matches the span id Dagger appends to a module error's
+// message.
+var traceparentSuffix = regexp.MustCompile(`\s*\[traceparent:[0-9a-f-]+\]\s*$`)
 
 // head trims a long output down to something readable in a failure message.
 func head(s string) string {


### PR DESCRIPTION
Closes #246.

`Drift` regenerates the collection from the OpenAPI document and reports the
difference against what is committed; `CheckDrift` is the same comparison as a
gate. An operation added to the spec that nobody added a request for is a
silently untested endpoint — nothing fails, because nothing asks.

```
bru drift: the collection does not match the OpenAPI document.
  a/requests is the request set the collection commits; b/requests is the one the document declares.
  + is an operation the document declares that the collection has no request for;
  - is a request the collection commits that the document does not declare.

diff --git a/requests b/requests
--- a/requests
+++ b/requests
@@ -2,3 +2,4 @@ GET /health
 GET /pets
 POST /pets
 GET /pets/:petId
+GET /pets/:petId/toys
```

## Scoped to the request set

The comparison is each request's method and path, not a diff of the two trees.
A generated request carries detail the document never described — the
assertions somebody added, the ordering, the scripts — and a byte-for-byte
comparison would call every one of those drift, which is a check nobody could
leave switched on. The server (`{{baseUrl}}/pets` and `https://host/pets` are
both `/pets`), the query string, path-parameter spelling (`{petId}` and
`:petId`) and duplicate requests against one endpoint all normalise away.

The expected set comes from `bru import` rather than from a second reading of
the document: drift means "what `bru` would generate from this spec versus what
is committed", and an independent OpenAPI parser could disagree with `bru` about
a document and report a difference nobody could act on.

The diff itself is `Directory.Changes` and the `Changeset` it returns —
`IsEmpty` is the verdict, `AsPatch` is the report — so nothing about it is
hand-rolled. This module owns only the normalisation, which is why the patch
names a synthetic `requests` file rather than any file on disk.

`Drift` returns the report and `CheckDrift` carries it inside its error, for the
same reason `Report` does not gate and `Lint` folds its findings into one:
Dagger drops a function's value when it also returns an error, so a gating
`Drift` could not hand back the report that says what to fix.

## Acceptance criteria

- [x] `Drift` and `CheckDrift` exist and are listed by `dagger functions`
- [x] A collection generated from the spec reports no drift, even after a
      hand-written test is added to one request — `DriftIgnoresHandWrittenTests`
- [x] Adding an endpoint to the spec makes `CheckDrift` fail, naming the missing
      request — `CheckDriftFailsOnAnEndpointAddedToTheSpec`
- [x] Removing a request from the collection makes `CheckDrift` fail —
      `CheckDriftFailsOnBothSidesOfTheRequestSet`, which also covers a committed
      request the document does not declare
- [x] Bindings regenerated in `daggerverse/bruno` and `daggerverse/bruno/tests`
      (and the root `ci` aggregator)
- [x] `dagger -m daggerverse/bruno/tests call all` is green
- [x] `dagger -m ci call generated` is green

## Notes

`loadTree` now takes the calling function's name so its diagnostics say whether
`Lint` or `Drift` wanted the file; no rule changed.

`hasReportLine` in the test module strips the `[traceparent:...]` span id Dagger
appends to the end of a module error's message — without that, the report's last
line, which for a patch is a route, arrives carrying an id that has nothing to
do with what drifted.

Unlike `Lint`, this check runs a container: regenerating means running
`bru import`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)