### PR TITLE
story(issue-248): redact headers and bodies from run reports

### DIFF
--- a/ci/internal/dagger/bruno-tests.gen.go
+++ b/ci/internal/dagger/bruno-tests.gen.go
@@ -28,6 +28,7 @@ type BrunoTests struct { // bruno-tests (../../../daggerverse/bruno/tests/main.g
 	ciCheckGatesOnFailingAssertion            *Void
 	ciLintFailsBeforeAnyRequest               *Void
 	ciReachesMtlsServiceBehindPrivateCa       *Void
+	ciRedactsSecretVarFromItsReports          *Void
 	ciRejectsUnknownReportFormat              *Void
 	ciRunProducesEveryRequestedReport         *Void
 	ciRunStillReportsWhenTheCollectionFails   *Void
@@ -54,14 +55,19 @@ type BrunoTests struct { // bruno-tests (../../../daggerverse/bruno/tests/main.g
 	reportEmitsJunitForFailingRun             *Void
 	reportRejectsUnknownFormat                *Void
 	reportShouldNotBeCached                   *Void
+	reportWithoutAllHeadersOmitsEveryHeader   *Void
+	reportWithoutBodiesOmitsBothBodies        *Void
+	reportWithoutNamedHeaderKeepsTheOthers    *Void
 	runFailsOnAssertionFailure                *Void
 	runPassesAgainstBoundService              *Void
 	runShouldNotBeCached                      *Void
 	secretVarIsNotOnArgv                      *Void
+	secretVarIsRedactedFromReportsByDefault   *Void
 	tlsControlsAreValidated                   *Void
 	unknownEnvironmentIsRejected              *Void
 	versionReportsPinnedRelease               *Void
 	withVarOverridesEnvironmentValue          *Void
+	withoutHeadersRejectsBlankName            *Void
 }
 
 func (r *BrunoTests) WithGraphQLQuery(q *querybuilder.Selection) *BrunoTests {
@@ -104,7 +110,7 @@ func (r *BrunoTests) All(ctx context.Context, opts ...BrunoTestsAllOpts) error {
 // alone. It has to still pass: the flag is a no-op that is easy to render into a
 // run that was going to pass anyway, and easy to get wrong in a way that severs
 // the connection.
-func (r *BrunoTests) CaCertReachesPrivateCaService(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1339:1)
+func (r *BrunoTests) CaCertReachesPrivateCaService(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1631:1)
 	if r.caCertReachesPrivateCaService != nil {
 		return nil
 	}
@@ -120,7 +126,7 @@ func (r *BrunoTests) CaCertReachesPrivateCaService(ctx context.Context) error { 
 // The failure has to name the missing request rather than only report that
 // something differs — an endpoint nobody noticed is not made findable by being
 // told a count changed.
-func (r *BrunoTests) CheckDriftFailsOnAnEndpointAddedToTheSpec(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:710:1)
+func (r *BrunoTests) CheckDriftFailsOnAnEndpointAddedToTheSpec(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:940:1)
 	if r.checkDriftFailsOnAnEndpointAddedToTheSpec != nil {
 		return nil
 	}
@@ -137,7 +143,7 @@ func (r *BrunoTests) CheckDriftFailsOnAnEndpointAddedToTheSpec(ctx context.Conte
 // opposite problem — an endpoint that was renamed or retired upstream, still
 // being exercised — and it has to read as its own thing rather than as the same
 // finding, because the fix is the opposite one.
-func (r *BrunoTests) CheckDriftFailsOnBothSidesOfTheRequestSet(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:754:1)
+func (r *BrunoTests) CheckDriftFailsOnBothSidesOfTheRequestSet(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:984:1)
 	if r.checkDriftFailsOnBothSidesOfTheRequestSet != nil {
 		return nil
 	}
@@ -152,7 +158,7 @@ func (r *BrunoTests) CheckDriftFailsOnBothSidesOfTheRequestSet(ctx context.Conte
 //
 // The lint stage is enabled deliberately, so the failure has to be the
 // assertion and not the linter having an opinion about the fixture.
-func (r *BrunoTests) CiCheckGatesOnFailingAssertion(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1041:1)
+func (r *BrunoTests) CiCheckGatesOnFailingAssertion(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1271:1)
 	if r.ciCheckGatesOnFailingAssertion != nil {
 		return nil
 	}
@@ -171,7 +177,7 @@ func (r *BrunoTests) CiCheckGatesOnFailingAssertion(ctx context.Context) error {
 // is checked afterwards and passes, so a request count of zero on the first
 // pass is the lint stage short-circuiting rather than the collection being
 // unrunnable.
-func (r *BrunoTests) CiLintFailsBeforeAnyRequest(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:991:1)
+func (r *BrunoTests) CiLintFailsBeforeAnyRequest(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1221:1)
 	if r.ciLintFailsBeforeAnyRequest != nil {
 		return nil
 	}
@@ -194,11 +200,30 @@ func (r *BrunoTests) CiLintFailsBeforeAnyRequest(ctx context.Context) error { //
 // Both terminals are exercised, since a report of a run that never connected is
 // the failure this would otherwise hide, and the lint stage is enabled so the
 // TLS material has to survive being validated ahead of the run.
-func (r *BrunoTests) CiReachesMtlsServiceBehindPrivateCa(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1645:1)
+func (r *BrunoTests) CiReachesMtlsServiceBehindPrivateCa(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1937:1)
 	if r.ciReachesMtlsServiceBehindPrivateCa != nil {
 		return nil
 	}
 	q := r.query.Select("ciReachesMtlsServiceBehindPrivateCa")
+
+	return q.Execute(ctx)
+}
+
+// CiRedactsSecretVarFromItsReports checks the redaction where it matters most.
+// Run is the terminal that writes the file a CI system archives, and an
+// archived report outlives the run that produced it.
+//
+// Both directions are exercised, because a builder that dropped the delegation
+// entirely would look identical to one that redacts: a report with no headers
+// is what the default produces and also what a pipeline that never passed the
+// controls along would produce if the collection redacted on its own account.
+// The unredacted pass is what tells the two apart — the secret has to come back
+// when the pipeline asks for it.
+func (r *BrunoTests) CiRedactsSecretVarFromItsReports(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1520:1)
+	if r.ciRedactsSecretVarFromItsReports != nil {
+		return nil
+	}
+	q := r.query.Select("ciRedactsSecretVarFromItsReports")
 
 	return q.Execute(ctx)
 }
@@ -208,7 +233,7 @@ func (r *BrunoTests) CiReachesMtlsServiceBehindPrivateCa(ctx context.Context) er
 // the finding belongs to the terminal — and it belongs to Check as much as to
 // Run, because a pipeline whose declared artifact cannot be produced is broken
 // whichever terminal is invoked first.
-func (r *BrunoTests) CiRejectsUnknownReportFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:951:1)
+func (r *BrunoTests) CiRejectsUnknownReportFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1181:1)
 	if r.ciRejectsUnknownReportFormat != nil {
 		return nil
 	}
@@ -225,7 +250,7 @@ func (r *BrunoTests) CiRejectsUnknownReportFormat(ctx context.Context) error { /
 // two-format Run is a pipeline that ran the collection once — and therefore two
 // reports describing the same set of responses, rather than two runs of the same
 // collection reporting on different ones.
-func (r *BrunoTests) CiRunProducesEveryRequestedReport(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1080:1)
+func (r *BrunoTests) CiRunProducesEveryRequestedReport(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1310:1)
 	if r.ciRunProducesEveryRequestedReport != nil {
 		return nil
 	}
@@ -243,7 +268,7 @@ func (r *BrunoTests) CiRunProducesEveryRequestedReport(ctx context.Context) erro
 // on exactly the runs whose report a pipeline needs — the JUnit file a CI system
 // turns into a test report names which assertion failed, and it is worthless if
 // it only arrives when nothing did.
-func (r *BrunoTests) CiRunStillReportsWhenTheCollectionFails(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1150:1)
+func (r *BrunoTests) CiRunStillReportsWhenTheCollectionFails(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1380:1)
 	if r.ciRunStillReportsWhenTheCollectionFails != nil {
 		return nil
 	}
@@ -266,7 +291,7 @@ func (r *BrunoTests) CiRunStillReportsWhenTheCollectionFails(ctx context.Context
 // and reading process.argv needs the developer sandbox. The pipeline builder
 // wraps no sandbox switch — a collection needing one is assembled through
 // Collection — so it gets the same request without the script.
-func (r *BrunoTests) CiSecretVarReachesTheCollection(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1247:1)
+func (r *BrunoTests) CiSecretVarReachesTheCollection(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1477:1)
 	if r.ciSecretVarReachesTheCollection != nil {
 		return nil
 	}
@@ -282,7 +307,7 @@ func (r *BrunoTests) CiSecretVarReachesTheCollection(ctx context.Context) error 
 //
 // Counted at the service rather than read out of bru's summary: a replayed run
 // prints a perfectly convincing "1 request, 1 passed".
-func (r *BrunoTests) CiShouldNotBeCached(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1191:1)
+func (r *BrunoTests) CiShouldNotBeCached(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1421:1)
 	if r.ciShouldNotBeCached != nil {
 		return nil
 	}
@@ -303,7 +328,7 @@ func (r *BrunoTests) CiShouldNotBeCached(ctx context.Context) error { // bruno-t
 // The first pass is the control: the same collection, verifying the same server,
 // with no client certificate configured. It has to fail, or the second pass says
 // nothing about the certificate having been needed.
-func (r *BrunoTests) ClientCertAuthenticatesToMtlsService(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1408:1)
+func (r *BrunoTests) ClientCertAuthenticatesToMtlsService(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1700:1)
 	if r.clientCertAuthenticatesToMtlsService != nil {
 		return nil
 	}
@@ -326,7 +351,7 @@ func (r *BrunoTests) ClientCertAuthenticatesToMtlsService(ctx context.Context) e
 // The responder demands the certificate, so this is not a run that skipped the
 // key: it reports the peer's Common Name back, and the key was necessary to
 // produce it.
-func (r *BrunoTests) ClientCertMaterialStaysOutOfTheCollection(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1494:1)
+func (r *BrunoTests) ClientCertMaterialStaysOutOfTheCollection(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1786:1)
 	if r.clientCertMaterialStaysOutOfTheCollection != nil {
 		return nil
 	}
@@ -346,7 +371,7 @@ func (r *BrunoTests) ClientCertMaterialStaysOutOfTheCollection(ctx context.Conte
 // So the same encrypted key is run twice. Without the passphrase the key cannot
 // be loaded and the run fails; with it, the run authenticates to the mTLS
 // endpoint and the responder reports the certificate back.
-func (r *BrunoTests) ClientCertPassphraseUnlocksTheKey(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1571:1)
+func (r *BrunoTests) ClientCertPassphraseUnlocksTheKey(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1863:1)
 	if r.clientCertPassphraseUnlocksTheKey != nil {
 		return nil
 	}
@@ -363,7 +388,7 @@ func (r *BrunoTests) ClientCertPassphraseUnlocksTheKey(ctx context.Context) erro
 // generated request is where anyone would put the assertions that make the
 // collection worth running, and a check that called that drift would be a check
 // nobody could leave switched on.
-func (r *BrunoTests) DriftIgnoresHandWrittenTests(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:652:1)
+func (r *BrunoTests) DriftIgnoresHandWrittenTests(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:882:1)
 	if r.driftIgnoresHandWrittenTests != nil {
 		return nil
 	}
@@ -379,7 +404,7 @@ func (r *BrunoTests) DriftIgnoresHandWrittenTests(ctx context.Context) error { /
 // It also pins the reason the default diverges from upstream's. The
 // opencollection shape carries no bruno.json, so it is not something Collection
 // could run — which is why this module defaults to the other one.
-func (r *BrunoTests) GenerateHonoursOpenCollectionFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:606:1)
+func (r *BrunoTests) GenerateHonoursOpenCollectionFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:836:1)
 	if r.generateHonoursOpenCollectionFormat != nil {
 		return nil
 	}
@@ -401,7 +426,7 @@ func (r *BrunoTests) GenerateHonoursOpenCollectionFormat(ctx context.Context) er
 // The environment's name is read off the generated tree rather than hardcoded:
 // bru derives it from the server's description, which is the spec's business
 // and not this module's.
-func (r *BrunoTests) GenerateProducesRunnableCollection(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:528:1)
+func (r *BrunoTests) GenerateProducesRunnableCollection(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:758:1)
 	if r.generateProducesRunnableCollection != nil {
 		return nil
 	}
@@ -414,7 +439,7 @@ func (r *BrunoTests) GenerateProducesRunnableCollection(ctx context.Context) err
 // is refused by name. bru refuses one too, but by printing its whole help text
 // with the actual complaint on the last line — and only after a container has
 // been started to find out.
-func (r *BrunoTests) GenerateRejectsUnknownFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:626:1)
+func (r *BrunoTests) GenerateRejectsUnknownFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:856:1)
 	if r.generateRejectsUnknownFormat != nil {
 		return nil
 	}
@@ -477,7 +502,7 @@ func (r *BrunoTests) UnmarshalJSON(bs []byte) error {
 // that extension and not from the contents, so a JSON environment staged as
 // .bru dies inside the Bruno grammar — with a Node stack trace, several layers
 // away from anything the caller did.
-func (r *BrunoTests) JSONEnvFileKeepsItsExtension(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:490:1)
+func (r *BrunoTests) JSONEnvFileKeepsItsExtension(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:720:1)
 	if r.jsonEnvFileKeepsItsExtension != nil {
 		return nil
 	}
@@ -493,7 +518,7 @@ func (r *BrunoTests) JSONEnvFileKeepsItsExtension(ctx context.Context) error { /
 //
 // It is checked under failOnWarnings=true as well, so the fixture has to be
 // free of warnings and not merely free of errors.
-func (r *BrunoTests) LintAcceptsValidCollection(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:800:1)
+func (r *BrunoTests) LintAcceptsValidCollection(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1030:1)
 	if r.lintAcceptsValidCollection != nil {
 		return nil
 	}
@@ -505,7 +530,7 @@ func (r *BrunoTests) LintAcceptsValidCollection(ctx context.Context) error { // 
 // LintRejectsDuplicateSequence checks that two requests claiming the same seq
 // in one folder is a finding, and that the same seq in a different folder is
 // not — seq orders a folder's requests, so it is only ambiguous within one.
-func (r *BrunoTests) LintRejectsDuplicateSequence(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:907:1)
+func (r *BrunoTests) LintRejectsDuplicateSequence(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1137:1)
 	if r.lintRejectsDuplicateSequence != nil {
 		return nil
 	}
@@ -517,7 +542,7 @@ func (r *BrunoTests) LintRejectsDuplicateSequence(ctx context.Context) error { /
 // LintRejectsMissingBrunoJson checks the finding that stands in for bru's exit
 // 4. bru reports that one as "not a collection root", from inside a container,
 // without naming the file it wanted.
-func (r *BrunoTests) LintRejectsMissingBrunoJSON(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:819:1)
+func (r *BrunoTests) LintRejectsMissingBrunoJSON(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1049:1)
 	if r.lintRejectsMissingBrunoJson != nil {
 		return nil
 	}
@@ -533,7 +558,7 @@ func (r *BrunoTests) LintRejectsMissingBrunoJSON(ctx context.Context) error { //
 // The fixture holds two controls beside the violation — a token whose value is
 // a {{process.env.*}} interpolation, and a name declared in a vars:secret
 // block — so this also pins that the rule accepts the shape it is asking for.
-func (r *BrunoTests) LintRejectsPlaintextSecret(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:883:1)
+func (r *BrunoTests) LintRejectsPlaintextSecret(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1113:1)
 	if r.lintRejectsPlaintextSecret != nil {
 		return nil
 	}
@@ -545,7 +570,7 @@ func (r *BrunoTests) LintRejectsPlaintextSecret(ctx context.Context) error { // 
 // LintRejectsUnknownEnvironment checks that a mistyped --env name is caught
 // here rather than as bru's exit 6, and that the finding lists the names the
 // collection does ship.
-func (r *BrunoTests) LintRejectsUnknownEnvironment(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:835:1)
+func (r *BrunoTests) LintRejectsUnknownEnvironment(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1065:1)
 	if r.lintRejectsUnknownEnvironment != nil {
 		return nil
 	}
@@ -561,7 +586,7 @@ func (r *BrunoTests) LintRejectsUnknownEnvironment(ctx context.Context) error { 
 // The fixture also references two undeclared variables from its docs block,
 // which bru never interpolates — so this pins that prose is not linted as
 // though it were a request.
-func (r *BrunoTests) LintRejectsUnresolvedVariable(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:855:1)
+func (r *BrunoTests) LintRejectsUnresolvedVariable(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1085:1)
 	if r.lintRejectsUnresolvedVariable != nil {
 		return nil
 	}
@@ -576,7 +601,7 @@ func (r *BrunoTests) LintRejectsUnresolvedVariable(ctx context.Context) error { 
 //
 // The fixture's only assertion is disabled, which is the same as not having
 // written it — so this also pins that a commented-out assert does not count.
-func (r *BrunoTests) LintWarnsOnRequestWithoutTests(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:929:1)
+func (r *BrunoTests) LintWarnsOnRequestWithoutTests(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1159:1)
 	if r.lintWarnsOnRequestWithoutTests != nil {
 		return nil
 	}
@@ -594,7 +619,7 @@ func (r *BrunoTests) LintWarnsOnRequestWithoutTests(ctx context.Context) error {
 // The api fixture tags its root request and leaves the nested one untagged, so
 // the tag filters also have to have selected the right request rather than
 // merely been tolerated.
-func (r *BrunoTests) PassThroughFlagsAreAccepted(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:451:1)
+func (r *BrunoTests) PassThroughFlagsAreAccepted(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:681:1)
 	if r.passThroughFlagsAreAccepted != nil {
 		return nil
 	}
@@ -612,7 +637,7 @@ func (r *BrunoTests) PassThroughFlagsAreAccepted(ctx context.Context) error { //
 // and the default wins — so `Recursive: false` would silently assert the
 // default all over again. It is reachable from the CLI as
 // `run --recursive=false`.
-func (r *BrunoTests) RecursiveDefaultReachesSubfolders(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:238:1)
+func (r *BrunoTests) RecursiveDefaultReachesSubfolders(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:244:1)
 	if r.recursiveDefaultReachesSubfolders != nil {
 		return nil
 	}
@@ -626,7 +651,7 @@ func (r *BrunoTests) RecursiveDefaultReachesSubfolders(ctx context.Context) erro
 // artifact, and the artifact says what failed. Run would have raised an error
 // here, and an error forfeits the value — which is why the two are separate
 // functions rather than one.
-func (r *BrunoTests) ReportEmitsJunitForFailingRun(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:271:1)
+func (r *BrunoTests) ReportEmitsJunitForFailingRun(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:277:1)
 	if r.reportEmitsJunitForFailingRun != nil {
 		return nil
 	}
@@ -638,7 +663,7 @@ func (r *BrunoTests) ReportEmitsJunitForFailingRun(ctx context.Context) error { 
 // ReportRejectsUnknownFormat checks that a format bru does not write is
 // refused by name, before a live collection has been run against a live
 // service to find out.
-func (r *BrunoTests) ReportRejectsUnknownFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:298:1)
+func (r *BrunoTests) ReportRejectsUnknownFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:304:1)
 	if r.reportRejectsUnknownFormat != nil {
 		return nil
 	}
@@ -650,7 +675,7 @@ func (r *BrunoTests) ReportRejectsUnknownFormat(ctx context.Context) error { // 
 // ReportShouldNotBeCached checks that two identical Reports each reach the
 // service. A report of a run that never happened describes an API nobody
 // asked about.
-func (r *BrunoTests) ReportShouldNotBeCached(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:320:1)
+func (r *BrunoTests) ReportShouldNotBeCached(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:326:1)
 	if r.reportShouldNotBeCached != nil {
 		return nil
 	}
@@ -659,10 +684,56 @@ func (r *BrunoTests) ReportShouldNotBeCached(ctx context.Context) error { // bru
 	return q.Execute(ctx)
 }
 
+// ReportWithoutAllHeadersOmitsEveryHeader checks the blunt control: nothing
+// that was sent or came back as a header survives into the report, on either
+// side of the exchange.
+//
+// Every redaction test here sets WithUnredactedReport first. The collection
+// carries a secret — that is what makes it worth redacting — and a secret is
+// enough to redact the report on its own, so without the opt-out these tests
+// would pass whether or not the flag under test was rendered at all.
+func (r *BrunoTests) ReportWithoutAllHeadersOmitsEveryHeader(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:465:1)
+	if r.reportWithoutAllHeadersOmitsEveryHeader != nil {
+		return nil
+	}
+	q := r.query.Select("reportWithoutAllHeadersOmitsEveryHeader")
+
+	return q.Execute(ctx)
+}
+
+// ReportWithoutBodiesOmitsBothBodies checks the three body controls together,
+// because what each one has to establish is which bodies it left alone.
+//
+// A flag that dropped both would satisfy the request-only case on its own, so
+// the assertion in every pass is the pair: what went, and what stayed.
+func (r *BrunoTests) ReportWithoutBodiesOmitsBothBodies(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:519:1)
+	if r.reportWithoutBodiesOmitsBothBodies != nil {
+		return nil
+	}
+	q := r.query.Select("reportWithoutBodiesOmitsBothBodies")
+
+	return q.Execute(ctx)
+}
+
+// ReportWithoutNamedHeaderKeepsTheOthers checks the narrow control, which is
+// the one worth having: the credential goes and the report is still a report.
+//
+// The name is given in lower case against a header the collection spells
+// Authorization, because bru matches case-insensitively and a caller should not
+// have to know how the collection capitalised it.
+func (r *BrunoTests) ReportWithoutNamedHeaderKeepsTheOthers(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:493:1)
+	if r.reportWithoutNamedHeaderKeepsTheOthers != nil {
+		return nil
+	}
+	q := r.query.Select("reportWithoutNamedHeaderKeepsTheOthers")
+
+	return q.Execute(ctx)
+}
+
 // RunFailsOnAssertionFailure checks that exit 1 — a failing request, test or
 // assertion — is an error, and that the error carries bru's own account of
 // what failed rather than just the exit code.
-func (r *BrunoTests) RunFailsOnAssertionFailure(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:145:1)
+func (r *BrunoTests) RunFailsOnAssertionFailure(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:151:1)
 	if r.runFailsOnAssertionFailure != nil {
 		return nil
 	}
@@ -673,7 +744,7 @@ func (r *BrunoTests) RunFailsOnAssertionFailure(ctx context.Context) error { // 
 
 // RunPassesAgainstBoundService checks the whole point of the module: a
 // collection whose environment names a bound service reaches it and passes.
-func (r *BrunoTests) RunPassesAgainstBoundService(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:113:1)
+func (r *BrunoTests) RunPassesAgainstBoundService(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:119:1)
 	if r.runPassesAgainstBoundService != nil {
 		return nil
 	}
@@ -685,7 +756,7 @@ func (r *BrunoTests) RunPassesAgainstBoundService(ctx context.Context) error { /
 // RunShouldNotBeCached checks that two identical Runs each reach the service.
 // A collection run hits a live API, so a cached pass would report a
 // now-broken API as green.
-func (r *BrunoTests) RunShouldNotBeCached(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:201:1)
+func (r *BrunoTests) RunShouldNotBeCached(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:207:1)
 	if r.runShouldNotBeCached != nil {
 		return nil
 	}
@@ -707,11 +778,36 @@ func (r *BrunoTests) RunShouldNotBeCached(ctx context.Context) error { // bruno-
 // command line" can actually be checked. That script needs the developer
 // sandbox — the safe one has no process — which is what makes WithSandbox
 // part of this test.
-func (r *BrunoTests) SecretVarIsNotOnArgv(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:397:1)
+func (r *BrunoTests) SecretVarIsNotOnArgv(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:627:1)
 	if r.secretVarIsNotOnArgv != nil {
 		return nil
 	}
 	q := r.query.Select("secretVarIsNotOnArgv")
+
+	return q.Execute(ctx)
+}
+
+// SecretVarIsRedactedFromReportsByDefault checks the module's answer to the
+// question the redaction story poses: what a report contains when the caller
+// has said nothing about redaction and the collection was handed a secret.
+//
+// The first pass is the control, and it is what makes the second one mean
+// something. bru masks header values by name — Authorization comes back as
+// "Bearer ********" without anyone having asked — so a default asserted on its
+// own could be passing on the strength of upstream's list rather than on
+// anything this module did. The control pins how far that list reaches: the
+// same secret in a header the list has never heard of, in the request body, and
+// echoed back in the response body is written out verbatim.
+//
+// That is why the default is all headers and both bodies rather than something
+// narrower. The module knows the value is sensitive; it does not know where the
+// collection interpolated it, and a partial redaction would be a promise it
+// cannot keep.
+func (r *BrunoTests) SecretVarIsRedactedFromReportsByDefault(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:375:1)
+	if r.secretVarIsRedactedFromReportsByDefault != nil {
+		return nil
+	}
+	q := r.query.Select("secretVarIsRedactedFromReportsByDefault")
 
 	return q.Execute(ctx)
 }
@@ -724,7 +820,7 @@ func (r *BrunoTests) SecretVarIsNotOnArgv(ctx context.Context) error { // bruno-
 // against a named CA. `--ignore-truststore` is evaluated in combination with
 // `--cacert` only, so on its own it is a flag that does nothing. Neither is a
 // non-zero exit, which is why they are the module's to catch.
-func (r *BrunoTests) TLSControlsAreValidated(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1288:1)
+func (r *BrunoTests) TLSControlsAreValidated(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1580:1)
 	if r.tlsControlsAreValidated != nil {
 		return nil
 	}
@@ -737,7 +833,7 @@ func (r *BrunoTests) TLSControlsAreValidated(ctx context.Context) error { // bru
 // bru exits 6 when the named environment does not exist; conflating that with
 // exit 1 would make "you typo'd the environment name" read as "your API is
 // broken".
-func (r *BrunoTests) UnknownEnvironmentIsRejected(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:175:1)
+func (r *BrunoTests) UnknownEnvironmentIsRejected(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:181:1)
 	if r.unknownEnvironmentIsRejected != nil {
 		return nil
 	}
@@ -750,7 +846,7 @@ func (r *BrunoTests) UnknownEnvironmentIsRejected(ctx context.Context) error { /
 // release the module pins. The Debian variant is not cosmetic — it is the
 // escape hatch for the Alpine image's musl/OpenSSL TLS failures — so it has
 // to be a tag that exists and ships the same CLI.
-func (r *BrunoTests) VersionReportsPinnedRelease(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:98:1)
+func (r *BrunoTests) VersionReportsPinnedRelease(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:104:1)
 	if r.versionReportsPinnedRelease != nil {
 		return nil
 	}
@@ -763,11 +859,24 @@ func (r *BrunoTests) VersionReportsPinnedRelease(ctx context.Context) error { //
 // selected environment declares. The fixture puts the variable in the request
 // path, so the responder records which of the two won rather than the module
 // having to trust bru's summary.
-func (r *BrunoTests) WithVarOverridesEnvironmentValue(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:357:1)
+func (r *BrunoTests) WithVarOverridesEnvironmentValue(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:587:1)
 	if r.withVarOverridesEnvironmentValue != nil {
 		return nil
 	}
 	q := r.query.Select("withVarOverridesEnvironmentValue")
+
+	return q.Execute(ctx)
+}
+
+// WithoutHeadersRejectsBlankName checks that a name bru could not act on is
+// refused. The builders have no error return, so the finding belongs to the
+// run — and a blank name renders a flag that consumes whatever follows it,
+// which is a redaction that silently applies to nothing.
+func (r *BrunoTests) WithoutHeadersRejectsBlankName(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:565:1)
+	if r.withoutHeadersRejectsBlankName != nil {
+		return nil
+	}
+	q := r.query.Select("withoutHeadersRejectsBlankName")
 
 	return q.Execute(ctx)
 }

--- a/daggerverse/bruno/README.md
+++ b/daggerverse/bruno/README.md
@@ -403,11 +403,63 @@ headers {
 collection.WithSecretVar("API_TOKEN", token).Run(ctx)
 ```
 
-Note what this does *not* cover: `bru`'s reporters record the resolved request,
-so a secret that ends up in a URL or an echoed header lands in the JSON, JUnit
-or HTML artifact. Keep secrets in headers you do not report on, or treat the
-artifact as sensitive. Reporter redaction (`--reporter-skip-headers` and
-friends) is reachable through `Container()`.
+Keeping a secret off argv is not the same as keeping it out of the artifact,
+which is what the next section is about.
+
+## Reporter redaction
+
+`bru`'s JSON reporter records each exchange in full — request headers, request
+body, response headers, response body — and that file is what a CI system
+archives. A collection that authenticates therefore publishes its credential,
+to whoever can read build artifacts, for as long as they are kept.
+
+```go
+collection.
+    WithoutHeaders([]string{"authorization"}).  // --reporter-skip-headers
+    WithoutAllHeaders().                        // --reporter-skip-all-headers
+    WithoutRequestBody().                       // --reporter-skip-request-body
+    WithoutResponseBody().                      // --reporter-skip-response-body
+    WithoutBodies().                            // --reporter-skip-body
+    Report(ctx, "json")
+```
+
+`WithoutHeaders` matches case-insensitively and drops the header from **both**
+sides of the exchange; the names accumulate across calls. All five are on `Ci`
+as well, since `Ci.Run` is the terminal that writes the archived file.
+
+**A collection holding a `WithSecretVar` secret redacts all headers and both
+bodies by default.** `WithUnredactedReport()` is the way back.
+
+That default is as broad as it is because nothing narrower would be honest.
+`bru` already masks header values by name — a value under `Authorization` is
+written out as `Bearer ********` without anyone asking — but that is a list of
+names, so the same secret under `X-Custom`, in the request body, or echoed back
+in the response body is written out verbatim. The module has been told which
+value is sensitive and knows nothing about where the collection interpolated it,
+so redacting only the place it is most often found would be a promise it cannot
+keep, and a report that *looks* redacted is worse than one that obviously is
+not. The safe choice is the one the caller gets without asking for it: the
+caller who would have thought to ask was never the one at risk.
+
+The default triggers on `WithSecretVar` alone. `WithClientCert`'s key and
+passphrase are secrets too, but they are consumed by the handshake and never
+reach a header or a body, so a collection that only authenticates with a
+certificate reports in full.
+
+Two limits worth knowing:
+
+- **Only the JSON reporter carries any of this.** As of 3.4.2 the JUnit
+  document holds test names, assertion expressions and failure messages, and the
+  HTML page holds the same — neither reports a header or a body at all, passing
+  or failing. So these controls change the JSON artifact and leave the other two
+  as they were.
+- **No flag reaches the request URL**, which every reporter records in full. A
+  secret interpolated into a path or a query string is in the report whatever is
+  set here, and `bru` offers nothing that would remove it. Put credentials in
+  headers.
+
+The flags are rendered only when a reporter was asked for: a plain `Run`
+publishes no artifact and there is nothing for them to trim out of it.
 
 ## Sandbox
 
@@ -509,6 +561,12 @@ tail.
 | `Collection.WithCaCert(cert)` | `--cacert`; verify peers against a private CA as well as the default truststore. |
 | `Collection.WithoutTruststore()` | `--ignore-truststore`; verify against the `WithCaCert` CA alone. |
 | `Collection.WithClientCert(host, cert, key, passphrase)` | `--client-cert-config`; present a client certificate to hosts matching `host`. |
+| `Collection.WithoutHeaders(names)` | `--reporter-skip-headers`; omit named headers from the report, both sides. |
+| `Collection.WithoutAllHeaders()` | `--reporter-skip-all-headers`; omit every header from the report. |
+| `Collection.WithoutRequestBody()` | `--reporter-skip-request-body`. |
+| `Collection.WithoutResponseBody()` | `--reporter-skip-response-body`. |
+| `Collection.WithoutBodies()` | `--reporter-skip-body`; omit both. |
+| `Collection.WithUnredactedReport()` | Cancel the redaction a `WithSecretVar` secret applies by default. |
 | `Collection.WithTestsOnly()` | `--tests-only`; skip requests with no test or assertion. |
 | `Collection.WithBail()` | `--bail`; stop at the first failure. |
 | `Collection.WithDelay(milliseconds)` | `--delay`; wait between requests. |
@@ -524,6 +582,12 @@ tail.
 | `Ci.WithCaCert(cert)` | `--cacert` for the pipeline; verify peers against a private CA. |
 | `Ci.WithoutTruststore()` | `--ignore-truststore` for the pipeline; verify against that CA alone. |
 | `Ci.WithClientCert(host, cert, key, passphrase)` | `--client-cert-config` for the pipeline; authenticate to an mTLS endpoint. |
+| `Ci.WithoutHeaders(names)` | `--reporter-skip-headers` for the pipeline's reports. |
+| `Ci.WithoutAllHeaders()` | `--reporter-skip-all-headers` for the pipeline's reports. |
+| `Ci.WithoutRequestBody()` | `--reporter-skip-request-body` for the pipeline's reports. |
+| `Ci.WithoutResponseBody()` | `--reporter-skip-response-body` for the pipeline's reports. |
+| `Ci.WithoutBodies()` | `--reporter-skip-body` for the pipeline's reports. |
+| `Ci.WithUnredactedReport()` | Cancel the redaction a `WithSecretVar` secret applies by default. |
 | `Ci.WithLint(failOnWarnings)` | Add the lint stage, ahead of the collection. |
 | `Ci.WithReport(format)` | Add a reporter format to the set `Ci.Run` returns. |
 | `Ci.Check()` | The pipeline as a gate: lint, then the collection. Produces nothing. |
@@ -576,6 +640,17 @@ pipeline builder wraps no sandbox switch.
 `ClientCertMaterialStaysOutOfTheCollection` uses the same trick for the same
 reason, and adds a `readdirSync` of the working directory, because the collection
 bru sees is the mount and not the caller's directory.
+
+`fixtures/redact/` puts the same secret in three places one request can leak it
+from: an `Authorization` header, an `X-Custom` header, and a JSON request body.
+The responder echoes `X-Custom` back, so it is in the response body too. Both
+header names are load-bearing — `Authorization` is on `bru`'s own mask list and
+`X-Custom` is not, which is what
+`SecretVarIsRedactedFromReportsByDefault` pins before asserting anything about
+the default: if the two ever stop disagreeing, upstream has widened its
+redaction and this module's default has less work to do than its documentation
+claims. Every redaction test sets `WithUnredactedReport` first, so that what the
+report holds is the doing of the control under test and not of the secret.
 
 The TLS tests get a second responder. `tests/tlsresponder.go` serves the same
 recording handler over HTTPS on 8443 — presenting a leaf signed by a CA minted

--- a/daggerverse/bruno/ci.go
+++ b/daggerverse/bruno/ci.go
@@ -167,6 +167,62 @@ func (c *Ci) WithReport(
 	return &out
 }
 
+// WithoutHeaders omits the named headers from the reports Run returns. See
+// Collection.WithoutHeaders.
+func (c *Ci) WithoutHeaders(
+	// Header names to omit, matched case-insensitively.
+	names []string,
+) *Ci {
+	out := *c
+	out.Collection = c.Collection.WithoutHeaders(names)
+	return &out
+}
+
+// WithoutAllHeaders omits every header from the reports Run returns. See
+// Collection.WithoutAllHeaders.
+func (c *Ci) WithoutAllHeaders() *Ci {
+	out := *c
+	out.Collection = c.Collection.WithoutAllHeaders()
+	return &out
+}
+
+// WithoutRequestBody omits every request body from the reports Run returns. See
+// Collection.WithoutRequestBody.
+func (c *Ci) WithoutRequestBody() *Ci {
+	out := *c
+	out.Collection = c.Collection.WithoutRequestBody()
+	return &out
+}
+
+// WithoutResponseBody omits every response body from the reports Run returns.
+// See Collection.WithoutResponseBody.
+func (c *Ci) WithoutResponseBody() *Ci {
+	out := *c
+	out.Collection = c.Collection.WithoutResponseBody()
+	return &out
+}
+
+// WithoutBodies omits both request and response bodies from the reports Run
+// returns. See Collection.WithoutBodies.
+func (c *Ci) WithoutBodies() *Ci {
+	out := *c
+	out.Collection = c.Collection.WithoutBodies()
+	return &out
+}
+
+// WithUnredactedReport reports every header and both bodies, cancelling the
+// redaction a WithSecretVar secret otherwise applies. See
+// Collection.WithUnredactedReport.
+//
+// This is the builder where the default matters most and where cancelling it
+// deserves the most thought: what Run produces is the artifact a CI system
+// archives, and an archived report outlives the run that wrote it.
+func (c *Ci) WithUnredactedReport() *Ci {
+	out := *c
+	out.Collection = c.Collection.WithUnredactedReport()
+	return &out
+}
+
 // Check runs the pipeline as a gate and produces nothing, for the PR that wants
 // to know whether the API is behaving.
 //

--- a/daggerverse/bruno/collection.go
+++ b/daggerverse/bruno/collection.go
@@ -130,6 +130,18 @@ type Collection struct {
 	Bail bool
 	// +private
 	Delay int
+	// +private
+	SkipHeaders []string
+	// +private
+	SkipAllHeaders bool
+	// +private
+	SkipRequestBody bool
+	// +private
+	SkipResponseBody bool
+	// +private
+	SkipBodies bool
+	// +private
+	Unredacted bool
 }
 
 // Collection binds a Bruno collection directory to the toolchain.
@@ -356,6 +368,7 @@ func (c *Collection) clone() *Collection {
 	out.ClientCerts = append([]*dagger.File(nil), c.ClientCerts...)
 	out.ClientKeys = append([]*dagger.Secret(nil), c.ClientKeys...)
 	out.ClientPassphrases = append([]*dagger.Secret(nil), c.ClientPassphrases...)
+	out.SkipHeaders = append([]string(nil), c.SkipHeaders...)
 	return &out
 }
 
@@ -481,6 +494,12 @@ func (c *Collection) args(recursive bool, reportFormats []string, envFile string
 		}
 		args = append(args, "--reporter-"+format, path)
 	}
+	// The redaction flags describe what a reporter writes, so they go on the
+	// command line only when one was asked for. A plain Run publishes no
+	// artifact and there is nothing for them to trim out of it.
+	if len(reportFormats) > 0 {
+		args = append(args, c.redactArgs()...)
+	}
 	return args, nil
 }
 
@@ -516,6 +535,9 @@ func (c *Collection) validate() error {
 	}
 	if c.Delay < 0 {
 		return fmt.Errorf("WithDelay: delay %d must not be negative", c.Delay)
+	}
+	if err := c.validateRedaction(); err != nil {
+		return err
 	}
 	return c.validateTLS()
 }

--- a/daggerverse/bruno/dagger.gen.go
+++ b/daggerverse/bruno/dagger.gen.go
@@ -144,6 +144,12 @@ func (r Collection) MarshalJSON() ([]byte, error) {
 		TestsOnly         bool
 		Bail              bool
 		Delay             int
+		SkipHeaders       []string
+		SkipAllHeaders    bool
+		SkipRequestBody   bool
+		SkipResponseBody  bool
+		SkipBodies        bool
+		Unredacted        bool
 	}
 	concrete.Bruno = r.Bruno
 	concrete.Source = r.Source
@@ -168,6 +174,12 @@ func (r Collection) MarshalJSON() ([]byte, error) {
 	concrete.TestsOnly = r.TestsOnly
 	concrete.Bail = r.Bail
 	concrete.Delay = r.Delay
+	concrete.SkipHeaders = r.SkipHeaders
+	concrete.SkipAllHeaders = r.SkipAllHeaders
+	concrete.SkipRequestBody = r.SkipRequestBody
+	concrete.SkipResponseBody = r.SkipResponseBody
+	concrete.SkipBodies = r.SkipBodies
+	concrete.Unredacted = r.Unredacted
 	return json.Marshal(&concrete)
 }
 
@@ -196,6 +208,12 @@ func (r *Collection) UnmarshalJSON(bs []byte) error {
 		TestsOnly         bool
 		Bail              bool
 		Delay             int
+		SkipHeaders       []string
+		SkipAllHeaders    bool
+		SkipRequestBody   bool
+		SkipResponseBody  bool
+		SkipBodies        bool
+		Unredacted        bool
 	}
 	err := json.Unmarshal(bs, &concrete)
 	if err != nil {
@@ -224,6 +242,12 @@ func (r *Collection) UnmarshalJSON(bs []byte) error {
 	r.TestsOnly = concrete.TestsOnly
 	r.Bail = concrete.Bail
 	r.Delay = concrete.Delay
+	r.SkipHeaders = concrete.SkipHeaders
+	r.SkipAllHeaders = concrete.SkipAllHeaders
+	r.SkipRequestBody = concrete.SkipRequestBody
+	r.SkipResponseBody = concrete.SkipResponseBody
+	r.SkipBodies = concrete.SkipBodies
+	r.Unredacted = concrete.Unredacted
 	return nil
 }
 
@@ -596,6 +620,55 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Ci).WithService(&parent, alias, service), nil
+		case "WithUnredactedReport":
+			var parent Ci
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Ci).WithUnredactedReport(&parent), nil
+		case "WithoutAllHeaders":
+			var parent Ci
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Ci).WithoutAllHeaders(&parent), nil
+		case "WithoutBodies":
+			var parent Ci
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Ci).WithoutBodies(&parent), nil
+		case "WithoutHeaders":
+			var parent Ci
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var names []string
+			if inputArgs["names"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["names"]), &names)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg names", err))
+				}
+			}
+			return (*Ci).WithoutHeaders(&parent, names), nil
+		case "WithoutRequestBody":
+			var parent Ci
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Ci).WithoutRequestBody(&parent), nil
+		case "WithoutResponseBody":
+			var parent Ci
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Ci).WithoutResponseBody(&parent), nil
 		case "WithoutTruststore":
 			var parent Ci
 			err = json.Unmarshal(parentJSON, &parent)
@@ -860,6 +933,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return (*Collection).WithTestsOnly(&parent), nil
+		case "WithUnredactedReport":
+			var parent Collection
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Collection).WithUnredactedReport(&parent), nil
 		case "WithVar":
 			var parent Collection
 			err = json.Unmarshal(parentJSON, &parent)
@@ -881,6 +961,48 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Collection).WithVar(&parent, name, value), nil
+		case "WithoutAllHeaders":
+			var parent Collection
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Collection).WithoutAllHeaders(&parent), nil
+		case "WithoutBodies":
+			var parent Collection
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Collection).WithoutBodies(&parent), nil
+		case "WithoutHeaders":
+			var parent Collection
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var names []string
+			if inputArgs["names"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["names"]), &names)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg names", err))
+				}
+			}
+			return (*Collection).WithoutHeaders(&parent, names), nil
+		case "WithoutRequestBody":
+			var parent Collection
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Collection).WithoutRequestBody(&parent), nil
+		case "WithoutResponseBody":
+			var parent Collection
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Collection).WithoutResponseBody(&parent), nil
 		case "WithoutTags":
 			var parent Collection
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/bruno/main.go
+++ b/daggerverse/bruno/main.go
@@ -79,8 +79,8 @@ func New(
 }
 
 // Container returns the bare Bruno CLI image. This is the escape hatch for
-// every flag this module does not wrap — `bru`'s long tail of proxy, cookie
-// and reporter-redaction options stays reachable via `container with-exec`.
+// every flag this module does not wrap — `bru`'s long tail of proxy and cookie
+// options stays reachable via `container with-exec`.
 //
 // +cache="session"
 func (b *Bruno) Container() *dagger.Container {

--- a/daggerverse/bruno/redact.go
+++ b/daggerverse/bruno/redact.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// This file is the reporter's redaction controls: which of a run's headers and
+// bodies reach the artifact CI archives.
+//
+// The problem is that a report is written to be read later, by whatever
+// collects build artifacts, and a collection that authenticates puts its
+// credential in a request. bru's JSON reporter records each exchange in full —
+// request headers, request body, response headers, response body — so the
+// artifact a pipeline publishes carries the credential the pipeline was given.
+//
+// bru masks some of that already, by header name: a value under Authorization
+// is written out as "Bearer ********" with nobody having asked. The list is
+// short and it is a list of names, so the same secret under a header the list
+// has never heard of, in the request body, or echoed back in the response body
+// is written out verbatim. That is what these controls are for, and it is why
+// the default below is as broad as it is.
+//
+// Only the JSON reporter carries any of this. As of 3.4.2 the JUnit document
+// holds test names, assertion expressions and failure messages, and the HTML
+// page holds the same — neither reports a header or a body at all, whether the
+// run passed or failed. So these flags change the JSON artifact and leave the
+// other two as they were.
+//
+// What none of them reach is the request URL, which every reporter records in
+// full. A secret interpolated into a path or a query string is in the report
+// whatever is set here, and bru has no flag that would remove it. Put
+// credentials in headers.
+
+// WithoutHeaders omits the named headers from the reporter output
+// (`--reporter-skip-headers`), on both sides of each exchange.
+//
+// Matching is case-insensitive and the header is dropped rather than blanked,
+// so "authorization" removes an Authorization that was sent and one that came
+// back. Call it once with every name, or more than once — the names accumulate.
+//
+// Use it to keep a report that is still worth reading: everything the run
+// carried survives except the headers named here. WithoutAllHeaders is the
+// blunter instrument for when the set of sensitive names is not known.
+func (c *Collection) WithoutHeaders(
+	// Header names to omit, matched case-insensitively.
+	names []string,
+) *Collection {
+	out := c.clone()
+	out.SkipHeaders = append(out.SkipHeaders, names...)
+	return out
+}
+
+// WithoutAllHeaders omits every header from the reporter output
+// (`--reporter-skip-all-headers`), on both sides of each exchange.
+//
+// This is the choice to make when the collection's headers are not enumerable
+// from where the pipeline is written — a header set by a script, or an auth
+// scheme that adds one. WithoutHeaders keeps the rest of them.
+func (c *Collection) WithoutAllHeaders() *Collection {
+	out := c.clone()
+	out.SkipAllHeaders = true
+	return out
+}
+
+// WithoutRequestBody omits every request body from the reporter output
+// (`--reporter-skip-request-body`), for the collection that posts credentials
+// rather than sending them in a header.
+func (c *Collection) WithoutRequestBody() *Collection {
+	out := c.clone()
+	out.SkipRequestBody = true
+	return out
+}
+
+// WithoutResponseBody omits every response body from the reporter output
+// (`--reporter-skip-response-body`), for the endpoint that answers with a token
+// — a login route being the obvious one, and the one whose report is most
+// worth reading and least safe to keep.
+func (c *Collection) WithoutResponseBody() *Collection {
+	out := c.clone()
+	out.SkipResponseBody = true
+	return out
+}
+
+// WithoutBodies omits both request and response bodies from the reporter output
+// (`--reporter-skip-body`).
+func (c *Collection) WithoutBodies() *Collection {
+	out := c.clone()
+	out.SkipBodies = true
+	return out
+}
+
+// WithUnredactedReport reports every header and both bodies, cancelling the
+// redaction that a WithSecretVar secret otherwise applies.
+//
+// A collection that was handed a secret redacts its reports by default: see
+// redactArgs for why that is the default rather than the option. This is the
+// way back for a pipeline that wants the whole exchange in its artifact and has
+// decided the artifact is somewhere that can hold it.
+//
+// It does not undo the five Without* controls above; it only cancels what the
+// secret added. So a pipeline that wants the bodies in its artifact and none of
+// the headers sets this alongside WithoutAllHeaders, and gets exactly that
+// rather than the default's both.
+func (c *Collection) WithUnredactedReport() *Collection {
+	out := c.clone()
+	out.Unredacted = true
+	return out
+}
+
+// redactArgs renders the reporter's redaction flags, including the ones nobody
+// asked for.
+//
+// A collection holding a WithSecretVar secret redacts all headers and both
+// bodies unless WithUnredactedReport says otherwise. The reasoning is that the
+// module has been told, explicitly and by the caller, that a particular value
+// is sensitive — and knows nothing at all about where the collection
+// interpolates it. It could be a header, it could be a field in the request
+// body, and if the endpoint is a login route it comes back in the response
+// body. Redacting the one place it is most often found would be a promise this
+// module cannot keep, and a report that looks redacted is worse than one that
+// obviously is not.
+//
+// So the safe choice is the one the caller gets without asking for it, which is
+// the point: the caller who would have thought to ask was never the one at
+// risk. The cost is a narrower artifact for a pipeline that passes a secret,
+// and WithUnredactedReport buys it back.
+//
+// TLS material is not a trigger. WithClientCert's key and passphrase are
+// secrets too, but they are consumed by the handshake and never reach a header
+// or a body, so a collection that only authenticates with a certificate reports
+// in full.
+func (c *Collection) redactArgs() []string {
+	skipAllHeaders, skipBodies := c.SkipAllHeaders, c.SkipBodies
+	if len(c.SecretVarNames) > 0 && !c.Unredacted {
+		skipAllHeaders, skipBodies = true, true
+	}
+
+	var args []string
+	if skipAllHeaders {
+		args = append(args, "--reporter-skip-all-headers")
+	}
+	for _, name := range c.SkipHeaders {
+		// The flag takes an array, and yargs accumulates it across repeats.
+		// Repeating is what this renders rather than passing the names as one
+		// space-separated run, which would go on swallowing whatever followed
+		// it on the command line.
+		args = append(args, "--reporter-skip-headers", name)
+	}
+	if skipBodies {
+		args = append(args, "--reporter-skip-body")
+	}
+	if c.SkipRequestBody {
+		args = append(args, "--reporter-skip-request-body")
+	}
+	if c.SkipResponseBody {
+		args = append(args, "--reporter-skip-response-body")
+	}
+	return args
+}
+
+// validateRedaction reports the deferred checks on the redaction builders.
+func (c *Collection) validateRedaction() error {
+	for _, name := range c.SkipHeaders {
+		if strings.TrimSpace(name) == "" {
+			return fmt.Errorf("WithoutHeaders: header name is required")
+		}
+	}
+	return nil
+}

--- a/daggerverse/bruno/tests/dagger.gen.go
+++ b/daggerverse/bruno/tests/dagger.gen.go
@@ -248,6 +248,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).CiReachesMtlsServiceBehindPrivateCa(&parent, ctx)
+		case "CiRedactsSecretVarFromItsReports":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).CiRedactsSecretVarFromItsReports(&parent, ctx)
 		case "CiRejectsUnknownReportFormat":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -423,6 +430,27 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).ReportShouldNotBeCached(&parent, ctx)
+		case "ReportWithoutAllHeadersOmitsEveryHeader":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ReportWithoutAllHeadersOmitsEveryHeader(&parent, ctx)
+		case "ReportWithoutBodiesOmitsBothBodies":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ReportWithoutBodiesOmitsBothBodies(&parent, ctx)
+		case "ReportWithoutNamedHeaderKeepsTheOthers":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ReportWithoutNamedHeaderKeepsTheOthers(&parent, ctx)
 		case "RunFailsOnAssertionFailure":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -451,6 +479,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).SecretVarIsNotOnArgv(&parent, ctx)
+		case "SecretVarIsRedactedFromReportsByDefault":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).SecretVarIsRedactedFromReportsByDefault(&parent, ctx)
 		case "TlsControlsAreValidated":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -479,6 +514,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).WithVarOverridesEnvironmentValue(&parent, ctx)
+		case "WithoutHeadersRejectsBlankName":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).WithoutHeadersRejectsBlankName(&parent, ctx)
 		default:
 			return nil, fmt.Errorf("unknown function %s", fnName)
 		}

--- a/daggerverse/bruno/tests/fixtures/redact/bruno.json
+++ b/daggerverse/bruno/tests/fixtures/redact/bruno.json
@@ -1,0 +1,5 @@
+{
+  "version": "1",
+  "name": "redact",
+  "type": "collection"
+}

--- a/daggerverse/bruno/tests/fixtures/redact/environments/local.bru
+++ b/daggerverse/bruno/tests/fixtures/redact/environments/local.bru
@@ -1,0 +1,3 @@
+vars {
+  baseUrl: http://api:8080
+}

--- a/daggerverse/bruno/tests/fixtures/redact/token.bru
+++ b/daggerverse/bruno/tests/fixtures/redact/token.bru
@@ -1,0 +1,27 @@
+meta {
+  name: token
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/token
+  body: json
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{process.env.API_TOKEN}}
+  X-Custom: {{process.env.API_TOKEN}}
+  X-Trace-Id: trace-abc123
+}
+
+body:json {
+  {
+    "credential": "{{process.env.API_TOKEN}}"
+  }
+}
+
+assert {
+  res.status: eq 200
+}

--- a/daggerverse/bruno/tests/internal/dagger/bruno.gen.go
+++ b/daggerverse/bruno/tests/internal/dagger/bruno.gen.go
@@ -66,7 +66,7 @@ func (r *Bruno) Ci(source *Directory) *BrunoCi { // bruno (../../../../../dagger
 }
 
 // Collection binds a Bruno collection directory to the toolchain.
-func (r *Bruno) Collection(source *Directory) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:136:1)
+func (r *Bruno) Collection(source *Directory) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:148:1)
 	assertNotNil("source", source)
 	q := r.query.Select("collection")
 	q = q.Arg("source", source)
@@ -77,8 +77,8 @@ func (r *Bruno) Collection(source *Directory) *BrunoCollection { // bruno (../..
 }
 
 // Container returns the bare Bruno CLI image. This is the escape hatch for
-// every flag this module does not wrap — `bru`'s long tail of proxy, cookie
-// and reporter-redaction options stays reachable via `container with-exec`.
+// every flag this module does not wrap — `bru`'s long tail of proxy and cookie
+// options stays reachable via `container with-exec`.
 func (r *Bruno) Container() *Container { // bruno (../../../../../daggerverse/bruno/main.go:86:1)
 	q := r.query.Select("container")
 
@@ -268,7 +268,7 @@ func (r *BrunoCi) WithGraphQLQuery(q *querybuilder.Selection) *BrunoCi {
 // No report is produced, because a gate that returns nothing can gate: see Run
 // for why the terminal that hands back artifacts cannot also be the one that
 // fails.
-func (r *BrunoCi) Check(ctx context.Context) error { // bruno (../../../../../daggerverse/bruno/ci.go:185:1)
+func (r *BrunoCi) Check(ctx context.Context) error { // bruno (../../../../../daggerverse/bruno/ci.go:241:1)
 	if r.check != nil {
 		return nil
 	}
@@ -338,7 +338,7 @@ func (r *BrunoCi) UnmarshalJSON(bs []byte) error {
 //
 // A lint error is still an error here, because then the collection never ran
 // and there is no report to return. So is a usage error, for the same reason.
-func (r *BrunoCi) Run() *Directory { // bruno (../../../../../daggerverse/bruno/ci.go:210:1)
+func (r *BrunoCi) Run() *Directory { // bruno (../../../../../daggerverse/bruno/ci.go:266:1)
 	q := r.query.Select("run")
 
 	return &Directory{
@@ -483,6 +483,72 @@ func (r *BrunoCi) WithService(alias string, service *Service) *BrunoCi { // brun
 	q := r.query.Select("withService")
 	q = q.Arg("alias", alias)
 	q = q.Arg("service", service)
+
+	return &BrunoCi{
+		query: q,
+	}
+}
+
+// WithUnredactedReport reports every header and both bodies, cancelling the
+// redaction a WithSecretVar secret otherwise applies. See
+// Collection.WithUnredactedReport.
+//
+// This is the builder where the default matters most and where cancelling it
+// deserves the most thought: what Run produces is the artifact a CI system
+// archives, and an archived report outlives the run that wrote it.
+func (r *BrunoCi) WithUnredactedReport() *BrunoCi { // bruno (../../../../../daggerverse/bruno/ci.go:220:1)
+	q := r.query.Select("withUnredactedReport")
+
+	return &BrunoCi{
+		query: q,
+	}
+}
+
+// WithoutAllHeaders omits every header from the reports Run returns. See
+// Collection.WithoutAllHeaders.
+func (r *BrunoCi) WithoutAllHeaders() *BrunoCi { // bruno (../../../../../daggerverse/bruno/ci.go:183:1)
+	q := r.query.Select("withoutAllHeaders")
+
+	return &BrunoCi{
+		query: q,
+	}
+}
+
+// WithoutBodies omits both request and response bodies from the reports Run
+// returns. See Collection.WithoutBodies.
+func (r *BrunoCi) WithoutBodies() *BrunoCi { // bruno (../../../../../daggerverse/bruno/ci.go:207:1)
+	q := r.query.Select("withoutBodies")
+
+	return &BrunoCi{
+		query: q,
+	}
+}
+
+// WithoutHeaders omits the named headers from the reports Run returns. See
+// Collection.WithoutHeaders.
+func (r *BrunoCi) WithoutHeaders(names []string) *BrunoCi { // bruno (../../../../../daggerverse/bruno/ci.go:172:1)
+	q := r.query.Select("withoutHeaders")
+	q = q.Arg("names", names)
+
+	return &BrunoCi{
+		query: q,
+	}
+}
+
+// WithoutRequestBody omits every request body from the reports Run returns. See
+// Collection.WithoutRequestBody.
+func (r *BrunoCi) WithoutRequestBody() *BrunoCi { // bruno (../../../../../daggerverse/bruno/ci.go:191:1)
+	q := r.query.Select("withoutRequestBody")
+
+	return &BrunoCi{
+		query: q,
+	}
+}
+
+// WithoutResponseBody omits every response body from the reports Run returns.
+// See Collection.WithoutResponseBody.
+func (r *BrunoCi) WithoutResponseBody() *BrunoCi { // bruno (../../../../../daggerverse/bruno/ci.go:199:1)
+	q := r.query.Select("withoutResponseBody")
 
 	return &BrunoCi{
 		query: q,
@@ -693,7 +759,7 @@ func (r *BrunoCollection) Lint(ctx context.Context, opts ...BrunoCollectionLintO
 //
 // The run is recursive, matching Run's default, so the artifact describes the
 // whole collection.
-func (r *BrunoCollection) Report(format string) *File { // bruno (../../../../../daggerverse/bruno/collection.go:322:1)
+func (r *BrunoCollection) Report(format string) *File { // bruno (../../../../../daggerverse/bruno/collection.go:334:1)
 	q := r.query.Select("report")
 	q = q.Arg("format", format)
 
@@ -712,7 +778,7 @@ type BrunoCollectionRunOpts struct {
 	//
 	//
 	// Default: true
-	Recursive bool // bruno (../../../../../daggerverse/bruno/collection.go:289:2)
+	Recursive bool // bruno (../../../../../daggerverse/bruno/collection.go:301:2)
 }
 
 // Run executes the collection and returns bru's output.
@@ -726,7 +792,7 @@ type BrunoCollectionRunOpts struct {
 // A failing Run returns no output alongside its error: a Dagger function that
 // returns an error forfeits its value. Pair it with Report when the artifact
 // matters.
-func (r *BrunoCollection) Run(ctx context.Context, opts ...BrunoCollectionRunOpts) (string, error) { // bruno (../../../../../daggerverse/bruno/collection.go:282:1)
+func (r *BrunoCollection) Run(ctx context.Context, opts ...BrunoCollectionRunOpts) (string, error) { // bruno (../../../../../daggerverse/bruno/collection.go:294:1)
 	if r.run != nil {
 		return *r.run, nil
 	}
@@ -746,7 +812,7 @@ func (r *BrunoCollection) Run(ctx context.Context, opts ...BrunoCollectionRunOpt
 
 // WithBail stops the run at the first failing request, test or assertion
 // (`--bail`) instead of working through the rest of the collection.
-func (r *BrunoCollection) WithBail() *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:255:1)
+func (r *BrunoCollection) WithBail() *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:267:1)
 	q := r.query.Select("withBail")
 
 	return &BrunoCollection{
@@ -816,7 +882,7 @@ func (r *BrunoCollection) WithClientCert(host string, cert *File, key *Secret, o
 
 // WithDelay waits the given number of milliseconds between requests
 // (`--delay`), for a target that rate-limits.
-func (r *BrunoCollection) WithDelay(milliseconds int) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:263:1)
+func (r *BrunoCollection) WithDelay(milliseconds int) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:275:1)
 	q := r.query.Select("withDelay")
 	q = q.Arg("milliseconds", milliseconds)
 
@@ -828,7 +894,7 @@ func (r *BrunoCollection) WithDelay(milliseconds int) *BrunoCollection { // brun
 // WithEnvFile supplies an environment file (`--env-file`), a .bru or .json
 // file holding the variables for the run. It is mounted outside the
 // collection, so it never shadows a file the collection ships.
-func (r *BrunoCollection) WithEnvFile(file *File) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:182:1)
+func (r *BrunoCollection) WithEnvFile(file *File) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:194:1)
 	assertNotNil("file", file)
 	q := r.query.Select("withEnvFile")
 	q = q.Arg("file", file)
@@ -841,7 +907,7 @@ func (r *BrunoCollection) WithEnvFile(file *File) *BrunoCollection { // bruno (.
 // WithEnvironment selects the environment bru resolves variables from
 // (`--env`), by the name of the file under environments/ without its
 // extension. An unknown name is bru's exit 6, reported as a usage error.
-func (r *BrunoCollection) WithEnvironment(name string) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:143:1)
+func (r *BrunoCollection) WithEnvironment(name string) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:155:1)
 	q := r.query.Select("withEnvironment")
 	q = q.Arg("name", name)
 
@@ -858,7 +924,7 @@ func (r *BrunoCollection) WithEnvironment(name string) *BrunoCollection { // bru
 // CA: use WithCaCert for that, and WithClientCert to authenticate with a
 // certificate of the run's own. bru drops `--cacert` when `--insecure` is set,
 // so combining the two is rejected rather than quietly verifying nothing.
-func (r *BrunoCollection) WithInsecure() *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:238:1)
+func (r *BrunoCollection) WithInsecure() *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:250:1)
 	q := r.query.Select("withInsecure")
 
 	return &BrunoCollection{
@@ -875,7 +941,7 @@ func (r *BrunoCollection) WithInsecure() *BrunoCollection { // bruno (../../../.
 // A collection that says nothing runs in "safe", matching both bru's default
 // and Collection's. Like WithVar, an unknown mode is reported by the run
 // rather than here.
-func (r *BrunoCollection) WithSandbox(mode string) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:224:1)
+func (r *BrunoCollection) WithSandbox(mode string) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:236:1)
 	q := r.query.Select("withSandbox")
 	q = q.Arg("mode", mode)
 
@@ -891,7 +957,7 @@ func (r *BrunoCollection) WithSandbox(mode string) *BrunoCollection { // bruno (
 // `--env-var` places its value on the process command line. A secret is bound
 // with WithSecretVariable instead, so it appears in neither argv nor any
 // diagnostic this module echoes back.
-func (r *BrunoCollection) WithSecretVar(name string, value *Secret) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:172:1)
+func (r *BrunoCollection) WithSecretVar(name string, value *Secret) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:184:1)
 	assertNotNil("value", value)
 	q := r.query.Select("withSecretVar")
 	q = q.Arg("name", name)
@@ -905,7 +971,7 @@ func (r *BrunoCollection) WithSecretVar(name string, value *Secret) *BrunoCollec
 // WithService binds a service into the run's network under alias, so the
 // collection can reach it by that hostname. A collection is inert without a
 // target, which is why this exists at all.
-func (r *BrunoCollection) WithService(alias string, service *Service) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:208:1)
+func (r *BrunoCollection) WithService(alias string, service *Service) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:220:1)
 	assertNotNil("service", service)
 	q := r.query.Select("withService")
 	q = q.Arg("alias", alias)
@@ -918,7 +984,7 @@ func (r *BrunoCollection) WithService(alias string, service *Service) *BrunoColl
 
 // WithTags restricts the run to requests carrying any of these tags
 // (`--tags`).
-func (r *BrunoCollection) WithTags(tags []string) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:190:1)
+func (r *BrunoCollection) WithTags(tags []string) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:202:1)
 	q := r.query.Select("withTags")
 	q = q.Arg("tags", tags)
 
@@ -930,8 +996,28 @@ func (r *BrunoCollection) WithTags(tags []string) *BrunoCollection { // bruno (.
 // WithTestsOnly runs only the requests that carry a test or an active
 // assertion (`--tests-only`), skipping the ones that exist to set up state
 // for a human.
-func (r *BrunoCollection) WithTestsOnly() *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:247:1)
+func (r *BrunoCollection) WithTestsOnly() *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:259:1)
 	q := r.query.Select("withTestsOnly")
+
+	return &BrunoCollection{
+		query: q,
+	}
+}
+
+// WithUnredactedReport reports every header and both bodies, cancelling the
+// redaction that a WithSecretVar secret otherwise applies.
+//
+// A collection that was handed a secret redacts its reports by default: see
+// redactArgs for why that is the default rather than the option. This is the
+// way back for a pipeline that wants the whole exchange in its artifact and has
+// decided the artifact is somewhere that can hold it.
+//
+// It does not undo the five Without* controls above; it only cancels what the
+// secret added. So a pipeline that wants the bodies in its artifact and none of
+// the headers sets this alongside WithoutAllHeaders, and gets exactly that
+// rather than the default's both.
+func (r *BrunoCollection) WithUnredactedReport() *BrunoCollection { // bruno (../../../../../daggerverse/bruno/redact.go:105:1)
+	q := r.query.Select("withUnredactedReport")
 
 	return &BrunoCollection{
 		query: q,
@@ -947,7 +1033,7 @@ func (r *BrunoCollection) WithTestsOnly() *BrunoCollection { // bruno (../../../
 //
 // Validation is deferred to the run: builder methods have no error return, so
 // a bad name surfaces on the Run or Report that would have used it.
-func (r *BrunoCollection) WithVar(name string, value string) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:158:1)
+func (r *BrunoCollection) WithVar(name string, value string) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:170:1)
 	q := r.query.Select("withVar")
 	q = q.Arg("name", name)
 	q = q.Arg("value", value)
@@ -957,10 +1043,76 @@ func (r *BrunoCollection) WithVar(name string, value string) *BrunoCollection { 
 	}
 }
 
+// WithoutAllHeaders omits every header from the reporter output
+// (`--reporter-skip-all-headers`), on both sides of each exchange.
+//
+// This is the choice to make when the collection's headers are not enumerable
+// from where the pipeline is written — a header set by a script, or an auth
+// scheme that adds one. WithoutHeaders keeps the rest of them.
+func (r *BrunoCollection) WithoutAllHeaders() *BrunoCollection { // bruno (../../../../../daggerverse/bruno/redact.go:60:1)
+	q := r.query.Select("withoutAllHeaders")
+
+	return &BrunoCollection{
+		query: q,
+	}
+}
+
+// WithoutBodies omits both request and response bodies from the reporter output
+// (`--reporter-skip-body`).
+func (r *BrunoCollection) WithoutBodies() *BrunoCollection { // bruno (../../../../../daggerverse/bruno/redact.go:87:1)
+	q := r.query.Select("withoutBodies")
+
+	return &BrunoCollection{
+		query: q,
+	}
+}
+
+// WithoutHeaders omits the named headers from the reporter output
+// (`--reporter-skip-headers`), on both sides of each exchange.
+//
+// Matching is case-insensitive and the header is dropped rather than blanked,
+// so "authorization" removes an Authorization that was sent and one that came
+// back. Call it once with every name, or more than once — the names accumulate.
+//
+// Use it to keep a report that is still worth reading: everything the run
+// carried survives except the headers named here. WithoutAllHeaders is the
+// blunter instrument for when the set of sensitive names is not known.
+func (r *BrunoCollection) WithoutHeaders(names []string) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/redact.go:45:1)
+	q := r.query.Select("withoutHeaders")
+	q = q.Arg("names", names)
+
+	return &BrunoCollection{
+		query: q,
+	}
+}
+
+// WithoutRequestBody omits every request body from the reporter output
+// (`--reporter-skip-request-body`), for the collection that posts credentials
+// rather than sending them in a header.
+func (r *BrunoCollection) WithoutRequestBody() *BrunoCollection { // bruno (../../../../../daggerverse/bruno/redact.go:69:1)
+	q := r.query.Select("withoutRequestBody")
+
+	return &BrunoCollection{
+		query: q,
+	}
+}
+
+// WithoutResponseBody omits every response body from the reporter output
+// (`--reporter-skip-response-body`), for the endpoint that answers with a token
+// — a login route being the obvious one, and the one whose report is most
+// worth reading and least safe to keep.
+func (r *BrunoCollection) WithoutResponseBody() *BrunoCollection { // bruno (../../../../../daggerverse/bruno/redact.go:79:1)
+	q := r.query.Select("withoutResponseBody")
+
+	return &BrunoCollection{
+		query: q,
+	}
+}
+
 // WithoutTags excludes requests carrying any of these tags
 // (`--exclude-tags`). It composes with WithTags: a request matching both is
 // excluded.
-func (r *BrunoCollection) WithoutTags(tags []string) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:199:1)
+func (r *BrunoCollection) WithoutTags(tags []string) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:211:1)
 	q := r.query.Select("withoutTags")
 	q = q.Arg("tags", tags)
 

--- a/daggerverse/bruno/tests/main.go
+++ b/daggerverse/bruno/tests/main.go
@@ -57,6 +57,11 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("ReportEmitsJunitForFailingRun", t.ReportEmitsJunitForFailingRun)
 	jobs = jobs.WithJob("ReportRejectsUnknownFormat", t.ReportRejectsUnknownFormat)
 	jobs = jobs.WithJob("ReportShouldNotBeCached", t.ReportShouldNotBeCached)
+	jobs = jobs.WithJob("SecretVarIsRedactedFromReportsByDefault", t.SecretVarIsRedactedFromReportsByDefault)
+	jobs = jobs.WithJob("ReportWithoutAllHeadersOmitsEveryHeader", t.ReportWithoutAllHeadersOmitsEveryHeader)
+	jobs = jobs.WithJob("ReportWithoutNamedHeaderKeepsTheOthers", t.ReportWithoutNamedHeaderKeepsTheOthers)
+	jobs = jobs.WithJob("ReportWithoutBodiesOmitsBothBodies", t.ReportWithoutBodiesOmitsBothBodies)
+	jobs = jobs.WithJob("WithoutHeadersRejectsBlankName", t.WithoutHeadersRejectsBlankName)
 	jobs = jobs.WithJob("WithVarOverridesEnvironmentValue", t.WithVarOverridesEnvironmentValue)
 	jobs = jobs.WithJob("SecretVarIsNotOnArgv", t.SecretVarIsNotOnArgv)
 	jobs = jobs.WithJob("PassThroughFlagsAreAccepted", t.PassThroughFlagsAreAccepted)
@@ -87,6 +92,7 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("CiRunStillReportsWhenTheCollectionFails", t.CiRunStillReportsWhenTheCollectionFails)
 	jobs = jobs.WithJob("CiShouldNotBeCached", t.CiShouldNotBeCached)
 	jobs = jobs.WithJob("CiSecretVarReachesTheCollection", t.CiSecretVarReachesTheCollection)
+	jobs = jobs.WithJob("CiRedactsSecretVarFromItsReports", t.CiRedactsSecretVarFromItsReports)
 
 	return jobs.Run(ctx)
 }
@@ -346,6 +352,230 @@ func (t *Tests) ReportShouldNotBeCached(ctx context.Context) error {
 		if got.Count != i {
 			return fmt.Errorf("expected %d request(s) at the service after %d report(s), got %d", i, i, got.Count)
 		}
+	}
+	return nil
+}
+
+// SecretVarIsRedactedFromReportsByDefault checks the module's answer to the
+// question the redaction story poses: what a report contains when the caller
+// has said nothing about redaction and the collection was handed a secret.
+//
+// The first pass is the control, and it is what makes the second one mean
+// something. bru masks header values by name — Authorization comes back as
+// "Bearer ********" without anyone having asked — so a default asserted on its
+// own could be passing on the strength of upstream's list rather than on
+// anything this module did. The control pins how far that list reaches: the
+// same secret in a header the list has never heard of, in the request body, and
+// echoed back in the response body is written out verbatim.
+//
+// That is why the default is all headers and both bodies rather than something
+// narrower. The module knows the value is sensitive; it does not know where the
+// collection interpolated it, and a partial redaction would be a promise it
+// cannot keep.
+func (t *Tests) SecretVarIsRedactedFromReportsByDefault(ctx context.Context) error {
+	rsp, err := newResponder(ctx)
+	if err != nil {
+		return err
+	}
+	defer rsp.stop(ctx)
+
+	value, err := dag.Random().Sha256(ctx)
+	if err != nil {
+		return fmt.Errorf("mint the test token: %w", err)
+	}
+	collection := dag.Bruno().
+		Collection(fixture("redact")).
+		WithEnvironment("local").
+		WithSecretVar("API_TOKEN", dag.SetSecret("bruno-redact-default-token", value)).
+		WithService(responderAlias, rsp.Svc)
+
+	loud, err := exportContents(ctx,
+		collection.WithUnredactedReport().Report("json"), "redact-unredacted.json")
+	if err != nil {
+		return fmt.Errorf("unredacted report: %w", err)
+	}
+	control, err := oneResult(loud)
+	if err != nil {
+		return fmt.Errorf("unredacted report: %w", err)
+	}
+	masked, ok := header(control.Request.Headers, "authorization")
+	if !ok {
+		return fmt.Errorf("expected an unredacted report to carry the Authorization header, got %v",
+			control.Request.Headers)
+	}
+	if strings.Contains(masked, value) {
+		return fmt.Errorf("expected bru to mask the Authorization header on its own, got %q", masked)
+	}
+	// Every place the secret survives upstream's masking. If one of these ever
+	// stops holding, bru has widened its own redaction and this module's
+	// default has less work to do than its documentation claims.
+	custom, _ := header(control.Request.Headers, "x-custom")
+	for _, leak := range []struct {
+		where string
+		got   string
+	}{
+		{"the X-Custom request header", custom},
+		{"the request body", string(control.Request.Data)},
+		{"the response body", string(control.Response.Data)},
+	} {
+		if !strings.Contains(leak.got, value) {
+			return fmt.Errorf(
+				"expected an unredacted report to carry the secret in %s, got %q", leak.where, leak.got)
+		}
+	}
+
+	quiet, err := exportContents(ctx, collection.Report("json"), "redact-default.json")
+	if err != nil {
+		return fmt.Errorf("default report: %w", err)
+	}
+	if strings.Contains(quiet, value) {
+		return fmt.Errorf("the secret is in the report the default produced:\n%s", head(quiet))
+	}
+	// Asserted against a report of a run that happened: a request bru never
+	// issued carries no secret either, and would satisfy the line above.
+	got, err := oneResult(quiet)
+	if err != nil {
+		return fmt.Errorf("default report: %w", err)
+	}
+	if len(got.Request.Headers) != 0 {
+		return fmt.Errorf("expected no request headers under the default, got %v", got.Request.Headers)
+	}
+	if len(got.Response.Headers) != 0 {
+		return fmt.Errorf("expected no response headers under the default, got %v", got.Response.Headers)
+	}
+	if got.Request.Data != nil || got.Response.Data != nil {
+		return fmt.Errorf("expected neither body under the default, got request %q and response %q",
+			got.Request.Data, got.Response.Data)
+	}
+	if got.Response.Status != 200 {
+		return fmt.Errorf("expected the redacted report to describe a request that was served, got status %d",
+			got.Response.Status)
+	}
+	return nil
+}
+
+// ReportWithoutAllHeadersOmitsEveryHeader checks the blunt control: nothing
+// that was sent or came back as a header survives into the report, on either
+// side of the exchange.
+//
+// Every redaction test here sets WithUnredactedReport first. The collection
+// carries a secret — that is what makes it worth redacting — and a secret is
+// enough to redact the report on its own, so without the opt-out these tests
+// would pass whether or not the flag under test was rendered at all.
+func (t *Tests) ReportWithoutAllHeadersOmitsEveryHeader(ctx context.Context) error {
+	got, err := redactedReport(ctx, "all-headers", func(c *dagger.BrunoCollection) *dagger.BrunoCollection {
+		return c.WithoutAllHeaders()
+	})
+	if err != nil {
+		return err
+	}
+	if len(got.Request.Headers) != 0 {
+		return fmt.Errorf("expected no request headers, got %v", got.Request.Headers)
+	}
+	if len(got.Response.Headers) != 0 {
+		return fmt.Errorf("expected no response headers, got %v", got.Response.Headers)
+	}
+	// The bodies are the control: this flag is about headers, and one that
+	// took the whole exchange with it would satisfy the two checks above.
+	if got.Request.Data == nil || got.Response.Data == nil {
+		return fmt.Errorf("expected both bodies to survive a header-only redaction, got request %q and response %q",
+			got.Request.Data, got.Response.Data)
+	}
+	return nil
+}
+
+// ReportWithoutNamedHeaderKeepsTheOthers checks the narrow control, which is
+// the one worth having: the credential goes and the report is still a report.
+//
+// The name is given in lower case against a header the collection spells
+// Authorization, because bru matches case-insensitively and a caller should not
+// have to know how the collection capitalised it.
+func (t *Tests) ReportWithoutNamedHeaderKeepsTheOthers(ctx context.Context) error {
+	got, err := redactedReport(ctx, "named-header", func(c *dagger.BrunoCollection) *dagger.BrunoCollection {
+		return c.WithoutHeaders([]string{"authorization"})
+	})
+	if err != nil {
+		return err
+	}
+	if value, ok := header(got.Request.Headers, "authorization"); ok {
+		return fmt.Errorf("expected the Authorization header to be omitted, got %q", value)
+	}
+	for _, name := range []string{"X-Trace-Id", "X-Custom"} {
+		if _, ok := header(got.Request.Headers, name); !ok {
+			return fmt.Errorf("expected the %s header to survive, got %v", name, got.Request.Headers)
+		}
+	}
+	if len(got.Response.Headers) == 0 {
+		return fmt.Errorf("expected the response headers to survive, got none")
+	}
+	return nil
+}
+
+// ReportWithoutBodiesOmitsBothBodies checks the three body controls together,
+// because what each one has to establish is which bodies it left alone.
+//
+// A flag that dropped both would satisfy the request-only case on its own, so
+// the assertion in every pass is the pair: what went, and what stayed.
+func (t *Tests) ReportWithoutBodiesOmitsBothBodies(ctx context.Context) error {
+	for _, tc := range []struct {
+		label   string
+		apply   func(*dagger.BrunoCollection) *dagger.BrunoCollection
+		request bool
+		response bool
+	}{
+		{
+			label:   "request-body",
+			apply:   func(c *dagger.BrunoCollection) *dagger.BrunoCollection { return c.WithoutRequestBody() },
+			request: false, response: true,
+		},
+		{
+			label:   "response-body",
+			apply:   func(c *dagger.BrunoCollection) *dagger.BrunoCollection { return c.WithoutResponseBody() },
+			request: true, response: false,
+		},
+		{
+			label:   "bodies",
+			apply:   func(c *dagger.BrunoCollection) *dagger.BrunoCollection { return c.WithoutBodies() },
+			request: false, response: false,
+		},
+	} {
+		got, err := redactedReport(ctx, tc.label, tc.apply)
+		if err != nil {
+			return err
+		}
+		if (got.Request.Data != nil) != tc.request {
+			return fmt.Errorf("%s: expected request body present=%t, got %q", tc.label, tc.request, got.Request.Data)
+		}
+		if (got.Response.Data != nil) != tc.response {
+			return fmt.Errorf("%s: expected response body present=%t, got %q", tc.label, tc.response, got.Response.Data)
+		}
+		// Headers are the control here for the same reason the bodies were one
+		// above: a flag that emptied the whole exchange would pass otherwise.
+		if len(got.Request.Headers) == 0 {
+			return fmt.Errorf("%s: expected the request headers to survive a body redaction, got none", tc.label)
+		}
+	}
+	return nil
+}
+
+// WithoutHeadersRejectsBlankName checks that a name bru could not act on is
+// refused. The builders have no error return, so the finding belongs to the
+// run — and a blank name renders a flag that consumes whatever follows it,
+// which is a redaction that silently applies to nothing.
+func (t *Tests) WithoutHeadersRejectsBlankName(ctx context.Context) error {
+	// Like every other deferred finding, it surfaces on the read: Report is
+	// lazy, so its error travels with the file rather than with the call.
+	_, err := dag.Bruno().
+		Collection(fixture("redact")).
+		WithEnvironment("local").
+		WithoutHeaders([]string{"authorization", " "}).
+		Report("json").
+		Contents(ctx)
+	if err == nil {
+		return fmt.Errorf("expected a blank header name to be rejected")
+	}
+	if !strings.Contains(err.Error(), "WithoutHeaders: header name is required") {
+		return fmt.Errorf("expected the error to name the builder, got: %v", err)
 	}
 	return nil
 }
@@ -1277,6 +1507,68 @@ func (t *Tests) CiSecretVarReachesTheCollection(ctx context.Context) error {
 	return nil
 }
 
+// CiRedactsSecretVarFromItsReports checks the redaction where it matters most.
+// Run is the terminal that writes the file a CI system archives, and an
+// archived report outlives the run that produced it.
+//
+// Both directions are exercised, because a builder that dropped the delegation
+// entirely would look identical to one that redacts: a report with no headers
+// is what the default produces and also what a pipeline that never passed the
+// controls along would produce if the collection redacted on its own account.
+// The unredacted pass is what tells the two apart — the secret has to come back
+// when the pipeline asks for it.
+func (t *Tests) CiRedactsSecretVarFromItsReports(ctx context.Context) error {
+	rsp, err := newResponder(ctx)
+	if err != nil {
+		return err
+	}
+	defer rsp.stop(ctx)
+
+	value, err := dag.Random().Sha256(ctx)
+	if err != nil {
+		return fmt.Errorf("mint the test token: %w", err)
+	}
+	ci := dag.Bruno().Ci(fixture("redact")).
+		WithEnvironment("local").
+		WithSecretVar("API_TOKEN", dag.SetSecret("bruno-ci-redact-token", value)).
+		WithService(responderAlias, rsp.Svc).
+		WithReport("json")
+
+	for _, tc := range []struct {
+		label     string
+		pipeline  *dagger.BrunoCi
+		wantValue bool
+	}{
+		{"default", ci, false},
+		{"unredacted", ci.WithUnredactedReport(), true},
+	} {
+		// Ci.Run is +cache="never", so the directory is resolved once before
+		// anything is selected out of it. Two selections would be two runs.
+		reports, err := pin(ctx, tc.pipeline.Run())
+		if err != nil {
+			return fmt.Errorf("%s run: %w", tc.label, err)
+		}
+		contents, err := exportContents(ctx,
+			reports.File("report.json"), "ci-redact-"+tc.label+".json")
+		if err != nil {
+			return fmt.Errorf("%s report: %w", tc.label, err)
+		}
+		if strings.Contains(contents, value) != tc.wantValue {
+			return fmt.Errorf("%s: expected the secret in the report=%t:\n%s",
+				tc.label, tc.wantValue, head(contents))
+		}
+		got, err := oneResult(contents)
+		if err != nil {
+			return fmt.Errorf("%s report: %w", tc.label, err)
+		}
+		if got.Response.Status != 200 {
+			return fmt.Errorf("%s: expected a report of a request that was served, got status %d",
+				tc.label, got.Response.Status)
+		}
+	}
+	return nil
+}
+
 // TlsControlsAreValidated checks the two TLS combinations that cannot mean what
 // they say, both of which bru accepts and then quietly does something else with.
 //
@@ -1756,6 +2048,100 @@ func exportContents(ctx context.Context, f *dagger.File, name string) (string, e
 		return "", fmt.Errorf("read exported %s: %w", name, err)
 	}
 	return contents, nil
+}
+
+// redactedReport runs the redact fixture under one explicit redaction control
+// and hands back the single exchange its JSON report describes.
+//
+// The collection is handed a secret, because a report worth redacting is one of
+// a run that carried something — and then WithUnredactedReport turns the
+// default off, so that what the report holds is the doing of the control under
+// test and not of the secret.
+func redactedReport(
+	ctx context.Context,
+	label string,
+	apply func(*dagger.BrunoCollection) *dagger.BrunoCollection,
+) (reportResult, error) {
+	rsp, err := newResponder(ctx)
+	if err != nil {
+		return reportResult{}, err
+	}
+	defer rsp.stop(ctx)
+
+	value, err := dag.Random().Sha256(ctx)
+	if err != nil {
+		return reportResult{}, fmt.Errorf("mint the test token: %w", err)
+	}
+	collection := dag.Bruno().
+		Collection(fixture("redact")).
+		WithEnvironment("local").
+		WithSecretVar("API_TOKEN", dag.SetSecret("bruno-redact-"+label+"-token", value)).
+		WithService(responderAlias, rsp.Svc).
+		WithUnredactedReport()
+
+	contents, err := exportContents(ctx, apply(collection).Report("json"), "redact-"+label+".json")
+	if err != nil {
+		return reportResult{}, fmt.Errorf("%s report: %w", label, err)
+	}
+	got, err := oneResult(contents)
+	if err != nil {
+		return reportResult{}, fmt.Errorf("%s report: %w", label, err)
+	}
+	return got, nil
+}
+
+// header looks a reported header up case-insensitively. bru writes each name
+// back the way the collection spelled it, so an exact-key lookup would be
+// asserting the fixture's capitalisation rather than what was reported.
+func header(headers map[string]string, name string) (string, bool) {
+	for key, value := range headers {
+		if strings.EqualFold(key, name) {
+			return value, true
+		}
+	}
+	return "", false
+}
+
+// reportResult is the part of one entry in bru's JSON report that the
+// redaction tests read: what the request carried and what came back.
+type reportResult struct {
+	Request  reportMessage `json:"request"`
+	Response reportMessage `json:"response"`
+}
+
+// reportMessage is one side of a reported exchange.
+//
+// Data is held raw because the two sides do not agree on its type — a request
+// body is reported as the string that was sent, a response body as the parsed
+// document — and because what the body flags do is remove the field rather than
+// blank it, so nil is the assertion those tests make.
+type reportMessage struct {
+	Headers map[string]string `json:"headers"`
+	Data    json.RawMessage   `json:"data"`
+	Status  int               `json:"status"`
+}
+
+// oneResult reads the single reported exchange out of a JSON report.
+//
+// The document is an array of iterations, each holding its own results, because
+// bru reports a data-driven run as one iteration per row. Every collection here
+// makes one request, so anything else means the run was not the one the test
+// set up.
+func oneResult(contents string) (reportResult, error) {
+	var iterations []struct {
+		Results []reportResult `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(contents), &iterations); err != nil {
+		return reportResult{}, fmt.Errorf("parse the json report: %w\n%s", err, head(contents))
+	}
+	var results []reportResult
+	for _, iteration := range iterations {
+		results = append(results, iteration.Results...)
+	}
+	if len(results) != 1 {
+		return reportResult{}, fmt.Errorf("expected 1 reported request, got %d:\n%s", len(results), head(contents))
+	}
+	return results[0], nil
 }
 
 // generatedRequests lists the request files in a generated collection.

--- a/daggerverse/bruno/tests/responder.go
+++ b/daggerverse/bruno/tests/responder.go
@@ -28,6 +28,12 @@ const (
 // statsPath answers 200 with a small JSON body, bumps a counter and remembers
 // what the request carried; statsPath hands that record back.
 //
+// That body echoes the request's X-Custom header back, which is what puts a
+// caller's own value in a *response* body. The redaction tests need one there:
+// a login route answering with the token it was given is the case
+// WithoutResponseBody exists for, and a responder that only ever said "ok"
+// could not stand in for it.
+//
 // It runs on the Bruno CLI image itself rather than a second image: that image
 // is node:22-alpine, so `node -e` needs nothing pulled that the module under
 // test has not already pulled.
@@ -57,7 +63,7 @@ http.createServer((req, res) => {
     argv: req.headers['x-argv'] || '',
   };
   res.writeHead(200, { 'content-type': 'application/json' });
-  res.end(JSON.stringify({ status: 'ok', count }));
+  res.end(JSON.stringify({ status: 'ok', count, echo: req.headers['x-custom'] || '' }));
 }).listen(%d, '0.0.0.0');
 `, id, statsPath, responderPort)
 }


### PR DESCRIPTION
Closes #248.

`bru`'s JSON reporter records each exchange in full — request headers, request body, response headers, response body — and that file is what a CI system archives. A collection that authenticates therefore publishes its credential to whoever can read build artifacts.

## The five controls

`WithoutHeaders(names)`, `WithoutAllHeaders()`, `WithoutRequestBody()`, `WithoutResponseBody()` and `WithoutBodies()` on `Collection`, rendering the matching `--reporter-skip-*` flags. `WithoutHeaders` matches case-insensitively, drops the header from **both** sides of the exchange, and accumulates across calls; it is rendered as a repeated flag rather than a space-separated array, which would go on swallowing whatever followed it on the command line.

All five are mirrored on `Ci` — the issue's motivation is the archived artifact, and `Ci.Run` is the terminal that writes it.

## The default, and what measurement decided it

The issue asks whether a `WithSecretVar` value should be redacted by default. It should, and broadly: **a collection holding a secret redacts all headers and both bodies unless `WithUnredactedReport()` says otherwise.**

What settled the shape was probing 3.4.2 rather than reasoning about it:

- `bru` already masks header values, but **by name**. `Authorization` comes back as `Bearer ********` unasked, and so does `X-Api-Key` — while `X-Custom` carrying the identical secret is written out verbatim, as is the request body and a response body that echoes it. Upstream's masking is a name allowlist, so a narrower default would be a promise the module cannot keep, and a report that *looks* redacted is worse than one that obviously is not.
- Only the **JSON** reporter carries any of this. The JUnit document and the HTML page report neither a header nor a body, passing or failing — so these controls change one artifact and leave the other two as they were.
- **No flag reaches the request URL**, which every reporter records in full. A secret in a path or query string is in the report whatever is set here. Documented, not papered over.

`WithClientCert`'s key and passphrase do not trigger the default: they are consumed by the handshake and never reach a header or a body.

The one departure from the issue's list is `WithUnredactedReport()` — a sixth function, and the necessary consequence of defaulting on. Without it a pipeline that passes a secret could never get response bodies into its artifact.

## Tests

Six new, all in `All`:

- `SecretVarIsRedactedFromReportsByDefault` — the control pass pins how far upstream's masking reaches (`Authorization` masked, `X-Custom`/both bodies not) *before* asserting the default, so the default cannot pass on the strength of bru's list. If those two ever stop disagreeing, upstream has widened its redaction and the docs here overstate the module's work.
- `ReportWithoutAllHeadersOmitsEveryHeader`, `ReportWithoutNamedHeaderKeepsTheOthers`, `ReportWithoutBodiesOmitsBothBodies` — each asserts the pair: what went *and* what stayed, so a flag that emptied the whole exchange cannot pass. All set `WithUnredactedReport` first, or they would be passing on the default rather than on the flag under test.
- `WithoutHeadersRejectsBlankName`, `CiRedactsSecretVarFromItsReports`.

New `fixtures/redact/` puts the same secret in an `Authorization` header, an `X-Custom` header and a JSON request body; the responder echoes `X-Custom` back so it is in the response body too.

`dagger -m daggerverse/bruno/tests call all` is green (45 jobs), and `dagger -m ci call generated` passes with bindings regenerated in `daggerverse/bruno`, `daggerverse/bruno/tests` and `ci/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)