### PR TITLE
story(issue-271): extract embedded images and file attachments

### DIFF
--- a/ci/internal/dagger/pdf-tests.gen.go
+++ b/ci/internal/dagger/pdf-tests.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type PdfTests
-func (r *Binding) AsPdfTests() *PdfTests { // pdf-tests (../../../daggerverse/pdf/tests/main.go:228:6)
+func (r *Binding) AsPdfTests() *PdfTests { // pdf-tests (../../../daggerverse/pdf/tests/main.go:295:6)
 	q := r.query.Select("asPdfTests")
 
 	return &PdfTests{
@@ -19,7 +19,7 @@ func (r *Binding) AsPdfTests() *PdfTests { // pdf-tests (../../../daggerverse/pd
 }
 
 // Create or update a binding of type PdfTests in the environment
-func (r *Env) WithPdfTestsInput(name string, value *PdfTests, description string) *Env { // pdf-tests (../../../daggerverse/pdf/tests/main.go:228:6)
+func (r *Env) WithPdfTestsInput(name string, value *PdfTests, description string) *Env { // pdf-tests (../../../daggerverse/pdf/tests/main.go:295:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withPdfTestsInput")
 	q = q.Arg("name", name)
@@ -32,7 +32,7 @@ func (r *Env) WithPdfTestsInput(name string, value *PdfTests, description string
 }
 
 // Declare a desired PdfTests output to be assigned in the environment
-func (r *Env) WithPdfTestsOutput(name string, description string) *Env { // pdf-tests (../../../daggerverse/pdf/tests/main.go:228:6)
+func (r *Env) WithPdfTestsOutput(name string, description string) *Env { // pdf-tests (../../../daggerverse/pdf/tests/main.go:295:6)
 	q := r.query.Select("withPdfTestsOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -42,61 +42,67 @@ func (r *Env) WithPdfTestsOutput(name string, description string) *Env { // pdf-
 	}
 }
 
-type PdfTests struct { // pdf-tests (../../../daggerverse/pdf/tests/main.go:228:6)
+type PdfTests struct { // pdf-tests (../../../daggerverse/pdf/tests/main.go:295:6)
 	query *querybuilder.Selection
 
-	all                                                 *Void
-	apkAuthInstallsFromAuthenticatedRepository          *Void
-	apkRepositoryAssemblesWorkingToolchainFromMirror    *Void
-	apkRepositoryReplacesImageDefaults                  *Void
-	authenticatedRepositoryIsRejectedWithoutApkAuth     *Void
-	bboxCarriesOneBoxPerWord                            *Void
-	bboxWithLayoutAddsBlockAndLineBoxes                 *Void
-	colorModesProduceDifferentPixels                    *Void
-	containerCarriesEveryPopplerBinaryAndTheFont        *Void
-	defaultApkConfigurationIsUntouched                  *Void
-	disablePageBreaksControlsFormFeeds                  *Void
-	dpiDefaultsToOneFiftyAndScalesWithTheSetting        *Void
-	encryptedDocumentNeedsThePassword                   *Void
-	epsWritesEveryPageOfTheDocument                     *Void
-	fontsNarrowsToThePageRange                          *Void
-	fontsReportsWhetherEachFaceIsEmbedded               *Void
-	geometryOfAnImageOnlyPdfReportsPagesWithoutWords    *Void
-	htmlCarriesPageMarkupAndItsImages                   *Void
-	id                                                  *ID
-	infoReportsPageCountAndSize                         *Void
-	jpegAndTiffFollowTheSameContract                    *Void
-	layoutModesProduceDifferentOrderings                *Void
-	mergePreservesTheOrderOfItsSources                  *Void
-	mergeRejectsWhatItCannotMerge                       *Void
-	metadataReturnsTheXmpPacketOrSaysThereIsNone        *Void
-	pageRangeNarrowsEveryPerPageFormat                  *Void
-	pageRangeNarrowsText                                *Void
-	pageRangeNarrowsTheGeometryOutputs                  *Void
-	pageRangeOpenEndedRunsToTheLastPage                 *Void
-	pageRangeRejectsInvalidBounds                       *Void
-	pngNamesEveryPageWithFourDigits                     *Void
-	pngNarrowedRangeKeepsFourDigitNames                 *Void
-	pngSinglePageIsStillNumbered                        *Void
-	psHoldsEveryPageInOneFile                           *Void
-	renderSettingsRejectNonPositiveValues               *Void
-	reportsOpenAnEncryptedDocumentWithThePassword       *Void
-	scaleToOverridesDpi                                 *Void
-	signaturesReportsAnUnsignedDocumentInsteadOfFailing *Void
-	splitAndMergeCannotOpenAnEncryptedDocument          *Void
-	splitNarrowsToThePageRange                          *Void
-	splitThenMergeRoundTripsTheDocument                 *Void
-	splitWritesOnePdfPerPage                            *Void
-	svgWritesOneVectorFilePerPage                       *Void
-	textOnImageOnlyPdfReturnsNothing                    *Void
-	textReproducesTextLayerExactly                      *Void
-	tsvRowsCarryPageNumbersAndWordGeometry              *Void
-	txtMatchesText                                      *Void
-	untrustedIndexIsRejectedWithoutApkKey               *Void
-	vectorFormatsIgnoreRasterOnlySettings               *Void
-	versionReportsPopplerRelease                        *Void
-	withFontsPutsFaceWhereFontconfigFindsIt             *Void
-	withoutAnnotationsRemovesTheAnnotationLayer         *Void
+	all                                                   *Void
+	apkAuthInstallsFromAuthenticatedRepository            *Void
+	apkRepositoryAssemblesWorkingToolchainFromMirror      *Void
+	apkRepositoryReplacesImageDefaults                    *Void
+	attachmentsReportsPopplersRefusalOfPathBearingNames   *Void
+	attachmentsReturnsEveryEmbeddedFileOrSaysThereAreNone *Void
+	authenticatedRepositoryIsRejectedWithoutApkAuth       *Void
+	bboxCarriesOneBoxPerWord                              *Void
+	bboxWithLayoutAddsBlockAndLineBoxes                   *Void
+	colorModesProduceDifferentPixels                      *Void
+	containerCarriesEveryPopplerBinaryAndTheFont          *Void
+	defaultApkConfigurationIsUntouched                    *Void
+	disablePageBreaksControlsFormFeeds                    *Void
+	dpiDefaultsToOneFiftyAndScalesWithTheSetting          *Void
+	embeddedImagesKeepsTheOriginalEncoding                *Void
+	embeddedImagesNamesEveryImageAndNarrowsToThePageRange *Void
+	embeddedImagesReturnsTheStoredImageNotTheRenderedPage *Void
+	encryptedDocumentNeedsThePassword                     *Void
+	epsWritesEveryPageOfTheDocument                       *Void
+	extractionsOpenAnEncryptedDocumentWithThePassword     *Void
+	fontsNarrowsToThePageRange                            *Void
+	fontsReportsWhetherEachFaceIsEmbedded                 *Void
+	geometryOfAnImageOnlyPdfReportsPagesWithoutWords      *Void
+	htmlCarriesPageMarkupAndItsImages                     *Void
+	id                                                    *ID
+	infoReportsPageCountAndSize                           *Void
+	jpegAndTiffFollowTheSameContract                      *Void
+	layoutModesProduceDifferentOrderings                  *Void
+	mergePreservesTheOrderOfItsSources                    *Void
+	mergeRejectsWhatItCannotMerge                         *Void
+	metadataReturnsTheXmpPacketOrSaysThereIsNone          *Void
+	pageRangeNarrowsEveryPerPageFormat                    *Void
+	pageRangeNarrowsText                                  *Void
+	pageRangeNarrowsTheGeometryOutputs                    *Void
+	pageRangeOpenEndedRunsToTheLastPage                   *Void
+	pageRangeRejectsInvalidBounds                         *Void
+	pngNamesEveryPageWithFourDigits                       *Void
+	pngNarrowedRangeKeepsFourDigitNames                   *Void
+	pngSinglePageIsStillNumbered                          *Void
+	psHoldsEveryPageInOneFile                             *Void
+	renderSettingsRejectNonPositiveValues                 *Void
+	reportsOpenAnEncryptedDocumentWithThePassword         *Void
+	scaleToOverridesDpi                                   *Void
+	signaturesReportsAnUnsignedDocumentInsteadOfFailing   *Void
+	splitAndMergeCannotOpenAnEncryptedDocument            *Void
+	splitNarrowsToThePageRange                            *Void
+	splitThenMergeRoundTripsTheDocument                   *Void
+	splitWritesOnePdfPerPage                              *Void
+	svgWritesOneVectorFilePerPage                         *Void
+	textOnImageOnlyPdfReturnsNothing                      *Void
+	textReproducesTextLayerExactly                        *Void
+	tsvRowsCarryPageNumbersAndWordGeometry                *Void
+	txtMatchesText                                        *Void
+	untrustedIndexIsRejectedWithoutApkKey                 *Void
+	vectorFormatsIgnoreRasterOnlySettings                 *Void
+	versionReportsPopplerRelease                          *Void
+	withFontsPutsFaceWhereFontconfigFindsIt               *Void
+	withoutAnnotationsRemovesTheAnnotationLayer           *Void
 }
 
 func (r *PdfTests) WithGraphQLQuery(q *querybuilder.Selection) *PdfTests {
@@ -110,7 +116,7 @@ type PdfTestsAllOpts struct {
 	//
 	// Maximum number of tests to run concurrently. Zero fans out unbounded.
 	//
-	Parallel int // pdf-tests (../../../daggerverse/pdf/tests/main.go:244:2)
+	Parallel int // pdf-tests (../../../daggerverse/pdf/tests/main.go:311:2)
 }
 
 // All runs every pdf-module test in parallel.
@@ -121,7 +127,7 @@ type PdfTestsAllOpts struct {
 // are single-threaded: twenty of them contend for cores the way any other
 // oversubscribed workload does. The cap stays available for a host that wants a
 // narrower slice.
-func (r *PdfTests) All(ctx context.Context, opts ...PdfTestsAllOpts) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:240:1)
+func (r *PdfTests) All(ctx context.Context, opts ...PdfTestsAllOpts) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:307:1)
 	if r.all != nil {
 		return nil
 	}
@@ -193,6 +199,55 @@ func (r *PdfTests) ApkRepositoryReplacesImageDefaults(ctx context.Context) error
 	return q.Execute(ctx)
 }
 
+// AttachmentsReportsPopplersRefusalOfPathBearingNames asserts what happens to a
+// document that names an attachment with a path in it, and asserts the failure
+// carries what a caller needs to get the rest of the attachments anyway.
+//
+// The behaviour is poppler's and it is coarse: one such name makes `-saveall`
+// refuse the *whole* extraction with `Preventing directory traversal`, so the
+// perfectly ordinary second attachment in this fixture comes back not at all. The
+// module cannot fix that — the name is the document's — so what it can do is say
+// which document did it, list the names, and point at the tool that fetches them
+// one at a time. The names are asserted for that reason: they are the argument
+// `pdfdetach -savefile` needs, and without them the message is a dead end.
+func (r *PdfTests) AttachmentsReportsPopplersRefusalOfPathBearingNames(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:745:1)
+	if r.attachmentsReportsPopplersRefusalOfPathBearingNames != nil {
+		return nil
+	}
+	q := r.query.Select("attachmentsReportsPopplersRefusalOfPathBearingNames")
+
+	return q.Execute(ctx)
+}
+
+// AttachmentsReturnsEveryEmbeddedFileOrSaysThereAreNone asserts both halves of
+// what the function promises: every file the document attached, under the name
+// the document gave it, and an answer a caller can act on for a document that
+// attached nothing.
+//
+// Two attachments is the minimum that tests "every" — one would be satisfied by
+// an implementation that saved the first and stopped — and their contents are
+// read rather than their names counted, because a name is not evidence the right
+// bytes landed under it.
+//
+// The names are the fixture's own and are deliberately *not* the page-style
+// contract the rest of this module's directories honour. An attachment's name is
+// data: it is what the producer called the file and what a consumer looks for, so
+// `invoice.xml` staying `invoice.xml` is the assertion, not a defect in the
+// naming discipline.
+//
+// The empty case is refused rather than returned as an empty directory. pdfdetach
+// exits 0 for a document with no attachments, so the directory would say nothing
+// about which of the two happened, and the message names `pdfdetach -list` as the
+// way to ask without failing.
+func (r *PdfTests) AttachmentsReturnsEveryEmbeddedFileOrSaysThereAreNone(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:676:1)
+	if r.attachmentsReturnsEveryEmbeddedFileOrSaysThereAreNone != nil {
+		return nil
+	}
+	q := r.query.Select("attachmentsReturnsEveryEmbeddedFileOrSaysThereAreNone")
+
+	return q.Execute(ctx)
+}
+
 // AuthenticatedRepositoryIsRejectedWithoutApkAuth asserts the authenticated
 // mirror really is authenticated — that the test above passes because the
 // credentials were supplied and used, and not because the server never asked
@@ -221,7 +276,7 @@ func (r *PdfTests) AuthenticatedRepositoryIsRejectedWithoutApkAuth(ctx context.C
 // The absence of layout boxes is asserted too, because that is what `withLayout`
 // is the difference between: a plain -bbox report carries words directly under
 // the page, with no flow, block or line around them.
-func (r *PdfTests) BboxCarriesOneBoxPerWord(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1346:1)
+func (r *PdfTests) BboxCarriesOneBoxPerWord(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1961:1)
 	if r.bboxCarriesOneBoxPerWord != nil {
 		return nil
 	}
@@ -244,7 +299,7 @@ func (r *PdfTests) BboxCarriesOneBoxPerWord(ctx context.Context) error { // pdf-
 // ledgerPdf is the fixture for it because its two lines land in two blocks: the
 // 40-point leading against a 22.2-point line is a gap poppler reads as a
 // paragraph break, so the block grouping is observable rather than degenerate.
-func (r *PdfTests) BboxWithLayoutAddsBlockAndLineBoxes(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1402:1)
+func (r *PdfTests) BboxWithLayoutAddsBlockAndLineBoxes(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2017:1)
 	if r.bboxWithLayoutAddsBlockAndLineBoxes != nil {
 		return nil
 	}
@@ -265,7 +320,7 @@ func (r *PdfTests) BboxWithLayoutAddsBlockAndLineBoxes(ctx context.Context) erro
 // The three properties are mutually exclusive by construction: colour keeps
 // chroma, grey drops chroma but keeps mid-tones, and mono drops both — flat tones
 // are dithered into black and white rather than averaged into grey.
-func (r *PdfTests) ColorModesProduceDifferentPixels(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2166:1)
+func (r *PdfTests) ColorModesProduceDifferentPixels(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2781:1)
 	if r.colorModesProduceDifferentPixels != nil {
 		return nil
 	}
@@ -282,7 +337,7 @@ func (r *PdfTests) ColorModesProduceDifferentPixels(ctx context.Context) error {
 // nothing to substitute for a PDF that names a base-14 face without embedding
 // it, and renders the page blank while exiting 0 — a silent wrong answer, which
 // is the failure mode this assertion exists to keep out.
-func (r *PdfTests) ContainerCarriesEveryPopplerBinaryAndTheFont(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:699:1)
+func (r *PdfTests) ContainerCarriesEveryPopplerBinaryAndTheFont(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1314:1)
 	if r.containerCarriesEveryPopplerBinaryAndTheFont != nil {
 		return nil
 	}
@@ -315,7 +370,7 @@ func (r *PdfTests) DefaultApkConfigurationIsUntouched(ctx context.Context) error
 // defaulting to true because a `Go SDK — the zero value is dropped before it reaches the API — so the
 // affirmative spelling would have produced an option no caller could turn off.
 // That makes the second half of this test the one that would have caught it.
-func (r *PdfTests) DisablePageBreaksControlsFormFeeds(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1234:1)
+func (r *PdfTests) DisablePageBreaksControlsFormFeeds(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1849:1)
 	if r.disablePageBreaksControlsFormFeeds != nil {
 		return nil
 	}
@@ -331,11 +386,85 @@ func (r *PdfTests) DisablePageBreaksControlsFormFeeds(ctx context.Context) error
 // remembered pixel count, so the assertion says "150 dpi of a US Letter page"
 // rather than "1275 by 1650" — which is the claim the documentation actually
 // makes.
-func (r *PdfTests) DpiDefaultsToOneFiftyAndScalesWithTheSetting(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2065:1)
+func (r *PdfTests) DpiDefaultsToOneFiftyAndScalesWithTheSetting(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2680:1)
 	if r.dpiDefaultsToOneFiftyAndScalesWithTheSetting != nil {
 		return nil
 	}
 	q := r.query.Select("dpiDefaultsToOneFiftyAndScalesWithTheSetting")
+
+	return q.Execute(ctx)
+}
+
+// EmbeddedImagesKeepsTheOriginalEncoding asserts what each ImageFormat member
+// does to an image that already has an encoding, and asserts the one that keeps
+// it does so byte for byte.
+//
+// Byte equality is the only assertion that actually says "kept". A `.jpg` that
+// decodes to the right dimensions would also come out of a re-encode, and a
+// re-encode is precisely what ORIGINAL exists to avoid — so the expectation here
+// is read out of the fixture itself: gallery.pdf's photograph is JPEG bytes
+// hex-armored inside the file, and hex-decoding them gives exactly what poppler
+// should have written.
+//
+// The extensions carry the rest of the claim. ORIGINAL falls back to netpbm for
+// the two unencoded strips, which is the part of that member most likely to
+// surprise a caller and therefore the part most worth pinning; ALL is the same
+// member with PNG as the fallback instead, which is the whole difference between
+// the two; and PNG and TIFF re-encode everything, the photograph included.
+func (r *PdfTests) EmbeddedImagesKeepsTheOriginalEncoding(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:458:1)
+	if r.embeddedImagesKeepsTheOriginalEncoding != nil {
+		return nil
+	}
+	q := r.query.Select("embeddedImagesKeepsTheOriginalEncoding")
+
+	return q.Execute(ctx)
+}
+
+// EmbeddedImagesNamesEveryImageAndNarrowsToThePageRange asserts both numbers in
+// an extracted image's name mean what the contract says, and asserts a document
+// with nothing to extract is told so rather than handed an empty directory.
+//
+// The names are checked against the images' *dimensions*, not merely counted.
+// gallery.pdf's three images are three different sizes on purpose, so decoding
+// each one says which image landed under which name — an assertion a numbering
+// that shuffled or off-by-oned the files would fail and an entry-count assertion
+// would not.
+//
+// The page range is where the two numbers part company. The page number is the
+// source document's, like everywhere else in this module, so page two's image
+// stays `page-0002` when page two is all that was asked for. The image index is
+// not: it is poppler's count for the run, so it restarts at zero. That is
+// asserted rather than worked around because it is the surprising half of the
+// contract, and a caller cross-referencing `pdfimages -list` needs to know which
+// number moved.
+func (r *PdfTests) EmbeddedImagesNamesEveryImageAndNarrowsToThePageRange(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:553:1)
+	if r.embeddedImagesNamesEveryImageAndNarrowsToThePageRange != nil {
+		return nil
+	}
+	q := r.query.Select("embeddedImagesNamesEveryImageAndNarrowsToThePageRange")
+
+	return q.Execute(ctx)
+}
+
+// EmbeddedImagesReturnsTheStoredImageNotTheRenderedPage asserts the distinction the
+// function is named for: what comes back is the image object the document
+// carries, not a rasterization of the page it sits on.
+//
+// The proof is the pixel dimensions, and it is only a proof because the two
+// numbers cannot be confused. scanPdf's image is 16x16; the US Letter page it is
+// drawn across covers 1275x1650 at the module's default resolution. A function
+// that quietly rasterized the page would return an image 79 times wider, and a
+// dimension assertion catches that where an entry-count assertion would not — one
+// page carrying one image produces one file either way.
+//
+// The render is fetched here rather than hardcoded so the comparison is against
+// what this module actually produces, which is the thing a caller would otherwise
+// mistake this for.
+func (r *PdfTests) EmbeddedImagesReturnsTheStoredImageNotTheRenderedPage(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:405:1)
+	if r.embeddedImagesReturnsTheStoredImageNotTheRenderedPage != nil {
+		return nil
+	}
+	q := r.query.Select("embeddedImagesReturnsTheStoredImageNotTheRenderedPage")
 
 	return q.Execute(ctx)
 }
@@ -355,7 +484,7 @@ func (r *PdfTests) DpiDefaultsToOneFiftyAndScalesWithTheSetting(ctx context.Cont
 // poppler alike through the environment rather than argv: a password in argv is
 // visible in every Dagger trace, which is exactly what the module's own posture
 // avoids.
-func (r *PdfTests) EncryptedDocumentNeedsThePassword(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2591:1)
+func (r *PdfTests) EncryptedDocumentNeedsThePassword(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:3206:1)
 	if r.encryptedDocumentNeedsThePassword != nil {
 		return nil
 	}
@@ -377,11 +506,34 @@ func (r *PdfTests) EncryptedDocumentNeedsThePassword(ctx context.Context) error 
 // Each file is then checked to be an EPS in its own right — the EPSF version
 // header, and exactly one page in it — because a loop that wrote twelve copies
 // of page one would satisfy the names alone.
-func (r *PdfTests) EpsWritesEveryPageOfTheDocument(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:375:1)
+func (r *PdfTests) EpsWritesEveryPageOfTheDocument(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:990:1)
 	if r.epsWritesEveryPageOfTheDocument != nil {
 		return nil
 	}
 	q := r.query.Select("epsWritesEveryPageOfTheDocument")
+
+	return q.Execute(ctx)
+}
+
+// ExtractionsOpenAnEncryptedDocumentWithThePassword asserts the passwords reach
+// both extractions, which is the property that separates them from Split and
+// Merge.
+//
+// It is worth an assertion of its own precisely because the module already has
+// two functions where it is false. pdfseparate and pdfunite take no password at
+// all, so `WithUserPassword(...).Split()` is a call that cannot be made to work
+// and says so; pdfimages and pdfdetach both take `-upw` and `-opw`, so the same
+// document that Split refuses these two open. Nothing about the two families
+// looks different from the outside, and only a test says which is which.
+//
+// Both branches are asserted for each: refused by naming the encryption when no
+// password was supplied — poppler says `Incorrect password` whether one was given
+// or not — and the full result when it was.
+func (r *PdfTests) ExtractionsOpenAnEncryptedDocumentWithThePassword(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:778:1)
+	if r.extractionsOpenAnEncryptedDocumentWithThePassword != nil {
+		return nil
+	}
+	q := r.query.Select("extractionsOpenAnEncryptedDocumentWithThePassword")
 
 	return q.Execute(ctx)
 }
@@ -396,7 +548,7 @@ func (r *PdfTests) EpsWritesEveryPageOfTheDocument(ctx context.Context) error { 
 // it, its two pages naming different faces, because narrowing a report of
 // ledgerPdf — every page of which names the same Helvetica — changes nothing at
 // all and would pass against a module that ignored the bounds entirely.
-func (r *PdfTests) FontsNarrowsToThePageRange(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:859:1)
+func (r *PdfTests) FontsNarrowsToThePageRange(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1474:1)
 	if r.fontsNarrowsToThePageRange != nil {
 		return nil
 	}
@@ -419,7 +571,7 @@ func (r *PdfTests) FontsNarrowsToThePageRange(ctx context.Context) error { // pd
 // construction, so the report has to read `yes` for it; without that contrast
 // the assertion would pass just as well on a report that said `no` about
 // everything, including one produced by a module that had hardcoded the answer.
-func (r *PdfTests) FontsReportsWhetherEachFaceIsEmbedded(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:804:1)
+func (r *PdfTests) FontsReportsWhetherEachFaceIsEmbedded(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1419:1)
 	if r.fontsReportsWhetherEachFaceIsEmbedded != nil {
 		return nil
 	}
@@ -442,7 +594,7 @@ func (r *PdfTests) FontsReportsWhetherEachFaceIsEmbedded(ctx context.Context) er
 // The page element still has to be there and still has to state its size, because
 // that is what distinguishes a page carrying no text from a document that was
 // never read.
-func (r *PdfTests) GeometryOfAnImageOnlyPdfReportsPagesWithoutWords(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1858:1)
+func (r *PdfTests) GeometryOfAnImageOnlyPdfReportsPagesWithoutWords(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2473:1)
 	if r.geometryOfAnImageOnlyPdfReportsPagesWithoutWords != nil {
 		return nil
 	}
@@ -465,7 +617,7 @@ func (r *PdfTests) GeometryOfAnImageOnlyPdfReportsPagesWithoutWords(ctx context.
 //
 // Two fixtures are needed because no one page is both: ledger.pdf is text and no
 // images, scan.pdf is one image and no text.
-func (r *PdfTests) HTMLCarriesPageMarkupAndItsImages(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:467:1)
+func (r *PdfTests) HTMLCarriesPageMarkupAndItsImages(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1082:1)
 	if r.htmlCarriesPageMarkupAndItsImages != nil {
 		return nil
 	}
@@ -530,7 +682,7 @@ func (r *PdfTests) UnmarshalJSON(bs []byte) error {
 // first: PageCount parses Info's `Pages:` line, so a change to how Info is
 // captured that broke the parse would otherwise show up only in whatever used
 // PageCount next.
-func (r *PdfTests) InfoReportsPageCountAndSize(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:763:1)
+func (r *PdfTests) InfoReportsPageCountAndSize(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1378:1)
 	if r.infoReportsPageCountAndSize != nil {
 		return nil
 	}
@@ -546,7 +698,7 @@ func (r *PdfTests) InfoReportsPageCountAndSize(ctx context.Context) error { // p
 // `-jpeg` writes `.jpg` and `-tiff` writes `.tif`, which are poppler's spellings
 // and not this module's: a caller building a path from the function's name would
 // get them wrong, so they are part of the documented contract.
-func (r *PdfTests) JpegAndTiffFollowTheSameContract(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2241:1)
+func (r *PdfTests) JpegAndTiffFollowTheSameContract(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2856:1)
 	if r.jpegAndTiffFollowTheSameContract != nil {
 		return nil
 	}
@@ -566,7 +718,7 @@ func (r *PdfTests) JpegAndTiffFollowTheSameContract(ctx context.Context) error {
 // physical layout puts the two columns side by side on one output line. A fixture
 // whose stream order matched its reading order would let two of these three pass
 // on the same output.
-func (r *PdfTests) LayoutModesProduceDifferentOrderings(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1271:1)
+func (r *PdfTests) LayoutModesProduceDifferentOrderings(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1886:1)
 	if r.layoutModesProduceDifferentOrderings != nil {
 		return nil
 	}
@@ -584,7 +736,7 @@ func (r *PdfTests) LayoutModesProduceDifferentOrderings(ctx context.Context) err
 // that was already sorted. Reading the text back is what says the pages landed
 // where they were put: the page count alone would pass on a merge that shuffled
 // them.
-func (r *PdfTests) MergePreservesTheOrderOfItsSources(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2378:1)
+func (r *PdfTests) MergePreservesTheOrderOfItsSources(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2993:1)
 	if r.mergePreservesTheOrderOfItsSources != nil {
 		return nil
 	}
@@ -605,7 +757,7 @@ func (r *PdfTests) MergePreservesTheOrderOfItsSources(ctx context.Context) error
 // the file it could not read, and the name it uses is this module's mount path,
 // so without the legend the one piece of information identifying which argument
 // was at fault is a path the caller has never seen.
-func (r *PdfTests) MergeRejectsWhatItCannotMerge(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2430:1)
+func (r *PdfTests) MergeRejectsWhatItCannotMerge(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:3045:1)
 	if r.mergeRejectsWhatItCannotMerge != nil {
 		return nil
 	}
@@ -629,7 +781,7 @@ func (r *PdfTests) MergeRejectsWhatItCannotMerge(ctx context.Context) error { //
 // indistinguishable from a function that did not run, so the module answers with
 // a line naming the absence and pointing at the report that does carry the
 // document's metadata.
-func (r *PdfTests) MetadataReturnsTheXmpPacketOrSaysThereIsNone(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:921:1)
+func (r *PdfTests) MetadataReturnsTheXmpPacketOrSaysThereIsNone(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1536:1)
 	if r.metadataReturnsTheXmpPacketOrSaysThereIsNone != nil {
 		return nil
 	}
@@ -652,7 +804,7 @@ func (r *PdfTests) MetadataReturnsTheXmpPacketOrSaysThereIsNone(ctx context.Cont
 // the range, which is why pages 4 through 6 come out `page-0004` through
 // `page-0006` — the same promise the raster contract makes, so a page stays
 // traceable to the page it came from whichever format it was rendered to.
-func (r *PdfTests) PageRangeNarrowsEveryPerPageFormat(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:544:1)
+func (r *PdfTests) PageRangeNarrowsEveryPerPageFormat(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1159:1)
 	if r.pageRangeNarrowsEveryPerPageFormat != nil {
 		return nil
 	}
@@ -664,7 +816,7 @@ func (r *PdfTests) PageRangeNarrowsEveryPerPageFormat(ctx context.Context) error
 // PageRangeNarrowsText asserts WithPageRange narrows extraction to the pages it
 // names, and that the bounds are the 1-based inclusive ones poppler uses rather
 // than an offset and a length.
-func (r *PdfTests) PageRangeNarrowsText(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1156:1)
+func (r *PdfTests) PageRangeNarrowsText(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1771:1)
 	if r.pageRangeNarrowsText != nil {
 		return nil
 	}
@@ -684,7 +836,7 @@ func (r *PdfTests) PageRangeNarrowsText(ctx context.Context) error { // pdf-test
 // here. A TSV row names its page outright, and names it with the page's number in
 // the *whole* document rather than its position in the range: pages 4 through 6
 // come back as 4, 5 and 6, not as 1, 2 and 3.
-func (r *PdfTests) PageRangeNarrowsTheGeometryOutputs(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1773:1)
+func (r *PdfTests) PageRangeNarrowsTheGeometryOutputs(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2388:1)
 	if r.pageRangeNarrowsTheGeometryOutputs != nil {
 		return nil
 	}
@@ -696,7 +848,7 @@ func (r *PdfTests) PageRangeNarrowsTheGeometryOutputs(ctx context.Context) error
 // PageRangeOpenEndedRunsToTheLastPage asserts a zero last means "to the end",
 // which is the only way to name an open-ended range without first asking how
 // many pages the document has.
-func (r *PdfTests) PageRangeOpenEndedRunsToTheLastPage(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1175:1)
+func (r *PdfTests) PageRangeOpenEndedRunsToTheLastPage(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1790:1)
 	if r.pageRangeOpenEndedRunsToTheLastPage != nil {
 		return nil
 	}
@@ -712,7 +864,7 @@ func (r *PdfTests) PageRangeOpenEndedRunsToTheLastPage(ctx context.Context) erro
 // renders nothing for them and exits 0, so a caller who asked for page 20 of a
 // 12-page document would otherwise get an empty result indistinguishable from a
 // document with no text in it.
-func (r *PdfTests) PageRangeRejectsInvalidBounds(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1198:1)
+func (r *PdfTests) PageRangeRejectsInvalidBounds(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1813:1)
 	if r.pageRangeRejectsInvalidBounds != nil {
 		return nil
 	}
@@ -732,7 +884,7 @@ func (r *PdfTests) PageRangeRejectsInvalidBounds(ctx context.Context) error { //
 // has no way to know which width it is holding. Asserting the full ordered list
 // covers both halves of the promise: the names, and that lexicographic order is
 // page order.
-func (r *PdfTests) PngNamesEveryPageWithFourDigits(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1992:1)
+func (r *PdfTests) PngNamesEveryPageWithFourDigits(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2607:1)
 	if r.pngNamesEveryPageWithFourDigits != nil {
 		return nil
 	}
@@ -752,7 +904,7 @@ func (r *PdfTests) PngNamesEveryPageWithFourDigits(ctx context.Context) error { 
 // The numbers are the source document's page numbers and not positions within
 // the range, which is why the second case starts at `page-0004.png`. That keeps a
 // rendered page traceable back to the page it came from.
-func (r *PdfTests) PngNarrowedRangeKeepsFourDigitNames(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2011:1)
+func (r *PdfTests) PngNarrowedRangeKeepsFourDigitNames(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2626:1)
 	if r.pngNarrowedRangeKeepsFourDigitNames != nil {
 		return nil
 	}
@@ -770,7 +922,7 @@ func (r *PdfTests) PngNarrowedRangeKeepsFourDigitNames(ctx context.Context) erro
 // document keeps the longer document's width. A consumer globbing for
 // `page-*.png` finds nothing in the first case and a caller indexing by name
 // finds the wrong file in the second.
-func (r *PdfTests) PngSinglePageIsStillNumbered(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2038:1)
+func (r *PdfTests) PngSinglePageIsStillNumbered(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2653:1)
 	if r.pngSinglePageIsStillNumbered != nil {
 		return nil
 	}
@@ -787,7 +939,7 @@ func (r *PdfTests) PngSinglePageIsStillNumbered(ctx context.Context) error { // 
 // directory of one-page fragments would be the wrong answer even though it would
 // look tidier beside Svg and Eps. Counting the markers is what says the pages
 // reached the file rather than only the header saying they did.
-func (r *PdfTests) PsHoldsEveryPageInOneFile(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:424:1)
+func (r *PdfTests) PsHoldsEveryPageInOneFile(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1039:1)
 	if r.psHoldsEveryPageInOneFile != nil {
 		return nil
 	}
@@ -801,7 +953,7 @@ func (r *PdfTests) PsHoldsEveryPageInOneFile(ctx context.Context) error { // pdf
 //
 // Left to poppler these arrive much later as a complaint about `-r` or
 // `-scale-to`, which names a flag the caller never wrote.
-func (r *PdfTests) RenderSettingsRejectNonPositiveValues(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2128:1)
+func (r *PdfTests) RenderSettingsRejectNonPositiveValues(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2743:1)
 	if r.renderSettingsRejectNonPositiveValues != nil {
 		return nil
 	}
@@ -822,7 +974,7 @@ func (r *PdfTests) RenderSettingsRejectNonPositiveValues(ctx context.Context) er
 // reports every wrong password as `Incorrect password` whether one was supplied
 // or not, so the message has to distinguish what the module knows and poppler
 // does not.
-func (r *PdfTests) ReportsOpenAnEncryptedDocumentWithThePassword(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:997:1)
+func (r *PdfTests) ReportsOpenAnEncryptedDocumentWithThePassword(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1612:1)
 	if r.reportsOpenAnEncryptedDocumentWithThePassword != nil {
 		return nil
 	}
@@ -838,7 +990,7 @@ func (r *PdfTests) ReportsOpenAnEncryptedDocumentWithThePassword(ctx context.Con
 // resolution flag off the command line rather than by relying on poppler's own
 // precedence, so this is the assertion that would catch the two being emitted
 // together and whichever poppler happened to prefer winning silently.
-func (r *PdfTests) ScaleToOverridesDpi(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2097:1)
+func (r *PdfTests) ScaleToOverridesDpi(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2712:1)
 	if r.scaleToOverridesDpi != nil {
 		return nil
 	}
@@ -861,7 +1013,7 @@ func (r *PdfTests) ScaleToOverridesDpi(ctx context.Context) error { // pdf-tests
 // an image carrying no certificate database, which is every image this module
 // builds, and a report assembled from both streams would carry that line into
 // every caller's output as though it were something the document said.
-func (r *PdfTests) SignaturesReportsAnUnsignedDocumentInsteadOfFailing(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:971:1)
+func (r *PdfTests) SignaturesReportsAnUnsignedDocumentInsteadOfFailing(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1586:1)
 	if r.signaturesReportsAnUnsignedDocumentInsteadOfFailing != nil {
 		return nil
 	}
@@ -882,7 +1034,7 @@ func (r *PdfTests) SignaturesReportsAnUnsignedDocumentInsteadOfFailing(ctx conte
 // that would send a caller to a builder that changes nothing, which is why the
 // password case is asserted alongside the passwordless one: both have to arrive
 // at the same message.
-func (r *PdfTests) SplitAndMergeCannotOpenAnEncryptedDocument(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2528:1)
+func (r *PdfTests) SplitAndMergeCannotOpenAnEncryptedDocument(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:3143:1)
 	if r.splitAndMergeCannotOpenAnEncryptedDocument != nil {
 		return nil
 	}
@@ -901,7 +1053,7 @@ func (r *PdfTests) SplitAndMergeCannotOpenAnEncryptedDocument(ctx context.Contex
 // caller gets a message about poppler's internals attached to a directory that
 // was half written. Checking the bounds against the document first is what turns
 // that into a sentence naming the builder and the page count.
-func (r *PdfTests) SplitNarrowsToThePageRange(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2333:1)
+func (r *PdfTests) SplitNarrowsToThePageRange(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2948:1)
 	if r.splitNarrowsToThePageRange != nil {
 		return nil
 	}
@@ -923,7 +1075,7 @@ func (r *PdfTests) SplitNarrowsToThePageRange(ctx context.Context) error { // pd
 // The names the split wrote are what the merge is driven by, in page order, which
 // is also the practical shape of the pair: split, do something to the pages,
 // merge the ones that survived.
-func (r *PdfTests) SplitThenMergeRoundTripsTheDocument(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2474:1)
+func (r *PdfTests) SplitThenMergeRoundTripsTheDocument(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:3089:1)
 	if r.splitThenMergeRoundTripsTheDocument != nil {
 		return nil
 	}
@@ -945,7 +1097,7 @@ func (r *PdfTests) SplitThenMergeRoundTripsTheDocument(ctx context.Context) erro
 // pdfseparate numbers with the width the caller's pattern asks for rather than
 // with the document's page count, so the four-digit contract here is this
 // module's and not a coincidence of the fixture's length.
-func (r *PdfTests) SplitWritesOnePdfPerPage(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2289:1)
+func (r *PdfTests) SplitWritesOnePdfPerPage(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2904:1)
 	if r.splitWritesOnePdfPerPage != nil {
 		return nil
 	}
@@ -969,7 +1121,7 @@ func (r *PdfTests) SplitWritesOnePdfPerPage(ctx context.Context) error { // pdf-
 // anywhere. Poppler converts text to glyph outlines rather than to `<text>`, so
 // the marker words are not in the file at all — a Contains check for one would
 // fail on a perfectly good SVG.
-func (r *PdfTests) SvgWritesOneVectorFilePerPage(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:332:1)
+func (r *PdfTests) SvgWritesOneVectorFilePerPage(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:947:1)
 	if r.svgWritesOneVectorFilePerPage != nil {
 		return nil
 	}
@@ -988,7 +1140,7 @@ func (r *PdfTests) SvgWritesOneVectorFilePerPage(ctx context.Context) error { //
 // a caller gets that this document needs rasterizing and handing to OCR. A
 // module that failed here instead would make the two paths impossible to choose
 // between programmatically.
-func (r *PdfTests) TextOnImageOnlyPdfReturnsNothing(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1106:1)
+func (r *PdfTests) TextOnImageOnlyPdfReturnsNothing(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1721:1)
 	if r.textOnImageOnlyPdfReturnsNothing != nil {
 		return nil
 	}
@@ -1006,7 +1158,7 @@ func (r *PdfTests) TextOnImageOnlyPdfReturnsNothing(ctx context.Context) error {
 // leading newline, pages in the wrong order — is a defect and not a recognition
 // error. A fixture whose content streams are readable is what makes an exact
 // expectation writable at all.
-func (r *PdfTests) TextReproducesTextLayerExactly(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1085:1)
+func (r *PdfTests) TextReproducesTextLayerExactly(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1700:1)
 	if r.textReproducesTextLayerExactly != nil {
 		return nil
 	}
@@ -1031,7 +1183,7 @@ func (r *PdfTests) TextReproducesTextLayerExactly(ctx context.Context) error { /
 // from the top of the page less the font's ascender, and its `height` is the
 // ascender-to-descender span — 22.2 points at 24pt Helvetica, the same for a
 // one-glyph word as for a seven-glyph one.
-func (r *PdfTests) TsvRowsCarryPageNumbersAndWordGeometry(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1656:1)
+func (r *PdfTests) TsvRowsCarryPageNumbersAndWordGeometry(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2271:1)
 	if r.tsvRowsCarryPageNumbersAndWordGeometry != nil {
 		return nil
 	}
@@ -1047,7 +1199,7 @@ func (r *PdfTests) TsvRowsCarryPageNumbersAndWordGeometry(ctx context.Context) e
 // straight off the handle: the point of Txt is that the bytes reach a filesystem
 // intact, and File.Contents would confirm the engine's copy while saying nothing
 // about the export a real consumer performs.
-func (r *PdfTests) TxtMatchesText(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1129:1)
+func (r *PdfTests) TxtMatchesText(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1744:1)
 	if r.txtMatchesText != nil {
 		return nil
 	}
@@ -1093,7 +1245,7 @@ func (r *PdfTests) UntrustedIndexIsRejectedWithoutApkKey(ctx context.Context) er
 //
 // WithDpi is the one setting that does reach pdftocairo, and it is set here too
 // so this is not accidentally asserting that no flags are passed at all.
-func (r *PdfTests) VectorFormatsIgnoreRasterOnlySettings(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:594:1)
+func (r *PdfTests) VectorFormatsIgnoreRasterOnlySettings(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1209:1)
 	if r.vectorFormatsIgnoreRasterOnlySettings != nil {
 		return nil
 	}
@@ -1111,7 +1263,7 @@ func (r *PdfTests) VectorFormatsIgnoreRasterOnlySettings(ctx context.Context) er
 // exact patch: Alpine may rebuild poppler-utils within the v3.24 branch, and a
 // test that pins the patch level would fail on a change this module has no
 // opinion about.
-func (r *PdfTests) VersionReportsPopplerRelease(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:673:1)
+func (r *PdfTests) VersionReportsPopplerRelease(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1288:1)
 	if r.versionReportsPopplerRelease != nil {
 		return nil
 	}
@@ -1129,7 +1281,7 @@ func (r *PdfTests) VersionReportsPopplerRelease(ctx context.Context) error { // 
 // module installs, so the negative control is real — the plain image genuinely
 // cannot see it, and the assertion is not passing on something the base image
 // already had.
-func (r *PdfTests) WithFontsPutsFaceWhereFontconfigFindsIt(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:733:1)
+func (r *PdfTests) WithFontsPutsFaceWhereFontconfigFindsIt(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:1348:1)
 	if r.withFontsPutsFaceWhereFontconfigFindsIt != nil {
 		return nil
 	}
@@ -1145,7 +1297,7 @@ func (r *PdfTests) WithFontsPutsFaceWhereFontconfigFindsIt(ctx context.Context) 
 // a render of it is the annotation's appearance stream and nothing else. Without
 // that separation the assertion could not tell an annotation that was not drawn
 // from one that was drawn somewhere else on the page.
-func (r *PdfTests) WithoutAnnotationsRemovesTheAnnotationLayer(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2208:1)
+func (r *PdfTests) WithoutAnnotationsRemovesTheAnnotationLayer(ctx context.Context) error { // pdf-tests (../../../daggerverse/pdf/tests/main.go:2823:1)
 	if r.withoutAnnotationsRemovesTheAnnotationLayer != nil {
 		return nil
 	}
@@ -1170,7 +1322,7 @@ func (r *PdfTests) AsNode() Node {
 // streams are uncompressed, so the text a page is supposed to render is readable
 // in the fixture itself and an assertion about it can be checked against the
 // PDF rather than against another tool's opinion of the PDF.
-func (r *Query) PdfTests() *PdfTests { // pdf-tests (../../../daggerverse/pdf/tests/main.go:228:6)
+func (r *Query) PdfTests() *PdfTests { // pdf-tests (../../../daggerverse/pdf/tests/main.go:295:6)
 	q := r.query.Select("pdfTests")
 
 	return &PdfTests{

--- a/daggerverse/pdf/README.md
+++ b/daggerverse/pdf/README.md
@@ -12,7 +12,11 @@ page count, page size, PDF version, whether it is encrypted and under which
 algorithm, which fonts it needs and whether they are embedded, what its XMP
 metadata says, and whether its signatures check out. Or leave it a PDF and change
 its page structure instead: `Split` takes a document apart a page per file,
-`Merge` puts several back together in the order you name them.
+`Merge` puts several back together in the order you name them. Or take out what
+the file already carries rather than a conversion of it: `EmbeddedImages` pulls
+the image objects off the pages at the resolution they are stored at, and
+`Attachments` pulls out the files hung off the document — the machine-readable
+XML an invoice carries next to its printable page.
 
 **There is no official poppler container image**, so this module assembles its
 own the way `tesseract` and `qemu` do rather than pinning a vendor image the way
@@ -142,12 +146,12 @@ Pdf.Merge(ctx, sources []*dagger.File) (*dagger.File, error)
 ```
 
 `Container` is the escape hatch. poppler-utils ships **thirteen** binaries and
-this module wraps nine of them — `pdftotext`, `pdftoppm`, `pdfinfo`,
-`pdftocairo`, `pdftohtml`, `pdffonts`, `pdfsig`, `pdfseparate` and `pdfunite` —
-so `pdfimages`, `pdftops`, `pdfattach` and `pdfdetach` stay reachable via
-`container with-exec` until they get wrapped too (see
-[Follow-ups](#follow-ups)). So do the flags of a wrapped tool that this module
-does not surface, `pdffonts -subst` among them.
+this module wraps eleven of them — `pdftotext`, `pdftoppm`, `pdfinfo`,
+`pdftocairo`, `pdftohtml`, `pdffonts`, `pdfsig`, `pdfseparate`, `pdfunite`,
+`pdfimages` and `pdfdetach` — so `pdftops` and `pdfattach` stay reachable via
+`container with-exec`. `pdfattach` is deliberately not planned (see
+[Follow-ups](#follow-ups)). So are the flags of a wrapped tool that this module
+does not surface, `pdffonts -subst` and `pdfdetach -savefile` among them.
 
 `Version` reads **stderr**, not stdout: poppler's tools print their version
 banner on stderr and still exit 0, so a module reading stdout would report the
@@ -167,6 +171,8 @@ Document.Fonts(ctx) (string, error)
 Document.Metadata(ctx) (string, error)
 Document.Signatures(ctx) (string, error)
 Document.Split(ctx) (*dagger.Directory, error)
+Document.EmbeddedImages(ctx, format ImageFormat) (*dagger.Directory, error)
+Document.Attachments(ctx) (*dagger.Directory, error)
 Document.Convert() *Convert
 ```
 
@@ -222,7 +228,9 @@ Bounds are **1-based and inclusive**, matching poppler's own `-f`/`-l`, so
 the first page alone. A zero `last` means "to the last page", which is the only
 way to spell an open-ended range without first asking how many pages there are.
 
-It narrows the text outputs, the raster outputs and `Split` alike.
+It narrows the text outputs, the raster outputs, `Split` and `EmbeddedImages`
+alike. It does not narrow `Info`, `PageCount`, `Metadata`, `Signatures` or
+`Attachments`, all of which describe the document rather than a slice of it.
 
 Bounds are checked against the document and rejected by naming the bound, at the
 point of use rather than in the builder — the check needs the page count, which
@@ -677,6 +685,152 @@ single pages to merge — and the pages keep their own size, so merging US Lette
 with A4 yields a document whose pages differ in size, which is what a
 concatenation should do.
 
+## `EmbeddedImages` and `Attachments` — what the file carries, not a render
+
+```go
+Document.EmbeddedImages(ctx, format ImageFormat) (*dagger.Directory, error)
+Document.Attachments(ctx) (*dagger.Directory, error)
+```
+
+Two extractions that are not renders, and are routinely mistaken for them.
+
+### `EmbeddedImages` is not `Convert().Png()`
+
+`Convert().Png()` **rasterizes a page**: it draws the text, the vectors, the
+annotations and the images into a new bitmap at whatever `WithDpi` names, and the
+pixels it produces have never existed before. `EmbeddedImages` returns the **image
+objects the file contains**, decoded no further than it has to be. For a scanned
+document that is the scan, at the resolution it was scanned at, with nothing
+resampled on the way out — which makes it strictly better OCR input than any
+resolution `Convert().Png()` can be asked for:
+
+```go
+doc := dag.Pdf().Document(scan)
+
+// Better: the scan itself, at its own resolution.
+images := doc.EmbeddedImages(dagger.PdfImageFormatPng)
+
+// Worse for OCR: a re-rasterization of pixels that were already pixels.
+pages := doc.Convert().WithDpi(300).Png()
+```
+
+The two are not interchangeable in the other direction either. A page of text and
+vectors carries **no image object at all**, so `EmbeddedImages` returns nothing
+for it and `Convert().Png()` is the only thing that draws it. Which is also why
+`WithDpi`, `WithColorMode`, `WithScaleTo` and `WithoutAnnotations` are not
+reachable from `EmbeddedImages`: they live on `Convert`, and there is nothing to
+choose about the resolution of an image that already has one.
+
+`EmbeddedImagesReturnsTheStoredImageNotTheRenderedPage` is the test that pins the
+distinction, and it pins it on the numbers: `scan.pdf`'s image is 16x16, and a
+render of the US Letter page it is drawn across is 1275x1650.
+
+### `ImageFormat` — keep the encoding, or replace it
+
+An embedded image already has an encoding, so every member either keeps it or
+replaces it. There is no default: which one is right depends entirely on what
+reads the result, and quietly re-encoding a caller's scan is not a decision this
+module makes on their behalf.
+
+| member | flags | encoded image | image with no writable encoding |
+| --- | --- | --- | --- |
+| `PNG` | `-png` | re-encoded as PNG | PNG |
+| `TIFF` | `-tiff` | re-encoded as TIFF | TIFF |
+| `ORIGINAL` | `-j -jp2 -jbig2 -ccitt` | **kept byte for byte** | netpbm — `.ppm`, `.pgm`, `.pbm` |
+| `ALL` | `-all` | **kept byte for byte** | PNG, or TIFF where PNG cannot represent it |
+
+"Kept byte for byte" is meant literally, and covers JPEG, JPEG 2000, JBIG2 and
+CCITT G4 — the four encodings poppler can copy through instead of decoding.
+`EmbeddedImagesKeepsTheOriginalEncoding` asserts it as byte equality against the
+JPEG stream read out of the fixture itself, because a `.jpg` of the right
+dimensions is also what a re-encode produces.
+
+The **fallback** is the whole difference between `ORIGINAL` and `ALL`. A raw or
+Flate-compressed bitmap — most PDFs not born as scans — has no encoding to keep,
+and `ORIGINAL` writes netpbm for it: a `.ppm` in the result is not a failure. Pick
+`ALL` when the images are of mixed encodings and every one of them has to be
+readable by something ordinary.
+
+### Image naming — `image-0000-page-0001.png`
+
+A different contract from the page families, and named so it can never be mistaken
+for one:
+
+```
+image-0000-page-0001.jpg   ← image 0, drawn on page 1
+image-0001-page-0001.png
+image-0002-page-0002.png
+```
+
+The number after `image-` is poppler's index for the image, 0-based — the `num`
+column of `pdfimages -list` for an unnarrowed run. The number after `-page-` is
+the **1-based source page** it was drawn on, the same promise `Split` makes. The
+index comes first so lexicographic order is document order, and both are padded to
+at least four digits by a rename pass in the same exec, for the reason the
+[page contract](#page-naming--page-0001png) has one: `pdfimages` pads to three, so
+the thousandth image of a document widens the field mid-directory.
+
+There is **no one-file-per-page contract** here, and there cannot be: a page may
+carry several images and most pages carry none.
+
+`WithPageRange` narrows it, and moves exactly one of the two numbers. The page
+number stays the document's; the image index restarts, being poppler's count for
+the *run*. Pages 2–3 of a document whose first image is on page 1 come back
+starting at `image-0000-page-0002`.
+
+### `Attachments` — the files hung off the document
+
+An embedded file is a whole file attached to the PDF, not part of any page's
+content: the machine-readable XML a ZUGFeRD or Factur-X invoice carries beside its
+printable page, a spreadsheet behind a report, a CAD file behind a drawing.
+Nothing in `Convert` reaches it and neither does `EmbeddedImages` — this is the
+only function that does.
+
+The names are the **document's own**, and this is the one directory here that is
+not renamed to a contract. An attachment's name is *data*: it is what the producer
+called the file and what a consumer looks for, so `invoice.xml` stays
+`invoice.xml`.
+
+```go
+attached := dag.Pdf().Document(invoice).Attachments()
+xml := attached.File("invoice.xml")
+```
+
+`WithPageRange` does not narrow it — an embedded file hangs off the catalog, and
+`pdfdetach` has no page bounds at all — and unlike `Split` and `Merge`, **the
+passwords do reach it**: `pdfdetach` takes both `-upw` and `-opw`, as does
+`pdfimages`.
+
+> **One path-bearing attachment name loses them all.** poppler refuses the whole
+> `-saveall` with `I/O Error: Preventing directory traversal` rather than skipping
+> the one file, so a document naming an attachment `../elsewhere.xml` yields
+> nothing at all. Nothing passed to this module changes that — the name is the
+> document's — so the failure says so and names `pdfdetach -list` plus
+> `pdfdetach -savefile <name> -o <path>` through `Container` as the way to fetch
+> the rest one at a time.
+
+### Nothing to extract is a failure, not an empty directory
+
+Both functions **refuse** a document with nothing to give them:
+
+```
+EmbeddedImages: this document carries no image objects: there is nothing to
+extract, and a page of text and vectors is drawn rather than extracted —
+Convert().Png() is what renders one. `pdfimages -list`, through Container,
+answers the same question without failing
+```
+
+That is a deliberate departure from `Signatures`, which reports an unsigned
+document rather than failing on it, and the reason is the return type. `Signatures`
+returns a string and has room to say "no signatures"; a `*dagger.Directory` has
+none, and an empty one is exactly what an extraction that failed to write anything
+also produces — while both tools exit 0 either way. So the module is the only place
+that can tell a caller which of the two happened, and the narrowed message names
+the pages that were asked for so a caller who narrowed to the wrong ones is not
+told the whole document is empty. A caller sweeping many documents, where "no
+attachments" is an ordinary outcome, wants either the `-list` reports through
+`Container` or to tolerate this error.
+
 ## Page naming — `page-0001.png`
 
 `Png`, `Jpeg`, `Tiff`, `Svg`, `Eps`, `Html` and `Split` return a directory of
@@ -693,6 +847,11 @@ module's:
 | `Eps` | `page-0001.eps` |
 | `Html` | `page-0001.html` (+ its images, see above) |
 | `Split` | `page-0001.pdf` |
+
+`EmbeddedImages` is **not** on that list and honours a contract of its own —
+[`image-0000-page-0001.png`](#image-naming--image-0000-page-0001png) — because an
+image is not a page: several can sit on one page and most pages carry none.
+`Attachments` is on no list at all, its names being the document's.
 
 The families reach that contract from opposite directions. `pdftoppm` and
 `pdfseparate` name the files and this module **renames** them; for `Svg`, `Eps`
@@ -760,12 +919,10 @@ about. Same posture as `tesseract`'s outputs and `kicad`.
 
 ## Follow-ups
 
-Text-layer geometry as bbox HTML and TSV (#269);
-extracting embedded images and attachments (#271); cropping the render
-window and selecting odd or even pages (#272); the chained `Ci` builder (#273);
-linearize, encrypt and repair via qpdf (#274); testing package assembly off a
-private apk mirror (#275); removing `tesseract`'s `FromPdf` in favour of this
-module (#276); renderer fidelity and colour-profile options (#277).
+Cropping the render window and selecting odd or even pages (#272); the chained
+`Ci` builder (#273); linearize, encrypt and repair via qpdf (#274); removing
+`tesseract`'s `FromPdf` in favour of this module (#276); renderer fidelity and
+colour-profile options (#277).
 
 Deliberately **not** planned: ghostscript or mupdf rendering backends, and
 `pdfattach`. A second rasterizer buys different rendering bugs rather than

--- a/daggerverse/pdf/dagger.gen.go
+++ b/daggerverse/pdf/dagger.gen.go
@@ -187,6 +187,60 @@ func (r *Convert) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
+func (r ImageFormat) IsEnum() {}
+
+func (r ImageFormat) Name() string {
+	switch r {
+	case ImageFormatAll:
+		return "All"
+	case ImageFormatOriginal:
+		return "Original"
+	case ImageFormatPng:
+		return "Png"
+	case ImageFormatTiff:
+		return "Tiff"
+	}
+	return ""
+}
+
+func (r ImageFormat) Value() string {
+	return string(r)
+}
+
+func (r ImageFormat) MarshalJSON() ([]byte, error) {
+	if r == "" {
+		return []byte("\"\""), nil
+	}
+	name := r.Name()
+	if name == "" {
+		return nil, fmt.Errorf("invalid enum value %q", r)
+	}
+	return json.Marshal(name)
+}
+
+func (r *ImageFormat) UnmarshalJSON(bs []byte) error {
+	var s string
+	err := json.Unmarshal(bs, &s)
+	if err != nil {
+		return err
+	}
+	switch s {
+	case "":
+		*r = ""
+	case "All":
+		*r = ImageFormatAll
+	case "Original":
+		*r = ImageFormatOriginal
+	case "Png":
+		*r = ImageFormatPng
+	case "Tiff":
+		*r = ImageFormatTiff
+	default:
+		return fmt.Errorf("invalid enum value %q", s)
+	}
+	return nil
+}
+
 func (r LayoutMode) IsEnum() {}
 
 func (r LayoutMode) Name() string {
@@ -572,6 +626,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 		}
 	case "Document":
 		switch fnName {
+		case "Attachments":
+			var parent Document
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Document).Attachments(&parent, ctx)
 		case "Convert":
 			var parent Document
 			err = json.Unmarshal(parentJSON, &parent)
@@ -579,6 +640,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return (*Document).Convert(&parent), nil
+		case "EmbeddedImages":
+			var parent Document
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var format ImageFormat
+			if inputArgs["format"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["format"]), &format)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg format", err))
+				}
+			}
+			return (*Document).EmbeddedImages(&parent, ctx, format)
 		case "Fonts":
 			var parent Document
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/pdf/enums.go
+++ b/daggerverse/pdf/enums.go
@@ -94,6 +94,71 @@ func (m LayoutMode) flags() ([]string, bool) {
 	return f, ok
 }
 
+// ImageFormat is the encoding EmbeddedImages writes an extracted image in, and
+// maps onto pdfimages' format flags.
+//
+// Unlike the render formats, this one *is* a Dagger enum, because here the
+// format is a genuine question rather than a choice of function. An embedded
+// image already has an encoding, so every member either keeps it or replaces it,
+// and which of those a caller wants depends on what reads the result: ORIGINAL
+// hands on the bytes the document carries, and PNG hands on something every
+// image library opens without a codec question.
+//
+// Note on rendered names: the Dagger Go SDK derives each GraphQL enum member
+// from the *constant identifier* in SCREAMING_SNAKE_CASE, so these surface as
+// `PNG`, `TIFF`, `ORIGINAL` and `ALL`.
+type ImageFormat string
+
+const (
+	// ImageFormatPng re-encodes every image as PNG. Lossless, so the
+	// re-encoding costs image quality nothing — it costs only the original
+	// encoding, which for a JPEG-encoded scan usually means a larger file.
+	ImageFormatPng ImageFormat = "PNG"
+	// ImageFormatTiff re-encodes every image as TIFF, which is the format the
+	// document-imaging world already speaks.
+	ImageFormatTiff ImageFormat = "TIFF"
+	// ImageFormatOriginal writes the encoded stream out unchanged wherever
+	// poppler can — JPEG, JPEG 2000, JBIG2 and CCITT G4 — and falls back to
+	// netpbm for an image encoded in none of them. It is the member for a caller
+	// who wants the document's own bytes, and the one whose fallback is worth
+	// reading about: see EmbeddedImages.
+	ImageFormatOriginal ImageFormat = "ORIGINAL"
+	// ImageFormatAll is ORIGINAL with a better fallback: an image with no
+	// natively writable encoding becomes PNG, or TIFF where PNG cannot represent
+	// it. It is the member to reach for when a document's images are of mixed
+	// encodings and every one of them has to be readable.
+	ImageFormatAll ImageFormat = "ALL"
+)
+
+// imageFormatFlags maps each format onto the pdfimages flags that select it.
+//
+// None of the values is empty, which is what makes this table different from
+// colorFlags: pdfimages' own default is netpbm, and no member of this enum
+// spells that. Asking for the module's four formats is always asking for a flag.
+var imageFormatFlags = map[ImageFormat][]string{
+	ImageFormatPng:  {"-png"},
+	ImageFormatTiff: {"-tiff"},
+	// The four together are what "keep the encoding" means: each one names an
+	// encoding poppler will copy through instead of decoding.
+	ImageFormatOriginal: {"-j", "-jp2", "-jbig2", "-ccitt"},
+	// -all is poppler's own spelling of the same four plus -png and -tiff, and
+	// is passed as itself rather than expanded so the flag the tool documents is
+	// the flag the trace shows.
+	ImageFormatAll: {"-all"},
+}
+
+// imageFormatOrder fixes the order formats are listed in a rejection message.
+var imageFormatOrder = []ImageFormat{
+	ImageFormatPng, ImageFormatTiff, ImageFormatOriginal, ImageFormatAll,
+}
+
+// flags returns the pdfimages flags for this format, and whether the format is
+// one this module knows.
+func (f ImageFormat) flags() ([]string, bool) {
+	flags, ok := imageFormatFlags[f]
+	return flags, ok
+}
+
 // rasterFormat is the image format a render produces. It is deliberately not a
 // Dagger enum: Png, Jpeg and Tiff are three named functions, so a caller never
 // spells a format at all and an enum would only add a way to spell it wrongly.
@@ -182,6 +247,16 @@ func layoutNames() string {
 	names := make([]string, 0, len(layoutOrder))
 	for _, m := range layoutOrder {
 		names = append(names, string(m))
+	}
+	return strings.Join(names, ", ")
+}
+
+// imageFormatNames lists every legal ImageFormat, for the message a rejection
+// carries.
+func imageFormatNames() string {
+	names := make([]string, 0, len(imageFormatOrder))
+	for _, f := range imageFormatOrder {
+		names = append(names, string(f))
 	}
 	return strings.Join(names, ", ")
 }

--- a/daggerverse/pdf/extract.go
+++ b/daggerverse/pdf/extract.go
@@ -1,0 +1,312 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"dagger/pdf/internal/dagger"
+)
+
+const (
+	// imagesRoot is the OUTPUTBASE pdfimages is handed, and is deliberately not
+	// the name the returned files carry. pdfimages appends `-<page>-<num>.<ext>`
+	// to it — hence no trailing separator here — and the rename pass that follows
+	// globs what it wrote, so the two names have to differ or the pass would find
+	// the files it had already renamed and rename them again.
+	imagesRoot      = outputDir + "/" + imagesRawName
+	imagesRawName   = "raw"
+	imagesRawPrefix = imagesRawName + "-"
+
+	// imageNamePrefix and imagePageInfix spell the naming contract an extracted
+	// image comes back under: `image-0000-page-0001.png`. See EmbeddedImages for
+	// what each number is.
+	imageNamePrefix = "image-"
+	imagePageInfix  = "-page-"
+
+	// pageNumbersFlag makes pdfimages put the source page in each file name,
+	// which is the only place that information survives at all — the extracted
+	// image itself carries no record of the page it was drawn on.
+	pageNumbersFlag = "-p"
+
+	// printFilenamesFlag makes pdfimages report what it wrote on stdout, which is
+	// how this module tells "the document carries no images" apart from a run that
+	// wrote none for some other reason. pdfimages exits 0 either way.
+	printFilenamesFlag = "-print-filenames"
+
+	// listFlag makes pdfdetach report the document's embedded files instead of
+	// saving them, and is run alongside -saveall in the same exec: the report is
+	// the only thing that says how many files there were, pdfdetach being silent
+	// about what it saved.
+	listFlag = "-list"
+
+	// saveAllFlag saves every embedded file, under the name the document gives it,
+	// into the working directory.
+	saveAllFlag = "-saveall"
+
+	// embeddedFilesSuffix ends pdfdetach's count line — `2 embedded files` — and
+	// noEmbeddedFilesCount is what that line reads for a document carrying none.
+	embeddedFilesSuffix  = "embedded files"
+	noEmbeddedFilesCount = 0
+
+	// traversalMarker is what poppler says when an attachment's own name has a
+	// path in it. It refuses the whole -saveall rather than that one file, which
+	// is why it earns a message of its own.
+	traversalMarker = "Preventing directory traversal"
+)
+
+// imageNormalizeScript renames every image pdfimages just wrote so both numbers
+// in its name are zero-padded to a fixed width, and is this family's version of
+// the pass the raster renders go through.
+//
+// It exists for the same reason: pdfimages pads with `%03d`, so the thousandth
+// image of a document widens the field and lexicographic order stops being
+// document order in the middle of one directory. The width here is the greater of
+// the module's minimum and whatever the widest number needs, so a document past
+// what four digits can express stays uniform.
+//
+// The extension is read off each file rather than passed in, unlike the raster
+// pass. It has to be: ORIGINAL and ALL write a directory of mixed extensions,
+// because which one an image gets depends on how that image was encoded.
+var imageNormalizeScript = strings.Join([]string{
+	// POSIX printf reads a leading-zero argument as an octal constant, so `010`
+	// would be 8 and `009` a diagnostic. Stripping the zeros first is the same
+	// dance normalizeScript does, factored out here because two numbers need it.
+	`strip0() {`,
+	`	s=$(printf '%s' "$1" | sed 's/^0*//')`,
+	`	[ -n "$s" ] || s=0`,
+	`	printf '%s' "$s"`,
+	`}`,
+	`width=` + strconv.Itoa(minPageNumberWidth),
+	`for f in ` + imagesGlob + `; do`,
+	`	[ -e "$f" ] || continue`,
+	`	rest=${f##*/` + imagesRawPrefix + `}`,
+	`	page=${rest%%-*}`,
+	`	num=${rest#*-}`,
+	`	num=${num%%.*}`,
+	`	if [ ${#page} -gt "$width" ]; then width=${#page}; fi`,
+	`	if [ ${#num} -gt "$width" ]; then width=${#num}; fi`,
+	`done`,
+	`for f in ` + imagesGlob + `; do`,
+	`	[ -e "$f" ] || continue`,
+	`	rest=${f##*/` + imagesRawPrefix + `}`,
+	`	page=${rest%%-*}`,
+	`	num=${rest#*-}`,
+	`	ext=${num#*.}`,
+	`	num=${num%%.*}`,
+	`	pp=$(printf "%0${width}d" "$(strip0 "$page")")`,
+	`	nn=$(printf "%0${width}d" "$(strip0 "$num")")`,
+	`	mv "$f" "` + outputDir + `/` + imageNamePrefix + `$nn` + imagePageInfix + `$pp.$ext"`,
+	`done`,
+}, "\n")
+
+// imagesGlob matches every file pdfimages wrote, whatever its extension and
+// whatever width the tool numbered it to.
+const imagesGlob = outputDir + `/` + imagesRawPrefix + `*`
+
+// EmbeddedImages extracts the image objects the document *contains* and returns
+// the directory holding them, named `image-0000-page-0001.png` and so on.
+//
+// This is not Convert().Png(), and the difference is the reason the function is
+// named this way. Convert().Png() *rasterizes a page*: it draws everything on
+// the page — text, vectors, annotations, images — into a new bitmap at whatever
+// resolution WithDpi names, and the pixels it produces have never existed before.
+// This returns the image objects themselves, decoded no further than it has to
+// be: for a scanned document that is the scan, at the resolution it was scanned
+// at, with no resampling in between. Which is why it is the better OCR input of
+// the two — every render is a resampling of an image that was already pixels, and
+// recognition accuracy is exactly what that costs.
+//
+// It follows that WithDpi, WithColorMode, WithScaleTo and WithoutAnnotations have
+// no meaning here and are not reachable from this function at all: they live on
+// Convert, which is where rendering decisions belong. There is nothing to choose
+// about the resolution of an image that already has one. By the same token this
+// returns *nothing* for a page whose content is text and vectors — there is no
+// image object on it to extract, and Convert().Png() is what draws such a page.
+//
+// The format is the one real choice, and it is required rather than defaulted
+// because every member either keeps the document's encoding or replaces it, and
+// no one of those is the obviously right thing to do quietly. See ImageFormat.
+// ORIGINAL is worth reading twice: it keeps JPEG, JPEG 2000, JBIG2 and CCITT G4
+// streams byte for byte, and for an image encoded in none of those — a raw or
+// Flate-compressed bitmap, which is most PDFs that were not born as scans — it
+// falls back to netpbm, so a `.ppm` or `.pgm` in the result is not a failure but
+// an image that had no encoding to keep. ALL is the member whose fallback is PNG
+// instead, and is what to reach for when every image has to be readable by
+// something ordinary.
+//
+// The names carry both numbers poppler reports, padded and reordered but not
+// renumbered. The one after `image-` is the image's index in this extraction,
+// 0-based, which for an unnarrowed run is the `num` column of
+// `pdfimages -list`; the one after `-page-` is the 1-based source page it was
+// drawn on. The index comes first so lexicographic order is document order —
+// which it is, images being extracted in page order — and the word `image` comes
+// first of all so a directory of these is never mistaken for a directory of
+// rendered pages.
+//
+// A page can carry several images and most pages carry none, so there is no
+// one-file-per-page contract here of the kind every render honours. A document
+// carrying no images at all is refused rather than returned as an empty
+// directory: pdfimages exits 0 for it, so the directory would be indistinguishable
+// from an extraction that failed to write anything, and the overwhelmingly common
+// thing a caller does with this function is export it.
+//
+// WithPageRange narrows it. Note that it renumbers nothing but does restart the
+// image index, that index being poppler's count for the run rather than for the
+// document: pages 2 through 3 of a document whose first image is on page 1 come
+// back starting at `image-0000-page-0002`. The page number stays the source
+// document's, the same promise Split makes.
+func (d *Document) EmbeddedImages(
+	ctx context.Context,
+	// Encoding to write each extracted image in.
+	format ImageFormat,
+) (*dagger.Directory, error) {
+	formatFlags, ok := format.flags()
+	if !ok {
+		return nil, fmt.Errorf(
+			"EmbeddedImages: unknown image format %q: must be one of %s",
+			string(format), imageFormatNames())
+	}
+	if err := d.validateRange(ctx); err != nil {
+		return nil, err
+	}
+
+	flags := append([]string(nil), formatFlags...)
+	flags = append(flags, pageNumbersFlag, printFilenamesFlag)
+	flags = append(flags, d.rangeArgs()...)
+
+	// set -e is what makes a document poppler cannot open fail here, carrying its
+	// own message, rather than turning into an empty directory a caller would read
+	// as a document with no images in it.
+	script := strings.Join([]string{
+		"set -e",
+		"mkdir -p " + outputDir,
+		d.command("pdfimages", flags, sourcePath, imagesRoot),
+		imageNormalizeScript,
+	}, "\n")
+
+	res, err := d.runScript(ctx, "EmbeddedImages", script)
+	if err != nil {
+		return nil, err
+	}
+	// -print-filenames named every file it wrote, so an empty stdout is the
+	// document saying it carries no images. Nothing else about the run says so:
+	// pdfimages exits 0 for a document with no images and for a document with a
+	// hundred alike.
+	if strings.TrimSpace(res.stdout) == "" {
+		return nil, fmt.Errorf(
+			"EmbeddedImages: this document carries no image objects%s: there is nothing to extract, and a page of text and vectors is drawn rather than extracted — Convert().Png() is what renders one. `pdfimages -list`, through Container, answers the same question without failing",
+			d.rangeSuffix())
+	}
+	return res.container.Directory(outputDir), nil
+}
+
+// Attachments extracts the files embedded in the document and returns the
+// directory holding them, each under the name the document gives it.
+//
+// This is the other half of what a PDF can carry that is not a page. An embedded
+// file is a whole file attached to the document — the machine-readable XML a
+// ZUGFeRD or Factur-X invoice carries alongside its human-readable page, a
+// spreadsheet behind a report, a CAD file behind a drawing — and it is not drawn,
+// not rendered and not part of any page's content. Neither Convert nor
+// EmbeddedImages will ever produce it: this is the only function that reaches it.
+//
+// The names are the document's own, not this module's, and that is the one place
+// this function departs from every other directory-returning function here. An
+// attachment's name is *data* — it is what the producer called the file and what
+// the consumer expects to find — so normalizing it to a contract the way the page
+// families do would destroy the thing that makes the result usable. A caller
+// wanting the invoice XML asks for `invoice.xml`.
+//
+// The flip side is that poppler polices those names, and polices them coarsely:
+// an attachment whose name carries a path — `../elsewhere.xml` — makes pdfdetach
+// refuse the *whole* extraction with `Preventing directory traversal` rather than
+// skip that one file, so one such name means no attachments at all. That is
+// reported as what it is, carrying the list of names the document holds, because
+// those names are what `pdfdetach -savefile` needs to fetch them one at a time
+// through Container.
+//
+// A document carrying no embedded files is refused rather than returned as an
+// empty directory, for the reason EmbeddedImages gives: pdfdetach exits 0 for it,
+// so the directory would be indistinguishable from an extraction that wrote
+// nothing. `pdfdetach -list` is the report that answers "does this carry any"
+// without failing, and the message names it.
+//
+// WithPageRange does not narrow it. An embedded file hangs off the document's
+// catalog rather than off any page — pdfdetach has no page bounds at all — which
+// is the same reason it does not narrow Metadata or Signatures. The passwords do
+// reach it, unlike Split and Merge: pdfdetach takes both.
+func (d *Document) Attachments(ctx context.Context) (*dagger.Directory, error) {
+	// The report and the save run in one exec, in that order, because the report
+	// is the only thing that says how many files there were — pdfdetach says
+	// nothing at all about what it saved — and two execs would mean opening the
+	// document twice to learn one number.
+	script := strings.Join([]string{
+		"set -e",
+		"mkdir -p " + outputDir,
+		// Saved from inside the output directory rather than to a named one:
+		// -o names a single output file for -savefile, and its meaning for
+		// -saveall is not something poppler documents.
+		"cd " + outputDir,
+		d.command("pdfdetach", []string{listFlag}, sourcePath),
+		d.command("pdfdetach", []string{saveAllFlag}, sourcePath),
+	}, "\n")
+
+	res, code, err := d.capture(ctx, script)
+	if err != nil {
+		return nil, err
+	}
+	if code != 0 {
+		if strings.Contains(res.stderr, traversalMarker) {
+			// The list report is the useful half of this failure: it survived, and
+			// the names in it are what -savefile has to be given.
+			return nil, fmt.Errorf(
+				"Attachments: this document names an attachment with a path in it, and poppler refuses the whole extraction rather than that one file: nothing was saved. The names are the document's own, so nothing passed to this module changes that — fetch them one at a time with `pdfdetach -savefile <name> -o <path>` through Container\n%s\n%s",
+				strings.TrimSpace(res.stdout), strings.TrimSpace(res.stderr))
+		}
+		return nil, d.failure("Attachments", code, res.stdout, res.stderr)
+	}
+
+	count, err := parseEmbeddedFileCount(res.stdout)
+	if err != nil {
+		return nil, fmt.Errorf("Attachments: %s", err.Error())
+	}
+	if count == noEmbeddedFilesCount {
+		return nil, fmt.Errorf(
+			"Attachments: this document carries no embedded files: nothing is attached to it, so there is nothing to extract. `pdfdetach -list`, through Container, answers the same question without failing")
+	}
+	return res.container.Directory(outputDir), nil
+}
+
+// rangeSuffix names the page range in a message about a document that came back
+// empty, so a caller who narrowed to the wrong pages is not told the whole
+// document is empty.
+func (d *Document) rangeSuffix() string {
+	if !d.HasRange {
+		return ""
+	}
+	if d.LastPage == endOfDocument {
+		return fmt.Sprintf(" from page %d on", d.FirstPage)
+	}
+	return fmt.Sprintf(" on pages %d through %d", d.FirstPage, d.LastPage)
+}
+
+// parseEmbeddedFileCount reads the count out of pdfdetach's report, which opens
+// with a `<n> embedded files` line whatever n is — including zero, and including
+// one, poppler not troubling itself about the plural.
+func parseEmbeddedFileCount(report string) (int, error) {
+	for _, line := range strings.Split(report, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasSuffix(line, embeddedFilesSuffix) {
+			continue
+		}
+		field := strings.TrimSpace(strings.TrimSuffix(line, embeddedFilesSuffix))
+		count, err := strconv.Atoi(field)
+		if err != nil {
+			return 0, fmt.Errorf("pdfdetach reported an unreadable file count %q", field)
+		}
+		return count, nil
+	}
+	return 0, fmt.Errorf("pdfdetach reported no file count:\n%s", report)
+}

--- a/daggerverse/pdf/main.go
+++ b/daggerverse/pdf/main.go
@@ -63,10 +63,19 @@
 // else here has: pdfseparate and pdfunite accept no password, so an encrypted
 // document has to be decrypted before either will touch it.
 //
+// Two more pull out what the document *contains* rather than a conversion of it,
+// and both are routinely confused with a render. EmbeddedImages is pdfimages: the
+// image objects on the pages, at the resolution they are stored at, which for a
+// scan is better OCR input than any resolution Convert.Png can be asked for
+// because nothing was resampled to produce it. Attachments is pdfdetach: whole
+// files hung off the document's catalog, which is how an invoice carries its
+// machine-readable XML, and which no amount of rendering reaches.
+//
 // File map (all `package main`, surfaced as one Dagger module):
 //
-//   - enums.go    — ColorMode and LayoutMode plus the tables mapping them onto
-//     poppler's flags, and the internal raster- and per-page-format tables.
+//   - enums.go    — ColorMode, LayoutMode and ImageFormat plus the tables
+//     mapping them onto poppler's flags, and the internal raster- and
+//     per-page-format tables.
 //   - document.go — *Document, one bound PDF: its passwords, its page range,
 //     and the four reports about it — what pdfinfo says, which fonts it needs,
 //     its XMP metadata, and its signatures.
@@ -76,6 +85,10 @@
 //     sit together rather than with their receivers because they are one
 //     story: the page-naming contract one writes is the order the other
 //     reads.
+//   - extract.go  — EmbeddedImages and Attachments, the two extractions. They
+//     sit together because they are one story too: both return what the file
+//     already carries, and both are reached for by mistake instead of a render
+//     or instead of each other.
 package main
 
 import (
@@ -100,9 +113,9 @@ const (
 	defaultAlpineTag = "3.24"
 
 	// popplerPkg carries all thirteen pdf* binaries this module reaches
-	// through Container, of which nine are wrapped: pdftotext, pdftoppm,
-	// pdfinfo, pdftocairo, pdftohtml, pdffonts, pdfsig, pdfseparate and
-	// pdfunite.
+	// through Container, of which eleven are wrapped: pdftotext, pdftoppm,
+	// pdfinfo, pdftocairo, pdftohtml, pdffonts, pdfsig, pdfseparate,
+	// pdfunite, pdfimages and pdfdetach.
 	popplerPkg = "poppler-utils"
 
 	// fontPkg is the substitute font family poppler draws with when a PDF
@@ -375,9 +388,9 @@ func (p *Pdf) WithFonts(
 
 // Container returns the assembled toolchain image. This is the escape hatch
 // for everything this module does not wrap: poppler-utils ships thirteen
-// binaries and nine of them are wrapped here, so pdfimages, pdfattach,
-// pdfdetach and pdftops stay reachable via `container with-exec` — as do the
-// flags of a wrapped tool that this module does not surface, `pdffonts -subst`
+// binaries and eleven of them are wrapped here, so pdfattach and pdftops stay
+// reachable via `container with-exec` — as do the flags of a wrapped tool that
+// this module does not surface, `pdffonts -subst` and `pdfdetach -savefile`
 // among them.
 func (p *Pdf) Container() *dagger.Container {
 	ctr := p.base().WithExec([]string{"apk", "add", "--no-cache", popplerPkg, fontPkg})

--- a/daggerverse/pdf/tests/dagger.gen.go
+++ b/daggerverse/pdf/tests/dagger.gen.go
@@ -227,6 +227,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).ApkRepositoryReplacesImageDefaults(&parent, ctx)
+		case "AttachmentsReportsPopplersRefusalOfPathBearingNames":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).AttachmentsReportsPopplersRefusalOfPathBearingNames(&parent, ctx)
+		case "AttachmentsReturnsEveryEmbeddedFileOrSaysThereAreNone":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).AttachmentsReturnsEveryEmbeddedFileOrSaysThereAreNone(&parent, ctx)
 		case "AuthenticatedRepositoryIsRejectedWithoutApkAuth":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -283,6 +297,27 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).DpiDefaultsToOneFiftyAndScalesWithTheSetting(&parent, ctx)
+		case "EmbeddedImagesKeepsTheOriginalEncoding":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).EmbeddedImagesKeepsTheOriginalEncoding(&parent, ctx)
+		case "EmbeddedImagesNamesEveryImageAndNarrowsToThePageRange":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).EmbeddedImagesNamesEveryImageAndNarrowsToThePageRange(&parent, ctx)
+		case "EmbeddedImagesReturnsTheStoredImageNotTheRenderedPage":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).EmbeddedImagesReturnsTheStoredImageNotTheRenderedPage(&parent, ctx)
 		case "EncryptedDocumentNeedsThePassword":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -297,6 +332,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).EpsWritesEveryPageOfTheDocument(&parent, ctx)
+		case "ExtractionsOpenAnEncryptedDocumentWithThePassword":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).ExtractionsOpenAnEncryptedDocumentWithThePassword(&parent, ctx)
 		case "FontsNarrowsToThePageRange":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/pdf/tests/fixtures/gallery.pdf
+++ b/daggerverse/pdf/tests/fixtures/gallery.pdf
@@ -1,0 +1,87 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 2 /Kids [3 0 R 4 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /XObject << /Iphoto 6 0 R /Iwide 7 0 R >> >> /Contents 5 0 R >>
+endobj
+4 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /XObject << /Ithin 8 0 R >> >> /Contents 9 0 R >>
+endobj
+5 0 obj
+<<  /Length 74 >>
+stream
+q
+288 0 0 216 162 432 cm
+/Iphoto Do
+Q
+q
+288 0 0 96 162 216 cm
+/Iwide Do
+Q
+endstream
+endobj
+6 0 obj
+<< /Type /XObject /Subtype /Image /Width 32 /Height 24 /ColorSpace /DeviceGray /BitsPerComponent 8 /Filter [/ASCIIHexDecode /DCTDecode] /Length 912 >>
+stream
+ffd8ffdb00840006040506050406060506070706080a100a0a09090a140e0f0c
+1017141818171416161a1d251f1a1b231c1616202c20232627292a29191f2d30
+2d283025282928010707070a080a130a0a13281a161a28282828282828282828
+2828282828282828282828282828282828282828282828282828282828282828
+2828282828282828ffc0000b080018002001011100ffc400d200000105010101
+01010100000000000000000102030405060708090a0b10000201030302040305
+0504040000017d01020300041105122131410613516107227114328191a10823
+42b1c11552d1f02433627282090a161718191a25262728292a3435363738393a
+434445464748494a535455565758595a636465666768696a737475767778797a
+838485868788898a92939495969798999aa2a3a4a5a6a7a8a9aab2b3b4b5b6b7
+b8b9bac2c3c4c5c6c7c8c9cad2d3d4d5d6d7d8d9dae1e2e3e4e5e6e7e8e9eaf1
+f2f3f4f5f6f7f8f9faffda0008010100003f00f9ff004dd33a7cb5d569ba674f
+96babd374ce9f2d755a6e99d3e5af38d374ce9f2d7170c3ed57a187dabea6d37
+4ce9f2d79c69ba674f96babd374ce9f2d755a6e99d3e5aeaf4dd33a7cb5fffd9
+>
+endstream
+endobj
+7 0 obj
+<< /Type /XObject /Subtype /Image /Width 6 /Height 2 /ColorSpace /DeviceGray /BitsPerComponent 8 /Filter /ASCIIHexDecode /Length 27 >>
+stream
+004080c0ff80004080c0ff80
+>
+endstream
+endobj
+8 0 obj
+<< /Type /XObject /Subtype /Image /Width 8 /Height 1 /ColorSpace /DeviceGray /BitsPerComponent 8 /Filter /ASCIIHexDecode /Length 19 >>
+stream
+ffe0c0a080604020
+>
+endstream
+endobj
+9 0 obj
+<<  /Length 36 >>
+stream
+q
+288 0 0 36 162 432 cm
+/Ithin Do
+Q
+endstream
+endobj
+xref
+0 10
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000127 00000 n 
+0000000273 00000 n 
+0000000405 00000 n 
+0000000529 00000 n 
+0000001624 00000 n 
+0000001818 00000 n 
+0000002004 00000 n 
+trailer
+<< /Size 10 /Root 1 0 R >>
+startxref
+2090
+%%EOF

--- a/daggerverse/pdf/tests/fixtures/invoice.pdf
+++ b/daggerverse/pdf/tests/fixtures/invoice.pdf
@@ -1,0 +1,72 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R /Names << /EmbeddedFiles 6 0 R >> >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+5 0 obj
+<<  /Length 76 >>
+stream
+BT
+/F1 18 Tf
+72 700 Td
+(Invoice INV-0042.) Tj
+0 -24 Td
+(Marker PAPA.) Tj
+ET
+endstream
+endobj
+6 0 obj
+<< /Names [(invoice.xml) 7 0 R (terms.txt) 9 0 R] >>
+endobj
+7 0 obj
+<< /Type /Filespec /F (invoice.xml) /UF (invoice.xml) /Desc (Machine-readable invoice) /EF << /F 8 0 R >> >>
+endobj
+8 0 obj
+<< /Type /EmbeddedFile /Subtype /text#2Fxml /Params << /Size 200 >> /Length 200 >>
+stream
+<?xml version="1.0" encoding="UTF-8"?>
+<Invoice>
+  <ID>INV-0042</ID>
+  <IssueDate>2026-07-30</IssueDate>
+  <PayableAmount currencyID="EUR">1312.00</PayableAmount>
+  <Marker>QUEBEC</Marker>
+</Invoice>
+endstream
+endobj
+9 0 obj
+<< /Type /Filespec /F (terms.txt) /UF (terms.txt) /Desc (Payment terms) /EF << /F 10 0 R >> >>
+endobj
+10 0 obj
+<< /Type /EmbeddedFile /Subtype /text#2Fplain /Params << /Size 39 >> /Length 39 >>
+stream
+Payment terms: net 30.
+Marker: SIERRA.
+endstream
+endobj
+xref
+0 11
+0000000000 65535 f 
+0000000015 00000 n 
+0000000098 00000 n 
+0000000155 00000 n 
+0000000281 00000 n 
+0000000351 00000 n 
+0000000477 00000 n 
+0000000545 00000 n 
+0000000669 00000 n 
+0000000984 00000 n 
+0000001094 00000 n 
+trailer
+<< /Size 11 /Root 1 0 R >>
+startxref
+1249
+%%EOF

--- a/daggerverse/pdf/tests/fixtures/traversal.pdf
+++ b/daggerverse/pdf/tests/fixtures/traversal.pdf
@@ -1,0 +1,48 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R /Names << /EmbeddedFiles 4 0 R >> >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>
+endobj
+4 0 obj
+<< /Names [(a-escaping) 5 0 R (b-ordinary) 7 0 R] >>
+endobj
+5 0 obj
+<< /Type /Filespec /F (../escaped.txt) /UF (../escaped.txt) /EF << /F 6 0 R >> >>
+endobj
+6 0 obj
+<< /Type /EmbeddedFile /Length 14 >>
+stream
+Marker TANGO.
+endstream
+endobj
+7 0 obj
+<< /Type /Filespec /F (ordinary.txt) /UF (ordinary.txt) /EF << /F 8 0 R >> >>
+endobj
+8 0 obj
+<< /Type /EmbeddedFile /Length 16 >>
+stream
+Marker UNIFORM.
+endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000015 00000 n 
+0000000098 00000 n 
+0000000155 00000 n 
+0000000226 00000 n 
+0000000294 00000 n 
+0000000391 00000 n 
+0000000474 00000 n 
+0000000567 00000 n 
+trailer
+<< /Size 9 /Root 1 0 R >>
+startxref
+652
+%%EOF

--- a/daggerverse/pdf/tests/internal/dagger/pdf.gen.go
+++ b/daggerverse/pdf/tests/internal/dagger/pdf.gen.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Retrieve the binding value, as type Pdf
-func (r *Binding) AsPdf() *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:236:6)
+func (r *Binding) AsPdf() *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:249:6)
 	q := r.query.Select("asPdf")
 
 	return &Pdf{
@@ -86,7 +86,7 @@ func (r *Env) WithPdfDocumentOutput(name string, description string) *Env { // p
 }
 
 // Create or update a binding of type Pdf in the environment
-func (r *Env) WithPdfInput(name string, value *Pdf, description string) *Env { // pdf (../../../../../daggerverse/pdf/main.go:236:6)
+func (r *Env) WithPdfInput(name string, value *Pdf, description string) *Env { // pdf (../../../../../daggerverse/pdf/main.go:249:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withPdfInput")
 	q = q.Arg("name", name)
@@ -99,7 +99,7 @@ func (r *Env) WithPdfInput(name string, value *Pdf, description string) *Env { /
 }
 
 // Declare a desired Pdf output to be assigned in the environment
-func (r *Env) WithPdfOutput(name string, description string) *Env { // pdf (../../../../../daggerverse/pdf/main.go:236:6)
+func (r *Env) WithPdfOutput(name string, description string) *Env { // pdf (../../../../../daggerverse/pdf/main.go:249:6)
 	q := r.query.Select("withPdfOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -113,7 +113,7 @@ func (r *Env) WithPdfOutput(name string, description string) *Env { // pdf (../.
 // carries the image coordinates and the fonts the image is built with;
 // Document hangs off it so the generated SDK surfaces conversion under
 // `dag.Pdf().Document(...)`.
-type Pdf struct { // pdf (../../../../../daggerverse/pdf/main.go:236:6)
+type Pdf struct { // pdf (../../../../../daggerverse/pdf/main.go:249:6)
 	query *querybuilder.Selection
 
 	id      *ID
@@ -136,11 +136,11 @@ func (r *Pdf) WithGraphQLQuery(q *querybuilder.Selection) *Pdf {
 
 // Container returns the assembled toolchain image. This is the escape hatch
 // for everything this module does not wrap: poppler-utils ships thirteen
-// binaries and nine of them are wrapped here, so pdfimages, pdfattach,
-// pdfdetach and pdftops stay reachable via `container with-exec` — as do the
-// flags of a wrapped tool that this module does not surface, `pdffonts -subst`
+// binaries and eleven of them are wrapped here, so pdfattach and pdftops stay
+// reachable via `container with-exec` — as do the flags of a wrapped tool that
+// this module does not surface, `pdffonts -subst` and `pdfdetach -savefile`
 // among them.
-func (r *Pdf) Container() *Container { // pdf (../../../../../daggerverse/pdf/main.go:382:1)
+func (r *Pdf) Container() *Container { // pdf (../../../../../daggerverse/pdf/main.go:395:1)
 	q := r.query.Select("container")
 
 	return &Container{
@@ -153,7 +153,7 @@ func (r *Pdf) Container() *Container { // pdf (../../../../../daggerverse/pdf/ma
 // The boundary input is a *dagger.File rather than a *dagger.Directory: a PDF
 // resolves nothing relative to its own location, so one file is the whole unit
 // of work however many pages it carries.
-func (r *Pdf) Document(source *File) *PdfDocument { // pdf (../../../../../daggerverse/pdf/main.go:415:1)
+func (r *Pdf) Document(source *File) *PdfDocument { // pdf (../../../../../daggerverse/pdf/main.go:428:1)
 	assertNotNil("source", source)
 	q := r.query.Select("document")
 	q = q.Arg("source", source)
@@ -249,7 +249,7 @@ func (r *Pdf) Merge(sources []*File) *File { // pdf (../../../../../daggerverse/
 
 // Version returns the poppler release the assembled image ships, as the bare
 // version number reported by `pdftotext -v`.
-func (r *Pdf) Version(ctx context.Context) (string, error) { // pdf (../../../../../daggerverse/pdf/main.go:395:1)
+func (r *Pdf) Version(ctx context.Context) (string, error) { // pdf (../../../../../daggerverse/pdf/main.go:408:1)
 	if r.version != nil {
 		return *r.version, nil
 	}
@@ -275,7 +275,7 @@ func (r *Pdf) Version(ctx context.Context) (string, error) { // pdf (../../../..
 // why the credentials are not simply userinfo in the WithApkRepository URL,
 // which would put them in /etc/apk/repositories and in every apk error
 // message that quotes it.
-func (r *Pdf) WithApkAuth(credentials *Secret) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:343:1)
+func (r *Pdf) WithApkAuth(credentials *Secret) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:356:1)
 	assertNotNil("credentials", credentials)
 	q := r.query.Select("withApkAuth")
 	q = q.Arg("credentials", credentials)
@@ -298,7 +298,7 @@ func (r *Pdf) WithApkAuth(credentials *Secret) *Pdf { // pdf (../../../../../dag
 // Repeatable, for a mirror set signed by more than one key. It is a *File
 // rather than a *Secret because a public key is not a credential: it is meant
 // to be in the image, and WithApkAuth is the option for the part that is not.
-func (r *Pdf) WithApkKey(key *File) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:320:1)
+func (r *Pdf) WithApkKey(key *File) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:333:1)
 	assertNotNil("key", key)
 	q := r.query.Select("withApkKey")
 	q = q.Arg("key", key)
@@ -328,7 +328,7 @@ func (r *Pdf) WithApkKey(key *File) *Pdf { // pdf (../../../../../daggerverse/pd
 // call per component. A repository's index is signed, so pair this with
 // WithApkKey unless the mirror is signed by a key the base image already
 // trusts.
-func (r *Pdf) WithApkRepository(url string) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:292:1)
+func (r *Pdf) WithApkRepository(url string) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:305:1)
 	q := r.query.Select("withApkRepository")
 	q = q.Arg("url", url)
 
@@ -352,7 +352,7 @@ func (r *Pdf) WithApkRepository(url string) *Pdf { // pdf (../../../../../dagger
 // /etc/fonts/fonts.conf tells fontconfig to scan, so the faces in it are
 // indistinguishable from packaged ones as far as poppler is concerned. It is
 // mounted rather than copied so a large family does not become an image layer.
-func (r *Pdf) WithFonts(dir *Directory) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:367:1)
+func (r *Pdf) WithFonts(dir *Directory) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:380:1)
 	assertNotNil("dir", dir)
 	q := r.query.Select("withFonts")
 	q = q.Arg("dir", dir)
@@ -893,6 +893,49 @@ func (r *PdfDocument) WithGraphQLQuery(q *querybuilder.Selection) *PdfDocument {
 	}
 }
 
+// Attachments extracts the files embedded in the document and returns the
+// directory holding them, each under the name the document gives it.
+//
+// This is the other half of what a PDF can carry that is not a page. An embedded
+// file is a whole file attached to the document — the machine-readable XML a
+// ZUGFeRD or Factur-X invoice carries alongside its human-readable page, a
+// spreadsheet behind a report, a CAD file behind a drawing — and it is not drawn,
+// not rendered and not part of any page's content. Neither Convert nor
+// EmbeddedImages will ever produce it: this is the only function that reaches it.
+//
+// The names are the document's own, not this module's, and that is the one place
+// this function departs from every other directory-returning function here. An
+// attachment's name is *data* — it is what the producer called the file and what
+// the consumer expects to find — so normalizing it to a contract the way the page
+// families do would destroy the thing that makes the result usable. A caller
+// wanting the invoice XML asks for `invoice.xml`.
+//
+// The flip side is that poppler polices those names, and polices them coarsely:
+// an attachment whose name carries a path — `../elsewhere.xml` — makes pdfdetach
+// refuse the *whole* extraction with `Preventing directory traversal` rather than
+// skip that one file, so one such name means no attachments at all. That is
+// reported as what it is, carrying the list of names the document holds, because
+// those names are what `pdfdetach -savefile` needs to fetch them one at a time
+// through Container.
+//
+// A document carrying no embedded files is refused rather than returned as an
+// empty directory, for the reason EmbeddedImages gives: pdfdetach exits 0 for it,
+// so the directory would be indistinguishable from an extraction that wrote
+// nothing. `pdfdetach -list` is the report that answers "does this carry any"
+// without failing, and the message names it.
+//
+// WithPageRange does not narrow it. An embedded file hangs off the document's
+// catalog rather than off any page — pdfdetach has no page bounds at all — which
+// is the same reason it does not narrow Metadata or Signatures. The passwords do
+// reach it, unlike Split and Merge: pdfdetach takes both.
+func (r *PdfDocument) Attachments() *Directory { // pdf (../../../../../daggerverse/pdf/extract.go:240:1)
+	q := r.query.Select("attachments")
+
+	return &Directory{
+		query: q,
+	}
+}
+
 // Convert opens the conversion namespace: the render options, and the eleven
 // outputs that read them.
 //
@@ -905,6 +948,67 @@ func (r *PdfDocument) Convert() *PdfConvert { // pdf (../../../../../daggerverse
 	q := r.query.Select("convert")
 
 	return &PdfConvert{
+		query: q,
+	}
+}
+
+// EmbeddedImages extracts the image objects the document *contains* and returns
+// the directory holding them, named `image-0000-page-0001.png` and so on.
+//
+// This is not Convert().Png(), and the difference is the reason the function is
+// named this way. Convert().Png() *rasterizes a page*: it draws everything on
+// the page — text, vectors, annotations, images — into a new bitmap at whatever
+// resolution WithDpi names, and the pixels it produces have never existed before.
+// This returns the image objects themselves, decoded no further than it has to
+// be: for a scanned document that is the scan, at the resolution it was scanned
+// at, with no resampling in between. Which is why it is the better OCR input of
+// the two — every render is a resampling of an image that was already pixels, and
+// recognition accuracy is exactly what that costs.
+//
+// It follows that WithDpi, WithColorMode, WithScaleTo and WithoutAnnotations have
+// no meaning here and are not reachable from this function at all: they live on
+// Convert, which is where rendering decisions belong. There is nothing to choose
+// about the resolution of an image that already has one. By the same token this
+// returns *nothing* for a page whose content is text and vectors — there is no
+// image object on it to extract, and Convert().Png() is what draws such a page.
+//
+// The format is the one real choice, and it is required rather than defaulted
+// because every member either keeps the document's encoding or replaces it, and
+// no one of those is the obviously right thing to do quietly. See ImageFormat.
+// ORIGINAL is worth reading twice: it keeps JPEG, JPEG 2000, JBIG2 and CCITT G4
+// streams byte for byte, and for an image encoded in none of those — a raw or
+// Flate-compressed bitmap, which is most PDFs that were not born as scans — it
+// falls back to netpbm, so a `.ppm` or `.pgm` in the result is not a failure but
+// an image that had no encoding to keep. ALL is the member whose fallback is PNG
+// instead, and is what to reach for when every image has to be readable by
+// something ordinary.
+//
+// The names carry both numbers poppler reports, padded and reordered but not
+// renumbered. The one after `image-` is the image's index in this extraction,
+// 0-based, which for an unnarrowed run is the `num` column of
+// `pdfimages -list`; the one after `-page-` is the 1-based source page it was
+// drawn on. The index comes first so lexicographic order is document order —
+// which it is, images being extracted in page order — and the word `image` comes
+// first of all so a directory of these is never mistaken for a directory of
+// rendered pages.
+//
+// A page can carry several images and most pages carry none, so there is no
+// one-file-per-page contract here of the kind every render honours. A document
+// carrying no images at all is refused rather than returned as an empty
+// directory: pdfimages exits 0 for it, so the directory would be indistinguishable
+// from an extraction that failed to write anything, and the overwhelmingly common
+// thing a caller does with this function is export it.
+//
+// WithPageRange narrows it. Note that it renumbers nothing but does restart the
+// image index, that index being poppler's count for the run rather than for the
+// document: pages 2 through 3 of a document whose first image is on page 1 come
+// back starting at `image-0000-page-0002`. The page number stays the source
+// document's, the same promise Split makes.
+func (r *PdfDocument) EmbeddedImages(format PdfImageFormat) *Directory { // pdf (../../../../../daggerverse/pdf/extract.go:160:1)
+	q := r.query.Select("embeddedImages")
+	q = q.Arg("format", format)
+
+	return &Directory{
 		query: q,
 	}
 }
@@ -1226,18 +1330,18 @@ type PdfOpts struct {
 	//
 	//
 	// Default: "docker.io"
-	Registry string // pdf (../../../../../daggerverse/pdf/main.go:258:2)
+	Registry string // pdf (../../../../../daggerverse/pdf/main.go:271:2)
 	//
 	// Tag of the alpine image the toolchain is assembled on.
 	//
 	//
 	// Default: "3.24"
-	AlpineTag string // pdf (../../../../../daggerverse/pdf/main.go:261:2)
+	AlpineTag string // pdf (../../../../../daggerverse/pdf/main.go:274:2)
 }
 
 // New returns a Pdf module backed by <registry>/library/alpine:<tag> with
 // poppler-utils and a substitute font family installed.
-func (r *Query) Pdf(opts ...PdfOpts) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:253:1)
+func (r *Query) Pdf(opts ...PdfOpts) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:266:1)
 	q := r.query.Select("pdf")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `registry` optional argument
@@ -1330,6 +1434,100 @@ const (
 	// ColorModeMono renders bilevel (`-mono`): every pixel pure black or pure
 	// white, with flat tones dithered rather than averaged.
 	PdfColorModeMono PdfColorMode = "MONO" // pdf (../../../../../daggerverse/pdf/enums.go:33:2)
+
+)
+
+// ImageFormat is the encoding EmbeddedImages writes an extracted image in, and
+// maps onto pdfimages' format flags.
+//
+// Unlike the render formats, this one *is* a Dagger enum, because here the
+// format is a genuine question rather than a choice of function. An embedded
+// image already has an encoding, so every member either keeps it or replaces it,
+// and which of those a caller wants depends on what reads the result: ORIGINAL
+// hands on the bytes the document carries, and PNG hands on something every
+// image library opens without a codec question.
+//
+// Note on rendered names: the Dagger Go SDK derives each GraphQL enum member
+// from the *constant identifier* in SCREAMING_SNAKE_CASE, so these surface as
+// `PNG`, `TIFF`, `ORIGINAL` and `ALL`.
+type PdfImageFormat string // pdf (../../../../../daggerverse/pdf/enums.go:110:6)
+
+func (PdfImageFormat) IsEnum() {}
+
+func (v PdfImageFormat) Name() string {
+	switch v {
+	case PdfImageFormatAll:
+		return "ALL"
+	case PdfImageFormatOriginal:
+		return "ORIGINAL"
+	case PdfImageFormatPng:
+		return "PNG"
+	case PdfImageFormatTiff:
+		return "TIFF"
+	default:
+		return ""
+	}
+}
+
+func (v PdfImageFormat) Value() string {
+	return string(v)
+}
+
+func (v *PdfImageFormat) MarshalJSON() ([]byte, error) {
+	if *v == "" {
+		return []byte(`""`), nil
+	}
+	name := v.Name()
+	if name == "" {
+		return nil, fmt.Errorf("invalid enum value %q", *v)
+	}
+	return json.Marshal(name)
+}
+
+func (v *PdfImageFormat) UnmarshalJSON(dt []byte) error {
+	var s string
+	if err := json.Unmarshal(dt, &s); err != nil {
+		return err
+	}
+	switch s {
+	case "":
+		*v = ""
+	case "ALL":
+		*v = PdfImageFormatAll
+	case "ORIGINAL":
+		*v = PdfImageFormatOriginal
+	case "PNG":
+		*v = PdfImageFormatPng
+	case "TIFF":
+		*v = PdfImageFormatTiff
+	default:
+		return fmt.Errorf("invalid enum value %q", s)
+	}
+	return nil
+}
+
+const (
+	// ImageFormatAll is ORIGINAL with a better fallback: an image with no
+	// natively writable encoding becomes PNG, or TIFF where PNG cannot represent
+	// it. It is the member to reach for when a document's images are of mixed
+	// encodings and every one of them has to be readable.
+	PdfImageFormatAll PdfImageFormat = "ALL" // pdf (../../../../../daggerverse/pdf/enums.go:130:2)
+
+	// ImageFormatOriginal writes the encoded stream out unchanged wherever
+	// poppler can — JPEG, JPEG 2000, JBIG2 and CCITT G4 — and falls back to
+	// netpbm for an image encoded in none of them. It is the member for a caller
+	// who wants the document's own bytes, and the one whose fallback is worth
+	// reading about: see EmbeddedImages.
+	PdfImageFormatOriginal PdfImageFormat = "ORIGINAL" // pdf (../../../../../daggerverse/pdf/enums.go:125:2)
+
+	// ImageFormatPng re-encodes every image as PNG. Lossless, so the
+	// re-encoding costs image quality nothing — it costs only the original
+	// encoding, which for a JPEG-encoded scan usually means a larger file.
+	PdfImageFormatPng PdfImageFormat = "PNG" // pdf (../../../../../daggerverse/pdf/enums.go:116:2)
+
+	// ImageFormatTiff re-encodes every image as TIFF, which is the format the
+	// document-imaging world already speaks.
+	PdfImageFormatTiff PdfImageFormat = "TIFF" // pdf (../../../../../daggerverse/pdf/enums.go:119:2)
 
 )
 

--- a/daggerverse/pdf/tests/main.go
+++ b/daggerverse/pdf/tests/main.go
@@ -9,12 +9,15 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/hex"
 	"encoding/xml"
 	"errors"
 	"fmt"
 	"image"
 	"io"
+	"maps"
 	"math"
 	"os"
 	"path/filepath"
@@ -67,6 +70,13 @@ const (
 	// be handed to the tesseract module.
 	scanPdf = "scan.pdf"
 
+	// scanImageSide is the width and the height, in pixels, of the one image
+	// object scanPdf carries. It is nothing like the size of a render of that
+	// page — 16 pixels against the 1275 a US Letter page covers at 150 dpi —
+	// which is what makes the difference between extracting an image and
+	// rasterizing the page it sits on measurable rather than arguable.
+	scanImageSide = 16
+
 	// fontsPdf is a two-page PDF whose pages name different faces: page one an
 	// unembedded Helvetica, page two an unembedded Courier alongside a Type 3
 	// font.
@@ -103,6 +113,63 @@ const (
 	// GRAY and MONO show up is in the pixels, and flat saturated colour is what
 	// makes them show up unambiguously.
 	swatchPdf = "swatch.pdf"
+
+	// galleryPdf is a two-page PDF carrying three image objects and no page a
+	// render would confuse them with: page one draws a DCT-encoded photograph
+	// and then a wide strip, page two a thin strip.
+	//
+	// All three halves of that are deliberate. The photograph is JPEG-encoded, so
+	// there is an encoding for ORIGINAL to keep; the strips are unencoded, so
+	// there is something for the same member to fall back on; and the three sit
+	// across two pages in a known draw order, which is what makes the naming
+	// contract and the page range observable at all.
+	galleryPdf = "gallery.pdf"
+
+	// galleryPhoto*, galleryWide* and galleryThin* are the pixel dimensions of
+	// gallery.pdf's three images. No two are alike and none is the size of any
+	// page render, so a dimension is an identity: an assertion can say which
+	// image it is holding without decoding what is drawn on it.
+	galleryPhotoWidth  = 32
+	galleryPhotoHeight = 24
+	galleryWideWidth   = 6
+	galleryWideHeight  = 2
+	galleryThinWidth   = 8
+	galleryThinHeight  = 1
+
+	// invoicePdf is a one-page PDF carrying two embedded files in its name tree —
+	// `invoice.xml` and `terms.txt` — which is the shape a ZUGFeRD or Factur-X
+	// invoice arrives in: a human-readable page plus the machine-readable record
+	// attached to it.
+	//
+	// Two rather than one, because "returns every attachment" is the claim, and
+	// one attachment is a claim a single-file implementation would also satisfy.
+	// Both streams are unfiltered, so the bytes pdfdetach writes out are the
+	// bytes visible in the fixture.
+	invoicePdf = "invoice.pdf"
+
+	// invoiceXMLName and invoiceTextName are what invoicePdf calls its two
+	// attachments, and invoiceXMLMarker and invoiceTextMarker are words occurring
+	// exactly once each, in one attachment apiece. The markers are what say the
+	// right bytes landed in the right file.
+	// traversalPdf is a one-page PDF whose first attachment is named with a path
+	// in it — `../escaped.txt` — beside an ordinary one.
+	//
+	// It exists for the module's message about poppler's refusal of such a name,
+	// which is a message of this module's own rather than a diagnostic passed
+	// through. The ordinary second attachment is the point of the fixture: poppler
+	// declines the *whole* extraction rather than the one file, so a document like
+	// this yields nothing at all, and no argument to this module changes that.
+	traversalPdf = "traversal.pdf"
+
+	// traversalOtherName is what traversalPdf calls the attachment that is named
+	// perfectly ordinarily, and which a caller has to reach with
+	// `pdfdetach -savefile` because of the other one.
+	traversalOtherName = "ordinary.txt"
+
+	invoiceXMLName    = "invoice.xml"
+	invoiceTextName   = "terms.txt"
+	invoiceXMLMarker  = "QUEBEC"
+	invoiceTextMarker = "SIERRA"
 
 	// annotatedPdf is a one-page PDF whose only colour comes from a Square
 	// annotation's appearance stream. Every red pixel in a render of it is the
@@ -215,10 +282,10 @@ var ledgerMarkers = []string{
 }
 
 // popplerBinaries is every executable poppler-utils installs. Container's
-// promise is that all of them are reachable, not just the nine this module
+// promise is that all of them are reachable, not just the eleven this module
 // wraps: the module wraps pdftotext, pdftoppm, pdfinfo, pdftocairo, pdftohtml,
-// pdffonts, pdfsig, pdfseparate and pdfunite, and the escape hatch is the whole
-// point of the other four.
+// pdffonts, pdfsig, pdfseparate, pdfunite, pdfimages and pdfdetach, and the
+// escape hatch is the whole point of the other two.
 var popplerBinaries = []string{
 	"pdfattach", "pdfdetach", "pdffonts", "pdfimages", "pdfinfo",
 	"pdfseparate", "pdfsig", "pdftocairo", "pdftohtml", "pdftoppm",
@@ -302,6 +369,13 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("SplitThenMergeRoundTripsTheDocument", t.SplitThenMergeRoundTripsTheDocument)
 	jobs = jobs.WithJob("SplitAndMergeCannotOpenAnEncryptedDocument", t.SplitAndMergeCannotOpenAnEncryptedDocument)
 
+	jobs = jobs.WithJob("EmbeddedImagesReturnsTheStoredImageNotTheRenderedPage", t.EmbeddedImagesReturnsTheStoredImageNotTheRenderedPage)
+	jobs = jobs.WithJob("EmbeddedImagesKeepsTheOriginalEncoding", t.EmbeddedImagesKeepsTheOriginalEncoding)
+	jobs = jobs.WithJob("EmbeddedImagesNamesEveryImageAndNarrowsToThePageRange", t.EmbeddedImagesNamesEveryImageAndNarrowsToThePageRange)
+	jobs = jobs.WithJob("AttachmentsReturnsEveryEmbeddedFileOrSaysThereAreNone", t.AttachmentsReturnsEveryEmbeddedFileOrSaysThereAreNone)
+	jobs = jobs.WithJob("AttachmentsReportsPopplersRefusalOfPathBearingNames", t.AttachmentsReportsPopplersRefusalOfPathBearingNames)
+	jobs = jobs.WithJob("ExtractionsOpenAnEncryptedDocumentWithThePassword", t.ExtractionsOpenAnEncryptedDocumentWithThePassword)
+
 	jobs = jobs.WithJob("EncryptedDocumentNeedsThePassword", t.EncryptedDocumentNeedsThePassword)
 
 	jobs = jobs.WithJob("ApkRepositoryAssemblesWorkingToolchainFromMirror", t.ApkRepositoryAssemblesWorkingToolchainFromMirror)
@@ -312,6 +386,547 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("DefaultApkConfigurationIsUntouched", t.DefaultApkConfigurationIsUntouched)
 
 	return jobs.Run(ctx)
+}
+
+// EmbeddedImagesReturnsTheStoredImageNotTheRenderedPage asserts the distinction the
+// function is named for: what comes back is the image object the document
+// carries, not a rasterization of the page it sits on.
+//
+// The proof is the pixel dimensions, and it is only a proof because the two
+// numbers cannot be confused. scanPdf's image is 16x16; the US Letter page it is
+// drawn across covers 1275x1650 at the module's default resolution. A function
+// that quietly rasterized the page would return an image 79 times wider, and a
+// dimension assertion catches that where an entry-count assertion would not — one
+// page carrying one image produces one file either way.
+//
+// The render is fetched here rather than hardcoded so the comparison is against
+// what this module actually produces, which is the thing a caller would otherwise
+// mistake this for.
+func (t *Tests) EmbeddedImagesReturnsTheStoredImageNotTheRenderedPage(ctx context.Context) error {
+	doc := pdf().Document(fixture(scanPdf))
+
+	dir := doc.EmbeddedImages(dagger.PdfImageFormatPng)
+	entries, err := dir.Entries(ctx)
+	if err != nil {
+		return fmt.Errorf("EmbeddedImages: %w", err)
+	}
+	if want := []string{"image-0000-page-0001.png"}; !slices.Equal(entries, want) {
+		return fmt.Errorf("expected %v, got %v", want, entries)
+	}
+
+	extracted, err := firstPageConfig(ctx, dir, "embedded-images")
+	if err != nil {
+		return fmt.Errorf("decoding the extracted image: %w", err)
+	}
+	if extracted.Width != scanImageSide || extracted.Height != scanImageSide {
+		return fmt.Errorf("expected the embedded image to be %dx%d, got %dx%d",
+			scanImageSide, scanImageSide, extracted.Width, extracted.Height)
+	}
+
+	rendered, err := firstPageConfig(ctx, doc.Convert().Png(), "embedded-images-render")
+	if err != nil {
+		return fmt.Errorf("decoding the page render: %w", err)
+	}
+	if rendered.Width == extracted.Width && rendered.Height == extracted.Height {
+		return fmt.Errorf(
+			"expected the extraction and the render to differ in size, both were %dx%d",
+			rendered.Width, rendered.Height)
+	}
+	if wantW, wantH := pixelsAt(defaultDpi); rendered.Width != wantW || rendered.Height != wantH {
+		return fmt.Errorf("expected the render to be %dx%d, got %dx%d",
+			wantW, wantH, rendered.Width, rendered.Height)
+	}
+	return nil
+}
+
+// EmbeddedImagesKeepsTheOriginalEncoding asserts what each ImageFormat member
+// does to an image that already has an encoding, and asserts the one that keeps
+// it does so byte for byte.
+//
+// Byte equality is the only assertion that actually says "kept". A `.jpg` that
+// decodes to the right dimensions would also come out of a re-encode, and a
+// re-encode is precisely what ORIGINAL exists to avoid — so the expectation here
+// is read out of the fixture itself: gallery.pdf's photograph is JPEG bytes
+// hex-armored inside the file, and hex-decoding them gives exactly what poppler
+// should have written.
+//
+// The extensions carry the rest of the claim. ORIGINAL falls back to netpbm for
+// the two unencoded strips, which is the part of that member most likely to
+// surprise a caller and therefore the part most worth pinning; ALL is the same
+// member with PNG as the fallback instead, which is the whole difference between
+// the two; and PNG and TIFF re-encode everything, the photograph included.
+func (t *Tests) EmbeddedImagesKeepsTheOriginalEncoding(ctx context.Context) error {
+	doc := pdf().Document(fixture(galleryPdf))
+	const photo = "image-0000-page-0001"
+
+	want, err := galleryJpegBytes(ctx)
+	if err != nil {
+		return fmt.Errorf("reading the fixture's JPEG stream: %w", err)
+	}
+
+	for _, tc := range []struct {
+		format  dagger.PdfImageFormat
+		entries []string
+		// keeps is whether the photograph's file should be the fixture's own
+		// JPEG bytes, unchanged.
+		keeps bool
+	}{
+		{
+			format: dagger.PdfImageFormatOriginal,
+			entries: []string{
+				photo + ".jpg", "image-0001-page-0001.ppm", "image-0002-page-0002.ppm",
+			},
+			keeps: true,
+		},
+		{
+			format: dagger.PdfImageFormatAll,
+			entries: []string{
+				photo + ".jpg", "image-0001-page-0001.png", "image-0002-page-0002.png",
+			},
+			keeps: true,
+		},
+		{
+			format: dagger.PdfImageFormatPng,
+			entries: []string{
+				photo + ".png", "image-0001-page-0001.png", "image-0002-page-0002.png",
+			},
+		},
+		{
+			format: dagger.PdfImageFormatTiff,
+			entries: []string{
+				photo + ".tif", "image-0001-page-0001.tif", "image-0002-page-0002.tif",
+			},
+		},
+	} {
+		label := string(tc.format)
+		dir := doc.EmbeddedImages(tc.format)
+
+		got, err := dir.Entries(ctx)
+		if err != nil {
+			return fmt.Errorf("%s: EmbeddedImages: %w", label, err)
+		}
+		if !slices.Equal(got, tc.entries) {
+			return fmt.Errorf("%s: expected %v, got %v", label, tc.entries, got)
+		}
+
+		tmp, cleanup, err := exportedDir(ctx, dir, "embedded-"+strings.ToLower(label))
+		if err != nil {
+			return fmt.Errorf("%s: %w", label, err)
+		}
+		bytesOut, err := os.ReadFile(filepath.Join(tmp, tc.entries[0]))
+		cleanup()
+		if err != nil {
+			return fmt.Errorf("%s: reading %s: %w", label, tc.entries[0], err)
+		}
+
+		if tc.keeps != bytes.Equal(bytesOut, want) {
+			if tc.keeps {
+				return fmt.Errorf(
+					"%s: expected %s to be the document's own %d JPEG bytes, got %d bytes",
+					label, tc.entries[0], len(want), len(bytesOut))
+			}
+			return fmt.Errorf(
+				"%s: expected %s to be re-encoded rather than the document's own JPEG bytes",
+				label, tc.entries[0])
+		}
+	}
+	return nil
+}
+
+// EmbeddedImagesNamesEveryImageAndNarrowsToThePageRange asserts both numbers in
+// an extracted image's name mean what the contract says, and asserts a document
+// with nothing to extract is told so rather than handed an empty directory.
+//
+// The names are checked against the images' *dimensions*, not merely counted.
+// gallery.pdf's three images are three different sizes on purpose, so decoding
+// each one says which image landed under which name — an assertion a numbering
+// that shuffled or off-by-oned the files would fail and an entry-count assertion
+// would not.
+//
+// The page range is where the two numbers part company. The page number is the
+// source document's, like everywhere else in this module, so page two's image
+// stays `page-0002` when page two is all that was asked for. The image index is
+// not: it is poppler's count for the run, so it restarts at zero. That is
+// asserted rather than worked around because it is the surprising half of the
+// contract, and a caller cross-referencing `pdfimages -list` needs to know which
+// number moved.
+func (t *Tests) EmbeddedImagesNamesEveryImageAndNarrowsToThePageRange(ctx context.Context) error {
+	doc := pdf().Document(fixture(galleryPdf))
+
+	for _, tc := range []struct {
+		name string
+		doc  *dagger.PdfDocument
+		want map[string][2]int
+	}{
+		{
+			name: "the whole document",
+			doc:  doc,
+			want: map[string][2]int{
+				"image-0000-page-0001.png": {galleryPhotoWidth, galleryPhotoHeight},
+				"image-0001-page-0001.png": {galleryWideWidth, galleryWideHeight},
+				"image-0002-page-0002.png": {galleryThinWidth, galleryThinHeight},
+			},
+		},
+		{
+			name: "both images of page one",
+			doc:  doc.WithPageRange(1, 1),
+			want: map[string][2]int{
+				"image-0000-page-0001.png": {galleryPhotoWidth, galleryPhotoHeight},
+				"image-0001-page-0001.png": {galleryWideWidth, galleryWideHeight},
+			},
+		},
+		{
+			// The index restarts and the page does not, which is the whole point
+			// of asserting a range that does not begin at page one.
+			name: "page two alone",
+			doc:  doc.WithPageRange(2, 2),
+			want: map[string][2]int{
+				"image-0000-page-0002.png": {galleryThinWidth, galleryThinHeight},
+			},
+		},
+	} {
+		dir := tc.doc.EmbeddedImages(dagger.PdfImageFormatPng)
+
+		entries, err := dir.Entries(ctx)
+		if err != nil {
+			return fmt.Errorf("%s: EmbeddedImages: %w", tc.name, err)
+		}
+		names := slices.Sorted(maps.Keys(tc.want))
+		if !slices.Equal(entries, names) {
+			return fmt.Errorf("%s: expected %v, got %v", tc.name, names, entries)
+		}
+
+		configs, err := imageConfigs(ctx, dir, "embedded-names")
+		if err != nil {
+			return fmt.Errorf("%s: %w", tc.name, err)
+		}
+		for name, size := range tc.want {
+			got := configs[name]
+			if got.Width != size[0] || got.Height != size[1] {
+				return fmt.Errorf("%s: expected %s to be %dx%d, got %dx%d",
+					tc.name, name, size[0], size[1], got.Width, got.Height)
+			}
+		}
+	}
+
+	// A range past the end of the document is refused before the extraction runs,
+	// the same check every other page-bounded function goes through.
+	_, err := doc.WithPageRange(1, 3).EmbeddedImages(dagger.PdfImageFormatPng).Entries(ctx)
+	if err == nil {
+		return fmt.Errorf("expected a range past the end of the document to be rejected")
+	}
+	for _, want := range []string{"last (3)", "2 pages"} {
+		if !strings.Contains(err.Error(), want) {
+			return fmt.Errorf("expected the rejection to mention %q, got: %v", want, err)
+		}
+	}
+
+	// A document of text and vectors carries no image objects at all, and
+	// pdfimages exits 0 for it — so the module is the only thing that can tell a
+	// caller the difference between that and an extraction that wrote nothing.
+	_, err = pdf().Document(fixture(ledgerPdf)).
+		EmbeddedImages(dagger.PdfImageFormatPng).Entries(ctx)
+	if err == nil {
+		return fmt.Errorf("expected a document with no images to be refused")
+	}
+	for _, want := range []string{"no image objects", "Convert().Png()", "pdfimages -list"} {
+		if !strings.Contains(err.Error(), want) {
+			return fmt.Errorf("expected the refusal to mention %q, got: %v", want, err)
+		}
+	}
+
+	// Narrowed, the same refusal names the pages that were asked for, so a caller
+	// who narrowed to the wrong ones is not told the whole document is empty.
+	_, err = pdf().Document(fixture(galleryPdf)).WithPageRange(2, 2).
+		EmbeddedImages(dagger.PdfImageFormatPng).Entries(ctx)
+	if err != nil {
+		return fmt.Errorf("page two of the gallery carries an image: %w", err)
+	}
+	_, err = pdf().Document(fixture(ledgerPdf)).WithPageRange(2, 3).
+		EmbeddedImages(dagger.PdfImageFormatPng).Entries(ctx)
+	if err == nil {
+		return fmt.Errorf("expected a narrowed extraction of a document with no images to be refused")
+	}
+	if want := "on pages 2 through 3"; !strings.Contains(err.Error(), want) {
+		return fmt.Errorf("expected the refusal to mention %q, got: %v", want, err)
+	}
+	return nil
+}
+
+// AttachmentsReturnsEveryEmbeddedFileOrSaysThereAreNone asserts both halves of
+// what the function promises: every file the document attached, under the name
+// the document gave it, and an answer a caller can act on for a document that
+// attached nothing.
+//
+// Two attachments is the minimum that tests "every" — one would be satisfied by
+// an implementation that saved the first and stopped — and their contents are
+// read rather than their names counted, because a name is not evidence the right
+// bytes landed under it.
+//
+// The names are the fixture's own and are deliberately *not* the page-style
+// contract the rest of this module's directories honour. An attachment's name is
+// data: it is what the producer called the file and what a consumer looks for, so
+// `invoice.xml` staying `invoice.xml` is the assertion, not a defect in the
+// naming discipline.
+//
+// The empty case is refused rather than returned as an empty directory. pdfdetach
+// exits 0 for a document with no attachments, so the directory would say nothing
+// about which of the two happened, and the message names `pdfdetach -list` as the
+// way to ask without failing.
+func (t *Tests) AttachmentsReturnsEveryEmbeddedFileOrSaysThereAreNone(ctx context.Context) error {
+	doc := pdf().Document(fixture(invoicePdf))
+
+	want := []string{invoiceXMLName, invoiceTextName}
+	slices.Sort(want)
+
+	// A page range has no meaning for an attachment, which hangs off the
+	// document's catalog rather than off any page, so it narrows nothing — the
+	// same posture Metadata and Signatures take.
+	for _, tc := range []struct {
+		name string
+		doc  *dagger.PdfDocument
+	}{
+		{"the whole document", doc},
+		{"narrowed to page one", doc.WithPageRange(1, 1)},
+	} {
+		entries, err := tc.doc.Attachments().Entries(ctx)
+		if err != nil {
+			return fmt.Errorf("%s: Attachments: %w", tc.name, err)
+		}
+		if !slices.Equal(entries, want) {
+			return fmt.Errorf("%s: expected %v, got %v", tc.name, want, entries)
+		}
+	}
+
+	dir := doc.Attachments()
+	for _, tc := range []struct {
+		file   string
+		prefix string
+		marker string
+	}{
+		{invoiceXMLName, "<?xml version=", invoiceXMLMarker},
+		{invoiceTextName, "Payment terms:", invoiceTextMarker},
+	} {
+		got, err := dir.File(tc.file).Contents(ctx)
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", tc.file, err)
+		}
+		if !strings.HasPrefix(got, tc.prefix) {
+			return fmt.Errorf("expected %s to open with %q, got:\n%s", tc.file, tc.prefix, head(got))
+		}
+		if !strings.Contains(got, tc.marker) {
+			return fmt.Errorf("expected %s to carry the marker %q, got:\n%s", tc.file, tc.marker, head(got))
+		}
+	}
+
+	_, err := pdf().Document(fixture(ledgerPdf)).Attachments().Entries(ctx)
+	if err == nil {
+		return fmt.Errorf("expected a document with no attachments to be refused")
+	}
+	for _, want := range []string{"no embedded files", "pdfdetach -list"} {
+		if !strings.Contains(err.Error(), want) {
+			return fmt.Errorf("expected the refusal to mention %q, got: %v", want, err)
+		}
+	}
+	return nil
+}
+
+// AttachmentsReportsPopplersRefusalOfPathBearingNames asserts what happens to a
+// document that names an attachment with a path in it, and asserts the failure
+// carries what a caller needs to get the rest of the attachments anyway.
+//
+// The behaviour is poppler's and it is coarse: one such name makes `-saveall`
+// refuse the *whole* extraction with `Preventing directory traversal`, so the
+// perfectly ordinary second attachment in this fixture comes back not at all. The
+// module cannot fix that — the name is the document's — so what it can do is say
+// which document did it, list the names, and point at the tool that fetches them
+// one at a time. The names are asserted for that reason: they are the argument
+// `pdfdetach -savefile` needs, and without them the message is a dead end.
+func (t *Tests) AttachmentsReportsPopplersRefusalOfPathBearingNames(ctx context.Context) error {
+	_, err := pdf().Document(fixture(traversalPdf)).Attachments().Entries(ctx)
+	if err == nil {
+		return fmt.Errorf("expected a path-bearing attachment name to be refused")
+	}
+	for _, want := range []string{
+		"names an attachment with a path",
+		"nothing was saved",
+		"pdfdetach -savefile",
+		traversalOtherName,
+		"Preventing directory traversal",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			return fmt.Errorf("expected the refusal to mention %q, got: %v", want, err)
+		}
+	}
+	return nil
+}
+
+// ExtractionsOpenAnEncryptedDocumentWithThePassword asserts the passwords reach
+// both extractions, which is the property that separates them from Split and
+// Merge.
+//
+// It is worth an assertion of its own precisely because the module already has
+// two functions where it is false. pdfseparate and pdfunite take no password at
+// all, so `WithUserPassword(...).Split()` is a call that cannot be made to work
+// and says so; pdfimages and pdfdetach both take `-upw` and `-opw`, so the same
+// document that Split refuses these two open. Nothing about the two families
+// looks different from the outside, and only a test says which is which.
+//
+// Both branches are asserted for each: refused by naming the encryption when no
+// password was supplied — poppler says `Incorrect password` whether one was given
+// or not — and the full result when it was.
+func (t *Tests) ExtractionsOpenAnEncryptedDocumentWithThePassword(ctx context.Context) error {
+	userPw, err := generatedPassword(ctx)
+	if err != nil {
+		return fmt.Errorf("generating the user password: %w", err)
+	}
+	ownerPw, err := generatedPassword(ctx)
+	if err != nil {
+		return fmt.Errorf("generating the owner password: %w", err)
+	}
+	user := dag.SetSecret("pdf-tests-extract-user-password", userPw)
+	owner := dag.SetSecret("pdf-tests-extract-owner-password", ownerPw)
+
+	images := pdf().Document(encryptedFixture(galleryPdf, user, owner))
+	files := pdf().Document(encryptedFixture(invoicePdf, user, owner))
+
+	for _, tc := range []struct {
+		name   string
+		bare   func(context.Context) ([]string, error)
+		opened func(context.Context) ([]string, error)
+		want   int
+	}{
+		{
+			name: "EmbeddedImages",
+			bare: func(ctx context.Context) ([]string, error) {
+				return images.EmbeddedImages(dagger.PdfImageFormatPng).Entries(ctx)
+			},
+			opened: func(ctx context.Context) ([]string, error) {
+				return images.WithUserPassword(user).
+					EmbeddedImages(dagger.PdfImageFormatPng).Entries(ctx)
+			},
+			want: 3,
+		},
+		{
+			name: "Attachments",
+			bare: func(ctx context.Context) ([]string, error) {
+				return files.Attachments().Entries(ctx)
+			},
+			opened: func(ctx context.Context) ([]string, error) {
+				return files.WithOwnerPassword(owner).Attachments().Entries(ctx)
+			},
+			want: 2,
+		},
+	} {
+		if _, err := tc.bare(ctx); err == nil {
+			return fmt.Errorf("%s: expected an encrypted document to be refused without a password", tc.name)
+		} else {
+			for _, want := range []string{"encrypted", "no password was supplied", "WithUserPassword"} {
+				if !strings.Contains(err.Error(), want) {
+					return fmt.Errorf("%s: expected the refusal to mention %q, got: %v", tc.name, want, err)
+				}
+			}
+		}
+
+		got, err := tc.opened(ctx)
+		if err != nil {
+			return fmt.Errorf("%s with the password: %w", tc.name, err)
+		}
+		if len(got) != tc.want {
+			return fmt.Errorf("%s: expected %d entries with the password, got %v", tc.name, tc.want, got)
+		}
+	}
+	return nil
+}
+
+// imageConfigs decodes the header of every file in an extracted directory, keyed
+// by name, which is what an assertion about *which* image landed under a name
+// needs. The headers are all it needs: the dimensions are the identity.
+func imageConfigs(ctx context.Context, dir *dagger.Directory, prefix string) (map[string]image.Config, error) {
+	tmp, cleanup, err := exportedDir(ctx, dir, prefix)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+
+	files, err := os.ReadDir(tmp)
+	if err != nil {
+		return nil, err
+	}
+	configs := make(map[string]image.Config, len(files))
+	for _, entry := range files {
+		if entry.IsDir() {
+			continue
+		}
+		f, err := os.Open(filepath.Join(tmp, entry.Name()))
+		if err != nil {
+			return nil, err
+		}
+		cfg, _, err := image.DecodeConfig(f)
+		f.Close()
+		if err != nil {
+			return nil, fmt.Errorf("decode %s: %w", entry.Name(), err)
+		}
+		configs[entry.Name()] = cfg
+	}
+	return configs, nil
+}
+
+// galleryJpegBytes is the JPEG stream gallery.pdf carries, read out of the
+// fixture and hex-decoded.
+//
+// This is the oracle the byte-equality assertion needs, and it is the fixture
+// rather than another tool's opinion of the fixture — which is the whole reason
+// the suite's fixtures are hex-armored. The one image object whose filter chain
+// ends in /DCTDecode is the photograph; the two strips carry no such filter.
+func galleryJpegBytes(ctx context.Context) ([]byte, error) {
+	raw, err := fixtureBytes(ctx, galleryPdf)
+	if err != nil {
+		return nil, err
+	}
+
+	at := bytes.Index(raw, []byte("/DCTDecode"))
+	if at < 0 {
+		return nil, fmt.Errorf("%s carries no /DCTDecode image object", galleryPdf)
+	}
+	const opener, closer = "stream\n", "\n>\n"
+	start := bytes.Index(raw[at:], []byte(opener))
+	if start < 0 {
+		return nil, fmt.Errorf("%s: no stream follows the /DCTDecode object", galleryPdf)
+	}
+	start += at + len(opener)
+	end := bytes.Index(raw[start:], []byte(closer))
+	if end < 0 {
+		return nil, fmt.Errorf("%s: the /DCTDecode stream is unterminated", galleryPdf)
+	}
+
+	// The armor is wrapped, so the line breaks come out before the decode.
+	packed := strings.Join(strings.Fields(string(raw[start:start+end])), "")
+	decoded, err := hex.DecodeString(packed)
+	if err != nil {
+		return nil, fmt.Errorf("%s: decoding the armored JPEG: %w", galleryPdf, err)
+	}
+	return decoded, nil
+}
+
+// fixtureBytes reads a committed fixture off a real filesystem.
+//
+// It goes through an export rather than File.Contents because a PDF opens with a
+// binary comment line by convention, and File.Contents is a GraphQL String —
+// which cannot carry arbitrary bytes intact. Same reason the rendered pages are
+// read this way.
+func fixtureBytes(ctx context.Context, name string) ([]byte, error) {
+	tmp, err := os.MkdirTemp(".", "pdf-fixture-")
+	if err != nil {
+		return nil, fmt.Errorf("temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmp)
+
+	path := filepath.Join(tmp, name)
+	if _, err := fixture(name).Export(ctx, path); err != nil {
+		return nil, err
+	}
+	return os.ReadFile(path)
 }
 
 // SvgWritesOneVectorFilePerPage asserts Svg renders a multi-page document to one
@@ -2701,19 +3316,25 @@ func generatedPassword(ctx context.Context) (string, error) {
 }
 
 // encryptedLedger returns ledgerPdf encrypted under the given passwords.
+func encryptedLedger(user, owner *dagger.Secret) *dagger.File {
+	return encryptedFixture(ledgerPdf, user, owner)
+}
+
+// encryptedFixture returns a committed fixture encrypted under the given
+// passwords.
 //
 // qpdf is installed into the module's own image rather than pulled as a separate
 // one so the fixture is encrypted by the same Alpine release that then reads it,
 // and the passwords reach it through the environment for the same reason the
 // module does it that way.
-func encryptedLedger(user, owner *dagger.Secret) *dagger.File {
+func encryptedFixture(name string, user, owner *dagger.Secret) *dagger.File {
 	const (
 		plain  = "/tmp/plain.pdf"
 		cipher = "/tmp/encrypted.pdf"
 	)
 	return pdf().Container().
 		WithExec([]string{"apk", "add", "--no-cache", "qpdf"}).
-		WithMountedFile(plain, fixture(ledgerPdf)).
+		WithMountedFile(plain, fixture(name)).
 		WithSecretVariable("QPDF_USER_PASSWORD", user).
 		WithSecretVariable("QPDF_OWNER_PASSWORD", owner).
 		WithExec([]string{"sh", "-c",


### PR DESCRIPTION
Closes #271.

Two extractions that are not renders, and are routinely confused with them.

`EmbeddedImages` is `pdfimages`: the image objects the file *contains*, at the
resolution they are stored at. For a scan that is strictly better OCR input than
any resolution `Convert().Png()` can be asked for, because nothing was resampled
to produce it — and by the same token it returns nothing for a page of text and
vectors, which only a render draws. `WithDpi` and friends are therefore not
reachable from it: they live on `Convert`, and an image that already has a
resolution has nothing to choose.

`Attachments` is `pdfdetach`: whole files hung off the document's catalog, which
is how a ZUGFeRD or Factur-X invoice carries its machine-readable XML. Nothing in
`Convert` reaches it and neither does `EmbeddedImages`.

### `ImageFormat`

A Dagger enum with four members, required rather than defaulted because each one
either keeps the document's encoding or replaces it, and quietly re-encoding a
caller's scan is not a decision the module makes for them.

| member | encoded image | image with no writable encoding |
| --- | --- | --- |
| `PNG` | re-encoded | PNG |
| `TIFF` | re-encoded | TIFF |
| `ORIGINAL` | **kept byte for byte** | netpbm |
| `ALL` | **kept byte for byte** | PNG, or TIFF where PNG cannot represent it |

The fallback is the whole difference between `ORIGINAL` and `ALL`.

### Naming

Extracted images get a contract of their own — `image-0000-page-0001.png` — and
deliberately not the page families': an image is not a page, several can sit on
one page and most pages carry none. The image index is poppler's, 0-based,
matching `pdfimages -list`; the page number is the 1-based source page, the
promise `Split` already makes. A page range moves exactly one of the two — the
index restarts, being poppler's count for the run — and that is asserted rather
than papered over.

Attachments keep the **document's own** names. An attachment's name is data — what
the producer called the file and what a consumer looks for — so normalizing it
would destroy what makes the result usable.

### Nothing to extract is a failure

Both refuse a document with nothing to give them rather than returning an empty
directory. Both tools exit 0 for it, so the directory would be indistinguishable
from an extraction that wrote nothing, and unlike `Signatures` a
`*dagger.Directory` has no room to report "there were none". The message names the
`-list` report that answers the question without failing, and the narrowed form
names the pages that were asked for.

### Poppler behaviour worth knowing

One attachment named with a path in it makes `pdfdetach -saveall` refuse the
**whole** extraction with `I/O Error: Preventing directory traversal`, so a
document like that yields nothing at all. Nothing passed to this module changes
that, so the failure lists the names the document holds — they are what
`pdfdetach -savefile` needs — and points at `Container`.

Unlike `Split` and `Merge`, **the passwords do reach both** of these: `pdfimages`
and `pdfdetach` each take `-upw` and `-opw`. That gets its own test, the module
already having two functions where it is false.

### Fixtures

Three new hand-authored, hex-armored fixtures:

- `gallery.pdf` — three images of three distinct sizes over two pages, the first
  DCT-encoded. The sizes are identities, so an assertion can say which image
  landed under which name; `ORIGINAL`'s byte-for-byte claim is asserted against
  the fixture's own hex-armored JPEG stream rather than against another tool's
  opinion of it.
- `invoice.pdf` — two embedded files in a name tree. Two, because "every
  attachment" is a claim one would also satisfy.
- `traversal.pdf` — a path-bearing attachment name beside an ordinary one, for
  the refusal above.

### Verified locally

- `dagger -m daggerverse/pdf/tests call all` — 45 jobs green, including the six
  new ones.
- `dagger -m ci call generated` — green.
- `dagger -m daggerverse/pdf functions document` lists `embedded-images` and
  `attachments`; `--format=BOGUS` is rejected with `ALL,ORIGINAL,PNG,TIFF`.
- No `+cache=` directive added anywhere.

Follow-ups unchanged; #271 dropped from the README's list. `Container`'s escape
hatch now covers `pdftops` and `pdfattach` alone — eleven of poppler's thirteen
binaries are wrapped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)