### PR TITLE
story(issue-270): split and merge PDF pages

### DIFF
--- a/ci/internal/dagger/pdf-tests.gen.go
+++ b/ci/internal/dagger/pdf-tests.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type PdfTests
-func (r *Binding) AsPdfTests() *PdfTests { // pdf-tests (../../../daggerverse/pdf/tests/main.go:150:6)
+func (r *Binding) AsPdfTests() *PdfTests { // pdf-tests (../../../daggerverse/pdf/tests/main.go:151:6)
 	q := r.query.Select("asPdfTests")
 
 	return &PdfTests{
@@ -19,7 +19,7 @@ func (r *Binding) AsPdfTests() *PdfTests { // pdf-tests (../../../daggerverse/pd
 }
 
 // Create or update a binding of type PdfTests in the environment
-func (r *Env) WithPdfTestsInput(name string, value *PdfTests, description string) *Env { // pdf-tests (../../../daggerverse/pdf/tests/main.go:150:6)
+func (r *Env) WithPdfTestsInput(name string, value *PdfTests, description string) *Env { // pdf-tests (../../../daggerverse/pdf/tests/main.go:151:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withPdfTestsInput")
 	q = q.Arg("name", name)
@@ -32,7 +32,7 @@ func (r *Env) WithPdfTestsInput(name string, value *PdfTests, description string
 }
 
 // Declare a desired PdfTests output to be assigned in the environment
-func (r *Env) WithPdfTestsOutput(name string, description string) *Env { // pdf-tests (../../../daggerverse/pdf/tests/main.go:150:6)
+func (r *Env) WithPdfTestsOutput(name string, description string) *Env { // pdf-tests (../../../daggerverse/pdf/tests/main.go:151:6)
 	q := r.query.Select("withPdfTestsOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -42,7 +42,7 @@ func (r *Env) WithPdfTestsOutput(name string, description string) *Env { // pdf-
 	}
 }
 
-type PdfTests struct { // pdf-tests (../../../daggerverse/pdf/tests/main.go:150:6)
+type PdfTests struct { // pdf-tests (../../../daggerverse/pdf/tests/main.go:151:6)
 	query *querybuilder.Selection
 
 	all                                                 *Void
@@ -59,6 +59,8 @@ type PdfTests struct { // pdf-tests (../../../daggerverse/pdf/tests/main.go:150:
 	infoReportsPageCountAndSize                         *Void
 	jpegAndTiffFollowTheSameContract                    *Void
 	layoutModesProduceDifferentOrderings                *Void
+	mergePreservesTheOrderOfItsSources                  *Void
+	mergeRejectsWhatItCannotMerge                       *Void
 	metadataReturnsTheXmpPacketOrSaysThereIsNone        *Void
 	pageRangeNarrowsEveryPerPageFormat                  *Void
 	pageRangeNarrowsText                                *Void
@@ -72,6 +74,10 @@ type PdfTests struct { // pdf-tests (../../../daggerverse/pdf/tests/main.go:150:
 	reportsOpenAnEncryptedDocumentWithThePassword       *Void
 	scaleToOverridesDpi                                 *Void
 	signaturesReportsAnUnsignedDocumentInsteadOfFailing *Void
+	splitAndMergeCannotOpenAnEncryptedDocument          *Void
+	splitNarrowsToThePageRange                          *Void
+	splitThenMergeRoundTripsTheDocument                 *Void
+	splitWritesOnePdfPerPage                            *Void
 	svgWritesOneVectorFilePerPage                       *Void
 	textOnImageOnlyPdfReturnsNothing                    *Void
 	textReproducesTextLayerExactly                      *Void
@@ -93,7 +99,7 @@ type PdfTestsAllOpts struct {
 	//
 	// Maximum number of tests to run concurrently. Zero fans out unbounded.
 	//
-	Parallel int // pdf-tests (../../../daggerverse/pdf/tests/main.go:166:2)
+	Parallel int // pdf-tests (../../../daggerverse/pdf/tests/main.go:167:2)
 }
 
 // All runs every pdf-module test in parallel.
@@ -104,7 +110,7 @@ type PdfTestsAllOpts struct {
 // are single-threaded: twenty of them contend for cores the way any other
 // oversubscribed workload does. The cap stays available for a host that wants a
 // narrower slice.
-func (r *PdfTests) All(ctx context.Context, opts ...PdfTestsAllOpts) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:162:1)
+func (r *PdfTests) All(ctx context.Context, opts ...PdfTestsAllOpts) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:163:1)
 	if r.all != nil {
 		return nil
 	}
@@ -131,7 +137,7 @@ func (r *PdfTests) All(ctx context.Context, opts ...PdfTestsAllOpts) error { // 
 // The three properties are mutually exclusive by construction: colour keeps
 // chroma, grey drops chroma but keeps mid-tones, and mono drops both — flat tones
 // are dithered into black and white rather than averaged into grey.
-func (r *PdfTests) ColorModesProduceDifferentPixels(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1419:1)
+func (r *PdfTests) ColorModesProduceDifferentPixels(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1427:1)
 	if r.colorModesProduceDifferentPixels != nil {
 		return nil
 	}
@@ -148,7 +154,7 @@ func (r *PdfTests) ColorModesProduceDifferentPixels(ctx context.Context) error {
 // nothing to substitute for a PDF that names a base-14 face without embedding
 // it, and renders the page blank while exiting 0 — a silent wrong answer, which
 // is the failure mode this assertion exists to keep out.
-func (r *PdfTests) ContainerCarriesEveryPopplerBinaryAndTheFont(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:601:1)
+func (r *PdfTests) ContainerCarriesEveryPopplerBinaryAndTheFont(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:609:1)
 	if r.containerCarriesEveryPopplerBinaryAndTheFont != nil {
 		return nil
 	}
@@ -164,7 +170,7 @@ func (r *PdfTests) ContainerCarriesEveryPopplerBinaryAndTheFont(ctx context.Cont
 // defaulting to true because a `Go SDK — the zero value is dropped before it reaches the API — so the
 // affirmative spelling would have produced an option no caller could turn off.
 // That makes the second half of this test the one that would have caught it.
-func (r *PdfTests) DisablePageBreaksControlsFormFeeds(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1136:1)
+func (r *PdfTests) DisablePageBreaksControlsFormFeeds(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1144:1)
 	if r.disablePageBreaksControlsFormFeeds != nil {
 		return nil
 	}
@@ -180,7 +186,7 @@ func (r *PdfTests) DisablePageBreaksControlsFormFeeds(ctx context.Context) error
 // remembered pixel count, so the assertion says "150 dpi of a US Letter page"
 // rather than "1275 by 1650" — which is the claim the documentation actually
 // makes.
-func (r *PdfTests) DpiDefaultsToOneFiftyAndScalesWithTheSetting(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1318:1)
+func (r *PdfTests) DpiDefaultsToOneFiftyAndScalesWithTheSetting(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1326:1)
 	if r.dpiDefaultsToOneFiftyAndScalesWithTheSetting != nil {
 		return nil
 	}
@@ -204,7 +210,7 @@ func (r *PdfTests) DpiDefaultsToOneFiftyAndScalesWithTheSetting(ctx context.Cont
 // poppler alike through the environment rather than argv: a password in argv is
 // visible in every Dagger trace, which is exactly what the module's own posture
 // avoids.
-func (r *PdfTests) EncryptedDocumentNeedsThePassword(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1544:1)
+func (r *PdfTests) EncryptedDocumentNeedsThePassword(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1852:1)
 	if r.encryptedDocumentNeedsThePassword != nil {
 		return nil
 	}
@@ -226,7 +232,7 @@ func (r *PdfTests) EncryptedDocumentNeedsThePassword(ctx context.Context) error 
 // Each file is then checked to be an EPS in its own right — the EPSF version
 // header, and exactly one page in it — because a loop that wrote twelve copies
 // of page one would satisfy the names alone.
-func (r *PdfTests) EpsWritesEveryPageOfTheDocument(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:277:1)
+func (r *PdfTests) EpsWritesEveryPageOfTheDocument(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:285:1)
 	if r.epsWritesEveryPageOfTheDocument != nil {
 		return nil
 	}
@@ -245,7 +251,7 @@ func (r *PdfTests) EpsWritesEveryPageOfTheDocument(ctx context.Context) error { 
 // it, its two pages naming different faces, because narrowing a report of
 // ledgerPdf — every page of which names the same Helvetica — changes nothing at
 // all and would pass against a module that ignored the bounds entirely.
-func (r *PdfTests) FontsNarrowsToThePageRange(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:761:1)
+func (r *PdfTests) FontsNarrowsToThePageRange(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:769:1)
 	if r.fontsNarrowsToThePageRange != nil {
 		return nil
 	}
@@ -268,7 +274,7 @@ func (r *PdfTests) FontsNarrowsToThePageRange(ctx context.Context) error { // pd
 // construction, so the report has to read `yes` for it; without that contrast
 // the assertion would pass just as well on a report that said `no` about
 // everything, including one produced by a module that had hardcoded the answer.
-func (r *PdfTests) FontsReportsWhetherEachFaceIsEmbedded(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:706:1)
+func (r *PdfTests) FontsReportsWhetherEachFaceIsEmbedded(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:714:1)
 	if r.fontsReportsWhetherEachFaceIsEmbedded != nil {
 		return nil
 	}
@@ -291,7 +297,7 @@ func (r *PdfTests) FontsReportsWhetherEachFaceIsEmbedded(ctx context.Context) er
 //
 // Two fixtures are needed because no one page is both: ledger.pdf is text and no
 // images, scan.pdf is one image and no text.
-func (r *PdfTests) HTMLCarriesPageMarkupAndItsImages(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:369:1)
+func (r *PdfTests) HTMLCarriesPageMarkupAndItsImages(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:377:1)
 	if r.htmlCarriesPageMarkupAndItsImages != nil {
 		return nil
 	}
@@ -356,7 +362,7 @@ func (r *PdfTests) UnmarshalJSON(bs []byte) error {
 // first: PageCount parses Info's `Pages:` line, so a change to how Info is
 // captured that broke the parse would otherwise show up only in whatever used
 // PageCount next.
-func (r *PdfTests) InfoReportsPageCountAndSize(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:665:1)
+func (r *PdfTests) InfoReportsPageCountAndSize(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:673:1)
 	if r.infoReportsPageCountAndSize != nil {
 		return nil
 	}
@@ -372,7 +378,7 @@ func (r *PdfTests) InfoReportsPageCountAndSize(ctx context.Context) error { // p
 // `-jpeg` writes `.jpg` and `-tiff` writes `.tif`, which are poppler's spellings
 // and not this module's: a caller building a path from the function's name would
 // get them wrong, so they are part of the documented contract.
-func (r *PdfTests) JpegAndTiffFollowTheSameContract(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1494:1)
+func (r *PdfTests) JpegAndTiffFollowTheSameContract(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1502:1)
 	if r.jpegAndTiffFollowTheSameContract != nil {
 		return nil
 	}
@@ -392,11 +398,50 @@ func (r *PdfTests) JpegAndTiffFollowTheSameContract(ctx context.Context) error {
 // physical layout puts the two columns side by side on one output line. A fixture
 // whose stream order matched its reading order would let two of these three pass
 // on the same output.
-func (r *PdfTests) LayoutModesProduceDifferentOrderings(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1173:1)
+func (r *PdfTests) LayoutModesProduceDifferentOrderings(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1181:1)
 	if r.layoutModesProduceDifferentOrderings != nil {
 		return nil
 	}
 	q := r.query.Select("layoutModesProduceDifferentOrderings")
+
+	return q.Execute(ctx)
+}
+
+// MergePreservesTheOrderOfItsSources asserts the merged document's pages come
+// out in the order the slice named them, which is the whole reason Merge takes
+// an ordered slice rather than a directory.
+//
+// The sources are deliberately handed over out of page order — 3, 1, 2 — because
+// any order-preserving implementation and any order-losing one agree on a slice
+// that was already sorted. Reading the text back is what says the pages landed
+// where they were put: the page count alone would pass on a merge that shuffled
+// them.
+func (r *PdfTests) MergePreservesTheOrderOfItsSources(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1639:1)
+	if r.mergePreservesTheOrderOfItsSources != nil {
+		return nil
+	}
+	q := r.query.Select("mergePreservesTheOrderOfItsSources")
+
+	return q.Execute(ctx)
+}
+
+// MergeRejectsWhatItCannotMerge asserts the two ways a merge goes wrong are
+// reported by naming the argument that was wrong.
+//
+// The empty slice is a caller error with no useful answer — there is no document
+// to return and no empty PDF worth inventing — and pdfunite's own answer to it is
+// its usage text, which describes a command line the caller never wrote. The
+// module refuses it before the container starts, for that reason.
+//
+// The unreadable source is the case the mount legend exists for. pdfunite names
+// the file it could not read, and the name it uses is this module's mount path,
+// so without the legend the one piece of information identifying which argument
+// was at fault is a path the caller has never seen.
+func (r *PdfTests) MergeRejectsWhatItCannotMerge(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1691:1)
+	if r.mergeRejectsWhatItCannotMerge != nil {
+		return nil
+	}
+	q := r.query.Select("mergeRejectsWhatItCannotMerge")
 
 	return q.Execute(ctx)
 }
@@ -416,7 +461,7 @@ func (r *PdfTests) LayoutModesProduceDifferentOrderings(ctx context.Context) err
 // indistinguishable from a function that did not run, so the module answers with
 // a line naming the absence and pointing at the report that does carry the
 // document's metadata.
-func (r *PdfTests) MetadataReturnsTheXmpPacketOrSaysThereIsNone(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:823:1)
+func (r *PdfTests) MetadataReturnsTheXmpPacketOrSaysThereIsNone(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:831:1)
 	if r.metadataReturnsTheXmpPacketOrSaysThereIsNone != nil {
 		return nil
 	}
@@ -439,7 +484,7 @@ func (r *PdfTests) MetadataReturnsTheXmpPacketOrSaysThereIsNone(ctx context.Cont
 // the range, which is why pages 4 through 6 come out `page-0004` through
 // `page-0006` — the same promise the raster contract makes, so a page stays
 // traceable to the page it came from whichever format it was rendered to.
-func (r *PdfTests) PageRangeNarrowsEveryPerPageFormat(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:446:1)
+func (r *PdfTests) PageRangeNarrowsEveryPerPageFormat(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:454:1)
 	if r.pageRangeNarrowsEveryPerPageFormat != nil {
 		return nil
 	}
@@ -451,7 +496,7 @@ func (r *PdfTests) PageRangeNarrowsEveryPerPageFormat(ctx context.Context) error
 // PageRangeNarrowsText asserts WithPageRange narrows extraction to the pages it
 // names, and that the bounds are the 1-based inclusive ones poppler uses rather
 // than an offset and a length.
-func (r *PdfTests) PageRangeNarrowsText(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1058:1)
+func (r *PdfTests) PageRangeNarrowsText(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1066:1)
 	if r.pageRangeNarrowsText != nil {
 		return nil
 	}
@@ -463,7 +508,7 @@ func (r *PdfTests) PageRangeNarrowsText(ctx context.Context) error { // pdf-test
 // PageRangeOpenEndedRunsToTheLastPage asserts a zero last means "to the end",
 // which is the only way to name an open-ended range without first asking how
 // many pages the document has.
-func (r *PdfTests) PageRangeOpenEndedRunsToTheLastPage(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1077:1)
+func (r *PdfTests) PageRangeOpenEndedRunsToTheLastPage(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1085:1)
 	if r.pageRangeOpenEndedRunsToTheLastPage != nil {
 		return nil
 	}
@@ -479,7 +524,7 @@ func (r *PdfTests) PageRangeOpenEndedRunsToTheLastPage(ctx context.Context) erro
 // renders nothing for them and exits 0, so a caller who asked for page 20 of a
 // 12-page document would otherwise get an empty result indistinguishable from a
 // document with no text in it.
-func (r *PdfTests) PageRangeRejectsInvalidBounds(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1100:1)
+func (r *PdfTests) PageRangeRejectsInvalidBounds(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1108:1)
 	if r.pageRangeRejectsInvalidBounds != nil {
 		return nil
 	}
@@ -499,7 +544,7 @@ func (r *PdfTests) PageRangeRejectsInvalidBounds(ctx context.Context) error { //
 // has no way to know which width it is holding. Asserting the full ordered list
 // covers both halves of the promise: the names, and that lexicographic order is
 // page order.
-func (r *PdfTests) PngNamesEveryPageWithFourDigits(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1245:1)
+func (r *PdfTests) PngNamesEveryPageWithFourDigits(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1253:1)
 	if r.pngNamesEveryPageWithFourDigits != nil {
 		return nil
 	}
@@ -519,7 +564,7 @@ func (r *PdfTests) PngNamesEveryPageWithFourDigits(ctx context.Context) error { 
 // The numbers are the source document's page numbers and not positions within
 // the range, which is why the second case starts at `page-0004.png`. That keeps a
 // rendered page traceable back to the page it came from.
-func (r *PdfTests) PngNarrowedRangeKeepsFourDigitNames(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1264:1)
+func (r *PdfTests) PngNarrowedRangeKeepsFourDigitNames(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1272:1)
 	if r.pngNarrowedRangeKeepsFourDigitNames != nil {
 		return nil
 	}
@@ -537,7 +582,7 @@ func (r *PdfTests) PngNarrowedRangeKeepsFourDigitNames(ctx context.Context) erro
 // document keeps the longer document's width. A consumer globbing for
 // `page-*.png` finds nothing in the first case and a caller indexing by name
 // finds the wrong file in the second.
-func (r *PdfTests) PngSinglePageIsStillNumbered(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1291:1)
+func (r *PdfTests) PngSinglePageIsStillNumbered(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1299:1)
 	if r.pngSinglePageIsStillNumbered != nil {
 		return nil
 	}
@@ -554,7 +599,7 @@ func (r *PdfTests) PngSinglePageIsStillNumbered(ctx context.Context) error { // 
 // directory of one-page fragments would be the wrong answer even though it would
 // look tidier beside Svg and Eps. Counting the markers is what says the pages
 // reached the file rather than only the header saying they did.
-func (r *PdfTests) PsHoldsEveryPageInOneFile(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:326:1)
+func (r *PdfTests) PsHoldsEveryPageInOneFile(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:334:1)
 	if r.psHoldsEveryPageInOneFile != nil {
 		return nil
 	}
@@ -568,7 +613,7 @@ func (r *PdfTests) PsHoldsEveryPageInOneFile(ctx context.Context) error { // pdf
 //
 // Left to poppler these arrive much later as a complaint about `-r` or
 // `-scale-to`, which names a flag the caller never wrote.
-func (r *PdfTests) RenderSettingsRejectNonPositiveValues(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1381:1)
+func (r *PdfTests) RenderSettingsRejectNonPositiveValues(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1389:1)
 	if r.renderSettingsRejectNonPositiveValues != nil {
 		return nil
 	}
@@ -589,7 +634,7 @@ func (r *PdfTests) RenderSettingsRejectNonPositiveValues(ctx context.Context) er
 // reports every wrong password as `Incorrect password` whether one was supplied
 // or not, so the message has to distinguish what the module knows and poppler
 // does not.
-func (r *PdfTests) ReportsOpenAnEncryptedDocumentWithThePassword(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:899:1)
+func (r *PdfTests) ReportsOpenAnEncryptedDocumentWithThePassword(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:907:1)
 	if r.reportsOpenAnEncryptedDocumentWithThePassword != nil {
 		return nil
 	}
@@ -605,7 +650,7 @@ func (r *PdfTests) ReportsOpenAnEncryptedDocumentWithThePassword(ctx context.Con
 // resolution flag off the command line rather than by relying on poppler's own
 // precedence, so this is the assertion that would catch the two being emitted
 // together and whichever poppler happened to prefer winning silently.
-func (r *PdfTests) ScaleToOverridesDpi(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1350:1)
+func (r *PdfTests) ScaleToOverridesDpi(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1358:1)
 	if r.scaleToOverridesDpi != nil {
 		return nil
 	}
@@ -628,11 +673,95 @@ func (r *PdfTests) ScaleToOverridesDpi(ctx context.Context) error { // pdf-tests
 // an image carrying no certificate database, which is every image this module
 // builds, and a report assembled from both streams would carry that line into
 // every caller's output as though it were something the document said.
-func (r *PdfTests) SignaturesReportsAnUnsignedDocumentInsteadOfFailing(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:873:1)
+func (r *PdfTests) SignaturesReportsAnUnsignedDocumentInsteadOfFailing(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:881:1)
 	if r.signaturesReportsAnUnsignedDocumentInsteadOfFailing != nil {
 		return nil
 	}
 	q := r.query.Select("signaturesReportsAnUnsignedDocumentInsteadOfFailing")
+
+	return q.Execute(ctx)
+}
+
+// SplitAndMergeCannotOpenAnEncryptedDocument asserts the limitation these two
+// carry that nothing else in the module does, and asserts it is reported as that
+// rather than as a wrong password.
+//
+// pdfseparate and pdfunite take no `-upw` and no `-opw` — passing one is a usage
+// error, not a wrong password — so an encrypted document is one they cannot be
+// made to open. What poppler says about it is `Incorrect password`, the same
+// sentence every other tool in the suite produces for a password that did not
+// work, and the module's usual reading of that line names WithUserPassword. Here
+// that would send a caller to a builder that changes nothing, which is why the
+// password case is asserted alongside the passwordless one: both have to arrive
+// at the same message.
+func (r *PdfTests) SplitAndMergeCannotOpenAnEncryptedDocument(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1789:1)
+	if r.splitAndMergeCannotOpenAnEncryptedDocument != nil {
+		return nil
+	}
+	q := r.query.Select("splitAndMergeCannotOpenAnEncryptedDocument")
+
+	return q.Execute(ctx)
+}
+
+// SplitNarrowsToThePageRange asserts the page bounds reach pdfseparate in all
+// three of the shapes a range comes in, and that a range it cannot honour is
+// refused before it runs.
+//
+// The refusal is the half worth asserting. Left to pdfseparate, a last bound past
+// the end of the document is not caught up front at all: it separates every page
+// it can and *then* fails with `Internal Error: Illegal pageNo: 13(12)`, so the
+// caller gets a message about poppler's internals attached to a directory that
+// was half written. Checking the bounds against the document first is what turns
+// that into a sentence naming the builder and the page count.
+func (r *PdfTests) SplitNarrowsToThePageRange(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1594:1)
+	if r.splitNarrowsToThePageRange != nil {
+		return nil
+	}
+	q := r.query.Select("splitNarrowsToThePageRange")
+
+	return q.Execute(ctx)
+}
+
+// SplitThenMergeRoundTripsTheDocument asserts the two halves of this pair
+// compose back into the document they started from.
+//
+// It is the assertion that says these are structural operations rather than
+// conversions. Each one alone could pass its own tests while quietly dropping
+// what it does not understand — a page's annotations, its size, the text layer
+// under it — and the round trip is where that shows up: twelve separated pages
+// put back together have to extract to the same text, in the same order, on
+// pages of the same size.
+//
+// The names the split wrote are what the merge is driven by, in page order, which
+// is also the practical shape of the pair: split, do something to the pages,
+// merge the ones that survived.
+func (r *PdfTests) SplitThenMergeRoundTripsTheDocument(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1735:1)
+	if r.splitThenMergeRoundTripsTheDocument != nil {
+		return nil
+	}
+	q := r.query.Select("splitThenMergeRoundTripsTheDocument")
+
+	return q.Execute(ctx)
+}
+
+// SplitWritesOnePdfPerPage asserts Split turns a twelve-page document into
+// twelve one-page PDFs named to the same contract every render family member
+// honours.
+//
+// The names alone would pass against a splitter that wrote twelve copies of page
+// one, so each file is opened and read: one page in it, and that page's own
+// marker in the text. ledgerPdf's markers are what make that check possible —
+// twelve pages of identical text would extract the same however they were
+// shuffled.
+//
+// pdfseparate numbers with the width the caller's pattern asks for rather than
+// with the document's page count, so the four-digit contract here is this
+// module's and not a coincidence of the fixture's length.
+func (r *PdfTests) SplitWritesOnePdfPerPage(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1550:1)
+	if r.splitWritesOnePdfPerPage != nil {
+		return nil
+	}
+	q := r.query.Select("splitWritesOnePdfPerPage")
 
 	return q.Execute(ctx)
 }
@@ -652,7 +781,7 @@ func (r *PdfTests) SignaturesReportsAnUnsignedDocumentInsteadOfFailing(ctx conte
 // anywhere. Poppler converts text to glyph outlines rather than to `<text>`, so
 // the marker words are not in the file at all — a Contains check for one would
 // fail on a perfectly good SVG.
-func (r *PdfTests) SvgWritesOneVectorFilePerPage(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:234:1)
+func (r *PdfTests) SvgWritesOneVectorFilePerPage(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:242:1)
 	if r.svgWritesOneVectorFilePerPage != nil {
 		return nil
 	}
@@ -671,7 +800,7 @@ func (r *PdfTests) SvgWritesOneVectorFilePerPage(ctx context.Context) error { //
 // a caller gets that this document needs rasterizing and handing to OCR. A
 // module that failed here instead would make the two paths impossible to choose
 // between programmatically.
-func (r *PdfTests) TextOnImageOnlyPdfReturnsNothing(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1008:1)
+func (r *PdfTests) TextOnImageOnlyPdfReturnsNothing(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1016:1)
 	if r.textOnImageOnlyPdfReturnsNothing != nil {
 		return nil
 	}
@@ -689,7 +818,7 @@ func (r *PdfTests) TextOnImageOnlyPdfReturnsNothing(ctx context.Context) error {
 // leading newline, pages in the wrong order — is a defect and not a recognition
 // error. A fixture whose content streams are readable is what makes an exact
 // expectation writable at all.
-func (r *PdfTests) TextReproducesTextLayerExactly(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:987:1)
+func (r *PdfTests) TextReproducesTextLayerExactly(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:995:1)
 	if r.textReproducesTextLayerExactly != nil {
 		return nil
 	}
@@ -705,7 +834,7 @@ func (r *PdfTests) TextReproducesTextLayerExactly(ctx context.Context) error { /
 // straight off the handle: the point of Txt is that the bytes reach a filesystem
 // intact, and File.Contents would confirm the engine's copy while saying nothing
 // about the export a real consumer performs.
-func (r *PdfTests) TxtMatchesText(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1031:1)
+func (r *PdfTests) TxtMatchesText(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1039:1)
 	if r.txtMatchesText != nil {
 		return nil
 	}
@@ -727,7 +856,7 @@ func (r *PdfTests) TxtMatchesText(ctx context.Context) error { // pdf-tests (../
 //
 // WithDpi is the one setting that does reach pdftocairo, and it is set here too
 // so this is not accidentally asserting that no flags are passed at all.
-func (r *PdfTests) VectorFormatsIgnoreRasterOnlySettings(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:496:1)
+func (r *PdfTests) VectorFormatsIgnoreRasterOnlySettings(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:504:1)
 	if r.vectorFormatsIgnoreRasterOnlySettings != nil {
 		return nil
 	}
@@ -745,7 +874,7 @@ func (r *PdfTests) VectorFormatsIgnoreRasterOnlySettings(ctx context.Context) er
 // exact patch: Alpine may rebuild poppler-utils within the v3.24 branch, and a
 // test that pins the patch level would fail on a change this module has no
 // opinion about.
-func (r *PdfTests) VersionReportsPopplerRelease(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:575:1)
+func (r *PdfTests) VersionReportsPopplerRelease(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:583:1)
 	if r.versionReportsPopplerRelease != nil {
 		return nil
 	}
@@ -763,7 +892,7 @@ func (r *PdfTests) VersionReportsPopplerRelease(ctx context.Context) error { // 
 // module installs, so the negative control is real — the plain image genuinely
 // cannot see it, and the assertion is not passing on something the base image
 // already had.
-func (r *PdfTests) WithFontsPutsFaceWhereFontconfigFindsIt(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:635:1)
+func (r *PdfTests) WithFontsPutsFaceWhereFontconfigFindsIt(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:643:1)
 	if r.withFontsPutsFaceWhereFontconfigFindsIt != nil {
 		return nil
 	}
@@ -779,7 +908,7 @@ func (r *PdfTests) WithFontsPutsFaceWhereFontconfigFindsIt(ctx context.Context) 
 // a render of it is the annotation's appearance stream and nothing else. Without
 // that separation the assertion could not tell an annotation that was not drawn
 // from one that was drawn somewhere else on the page.
-func (r *PdfTests) WithoutAnnotationsRemovesTheAnnotationLayer(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1461:1)
+func (r *PdfTests) WithoutAnnotationsRemovesTheAnnotationLayer(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1469:1)
 	if r.withoutAnnotationsRemovesTheAnnotationLayer != nil {
 		return nil
 	}
@@ -804,7 +933,7 @@ func (r *PdfTests) AsNode() Node {
 // streams are uncompressed, so the text a page is supposed to render is readable
 // in the fixture itself and an assertion about it can be checked against the
 // PDF rather than against another tool's opinion of the PDF.
-func (r *Query) PdfTests() *PdfTests { // pdf-tests (../../../daggerverse/pdf/tests/main.go:150:6)
+func (r *Query) PdfTests() *PdfTests { // pdf-tests (../../../daggerverse/pdf/tests/main.go:151:6)
 	q := r.query.Select("pdfTests")
 
 	return &PdfTests{

--- a/daggerverse/pdf/README.md
+++ b/daggerverse/pdf/README.md
@@ -9,7 +9,9 @@ and it gives you SVG, EPS or PostScript; ask for markup and it gives you HTML
 with the page's images beside it. Ask it what the document is and it tells you:
 page count, page size, PDF version, whether it is encrypted and under which
 algorithm, which fonts it needs and whether they are embedded, what its XMP
-metadata says, and whether its signatures check out.
+metadata says, and whether its signatures check out. Or leave it a PDF and change
+its page structure instead: `Split` takes a document apart a page per file,
+`Merge` puts several back together in the order you name them.
 
 **There is no official poppler container image**, so this module assembles its
 own the way `tesseract` and `qemu` do rather than pinning a vendor image the way
@@ -135,13 +137,14 @@ dag.Pdf().
 New(registry="docker.io", alpineTag="3.24") (*Pdf, error)
 Pdf.Container() *dagger.Container
 Pdf.Version(ctx) (string, error)
+Pdf.Merge(ctx, sources []*dagger.File) (*dagger.File, error)
 ```
 
 `Container` is the escape hatch. poppler-utils ships **thirteen** binaries and
-this module wraps seven of them — `pdftotext`, `pdftoppm`, `pdfinfo`,
-`pdftocairo`, `pdftohtml`, `pdffonts` and `pdfsig` — so `pdfimages`,
-`pdfseparate`, `pdfunite`, `pdftops`, `pdfattach` and `pdfdetach` stay reachable
-via `container with-exec` until they get wrapped too (see
+this module wraps nine of them — `pdftotext`, `pdftoppm`, `pdfinfo`,
+`pdftocairo`, `pdftohtml`, `pdffonts`, `pdfsig`, `pdfseparate` and `pdfunite` —
+so `pdfimages`, `pdftops`, `pdfattach` and `pdfdetach` stay reachable via
+`container with-exec` until they get wrapped too (see
 [Follow-ups](#follow-ups)). So do the flags of a wrapped tool that this module
 does not surface, `pdffonts -subst` among them.
 
@@ -162,6 +165,7 @@ Document.PageCount(ctx) (int, error)
 Document.Fonts(ctx) (string, error)
 Document.Metadata(ctx) (string, error)
 Document.Signatures(ctx) (string, error)
+Document.Split(ctx) (*dagger.Directory, error)
 Document.Convert() *Convert
 ```
 
@@ -217,7 +221,7 @@ Bounds are **1-based and inclusive**, matching poppler's own `-f`/`-l`, so
 the first page alone. A zero `last` means "to the last page", which is the only
 way to spell an open-ended range without first asking how many pages there are.
 
-It narrows the text outputs and the raster outputs alike.
+It narrows the text outputs, the raster outputs and `Split` alike.
 
 Bounds are checked against the document and rejected by naming the bound, at the
 point of use rather than in the builder — the check needs the page count, which
@@ -524,9 +528,81 @@ that rendered them, while still passing every assertion about entry names.
 frameset — a frameset, an index and the content — of which only the last carries
 anything.
 
+## `Split` and `Merge` — page structure, not pixels
+
+```go
+Document.Split(ctx) (*dagger.Directory, error)
+Pdf.Merge(ctx, sources []*dagger.File) (*dagger.File, error)
+```
+
+These two are the other half of "working with PDFs", and they need no rendering
+at all. `Split` is `pdfseparate`: one PDF per page, named to the same
+[page-naming contract](#page-naming--page-0001png) the render family honours,
+`page-0001.pdf` onwards. `Merge` is `pdfunite`: several PDFs concatenated into
+one.
+
+They are **lossless** in a way no conversion is. Each split page carries the
+original page's own objects across — its text layer, its fonts, its annotations,
+its size — so a split page is still a searchable PDF and a round trip gives back
+the document it started from:
+
+```go
+pages := dag.Pdf().Document(source).Split()
+
+var keep []*dagger.File
+for _, name := range wanted {          // page-0004.pdf, page-0007.pdf, …
+    keep = append(keep, pages.File(name))
+}
+excerpt := dag.Pdf().Merge(keep)
+```
+
+`Merge` hangs off the **root** rather than off `Document` because it takes
+several sources and no single one of them is "the" document — a bound document
+carries passwords and a page range, and neither means anything for a merge. It
+takes an ordered `[]*dagger.File` rather than a directory and a glob because
+**merge order is meaning**: a directory has no order of its own, so a caller
+would be relying on whatever file names it happens to carry, and that is a
+contract nobody wrote down. The slice is where the caller states what the result
+should read like.
+
+One source is legal and produces that source's document, so a caller merging a
+computed list does not have to special-case its length. An empty slice is not:
+there is no document to return and no empty PDF worth inventing, and
+`pdfunite`'s own answer to it is its usage text — a description of a command
+line the caller never wrote. The module refuses it before the container starts,
+naming what to pass instead.
+
+`Merge` mounts its sources at `/in/source-0001.pdf`, `/in/source-0002.pdf`, … in
+slice order, and a failure carries a legend saying so, because the only thing
+`pdfunite` tells you about a source it could not read is that path:
+
+```
+Merge failed (exit 255):
+Syntax Warning: May not be a PDF file (continuing anyway)
+…
+Syntax Error: Could not merge damaged documents ('/in/source-0002.pdf')
+any /in/source-NNNN.pdf above is this module's mount for the NNNNth of the 2
+sources, numbered from 1 in the order they were passed
+```
+
+> **Neither tool takes a password.** There is no `-upw` and no `-opw` on
+> `pdfseparate` or on `pdfunite` — passing one is a *usage* error, not a wrong
+> password — so an encrypted document is one these two cannot be made to open,
+> and `WithUserPassword` does not change that. What poppler says about it is
+> `Incorrect password`, the same sentence a genuinely wrong password produces
+> everywhere else in this module, so `Split` and `Merge` report it as the
+> limitation it is and point at decrypting the document first (`qpdf --decrypt`;
+> wrapping qpdf is #274). This is the one place a password reaches some of the
+> module's functions and not others.
+
+Whole documents go in whole. `Merge` narrows nothing — `Split` is what produces
+single pages to merge — and the pages keep their own size, so merging US Letter
+with A4 yields a document whose pages differ in size, which is what a
+concatenation should do.
+
 ## Page naming — `page-0001.png`
 
-`Png`, `Jpeg`, `Tiff`, `Svg`, `Eps` and `Html` return a directory of
+`Png`, `Jpeg`, `Tiff`, `Svg`, `Eps`, `Html` and `Split` return a directory of
 `page-0001.<ext>`, `page-0002.<ext>`, … zero-padded to at least four digits and
 uniform within a document. The extensions are **poppler's** spellings, not this
 module's:
@@ -539,15 +615,22 @@ module's:
 | `Svg` | `page-0001.svg` |
 | `Eps` | `page-0001.eps` |
 | `Html` | `page-0001.html` (+ its images, see above) |
+| `Split` | `page-0001.pdf` |
 
-The raster family and the per-page family reach that contract from opposite
-directions. `pdftoppm` names the files and this module **renames** them; for
-`Svg`, `Eps` and `Html` the module drives the page loop itself and **names them
-outright**, one invocation per page, because neither `pdftocairo` nor
-`pdftohtml` will produce a usable page-per-file set on its own. The upper bound
-of that loop — a `WithPageRange` open-ended `last`, or no range at all — is
-resolved from `pdfinfo` **inside the same exec** that renders, so the whole
-conversion stays one exec either way.
+The families reach that contract from opposite directions. `pdftoppm` and
+`pdfseparate` name the files and this module **renames** them; for `Svg`, `Eps`
+and `Html` the module drives the page loop itself and **names them outright**,
+one invocation per page, because neither `pdftocairo` nor `pdftohtml` will
+produce a usable page-per-file set on its own. The upper bound of that loop — a
+`WithPageRange` open-ended `last`, or no range at all — is resolved from
+`pdfinfo` **inside the same exec** that renders, so the whole conversion stays
+one exec either way.
+
+`pdfseparate` is the one that would honour a padded name if it were asked:
+handed a `page-%04d.pdf` destination pattern it zero-pads for you. It goes
+through the rename pass anyway, because a fixed width in the pattern is a width
+and not a *floor* — a document with more than 9999 pages would come out numbered
+to two widths, which is the exact ambiguity the contract exists to remove.
 
 For the raster family in particular, **this is a normalization, not
 `pdftoppm`'s own behaviour.** `pdftoppm` pads a
@@ -564,9 +647,9 @@ makes the shape a contract instead of a consequence, and that is what lets this
 directory be handed to another module at all.
 
 A rename pass runs **in the same exec** as the render, so the directory never
-existed under the other names. The width is the greater of four and whatever
-`pdftoppm` chose, so a document longer than four digits can express stays
-uniform rather than being truncated into ambiguity.
+existed under the other names. The width is the greater of four and whatever the
+tool chose, so a document longer than four digits can express stays uniform
+rather than being truncated into ambiguity.
 
 Page numbers are the **source document's**, not positions within a range, so
 `WithPageRange(4, 6)` yields `page-0004`…`page-0006`. That keeps a rendered page
@@ -600,8 +683,8 @@ about. Same posture as `tesseract`'s outputs and `kicad`.
 
 ## Follow-ups
 
-Text-layer geometry as bbox HTML and TSV (#269); splitting and merging pages
-(#270); extracting embedded images and attachments (#271); cropping the render
+Text-layer geometry as bbox HTML and TSV (#269);
+extracting embedded images and attachments (#271); cropping the render
 window and selecting odd or even pages (#272); the chained `Ci` builder (#273);
 linearize, encrypt and repair via qpdf (#274); testing package assembly off a
 private apk mirror (#275); removing `tesseract`'s `FromPdf` in favour of this

--- a/daggerverse/pdf/convert.go
+++ b/daggerverse/pdf/convert.go
@@ -14,9 +14,10 @@ import (
 // text.
 const rasterArgv0 = "pdf-raster"
 
-// normalizeScript renames every page pdftoppm just wrote so its number is
+// normalizeScript renames every page the tool just wrote so its number is
 // zero-padded to a fixed width, and is the reason this directory can be handed
-// to another module at all.
+// to another module at all. It is the raster renders' pass and Split's alike:
+// both write a page per file, and both leave the number unpadded for it.
 //
 // pdftoppm pads a page number to the width of the document's page count, so a
 // 9-page document yields `page-1.png` and a 10-page one `page-01.png`.

--- a/daggerverse/pdf/dagger.gen.go
+++ b/daggerverse/pdf/dagger.gen.go
@@ -593,6 +593,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return (*Document).Signatures(&parent, ctx)
+		case "Split":
+			var parent Document
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Document).Split(&parent, ctx)
 		case "WithOwnerPassword":
 			var parent Document
 			err = json.Unmarshal(parentJSON, &parent)
@@ -668,6 +675,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Pdf).Document(&parent, source), nil
+		case "Merge":
+			var parent Pdf
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var sources []*dagger.File
+			if inputArgs["sources"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["sources"]), &sources)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg sources", err))
+				}
+			}
+			return (*Pdf).Merge(&parent, ctx, sources)
 		case "Version":
 			var parent Pdf
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/pdf/document.go
+++ b/daggerverse/pdf/document.go
@@ -270,7 +270,7 @@ func isSignatureReport(out string) bool {
 	return strings.Contains(out, noSignaturesMarker) || strings.Contains(out, signatureInfoMarker)
 }
 
-// Convert opens the conversion namespace: the render options, and the five
+// Convert opens the conversion namespace: the render options, and the nine
 // outputs that read them.
 //
 // It is a separate object rather than more methods on Document because the
@@ -441,7 +441,14 @@ func (d *Document) runScript(ctx context.Context, label string, script string, a
 // output is still readable; without it the exit code is the error and poppler's
 // own message about the document is lost inside Dagger's.
 func (d *Document) capture(ctx context.Context, script string, args ...string) (*popplerResult, int, error) {
-	exec := d.container().WithExec(
+	return capture(ctx, d.container(), script, args...)
+}
+
+// capture is the same for a container that carries no bound document, which is
+// what Merge runs in: its sources are several files and none of them is "the"
+// document, so there is nothing for Document to be.
+func capture(ctx context.Context, ctr *dagger.Container, script string, args ...string) (*popplerResult, int, error) {
+	exec := ctr.WithExec(
 		append([]string{"sh", "-c", script}, args...),
 		dagger.ContainerWithExecOpts{Expect: dagger.ReturnTypeAny})
 

--- a/daggerverse/pdf/main.go
+++ b/daggerverse/pdf/main.go
@@ -48,6 +48,13 @@
 // wide, and a caller who wants one field can read it out of these lines more
 // cheaply than this module can model all of them.
 //
+// Two functions change the document's page structure rather than reading it or
+// drawing it: Split takes it apart a page per file, Merge concatenates several
+// into one. They are lossless where every conversion is not — the pages carry
+// their own objects across — and they are the pair with a limitation nothing
+// else here has: pdfseparate and pdfunite accept no password, so an encrypted
+// document has to be decrypted before either will touch it.
+//
 // File map (all `package main`, surfaced as one Dagger module):
 //
 //   - enums.go    — ColorMode and LayoutMode plus the tables mapping them onto
@@ -57,6 +64,10 @@
 //     its XMP metadata, and its signatures.
 //   - convert.go  — *Convert, the render options and the nine outputs that
 //     read them.
+//   - pages.go    — Split and Merge, the two page-structure operations. They
+//     sit together rather than with their receivers because they are one
+//     story: the page-naming contract one writes is the order the other
+//     reads.
 package main
 
 import (
@@ -81,8 +92,9 @@ const (
 	defaultAlpineTag = "3.24"
 
 	// popplerPkg carries all thirteen pdf* binaries this module reaches
-	// through Container, of which seven are wrapped: pdftotext, pdftoppm,
-	// pdfinfo, pdftocairo, pdftohtml, pdffonts and pdfsig.
+	// through Container, of which nine are wrapped: pdftotext, pdftoppm,
+	// pdfinfo, pdftocairo, pdftohtml, pdffonts, pdfsig, pdfseparate and
+	// pdfunite.
 	popplerPkg = "poppler-utils"
 
 	// fontPkg is the substitute font family poppler draws with when a PDF
@@ -336,10 +348,10 @@ func (p *Pdf) WithFonts(
 
 // Container returns the assembled toolchain image. This is the escape hatch
 // for everything this module does not wrap: poppler-utils ships thirteen
-// binaries and seven of them are wrapped here, so pdfimages, pdfseparate,
-// pdfunite, pdfattach, pdfdetach and pdftops stay reachable via
-// `container with-exec` — as do the flags of a wrapped tool that this module
-// does not surface, `pdffonts -subst` among them.
+// binaries and nine of them are wrapped here, so pdfimages, pdfattach,
+// pdfdetach and pdftops stay reachable via `container with-exec` — as do the
+// flags of a wrapped tool that this module does not surface, `pdffonts -subst`
+// among them.
 func (p *Pdf) Container() *dagger.Container {
 	ctr := p.base().WithExec([]string{"apk", "add", "--no-cache", popplerPkg, fontPkg})
 	// Mounted after the install because the install is what brings

--- a/daggerverse/pdf/pages.go
+++ b/daggerverse/pdf/pages.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"dagger/pdf/internal/dagger"
+)
+
+const (
+	// splitPattern is the destination pdfseparate is handed. It is a printf
+	// format and not a path: the tool substitutes the page number for `%d` and
+	// refuses a pattern without one, which is how a multi-page document is
+	// allowed to write more than one file.
+	//
+	// The number goes in unpadded and is padded afterwards by normalizeScript,
+	// the same pass the raster renders go through. pdfseparate would honour a
+	// `%04d` here, but the width would then be fixed rather than a floor, and a
+	// document with more than 9999 pages would come out numbered to two
+	// different widths.
+	splitPattern = outputDir + "/" + pageNamePrefix + "%d.pdf"
+
+	// splitArgv0 is the `$0` the split script runs under, so the extension
+	// normalizeScript matches on reaches it as `$1`.
+	splitArgv0 = "pdf-split"
+
+	// pdfExt is the extension both halves of this file work in.
+	pdfExt = "pdf"
+
+	// mergeInputDir is where Merge mounts its sources and mergedPath the file it
+	// writes. The sources are named by their position in the slice, padded like
+	// everything else this module names, because poppler quotes the path of a
+	// source it could not read and that path is the only thing tying its
+	// complaint back to an argument the caller passed.
+	mergeInputDir = "/in"
+	mergedPath    = outputDir + "/merged.pdf"
+)
+
+// Split writes each page of the document to its own PDF and returns the
+// directory holding them, named `page-0001.pdf`, `page-0002.pdf`, and so on.
+//
+// This is page extraction and not rendering: each file carries the original
+// page's objects — its text layer, its fonts, its annotations — so a split page
+// is still a PDF a reader can search, and splitting is lossless in a way that
+// rendering to PNG is not.
+//
+// The names are the same contract the render family honours, and for the same
+// reason: a consumer that sorts this directory has to get page order. They are
+// this module's and not the tool's — pdfseparate numbers to whatever width the
+// destination pattern asks for, so the four digits are a promise rather than a
+// consequence of the document's length. The numbers are the source document's
+// page numbers, so pages 4 through 6 come out `page-0004.pdf` through
+// `page-0006.pdf` and stay traceable to the page they came from.
+//
+// WithPageRange narrows it. The passwords do not reach it: pdfseparate has no
+// password option at all, so an encrypted document is one it cannot open however
+// the document was bound — see the message a run against one carries.
+func (d *Document) Split(ctx context.Context) (*dagger.Directory, error) {
+	if err := d.validateRange(ctx); err != nil {
+		return nil, err
+	}
+
+	words := append([]string{"pdfseparate"}, d.rangeArgs()...)
+	words = append(words, sourcePath, splitPattern)
+
+	// set -e is what makes a document poppler cannot open fail here, carrying
+	// its own message, rather than turning into an empty directory a caller
+	// would read as a document with no pages in it.
+	script := strings.Join([]string{
+		"set -e",
+		"mkdir -p " + outputDir,
+		strings.Join(words, " "),
+		normalizeScript,
+	}, "\n")
+
+	res, code, err := d.capture(ctx, script, splitArgv0, pdfExt)
+	if err != nil {
+		return nil, err
+	}
+	if code != 0 {
+		return nil, pageToolFailure("Split", "pdfseparate", "the document", code, res.stdout, res.stderr)
+	}
+	return res.container.Directory(outputDir), nil
+}
+
+// Merge concatenates several PDFs into one, in the order they are given, and
+// returns the result.
+//
+// It hangs off the root rather than off Document because it takes several
+// sources and no single one of them is "the" document: a bound document carries
+// passwords and a page range, and neither has any meaning for a merge.
+//
+// The sources are an ordered slice rather than a directory and a glob because
+// merge order is meaning. A directory has no order of its own — a caller would
+// be relying on the file names it happens to carry, which is a contract nobody
+// wrote down — so the slice is where the caller states what the result should
+// read like.
+//
+// One source is legal and produces that source's document, so a caller merging a
+// computed list does not have to special-case its length. An empty slice is not:
+// there is no document to return and no sensible empty PDF to invent, and
+// pdfunite handed no sources answers with its own usage text.
+//
+// Nothing else about the sources is narrowed or transformed. Whole documents go
+// in whole — Split is what produces single pages to merge — and the pages keep
+// their own size, so merging US Letter with A4 yields a document whose pages
+// differ in size, which is what a concatenation should do.
+//
+// Encrypted sources are the one shape this cannot take: pdfunite has no password
+// option, so there is no argument that would let it read one. See the message a
+// run against one carries.
+func (p *Pdf) Merge(
+	ctx context.Context,
+	// The PDFs to concatenate, in the order their pages should appear in the
+	// result.
+	sources []*dagger.File,
+) (*dagger.File, error) {
+	if len(sources) == 0 {
+		return nil, fmt.Errorf(
+			"Merge: no sources to merge: pass at least one PDF, in the order the pages should appear in the result")
+	}
+
+	ctr := p.Container()
+	words := []string{"pdfunite"}
+	for i, source := range sources {
+		path := mergeSourcePath(i)
+		ctr = ctr.WithMountedFile(path, source)
+		words = append(words, path)
+	}
+	words = append(words, mergedPath)
+
+	script := strings.Join([]string{
+		"set -e",
+		"mkdir -p " + outputDir,
+		strings.Join(words, " "),
+	}, "\n")
+
+	res, code, err := capture(ctx, ctr, script)
+	if err != nil {
+		return nil, err
+	}
+	if code != 0 {
+		return nil, mergeFailure(code, len(sources), res.stdout, res.stderr)
+	}
+	return res.container.File(mergedPath), nil
+}
+
+// mergeSourcePath is where the i-th source of a merge is mounted, numbered from
+// 1 and padded like everything else this module names.
+func mergeSourcePath(i int) string {
+	return fmt.Sprintf("%s/source-%0*d.pdf", mergeInputDir, minPageNumberWidth, i+1)
+}
+
+// mergeFailure builds the error a failed pdfunite run becomes, with a legend for
+// the paths in it.
+//
+// The legend is the whole reason this is not pageToolFailure directly. pdfunite
+// names the source it could not read — `Could not merge damaged documents
+// ('/in/source-0002.pdf')` — and that path is this module's mount rather than
+// anything the caller wrote, so without the legend the one piece of information
+// that identifies *which* argument was wrong is unreadable.
+func mergeFailure(code, count int, stdout, stderr string) error {
+	err := pageToolFailure("Merge", "pdfunite", "a source document", code, stdout, stderr)
+	return fmt.Errorf(
+		"%s\nany %s/source-NNNN.pdf above is this module's mount for the NNNNth of the %d sources, numbered from 1 in the order they were passed",
+		err.Error(), mergeInputDir, count)
+}
+
+// pageToolFailure builds the error a failed pdfseparate or pdfunite run becomes.
+//
+// The encrypted case gets its own message and cannot reuse Document.failure's,
+// which names the two builders that supply a password. Neither of poppler's page
+// tools takes one — there is no `-upw` on either, and passing one is a usage
+// error rather than a wrong password — so an encrypted document is not a
+// document these functions can be made to open. Pointing at WithUserPassword
+// here would send a caller to a builder that changes nothing.
+func pageToolFailure(label, tool, subject string, code int, stdout, stderr string) error {
+	out := strings.TrimSpace(strings.TrimSpace(stdout) + "\n" + strings.TrimSpace(stderr))
+	if strings.Contains(stderr, incorrectPasswordMarker) {
+		return fmt.Errorf(
+			"%s: %s is encrypted, and %s has no password option: WithUserPassword and WithOwnerPassword reach the tools that take one, and this is not one of them. Decrypt it first — `qpdf --decrypt` — and %s the result\n%s",
+			label, subject, tool, strings.ToLower(label), out)
+	}
+	return fmt.Errorf("%s failed (exit %d):\n%s", label, code, out)
+}

--- a/daggerverse/pdf/tests/dagger.gen.go
+++ b/daggerverse/pdf/tests/dagger.gen.go
@@ -290,6 +290,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).LayoutModesProduceDifferentOrderings(&parent, ctx)
+		case "MergePreservesTheOrderOfItsSources":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).MergePreservesTheOrderOfItsSources(&parent, ctx)
+		case "MergeRejectsWhatItCannotMerge":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).MergeRejectsWhatItCannotMerge(&parent, ctx)
 		case "MetadataReturnsTheXmpPacketOrSaysThereIsNone":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -381,6 +395,34 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).SignaturesReportsAnUnsignedDocumentInsteadOfFailing(&parent, ctx)
+		case "SplitAndMergeCannotOpenAnEncryptedDocument":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).SplitAndMergeCannotOpenAnEncryptedDocument(&parent, ctx)
+		case "SplitNarrowsToThePageRange":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).SplitNarrowsToThePageRange(&parent, ctx)
+		case "SplitThenMergeRoundTripsTheDocument":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).SplitThenMergeRoundTripsTheDocument(&parent, ctx)
+		case "SplitWritesOnePdfPerPage":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).SplitWritesOnePdfPerPage(&parent, ctx)
 		case "SvgWritesOneVectorFilePerPage":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/pdf/tests/internal/dagger/pdf.gen.go
+++ b/daggerverse/pdf/tests/internal/dagger/pdf.gen.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Retrieve the binding value, as type Pdf
-func (r *Binding) AsPdf() *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:197:6)
+func (r *Binding) AsPdf() *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:209:6)
 	q := r.query.Select("asPdf")
 
 	return &Pdf{
@@ -20,7 +20,7 @@ func (r *Binding) AsPdf() *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:
 }
 
 // Retrieve the binding value, as type PdfConvert
-func (r *Binding) AsPdfConvert() *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:75:6)
+func (r *Binding) AsPdfConvert() *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:76:6)
 	q := r.query.Select("asPdfConvert")
 
 	return &PdfConvert{
@@ -38,7 +38,7 @@ func (r *Binding) AsPdfDocument() *PdfDocument { // pdf (../../../../../daggerve
 }
 
 // Create or update a binding of type PdfConvert in the environment
-func (r *Env) WithPdfConvertInput(name string, value *PdfConvert, description string) *Env { // pdf (../../../../../daggerverse/pdf/convert.go:75:6)
+func (r *Env) WithPdfConvertInput(name string, value *PdfConvert, description string) *Env { // pdf (../../../../../daggerverse/pdf/convert.go:76:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withPdfConvertInput")
 	q = q.Arg("name", name)
@@ -51,7 +51,7 @@ func (r *Env) WithPdfConvertInput(name string, value *PdfConvert, description st
 }
 
 // Declare a desired PdfConvert output to be assigned in the environment
-func (r *Env) WithPdfConvertOutput(name string, description string) *Env { // pdf (../../../../../daggerverse/pdf/convert.go:75:6)
+func (r *Env) WithPdfConvertOutput(name string, description string) *Env { // pdf (../../../../../daggerverse/pdf/convert.go:76:6)
 	q := r.query.Select("withPdfConvertOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -86,7 +86,7 @@ func (r *Env) WithPdfDocumentOutput(name string, description string) *Env { // p
 }
 
 // Create or update a binding of type Pdf in the environment
-func (r *Env) WithPdfInput(name string, value *Pdf, description string) *Env { // pdf (../../../../../daggerverse/pdf/main.go:197:6)
+func (r *Env) WithPdfInput(name string, value *Pdf, description string) *Env { // pdf (../../../../../daggerverse/pdf/main.go:209:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withPdfInput")
 	q = q.Arg("name", name)
@@ -99,7 +99,7 @@ func (r *Env) WithPdfInput(name string, value *Pdf, description string) *Env { /
 }
 
 // Declare a desired Pdf output to be assigned in the environment
-func (r *Env) WithPdfOutput(name string, description string) *Env { // pdf (../../../../../daggerverse/pdf/main.go:197:6)
+func (r *Env) WithPdfOutput(name string, description string) *Env { // pdf (../../../../../daggerverse/pdf/main.go:209:6)
 	q := r.query.Select("withPdfOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -113,7 +113,7 @@ func (r *Env) WithPdfOutput(name string, description string) *Env { // pdf (../.
 // carries the image coordinates and the fonts the image is built with;
 // Document hangs off it so the generated SDK surfaces conversion under
 // `dag.Pdf().Document(...)`.
-type Pdf struct { // pdf (../../../../../daggerverse/pdf/main.go:197:6)
+type Pdf struct { // pdf (../../../../../daggerverse/pdf/main.go:209:6)
 	query *querybuilder.Selection
 
 	id      *ID
@@ -136,11 +136,11 @@ func (r *Pdf) WithGraphQLQuery(q *querybuilder.Selection) *Pdf {
 
 // Container returns the assembled toolchain image. This is the escape hatch
 // for everything this module does not wrap: poppler-utils ships thirteen
-// binaries and seven of them are wrapped here, so pdfimages, pdfseparate,
-// pdfunite, pdfattach, pdfdetach and pdftops stay reachable via
-// `container with-exec` — as do the flags of a wrapped tool that this module
-// does not surface, `pdffonts -subst` among them.
-func (r *Pdf) Container() *Container { // pdf (../../../../../daggerverse/pdf/main.go:343:1)
+// binaries and nine of them are wrapped here, so pdfimages, pdfattach,
+// pdfdetach and pdftops stay reachable via `container with-exec` — as do the
+// flags of a wrapped tool that this module does not surface, `pdffonts -subst`
+// among them.
+func (r *Pdf) Container() *Container { // pdf (../../../../../daggerverse/pdf/main.go:355:1)
 	q := r.query.Select("container")
 
 	return &Container{
@@ -153,7 +153,7 @@ func (r *Pdf) Container() *Container { // pdf (../../../../../daggerverse/pdf/ma
 // The boundary input is a *dagger.File rather than a *dagger.Directory: a PDF
 // resolves nothing relative to its own location, so one file is the whole unit
 // of work however many pages it carries.
-func (r *Pdf) Document(source *File) *PdfDocument { // pdf (../../../../../daggerverse/pdf/main.go:376:1)
+func (r *Pdf) Document(source *File) *PdfDocument { // pdf (../../../../../daggerverse/pdf/main.go:388:1)
 	assertNotNil("source", source)
 	q := r.query.Select("document")
 	q = q.Arg("source", source)
@@ -212,9 +212,44 @@ func (r *Pdf) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
+// Merge concatenates several PDFs into one, in the order they are given, and
+// returns the result.
+//
+// It hangs off the root rather than off Document because it takes several
+// sources and no single one of them is "the" document: a bound document carries
+// passwords and a page range, and neither has any meaning for a merge.
+//
+// The sources are an ordered slice rather than a directory and a glob because
+// merge order is meaning. A directory has no order of its own — a caller would
+// be relying on the file names it happens to carry, which is a contract nobody
+// wrote down — so the slice is where the caller states what the result should
+// read like.
+//
+// One source is legal and produces that source's document, so a caller merging a
+// computed list does not have to special-case its length. An empty slice is not:
+// there is no document to return and no sensible empty PDF to invent, and
+// pdfunite handed no sources answers with its own usage text.
+//
+// Nothing else about the sources is narrowed or transformed. Whole documents go
+// in whole — Split is what produces single pages to merge — and the pages keep
+// their own size, so merging US Letter with A4 yields a document whose pages
+// differ in size, which is what a concatenation should do.
+//
+// Encrypted sources are the one shape this cannot take: pdfunite has no password
+// option, so there is no argument that would let it read one. See the message a
+// run against one carries.
+func (r *Pdf) Merge(sources []*File) *File { // pdf (../../../../../daggerverse/pdf/pages.go:113:1)
+	q := r.query.Select("merge")
+	q = q.Arg("sources", sources)
+
+	return &File{
+		query: q,
+	}
+}
+
 // Version returns the poppler release the assembled image ships, as the bare
 // version number reported by `pdftotext -v`.
-func (r *Pdf) Version(ctx context.Context) (string, error) { // pdf (../../../../../daggerverse/pdf/main.go:356:1)
+func (r *Pdf) Version(ctx context.Context) (string, error) { // pdf (../../../../../daggerverse/pdf/main.go:368:1)
 	if r.version != nil {
 		return *r.version, nil
 	}
@@ -240,7 +275,7 @@ func (r *Pdf) Version(ctx context.Context) (string, error) { // pdf (../../../..
 // why the credentials are not simply userinfo in the WithApkRepository URL,
 // which would put them in /etc/apk/repositories and in every apk error
 // message that quotes it.
-func (r *Pdf) WithApkAuth(credentials *Secret) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:304:1)
+func (r *Pdf) WithApkAuth(credentials *Secret) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:316:1)
 	assertNotNil("credentials", credentials)
 	q := r.query.Select("withApkAuth")
 	q = q.Arg("credentials", credentials)
@@ -263,7 +298,7 @@ func (r *Pdf) WithApkAuth(credentials *Secret) *Pdf { // pdf (../../../../../dag
 // Repeatable, for a mirror set signed by more than one key. It is a *File
 // rather than a *Secret because a public key is not a credential: it is meant
 // to be in the image, and WithApkAuth is the option for the part that is not.
-func (r *Pdf) WithApkKey(key *File) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:281:1)
+func (r *Pdf) WithApkKey(key *File) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:293:1)
 	assertNotNil("key", key)
 	q := r.query.Select("withApkKey")
 	q = q.Arg("key", key)
@@ -293,7 +328,7 @@ func (r *Pdf) WithApkKey(key *File) *Pdf { // pdf (../../../../../daggerverse/pd
 // call per component. A repository's index is signed, so pair this with
 // WithApkKey unless the mirror is signed by a key the base image already
 // trusts.
-func (r *Pdf) WithApkRepository(url string) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:253:1)
+func (r *Pdf) WithApkRepository(url string) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:265:1)
 	q := r.query.Select("withApkRepository")
 	q = q.Arg("url", url)
 
@@ -317,7 +352,7 @@ func (r *Pdf) WithApkRepository(url string) *Pdf { // pdf (../../../../../dagger
 // /etc/fonts/fonts.conf tells fontconfig to scan, so the faces in it are
 // indistinguishable from packaged ones as far as poppler is concerned. It is
 // mounted rather than copied so a large family does not become an image layer.
-func (r *Pdf) WithFonts(dir *Directory) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:328:1)
+func (r *Pdf) WithFonts(dir *Directory) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:340:1)
 	assertNotNil("dir", dir)
 	q := r.query.Select("withFonts")
 	q = q.Arg("dir", dir)
@@ -348,7 +383,7 @@ func (r *Pdf) AsNode() Node {
 // documented no-ops there rather than rejections: a DPI set before asking for
 // text is inapplicable rather than wrong, unlike a bound past the end of the
 // document, which is always a mistake.
-type PdfConvert struct { // pdf (../../../../../daggerverse/pdf/convert.go:75:6)
+type PdfConvert struct { // pdf (../../../../../daggerverse/pdf/convert.go:76:6)
 	query *querybuilder.Selection
 
 	id   *ID
@@ -387,7 +422,7 @@ func (r *PdfConvert) WithGraphQLQuery(q *querybuilder.Selection) *PdfConvert {
 //
 // WithDpi governs rasterized regions; WithColorMode, WithScaleTo and
 // WithoutAnnotations are ignored: see the note on Ps.
-func (r *PdfConvert) Eps() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:319:1)
+func (r *PdfConvert) Eps() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:320:1)
 	q := r.query.Select("eps")
 
 	return &Directory{
@@ -414,7 +449,7 @@ func (r *PdfConvert) Eps() *Directory { // pdf (../../../../../daggerverse/pdf/c
 //
 // Every render option is ignored, pdftohtml having no resolution, colour or
 // annotation switch of any kind. WithPageRange narrows it like everything else.
-func (r *PdfConvert) HTML() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:381:1)
+func (r *PdfConvert) HTML() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:382:1)
 	q := r.query.Select("html")
 
 	return &Directory{
@@ -478,7 +513,7 @@ func (r *PdfConvert) UnmarshalJSON(bs []byte) error {
 // Lossy, so it is the format for a preview a human looks at rather than for
 // input another program measures: the artefacts a flat page compresses into sit
 // exactly where thin strokes are, which is where OCR reads.
-func (r *PdfConvert) Jpeg() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:262:1)
+func (r *PdfConvert) Jpeg() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:263:1)
 	q := r.query.Select("jpeg")
 
 	return &Directory{
@@ -492,7 +527,7 @@ func (r *PdfConvert) Jpeg() *Directory { // pdf (../../../../../daggerverse/pdf/
 // PNG is the format to hand another module: it is lossless, so nothing
 // downstream is reading compression artefacts as page content, and it is what
 // every image library reads without a codec question.
-func (r *PdfConvert) Png() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:251:1)
+func (r *PdfConvert) Png() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:252:1)
 	q := r.query.Select("png")
 
 	return &Directory{
@@ -516,7 +551,7 @@ func (r *PdfConvert) Png() *Directory { // pdf (../../../../../daggerverse/pdf/c
 // are dropped rather than forwarded because poppler does not ignore them — it
 // exits non-zero with `-mono may only be used with the -png, -jpeg, or -tiff
 // output options`, and `-hide-annotations` is not a pdftocairo option at all.
-func (r *PdfConvert) Ps() *File { // pdf (../../../../../daggerverse/pdf/convert.go:339:1)
+func (r *PdfConvert) Ps() *File { // pdf (../../../../../daggerverse/pdf/convert.go:340:1)
 	q := r.query.Select("ps")
 
 	return &File{
@@ -544,7 +579,7 @@ func (r *PdfConvert) Ps() *File { // pdf (../../../../../daggerverse/pdf/convert
 // WithDpi governs the rasterized regions a page can still contain — an embedded
 // photograph has no vector form to keep. WithColorMode, WithScaleTo and
 // WithoutAnnotations are ignored: see the note on Ps.
-func (r *PdfConvert) Svg() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:297:1)
+func (r *PdfConvert) Svg() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:298:1)
 	q := r.query.Select("svg")
 
 	return &Directory{
@@ -558,11 +593,11 @@ type PdfConvertTextOpts struct {
 	// How much of the page's physical arrangement survives into the text.
 	// Defaults to reading order.
 	//
-	Layout PdfLayoutMode // pdf (../../../../../daggerverse/pdf/convert.go:192:2)
+	Layout PdfLayoutMode // pdf (../../../../../daggerverse/pdf/convert.go:193:2)
 	//
 	// Emit no form feed between pages.
 	//
-	DisablePageBreaks bool // pdf (../../../../../daggerverse/pdf/convert.go:195:2)
+	DisablePageBreaks bool // pdf (../../../../../daggerverse/pdf/convert.go:196:2)
 }
 
 // Text returns the document's text layer as a string.
@@ -577,7 +612,7 @@ type PdfConvertTextOpts struct {
 // Pages are separated by a form feed (U+000C), including after the last one,
 // which is pdftotext's own convention. Pass disablePageBreaks to drop them, for
 // a consumer that wants one flat stream of text.
-func (r *PdfConvert) Text(ctx context.Context, opts ...PdfConvertTextOpts) (string, error) { // pdf (../../../../../daggerverse/pdf/convert.go:187:1)
+func (r *PdfConvert) Text(ctx context.Context, opts ...PdfConvertTextOpts) (string, error) { // pdf (../../../../../daggerverse/pdf/convert.go:188:1)
 	if r.text != nil {
 		return *r.text, nil
 	}
@@ -606,7 +641,7 @@ func (r *PdfConvert) Text(ctx context.Context, opts ...PdfConvertTextOpts) (stri
 // It is the format the document-imaging world already speaks, and the one to
 // pair with MONO: a bilevel TIFF is what a scanner emits and what an archive
 // expects.
-func (r *PdfConvert) Tiff() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:273:1)
+func (r *PdfConvert) Tiff() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:274:1)
 	q := r.query.Select("tiff")
 
 	return &Directory{
@@ -620,11 +655,11 @@ type PdfConvertTxtOpts struct {
 	// How much of the page's physical arrangement survives into the text.
 	// Defaults to reading order.
 	//
-	Layout PdfLayoutMode // pdf (../../../../../daggerverse/pdf/convert.go:222:2)
+	Layout PdfLayoutMode // pdf (../../../../../daggerverse/pdf/convert.go:223:2)
 	//
 	// Emit no form feed between pages.
 	//
-	DisablePageBreaks bool // pdf (../../../../../daggerverse/pdf/convert.go:225:2)
+	DisablePageBreaks bool // pdf (../../../../../daggerverse/pdf/convert.go:226:2)
 }
 
 // Txt returns the same text Text returns, as a file rather than a string.
@@ -632,7 +667,7 @@ type PdfConvertTxtOpts struct {
 // Which of the two to reach for is plumbing and nothing more: a file composes
 // with whatever consumes files — another module, an export, a directory being
 // assembled — without the bytes passing through the caller.
-func (r *PdfConvert) Txt(opts ...PdfConvertTxtOpts) *File { // pdf (../../../../../daggerverse/pdf/convert.go:217:1)
+func (r *PdfConvert) Txt(opts ...PdfConvertTxtOpts) *File { // pdf (../../../../../daggerverse/pdf/convert.go:218:1)
 	q := r.query.Select("txt")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `layout` optional argument
@@ -658,7 +693,7 @@ func (r *PdfConvert) Txt(opts ...PdfConvertTxtOpts) *File { // pdf (../../../../
 // threshold a colour image itself.
 //
 // Ignored by Text and Txt.
-func (r *PdfConvert) WithColorMode(mode PdfColorMode) *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:123:1)
+func (r *PdfConvert) WithColorMode(mode PdfColorMode) *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:124:1)
 	q := r.query.Select("withColorMode")
 	q = q.Arg("mode", mode)
 
@@ -680,7 +715,7 @@ func (r *PdfConvert) WithColorMode(mode PdfColorMode) *PdfConvert { // pdf (../.
 // Ignored by Text and Txt, which read a text layer rather than rendering
 // anything. Overridden by WithScaleTo, which fixes the output's pixel
 // dimensions directly.
-func (r *PdfConvert) WithDpi(dpi int) *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:105:1)
+func (r *PdfConvert) WithDpi(dpi int) *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:106:1)
 	q := r.query.Select("withDpi")
 	q = q.Arg("dpi", dpi)
 
@@ -703,7 +738,7 @@ func (r *PdfConvert) WithDpi(dpi int) *PdfConvert { // pdf (../../../../../dagge
 // is on the page, which is every OCR and measurement case.
 //
 // Ignored by Text and Txt.
-func (r *PdfConvert) WithScaleTo(pixels int) *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:146:1)
+func (r *PdfConvert) WithScaleTo(pixels int) *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:147:1)
 	q := r.query.Select("withScaleTo")
 	q = q.Arg("pixels", pixels)
 
@@ -724,7 +759,7 @@ func (r *PdfConvert) WithScaleTo(pixels int) *PdfConvert { // pdf (../../../../.
 // could ever turn annotations off.
 //
 // Ignored by Text and Txt.
-func (r *PdfConvert) WithoutAnnotations() *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:169:1)
+func (r *PdfConvert) WithoutAnnotations() *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:170:1)
 	q := r.query.Select("withoutAnnotations")
 
 	return &PdfConvert{
@@ -771,7 +806,7 @@ func (r *PdfDocument) WithGraphQLQuery(q *querybuilder.Selection) *PdfDocument {
 	}
 }
 
-// Convert opens the conversion namespace: the render options, and the five
+// Convert opens the conversion namespace: the render options, and the nine
 // outputs that read them.
 //
 // It is a separate object rather than more methods on Document because the
@@ -981,6 +1016,33 @@ func (r *PdfDocument) Signatures(ctx context.Context) (string, error) { // pdf (
 	return response, q.Execute(ctx)
 }
 
+// Split writes each page of the document to its own PDF and returns the
+// directory holding them, named `page-0001.pdf`, `page-0002.pdf`, and so on.
+//
+// This is page extraction and not rendering: each file carries the original
+// page's objects — its text layer, its fonts, its annotations — so a split page
+// is still a PDF a reader can search, and splitting is lossless in a way that
+// rendering to PNG is not.
+//
+// The names are the same contract the render family honours, and for the same
+// reason: a consumer that sorts this directory has to get page order. They are
+// this module's and not the tool's — pdfseparate numbers to whatever width the
+// destination pattern asks for, so the four digits are a promise rather than a
+// consequence of the document's length. The numbers are the source document's
+// page numbers, so pages 4 through 6 come out `page-0004.pdf` through
+// `page-0006.pdf` and stay traceable to the page they came from.
+//
+// WithPageRange narrows it. The passwords do not reach it: pdfseparate has no
+// password option at all, so an encrypted document is one it cannot open however
+// the document was bound — see the message a run against one carries.
+func (r *PdfDocument) Split() *Directory { // pdf (../../../../../daggerverse/pdf/pages.go:59:1)
+	q := r.query.Select("split")
+
+	return &Directory{
+		query: q,
+	}
+}
+
 // WithOwnerPassword supplies the document's owner password, which opens an
 // encrypted document as fully as the user password does and additionally
 // clears the permission bits poppler otherwise honours.
@@ -1077,18 +1139,18 @@ type PdfOpts struct {
 	//
 	//
 	// Default: "docker.io"
-	Registry string // pdf (../../../../../daggerverse/pdf/main.go:219:2)
+	Registry string // pdf (../../../../../daggerverse/pdf/main.go:231:2)
 	//
 	// Tag of the alpine image the toolchain is assembled on.
 	//
 	//
 	// Default: "3.24"
-	AlpineTag string // pdf (../../../../../daggerverse/pdf/main.go:222:2)
+	AlpineTag string // pdf (../../../../../daggerverse/pdf/main.go:234:2)
 }
 
 // New returns a Pdf module backed by <registry>/library/alpine:<tag> with
 // poppler-utils and a substitute font family installed.
-func (r *Query) Pdf(opts ...PdfOpts) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:214:1)
+func (r *Query) Pdf(opts ...PdfOpts) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:226:1)
 	q := r.query.Select("pdf")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `registry` optional argument

--- a/daggerverse/pdf/tests/main.go
+++ b/daggerverse/pdf/tests/main.go
@@ -138,9 +138,10 @@ var ledgerMarkers = []string{
 }
 
 // popplerBinaries is every executable poppler-utils installs. Container's
-// promise is that all of them are reachable, not just the seven this module
+// promise is that all of them are reachable, not just the nine this module
 // wraps: the module wraps pdftotext, pdftoppm, pdfinfo, pdftocairo, pdftohtml,
-// pdffonts and pdfsig, and the escape hatch is the whole point of the other six.
+// pdffonts, pdfsig, pdfseparate and pdfunite, and the escape hatch is the whole
+// point of the other four.
 var popplerBinaries = []string{
 	"pdfattach", "pdfdetach", "pdffonts", "pdfimages", "pdfinfo",
 	"pdfseparate", "pdfsig", "pdftocairo", "pdftohtml", "pdftoppm",
@@ -210,6 +211,13 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("HtmlCarriesPageMarkupAndItsImages", t.HtmlCarriesPageMarkupAndItsImages)
 	jobs = jobs.WithJob("PageRangeNarrowsEveryPerPageFormat", t.PageRangeNarrowsEveryPerPageFormat)
 	jobs = jobs.WithJob("VectorFormatsIgnoreRasterOnlySettings", t.VectorFormatsIgnoreRasterOnlySettings)
+
+	jobs = jobs.WithJob("SplitWritesOnePdfPerPage", t.SplitWritesOnePdfPerPage)
+	jobs = jobs.WithJob("SplitNarrowsToThePageRange", t.SplitNarrowsToThePageRange)
+	jobs = jobs.WithJob("MergePreservesTheOrderOfItsSources", t.MergePreservesTheOrderOfItsSources)
+	jobs = jobs.WithJob("MergeRejectsWhatItCannotMerge", t.MergeRejectsWhatItCannotMerge)
+	jobs = jobs.WithJob("SplitThenMergeRoundTripsTheDocument", t.SplitThenMergeRoundTripsTheDocument)
+	jobs = jobs.WithJob("SplitAndMergeCannotOpenAnEncryptedDocument", t.SplitAndMergeCannotOpenAnEncryptedDocument)
 
 	jobs = jobs.WithJob("EncryptedDocumentNeedsThePassword", t.EncryptedDocumentNeedsThePassword)
 
@@ -1522,6 +1530,306 @@ func (t *Tests) JpegAndTiffFollowTheSameContract(ctx context.Context) error {
 	wantW, wantH := pixelsAt(defaultDpi)
 	if cfg.Width != wantW || cfg.Height != wantH {
 		return fmt.Errorf("expected %dx%d, got %dx%d", wantW, wantH, cfg.Width, cfg.Height)
+	}
+	return nil
+}
+
+// SplitWritesOnePdfPerPage asserts Split turns a twelve-page document into
+// twelve one-page PDFs named to the same contract every render family member
+// honours.
+//
+// The names alone would pass against a splitter that wrote twelve copies of page
+// one, so each file is opened and read: one page in it, and that page's own
+// marker in the text. ledgerPdf's markers are what make that check possible —
+// twelve pages of identical text would extract the same however they were
+// shuffled.
+//
+// pdfseparate numbers with the width the caller's pattern asks for rather than
+// with the document's page count, so the four-digit contract here is this
+// module's and not a coincidence of the fixture's length.
+func (t *Tests) SplitWritesOnePdfPerPage(ctx context.Context) error {
+	dir := pdf().Document(fixture(ledgerPdf)).Split()
+
+	entries, err := dir.Entries(ctx)
+	if err != nil {
+		return fmt.Errorf("Split: %w", err)
+	}
+	if err := assertPageNames(entries, pageNames("pdf", 1, ledgerPages)); err != nil {
+		return err
+	}
+
+	for _, page := range []int{1, 7, ledgerPages} {
+		name := fmt.Sprintf("page-%04d.pdf", page)
+		one := pdf().Document(dir.File(name))
+
+		count, err := one.PageCount(ctx)
+		if err != nil {
+			return fmt.Errorf("PageCount of %s: %w", name, err)
+		}
+		if count != 1 {
+			return fmt.Errorf("expected %s to hold exactly one page, got %d", name, count)
+		}
+
+		got, err := one.Convert().Text(ctx)
+		if err != nil {
+			return fmt.Errorf("Text of %s: %w", name, err)
+		}
+		if want := ledgerText(page, page); got != want {
+			return fmt.Errorf("expected %s to carry page %d:\n%q\ngot:\n%q", name, page, want, got)
+		}
+	}
+	return nil
+}
+
+// SplitNarrowsToThePageRange asserts the page bounds reach pdfseparate in all
+// three of the shapes a range comes in, and that a range it cannot honour is
+// refused before it runs.
+//
+// The refusal is the half worth asserting. Left to pdfseparate, a last bound past
+// the end of the document is not caught up front at all: it separates every page
+// it can and *then* fails with `Internal Error: Illegal pageNo: 13(12)`, so the
+// caller gets a message about poppler's internals attached to a directory that
+// was half written. Checking the bounds against the document first is what turns
+// that into a sentence naming the builder and the page count.
+func (t *Tests) SplitNarrowsToThePageRange(ctx context.Context) error {
+	doc := pdf().Document(fixture(ledgerPdf))
+
+	for _, tc := range []struct {
+		name        string
+		first, last int
+		wantFirst   int
+		wantLast    int
+	}{
+		{"a span", 4, 6, 4, 6},
+		// A one-page range is where pdfseparate writes a single-digit number, so
+		// this is also the case the padding contract has to survive.
+		{"one page", 2, 2, 2, 2},
+		{"open ended", 10, 0, 10, ledgerPages},
+	} {
+		got, err := doc.WithPageRange(tc.first, tc.last).Split().Entries(ctx)
+		if err != nil {
+			return fmt.Errorf("%s: Split: %w", tc.name, err)
+		}
+		if err := assertPageNames(got, pageNames("pdf", tc.wantFirst, tc.wantLast)); err != nil {
+			return fmt.Errorf("%s: %s", tc.name, err.Error())
+		}
+	}
+
+	if _, err := doc.WithPageRange(1, ledgerPages+1).Split().Entries(ctx); err == nil {
+		return fmt.Errorf("expected a range past the end of the document to be rejected")
+	} else {
+		for _, want := range []string{"last (13)", "12 pages"} {
+			if !strings.Contains(err.Error(), want) {
+				return fmt.Errorf("expected the rejection to mention %q, got: %v", want, err)
+			}
+		}
+	}
+	return nil
+}
+
+// MergePreservesTheOrderOfItsSources asserts the merged document's pages come
+// out in the order the slice named them, which is the whole reason Merge takes
+// an ordered slice rather than a directory.
+//
+// The sources are deliberately handed over out of page order — 3, 1, 2 — because
+// any order-preserving implementation and any order-losing one agree on a slice
+// that was already sorted. Reading the text back is what says the pages landed
+// where they were put: the page count alone would pass on a merge that shuffled
+// them.
+func (t *Tests) MergePreservesTheOrderOfItsSources(ctx context.Context) error {
+	pages := pdf().Document(fixture(ledgerPdf)).WithPageRange(1, 3).Split()
+
+	order := []int{3, 1, 2}
+	sources := make([]*dagger.File, 0, len(order))
+	var want strings.Builder
+	for _, page := range order {
+		sources = append(sources, pages.File(fmt.Sprintf("page-%04d.pdf", page)))
+		want.WriteString(ledgerText(page, page))
+	}
+
+	merged := pdf().Document(pdf().Merge(sources))
+	count, err := merged.PageCount(ctx)
+	if err != nil {
+		return fmt.Errorf("PageCount of the merged document: %w", err)
+	}
+	if count != len(order) {
+		return fmt.Errorf("expected %d pages, got %d", len(order), count)
+	}
+	got, err := merged.Convert().Text(ctx)
+	if err != nil {
+		return fmt.Errorf("Text of the merged document: %w", err)
+	}
+	if got != want.String() {
+		return fmt.Errorf("expected the pages in the order given:\n%q\ngot:\n%q", want.String(), got)
+	}
+
+	// One source is a legal merge and produces that source's document, so a
+	// caller merging a computed list does not have to special-case its length.
+	one := pdf().Document(pdf().Merge([]*dagger.File{pages.File("page-0002.pdf")}))
+	got, err = one.Convert().Text(ctx)
+	if err != nil {
+		return fmt.Errorf("Text of a one-source merge: %w", err)
+	}
+	if want := ledgerText(2, 2); got != want {
+		return fmt.Errorf("expected a one-source merge to carry page 2:\n%q\ngot:\n%q", want, got)
+	}
+	return nil
+}
+
+// MergeRejectsWhatItCannotMerge asserts the two ways a merge goes wrong are
+// reported by naming the argument that was wrong.
+//
+// The empty slice is a caller error with no useful answer — there is no document
+// to return and no empty PDF worth inventing — and pdfunite's own answer to it is
+// its usage text, which describes a command line the caller never wrote. The
+// module refuses it before the container starts, for that reason.
+//
+// The unreadable source is the case the mount legend exists for. pdfunite names
+// the file it could not read, and the name it uses is this module's mount path,
+// so without the legend the one piece of information identifying which argument
+// was at fault is a path the caller has never seen.
+func (t *Tests) MergeRejectsWhatItCannotMerge(ctx context.Context) error {
+	_, err := pdf().Merge(nil).Contents(ctx)
+	if err == nil {
+		return fmt.Errorf("expected a merge of no sources to be rejected")
+	}
+	for _, want := range []string{"Merge", "at least one PDF", "order"} {
+		if !strings.Contains(err.Error(), want) {
+			return fmt.Errorf("expected the rejection to mention %q, got: %v", want, err)
+		}
+	}
+	// pdfunite answers an empty command line with its usage text, which is a
+	// description of a command line the caller did not write.
+	if strings.Contains(err.Error(), "Usage: pdfunite") {
+		return fmt.Errorf("expected the module's own rejection rather than poppler's usage text, got: %v", err)
+	}
+
+	notPdf := dag.Directory().WithNewFile("notes.txt", "this is not a PDF").File("notes.txt")
+	page := pdf().Document(fixture(ledgerPdf)).WithPageRange(1, 1).Split().File("page-0001.pdf")
+
+	_, err = pdf().Merge([]*dagger.File{page, notPdf}).Contents(ctx)
+	if err == nil {
+		return fmt.Errorf("expected a merge of an unreadable source to be rejected")
+	}
+	for _, want := range []string{"Merge", "source-0002", "numbered from 1"} {
+		if !strings.Contains(err.Error(), want) {
+			return fmt.Errorf("expected the failure to mention %q, got: %v", want, err)
+		}
+	}
+	return nil
+}
+
+// SplitThenMergeRoundTripsTheDocument asserts the two halves of this pair
+// compose back into the document they started from.
+//
+// It is the assertion that says these are structural operations rather than
+// conversions. Each one alone could pass its own tests while quietly dropping
+// what it does not understand — a page's annotations, its size, the text layer
+// under it — and the round trip is where that shows up: twelve separated pages
+// put back together have to extract to the same text, in the same order, on
+// pages of the same size.
+//
+// The names the split wrote are what the merge is driven by, in page order, which
+// is also the practical shape of the pair: split, do something to the pages,
+// merge the ones that survived.
+func (t *Tests) SplitThenMergeRoundTripsTheDocument(ctx context.Context) error {
+	original := pdf().Document(fixture(ledgerPdf))
+	pages := original.Split()
+
+	sources := make([]*dagger.File, 0, ledgerPages)
+	for page := 1; page <= ledgerPages; page++ {
+		sources = append(sources, pages.File(fmt.Sprintf("page-%04d.pdf", page)))
+	}
+	rebuilt := pdf().Document(pdf().Merge(sources))
+
+	count, err := rebuilt.PageCount(ctx)
+	if err != nil {
+		return fmt.Errorf("PageCount of the rebuilt document: %w", err)
+	}
+	if count != ledgerPages {
+		return fmt.Errorf("expected %d pages after the round trip, got %d", ledgerPages, count)
+	}
+
+	got, err := rebuilt.Convert().Text(ctx)
+	if err != nil {
+		return fmt.Errorf("Text of the rebuilt document: %w", err)
+	}
+	want, err := original.Convert().Text(ctx)
+	if err != nil {
+		return fmt.Errorf("Text of the original: %w", err)
+	}
+	if got != want {
+		return fmt.Errorf("expected the round trip to preserve the text:\n%q\ngot:\n%q", want, got)
+	}
+
+	// The pages keep their geometry, which is the property a re-render would lose
+	// while still extracting to the same text.
+	info, err := rebuilt.Info(ctx)
+	if err != nil {
+		return fmt.Errorf("Info of the rebuilt document: %w", err)
+	}
+	if wantSize := fmt.Sprintf("%d x %d pts", ledgerPageWidth, ledgerPageHeight); !strings.Contains(info, wantSize) {
+		return fmt.Errorf("expected the pages to keep their size %q, got:\n%s", wantSize, info)
+	}
+	return nil
+}
+
+// SplitAndMergeCannotOpenAnEncryptedDocument asserts the limitation these two
+// carry that nothing else in the module does, and asserts it is reported as that
+// rather than as a wrong password.
+//
+// pdfseparate and pdfunite take no `-upw` and no `-opw` — passing one is a usage
+// error, not a wrong password — so an encrypted document is one they cannot be
+// made to open. What poppler says about it is `Incorrect password`, the same
+// sentence every other tool in the suite produces for a password that did not
+// work, and the module's usual reading of that line names WithUserPassword. Here
+// that would send a caller to a builder that changes nothing, which is why the
+// password case is asserted alongside the passwordless one: both have to arrive
+// at the same message.
+func (t *Tests) SplitAndMergeCannotOpenAnEncryptedDocument(ctx context.Context) error {
+	userPw, err := generatedPassword(ctx)
+	if err != nil {
+		return fmt.Errorf("generating the user password: %w", err)
+	}
+	ownerPw, err := generatedPassword(ctx)
+	if err != nil {
+		return fmt.Errorf("generating the owner password: %w", err)
+	}
+	user := dag.SetSecret("pdf-tests-pages-user-password", userPw)
+	owner := dag.SetSecret("pdf-tests-pages-owner-password", ownerPw)
+	encrypted := encryptedLedger(user, owner)
+
+	for _, tc := range []struct {
+		name string
+		doc  *dagger.PdfDocument
+	}{
+		{"without a password", pdf().Document(encrypted)},
+		{"with the password", pdf().Document(encrypted).WithUserPassword(user)},
+	} {
+		_, err := tc.doc.Split().Entries(ctx)
+		if err == nil {
+			return fmt.Errorf("%s: expected Split of an encrypted document to be refused", tc.name)
+		}
+		for _, want := range []string{
+			"Split", "encrypted", "pdfseparate has no password option", "qpdf --decrypt",
+		} {
+			if !strings.Contains(err.Error(), want) {
+				return fmt.Errorf("%s: expected the refusal to mention %q, got: %v", tc.name, want, err)
+			}
+		}
+	}
+
+	page := pdf().Document(fixture(ledgerPdf)).WithPageRange(1, 1).Split().File("page-0001.pdf")
+	_, err = pdf().Merge([]*dagger.File{page, encrypted}).Contents(ctx)
+	if err == nil {
+		return fmt.Errorf("expected a merge with an encrypted source to be refused")
+	}
+	for _, want := range []string{
+		"Merge", "encrypted", "pdfunite has no password option", "source-0002",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			return fmt.Errorf("expected the refusal to mention %q, got: %v", want, err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #270.

`Document.Split` is `pdfseparate` and `Pdf.Merge` is `pdfunite` — page-level
structural surgery, the other half of "working with PDFs", which needs no
rendering at all and is lossless where every conversion is not: a split page
carries the original page's own objects across, so it is still a searchable PDF.

```go
Document.Split(ctx) (*dagger.Directory, error)
Pdf.Merge(ctx, sources []*dagger.File) (*dagger.File, error)
```

### Naming

`Split` writes `page-0001.pdf` onwards under the same uniform-padding contract
the render family uses, through the same rename pass. `pdfseparate` would
zero-pad a `%04d` destination pattern itself, but a fixed width is a width and
not a *floor* — a document past 9999 pages would come out numbered to two of
them, which is the exact ambiguity the contract exists to remove.

### Why `Merge` hangs off the root and takes a slice

No one of its sources is "the" document — a bound `Document` carries passwords
and a page range, and neither means anything for a merge. It takes an ordered
`[]*dagger.File` rather than a directory and a glob because merge order is
meaning: a directory has no order of its own, so a caller would be relying on
whatever file names it happens to carry.

One source is legal and produces that source's document, so a caller merging a
computed list does not have to special-case its length. An empty slice is
refused before the container starts — `pdfunite`'s own answer to it is its usage
text, describing a command line the caller never wrote. Sources are mounted at
`/in/source-NNNN.pdf` in slice order and a failure carries a legend saying so,
because that path is the only thing tying poppler's complaint back to an
argument.

### Neither tool takes a password

There is no `-upw` on `pdfseparate` or `pdfunite` — passing one is a *usage*
error, not a wrong password — so an encrypted document is one these two cannot
be made to open. poppler says `Incorrect password` about it, the same sentence a
genuinely wrong password produces everywhere else in this module, and the
module's usual reading of that line names `WithUserPassword`. Here that would
send a caller to a builder that changes nothing, so both report the limitation
and point at decrypting first (`qpdf --decrypt`; wrapping qpdf is #274). This is
the one place a password reaches some of the module's functions and not others.

### Tests

Six new tests, all wired into `All`, which is green:

- `SplitWritesOnePdfPerPage` — the twelve names, and each file opened to confirm
  it holds one page carrying its own marker.
- `SplitNarrowsToThePageRange` — a span, one page, open-ended, plus the
  rejection: left to `pdfseparate`, a last bound past the end separates every
  page it can and *then* fails with `Internal Error: Illegal pageNo: 13(12)`.
- `MergePreservesTheOrderOfItsSources` — sources handed over as 3, 1, 2, read
  back as text; plus the one-source case.
- `MergeRejectsWhatItCannotMerge` — the empty slice, and an unreadable source
  identified by its mount legend.
- `SplitThenMergeRoundTripsTheDocument` — page count, text and page size.
- `SplitAndMergeCannotOpenAnEncryptedDocument` — with and without the password,
  since both have to arrive at the same message.

No `+cache=` directive was added; every function here is a pure transform of its
inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)