### PR TITLE
story(issue-269): extract text-layer geometry as bbox HTML and TSV

### DIFF
--- a/ci/internal/dagger/pdf-tests.gen.go
+++ b/ci/internal/dagger/pdf-tests.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type PdfTests
-func (r *Binding) AsPdfTests() *PdfTests { // pdf-tests (../../../daggerverse/pdf/tests/main.go:151:6)
+func (r *Binding) AsPdfTests() *PdfTests { // pdf-tests (../../../daggerverse/pdf/tests/main.go:228:6)
 	q := r.query.Select("asPdfTests")
 
 	return &PdfTests{
@@ -19,7 +19,7 @@ func (r *Binding) AsPdfTests() *PdfTests { // pdf-tests (../../../daggerverse/pd
 }
 
 // Create or update a binding of type PdfTests in the environment
-func (r *Env) WithPdfTestsInput(name string, value *PdfTests, description string) *Env { // pdf-tests (../../../daggerverse/pdf/tests/main.go:151:6)
+func (r *Env) WithPdfTestsInput(name string, value *PdfTests, description string) *Env { // pdf-tests (../../../daggerverse/pdf/tests/main.go:228:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withPdfTestsInput")
 	q = q.Arg("name", name)
@@ -32,7 +32,7 @@ func (r *Env) WithPdfTestsInput(name string, value *PdfTests, description string
 }
 
 // Declare a desired PdfTests output to be assigned in the environment
-func (r *Env) WithPdfTestsOutput(name string, description string) *Env { // pdf-tests (../../../daggerverse/pdf/tests/main.go:151:6)
+func (r *Env) WithPdfTestsOutput(name string, description string) *Env { // pdf-tests (../../../daggerverse/pdf/tests/main.go:228:6)
 	q := r.query.Select("withPdfTestsOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -42,7 +42,7 @@ func (r *Env) WithPdfTestsOutput(name string, description string) *Env { // pdf-
 	}
 }
 
-type PdfTests struct { // pdf-tests (../../../daggerverse/pdf/tests/main.go:151:6)
+type PdfTests struct { // pdf-tests (../../../daggerverse/pdf/tests/main.go:228:6)
 	query *querybuilder.Selection
 
 	all                                                 *Void
@@ -50,6 +50,8 @@ type PdfTests struct { // pdf-tests (../../../daggerverse/pdf/tests/main.go:151:
 	apkRepositoryAssemblesWorkingToolchainFromMirror    *Void
 	apkRepositoryReplacesImageDefaults                  *Void
 	authenticatedRepositoryIsRejectedWithoutApkAuth     *Void
+	bboxCarriesOneBoxPerWord                            *Void
+	bboxWithLayoutAddsBlockAndLineBoxes                 *Void
 	colorModesProduceDifferentPixels                    *Void
 	containerCarriesEveryPopplerBinaryAndTheFont        *Void
 	defaultApkConfigurationIsUntouched                  *Void
@@ -59,6 +61,7 @@ type PdfTests struct { // pdf-tests (../../../daggerverse/pdf/tests/main.go:151:
 	epsWritesEveryPageOfTheDocument                     *Void
 	fontsNarrowsToThePageRange                          *Void
 	fontsReportsWhetherEachFaceIsEmbedded               *Void
+	geometryOfAnImageOnlyPdfReportsPagesWithoutWords    *Void
 	htmlCarriesPageMarkupAndItsImages                   *Void
 	id                                                  *ID
 	infoReportsPageCountAndSize                         *Void
@@ -69,6 +72,7 @@ type PdfTests struct { // pdf-tests (../../../daggerverse/pdf/tests/main.go:151:
 	metadataReturnsTheXmpPacketOrSaysThereIsNone        *Void
 	pageRangeNarrowsEveryPerPageFormat                  *Void
 	pageRangeNarrowsText                                *Void
+	pageRangeNarrowsTheGeometryOutputs                  *Void
 	pageRangeOpenEndedRunsToTheLastPage                 *Void
 	pageRangeRejectsInvalidBounds                       *Void
 	pngNamesEveryPageWithFourDigits                     *Void
@@ -86,6 +90,7 @@ type PdfTests struct { // pdf-tests (../../../daggerverse/pdf/tests/main.go:151:
 	svgWritesOneVectorFilePerPage                       *Void
 	textOnImageOnlyPdfReturnsNothing                    *Void
 	textReproducesTextLayerExactly                      *Void
+	tsvRowsCarryPageNumbersAndWordGeometry              *Void
 	txtMatchesText                                      *Void
 	untrustedIndexIsRejectedWithoutApkKey               *Void
 	vectorFormatsIgnoreRasterOnlySettings               *Void
@@ -105,7 +110,7 @@ type PdfTestsAllOpts struct {
 	//
 	// Maximum number of tests to run concurrently. Zero fans out unbounded.
 	//
-	Parallel int // pdf-tests (../../../daggerverse/pdf/tests/main.go:167:2)
+	Parallel int // pdf-tests (../../../daggerverse/pdf/tests/main.go:244:2)
 }
 
 // All runs every pdf-module test in parallel.
@@ -116,7 +121,7 @@ type PdfTestsAllOpts struct {
 // are single-threaded: twenty of them contend for cores the way any other
 // oversubscribed workload does. The cap stays available for a host that wants a
 // narrower slice.
-func (r *PdfTests) All(ctx context.Context, opts ...PdfTestsAllOpts) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:163:1)
+func (r *PdfTests) All(ctx context.Context, opts ...PdfTestsAllOpts) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:240:1)
 	if r.all != nil {
 		return nil
 	}
@@ -202,6 +207,52 @@ func (r *PdfTests) AuthenticatedRepositoryIsRejectedWithoutApkAuth(ctx context.C
 	return q.Execute(ctx)
 }
 
+// BboxCarriesOneBoxPerWord asserts Bbox reports the page's size and one box per
+// word, at the coordinates the document itself draws the words at.
+//
+// The coordinates are the whole point of the function, so they are checked and
+// not merely counted. ledgerPdf sets its pages with `/F1 24 Tf`, `72 680 Td` and
+// `40 TL`, so every number poppler can print here is derivable from the fixture:
+// the first word of a line starts at x=72, and a line's box runs from the
+// baseline less Helvetica's ascender to the baseline plus its descender, measured
+// down from the top of the 792-point page. A test that asserted the boxes were
+// non-empty would pass just as well on boxes that were all the same.
+//
+// The absence of layout boxes is asserted too, because that is what `withLayout`
+// is the difference between: a plain -bbox report carries words directly under
+// the page, with no flow, block or line around them.
+func (r *PdfTests) BboxCarriesOneBoxPerWord(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1346:1)
+	if r.bboxCarriesOneBoxPerWord != nil {
+		return nil
+	}
+	q := r.query.Select("bboxCarriesOneBoxPerWord")
+
+	return q.Execute(ctx)
+}
+
+// BboxWithLayoutAddsBlockAndLineBoxes asserts withLayout wraps the same word
+// boxes in the block and line boxes poppler groups them into.
+//
+// Both halves matter. The words have to be the same words at the same
+// coordinates, because the layout report is meant to be the plain one with more
+// structure and not a differently measured one — so the two reports' words are
+// compared box for box. And the boxes that were added have to mean something:
+// each line's box is asserted to be exactly the union of the words under it, and
+// each block's the union of its lines. A test that only counted `block` elements
+// would pass on boxes that were all the page.
+//
+// ledgerPdf is the fixture for it because its two lines land in two blocks: the
+// 40-point leading against a 22.2-point line is a gap poppler reads as a
+// paragraph break, so the block grouping is observable rather than degenerate.
+func (r *PdfTests) BboxWithLayoutAddsBlockAndLineBoxes(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1402:1)
+	if r.bboxWithLayoutAddsBlockAndLineBoxes != nil {
+		return nil
+	}
+	q := r.query.Select("bboxWithLayoutAddsBlockAndLineBoxes")
+
+	return q.Execute(ctx)
+}
+
 // ColorModesProduceDifferentPixels asserts the three colour modes render three
 // different images.
 //
@@ -214,7 +265,7 @@ func (r *PdfTests) AuthenticatedRepositoryIsRejectedWithoutApkAuth(ctx context.C
 // The three properties are mutually exclusive by construction: colour keeps
 // chroma, grey drops chroma but keeps mid-tones, and mono drops both — flat tones
 // are dithered into black and white rather than averaged into grey.
-func (r *PdfTests) ColorModesProduceDifferentPixels(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1434:1)
+func (r *PdfTests) ColorModesProduceDifferentPixels(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2166:1)
 	if r.colorModesProduceDifferentPixels != nil {
 		return nil
 	}
@@ -231,7 +282,7 @@ func (r *PdfTests) ColorModesProduceDifferentPixels(ctx context.Context) error {
 // nothing to substitute for a PDF that names a base-14 face without embedding
 // it, and renders the page blank while exiting 0 — a silent wrong answer, which
 // is the failure mode this assertion exists to keep out.
-func (r *PdfTests) ContainerCarriesEveryPopplerBinaryAndTheFont(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:616:1)
+func (r *PdfTests) ContainerCarriesEveryPopplerBinaryAndTheFont(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:699:1)
 	if r.containerCarriesEveryPopplerBinaryAndTheFont != nil {
 		return nil
 	}
@@ -264,7 +315,7 @@ func (r *PdfTests) DefaultApkConfigurationIsUntouched(ctx context.Context) error
 // defaulting to true because a `Go SDK — the zero value is dropped before it reaches the API — so the
 // affirmative spelling would have produced an option no caller could turn off.
 // That makes the second half of this test the one that would have caught it.
-func (r *PdfTests) DisablePageBreaksControlsFormFeeds(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1151:1)
+func (r *PdfTests) DisablePageBreaksControlsFormFeeds(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1234:1)
 	if r.disablePageBreaksControlsFormFeeds != nil {
 		return nil
 	}
@@ -280,7 +331,7 @@ func (r *PdfTests) DisablePageBreaksControlsFormFeeds(ctx context.Context) error
 // remembered pixel count, so the assertion says "150 dpi of a US Letter page"
 // rather than "1275 by 1650" — which is the claim the documentation actually
 // makes.
-func (r *PdfTests) DpiDefaultsToOneFiftyAndScalesWithTheSetting(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1333:1)
+func (r *PdfTests) DpiDefaultsToOneFiftyAndScalesWithTheSetting(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2065:1)
 	if r.dpiDefaultsToOneFiftyAndScalesWithTheSetting != nil {
 		return nil
 	}
@@ -304,7 +355,7 @@ func (r *PdfTests) DpiDefaultsToOneFiftyAndScalesWithTheSetting(ctx context.Cont
 // poppler alike through the environment rather than argv: a password in argv is
 // visible in every Dagger trace, which is exactly what the module's own posture
 // avoids.
-func (r *PdfTests) EncryptedDocumentNeedsThePassword(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1859:1)
+func (r *PdfTests) EncryptedDocumentNeedsThePassword(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2591:1)
 	if r.encryptedDocumentNeedsThePassword != nil {
 		return nil
 	}
@@ -326,7 +377,7 @@ func (r *PdfTests) EncryptedDocumentNeedsThePassword(ctx context.Context) error 
 // Each file is then checked to be an EPS in its own right — the EPSF version
 // header, and exactly one page in it — because a loop that wrote twelve copies
 // of page one would satisfy the names alone.
-func (r *PdfTests) EpsWritesEveryPageOfTheDocument(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:292:1)
+func (r *PdfTests) EpsWritesEveryPageOfTheDocument(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:375:1)
 	if r.epsWritesEveryPageOfTheDocument != nil {
 		return nil
 	}
@@ -345,7 +396,7 @@ func (r *PdfTests) EpsWritesEveryPageOfTheDocument(ctx context.Context) error { 
 // it, its two pages naming different faces, because narrowing a report of
 // ledgerPdf — every page of which names the same Helvetica — changes nothing at
 // all and would pass against a module that ignored the bounds entirely.
-func (r *PdfTests) FontsNarrowsToThePageRange(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:776:1)
+func (r *PdfTests) FontsNarrowsToThePageRange(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:859:1)
 	if r.fontsNarrowsToThePageRange != nil {
 		return nil
 	}
@@ -368,11 +419,34 @@ func (r *PdfTests) FontsNarrowsToThePageRange(ctx context.Context) error { // pd
 // construction, so the report has to read `yes` for it; without that contrast
 // the assertion would pass just as well on a report that said `no` about
 // everything, including one produced by a module that had hardcoded the answer.
-func (r *PdfTests) FontsReportsWhetherEachFaceIsEmbedded(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:721:1)
+func (r *PdfTests) FontsReportsWhetherEachFaceIsEmbedded(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:804:1)
 	if r.fontsReportsWhetherEachFaceIsEmbedded != nil {
 		return nil
 	}
 	q := r.query.Select("fontsReportsWhetherEachFaceIsEmbedded")
+
+	return q.Execute(ctx)
+}
+
+// GeometryOfAnImageOnlyPdfReportsPagesWithoutWords asserts a PDF with no text
+// layer produces a well-formed report of a page with nothing on it, and does not
+// fail.
+//
+// It is the same boundary with the tesseract module that TextOnImageOnlyPdfReturnsNothing
+// draws, and it needs its own assertion because the failure mode here is louder:
+// poppler writes `no word list` to *stderr* for such a page and exits 0, having
+// written a perfectly good report to the output file. A module that read stderr as
+// a diagnostic, or that treated the absence of words as a document it could not
+// open, would turn the signal to go and rasterize this document into an error.
+//
+// The page element still has to be there and still has to state its size, because
+// that is what distinguishes a page carrying no text from a document that was
+// never read.
+func (r *PdfTests) GeometryOfAnImageOnlyPdfReportsPagesWithoutWords(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1858:1)
+	if r.geometryOfAnImageOnlyPdfReportsPagesWithoutWords != nil {
+		return nil
+	}
+	q := r.query.Select("geometryOfAnImageOnlyPdfReportsPagesWithoutWords")
 
 	return q.Execute(ctx)
 }
@@ -391,7 +465,7 @@ func (r *PdfTests) FontsReportsWhetherEachFaceIsEmbedded(ctx context.Context) er
 //
 // Two fixtures are needed because no one page is both: ledger.pdf is text and no
 // images, scan.pdf is one image and no text.
-func (r *PdfTests) HTMLCarriesPageMarkupAndItsImages(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:384:1)
+func (r *PdfTests) HTMLCarriesPageMarkupAndItsImages(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:467:1)
 	if r.htmlCarriesPageMarkupAndItsImages != nil {
 		return nil
 	}
@@ -456,7 +530,7 @@ func (r *PdfTests) UnmarshalJSON(bs []byte) error {
 // first: PageCount parses Info's `Pages:` line, so a change to how Info is
 // captured that broke the parse would otherwise show up only in whatever used
 // PageCount next.
-func (r *PdfTests) InfoReportsPageCountAndSize(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:680:1)
+func (r *PdfTests) InfoReportsPageCountAndSize(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:763:1)
 	if r.infoReportsPageCountAndSize != nil {
 		return nil
 	}
@@ -472,7 +546,7 @@ func (r *PdfTests) InfoReportsPageCountAndSize(ctx context.Context) error { // p
 // `-jpeg` writes `.jpg` and `-tiff` writes `.tif`, which are poppler's spellings
 // and not this module's: a caller building a path from the function's name would
 // get them wrong, so they are part of the documented contract.
-func (r *PdfTests) JpegAndTiffFollowTheSameContract(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1509:1)
+func (r *PdfTests) JpegAndTiffFollowTheSameContract(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2241:1)
 	if r.jpegAndTiffFollowTheSameContract != nil {
 		return nil
 	}
@@ -492,7 +566,7 @@ func (r *PdfTests) JpegAndTiffFollowTheSameContract(ctx context.Context) error {
 // physical layout puts the two columns side by side on one output line. A fixture
 // whose stream order matched its reading order would let two of these three pass
 // on the same output.
-func (r *PdfTests) LayoutModesProduceDifferentOrderings(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1188:1)
+func (r *PdfTests) LayoutModesProduceDifferentOrderings(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1271:1)
 	if r.layoutModesProduceDifferentOrderings != nil {
 		return nil
 	}
@@ -510,7 +584,7 @@ func (r *PdfTests) LayoutModesProduceDifferentOrderings(ctx context.Context) err
 // that was already sorted. Reading the text back is what says the pages landed
 // where they were put: the page count alone would pass on a merge that shuffled
 // them.
-func (r *PdfTests) MergePreservesTheOrderOfItsSources(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1646:1)
+func (r *PdfTests) MergePreservesTheOrderOfItsSources(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2378:1)
 	if r.mergePreservesTheOrderOfItsSources != nil {
 		return nil
 	}
@@ -531,7 +605,7 @@ func (r *PdfTests) MergePreservesTheOrderOfItsSources(ctx context.Context) error
 // the file it could not read, and the name it uses is this module's mount path,
 // so without the legend the one piece of information identifying which argument
 // was at fault is a path the caller has never seen.
-func (r *PdfTests) MergeRejectsWhatItCannotMerge(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1698:1)
+func (r *PdfTests) MergeRejectsWhatItCannotMerge(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2430:1)
 	if r.mergeRejectsWhatItCannotMerge != nil {
 		return nil
 	}
@@ -555,7 +629,7 @@ func (r *PdfTests) MergeRejectsWhatItCannotMerge(ctx context.Context) error { //
 // indistinguishable from a function that did not run, so the module answers with
 // a line naming the absence and pointing at the report that does carry the
 // document's metadata.
-func (r *PdfTests) MetadataReturnsTheXmpPacketOrSaysThereIsNone(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:838:1)
+func (r *PdfTests) MetadataReturnsTheXmpPacketOrSaysThereIsNone(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:921:1)
 	if r.metadataReturnsTheXmpPacketOrSaysThereIsNone != nil {
 		return nil
 	}
@@ -578,7 +652,7 @@ func (r *PdfTests) MetadataReturnsTheXmpPacketOrSaysThereIsNone(ctx context.Cont
 // the range, which is why pages 4 through 6 come out `page-0004` through
 // `page-0006` — the same promise the raster contract makes, so a page stays
 // traceable to the page it came from whichever format it was rendered to.
-func (r *PdfTests) PageRangeNarrowsEveryPerPageFormat(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:461:1)
+func (r *PdfTests) PageRangeNarrowsEveryPerPageFormat(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:544:1)
 	if r.pageRangeNarrowsEveryPerPageFormat != nil {
 		return nil
 	}
@@ -590,7 +664,7 @@ func (r *PdfTests) PageRangeNarrowsEveryPerPageFormat(ctx context.Context) error
 // PageRangeNarrowsText asserts WithPageRange narrows extraction to the pages it
 // names, and that the bounds are the 1-based inclusive ones poppler uses rather
 // than an offset and a length.
-func (r *PdfTests) PageRangeNarrowsText(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1073:1)
+func (r *PdfTests) PageRangeNarrowsText(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1156:1)
 	if r.pageRangeNarrowsText != nil {
 		return nil
 	}
@@ -599,10 +673,30 @@ func (r *PdfTests) PageRangeNarrowsText(ctx context.Context) error { // pdf-test
 	return q.Execute(ctx)
 }
 
+// PageRangeNarrowsTheGeometryOutputs asserts WithPageRange narrows Bbox and Tsv
+// to the pages it names, in all three shapes the two functions come in.
+//
+// The two formats answer "which page is this" differently, and that difference is
+// the reason this test checks the narrowing on both rather than trusting one. A
+// `-bbox` page element carries a width and a height and no number at all, so the
+// only thing that ties a narrowed report back to the document is the order of its
+// pages and the words on them — which is what the marker words are checked for
+// here. A TSV row names its page outright, and names it with the page's number in
+// the *whole* document rather than its position in the range: pages 4 through 6
+// come back as 4, 5 and 6, not as 1, 2 and 3.
+func (r *PdfTests) PageRangeNarrowsTheGeometryOutputs(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1773:1)
+	if r.pageRangeNarrowsTheGeometryOutputs != nil {
+		return nil
+	}
+	q := r.query.Select("pageRangeNarrowsTheGeometryOutputs")
+
+	return q.Execute(ctx)
+}
+
 // PageRangeOpenEndedRunsToTheLastPage asserts a zero last means "to the end",
 // which is the only way to name an open-ended range without first asking how
 // many pages the document has.
-func (r *PdfTests) PageRangeOpenEndedRunsToTheLastPage(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1092:1)
+func (r *PdfTests) PageRangeOpenEndedRunsToTheLastPage(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1175:1)
 	if r.pageRangeOpenEndedRunsToTheLastPage != nil {
 		return nil
 	}
@@ -618,7 +712,7 @@ func (r *PdfTests) PageRangeOpenEndedRunsToTheLastPage(ctx context.Context) erro
 // renders nothing for them and exits 0, so a caller who asked for page 20 of a
 // 12-page document would otherwise get an empty result indistinguishable from a
 // document with no text in it.
-func (r *PdfTests) PageRangeRejectsInvalidBounds(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1115:1)
+func (r *PdfTests) PageRangeRejectsInvalidBounds(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1198:1)
 	if r.pageRangeRejectsInvalidBounds != nil {
 		return nil
 	}
@@ -638,7 +732,7 @@ func (r *PdfTests) PageRangeRejectsInvalidBounds(ctx context.Context) error { //
 // has no way to know which width it is holding. Asserting the full ordered list
 // covers both halves of the promise: the names, and that lexicographic order is
 // page order.
-func (r *PdfTests) PngNamesEveryPageWithFourDigits(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1260:1)
+func (r *PdfTests) PngNamesEveryPageWithFourDigits(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1992:1)
 	if r.pngNamesEveryPageWithFourDigits != nil {
 		return nil
 	}
@@ -658,7 +752,7 @@ func (r *PdfTests) PngNamesEveryPageWithFourDigits(ctx context.Context) error { 
 // The numbers are the source document's page numbers and not positions within
 // the range, which is why the second case starts at `page-0004.png`. That keeps a
 // rendered page traceable back to the page it came from.
-func (r *PdfTests) PngNarrowedRangeKeepsFourDigitNames(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1279:1)
+func (r *PdfTests) PngNarrowedRangeKeepsFourDigitNames(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2011:1)
 	if r.pngNarrowedRangeKeepsFourDigitNames != nil {
 		return nil
 	}
@@ -676,7 +770,7 @@ func (r *PdfTests) PngNarrowedRangeKeepsFourDigitNames(ctx context.Context) erro
 // document keeps the longer document's width. A consumer globbing for
 // `page-*.png` finds nothing in the first case and a caller indexing by name
 // finds the wrong file in the second.
-func (r *PdfTests) PngSinglePageIsStillNumbered(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1306:1)
+func (r *PdfTests) PngSinglePageIsStillNumbered(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2038:1)
 	if r.pngSinglePageIsStillNumbered != nil {
 		return nil
 	}
@@ -693,7 +787,7 @@ func (r *PdfTests) PngSinglePageIsStillNumbered(ctx context.Context) error { // 
 // directory of one-page fragments would be the wrong answer even though it would
 // look tidier beside Svg and Eps. Counting the markers is what says the pages
 // reached the file rather than only the header saying they did.
-func (r *PdfTests) PsHoldsEveryPageInOneFile(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:341:1)
+func (r *PdfTests) PsHoldsEveryPageInOneFile(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:424:1)
 	if r.psHoldsEveryPageInOneFile != nil {
 		return nil
 	}
@@ -707,7 +801,7 @@ func (r *PdfTests) PsHoldsEveryPageInOneFile(ctx context.Context) error { // pdf
 //
 // Left to poppler these arrive much later as a complaint about `-r` or
 // `-scale-to`, which names a flag the caller never wrote.
-func (r *PdfTests) RenderSettingsRejectNonPositiveValues(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1396:1)
+func (r *PdfTests) RenderSettingsRejectNonPositiveValues(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2128:1)
 	if r.renderSettingsRejectNonPositiveValues != nil {
 		return nil
 	}
@@ -728,7 +822,7 @@ func (r *PdfTests) RenderSettingsRejectNonPositiveValues(ctx context.Context) er
 // reports every wrong password as `Incorrect password` whether one was supplied
 // or not, so the message has to distinguish what the module knows and poppler
 // does not.
-func (r *PdfTests) ReportsOpenAnEncryptedDocumentWithThePassword(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:914:1)
+func (r *PdfTests) ReportsOpenAnEncryptedDocumentWithThePassword(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:997:1)
 	if r.reportsOpenAnEncryptedDocumentWithThePassword != nil {
 		return nil
 	}
@@ -744,7 +838,7 @@ func (r *PdfTests) ReportsOpenAnEncryptedDocumentWithThePassword(ctx context.Con
 // resolution flag off the command line rather than by relying on poppler's own
 // precedence, so this is the assertion that would catch the two being emitted
 // together and whichever poppler happened to prefer winning silently.
-func (r *PdfTests) ScaleToOverridesDpi(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1365:1)
+func (r *PdfTests) ScaleToOverridesDpi(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2097:1)
 	if r.scaleToOverridesDpi != nil {
 		return nil
 	}
@@ -767,7 +861,7 @@ func (r *PdfTests) ScaleToOverridesDpi(ctx context.Context) error { // pdf-tests
 // an image carrying no certificate database, which is every image this module
 // builds, and a report assembled from both streams would carry that line into
 // every caller's output as though it were something the document said.
-func (r *PdfTests) SignaturesReportsAnUnsignedDocumentInsteadOfFailing(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:888:1)
+func (r *PdfTests) SignaturesReportsAnUnsignedDocumentInsteadOfFailing(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:971:1)
 	if r.signaturesReportsAnUnsignedDocumentInsteadOfFailing != nil {
 		return nil
 	}
@@ -788,7 +882,7 @@ func (r *PdfTests) SignaturesReportsAnUnsignedDocumentInsteadOfFailing(ctx conte
 // that would send a caller to a builder that changes nothing, which is why the
 // password case is asserted alongside the passwordless one: both have to arrive
 // at the same message.
-func (r *PdfTests) SplitAndMergeCannotOpenAnEncryptedDocument(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1796:1)
+func (r *PdfTests) SplitAndMergeCannotOpenAnEncryptedDocument(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2528:1)
 	if r.splitAndMergeCannotOpenAnEncryptedDocument != nil {
 		return nil
 	}
@@ -807,7 +901,7 @@ func (r *PdfTests) SplitAndMergeCannotOpenAnEncryptedDocument(ctx context.Contex
 // caller gets a message about poppler's internals attached to a directory that
 // was half written. Checking the bounds against the document first is what turns
 // that into a sentence naming the builder and the page count.
-func (r *PdfTests) SplitNarrowsToThePageRange(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1601:1)
+func (r *PdfTests) SplitNarrowsToThePageRange(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2333:1)
 	if r.splitNarrowsToThePageRange != nil {
 		return nil
 	}
@@ -829,7 +923,7 @@ func (r *PdfTests) SplitNarrowsToThePageRange(ctx context.Context) error { // pd
 // The names the split wrote are what the merge is driven by, in page order, which
 // is also the practical shape of the pair: split, do something to the pages,
 // merge the ones that survived.
-func (r *PdfTests) SplitThenMergeRoundTripsTheDocument(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1742:1)
+func (r *PdfTests) SplitThenMergeRoundTripsTheDocument(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2474:1)
 	if r.splitThenMergeRoundTripsTheDocument != nil {
 		return nil
 	}
@@ -851,7 +945,7 @@ func (r *PdfTests) SplitThenMergeRoundTripsTheDocument(ctx context.Context) erro
 // pdfseparate numbers with the width the caller's pattern asks for rather than
 // with the document's page count, so the four-digit contract here is this
 // module's and not a coincidence of the fixture's length.
-func (r *PdfTests) SplitWritesOnePdfPerPage(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1557:1)
+func (r *PdfTests) SplitWritesOnePdfPerPage(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2289:1)
 	if r.splitWritesOnePdfPerPage != nil {
 		return nil
 	}
@@ -875,7 +969,7 @@ func (r *PdfTests) SplitWritesOnePdfPerPage(ctx context.Context) error { // pdf-
 // anywhere. Poppler converts text to glyph outlines rather than to `<text>`, so
 // the marker words are not in the file at all — a Contains check for one would
 // fail on a perfectly good SVG.
-func (r *PdfTests) SvgWritesOneVectorFilePerPage(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:249:1)
+func (r *PdfTests) SvgWritesOneVectorFilePerPage(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:332:1)
 	if r.svgWritesOneVectorFilePerPage != nil {
 		return nil
 	}
@@ -894,7 +988,7 @@ func (r *PdfTests) SvgWritesOneVectorFilePerPage(ctx context.Context) error { //
 // a caller gets that this document needs rasterizing and handing to OCR. A
 // module that failed here instead would make the two paths impossible to choose
 // between programmatically.
-func (r *PdfTests) TextOnImageOnlyPdfReturnsNothing(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1023:1)
+func (r *PdfTests) TextOnImageOnlyPdfReturnsNothing(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1106:1)
 	if r.textOnImageOnlyPdfReturnsNothing != nil {
 		return nil
 	}
@@ -912,11 +1006,36 @@ func (r *PdfTests) TextOnImageOnlyPdfReturnsNothing(ctx context.Context) error {
 // leading newline, pages in the wrong order — is a defect and not a recognition
 // error. A fixture whose content streams are readable is what makes an exact
 // expectation writable at all.
-func (r *PdfTests) TextReproducesTextLayerExactly(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1002:1)
+func (r *PdfTests) TextReproducesTextLayerExactly(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1085:1)
 	if r.textReproducesTextLayerExactly != nil {
 		return nil
 	}
 	q := r.query.Select("textReproducesTextLayerExactly")
+
+	return q.Execute(ctx)
+}
+
+// TsvRowsCarryPageNumbersAndWordGeometry asserts Tsv reports one row per layout
+// element, each naming the page it came from and the box it occupies.
+//
+// The page number is the half that makes the format worth having next to Bbox: a
+// `-bbox` page element carries a size and no number, so a report of a multi-page
+// document is traceable back to its pages only positionally, while every TSV row
+// names its page outright. This asserts the numbers run 1..12 in order on the page
+// rows, and that each page's word rows carry that page's marker word — so a row
+// attributed to the wrong page fails here.
+//
+// The geometry is the other half, and is checked against the fixture's own
+// content stream rather than asserted non-empty: a word row's `left` is the text
+// origin for the first word of a line, its `top` is the baseline measured down
+// from the top of the page less the font's ascender, and its `height` is the
+// ascender-to-descender span — 22.2 points at 24pt Helvetica, the same for a
+// one-glyph word as for a seven-glyph one.
+func (r *PdfTests) TsvRowsCarryPageNumbersAndWordGeometry(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1656:1)
+	if r.tsvRowsCarryPageNumbersAndWordGeometry != nil {
+		return nil
+	}
+	q := r.query.Select("tsvRowsCarryPageNumbersAndWordGeometry")
 
 	return q.Execute(ctx)
 }
@@ -928,7 +1047,7 @@ func (r *PdfTests) TextReproducesTextLayerExactly(ctx context.Context) error { /
 // straight off the handle: the point of Txt is that the bytes reach a filesystem
 // intact, and File.Contents would confirm the engine's copy while saying nothing
 // about the export a real consumer performs.
-func (r *PdfTests) TxtMatchesText(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1046:1)
+func (r *PdfTests) TxtMatchesText(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1129:1)
 	if r.txtMatchesText != nil {
 		return nil
 	}
@@ -974,7 +1093,7 @@ func (r *PdfTests) UntrustedIndexIsRejectedWithoutApkKey(ctx context.Context) er
 //
 // WithDpi is the one setting that does reach pdftocairo, and it is set here too
 // so this is not accidentally asserting that no flags are passed at all.
-func (r *PdfTests) VectorFormatsIgnoreRasterOnlySettings(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:511:1)
+func (r *PdfTests) VectorFormatsIgnoreRasterOnlySettings(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:594:1)
 	if r.vectorFormatsIgnoreRasterOnlySettings != nil {
 		return nil
 	}
@@ -992,7 +1111,7 @@ func (r *PdfTests) VectorFormatsIgnoreRasterOnlySettings(ctx context.Context) er
 // exact patch: Alpine may rebuild poppler-utils within the v3.24 branch, and a
 // test that pins the patch level would fail on a change this module has no
 // opinion about.
-func (r *PdfTests) VersionReportsPopplerRelease(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:590:1)
+func (r *PdfTests) VersionReportsPopplerRelease(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:673:1)
 	if r.versionReportsPopplerRelease != nil {
 		return nil
 	}
@@ -1010,7 +1129,7 @@ func (r *PdfTests) VersionReportsPopplerRelease(ctx context.Context) error { // 
 // module installs, so the negative control is real — the plain image genuinely
 // cannot see it, and the assertion is not passing on something the base image
 // already had.
-func (r *PdfTests) WithFontsPutsFaceWhereFontconfigFindsIt(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:650:1)
+func (r *PdfTests) WithFontsPutsFaceWhereFontconfigFindsIt(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:733:1)
 	if r.withFontsPutsFaceWhereFontconfigFindsIt != nil {
 		return nil
 	}
@@ -1026,7 +1145,7 @@ func (r *PdfTests) WithFontsPutsFaceWhereFontconfigFindsIt(ctx context.Context) 
 // a render of it is the annotation's appearance stream and nothing else. Without
 // that separation the assertion could not tell an annotation that was not drawn
 // from one that was drawn somewhere else on the page.
-func (r *PdfTests) WithoutAnnotationsRemovesTheAnnotationLayer(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1476:1)
+func (r *PdfTests) WithoutAnnotationsRemovesTheAnnotationLayer(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2208:1)
 	if r.withoutAnnotationsRemovesTheAnnotationLayer != nil {
 		return nil
 	}
@@ -1051,7 +1170,7 @@ func (r *PdfTests) AsNode() Node {
 // streams are uncompressed, so the text a page is supposed to render is readable
 // in the fixture itself and an assertion about it can be checked against the
 // PDF rather than against another tool's opinion of the PDF.
-func (r *Query) PdfTests() *PdfTests { // pdf-tests (../../../daggerverse/pdf/tests/main.go:151:6)
+func (r *Query) PdfTests() *PdfTests { // pdf-tests (../../../daggerverse/pdf/tests/main.go:228:6)
 	q := r.query.Select("pdfTests")
 
 	return &PdfTests{

--- a/daggerverse/pdf/README.md
+++ b/daggerverse/pdf/README.md
@@ -3,7 +3,8 @@
 Daggerverse module that reads and renders PDFs with
 [poppler](https://poppler.freedesktop.org/) as a `dagger call`. Bind a PDF and
 get back its text — exactly, in reading order, physical layout or content-stream
-order — or its pages as PNG, JPEG or TIFF images, at a resolution or a pixel
+order, or with a bounding box per word so you know where on the page each one
+was — or its pages as PNG, JPEG or TIFF images, at a resolution or a pixel
 size you choose, in colour, grayscale or bilevel. Keep the type outlines instead
 and it gives you SVG, EPS or PostScript; ask for markup and it gives you HTML
 with the page's images beside it. Ask it what the document is and it tells you:
@@ -331,7 +332,7 @@ and not by the document: chain validation needs a trust database, this image
 carries none, and `pdfsig` says so on stderr — which is not part of the report.
 Supply one with `-nssdir` through [`Container`](#toolchain).
 
-## Convert — the render options and the nine outputs
+## Convert — the render options and the eleven outputs
 
 ```go
 Document.Convert() *Convert
@@ -343,6 +344,8 @@ Convert.WithoutAnnotations() *Convert
 
 Convert.Text(ctx, layout LayoutMode, disablePageBreaks bool) (string, error)
 Convert.Txt(ctx, layout LayoutMode, disablePageBreaks bool) (*dagger.File, error)
+Convert.Bbox(ctx, withLayout bool) (*dagger.File, error)
+Convert.Tsv(ctx) (*dagger.File, error)
 Convert.Png(ctx) (*dagger.Directory, error)
 Convert.Jpeg(ctx) (*dagger.Directory, error)
 Convert.Tiff(ctx) (*dagger.Directory, error)
@@ -361,6 +364,7 @@ Which options an output actually reads depends on the renderer behind it:
 | output | renderer | reads |
 | --- | --- | --- |
 | `Text`, `Txt` | `pdftotext` | `layout`, `disablePageBreaks` |
+| `Bbox`, `Tsv` | `pdftotext` | — |
 | `Png`, `Jpeg`, `Tiff` | `pdftoppm` | `WithDpi`, `WithColorMode`, `WithScaleTo`, `WithoutAnnotations` |
 | `Svg`, `Eps`, `Ps` | `pdftocairo` | `WithDpi` |
 | `Html` | `pdftohtml` | — |
@@ -426,6 +430,79 @@ disagree:
 
 A table wants `PHYSICAL`, prose in columns wants `READING`, and a caller
 reconstructing the content stream wants `RAW`.
+
+### `Bbox` and `Tsv` — where the text *is*
+
+`Text` returns words. Layout-aware post-processing needs where each word **was**,
+and `Bbox` and `Tsv` report it. They are the text-layer analogues of the
+[`tesseract`](../tesseract) module's `Hocr` and `Tsv` — the same shape of answer,
+sourced from the document's own coordinates rather than from recognition, so the
+boxes are **exact rather than estimated**. Reach for them when the words are not
+the whole answer: redacting a region, cropping a figure, deciding which column a
+phrase belongs to, or lining extracted text up against a render of the same page.
+
+`Bbox` emits XHTML — a `page` element per page naming its size, holding a `word`
+element per space-separated word:
+
+```xml
+<page width="612.000000" height="792.000000">
+  <word xMin="72.000000" yMin="94.768000" xMax="128.040000" yMax="116.968000">Page</word>
+  <word xMin="134.712000" yMin="94.768000" xMax="148.056000" yMax="116.968000">1</word>
+</page>
+```
+
+`withLayout` wraps those in the `flow`, `block` and `line` elements poppler groups
+them into, each carrying the box around everything under it — the same words at
+the same coordinates, with the paragraph structure a caller reconstructing prose
+needs and a caller reading word boxes pays parsing for.
+
+> The report is a **whole XHTML document** — `-bbox` implies poppler's
+> `-htmlmeta`, so the boxes arrive inside a `doc` element inside an `html` element
+> with a doctype ahead of it. Read the `doc` subtree, not the file's root.
+
+`Tsv` emits the twelve-column table tesseract's TSV renderer defines, header row
+included: `level`, `page_num`, `par_num`, `block_num`, `line_num`, `word_num`,
+`left`, `top`, `width`, `height`, `conf`, `text`. `level` says what a row is — **1**
+a page, **3** a flow, **4** a line, **5** a word — and structural rows name
+themselves in the text column:
+
+```tsv
+level	page_num	…	left	top	width	height	conf	text
+1	1	…	0.000000	0.000000	612.000000	792.000000	-1	###PAGE###
+4	1	…	72.000000	94.768000	222.816000	22.200000	-1	###LINE###
+5	1	…	72.00	94.77	56.04	22.20	100	Page
+```
+
+Reach for `Tsv` over `Bbox` when the consumer is a table reader — a dataframe, a
+spreadsheet, `awk` — and when **the page a row belongs to has to be recoverable
+from the row itself**. That is the one thing this format carries and `Bbox` does
+not: a `page` element states its size and never its number, so a narrowed `Bbox`
+report is traceable only by position, while `page_num` is the page's number in the
+whole document even under `WithPageRange` — pages 4 through 6 come back as 4, 5
+and 6, not as 1, 2 and 3.
+
+Coordinates are in **points, from the top-left of the page**, which is not where
+the PDF's own coordinate system starts. A word's box is the font's
+ascender-to-descender span around the baseline rather than the glyphs' ink, so a
+one-glyph word is exactly as tall as a long one — 22.2 points at 24pt Helvetica.
+
+A few of poppler's own details are worth knowing before writing an assertion
+against either format:
+
+- There is **no level-2 paragraph row**, the `par_num` column notwithstanding.
+- `conf` is `-1` on structural rows and `100` on every word. This is extraction,
+  not recognition: there is nothing to be uncertain about.
+- Word rows round to **two** decimals where structural rows print six.
+- A TSV page row's `left` and `top` are junk after the first page — poppler leaves
+  the previous page's last word in them. The size is right; the position is not.
+- A page with **no text layer** yields an empty `page` element and no word rows
+  rather than a failure: poppler notes `no word list` on stderr and exits 0. That
+  is the same boundary `Text` draws — no words is the signal to render the page
+  and hand it to OCR, not a sign anything went wrong.
+
+The render options are ignored, these being extractions and not renders, and so is
+`LayoutMode`: the report's structure is poppler's own and is not the text's reading
+order. `WithPageRange` narrows both.
 
 ### `ColorMode`
 

--- a/daggerverse/pdf/convert.go
+++ b/daggerverse/pdf/convert.go
@@ -243,6 +243,80 @@ func (c *Convert) Txt(
 	return res.container.File(textOutputPath), nil
 }
 
+// Bbox returns the document's text layer as an XHTML report carrying a bounding
+// box for every word, in points, measured from the top-left of the page.
+//
+// It is the text-layer analogue of the tesseract module's Hocr — the same shape
+// of answer, sourced from the document's own coordinates rather than from
+// recognition, so the boxes are exact rather than estimated. Reach for it when
+// the words are not the whole answer: redacting a region, cropping a figure out
+// of a page, deciding which of two columns a phrase belongs to, or lining
+// extracted text up against a render of the same page.
+//
+// Every page arrives as a `page` element naming its width and height, holding one
+// `word` element per space-separated word with its `xMin`, `yMin`, `xMax` and
+// `yMax`. Pass withLayout to wrap those in the `flow`, `block` and `line`
+// elements poppler groups them into, each carrying the box around everything
+// under it — which is what a caller reconstructing paragraphs wants, and what a
+// caller who only needs word boxes pays parsing for.
+//
+// The report is a whole XHTML document, `-bbox` implying poppler's `-htmlmeta`:
+// the boxes sit inside a `doc` element inside an `html` element with a doctype
+// ahead of it. Read the `doc` subtree, not the file's root.
+//
+// A page with no text layer is reported as an empty `page` element rather than as
+// a failure — poppler notes `no word list` on stderr and exits 0 — which is the
+// same boundary Text draws: no words is the signal to render the page and hand it
+// to OCR, not a sign that anything went wrong.
+//
+// The render options are ignored, this being an extraction and not a render, and
+// so is LayoutMode: the report's structure is poppler's own and is not the text's
+// reading order. WithPageRange narrows it.
+func (c *Convert) Bbox(
+	ctx context.Context,
+	// Add the block and line boxes poppler groups the words into.
+	// +optional
+	withLayout bool,
+) (*dagger.File, error) {
+	flag := bboxFlag
+	if withLayout {
+		flag = bboxLayoutFlag
+	}
+	return c.geometry(ctx, "Bbox", flag, bboxOutputPath)
+}
+
+// Tsv returns the document's text layer as a tab-separated table with one row
+// per layout element, each naming the page it came from and the box it occupies.
+//
+// It is the text-layer analogue of the tesseract module's Tsv, and the format is
+// literally tesseract's: twelve columns — `level`, `page_num`, `par_num`,
+// `block_num`, `line_num`, `word_num`, `left`, `top`, `width`, `height`, `conf`,
+// `text` — with a header row ahead of them. `level` says what a row describes: 1
+// a page, 3 a flow, 4 a line, 5 a word. Poppler emits no level-2 paragraph row
+// despite carrying the column for it. Structural rows name themselves in the text
+// column — `###PAGE###`, `###FLOW###`, `###LINE###` — and `conf` is -1 on them
+// and 100 on every word, this being extraction and not recognition: there is
+// nothing to be uncertain about.
+//
+// Reach for it over Bbox when the consumer is a table reader — a dataframe, a
+// spreadsheet, awk — rather than a markup parser, and when the page a row belongs
+// to has to be recoverable from the row itself. That is the one thing this format
+// carries and Bbox does not: a `-bbox` page element states its size and never its
+// number, so a narrowed report is traceable only by position, while `page_num`
+// here is the page's number in the whole document even under WithPageRange.
+//
+// Coordinates are in points, from the top-left of the page, and a word's box is
+// the font's ascender-to-descender span around the baseline rather than the
+// glyphs' ink — so a one-glyph word is exactly as tall as a long one. Word rows
+// round to two decimals where the structural rows print six.
+//
+// A page with no text layer yields its page row and no word rows rather than a
+// failure, the same boundary Text and Bbox draw. The render options are ignored,
+// as is LayoutMode. WithPageRange narrows it.
+func (c *Convert) Tsv(ctx context.Context) (*dagger.File, error) {
+	return c.geometry(ctx, "Tsv", tsvFlag, tsvOutputPath)
+}
+
 // Png renders each page in range to a PNG and returns the directory holding
 // them, named `page-0001.png`, `page-0002.png`, and so on.
 //
@@ -562,6 +636,30 @@ func (c *Convert) pageLoop(render string) string {
 		`	p=$((p + 1))`,
 		`done`,
 	}, "\n")
+}
+
+// geometry runs pdftotext in one of its geometry-reporting modes and returns the
+// report it wrote.
+//
+// The three modes share everything but their flag: none of them takes a layout
+// mode, none of them takes a page-break switch, and all of them narrow to the
+// document's page range. The report is written to a file rather than read off
+// stdout because both formats are structured — markup and a table — and a
+// consumer parses them rather than reading them.
+func (c *Convert) geometry(ctx context.Context, label, flag, output string) (*dagger.File, error) {
+	if err := c.Document.validateRange(ctx); err != nil {
+		return nil, err
+	}
+	flags := append([]string{flag}, c.Document.rangeArgs()...)
+	res, err := c.Document.runScript(ctx, label, strings.Join([]string{
+		"set -e",
+		"mkdir -p " + outputDir,
+		c.Document.command("pdftotext", flags, sourcePath, output),
+	}, "\n"))
+	if err != nil {
+		return nil, err
+	}
+	return res.container.File(output), nil
 }
 
 // raster renders the pages and returns the directory holding them, with every

--- a/daggerverse/pdf/dagger.gen.go
+++ b/daggerverse/pdf/dagger.gen.go
@@ -406,6 +406,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 	switch parentName {
 	case "Convert":
 		switch fnName {
+		case "Bbox":
+			var parent Convert
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var withLayout bool
+			if inputArgs["withLayout"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["withLayout"]), &withLayout)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg withLayout", err))
+				}
+			}
+			return (*Convert).Bbox(&parent, ctx, withLayout)
 		case "Eps":
 			var parent Convert
 			err = json.Unmarshal(parentJSON, &parent)
@@ -476,6 +490,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return (*Convert).Tiff(&parent, ctx)
+		case "Tsv":
+			var parent Convert
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Convert).Tsv(&parent, ctx)
 		case "Txt":
 			var parent Convert
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/pdf/document.go
+++ b/daggerverse/pdf/document.go
@@ -270,7 +270,7 @@ func isSignatureReport(out string) bool {
 	return strings.Contains(out, noSignaturesMarker) || strings.Contains(out, signatureInfoMarker)
 }
 
-// Convert opens the conversion namespace: the render options, and the nine
+// Convert opens the conversion namespace: the render options, and the eleven
 // outputs that read them.
 //
 // It is a separate object rather than more methods on Document because the

--- a/daggerverse/pdf/main.go
+++ b/daggerverse/pdf/main.go
@@ -41,6 +41,14 @@
 // them. HTML is pdftohtml's, which is not a renderer at all so much as a
 // re-layout, and shares no options with either.
 //
+// Two of the outputs report where the text *is* rather than what it says, and
+// are pdftotext's as well: Bbox emits a box per word as XHTML, Tsv emits a row
+// per layout element as a table. They are the text-layer analogues of the
+// tesseract module's Hocr and Tsv — the same shape of answer, sourced from the
+// document's own coordinates rather than from recognition, so the boxes are exact
+// rather than estimated. That is the whole argument for reaching for this module
+// before that one even when geometry is what is wanted.
+//
 // Four reports describe the document instead of converting it, one per tool:
 // Info is pdfinfo, Fonts is pdffonts, Metadata is `pdfinfo -meta` and Signatures
 // is pdfsig. Each returns its tool's own report as text. Parsing those into
@@ -62,7 +70,7 @@
 //   - document.go — *Document, one bound PDF: its passwords, its page range,
 //     and the four reports about it — what pdfinfo says, which fonts it needs,
 //     its XMP metadata, and its signatures.
-//   - convert.go  — *Convert, the render options and the nine outputs that
+//   - convert.go  — *Convert, the render options and the eleven outputs that
 //     read them.
 //   - pages.go    — Split and Merge, the two page-structure operations. They
 //     sit together rather than with their receivers because they are one
@@ -145,6 +153,25 @@ const (
 	textOutputPath = outputDir + "/document.txt"
 	psOutputPath   = outputDir + "/document.ps"
 	pageBase       = outputDir + "/page"
+
+	// bboxOutputPath is the file Convert.Bbox writes and tsvOutputPath the one
+	// Convert.Tsv writes. The extensions are this module's choice — pdftotext
+	// writes whichever format its flags name, whatever the output is called — and
+	// they name what the bytes are so a consumer, or a human who exported the
+	// file, does not have to open it to find out.
+	bboxOutputPath = outputDir + "/document.bbox.html"
+	tsvOutputPath  = outputDir + "/document.tsv"
+
+	// bboxFlag, bboxLayoutFlag and tsvFlag are the three geometry-reporting
+	// modes of pdftotext. Each replaces the plain text output with a structured
+	// report of its own rather than modifying it, so exactly one of them reaches
+	// a command line and the layout flags LayoutMode maps onto never join it.
+	// Poppler would accept the combination — `-bbox -layout` exits 0 — and
+	// silently ignore the layout flag, which is precisely why LayoutMode is left
+	// off here rather than forwarded and trusted.
+	bboxFlag       = "-bbox"
+	bboxLayoutFlag = "-bbox-layout"
+	tsvFlag        = "-tsv"
 
 	// pageNamePrefix is the leading part of a rendered page's file name, and
 	// has to agree with pageBase: the normalization pass strips it to read the

--- a/daggerverse/pdf/tests/dagger.gen.go
+++ b/daggerverse/pdf/tests/dagger.gen.go
@@ -234,6 +234,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).AuthenticatedRepositoryIsRejectedWithoutApkAuth(&parent, ctx)
+		case "BboxCarriesOneBoxPerWord":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).BboxCarriesOneBoxPerWord(&parent, ctx)
+		case "BboxWithLayoutAddsBlockAndLineBoxes":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).BboxWithLayoutAddsBlockAndLineBoxes(&parent, ctx)
 		case "ColorModesProduceDifferentPixels":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -297,6 +311,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).FontsReportsWhetherEachFaceIsEmbedded(&parent, ctx)
+		case "GeometryOfAnImageOnlyPdfReportsPagesWithoutWords":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).GeometryOfAnImageOnlyPdfReportsPagesWithoutWords(&parent, ctx)
 		case "HtmlCarriesPageMarkupAndItsImages":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -360,6 +381,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).PageRangeNarrowsText(&parent, ctx)
+		case "PageRangeNarrowsTheGeometryOutputs":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).PageRangeNarrowsTheGeometryOutputs(&parent, ctx)
 		case "PageRangeOpenEndedRunsToTheLastPage":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -479,6 +507,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).TextReproducesTextLayerExactly(&parent, ctx)
+		case "TsvRowsCarryPageNumbersAndWordGeometry":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).TsvRowsCarryPageNumbersAndWordGeometry(&parent, ctx)
 		case "TxtMatchesText":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/pdf/tests/internal/dagger/pdf.gen.go
+++ b/daggerverse/pdf/tests/internal/dagger/pdf.gen.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Retrieve the binding value, as type Pdf
-func (r *Binding) AsPdf() *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:209:6)
+func (r *Binding) AsPdf() *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:236:6)
 	q := r.query.Select("asPdf")
 
 	return &Pdf{
@@ -86,7 +86,7 @@ func (r *Env) WithPdfDocumentOutput(name string, description string) *Env { // p
 }
 
 // Create or update a binding of type Pdf in the environment
-func (r *Env) WithPdfInput(name string, value *Pdf, description string) *Env { // pdf (../../../../../daggerverse/pdf/main.go:209:6)
+func (r *Env) WithPdfInput(name string, value *Pdf, description string) *Env { // pdf (../../../../../daggerverse/pdf/main.go:236:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withPdfInput")
 	q = q.Arg("name", name)
@@ -99,7 +99,7 @@ func (r *Env) WithPdfInput(name string, value *Pdf, description string) *Env { /
 }
 
 // Declare a desired Pdf output to be assigned in the environment
-func (r *Env) WithPdfOutput(name string, description string) *Env { // pdf (../../../../../daggerverse/pdf/main.go:209:6)
+func (r *Env) WithPdfOutput(name string, description string) *Env { // pdf (../../../../../daggerverse/pdf/main.go:236:6)
 	q := r.query.Select("withPdfOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -113,7 +113,7 @@ func (r *Env) WithPdfOutput(name string, description string) *Env { // pdf (../.
 // carries the image coordinates and the fonts the image is built with;
 // Document hangs off it so the generated SDK surfaces conversion under
 // `dag.Pdf().Document(...)`.
-type Pdf struct { // pdf (../../../../../daggerverse/pdf/main.go:209:6)
+type Pdf struct { // pdf (../../../../../daggerverse/pdf/main.go:236:6)
 	query *querybuilder.Selection
 
 	id      *ID
@@ -140,7 +140,7 @@ func (r *Pdf) WithGraphQLQuery(q *querybuilder.Selection) *Pdf {
 // pdfdetach and pdftops stay reachable via `container with-exec` — as do the
 // flags of a wrapped tool that this module does not surface, `pdffonts -subst`
 // among them.
-func (r *Pdf) Container() *Container { // pdf (../../../../../daggerverse/pdf/main.go:355:1)
+func (r *Pdf) Container() *Container { // pdf (../../../../../daggerverse/pdf/main.go:382:1)
 	q := r.query.Select("container")
 
 	return &Container{
@@ -153,7 +153,7 @@ func (r *Pdf) Container() *Container { // pdf (../../../../../daggerverse/pdf/ma
 // The boundary input is a *dagger.File rather than a *dagger.Directory: a PDF
 // resolves nothing relative to its own location, so one file is the whole unit
 // of work however many pages it carries.
-func (r *Pdf) Document(source *File) *PdfDocument { // pdf (../../../../../daggerverse/pdf/main.go:388:1)
+func (r *Pdf) Document(source *File) *PdfDocument { // pdf (../../../../../daggerverse/pdf/main.go:415:1)
 	assertNotNil("source", source)
 	q := r.query.Select("document")
 	q = q.Arg("source", source)
@@ -249,7 +249,7 @@ func (r *Pdf) Merge(sources []*File) *File { // pdf (../../../../../daggerverse/
 
 // Version returns the poppler release the assembled image ships, as the bare
 // version number reported by `pdftotext -v`.
-func (r *Pdf) Version(ctx context.Context) (string, error) { // pdf (../../../../../daggerverse/pdf/main.go:368:1)
+func (r *Pdf) Version(ctx context.Context) (string, error) { // pdf (../../../../../daggerverse/pdf/main.go:395:1)
 	if r.version != nil {
 		return *r.version, nil
 	}
@@ -275,7 +275,7 @@ func (r *Pdf) Version(ctx context.Context) (string, error) { // pdf (../../../..
 // why the credentials are not simply userinfo in the WithApkRepository URL,
 // which would put them in /etc/apk/repositories and in every apk error
 // message that quotes it.
-func (r *Pdf) WithApkAuth(credentials *Secret) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:316:1)
+func (r *Pdf) WithApkAuth(credentials *Secret) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:343:1)
 	assertNotNil("credentials", credentials)
 	q := r.query.Select("withApkAuth")
 	q = q.Arg("credentials", credentials)
@@ -298,7 +298,7 @@ func (r *Pdf) WithApkAuth(credentials *Secret) *Pdf { // pdf (../../../../../dag
 // Repeatable, for a mirror set signed by more than one key. It is a *File
 // rather than a *Secret because a public key is not a credential: it is meant
 // to be in the image, and WithApkAuth is the option for the part that is not.
-func (r *Pdf) WithApkKey(key *File) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:293:1)
+func (r *Pdf) WithApkKey(key *File) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:320:1)
 	assertNotNil("key", key)
 	q := r.query.Select("withApkKey")
 	q = q.Arg("key", key)
@@ -328,7 +328,7 @@ func (r *Pdf) WithApkKey(key *File) *Pdf { // pdf (../../../../../daggerverse/pd
 // call per component. A repository's index is signed, so pair this with
 // WithApkKey unless the mirror is signed by a key the base image already
 // trusts.
-func (r *Pdf) WithApkRepository(url string) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:265:1)
+func (r *Pdf) WithApkRepository(url string) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:292:1)
 	q := r.query.Select("withApkRepository")
 	q = q.Arg("url", url)
 
@@ -352,7 +352,7 @@ func (r *Pdf) WithApkRepository(url string) *Pdf { // pdf (../../../../../dagger
 // /etc/fonts/fonts.conf tells fontconfig to scan, so the faces in it are
 // indistinguishable from packaged ones as far as poppler is concerned. It is
 // mounted rather than copied so a large family does not become an image layer.
-func (r *Pdf) WithFonts(dir *Directory) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:340:1)
+func (r *Pdf) WithFonts(dir *Directory) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:367:1)
 	assertNotNil("dir", dir)
 	q := r.query.Select("withFonts")
 	q = q.Arg("dir", dir)
@@ -404,6 +404,57 @@ func (r *PdfConvert) WithGraphQLQuery(q *querybuilder.Selection) *PdfConvert {
 	}
 }
 
+// PdfConvertBboxOpts contains options for PdfConvert.Bbox
+type PdfConvertBboxOpts struct {
+	//
+	// Add the block and line boxes poppler groups the words into.
+	//
+	WithLayout bool // pdf (../../../../../daggerverse/pdf/convert.go:279:2)
+}
+
+// Bbox returns the document's text layer as an XHTML report carrying a bounding
+// box for every word, in points, measured from the top-left of the page.
+//
+// It is the text-layer analogue of the tesseract module's Hocr — the same shape
+// of answer, sourced from the document's own coordinates rather than from
+// recognition, so the boxes are exact rather than estimated. Reach for it when
+// the words are not the whole answer: redacting a region, cropping a figure out
+// of a page, deciding which of two columns a phrase belongs to, or lining
+// extracted text up against a render of the same page.
+//
+// Every page arrives as a `page` element naming its width and height, holding one
+// `word` element per space-separated word with its `xMin`, `yMin`, `xMax` and
+// `yMax`. Pass withLayout to wrap those in the `flow`, `block` and `line`
+// elements poppler groups them into, each carrying the box around everything
+// under it — which is what a caller reconstructing paragraphs wants, and what a
+// caller who only needs word boxes pays parsing for.
+//
+// The report is a whole XHTML document, `-bbox` implying poppler's `-htmlmeta`:
+// the boxes sit inside a `doc` element inside an `html` element with a doctype
+// ahead of it. Read the `doc` subtree, not the file's root.
+//
+// A page with no text layer is reported as an empty `page` element rather than as
+// a failure — poppler notes `no word list` on stderr and exits 0 — which is the
+// same boundary Text draws: no words is the signal to render the page and hand it
+// to OCR, not a sign that anything went wrong.
+//
+// The render options are ignored, this being an extraction and not a render, and
+// so is LayoutMode: the report's structure is poppler's own and is not the text's
+// reading order. WithPageRange narrows it.
+func (r *PdfConvert) Bbox(opts ...PdfConvertBboxOpts) *File { // pdf (../../../../../daggerverse/pdf/convert.go:275:1)
+	q := r.query.Select("bbox")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `withLayout` optional argument
+		if !querybuilder.IsZeroValue(opts[i].WithLayout) {
+			q = q.Arg("withLayout", opts[i].WithLayout)
+		}
+	}
+
+	return &File{
+		query: q,
+	}
+}
+
 // Eps renders each page in range to its own Encapsulated PostScript file and
 // returns the directory holding them, named `page-0001.eps`, `page-0002.eps`,
 // and so on.
@@ -422,7 +473,7 @@ func (r *PdfConvert) WithGraphQLQuery(q *querybuilder.Selection) *PdfConvert {
 //
 // WithDpi governs rasterized regions; WithColorMode, WithScaleTo and
 // WithoutAnnotations are ignored: see the note on Ps.
-func (r *PdfConvert) Eps() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:320:1)
+func (r *PdfConvert) Eps() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:394:1)
 	q := r.query.Select("eps")
 
 	return &Directory{
@@ -449,7 +500,7 @@ func (r *PdfConvert) Eps() *Directory { // pdf (../../../../../daggerverse/pdf/c
 //
 // Every render option is ignored, pdftohtml having no resolution, colour or
 // annotation switch of any kind. WithPageRange narrows it like everything else.
-func (r *PdfConvert) HTML() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:382:1)
+func (r *PdfConvert) HTML() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:456:1)
 	q := r.query.Select("html")
 
 	return &Directory{
@@ -513,7 +564,7 @@ func (r *PdfConvert) UnmarshalJSON(bs []byte) error {
 // Lossy, so it is the format for a preview a human looks at rather than for
 // input another program measures: the artefacts a flat page compresses into sit
 // exactly where thin strokes are, which is where OCR reads.
-func (r *PdfConvert) Jpeg() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:263:1)
+func (r *PdfConvert) Jpeg() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:337:1)
 	q := r.query.Select("jpeg")
 
 	return &Directory{
@@ -527,7 +578,7 @@ func (r *PdfConvert) Jpeg() *Directory { // pdf (../../../../../daggerverse/pdf/
 // PNG is the format to hand another module: it is lossless, so nothing
 // downstream is reading compression artefacts as page content, and it is what
 // every image library reads without a codec question.
-func (r *PdfConvert) Png() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:252:1)
+func (r *PdfConvert) Png() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:326:1)
 	q := r.query.Select("png")
 
 	return &Directory{
@@ -551,7 +602,7 @@ func (r *PdfConvert) Png() *Directory { // pdf (../../../../../daggerverse/pdf/c
 // are dropped rather than forwarded because poppler does not ignore them — it
 // exits non-zero with `-mono may only be used with the -png, -jpeg, or -tiff
 // output options`, and `-hide-annotations` is not a pdftocairo option at all.
-func (r *PdfConvert) Ps() *File { // pdf (../../../../../daggerverse/pdf/convert.go:340:1)
+func (r *PdfConvert) Ps() *File { // pdf (../../../../../daggerverse/pdf/convert.go:414:1)
 	q := r.query.Select("ps")
 
 	return &File{
@@ -579,7 +630,7 @@ func (r *PdfConvert) Ps() *File { // pdf (../../../../../daggerverse/pdf/convert
 // WithDpi governs the rasterized regions a page can still contain — an embedded
 // photograph has no vector form to keep. WithColorMode, WithScaleTo and
 // WithoutAnnotations are ignored: see the note on Ps.
-func (r *PdfConvert) Svg() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:298:1)
+func (r *PdfConvert) Svg() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:372:1)
 	q := r.query.Select("svg")
 
 	return &Directory{
@@ -641,10 +692,46 @@ func (r *PdfConvert) Text(ctx context.Context, opts ...PdfConvertTextOpts) (stri
 // It is the format the document-imaging world already speaks, and the one to
 // pair with MONO: a bilevel TIFF is what a scanner emits and what an archive
 // expects.
-func (r *PdfConvert) Tiff() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:274:1)
+func (r *PdfConvert) Tiff() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:348:1)
 	q := r.query.Select("tiff")
 
 	return &Directory{
+		query: q,
+	}
+}
+
+// Tsv returns the document's text layer as a tab-separated table with one row
+// per layout element, each naming the page it came from and the box it occupies.
+//
+// It is the text-layer analogue of the tesseract module's Tsv, and the format is
+// literally tesseract's: twelve columns — `level`, `page_num`, `par_num`,
+// `block_num`, `line_num`, `word_num`, `left`, `top`, `width`, `height`, `conf`,
+// `text` — with a header row ahead of them. `level` says what a row describes: 1
+// a page, 3 a flow, 4 a line, 5 a word. Poppler emits no level-2 paragraph row
+// despite carrying the column for it. Structural rows name themselves in the text
+// column — `###PAGE###`, `###FLOW###`, `###LINE###` — and `conf` is -1 on them
+// and 100 on every word, this being extraction and not recognition: there is
+// nothing to be uncertain about.
+//
+// Reach for it over Bbox when the consumer is a table reader — a dataframe, a
+// spreadsheet, awk — rather than a markup parser, and when the page a row belongs
+// to has to be recoverable from the row itself. That is the one thing this format
+// carries and Bbox does not: a `-bbox` page element states its size and never its
+// number, so a narrowed report is traceable only by position, while `page_num`
+// here is the page's number in the whole document even under WithPageRange.
+//
+// Coordinates are in points, from the top-left of the page, and a word's box is
+// the font's ascender-to-descender span around the baseline rather than the
+// glyphs' ink — so a one-glyph word is exactly as tall as a long one. Word rows
+// round to two decimals where the structural rows print six.
+//
+// A page with no text layer yields its page row and no word rows rather than a
+// failure, the same boundary Text and Bbox draw. The render options are ignored,
+// as is LayoutMode. WithPageRange narrows it.
+func (r *PdfConvert) Tsv() *File { // pdf (../../../../../daggerverse/pdf/convert.go:316:1)
+	q := r.query.Select("tsv")
+
+	return &File{
 		query: q,
 	}
 }
@@ -806,7 +893,7 @@ func (r *PdfDocument) WithGraphQLQuery(q *querybuilder.Selection) *PdfDocument {
 	}
 }
 
-// Convert opens the conversion namespace: the render options, and the nine
+// Convert opens the conversion namespace: the render options, and the eleven
 // outputs that read them.
 //
 // It is a separate object rather than more methods on Document because the
@@ -1139,18 +1226,18 @@ type PdfOpts struct {
 	//
 	//
 	// Default: "docker.io"
-	Registry string // pdf (../../../../../daggerverse/pdf/main.go:231:2)
+	Registry string // pdf (../../../../../daggerverse/pdf/main.go:258:2)
 	//
 	// Tag of the alpine image the toolchain is assembled on.
 	//
 	//
 	// Default: "3.24"
-	AlpineTag string // pdf (../../../../../daggerverse/pdf/main.go:234:2)
+	AlpineTag string // pdf (../../../../../daggerverse/pdf/main.go:261:2)
 }
 
 // New returns a Pdf module backed by <registry>/library/alpine:<tag> with
 // poppler-utils and a substitute font family installed.
-func (r *Query) Pdf(opts ...PdfOpts) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:226:1)
+func (r *Query) Pdf(opts ...PdfOpts) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:253:1)
 	q := r.query.Select("pdf")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `registry` optional argument

--- a/daggerverse/pdf/tests/main.go
+++ b/daggerverse/pdf/tests/main.go
@@ -10,11 +10,16 @@ package main
 
 import (
 	"context"
+	"encoding/xml"
+	"errors"
 	"fmt"
 	"image"
+	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 
 	// Registered for their decoders alone: the geometry and pixel assertions
@@ -125,7 +130,79 @@ const (
 	// the render geometry assertions are derived from.
 	ledgerPageWidth  = 612
 	ledgerPageHeight = 792
+
+	// The next six constants are ledgerPdf's text geometry, read straight out of
+	// the fixture's own content stream — `/F1 24 Tf`, `72 680 Td`, `40 TL` — and
+	// are what the bbox and TSV assertions derive their expected boxes from. They
+	// are the reason those assertions can be exact rather than non-empty: the
+	// coordinates poppler reports are the document's own, so any number it prints
+	// is predictable from the fixture without asking another tool.
+
+	// ledgerTextX is the x of every line's text origin, and so the xMin the
+	// first word of every line has to report.
+	ledgerTextX = 72
+	// ledgerFirstBaseline is the y of the first line's baseline, measured from
+	// the bottom of the page the way PDF coordinates are. Poppler reports boxes
+	// from the *top*, so every expectation below subtracts.
+	ledgerFirstBaseline = 680
+	// ledgerLeading is the `TL` each subsequent line drops the baseline by.
+	ledgerLeading = 40
+	// ledgerFontSize is the size the pages are set at.
+	ledgerFontSize = 24
+	// helveticaAscent and helveticaDescent are Helvetica's AFM ascender and
+	// descender as fractions of the font size — 718 and -207 per 1000 — and are
+	// what poppler measures a word's box from rather than the glyphs' own ink.
+	// That is why the box is the same height for `ledger.` as for `1`, and why a
+	// word's height comes out (0.718 + 0.207) x 24 = 22.2 points.
+	helveticaAscent  = 0.718
+	helveticaDescent = 0.207
+
+	// ledgerWordsPerPage is how many space-separated words a ledgerPdf page
+	// carries: five on the first line, two on the second.
+	ledgerWordsPerPage = 7
+	// ledgerFirstLineWords is how many of those are on the first line.
+	ledgerFirstLineWords = 5
+	// ledgerLines is how many lines each page carries, which is how many blocks
+	// -bbox-layout groups them into: the 40-point leading against a 22.2-point
+	// line is a gap poppler reads as a paragraph break.
+	ledgerLines = 2
+
+	// geometryEpsilon is the slack a coordinate comparison allows. It is set by
+	// the *output* rather than by the arithmetic: pdftotext prints a bbox
+	// coordinate to six decimals but rounds a TSV word row to two, so a two-
+	// decimal row is up to 0.005 away from the exact value.
+	geometryEpsilon = 0.01
+
+	// tsvLevelPage, tsvLevelFlow, tsvLevelLine and tsvLevelWord are the layout
+	// elements a -tsv row's `level` column names. The numbering is tesseract's
+	// — the format is a port of its TSV renderer, which is what makes the two
+	// modules' geometry outputs the same shape — and poppler uses four of the
+	// five: there is no level-2 paragraph row, the `par_num` column
+	// notwithstanding.
+	tsvLevelPage = 1
+	tsvLevelFlow = 3
+	tsvLevelLine = 4
+	tsvLevelWord = 5
+
+	// The columns a -tsv row is read out of, by index into the twelve tsvColumns
+	// name.
+	tsvColumnLevel  = 0
+	tsvColumnPage   = 1
+	tsvColumnLeft   = 6
+	tsvColumnTop    = 7
+	tsvColumnWidth  = 8
+	tsvColumnHeight = 9
+	tsvColumnText   = 11
 )
+
+// tsvColumns is the header row pdftotext -tsv writes, and the shape every row
+// under it has. Asserting it whole is what makes the index constants above safe:
+// a column inserted upstream moves every coordinate this suite reads, and would
+// otherwise turn into a silently wrong geometry assertion.
+var tsvColumns = []string{
+	"level", "page_num", "par_num", "block_num", "line_num", "word_num",
+	"left", "top", "width", "height", "conf", "text",
+}
 
 // ledgerMarkers is the marker word on each page of ledgerPdf, in page order.
 //
@@ -189,6 +266,12 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("TxtMatchesText", t.TxtMatchesText)
 	jobs = jobs.WithJob("DisablePageBreaksControlsFormFeeds", t.DisablePageBreaksControlsFormFeeds)
 	jobs = jobs.WithJob("LayoutModesProduceDifferentOrderings", t.LayoutModesProduceDifferentOrderings)
+
+	jobs = jobs.WithJob("BboxCarriesOneBoxPerWord", t.BboxCarriesOneBoxPerWord)
+	jobs = jobs.WithJob("BboxWithLayoutAddsBlockAndLineBoxes", t.BboxWithLayoutAddsBlockAndLineBoxes)
+	jobs = jobs.WithJob("TsvRowsCarryPageNumbersAndWordGeometry", t.TsvRowsCarryPageNumbersAndWordGeometry)
+	jobs = jobs.WithJob("PageRangeNarrowsTheGeometryOutputs", t.PageRangeNarrowsTheGeometryOutputs)
+	jobs = jobs.WithJob("GeometryOfAnImageOnlyPdfReportsPagesWithoutWords", t.GeometryOfAnImageOnlyPdfReportsPagesWithoutWords)
 
 	jobs = jobs.WithJob("PageRangeNarrowsText", t.PageRangeNarrowsText)
 	jobs = jobs.WithJob("PageRangeOpenEndedRunsToTheLastPage", t.PageRangeOpenEndedRunsToTheLastPage)
@@ -1244,6 +1327,655 @@ func hasSideBySideLine(text, left, right string) bool {
 		}
 	}
 	return false
+}
+
+// BboxCarriesOneBoxPerWord asserts Bbox reports the page's size and one box per
+// word, at the coordinates the document itself draws the words at.
+//
+// The coordinates are the whole point of the function, so they are checked and
+// not merely counted. ledgerPdf sets its pages with `/F1 24 Tf`, `72 680 Td` and
+// `40 TL`, so every number poppler can print here is derivable from the fixture:
+// the first word of a line starts at x=72, and a line's box runs from the
+// baseline less Helvetica's ascender to the baseline plus its descender, measured
+// down from the top of the 792-point page. A test that asserted the boxes were
+// non-empty would pass just as well on boxes that were all the same.
+//
+// The absence of layout boxes is asserted too, because that is what `withLayout`
+// is the difference between: a plain -bbox report carries words directly under
+// the page, with no flow, block or line around them.
+func (t *Tests) BboxCarriesOneBoxPerWord(ctx context.Context) error {
+	report, err := pdf().Document(fixture(ledgerPdf)).Convert().Bbox().Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("Bbox: %w", err)
+	}
+	doc, err := parseBbox(report)
+	if err != nil {
+		return err
+	}
+	if len(doc.Pages) != ledgerPages {
+		return fmt.Errorf("expected %d pages in the report, got %d", ledgerPages, len(doc.Pages))
+	}
+
+	for i, page := range doc.Pages {
+		number := i + 1
+		if !nearly(page.Width, ledgerPageWidth) || !nearly(page.Height, ledgerPageHeight) {
+			return fmt.Errorf("page %d: expected a %dx%d point page, got %gx%g",
+				number, ledgerPageWidth, ledgerPageHeight, page.Width, page.Height)
+		}
+		if len(page.Flows) != 0 {
+			return fmt.Errorf("page %d: expected no layout boxes without withLayout, got %d flows",
+				number, len(page.Flows))
+		}
+		if len(page.Words) != ledgerWordsPerPage {
+			return fmt.Errorf("page %d: expected %d words, got %d: %v",
+				number, ledgerWordsPerPage, len(page.Words), wordTexts(page.Words))
+		}
+
+		// The marker word is what makes this page this page: it occurs nowhere
+		// else in the document, so a report whose pages were reordered or whose
+		// words were carried over from the previous page fails here.
+		if want := ledgerMarkers[i] + "."; page.Words[ledgerWordsPerPage-1].Text != want {
+			return fmt.Errorf("page %d: expected the last word to be %q, got %v",
+				number, want, wordTexts(page.Words))
+		}
+		if err := assertLedgerWordBoxes(number, page.Words); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// BboxWithLayoutAddsBlockAndLineBoxes asserts withLayout wraps the same word
+// boxes in the block and line boxes poppler groups them into.
+//
+// Both halves matter. The words have to be the same words at the same
+// coordinates, because the layout report is meant to be the plain one with more
+// structure and not a differently measured one — so the two reports' words are
+// compared box for box. And the boxes that were added have to mean something:
+// each line's box is asserted to be exactly the union of the words under it, and
+// each block's the union of its lines. A test that only counted `block` elements
+// would pass on boxes that were all the page.
+//
+// ledgerPdf is the fixture for it because its two lines land in two blocks: the
+// 40-point leading against a 22.2-point line is a gap poppler reads as a
+// paragraph break, so the block grouping is observable rather than degenerate.
+func (t *Tests) BboxWithLayoutAddsBlockAndLineBoxes(ctx context.Context) error {
+	conv := pdf().Document(fixture(ledgerPdf)).Convert()
+
+	plainReport, err := conv.Bbox().Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("Bbox: %w", err)
+	}
+	plain, err := parseBbox(plainReport)
+	if err != nil {
+		return err
+	}
+
+	layoutReport, err := conv.Bbox(dagger.PdfConvertBboxOpts{WithLayout: true}).Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("Bbox with layout: %w", err)
+	}
+	layout, err := parseBbox(layoutReport)
+	if err != nil {
+		return err
+	}
+
+	if len(layout.Pages) != len(plain.Pages) {
+		return fmt.Errorf("expected withLayout to report the same %d pages, got %d",
+			len(plain.Pages), len(layout.Pages))
+	}
+	for i, page := range layout.Pages {
+		number := i + 1
+		if len(page.Words) != 0 {
+			return fmt.Errorf("page %d: expected withLayout to put every word under a line, got %d loose words",
+				number, len(page.Words))
+		}
+
+		var blocks []bboxBlock
+		for _, flow := range page.Flows {
+			blocks = append(blocks, flow.Blocks...)
+		}
+		if len(blocks) != ledgerLines {
+			return fmt.Errorf("page %d: expected %d blocks, one per line of the page, got %d",
+				number, ledgerLines, len(blocks))
+		}
+
+		var words []bboxWord
+		for _, block := range blocks {
+			var blockWords []bboxWord
+			for _, line := range block.Lines {
+				if len(line.Words) == 0 {
+					return fmt.Errorf("page %d: a line box carries no words: %s", number, line.bboxRect)
+				}
+				if got, want := line.bboxRect, union(line.Words); got != want {
+					return fmt.Errorf("page %d: expected the line box to be the union of its words %s, got %s",
+						number, want, got)
+				}
+				blockWords = append(blockWords, line.Words...)
+			}
+			if got, want := block.bboxRect, union(blockWords); got != want {
+				return fmt.Errorf("page %d: expected the block box to be the union of its lines %s, got %s",
+					number, want, got)
+			}
+			words = append(words, blockWords...)
+		}
+
+		// Same words, same boxes: the layout report is the plain one with
+		// structure added, not a second measurement of the page.
+		if !slices.Equal(words, plain.Pages[i].Words) {
+			return fmt.Errorf("page %d: expected withLayout to carry the same word boxes\nplain:  %v\nlayout: %v",
+				number, plain.Pages[i].Words, words)
+		}
+	}
+	return nil
+}
+
+// union is the smallest box containing every word's box, which is what a line's
+// and a block's box have to report for what sits under them.
+func union(words []bboxWord) bboxRect {
+	if len(words) == 0 {
+		return bboxRect{}
+	}
+	out := words[0].bboxRect
+	for _, w := range words[1:] {
+		out.XMin = min(out.XMin, w.XMin)
+		out.YMin = min(out.YMin, w.YMin)
+		out.XMax = max(out.XMax, w.XMax)
+		out.YMax = max(out.YMax, w.YMax)
+	}
+	return out
+}
+
+// assertLedgerWordBoxes checks one ledgerPdf page's word boxes against the
+// geometry its content stream draws them at.
+//
+// Each of the page's two lines is checked as a line: its words share the vertical
+// extent the baseline and the font's metrics fix, the first of them opens at the
+// text origin, and the rest advance to the right of it without overlapping. The
+// horizontal progression is what would catch boxes that carried the right
+// vertical extent while being pinned to one x.
+func assertLedgerWordBoxes(page int, words []bboxWord) error {
+	for line, span := range [][]bboxWord{
+		words[:ledgerFirstLineWords],
+		words[ledgerFirstLineWords:],
+	} {
+		top, bottom := ledgerLineExtent(line)
+		for i, word := range span {
+			if !nearly(word.YMin, top) || !nearly(word.YMax, bottom) {
+				return fmt.Errorf("page %d line %d: expected %q to run from y=%g to y=%g, got %s",
+					page, line, word.Text, top, bottom, word.bboxRect)
+			}
+			if word.XMax <= word.XMin {
+				return fmt.Errorf("page %d line %d: expected %q to have width, got %s",
+					page, line, word.Text, word.bboxRect)
+			}
+			if i == 0 {
+				if !nearly(word.XMin, ledgerTextX) {
+					return fmt.Errorf("page %d line %d: expected %q to open the line at x=%d, got %s",
+						page, line, word.Text, ledgerTextX, word.bboxRect)
+				}
+				continue
+			}
+			if prev := span[i-1]; word.XMin < prev.XMax {
+				return fmt.Errorf("page %d line %d: expected %q to start right of %q, got %s after %s",
+					page, line, word.Text, prev.Text, word.bboxRect, prev.bboxRect)
+			}
+		}
+	}
+	return nil
+}
+
+// ledgerLineExtent is the top and bottom a word on the given line of a ledgerPdf
+// page has to report, lines counted from zero.
+//
+// Poppler reports a box from the top of the page while the document places its
+// text from the bottom, so the baseline is subtracted from the page height rather
+// than used directly — and the box is the font's ascender-to-descender span
+// around that baseline, not the glyphs' ink.
+func ledgerLineExtent(line int) (top, bottom float64) {
+	baseline := float64(ledgerFirstBaseline - line*ledgerLeading)
+	return ledgerPageHeight - baseline - helveticaAscent*ledgerFontSize,
+		ledgerPageHeight - baseline + helveticaDescent*ledgerFontSize
+}
+
+// nearly compares two coordinates in points. See geometryEpsilon for why the
+// slack exists at all.
+func nearly(got, want float64) bool {
+	return math.Abs(got-want) < geometryEpsilon
+}
+
+// bboxRect is the four numbers every element of a -bbox report carries, in
+// points, measured from the top-left of the page.
+type bboxRect struct {
+	XMin float64 `xml:"xMin,attr"`
+	YMin float64 `xml:"yMin,attr"`
+	XMax float64 `xml:"xMax,attr"`
+	YMax float64 `xml:"yMax,attr"`
+}
+
+// String renders a box for an assertion message, which is the only reason a
+// coordinate ever needs formatting here.
+func (r bboxRect) String() string {
+	return fmt.Sprintf("[%g %g %g %g]", r.XMin, r.YMin, r.XMax, r.YMax)
+}
+
+// bboxWord is one word and the box it occupies.
+type bboxWord struct {
+	bboxRect
+	Text string `xml:",chardata"`
+}
+
+// bboxLine and bboxBlock are the layout boxes -bbox-layout adds around the
+// words. A plain -bbox report has neither.
+type bboxLine struct {
+	bboxRect
+	Words []bboxWord `xml:"word"`
+}
+
+type bboxBlock struct {
+	bboxRect
+	Lines []bboxLine `xml:"line"`
+}
+
+// bboxFlow is the outermost layout grouping, and carries no box of its own.
+type bboxFlow struct {
+	Blocks []bboxBlock `xml:"block"`
+}
+
+// bboxPage is one page of the report. Both shapes are modelled at once because
+// which one a page arrives in is exactly what `withLayout` decides: plain -bbox
+// puts the words directly under the page, and -bbox-layout puts them under
+// flow/block/line — so exactly one of Words and Flows is ever populated, and
+// which one is an assertion rather than an assumption.
+type bboxPage struct {
+	Width  float64    `xml:"width,attr"`
+	Height float64    `xml:"height,attr"`
+	Words  []bboxWord `xml:"word"`
+	Flows  []bboxFlow `xml:"flow"`
+}
+
+type bboxDoc struct {
+	Pages []bboxPage `xml:"page"`
+}
+
+// parseBbox reads the <doc> subtree out of a -bbox report.
+//
+// The report is a whole XHTML document — `-bbox` sets `-htmlmeta`, so the boxes
+// arrive wrapped in a doctype, an html element and a head — and only the <doc>
+// inside it is the report. Tokenising down to that element rather than modelling
+// the wrapper keeps the expectations about the boxes and not about the markup
+// poppler carries them in.
+func parseBbox(report string) (bboxDoc, error) {
+	dec := xml.NewDecoder(strings.NewReader(report))
+	for {
+		tok, err := dec.Token()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return bboxDoc{}, fmt.Errorf("parse the bbox report: %w\n%s", err, head(report))
+		}
+		start, ok := tok.(xml.StartElement)
+		if !ok || start.Name.Local != "doc" {
+			continue
+		}
+		var doc bboxDoc
+		if err := dec.DecodeElement(&doc, &start); err != nil {
+			return bboxDoc{}, fmt.Errorf("decode the bbox report: %w\n%s", err, head(report))
+		}
+		return doc, nil
+	}
+	return bboxDoc{}, fmt.Errorf("expected a <doc> element in the report, got:\n%s", head(report))
+}
+
+// wordTexts is a page's words in order, for an assertion message.
+func wordTexts(words []bboxWord) []string {
+	out := make([]string, 0, len(words))
+	for _, w := range words {
+		out = append(out, w.Text)
+	}
+	return out
+}
+
+// TsvRowsCarryPageNumbersAndWordGeometry asserts Tsv reports one row per layout
+// element, each naming the page it came from and the box it occupies.
+//
+// The page number is the half that makes the format worth having next to Bbox: a
+// `-bbox` page element carries a size and no number, so a report of a multi-page
+// document is traceable back to its pages only positionally, while every TSV row
+// names its page outright. This asserts the numbers run 1..12 in order on the page
+// rows, and that each page's word rows carry that page's marker word — so a row
+// attributed to the wrong page fails here.
+//
+// The geometry is the other half, and is checked against the fixture's own
+// content stream rather than asserted non-empty: a word row's `left` is the text
+// origin for the first word of a line, its `top` is the baseline measured down
+// from the top of the page less the font's ascender, and its `height` is the
+// ascender-to-descender span — 22.2 points at 24pt Helvetica, the same for a
+// one-glyph word as for a seven-glyph one.
+func (t *Tests) TsvRowsCarryPageNumbersAndWordGeometry(ctx context.Context) error {
+	report, err := pdf().Document(fixture(ledgerPdf)).Convert().Tsv().Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("Tsv: %w", err)
+	}
+	rows, err := parseTsv(report)
+	if err != nil {
+		return err
+	}
+
+	pages := rowsAtLevel(rows, tsvLevelPage)
+	if len(pages) != ledgerPages {
+		return fmt.Errorf("expected %d page rows, got %d", ledgerPages, len(pages))
+	}
+	for i, row := range pages {
+		if want := i + 1; row.page != want {
+			return fmt.Errorf("expected page row %d to be numbered %d, got %d", i, want, row.page)
+		}
+		// Only the size is checked. A page row's `left` and `top` are poppler's
+		// own quirk: the first page reports 0,0 and every page after it reports
+		// the previous page's last word, so an assertion about them would be an
+		// assertion about a bug.
+		if !nearly(row.width, ledgerPageWidth) || !nearly(row.height, ledgerPageHeight) {
+			return fmt.Errorf("page %d: expected a %dx%d point page row, got %gx%g",
+				row.page, ledgerPageWidth, ledgerPageHeight, row.width, row.height)
+		}
+	}
+
+	// The structural rows are part of the format and are what a consumer groups
+	// words by, so their count is asserted too: ledgerPdf's two lines are two
+	// flows of one line each on every page.
+	for _, level := range []struct {
+		level int
+		name  string
+	}{{tsvLevelFlow, "flow"}, {tsvLevelLine, "line"}} {
+		got := rowsAtLevel(rows, level.level)
+		if want := ledgerPages * ledgerLines; len(got) != want {
+			return fmt.Errorf("expected %d %s rows, got %d", want, level.name, len(got))
+		}
+	}
+
+	words := rowsAtLevel(rows, tsvLevelWord)
+	if want := ledgerPages * ledgerWordsPerPage; len(words) != want {
+		return fmt.Errorf("expected %d word rows, got %d", want, len(words))
+	}
+	for page := 1; page <= ledgerPages; page++ {
+		onPage := rowsOnPage(words, page)
+		if len(onPage) != ledgerWordsPerPage {
+			return fmt.Errorf("page %d: expected %d word rows, got %d",
+				page, ledgerWordsPerPage, len(onPage))
+		}
+		// The marker word occurs on exactly one page of the document, so a row
+		// attributed to the wrong page is visible here and nowhere else.
+		if want := ledgerMarkers[page-1] + "."; onPage[ledgerWordsPerPage-1].text != want {
+			return fmt.Errorf("page %d: expected the last word row to read %q, got %q",
+				page, want, onPage[ledgerWordsPerPage-1].text)
+		}
+		if err := assertLedgerWordRows(page, onPage); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// assertLedgerWordRows checks one ledgerPdf page's word rows against the geometry
+// its content stream draws them at.
+//
+// A row reports a position and a size where a bbox element reports two corners,
+// so this is the same assertion in the other spelling — which is the point of
+// checking it twice: a `width` that was really an `xMax` would satisfy the bbox
+// test and fail here.
+func assertLedgerWordRows(page int, rows []tsvRow) error {
+	for line, span := range [][]tsvRow{
+		rows[:ledgerFirstLineWords],
+		rows[ledgerFirstLineWords:],
+	} {
+		top, bottom := ledgerLineExtent(line)
+		for i, row := range span {
+			if !nearly(row.top, top) {
+				return fmt.Errorf("page %d line %d: expected %q at top=%g, got %g",
+					page, line, row.text, top, row.top)
+			}
+			if !nearly(row.height, bottom-top) {
+				return fmt.Errorf("page %d line %d: expected %q to be %g points tall, got %g",
+					page, line, row.text, bottom-top, row.height)
+			}
+			if row.width <= 0 {
+				return fmt.Errorf("page %d line %d: expected %q to have width, got %g",
+					page, line, row.text, row.width)
+			}
+			if i == 0 {
+				if !nearly(row.left, ledgerTextX) {
+					return fmt.Errorf("page %d line %d: expected %q to open the line at left=%d, got %g",
+						page, line, row.text, ledgerTextX, row.left)
+				}
+				continue
+			}
+			if prev := span[i-1]; row.left < prev.left+prev.width {
+				return fmt.Errorf("page %d line %d: expected %q to start right of %q, got left=%g after left=%g width=%g",
+					page, line, row.text, prev.text, row.left, prev.left, prev.width)
+			}
+		}
+	}
+	return nil
+}
+
+// PageRangeNarrowsTheGeometryOutputs asserts WithPageRange narrows Bbox and Tsv
+// to the pages it names, in all three shapes the two functions come in.
+//
+// The two formats answer "which page is this" differently, and that difference is
+// the reason this test checks the narrowing on both rather than trusting one. A
+// `-bbox` page element carries a width and a height and no number at all, so the
+// only thing that ties a narrowed report back to the document is the order of its
+// pages and the words on them — which is what the marker words are checked for
+// here. A TSV row names its page outright, and names it with the page's number in
+// the *whole* document rather than its position in the range: pages 4 through 6
+// come back as 4, 5 and 6, not as 1, 2 and 3.
+func (t *Tests) PageRangeNarrowsTheGeometryOutputs(ctx context.Context) error {
+	const first, last = 4, 6
+
+	conv := pdf().Document(fixture(ledgerPdf)).WithPageRange(first, last).Convert()
+
+	for _, tc := range []struct {
+		name string
+		file *dagger.File
+	}{
+		{"Bbox", conv.Bbox()},
+		{"Bbox with layout", conv.Bbox(dagger.PdfConvertBboxOpts{WithLayout: true})},
+	} {
+		report, err := tc.file.Contents(ctx)
+		if err != nil {
+			return fmt.Errorf("%s: %w", tc.name, err)
+		}
+		doc, err := parseBbox(report)
+		if err != nil {
+			return fmt.Errorf("%s: %w", tc.name, err)
+		}
+		if want := last - first + 1; len(doc.Pages) != want {
+			return fmt.Errorf("%s: expected %d pages, got %d", tc.name, want, len(doc.Pages))
+		}
+		for i, page := range doc.Pages {
+			words := page.Words
+			for _, flow := range page.Flows {
+				for _, block := range flow.Blocks {
+					for _, line := range block.Lines {
+						words = append(words, line.Words...)
+					}
+				}
+			}
+			// The marker word is the only thing in the report that says which
+			// page of the document this is.
+			if want := ledgerMarkers[first-1+i] + "."; words[len(words)-1].Text != want {
+				return fmt.Errorf("%s: expected page %d of the report to be document page %d, carrying %q, got %v",
+					tc.name, i+1, first+i, want, wordTexts(words))
+			}
+		}
+	}
+
+	report, err := conv.Tsv().Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("Tsv: %w", err)
+	}
+	rows, err := parseTsv(report)
+	if err != nil {
+		return err
+	}
+	var numbered []int
+	for _, row := range rowsAtLevel(rows, tsvLevelPage) {
+		numbered = append(numbered, row.page)
+	}
+	want := []int{}
+	for page := first; page <= last; page++ {
+		want = append(want, page)
+	}
+	if !slices.Equal(numbered, want) {
+		return fmt.Errorf("expected the page rows to name the document's own pages %v, got %v", want, numbered)
+	}
+	// Every word row belongs to a page in range too, which is what would catch a
+	// report that narrowed its page rows and not its words.
+	for _, row := range rowsAtLevel(rows, tsvLevelWord) {
+		if row.page < first || row.page > last {
+			return fmt.Errorf("expected every word row to be on pages %d-%d, got %q on page %d",
+				first, last, row.text, row.page)
+		}
+	}
+	return nil
+}
+
+// GeometryOfAnImageOnlyPdfReportsPagesWithoutWords asserts a PDF with no text
+// layer produces a well-formed report of a page with nothing on it, and does not
+// fail.
+//
+// It is the same boundary with the tesseract module that TextOnImageOnlyPdfReturnsNothing
+// draws, and it needs its own assertion because the failure mode here is louder:
+// poppler writes `no word list` to *stderr* for such a page and exits 0, having
+// written a perfectly good report to the output file. A module that read stderr as
+// a diagnostic, or that treated the absence of words as a document it could not
+// open, would turn the signal to go and rasterize this document into an error.
+//
+// The page element still has to be there and still has to state its size, because
+// that is what distinguishes a page carrying no text from a document that was
+// never read.
+func (t *Tests) GeometryOfAnImageOnlyPdfReportsPagesWithoutWords(ctx context.Context) error {
+	conv := pdf().Document(fixture(scanPdf)).Convert()
+
+	report, err := conv.Bbox().Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("Bbox: %w", err)
+	}
+	doc, err := parseBbox(report)
+	if err != nil {
+		return err
+	}
+	if len(doc.Pages) != 1 {
+		return fmt.Errorf("expected one page in the report, got %d", len(doc.Pages))
+	}
+	page := doc.Pages[0]
+	if !nearly(page.Width, ledgerPageWidth) || !nearly(page.Height, ledgerPageHeight) {
+		return fmt.Errorf("expected a %dx%d point page, got %gx%g",
+			ledgerPageWidth, ledgerPageHeight, page.Width, page.Height)
+	}
+	if len(page.Words) != 0 || len(page.Flows) != 0 {
+		return fmt.Errorf("expected no words on a page with no text layer, got %v",
+			wordTexts(page.Words))
+	}
+
+	tsv, err := conv.Tsv().Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("Tsv: %w", err)
+	}
+	rows, err := parseTsv(tsv)
+	if err != nil {
+		return err
+	}
+	if got := len(rowsAtLevel(rows, tsvLevelPage)); got != 1 {
+		return fmt.Errorf("expected one page row, got %d", got)
+	}
+	if got := rowsAtLevel(rows, tsvLevelWord); len(got) != 0 {
+		return fmt.Errorf("expected no word rows on a page with no text layer, got %d", len(got))
+	}
+	return nil
+}
+
+// tsvRow is one row of a -tsv report: which layout element it describes, which
+// page it came from, the box it occupies and the text in it.
+type tsvRow struct {
+	level  int
+	page   int
+	left   float64
+	top    float64
+	width  float64
+	height float64
+	text   string
+}
+
+// parseTsv reads a -tsv report, header included, and rejects anything that is not
+// the twelve-column table poppler documents.
+func parseTsv(report string) ([]tsvRow, error) {
+	lines := strings.Split(strings.TrimRight(report, "\n"), "\n")
+	if len(lines) == 0 {
+		return nil, fmt.Errorf("the report is empty")
+	}
+	if got := strings.Split(lines[0], "\t"); !slices.Equal(got, tsvColumns) {
+		return nil, fmt.Errorf("expected the header %v, got %v", tsvColumns, got)
+	}
+
+	rows := make([]tsvRow, 0, len(lines)-1)
+	for i, line := range lines[1:] {
+		fields := strings.Split(line, "\t")
+		if len(fields) != len(tsvColumns) {
+			return nil, fmt.Errorf("row %d: expected %d columns, got %d: %q",
+				i, len(tsvColumns), len(fields), line)
+		}
+		var row tsvRow
+		var err error
+		for _, num := range []struct {
+			column int
+			into   *int
+		}{{tsvColumnLevel, &row.level}, {tsvColumnPage, &row.page}} {
+			if *num.into, err = strconv.Atoi(fields[num.column]); err != nil {
+				return nil, fmt.Errorf("row %d: %q is not a number: %q", i, fields[num.column], line)
+			}
+		}
+		for _, coord := range []struct {
+			column int
+			into   *float64
+		}{
+			{tsvColumnLeft, &row.left},
+			{tsvColumnTop, &row.top},
+			{tsvColumnWidth, &row.width},
+			{tsvColumnHeight, &row.height},
+		} {
+			if *coord.into, err = strconv.ParseFloat(fields[coord.column], 64); err != nil {
+				return nil, fmt.Errorf("row %d: %q is not a coordinate: %q", i, fields[coord.column], line)
+			}
+		}
+		row.text = fields[tsvColumnText]
+		rows = append(rows, row)
+	}
+	return rows, nil
+}
+
+// rowsAtLevel is every row describing one kind of layout element, in report
+// order.
+func rowsAtLevel(rows []tsvRow, level int) []tsvRow {
+	var out []tsvRow
+	for _, row := range rows {
+		if row.level == level {
+			out = append(out, row)
+		}
+	}
+	return out
+}
+
+// rowsOnPage is every row a report attributes to one page, in report order.
+func rowsOnPage(rows []tsvRow, page int) []tsvRow {
+	var out []tsvRow
+	for _, row := range rows {
+		if row.page == page {
+			out = append(out, row)
+		}
+	}
+	return out
 }
 
 // PngNamesEveryPageWithFourDigits asserts the page-naming contract on a


### PR DESCRIPTION
Closes #269.

`Text` returns words. Layout-aware post-processing needs where each word *was*, so `Convert` grows the two `pdftotext` modes that report it.

```go
Convert.Bbox(ctx, withLayout bool) (*dagger.File, error)
Convert.Tsv(ctx) (*dagger.File, error)
```

`Bbox` emits an XHTML report — a `page` element per page naming its size, holding a `word` element per space-separated word with its `xMin`/`yMin`/`xMax`/`yMax`. `withLayout` selects `-bbox-layout` over `-bbox`, wrapping the same words at the same coordinates in the `flow`, `block` and `line` boxes poppler groups them into. `Tsv` emits the twelve-column table with a row per layout element.

These are the text-layer analogues of the `tesseract` module's `Hocr` and `Tsv` — the same shape of answer, sourced from the document's own coordinates rather than from recognition, so the boxes are **exact rather than estimated**.

Both go through one `geometry` helper, because the three modes differ only in their flag: none takes a layout mode, none takes a page-break switch, and both narrow to `WithPageRange`.

## The coordinates are checked, not counted

`ledger.pdf`'s content stream sets its pages with `/F1 24 Tf`, `72 680 Td` and `40 TL`, so every number poppler can print here is derivable from the fixture without asking another tool: a line's box runs from its baseline less Helvetica's ascender (718/1000) to that baseline plus its descender (207/1000), measured **down** from the top of the 792-point page. Each expectation was mutation-checked — moving the ascender from 0.718 to 0.719 fails `BboxCarriesOneBoxPerWord` on a 0.024-point drift, and swapping the TSV `width`/`height` column indices fails `TsvRowsCarryPageNumbersAndWordGeometry`.

The same geometry is asserted in both spellings on purpose: bbox reports two corners where TSV reports a position and a size, so a `width` that was really an `xMax` would satisfy one test and fail the other.

## Two behaviours the prose alone would not pin

- **A TSV row names its page with that page's number in the whole document**, even under `WithPageRange` — pages 4 through 6 come back as 4, 5 and 6 — while a bbox `page` element carries a size and *no number at all*, so a narrowed bbox report is traceable only positionally. That asymmetry is the reason to reach for one format over the other, so `PageRangeNarrowsTheGeometryOutputs` asserts both halves.
- **A page with no text layer yields a well-formed empty report and exits 0**, poppler noting `no word list` on *stderr*. That is the same boundary `Text` draws — no words is the signal to rasterize and hand the page to `tesseract`, not a failure — and it needs its own assertion precisely because the diagnostic lands on a stream this module does not read.

Also documented from measurement: there is no level-2 paragraph row despite the `par_num` column; `conf` is -1 on structural rows and 100 on every word (this is extraction, not recognition); word rows round to two decimals where structural rows print six; and a TSV page row's `left`/`top` are stale after the first page, carrying the previous page's last word — so the tests assert the size and deliberately not the position.

## Verification

- Each of the five new tests written, watched fail for the expected reason, implemented against, and mutation-checked individually.
- `dagger -m daggerverse/pdf/tests call all` — green (44 tests).
- `dagger -m ci call generated` — green, root `ci/internal/dagger/pdf-tests.gen.go` regenerated after the last source edit.
- `bbox` and `tsv` confirmed in `dagger call document ... convert --help`.
- No `+cache=` directive added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)