### PR TITLE
story(issue-275): test package assembly off a private apk mirror

### DIFF
--- a/ci/internal/dagger/pdf-tests.gen.go
+++ b/ci/internal/dagger/pdf-tests.gen.go
@@ -46,8 +46,13 @@ type PdfTests struct { // pdf-tests (../../../daggerverse/pdf/tests/main.go:151:
 	query *querybuilder.Selection
 
 	all                                                 *Void
+	apkAuthInstallsFromAuthenticatedRepository          *Void
+	apkRepositoryAssemblesWorkingToolchainFromMirror    *Void
+	apkRepositoryReplacesImageDefaults                  *Void
+	authenticatedRepositoryIsRejectedWithoutApkAuth     *Void
 	colorModesProduceDifferentPixels                    *Void
 	containerCarriesEveryPopplerBinaryAndTheFont        *Void
+	defaultApkConfigurationIsUntouched                  *Void
 	disablePageBreaksControlsFormFeeds                  *Void
 	dpiDefaultsToOneFiftyAndScalesWithTheSetting        *Void
 	encryptedDocumentNeedsThePassword                   *Void
@@ -82,6 +87,7 @@ type PdfTests struct { // pdf-tests (../../../daggerverse/pdf/tests/main.go:151:
 	textOnImageOnlyPdfReturnsNothing                    *Void
 	textReproducesTextLayerExactly                      *Void
 	txtMatchesText                                      *Void
+	untrustedIndexIsRejectedWithoutApkKey               *Void
 	vectorFormatsIgnoreRasterOnlySettings               *Void
 	versionReportsPopplerRelease                        *Void
 	withFontsPutsFaceWhereFontconfigFindsIt             *Void
@@ -125,6 +131,77 @@ func (r *PdfTests) All(ctx context.Context, opts ...PdfTestsAllOpts) error { // 
 	return q.Execute(ctx)
 }
 
+// ApkAuthInstallsFromAuthenticatedRepository asserts credentials reach the
+// fetch, and that they reach it without becoming part of the image.
+//
+// The second half is the reason the option takes a Secret. A mirror password
+// spelled into a repository URL would land in /etc/apk/repositories, in every
+// apk message quoting it, and in the layer a caller exports — so all three
+// places are searched for it here, and the message is checked to be one that
+// names the repository at all, or its silence about the password would prove
+// nothing.
+func (r *PdfTests) ApkAuthInstallsFromAuthenticatedRepository(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/apk.go:352:1)
+	if r.apkAuthInstallsFromAuthenticatedRepository != nil {
+		return nil
+	}
+	q := r.query.Select("apkAuthInstallsFromAuthenticatedRepository")
+
+	return q.Execute(ctx)
+}
+
+// ApkRepositoryAssemblesWorkingToolchainFromMirror asserts the image can be built
+// entirely out of a caller-supplied repository and that what comes out of it
+// works, which is the whole point of the option.
+//
+// Three things are checked rather than one, because this module's packages fail
+// in three different ways. A missing poppler fails the build outright, so
+// Version covers it. A poppler that installed but cannot run fails the
+// conversion, so the text of the ledger covers that. And a missing font fails
+// nothing at all — poppler substitutes what fontconfig offers, which with no
+// family installed is nothing, and the page renders blank and exits 0. Only the
+// pixels say so.
+func (r *PdfTests) ApkRepositoryAssemblesWorkingToolchainFromMirror(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/apk.go:252:1)
+	if r.apkRepositoryAssemblesWorkingToolchainFromMirror != nil {
+		return nil
+	}
+	q := r.query.Select("apkRepositoryAssemblesWorkingToolchainFromMirror")
+
+	return q.Execute(ctx)
+}
+
+// ApkRepositoryReplacesImageDefaults asserts the first WithApkRepository
+// replaces the image's repository list rather than appending to it, which is
+// what makes every other test here mean what it says: with the CDN still in the
+// file, an install that quietly came from dl-cdn.alpinelinux.org is
+// indistinguishable from one that came from the mirror.
+//
+// It is also the assertion the air-gapped network needs on its own terms. A
+// surviving default there is not a harmless second choice — it is a repository
+// apk consults and waits on until it times out. So the assertion is on the
+// file, and it is that the CDN is *gone*.
+func (r *PdfTests) ApkRepositoryReplacesImageDefaults(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/apk.go:296:1)
+	if r.apkRepositoryReplacesImageDefaults != nil {
+		return nil
+	}
+	q := r.query.Select("apkRepositoryReplacesImageDefaults")
+
+	return q.Execute(ctx)
+}
+
+// AuthenticatedRepositoryIsRejectedWithoutApkAuth asserts the authenticated
+// mirror really is authenticated — that the test above passes because the
+// credentials were supplied and used, and not because the server never asked
+// for any. Both installs run against the one mirror, so WithApkAuth is the
+// only difference between them.
+func (r *PdfTests) AuthenticatedRepositoryIsRejectedWithoutApkAuth(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/apk.go:431:1)
+	if r.authenticatedRepositoryIsRejectedWithoutApkAuth != nil {
+		return nil
+	}
+	q := r.query.Select("authenticatedRepositoryIsRejectedWithoutApkAuth")
+
+	return q.Execute(ctx)
+}
+
 // ColorModesProduceDifferentPixels asserts the three colour modes render three
 // different images.
 //
@@ -137,7 +214,7 @@ func (r *PdfTests) All(ctx context.Context, opts ...PdfTestsAllOpts) error { // 
 // The three properties are mutually exclusive by construction: colour keeps
 // chroma, grey drops chroma but keeps mid-tones, and mono drops both — flat tones
 // are dithered into black and white rather than averaged into grey.
-func (r *PdfTests) ColorModesProduceDifferentPixels(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1427:1)
+func (r *PdfTests) ColorModesProduceDifferentPixels(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1434:1)
 	if r.colorModesProduceDifferentPixels != nil {
 		return nil
 	}
@@ -154,11 +231,28 @@ func (r *PdfTests) ColorModesProduceDifferentPixels(ctx context.Context) error {
 // nothing to substitute for a PDF that names a base-14 face without embedding
 // it, and renders the page blank while exiting 0 — a silent wrong answer, which
 // is the failure mode this assertion exists to keep out.
-func (r *PdfTests) ContainerCarriesEveryPopplerBinaryAndTheFont(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:609:1)
+func (r *PdfTests) ContainerCarriesEveryPopplerBinaryAndTheFont(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:616:1)
 	if r.containerCarriesEveryPopplerBinaryAndTheFont != nil {
 		return nil
 	}
 	q := r.query.Select("containerCarriesEveryPopplerBinaryAndTheFont")
+
+	return q.Execute(ctx)
+}
+
+// DefaultApkConfigurationIsUntouched asserts an image built without any of
+// these options is the image this module built before they existed: the stock
+// repository list, and no credential plumbing at all.
+//
+// It is the guard against the cheap implementation of all of the above —
+// writing a repositories file, or setting the credential variable,
+// unconditionally — which would work for the mirror and rebuild the world for
+// every existing caller.
+func (r *PdfTests) DefaultApkConfigurationIsUntouched(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/apk.go:453:1)
+	if r.defaultApkConfigurationIsUntouched != nil {
+		return nil
+	}
+	q := r.query.Select("defaultApkConfigurationIsUntouched")
 
 	return q.Execute(ctx)
 }
@@ -170,7 +264,7 @@ func (r *PdfTests) ContainerCarriesEveryPopplerBinaryAndTheFont(ctx context.Cont
 // defaulting to true because a `Go SDK — the zero value is dropped before it reaches the API — so the
 // affirmative spelling would have produced an option no caller could turn off.
 // That makes the second half of this test the one that would have caught it.
-func (r *PdfTests) DisablePageBreaksControlsFormFeeds(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1144:1)
+func (r *PdfTests) DisablePageBreaksControlsFormFeeds(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1151:1)
 	if r.disablePageBreaksControlsFormFeeds != nil {
 		return nil
 	}
@@ -186,7 +280,7 @@ func (r *PdfTests) DisablePageBreaksControlsFormFeeds(ctx context.Context) error
 // remembered pixel count, so the assertion says "150 dpi of a US Letter page"
 // rather than "1275 by 1650" — which is the claim the documentation actually
 // makes.
-func (r *PdfTests) DpiDefaultsToOneFiftyAndScalesWithTheSetting(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1326:1)
+func (r *PdfTests) DpiDefaultsToOneFiftyAndScalesWithTheSetting(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1333:1)
 	if r.dpiDefaultsToOneFiftyAndScalesWithTheSetting != nil {
 		return nil
 	}
@@ -210,7 +304,7 @@ func (r *PdfTests) DpiDefaultsToOneFiftyAndScalesWithTheSetting(ctx context.Cont
 // poppler alike through the environment rather than argv: a password in argv is
 // visible in every Dagger trace, which is exactly what the module's own posture
 // avoids.
-func (r *PdfTests) EncryptedDocumentNeedsThePassword(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1852:1)
+func (r *PdfTests) EncryptedDocumentNeedsThePassword(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1859:1)
 	if r.encryptedDocumentNeedsThePassword != nil {
 		return nil
 	}
@@ -232,7 +326,7 @@ func (r *PdfTests) EncryptedDocumentNeedsThePassword(ctx context.Context) error 
 // Each file is then checked to be an EPS in its own right — the EPSF version
 // header, and exactly one page in it — because a loop that wrote twelve copies
 // of page one would satisfy the names alone.
-func (r *PdfTests) EpsWritesEveryPageOfTheDocument(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:285:1)
+func (r *PdfTests) EpsWritesEveryPageOfTheDocument(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:292:1)
 	if r.epsWritesEveryPageOfTheDocument != nil {
 		return nil
 	}
@@ -251,7 +345,7 @@ func (r *PdfTests) EpsWritesEveryPageOfTheDocument(ctx context.Context) error { 
 // it, its two pages naming different faces, because narrowing a report of
 // ledgerPdf — every page of which names the same Helvetica — changes nothing at
 // all and would pass against a module that ignored the bounds entirely.
-func (r *PdfTests) FontsNarrowsToThePageRange(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:769:1)
+func (r *PdfTests) FontsNarrowsToThePageRange(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:776:1)
 	if r.fontsNarrowsToThePageRange != nil {
 		return nil
 	}
@@ -274,7 +368,7 @@ func (r *PdfTests) FontsNarrowsToThePageRange(ctx context.Context) error { // pd
 // construction, so the report has to read `yes` for it; without that contrast
 // the assertion would pass just as well on a report that said `no` about
 // everything, including one produced by a module that had hardcoded the answer.
-func (r *PdfTests) FontsReportsWhetherEachFaceIsEmbedded(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:714:1)
+func (r *PdfTests) FontsReportsWhetherEachFaceIsEmbedded(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:721:1)
 	if r.fontsReportsWhetherEachFaceIsEmbedded != nil {
 		return nil
 	}
@@ -297,7 +391,7 @@ func (r *PdfTests) FontsReportsWhetherEachFaceIsEmbedded(ctx context.Context) er
 //
 // Two fixtures are needed because no one page is both: ledger.pdf is text and no
 // images, scan.pdf is one image and no text.
-func (r *PdfTests) HTMLCarriesPageMarkupAndItsImages(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:377:1)
+func (r *PdfTests) HTMLCarriesPageMarkupAndItsImages(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:384:1)
 	if r.htmlCarriesPageMarkupAndItsImages != nil {
 		return nil
 	}
@@ -362,7 +456,7 @@ func (r *PdfTests) UnmarshalJSON(bs []byte) error {
 // first: PageCount parses Info's `Pages:` line, so a change to how Info is
 // captured that broke the parse would otherwise show up only in whatever used
 // PageCount next.
-func (r *PdfTests) InfoReportsPageCountAndSize(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:673:1)
+func (r *PdfTests) InfoReportsPageCountAndSize(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:680:1)
 	if r.infoReportsPageCountAndSize != nil {
 		return nil
 	}
@@ -378,7 +472,7 @@ func (r *PdfTests) InfoReportsPageCountAndSize(ctx context.Context) error { // p
 // `-jpeg` writes `.jpg` and `-tiff` writes `.tif`, which are poppler's spellings
 // and not this module's: a caller building a path from the function's name would
 // get them wrong, so they are part of the documented contract.
-func (r *PdfTests) JpegAndTiffFollowTheSameContract(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1502:1)
+func (r *PdfTests) JpegAndTiffFollowTheSameContract(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1509:1)
 	if r.jpegAndTiffFollowTheSameContract != nil {
 		return nil
 	}
@@ -398,7 +492,7 @@ func (r *PdfTests) JpegAndTiffFollowTheSameContract(ctx context.Context) error {
 // physical layout puts the two columns side by side on one output line. A fixture
 // whose stream order matched its reading order would let two of these three pass
 // on the same output.
-func (r *PdfTests) LayoutModesProduceDifferentOrderings(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1181:1)
+func (r *PdfTests) LayoutModesProduceDifferentOrderings(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1188:1)
 	if r.layoutModesProduceDifferentOrderings != nil {
 		return nil
 	}
@@ -416,7 +510,7 @@ func (r *PdfTests) LayoutModesProduceDifferentOrderings(ctx context.Context) err
 // that was already sorted. Reading the text back is what says the pages landed
 // where they were put: the page count alone would pass on a merge that shuffled
 // them.
-func (r *PdfTests) MergePreservesTheOrderOfItsSources(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1639:1)
+func (r *PdfTests) MergePreservesTheOrderOfItsSources(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1646:1)
 	if r.mergePreservesTheOrderOfItsSources != nil {
 		return nil
 	}
@@ -437,7 +531,7 @@ func (r *PdfTests) MergePreservesTheOrderOfItsSources(ctx context.Context) error
 // the file it could not read, and the name it uses is this module's mount path,
 // so without the legend the one piece of information identifying which argument
 // was at fault is a path the caller has never seen.
-func (r *PdfTests) MergeRejectsWhatItCannotMerge(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1691:1)
+func (r *PdfTests) MergeRejectsWhatItCannotMerge(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1698:1)
 	if r.mergeRejectsWhatItCannotMerge != nil {
 		return nil
 	}
@@ -461,7 +555,7 @@ func (r *PdfTests) MergeRejectsWhatItCannotMerge(ctx context.Context) error { //
 // indistinguishable from a function that did not run, so the module answers with
 // a line naming the absence and pointing at the report that does carry the
 // document's metadata.
-func (r *PdfTests) MetadataReturnsTheXmpPacketOrSaysThereIsNone(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:831:1)
+func (r *PdfTests) MetadataReturnsTheXmpPacketOrSaysThereIsNone(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:838:1)
 	if r.metadataReturnsTheXmpPacketOrSaysThereIsNone != nil {
 		return nil
 	}
@@ -484,7 +578,7 @@ func (r *PdfTests) MetadataReturnsTheXmpPacketOrSaysThereIsNone(ctx context.Cont
 // the range, which is why pages 4 through 6 come out `page-0004` through
 // `page-0006` — the same promise the raster contract makes, so a page stays
 // traceable to the page it came from whichever format it was rendered to.
-func (r *PdfTests) PageRangeNarrowsEveryPerPageFormat(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:454:1)
+func (r *PdfTests) PageRangeNarrowsEveryPerPageFormat(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:461:1)
 	if r.pageRangeNarrowsEveryPerPageFormat != nil {
 		return nil
 	}
@@ -496,7 +590,7 @@ func (r *PdfTests) PageRangeNarrowsEveryPerPageFormat(ctx context.Context) error
 // PageRangeNarrowsText asserts WithPageRange narrows extraction to the pages it
 // names, and that the bounds are the 1-based inclusive ones poppler uses rather
 // than an offset and a length.
-func (r *PdfTests) PageRangeNarrowsText(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1066:1)
+func (r *PdfTests) PageRangeNarrowsText(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1073:1)
 	if r.pageRangeNarrowsText != nil {
 		return nil
 	}
@@ -508,7 +602,7 @@ func (r *PdfTests) PageRangeNarrowsText(ctx context.Context) error { // pdf-test
 // PageRangeOpenEndedRunsToTheLastPage asserts a zero last means "to the end",
 // which is the only way to name an open-ended range without first asking how
 // many pages the document has.
-func (r *PdfTests) PageRangeOpenEndedRunsToTheLastPage(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1085:1)
+func (r *PdfTests) PageRangeOpenEndedRunsToTheLastPage(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1092:1)
 	if r.pageRangeOpenEndedRunsToTheLastPage != nil {
 		return nil
 	}
@@ -524,7 +618,7 @@ func (r *PdfTests) PageRangeOpenEndedRunsToTheLastPage(ctx context.Context) erro
 // renders nothing for them and exits 0, so a caller who asked for page 20 of a
 // 12-page document would otherwise get an empty result indistinguishable from a
 // document with no text in it.
-func (r *PdfTests) PageRangeRejectsInvalidBounds(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1108:1)
+func (r *PdfTests) PageRangeRejectsInvalidBounds(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1115:1)
 	if r.pageRangeRejectsInvalidBounds != nil {
 		return nil
 	}
@@ -544,7 +638,7 @@ func (r *PdfTests) PageRangeRejectsInvalidBounds(ctx context.Context) error { //
 // has no way to know which width it is holding. Asserting the full ordered list
 // covers both halves of the promise: the names, and that lexicographic order is
 // page order.
-func (r *PdfTests) PngNamesEveryPageWithFourDigits(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1253:1)
+func (r *PdfTests) PngNamesEveryPageWithFourDigits(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1260:1)
 	if r.pngNamesEveryPageWithFourDigits != nil {
 		return nil
 	}
@@ -564,7 +658,7 @@ func (r *PdfTests) PngNamesEveryPageWithFourDigits(ctx context.Context) error { 
 // The numbers are the source document's page numbers and not positions within
 // the range, which is why the second case starts at `page-0004.png`. That keeps a
 // rendered page traceable back to the page it came from.
-func (r *PdfTests) PngNarrowedRangeKeepsFourDigitNames(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1272:1)
+func (r *PdfTests) PngNarrowedRangeKeepsFourDigitNames(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1279:1)
 	if r.pngNarrowedRangeKeepsFourDigitNames != nil {
 		return nil
 	}
@@ -582,7 +676,7 @@ func (r *PdfTests) PngNarrowedRangeKeepsFourDigitNames(ctx context.Context) erro
 // document keeps the longer document's width. A consumer globbing for
 // `page-*.png` finds nothing in the first case and a caller indexing by name
 // finds the wrong file in the second.
-func (r *PdfTests) PngSinglePageIsStillNumbered(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1299:1)
+func (r *PdfTests) PngSinglePageIsStillNumbered(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1306:1)
 	if r.pngSinglePageIsStillNumbered != nil {
 		return nil
 	}
@@ -599,7 +693,7 @@ func (r *PdfTests) PngSinglePageIsStillNumbered(ctx context.Context) error { // 
 // directory of one-page fragments would be the wrong answer even though it would
 // look tidier beside Svg and Eps. Counting the markers is what says the pages
 // reached the file rather than only the header saying they did.
-func (r *PdfTests) PsHoldsEveryPageInOneFile(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:334:1)
+func (r *PdfTests) PsHoldsEveryPageInOneFile(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:341:1)
 	if r.psHoldsEveryPageInOneFile != nil {
 		return nil
 	}
@@ -613,7 +707,7 @@ func (r *PdfTests) PsHoldsEveryPageInOneFile(ctx context.Context) error { // pdf
 //
 // Left to poppler these arrive much later as a complaint about `-r` or
 // `-scale-to`, which names a flag the caller never wrote.
-func (r *PdfTests) RenderSettingsRejectNonPositiveValues(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1389:1)
+func (r *PdfTests) RenderSettingsRejectNonPositiveValues(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1396:1)
 	if r.renderSettingsRejectNonPositiveValues != nil {
 		return nil
 	}
@@ -634,7 +728,7 @@ func (r *PdfTests) RenderSettingsRejectNonPositiveValues(ctx context.Context) er
 // reports every wrong password as `Incorrect password` whether one was supplied
 // or not, so the message has to distinguish what the module knows and poppler
 // does not.
-func (r *PdfTests) ReportsOpenAnEncryptedDocumentWithThePassword(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:907:1)
+func (r *PdfTests) ReportsOpenAnEncryptedDocumentWithThePassword(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:914:1)
 	if r.reportsOpenAnEncryptedDocumentWithThePassword != nil {
 		return nil
 	}
@@ -650,7 +744,7 @@ func (r *PdfTests) ReportsOpenAnEncryptedDocumentWithThePassword(ctx context.Con
 // resolution flag off the command line rather than by relying on poppler's own
 // precedence, so this is the assertion that would catch the two being emitted
 // together and whichever poppler happened to prefer winning silently.
-func (r *PdfTests) ScaleToOverridesDpi(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1358:1)
+func (r *PdfTests) ScaleToOverridesDpi(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1365:1)
 	if r.scaleToOverridesDpi != nil {
 		return nil
 	}
@@ -673,7 +767,7 @@ func (r *PdfTests) ScaleToOverridesDpi(ctx context.Context) error { // pdf-tests
 // an image carrying no certificate database, which is every image this module
 // builds, and a report assembled from both streams would carry that line into
 // every caller's output as though it were something the document said.
-func (r *PdfTests) SignaturesReportsAnUnsignedDocumentInsteadOfFailing(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:881:1)
+func (r *PdfTests) SignaturesReportsAnUnsignedDocumentInsteadOfFailing(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:888:1)
 	if r.signaturesReportsAnUnsignedDocumentInsteadOfFailing != nil {
 		return nil
 	}
@@ -694,7 +788,7 @@ func (r *PdfTests) SignaturesReportsAnUnsignedDocumentInsteadOfFailing(ctx conte
 // that would send a caller to a builder that changes nothing, which is why the
 // password case is asserted alongside the passwordless one: both have to arrive
 // at the same message.
-func (r *PdfTests) SplitAndMergeCannotOpenAnEncryptedDocument(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1789:1)
+func (r *PdfTests) SplitAndMergeCannotOpenAnEncryptedDocument(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1796:1)
 	if r.splitAndMergeCannotOpenAnEncryptedDocument != nil {
 		return nil
 	}
@@ -713,7 +807,7 @@ func (r *PdfTests) SplitAndMergeCannotOpenAnEncryptedDocument(ctx context.Contex
 // caller gets a message about poppler's internals attached to a directory that
 // was half written. Checking the bounds against the document first is what turns
 // that into a sentence naming the builder and the page count.
-func (r *PdfTests) SplitNarrowsToThePageRange(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1594:1)
+func (r *PdfTests) SplitNarrowsToThePageRange(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1601:1)
 	if r.splitNarrowsToThePageRange != nil {
 		return nil
 	}
@@ -735,7 +829,7 @@ func (r *PdfTests) SplitNarrowsToThePageRange(ctx context.Context) error { // pd
 // The names the split wrote are what the merge is driven by, in page order, which
 // is also the practical shape of the pair: split, do something to the pages,
 // merge the ones that survived.
-func (r *PdfTests) SplitThenMergeRoundTripsTheDocument(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1735:1)
+func (r *PdfTests) SplitThenMergeRoundTripsTheDocument(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1742:1)
 	if r.splitThenMergeRoundTripsTheDocument != nil {
 		return nil
 	}
@@ -757,7 +851,7 @@ func (r *PdfTests) SplitThenMergeRoundTripsTheDocument(ctx context.Context) erro
 // pdfseparate numbers with the width the caller's pattern asks for rather than
 // with the document's page count, so the four-digit contract here is this
 // module's and not a coincidence of the fixture's length.
-func (r *PdfTests) SplitWritesOnePdfPerPage(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1550:1)
+func (r *PdfTests) SplitWritesOnePdfPerPage(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1557:1)
 	if r.splitWritesOnePdfPerPage != nil {
 		return nil
 	}
@@ -781,7 +875,7 @@ func (r *PdfTests) SplitWritesOnePdfPerPage(ctx context.Context) error { // pdf-
 // anywhere. Poppler converts text to glyph outlines rather than to `<text>`, so
 // the marker words are not in the file at all — a Contains check for one would
 // fail on a perfectly good SVG.
-func (r *PdfTests) SvgWritesOneVectorFilePerPage(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:242:1)
+func (r *PdfTests) SvgWritesOneVectorFilePerPage(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:249:1)
 	if r.svgWritesOneVectorFilePerPage != nil {
 		return nil
 	}
@@ -800,7 +894,7 @@ func (r *PdfTests) SvgWritesOneVectorFilePerPage(ctx context.Context) error { //
 // a caller gets that this document needs rasterizing and handing to OCR. A
 // module that failed here instead would make the two paths impossible to choose
 // between programmatically.
-func (r *PdfTests) TextOnImageOnlyPdfReturnsNothing(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1016:1)
+func (r *PdfTests) TextOnImageOnlyPdfReturnsNothing(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1023:1)
 	if r.textOnImageOnlyPdfReturnsNothing != nil {
 		return nil
 	}
@@ -818,7 +912,7 @@ func (r *PdfTests) TextOnImageOnlyPdfReturnsNothing(ctx context.Context) error {
 // leading newline, pages in the wrong order — is a defect and not a recognition
 // error. A fixture whose content streams are readable is what makes an exact
 // expectation writable at all.
-func (r *PdfTests) TextReproducesTextLayerExactly(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:995:1)
+func (r *PdfTests) TextReproducesTextLayerExactly(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1002:1)
 	if r.textReproducesTextLayerExactly != nil {
 		return nil
 	}
@@ -834,11 +928,35 @@ func (r *PdfTests) TextReproducesTextLayerExactly(ctx context.Context) error { /
 // straight off the handle: the point of Txt is that the bytes reach a filesystem
 // intact, and File.Contents would confirm the engine's copy while saying nothing
 // about the export a real consumer performs.
-func (r *PdfTests) TxtMatchesText(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1039:1)
+func (r *PdfTests) TxtMatchesText(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1046:1)
 	if r.txtMatchesText != nil {
 		return nil
 	}
 	q := r.query.Select("txtMatchesText")
+
+	return q.Execute(ctx)
+}
+
+// UntrustedIndexIsRejectedWithoutApkKey asserts a repository whose index is
+// signed by a key the image does not trust is refused rather than installed
+// from, so WithApkKey is doing verification and not decoration. It is also what
+// says `--allow-untrusted` is genuinely not on offer: a module that quietly
+// installed from an unverifiable index would make the air-gapped path the least
+// trustworthy one.
+//
+// The failing half is the suite's proof that nothing falls back to the CDN
+// either. The two installs differ only in the key, so if a rejected index sent
+// apk to dl-cdn.alpinelinux.org for the same packages the build would succeed
+// and this test would fail.
+//
+// Asserting on apk's own wording (it says `UNTRUSTED signature`) is not
+// available: an exec failure crosses the module boundary as its exit status,
+// with the output left in the logs.
+func (r *PdfTests) UntrustedIndexIsRejectedWithoutApkKey(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/apk.go:329:1)
+	if r.untrustedIndexIsRejectedWithoutApkKey != nil {
+		return nil
+	}
+	q := r.query.Select("untrustedIndexIsRejectedWithoutApkKey")
 
 	return q.Execute(ctx)
 }
@@ -856,7 +974,7 @@ func (r *PdfTests) TxtMatchesText(ctx context.Context) error { // pdf-tests (../
 //
 // WithDpi is the one setting that does reach pdftocairo, and it is set here too
 // so this is not accidentally asserting that no flags are passed at all.
-func (r *PdfTests) VectorFormatsIgnoreRasterOnlySettings(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:504:1)
+func (r *PdfTests) VectorFormatsIgnoreRasterOnlySettings(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:511:1)
 	if r.vectorFormatsIgnoreRasterOnlySettings != nil {
 		return nil
 	}
@@ -874,7 +992,7 @@ func (r *PdfTests) VectorFormatsIgnoreRasterOnlySettings(ctx context.Context) er
 // exact patch: Alpine may rebuild poppler-utils within the v3.24 branch, and a
 // test that pins the patch level would fail on a change this module has no
 // opinion about.
-func (r *PdfTests) VersionReportsPopplerRelease(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:583:1)
+func (r *PdfTests) VersionReportsPopplerRelease(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:590:1)
 	if r.versionReportsPopplerRelease != nil {
 		return nil
 	}
@@ -892,7 +1010,7 @@ func (r *PdfTests) VersionReportsPopplerRelease(ctx context.Context) error { // 
 // module installs, so the negative control is real — the plain image genuinely
 // cannot see it, and the assertion is not passing on something the base image
 // already had.
-func (r *PdfTests) WithFontsPutsFaceWhereFontconfigFindsIt(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:643:1)
+func (r *PdfTests) WithFontsPutsFaceWhereFontconfigFindsIt(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:650:1)
 	if r.withFontsPutsFaceWhereFontconfigFindsIt != nil {
 		return nil
 	}
@@ -908,7 +1026,7 @@ func (r *PdfTests) WithFontsPutsFaceWhereFontconfigFindsIt(ctx context.Context) 
 // a render of it is the annotation's appearance stream and nothing else. Without
 // that separation the assertion could not tell an annotation that was not drawn
 // from one that was drawn somewhere else on the page.
-func (r *PdfTests) WithoutAnnotationsRemovesTheAnnotationLayer(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1469:1)
+func (r *PdfTests) WithoutAnnotationsRemovesTheAnnotationLayer(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1476:1)
 	if r.withoutAnnotationsRemovesTheAnnotationLayer != nil {
 		return nil
 	}

--- a/daggerverse/pdf/tests/apk.go
+++ b/daggerverse/pdf/tests/apk.go
@@ -1,0 +1,479 @@
+package main
+
+// apk.go covers the air-gapped story: installing the module's packages from an
+// Alpine repository the caller controls rather than from dl-cdn.alpinelinux.org.
+//
+// The repository the tests install from is a real one — a real package set, a
+// real signed index, served over real HTTP by a Dagger service — because every
+// part of what these tests are about lives in apk rather than in this module:
+// whether a replaced /etc/apk/repositories is honoured, whether an index signed
+// by an unknown key is refused, whether credentials reach the fetch. Asserting
+// on the flags the module passes would test none of it.
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"dagger/tests/internal/dagger"
+)
+
+const (
+	// mirrorImage is what the mirror is built and served on: the same Alpine
+	// release the module pins, so the packages the mirror carries are exactly
+	// the packages the module would otherwise have fetched from the CDN.
+	mirrorImage = "docker.io/library/alpine:3.24"
+
+	// mirrorPackages is what the mirror has to carry to stand in for the public
+	// repositories completely. It is the module's whole install line and not
+	// just poppler: the font is what a PDF naming an unembedded base-14 face is
+	// rendered with, and a mirror without it produces an image that builds,
+	// exits 0, and draws blank pages.
+	mirrorPackages = popplerPkg + " " + fontPkg
+
+	// popplerPkg is the package carrying the pdf* binaries. fontPkg is declared
+	// alongside the rest of the suite's constants in main.go.
+	popplerPkg = "poppler-utils"
+
+	// mirrorBuildDir is the repository tree the build container assembles —
+	// one architecture directory holding the packages and the signed index —
+	// and mirrorKeyDir the keypair it signs with.
+	mirrorBuildDir = "/mirror"
+	mirrorKeyDir   = "/keys"
+
+	// mirrorKeyName is the file name of the key the index is signed with, and
+	// it is load-bearing at both ends: abuild-sign writes the name into the
+	// index's signature and apk looks that exact file up in /etc/apk/keys. It
+	// is what WithApkKey has to preserve, and the reason that option takes a
+	// file rather than the key's bytes.
+	mirrorKeyName = "pdf-mirror.rsa.pub"
+	mirrorKeyFile = mirrorKeyDir + "/pdf-mirror.rsa"
+
+	// mirrorRoot is the served document root and mirrorPath the path under it
+	// the repository sits at. The repository is not at the root of the host on
+	// purpose: a URL whose path is dropped would still resolve, and that is a
+	// bug this suite should catch rather than tolerate.
+	mirrorRoot = "/srv"
+	mirrorPath = "alpine"
+
+	// mirrorPort is where the mirror listens. It is above 1024 so the server
+	// needs no privileges it would not have anyway.
+	mirrorPort = 8080
+
+	// mirrorUser is the account the authenticated mirror requires. Its
+	// password is generated per run rather than written down here.
+	mirrorUser = "pdf"
+
+	// httpdPkg is the server the mirror is published with. Alpine's busybox
+	// carries no httpd applet, and what this needs beyond serving a directory
+	// is one flag's worth of basic authentication — which darkhttpd has and
+	// nginx would want a config file and a password-hashing tool for.
+	httpdPkg = "darkhttpd"
+
+	// apkRepositoriesFile is the list `apk add` resolves packages from, and
+	// therefore the file that says whether the image's defaults survived.
+	apkRepositoriesFile = "/etc/apk/repositories"
+
+	// alpineCdnHost appears in every repository line a stock Alpine image
+	// ships, and in none that WithApkRepository writes.
+	alpineCdnHost = "dl-cdn.alpinelinux.org"
+
+	// apkNetrcEnv is the variable WithApkAuth points at its mounted
+	// credentials, and apkNetrcPath the mount it names. An image built without
+	// that option must carry neither.
+	apkNetrcEnv  = "NETRC"
+	apkNetrcPath = "/run/apk/netrc"
+)
+
+// mirrorBuildScript assembles the private repository.
+//
+// The packages are fetched with their whole dependency closure rather than
+// listed by hand: a mirror missing one transitive library fails the same way a
+// missing repository does, and would make these tests assert on the wrong
+// thing.
+//
+// `--rewrite-arch` is not decoration. apk resolves a package's path as
+// `$base/$arch/$name-$version.apk` using the *package's* architecture, so the
+// `noarch` packages in the closure — the font family among them, fonts being
+// architecture-independent — would be looked for under a `noarch/` directory
+// that no mirror has. Alpine's own index generation rewrites them for the same
+// reason; without it the font fails to install while poppler succeeds, which is
+// this module's quietest failure dressed up as a flake.
+//
+// The index is signed because an unsigned one is not a lesser mirror, it is an
+// unusable one: apk refuses an index it cannot verify rather than installing
+// from it, and `--allow-untrusted` is deliberately not something this module
+// offers.
+const mirrorBuildScript = `set -e
+arch=$(apk --print-arch)
+apk update
+apk add abuild openssl
+mkdir -p ` + mirrorBuildDir + `/$arch ` + mirrorKeyDir + `
+openssl genrsa -out ` + mirrorKeyFile + ` 2048
+openssl rsa -in ` + mirrorKeyFile + ` -pubout -out ` + mirrorKeyDir + `/` + mirrorKeyName + `
+apk fetch --recursive --output ` + mirrorBuildDir + `/$arch ` + mirrorPackages + `
+cd ` + mirrorBuildDir + `/$arch
+apk index --rewrite-arch $arch --output APKINDEX.tar.gz *.apk
+abuild-sign -k ` + mirrorKeyFile + ` -p ` + mirrorKeyName + ` APKINDEX.tar.gz`
+
+// ------------------------------------------------------------------ the mirror
+
+// apkMirror is a private Alpine repository standing in for the one an
+// air-gapped network would run: a signed package set on a host that is not the
+// CDN, optionally behind credentials.
+type apkMirror struct {
+	// URL is the repository base, spelled the way it would be spelled in
+	// /etc/apk/repositories.
+	URL string
+	// Key is the public half of what the index was signed with, named the way
+	// the signature names it.
+	Key *dagger.File
+	// Auth carries the mirror's credentials in netrc form, and is nil for a
+	// mirror that asks for none.
+	Auth *dagger.Secret
+	// Password is the plaintext inside Auth, kept so a test can go looking for
+	// it in places it must never turn up.
+	Password string
+}
+
+// startApkMirror builds the repository, serves it, and returns what a caller
+// needs to install from it.
+//
+// The service is started here rather than left to the first use: nothing binds
+// it into the module's containers, so it is reached by the hostname the engine
+// gives a running service, and that hostname does not exist until it runs.
+func startApkMirror(ctx context.Context, authenticated bool) (*apkMirror, error) {
+	build, err := mirrorBuild(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	srv := dag.Container().
+		From(mirrorImage).
+		WithExec([]string{"apk", "add", "--no-cache", httpdPkg}).
+		WithDirectory(mirrorRoot+"/"+mirrorPath, build.Directory(mirrorBuildDir)).
+		WithExposedPort(mirrorPort)
+	args := []string{httpdPkg, mirrorRoot, "--port", strconv.Itoa(mirrorPort)}
+
+	var password string
+	if authenticated {
+		if password, err = mirrorCredential(ctx); err != nil {
+			return nil, err
+		}
+		args = append(args, "--auth", mirrorUser+":"+password)
+	}
+
+	// The server goes in Args rather than in a WithExec: a server does not
+	// exit, so building it as a step would hang before ever becoming a
+	// service.
+	svc := srv.AsService(dagger.ContainerAsServiceOpts{Args: args})
+	if _, err := svc.Start(ctx); err != nil {
+		return nil, fmt.Errorf("start the apk mirror: %w", err)
+	}
+	host, err := svc.Hostname(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("apk mirror hostname: %w", err)
+	}
+
+	mirror := &apkMirror{
+		URL: fmt.Sprintf("http://%s:%d/%s", host, mirrorPort, mirrorPath),
+		Key: build.File(mirrorKeyDir + "/" + mirrorKeyName),
+	}
+	if authenticated {
+		// The stanza names the host and not the port, which is all libfetch
+		// matches on. The secret's name is unique per run because two secrets
+		// sharing a name in one session are one secret, and every
+		// authenticated mirror here has its own password.
+		nonce, err := mirrorCredential(ctx)
+		if err != nil {
+			return nil, err
+		}
+		mirror.Auth = dag.SetSecret(
+			"apk-mirror-netrc-"+nonce,
+			fmt.Sprintf("machine %s login %s password %s\n", host, mirrorUser, password))
+		mirror.Password = password
+	}
+	return mirror, nil
+}
+
+// mirrorBuild returns the container the repository and its keypair are lifted
+// out of.
+//
+// It is resolved to an ID and loaded back before anything is selected off it,
+// because the build generates a keypair: two selections off an unpinned
+// generator are two evaluations, and a repository signed by one key with the
+// other key's public half published beside it is a mirror nothing can install
+// from.
+func mirrorBuild(ctx context.Context) (*dagger.Container, error) {
+	id, err := dag.Container().
+		From(mirrorImage).
+		WithExec([]string{"sh", "-c", mirrorBuildScript}).
+		ID(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("build the apk mirror: %w", err)
+	}
+	return dag.LoadContainerFromID(dagger.ContainerID(id)), nil
+}
+
+// apply points the module at this mirror and at nothing else.
+func (m *apkMirror) apply(p *dagger.Pdf) *dagger.Pdf {
+	p = p.WithApkRepository(m.URL).WithApkKey(m.Key)
+	if m.Auth != nil {
+		p = p.WithApkAuth(m.Auth)
+	}
+	return p
+}
+
+// mirrorCredential returns a secret that exists only for the run that generated
+// it, so no test password is ever committed. It is the same generator the
+// encryption tests draw their passwords from.
+func mirrorCredential(ctx context.Context) (string, error) {
+	hex, err := dag.Random().Sha256(ctx, dagger.RandomSha256Opts{N: 32})
+	if err != nil {
+		return "", fmt.Errorf("generate a mirror credential: %w", err)
+	}
+	return hex, nil
+}
+
+// ------------------------------------------------------------------- the tests
+
+// ApkRepositoryAssemblesWorkingToolchainFromMirror asserts the image can be built
+// entirely out of a caller-supplied repository and that what comes out of it
+// works, which is the whole point of the option.
+//
+// Three things are checked rather than one, because this module's packages fail
+// in three different ways. A missing poppler fails the build outright, so
+// Version covers it. A poppler that installed but cannot run fails the
+// conversion, so the text of the ledger covers that. And a missing font fails
+// nothing at all — poppler substitutes what fontconfig offers, which with no
+// family installed is nothing, and the page renders blank and exits 0. Only the
+// pixels say so.
+func (t *Tests) ApkRepositoryAssemblesWorkingToolchainFromMirror(ctx context.Context) error {
+	mirror, err := startApkMirror(ctx, false)
+	if err != nil {
+		return err
+	}
+	mirrored := mirror.apply(pdf())
+
+	version, err := mirrored.Version(ctx)
+	if err != nil {
+		return fmt.Errorf("Version off a private mirror: %w", err)
+	}
+	if !strings.HasPrefix(version, "25.") {
+		return fmt.Errorf("expected a 25.x poppler off the mirror, got %q", version)
+	}
+
+	doc := mirrored.Document(fixture(ledgerPdf))
+	text, err := doc.Convert().Text(ctx)
+	if err != nil {
+		return fmt.Errorf("Text off a private mirror: %w", err)
+	}
+	if want := ledgerText(1, ledgerPages); text != want {
+		return fmt.Errorf("expected text:\n%q\ngot:\n%q", want, text)
+	}
+
+	stats, err := firstPagePixels(ctx, doc.WithPageRange(1, 1).Convert().Png(), "apk-mirror")
+	if err != nil {
+		return err
+	}
+	if stats.ink == 0 {
+		return fmt.Errorf("expected a rendered page off the mirror to carry ink, got %d white pixels and nothing else", stats.total)
+	}
+	return nil
+}
+
+// ApkRepositoryReplacesImageDefaults asserts the first WithApkRepository
+// replaces the image's repository list rather than appending to it, which is
+// what makes every other test here mean what it says: with the CDN still in the
+// file, an install that quietly came from dl-cdn.alpinelinux.org is
+// indistinguishable from one that came from the mirror.
+//
+// It is also the assertion the air-gapped network needs on its own terms. A
+// surviving default there is not a harmless second choice — it is a repository
+// apk consults and waits on until it times out. So the assertion is on the
+// file, and it is that the CDN is *gone*.
+func (t *Tests) ApkRepositoryReplacesImageDefaults(ctx context.Context) error {
+	mirror, err := startApkMirror(ctx, false)
+	if err != nil {
+		return err
+	}
+	got, err := readRepositories(ctx, mirror.apply(pdf()))
+	if err != nil {
+		return err
+	}
+	if strings.Contains(got, alpineCdnHost) {
+		return fmt.Errorf("expected %s gone from %s, got:\n%s", alpineCdnHost, apkRepositoriesFile, got)
+	}
+	if strings.TrimSpace(got) != mirror.URL {
+		return fmt.Errorf("expected %s to hold only %q, got:\n%s", apkRepositoriesFile, mirror.URL, got)
+	}
+	return nil
+}
+
+// UntrustedIndexIsRejectedWithoutApkKey asserts a repository whose index is
+// signed by a key the image does not trust is refused rather than installed
+// from, so WithApkKey is doing verification and not decoration. It is also what
+// says `--allow-untrusted` is genuinely not on offer: a module that quietly
+// installed from an unverifiable index would make the air-gapped path the least
+// trustworthy one.
+//
+// The failing half is the suite's proof that nothing falls back to the CDN
+// either. The two installs differ only in the key, so if a rejected index sent
+// apk to dl-cdn.alpinelinux.org for the same packages the build would succeed
+// and this test would fail.
+//
+// Asserting on apk's own wording (it says `UNTRUSTED signature`) is not
+// available: an exec failure crosses the module boundary as its exit status,
+// with the output left in the logs.
+func (t *Tests) UntrustedIndexIsRejectedWithoutApkKey(ctx context.Context) error {
+	mirror, err := startApkMirror(ctx, false)
+	if err != nil {
+		return err
+	}
+	if _, err := mirror.apply(pdf()).Version(ctx); err != nil {
+		return fmt.Errorf("Version off a mirror whose key was supplied: %w", err)
+	}
+	if _, err := pdf().WithApkRepository(mirror.URL).Version(ctx); err == nil {
+		return fmt.Errorf("expected an index signed by an untrusted key to be refused, got a working image")
+	}
+	return nil
+}
+
+// ApkAuthInstallsFromAuthenticatedRepository asserts credentials reach the
+// fetch, and that they reach it without becoming part of the image.
+//
+// The second half is the reason the option takes a Secret. A mirror password
+// spelled into a repository URL would land in /etc/apk/repositories, in every
+// apk message quoting it, and in the layer a caller exports — so all three
+// places are searched for it here, and the message is checked to be one that
+// names the repository at all, or its silence about the password would prove
+// nothing.
+func (t *Tests) ApkAuthInstallsFromAuthenticatedRepository(ctx context.Context) error {
+	mirror, err := startApkMirror(ctx, true)
+	if err != nil {
+		return err
+	}
+	configured := mirror.apply(pdf())
+	ctr := configured.Container()
+	if _, err := ctr.WithExec([]string{"pdftotext", "-v"}).Stderr(ctx); err != nil {
+		return fmt.Errorf("install from an authenticated mirror: %w", err)
+	}
+
+	// The repository list is the file the credentials would have ended up in
+	// had they been userinfo in the URL.
+	repositories, err := readRepositories(ctx, configured)
+	if err != nil {
+		return err
+	}
+	if strings.Contains(repositories, mirror.Password) || strings.Contains(repositories, mirrorUser+":") {
+		return fmt.Errorf("expected no credentials in %s, got:\n%s", apkRepositoriesFile, repositories)
+	}
+
+	// Every message apk prints about a fetch quotes the repository line it came
+	// from, which is the other place a credential spelled into the URL would
+	// surface — in a caller's terminal rather than in their image. A refused
+	// fetch is provoked to get one of those messages: the credentials are taken
+	// away for the length of one exec, so the mirror answers 401 and apk says
+	// so, naming the repository as it does. The message is captured rather than
+	// raised because an exec that fails crosses the module boundary as an exit
+	// status with its output left in the logs.
+	message, err := ctr.WithExec([]string{"sh", "-c", "unset " + apkNetrcEnv + "; apk update 2>&1; true"}).Stdout(ctx)
+	if err != nil {
+		return fmt.Errorf("capture apk's message for a refused fetch: %w", err)
+	}
+	if !strings.Contains(message, mirror.URL) {
+		return fmt.Errorf("expected apk's message to name the repository %q, got:\n%s", mirror.URL, message)
+	}
+	if strings.Contains(message, mirror.Password) {
+		return fmt.Errorf("expected no credentials in apk's message, got:\n%s", message)
+	}
+
+	// The credentials are mounted rather than written, so the assembled
+	// image's own filesystem carries nothing under the mount point.
+	leaked, err := ctr.Directory("/").Glob(ctx, strings.TrimPrefix(apkNetrcPath, "/"))
+	if err != nil {
+		return fmt.Errorf("look for %s in the assembled image: %w", apkNetrcPath, err)
+	}
+	if len(leaked) > 0 {
+		return fmt.Errorf("expected %s to be a mount and not a layer, found %v", apkNetrcPath, leaked)
+	}
+
+	// What the environment carries is the path, never the credential.
+	env, err := ctr.EnvVariables(ctx)
+	if err != nil {
+		return fmt.Errorf("read the assembled image's environment: %w", err)
+	}
+	for _, v := range env {
+		name, err := v.Name(ctx)
+		if err != nil {
+			return fmt.Errorf("read an environment variable's name: %w", err)
+		}
+		value, err := v.Value(ctx)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", name, err)
+		}
+		if name == apkNetrcEnv && value != apkNetrcPath {
+			return fmt.Errorf("expected %s to name the mount %q, got %q", apkNetrcEnv, apkNetrcPath, value)
+		}
+		if strings.Contains(value, mirror.Password) {
+			return fmt.Errorf("expected no credentials in the image's environment, %s carries them", name)
+		}
+	}
+	return nil
+}
+
+// AuthenticatedRepositoryIsRejectedWithoutApkAuth asserts the authenticated
+// mirror really is authenticated — that the test above passes because the
+// credentials were supplied and used, and not because the server never asked
+// for any. Both installs run against the one mirror, so WithApkAuth is the
+// only difference between them.
+func (t *Tests) AuthenticatedRepositoryIsRejectedWithoutApkAuth(ctx context.Context) error {
+	mirror, err := startApkMirror(ctx, true)
+	if err != nil {
+		return err
+	}
+	if _, err := mirror.apply(pdf()).Version(ctx); err != nil {
+		return fmt.Errorf("Version off an authenticated mirror with credentials: %w", err)
+	}
+	if _, err := pdf().WithApkRepository(mirror.URL).WithApkKey(mirror.Key).Version(ctx); err == nil {
+		return fmt.Errorf("expected a fetch with no credentials to be refused, got a working image")
+	}
+	return nil
+}
+
+// DefaultApkConfigurationIsUntouched asserts an image built without any of
+// these options is the image this module built before they existed: the stock
+// repository list, and no credential plumbing at all.
+//
+// It is the guard against the cheap implementation of all of the above —
+// writing a repositories file, or setting the credential variable,
+// unconditionally — which would work for the mirror and rebuild the world for
+// every existing caller.
+func (t *Tests) DefaultApkConfigurationIsUntouched(ctx context.Context) error {
+	got, err := readRepositories(ctx, pdf())
+	if err != nil {
+		return err
+	}
+	if !strings.Contains(got, alpineCdnHost) {
+		return fmt.Errorf("expected the image's own repositories to survive, got:\n%s", got)
+	}
+	env, err := pdf().Container().WithExec([]string{"sh", "-c", `printf %s "$` + apkNetrcEnv + `"`}).Stdout(ctx)
+	if err != nil {
+		return fmt.Errorf("read %s from an unconfigured image: %w", apkNetrcEnv, err)
+	}
+	if env != "" {
+		return fmt.Errorf("expected no %s on an unconfigured image, got %q", apkNetrcEnv, env)
+	}
+	return nil
+}
+
+// readRepositories reports the repository list of an assembled image, which is
+// what says where its packages came from.
+func readRepositories(ctx context.Context, p *dagger.Pdf) (string, error) {
+	out, err := p.Container().WithExec([]string{"cat", apkRepositoriesFile}).Stdout(ctx)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", apkRepositoriesFile, err)
+	}
+	return out, nil
+}

--- a/daggerverse/pdf/tests/dagger.gen.go
+++ b/daggerverse/pdf/tests/dagger.gen.go
@@ -206,6 +206,34 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Tests).All(&parent, ctx, parallel)
+		case "ApkAuthInstallsFromAuthenticatedRepository":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ApkAuthInstallsFromAuthenticatedRepository(&parent, ctx)
+		case "ApkRepositoryAssemblesWorkingToolchainFromMirror":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ApkRepositoryAssemblesWorkingToolchainFromMirror(&parent, ctx)
+		case "ApkRepositoryReplacesImageDefaults":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ApkRepositoryReplacesImageDefaults(&parent, ctx)
+		case "AuthenticatedRepositoryIsRejectedWithoutApkAuth":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).AuthenticatedRepositoryIsRejectedWithoutApkAuth(&parent, ctx)
 		case "ColorModesProduceDifferentPixels":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -220,6 +248,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).ContainerCarriesEveryPopplerBinaryAndTheFont(&parent, ctx)
+		case "DefaultApkConfigurationIsUntouched":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).DefaultApkConfigurationIsUntouched(&parent, ctx)
 		case "DisablePageBreaksControlsFormFeeds":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -451,6 +486,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).TxtMatchesText(&parent, ctx)
+		case "UntrustedIndexIsRejectedWithoutApkKey":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).UntrustedIndexIsRejectedWithoutApkKey(&parent, ctx)
 		case "VectorFormatsIgnoreRasterOnlySettings":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/pdf/tests/main.go
+++ b/daggerverse/pdf/tests/main.go
@@ -221,6 +221,13 @@ func (t *Tests) All(
 
 	jobs = jobs.WithJob("EncryptedDocumentNeedsThePassword", t.EncryptedDocumentNeedsThePassword)
 
+	jobs = jobs.WithJob("ApkRepositoryAssemblesWorkingToolchainFromMirror", t.ApkRepositoryAssemblesWorkingToolchainFromMirror)
+	jobs = jobs.WithJob("ApkRepositoryReplacesImageDefaults", t.ApkRepositoryReplacesImageDefaults)
+	jobs = jobs.WithJob("UntrustedIndexIsRejectedWithoutApkKey", t.UntrustedIndexIsRejectedWithoutApkKey)
+	jobs = jobs.WithJob("ApkAuthInstallsFromAuthenticatedRepository", t.ApkAuthInstallsFromAuthenticatedRepository)
+	jobs = jobs.WithJob("AuthenticatedRepositoryIsRejectedWithoutApkAuth", t.AuthenticatedRepositoryIsRejectedWithoutApkAuth)
+	jobs = jobs.WithJob("DefaultApkConfigurationIsUntouched", t.DefaultApkConfigurationIsUntouched)
+
 	return jobs.Run(ctx)
 }
 
@@ -2056,12 +2063,18 @@ func firstPageConfig(ctx context.Context, dir *dagger.Directory, prefix string) 
 	return cfg, nil
 }
 
-// pixelStats is what a colour-mode assertion measures: whether any pixel carries
-// colour, and whether any carries a tone that is neither black nor white.
+// pixelStats is what a rendered page is measured by: how much of it carries
+// colour, how much carries a tone that is neither black nor white, and how much
+// carries anything at all.
+//
+// The last of those is the one that says a page was drawn. Poppler renders a PDF
+// naming a font it cannot substitute as an empty sheet and exits 0, so a page
+// with no ink on it is a successful render of nothing.
 type pixelStats struct {
 	total   int
 	chroma  int
 	midtone int
+	ink     int
 }
 
 // firstPagePixels decodes the first page of a rendered directory and summarises
@@ -2097,6 +2110,9 @@ func firstPagePixels(ctx context.Context, dir *dagger.Directory, prefix string) 
 			// the 8-bit value poppler actually wrote.
 			r8, g8, b8 := r>>8, g>>8, b>>8
 			stats.total++
+			if r8 != 0xff || g8 != 0xff || b8 != 0xff {
+				stats.ink++
+			}
 			switch {
 			case r8 != g8 || g8 != b8:
 				stats.chroma++


### PR DESCRIPTION
Closes #275.

The main story shipped `WithApkRepository`, `WithApkKey` and `WithApkAuth`
documented but only lightly proven. Everything those options are about lives in
apk rather than in this module — whether a replaced `/etc/apk/repositories` is
honoured, whether an index signed by an unknown key is refused, whether
credentials reach the fetch — so asserting on the flags the module passes would
have tested none of it.

`daggerverse/pdf/tests/apk.go` stands up a real repository instead, modeled on
`tesseract/tests/apk.go`: the module's own package set fetched with its whole
dependency closure, indexed, signed with a generated key, and served over HTTP
by darkhttpd, optionally behind basic auth whose password comes from
`dag.Random().Sha256`. Unlike tesseract there is one `apk add` here rather than
two, so there is a single place to verify.

## The six tests

| Test | What it pins down |
| --- | --- |
| `ApkRepositoryAssemblesWorkingToolchainFromMirror` | poppler 25.x off the mirror, the ledger's text extracted exactly, and a rendered page carrying ink |
| `ApkRepositoryReplacesImageDefaults` | the repository list holds the mirror and only the mirror — `dl-cdn.alpinelinux.org` is gone |
| `UntrustedIndexIsRejectedWithoutApkKey` | an index signed by an untrusted key is refused, and refusal does not become a CDN fallback |
| `ApkAuthInstallsFromAuthenticatedRepository` | credentials reach the fetch and appear in none of the four places they could leak |
| `AuthenticatedRepositoryIsRejectedWithoutApkAuth` | the authenticated mirror really is authenticated |
| `DefaultApkConfigurationIsUntouched` | an unconfigured image is the stock one — no repositories file written, no `NETRC` set |

Three details worth calling out.

**The ink assertion is the one that catches a mirror missing the font.** A
mirror carrying poppler but not `ttf-liberation` produces an image that builds,
runs, exits 0 and draws blank pages, because poppler substitutes whatever
fontconfig offers and with no family installed that is nothing. Version and text
extraction both pass on that image; only the pixels say otherwise. `pixelStats`
grows an `ink` counter for it, which the existing colour-mode tests ignore.

**Fallback to the CDN fails the suite rather than passing it.** With the
defaults replaced there is nothing to fall back *to*, and the untrusted-key test
is where that is load-bearing: the two installs differ only in the key, so if a
rejected index sent apk to the CDN for the same packages the build would succeed
and the test would fail. Confirmed against apk's own words —
`WARNING: fetching http://<mirror>/x86_64/APKINDEX.tar.gz: UNTRUSTED signature`.

**"No credentials in any error message" is asserted against a message that
actually quotes the repository.** apk's `no such package` message names nothing,
so a refused fetch is provoked instead — the credentials are taken away for the
length of one exec — which yields
`WARNING: updating and opening http://<mirror>/x86_64/APKINDEX.tar.gz: HTTP 401: Unauthorized`.
That is the message a credential spelled into the URL would have surfaced in;
this one names the repository and carries nothing else.

## Verification

- each of the six tests run individually, green
- `dagger -m daggerverse/pdf/tests call all` — 44 tests, green
- `dagger -m ci call generated` — green (the root `ci/internal/dagger/pdf-tests.gen.go` regen is in the diff)
- both failure branches confirmed from the trace to fail for the right reason, not merely to fail

No module source changed; this is test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)