### PR TITLE
story(issue-249): run collections data-driven from CSV or JSON

### DIFF
--- a/ci/internal/dagger/bruno-tests.gen.go
+++ b/ci/internal/dagger/bruno-tests.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type BrunoTests
-func (r *Binding) AsBrunoTests() *BrunoTests { // bruno-tests (../../../daggerverse/bruno/tests/main.go:33:6)
+func (r *Binding) AsBrunoTests() *BrunoTests { // bruno-tests (../../../daggerverse/bruno/tests/main.go:37:6)
 	q := r.query.Select("asBrunoTests")
 
 	return &BrunoTests{
@@ -18,56 +18,60 @@ func (r *Binding) AsBrunoTests() *BrunoTests { // bruno-tests (../../../daggerve
 	}
 }
 
-type BrunoTests struct { // bruno-tests (../../../daggerverse/bruno/tests/main.go:33:6)
+type BrunoTests struct { // bruno-tests (../../../daggerverse/bruno/tests/main.go:37:6)
 	query *querybuilder.Selection
 
-	all                                       *Void
-	caCertReachesPrivateCaService             *Void
-	checkDriftFailsOnAnEndpointAddedToTheSpec *Void
-	checkDriftFailsOnBothSidesOfTheRequestSet *Void
-	ciCheckGatesOnFailingAssertion            *Void
-	ciLintFailsBeforeAnyRequest               *Void
-	ciReachesMtlsServiceBehindPrivateCa       *Void
-	ciRedactsSecretVarFromItsReports          *Void
-	ciRejectsUnknownReportFormat              *Void
-	ciRunProducesEveryRequestedReport         *Void
-	ciRunStillReportsWhenTheCollectionFails   *Void
-	ciSecretVarReachesTheCollection           *Void
-	ciShouldNotBeCached                       *Void
-	clientCertAuthenticatesToMtlsService      *Void
-	clientCertMaterialStaysOutOfTheCollection *Void
-	clientCertPassphraseUnlocksTheKey         *Void
-	driftIgnoresHandWrittenTests              *Void
-	generateHonoursOpenCollectionFormat       *Void
-	generateProducesRunnableCollection        *Void
-	generateRejectsUnknownFormat              *Void
-	id                                        *ID
-	jsonEnvFileKeepsItsExtension              *Void
-	lintAcceptsValidCollection                *Void
-	lintRejectsDuplicateSequence              *Void
-	lintRejectsMissingBrunoJson               *Void
-	lintRejectsPlaintextSecret                *Void
-	lintRejectsUnknownEnvironment             *Void
-	lintRejectsUnresolvedVariable             *Void
-	lintWarnsOnRequestWithoutTests            *Void
-	passThroughFlagsAreAccepted               *Void
-	recursiveDefaultReachesSubfolders         *Void
-	reportEmitsJunitForFailingRun             *Void
-	reportRejectsUnknownFormat                *Void
-	reportShouldNotBeCached                   *Void
-	reportWithoutAllHeadersOmitsEveryHeader   *Void
-	reportWithoutBodiesOmitsBothBodies        *Void
-	reportWithoutNamedHeaderKeepsTheOthers    *Void
-	runFailsOnAssertionFailure                *Void
-	runPassesAgainstBoundService              *Void
-	runShouldNotBeCached                      *Void
-	secretVarIsNotOnArgv                      *Void
-	secretVarIsRedactedFromReportsByDefault   *Void
-	tlsControlsAreValidated                   *Void
-	unknownEnvironmentIsRejected              *Void
-	versionReportsPinnedRelease               *Void
-	withVarOverridesEnvironmentValue          *Void
-	withoutHeadersRejectsBlankName            *Void
+	all                                           *Void
+	caCertReachesPrivateCaService                 *Void
+	checkDriftFailsOnAnEndpointAddedToTheSpec     *Void
+	checkDriftFailsOnBothSidesOfTheRequestSet     *Void
+	ciCheckGatesOnFailingAssertion                *Void
+	ciLintFailsBeforeAnyRequest                   *Void
+	ciReachesMtlsServiceBehindPrivateCa           *Void
+	ciRedactsSecretVarFromItsReports              *Void
+	ciRejectsUnknownReportFormat                  *Void
+	ciRunProducesEveryRequestedReport             *Void
+	ciRunStillReportsWhenTheCollectionFails       *Void
+	ciSecretVarReachesTheCollection               *Void
+	ciShouldNotBeCached                           *Void
+	clientCertAuthenticatesToMtlsService          *Void
+	clientCertMaterialStaysOutOfTheCollection     *Void
+	clientCertPassphraseUnlocksTheKey             *Void
+	csvDataDrivesOneRunPerRow                     *Void
+	dataFileWithoutKnownExtensionIsRejected       *Void
+	driftIgnoresHandWrittenTests                  *Void
+	failingIterationFailsRunAndIsNamedInTheReport *Void
+	generateHonoursOpenCollectionFormat           *Void
+	generateProducesRunnableCollection            *Void
+	generateRejectsUnknownFormat                  *Void
+	id                                            *ID
+	jsonDataDrivesOneRunPerRow                    *Void
+	jsonEnvFileKeepsItsExtension                  *Void
+	lintAcceptsValidCollection                    *Void
+	lintRejectsDuplicateSequence                  *Void
+	lintRejectsMissingBrunoJson                   *Void
+	lintRejectsPlaintextSecret                    *Void
+	lintRejectsUnknownEnvironment                 *Void
+	lintRejectsUnresolvedVariable                 *Void
+	lintWarnsOnRequestWithoutTests                *Void
+	passThroughFlagsAreAccepted                   *Void
+	recursiveDefaultReachesSubfolders             *Void
+	reportEmitsJunitForFailingRun                 *Void
+	reportRejectsUnknownFormat                    *Void
+	reportShouldNotBeCached                       *Void
+	reportWithoutAllHeadersOmitsEveryHeader       *Void
+	reportWithoutBodiesOmitsBothBodies            *Void
+	reportWithoutNamedHeaderKeepsTheOthers        *Void
+	runFailsOnAssertionFailure                    *Void
+	runPassesAgainstBoundService                  *Void
+	runShouldNotBeCached                          *Void
+	secretVarIsNotOnArgv                          *Void
+	secretVarIsRedactedFromReportsByDefault       *Void
+	tlsControlsAreValidated                       *Void
+	unknownEnvironmentIsRejected                  *Void
+	versionReportsPinnedRelease                   *Void
+	withVarOverridesEnvironmentValue              *Void
+	withoutHeadersRejectsBlankName                *Void
 }
 
 func (r *BrunoTests) WithGraphQLQuery(q *querybuilder.Selection) *BrunoTests {
@@ -78,11 +82,11 @@ func (r *BrunoTests) WithGraphQLQuery(q *querybuilder.Selection) *BrunoTests {
 
 // BrunoTestsAllOpts contains options for BrunoTests.All
 type BrunoTestsAllOpts struct {
-	Parallel int // bruno-tests (../../../daggerverse/bruno/tests/main.go:42:2)
+	Parallel int // bruno-tests (../../../daggerverse/bruno/tests/main.go:46:2)
 }
 
 // All runs every bruno-module test in parallel.
-func (r *BrunoTests) All(ctx context.Context, opts ...BrunoTestsAllOpts) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:39:1)
+func (r *BrunoTests) All(ctx context.Context, opts ...BrunoTestsAllOpts) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:43:1)
 	if r.all != nil {
 		return nil
 	}
@@ -110,7 +114,7 @@ func (r *BrunoTests) All(ctx context.Context, opts ...BrunoTestsAllOpts) error {
 // alone. It has to still pass: the flag is a no-op that is easy to render into a
 // run that was going to pass anyway, and easy to get wrong in a way that severs
 // the connection.
-func (r *BrunoTests) CaCertReachesPrivateCaService(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1631:1)
+func (r *BrunoTests) CaCertReachesPrivateCaService(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1763:1)
 	if r.caCertReachesPrivateCaService != nil {
 		return nil
 	}
@@ -126,7 +130,7 @@ func (r *BrunoTests) CaCertReachesPrivateCaService(ctx context.Context) error { 
 // The failure has to name the missing request rather than only report that
 // something differs — an endpoint nobody noticed is not made findable by being
 // told a count changed.
-func (r *BrunoTests) CheckDriftFailsOnAnEndpointAddedToTheSpec(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:940:1)
+func (r *BrunoTests) CheckDriftFailsOnAnEndpointAddedToTheSpec(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1072:1)
 	if r.checkDriftFailsOnAnEndpointAddedToTheSpec != nil {
 		return nil
 	}
@@ -143,7 +147,7 @@ func (r *BrunoTests) CheckDriftFailsOnAnEndpointAddedToTheSpec(ctx context.Conte
 // opposite problem — an endpoint that was renamed or retired upstream, still
 // being exercised — and it has to read as its own thing rather than as the same
 // finding, because the fix is the opposite one.
-func (r *BrunoTests) CheckDriftFailsOnBothSidesOfTheRequestSet(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:984:1)
+func (r *BrunoTests) CheckDriftFailsOnBothSidesOfTheRequestSet(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1116:1)
 	if r.checkDriftFailsOnBothSidesOfTheRequestSet != nil {
 		return nil
 	}
@@ -158,7 +162,7 @@ func (r *BrunoTests) CheckDriftFailsOnBothSidesOfTheRequestSet(ctx context.Conte
 //
 // The lint stage is enabled deliberately, so the failure has to be the
 // assertion and not the linter having an opinion about the fixture.
-func (r *BrunoTests) CiCheckGatesOnFailingAssertion(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1271:1)
+func (r *BrunoTests) CiCheckGatesOnFailingAssertion(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1403:1)
 	if r.ciCheckGatesOnFailingAssertion != nil {
 		return nil
 	}
@@ -177,7 +181,7 @@ func (r *BrunoTests) CiCheckGatesOnFailingAssertion(ctx context.Context) error {
 // is checked afterwards and passes, so a request count of zero on the first
 // pass is the lint stage short-circuiting rather than the collection being
 // unrunnable.
-func (r *BrunoTests) CiLintFailsBeforeAnyRequest(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1221:1)
+func (r *BrunoTests) CiLintFailsBeforeAnyRequest(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1353:1)
 	if r.ciLintFailsBeforeAnyRequest != nil {
 		return nil
 	}
@@ -200,7 +204,7 @@ func (r *BrunoTests) CiLintFailsBeforeAnyRequest(ctx context.Context) error { //
 // Both terminals are exercised, since a report of a run that never connected is
 // the failure this would otherwise hide, and the lint stage is enabled so the
 // TLS material has to survive being validated ahead of the run.
-func (r *BrunoTests) CiReachesMtlsServiceBehindPrivateCa(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1937:1)
+func (r *BrunoTests) CiReachesMtlsServiceBehindPrivateCa(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:2069:1)
 	if r.ciReachesMtlsServiceBehindPrivateCa != nil {
 		return nil
 	}
@@ -219,7 +223,7 @@ func (r *BrunoTests) CiReachesMtlsServiceBehindPrivateCa(ctx context.Context) er
 // controls along would produce if the collection redacted on its own account.
 // The unredacted pass is what tells the two apart — the secret has to come back
 // when the pipeline asks for it.
-func (r *BrunoTests) CiRedactsSecretVarFromItsReports(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1520:1)
+func (r *BrunoTests) CiRedactsSecretVarFromItsReports(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1652:1)
 	if r.ciRedactsSecretVarFromItsReports != nil {
 		return nil
 	}
@@ -233,7 +237,7 @@ func (r *BrunoTests) CiRedactsSecretVarFromItsReports(ctx context.Context) error
 // the finding belongs to the terminal — and it belongs to Check as much as to
 // Run, because a pipeline whose declared artifact cannot be produced is broken
 // whichever terminal is invoked first.
-func (r *BrunoTests) CiRejectsUnknownReportFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1181:1)
+func (r *BrunoTests) CiRejectsUnknownReportFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1313:1)
 	if r.ciRejectsUnknownReportFormat != nil {
 		return nil
 	}
@@ -250,7 +254,7 @@ func (r *BrunoTests) CiRejectsUnknownReportFormat(ctx context.Context) error { /
 // two-format Run is a pipeline that ran the collection once — and therefore two
 // reports describing the same set of responses, rather than two runs of the same
 // collection reporting on different ones.
-func (r *BrunoTests) CiRunProducesEveryRequestedReport(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1310:1)
+func (r *BrunoTests) CiRunProducesEveryRequestedReport(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1442:1)
 	if r.ciRunProducesEveryRequestedReport != nil {
 		return nil
 	}
@@ -268,7 +272,7 @@ func (r *BrunoTests) CiRunProducesEveryRequestedReport(ctx context.Context) erro
 // on exactly the runs whose report a pipeline needs — the JUnit file a CI system
 // turns into a test report names which assertion failed, and it is worthless if
 // it only arrives when nothing did.
-func (r *BrunoTests) CiRunStillReportsWhenTheCollectionFails(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1380:1)
+func (r *BrunoTests) CiRunStillReportsWhenTheCollectionFails(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1512:1)
 	if r.ciRunStillReportsWhenTheCollectionFails != nil {
 		return nil
 	}
@@ -291,7 +295,7 @@ func (r *BrunoTests) CiRunStillReportsWhenTheCollectionFails(ctx context.Context
 // and reading process.argv needs the developer sandbox. The pipeline builder
 // wraps no sandbox switch — a collection needing one is assembled through
 // Collection — so it gets the same request without the script.
-func (r *BrunoTests) CiSecretVarReachesTheCollection(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1477:1)
+func (r *BrunoTests) CiSecretVarReachesTheCollection(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1609:1)
 	if r.ciSecretVarReachesTheCollection != nil {
 		return nil
 	}
@@ -307,7 +311,7 @@ func (r *BrunoTests) CiSecretVarReachesTheCollection(ctx context.Context) error 
 //
 // Counted at the service rather than read out of bru's summary: a replayed run
 // prints a perfectly convincing "1 request, 1 passed".
-func (r *BrunoTests) CiShouldNotBeCached(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1421:1)
+func (r *BrunoTests) CiShouldNotBeCached(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1553:1)
 	if r.ciShouldNotBeCached != nil {
 		return nil
 	}
@@ -328,7 +332,7 @@ func (r *BrunoTests) CiShouldNotBeCached(ctx context.Context) error { // bruno-t
 // The first pass is the control: the same collection, verifying the same server,
 // with no client certificate configured. It has to fail, or the second pass says
 // nothing about the certificate having been needed.
-func (r *BrunoTests) ClientCertAuthenticatesToMtlsService(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1700:1)
+func (r *BrunoTests) ClientCertAuthenticatesToMtlsService(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1832:1)
 	if r.clientCertAuthenticatesToMtlsService != nil {
 		return nil
 	}
@@ -351,7 +355,7 @@ func (r *BrunoTests) ClientCertAuthenticatesToMtlsService(ctx context.Context) e
 // The responder demands the certificate, so this is not a run that skipped the
 // key: it reports the peer's Common Name back, and the key was necessary to
 // produce it.
-func (r *BrunoTests) ClientCertMaterialStaysOutOfTheCollection(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1786:1)
+func (r *BrunoTests) ClientCertMaterialStaysOutOfTheCollection(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1918:1)
 	if r.clientCertMaterialStaysOutOfTheCollection != nil {
 		return nil
 	}
@@ -371,11 +375,50 @@ func (r *BrunoTests) ClientCertMaterialStaysOutOfTheCollection(ctx context.Conte
 // So the same encrypted key is run twice. Without the passphrase the key cannot
 // be loaded and the run fails; with it, the run authenticates to the mTLS
 // endpoint and the responder reports the certificate back.
-func (r *BrunoTests) ClientCertPassphraseUnlocksTheKey(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1863:1)
+func (r *BrunoTests) ClientCertPassphraseUnlocksTheKey(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1995:1)
 	if r.clientCertPassphraseUnlocksTheKey != nil {
 		return nil
 	}
 	q := r.query.Select("clientCertPassphraseUnlocksTheKey")
+
+	return q.Execute(ctx)
+}
+
+// CsvDataDrivesOneRunPerRow checks the point of WithData: one collection, one
+// request, and a run per row of the data file.
+//
+// The count at the service is what says the rows drove iterations rather than
+// bru having accepted a flag and ignored it — a data file that was never read
+// leaves a collection that runs exactly once and passes. And the last request's
+// path is read back, because a run that iterated three times over the same row
+// would count the same.
+//
+// The tenants fixture asserts on the row as well: it echoes {{tenant}} back
+// through the responder and compares it against the row's own expectedEcho, so
+// a run whose variables did not resolve fails rather than passing with the
+// literal {{tenant}} in the URL.
+func (r *BrunoTests) CsvDataDrivesOneRunPerRow(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:766:1)
+	if r.csvDataDrivesOneRunPerRow != nil {
+		return nil
+	}
+	q := r.query.Select("csvDataDrivesOneRunPerRow")
+
+	return q.Execute(ctx)
+}
+
+// DataFileWithoutKnownExtensionIsRejected checks that a data file bru has no
+// reader for is refused by name, and that the message names both extensions.
+//
+// The extension is the whole interface: WithData takes one file and picks
+// `--csv-file-path` or `--json-file-path` off it, so a caller holding a data
+// file with the wrong suffix has no other way to be told which two are meant.
+// bru's own answer is exit 10 or 11 — "the CSV data file was not found" for a
+// file that is sitting right there — after the collection has already been run.
+func (r *BrunoTests) DataFileWithoutKnownExtensionIsRejected(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:860:1)
+	if r.dataFileWithoutKnownExtensionIsRejected != nil {
+		return nil
+	}
+	q := r.query.Select("dataFileWithoutKnownExtensionIsRejected")
 
 	return q.Execute(ctx)
 }
@@ -388,11 +431,34 @@ func (r *BrunoTests) ClientCertPassphraseUnlocksTheKey(ctx context.Context) erro
 // generated request is where anyone would put the assertions that make the
 // collection worth running, and a check that called that drift would be a check
 // nobody could leave switched on.
-func (r *BrunoTests) DriftIgnoresHandWrittenTests(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:882:1)
+func (r *BrunoTests) DriftIgnoresHandWrittenTests(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1014:1)
 	if r.driftIgnoresHandWrittenTests != nil {
 		return nil
 	}
 	q := r.query.Select("driftIgnoresHandWrittenTests")
+
+	return q.Execute(ctx)
+}
+
+// FailingIterationFailsRunAndIsNamedInTheReport checks the half of a
+// data-driven run that matters when the matrix is not uniform: one row out of
+// several behaving differently.
+//
+// A run over N rows is N runs of the same requests, so a gate that only looked
+// at the last of them — or at the first — would pass a suite in which one
+// tenant is broken. Run has to fail on the collection as a whole, and the report
+// has to say which row it was, or the caller is left re-running rows by hand to
+// find out.
+//
+// The fixture is the same collection the passing tests drive, with only the data
+// file swapped for one whose second row expects the wrong echo. That is what
+// makes the failure the row's and not the collection's: the first iteration of
+// this very run passes.
+func (r *BrunoTests) FailingIterationFailsRunAndIsNamedInTheReport(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:796:1)
+	if r.failingIterationFailsRunAndIsNamedInTheReport != nil {
+		return nil
+	}
+	q := r.query.Select("failingIterationFailsRunAndIsNamedInTheReport")
 
 	return q.Execute(ctx)
 }
@@ -404,7 +470,7 @@ func (r *BrunoTests) DriftIgnoresHandWrittenTests(ctx context.Context) error { /
 // It also pins the reason the default diverges from upstream's. The
 // opencollection shape carries no bruno.json, so it is not something Collection
 // could run — which is why this module defaults to the other one.
-func (r *BrunoTests) GenerateHonoursOpenCollectionFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:836:1)
+func (r *BrunoTests) GenerateHonoursOpenCollectionFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:968:1)
 	if r.generateHonoursOpenCollectionFormat != nil {
 		return nil
 	}
@@ -426,7 +492,7 @@ func (r *BrunoTests) GenerateHonoursOpenCollectionFormat(ctx context.Context) er
 // The environment's name is read off the generated tree rather than hardcoded:
 // bru derives it from the server's description, which is the spec's business
 // and not this module's.
-func (r *BrunoTests) GenerateProducesRunnableCollection(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:758:1)
+func (r *BrunoTests) GenerateProducesRunnableCollection(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:890:1)
 	if r.generateProducesRunnableCollection != nil {
 		return nil
 	}
@@ -439,7 +505,7 @@ func (r *BrunoTests) GenerateProducesRunnableCollection(ctx context.Context) err
 // is refused by name. bru refuses one too, but by printing its whole help text
 // with the actual complaint on the last line — and only after a container has
 // been started to find out.
-func (r *BrunoTests) GenerateRejectsUnknownFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:856:1)
+func (r *BrunoTests) GenerateRejectsUnknownFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:988:1)
 	if r.generateRejectsUnknownFormat != nil {
 		return nil
 	}
@@ -497,12 +563,29 @@ func (r *BrunoTests) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
+// JsonDataDrivesOneRunPerRow checks the other half of WithData's one argument:
+// the same collection, the same rows and the same result, off a JSON array
+// rather than a CSV.
+//
+// It is a separate test rather than a second case in the first because the two
+// travel under different flags — bru reads nothing off the contents — so the
+// extension is the only thing standing between a JSON data file and
+// `--csv-file-path`, which would report it as not found.
+func (r *BrunoTests) JSONDataDrivesOneRunPerRow(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:778:1)
+	if r.jsonDataDrivesOneRunPerRow != nil {
+		return nil
+	}
+	q := r.query.Select("jsonDataDrivesOneRunPerRow")
+
+	return q.Execute(ctx)
+}
+
 // JsonEnvFileKeepsItsExtension checks that an environment file is mounted
 // under the extension it arrived with. bru picks its environment parser from
 // that extension and not from the contents, so a JSON environment staged as
 // .bru dies inside the Bruno grammar — with a Node stack trace, several layers
 // away from anything the caller did.
-func (r *BrunoTests) JSONEnvFileKeepsItsExtension(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:720:1)
+func (r *BrunoTests) JSONEnvFileKeepsItsExtension(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:728:1)
 	if r.jsonEnvFileKeepsItsExtension != nil {
 		return nil
 	}
@@ -518,7 +601,7 @@ func (r *BrunoTests) JSONEnvFileKeepsItsExtension(ctx context.Context) error { /
 //
 // It is checked under failOnWarnings=true as well, so the fixture has to be
 // free of warnings and not merely free of errors.
-func (r *BrunoTests) LintAcceptsValidCollection(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1030:1)
+func (r *BrunoTests) LintAcceptsValidCollection(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1162:1)
 	if r.lintAcceptsValidCollection != nil {
 		return nil
 	}
@@ -530,7 +613,7 @@ func (r *BrunoTests) LintAcceptsValidCollection(ctx context.Context) error { // 
 // LintRejectsDuplicateSequence checks that two requests claiming the same seq
 // in one folder is a finding, and that the same seq in a different folder is
 // not — seq orders a folder's requests, so it is only ambiguous within one.
-func (r *BrunoTests) LintRejectsDuplicateSequence(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1137:1)
+func (r *BrunoTests) LintRejectsDuplicateSequence(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1269:1)
 	if r.lintRejectsDuplicateSequence != nil {
 		return nil
 	}
@@ -542,7 +625,7 @@ func (r *BrunoTests) LintRejectsDuplicateSequence(ctx context.Context) error { /
 // LintRejectsMissingBrunoJson checks the finding that stands in for bru's exit
 // 4. bru reports that one as "not a collection root", from inside a container,
 // without naming the file it wanted.
-func (r *BrunoTests) LintRejectsMissingBrunoJSON(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1049:1)
+func (r *BrunoTests) LintRejectsMissingBrunoJSON(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1181:1)
 	if r.lintRejectsMissingBrunoJson != nil {
 		return nil
 	}
@@ -558,7 +641,7 @@ func (r *BrunoTests) LintRejectsMissingBrunoJSON(ctx context.Context) error { //
 // The fixture holds two controls beside the violation — a token whose value is
 // a {{process.env.*}} interpolation, and a name declared in a vars:secret
 // block — so this also pins that the rule accepts the shape it is asking for.
-func (r *BrunoTests) LintRejectsPlaintextSecret(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1113:1)
+func (r *BrunoTests) LintRejectsPlaintextSecret(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1245:1)
 	if r.lintRejectsPlaintextSecret != nil {
 		return nil
 	}
@@ -570,7 +653,7 @@ func (r *BrunoTests) LintRejectsPlaintextSecret(ctx context.Context) error { // 
 // LintRejectsUnknownEnvironment checks that a mistyped --env name is caught
 // here rather than as bru's exit 6, and that the finding lists the names the
 // collection does ship.
-func (r *BrunoTests) LintRejectsUnknownEnvironment(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1065:1)
+func (r *BrunoTests) LintRejectsUnknownEnvironment(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1197:1)
 	if r.lintRejectsUnknownEnvironment != nil {
 		return nil
 	}
@@ -586,7 +669,7 @@ func (r *BrunoTests) LintRejectsUnknownEnvironment(ctx context.Context) error { 
 // The fixture also references two undeclared variables from its docs block,
 // which bru never interpolates — so this pins that prose is not linted as
 // though it were a request.
-func (r *BrunoTests) LintRejectsUnresolvedVariable(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1085:1)
+func (r *BrunoTests) LintRejectsUnresolvedVariable(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1217:1)
 	if r.lintRejectsUnresolvedVariable != nil {
 		return nil
 	}
@@ -601,7 +684,7 @@ func (r *BrunoTests) LintRejectsUnresolvedVariable(ctx context.Context) error { 
 //
 // The fixture's only assertion is disabled, which is the same as not having
 // written it — so this also pins that a commented-out assert does not count.
-func (r *BrunoTests) LintWarnsOnRequestWithoutTests(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1159:1)
+func (r *BrunoTests) LintWarnsOnRequestWithoutTests(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1291:1)
 	if r.lintWarnsOnRequestWithoutTests != nil {
 		return nil
 	}
@@ -619,7 +702,7 @@ func (r *BrunoTests) LintWarnsOnRequestWithoutTests(ctx context.Context) error {
 // The api fixture tags its root request and leaves the nested one untagged, so
 // the tag filters also have to have selected the right request rather than
 // merely been tolerated.
-func (r *BrunoTests) PassThroughFlagsAreAccepted(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:681:1)
+func (r *BrunoTests) PassThroughFlagsAreAccepted(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:689:1)
 	if r.passThroughFlagsAreAccepted != nil {
 		return nil
 	}
@@ -637,7 +720,7 @@ func (r *BrunoTests) PassThroughFlagsAreAccepted(ctx context.Context) error { //
 // and the default wins — so `Recursive: false` would silently assert the
 // default all over again. It is reachable from the CLI as
 // `run --recursive=false`.
-func (r *BrunoTests) RecursiveDefaultReachesSubfolders(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:244:1)
+func (r *BrunoTests) RecursiveDefaultReachesSubfolders(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:252:1)
 	if r.recursiveDefaultReachesSubfolders != nil {
 		return nil
 	}
@@ -651,7 +734,7 @@ func (r *BrunoTests) RecursiveDefaultReachesSubfolders(ctx context.Context) erro
 // artifact, and the artifact says what failed. Run would have raised an error
 // here, and an error forfeits the value — which is why the two are separate
 // functions rather than one.
-func (r *BrunoTests) ReportEmitsJunitForFailingRun(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:277:1)
+func (r *BrunoTests) ReportEmitsJunitForFailingRun(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:285:1)
 	if r.reportEmitsJunitForFailingRun != nil {
 		return nil
 	}
@@ -663,7 +746,7 @@ func (r *BrunoTests) ReportEmitsJunitForFailingRun(ctx context.Context) error { 
 // ReportRejectsUnknownFormat checks that a format bru does not write is
 // refused by name, before a live collection has been run against a live
 // service to find out.
-func (r *BrunoTests) ReportRejectsUnknownFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:304:1)
+func (r *BrunoTests) ReportRejectsUnknownFormat(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:312:1)
 	if r.reportRejectsUnknownFormat != nil {
 		return nil
 	}
@@ -675,7 +758,7 @@ func (r *BrunoTests) ReportRejectsUnknownFormat(ctx context.Context) error { // 
 // ReportShouldNotBeCached checks that two identical Reports each reach the
 // service. A report of a run that never happened describes an API nobody
 // asked about.
-func (r *BrunoTests) ReportShouldNotBeCached(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:326:1)
+func (r *BrunoTests) ReportShouldNotBeCached(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:334:1)
 	if r.reportShouldNotBeCached != nil {
 		return nil
 	}
@@ -692,7 +775,7 @@ func (r *BrunoTests) ReportShouldNotBeCached(ctx context.Context) error { // bru
 // carries a secret — that is what makes it worth redacting — and a secret is
 // enough to redact the report on its own, so without the opt-out these tests
 // would pass whether or not the flag under test was rendered at all.
-func (r *BrunoTests) ReportWithoutAllHeadersOmitsEveryHeader(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:465:1)
+func (r *BrunoTests) ReportWithoutAllHeadersOmitsEveryHeader(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:473:1)
 	if r.reportWithoutAllHeadersOmitsEveryHeader != nil {
 		return nil
 	}
@@ -706,7 +789,7 @@ func (r *BrunoTests) ReportWithoutAllHeadersOmitsEveryHeader(ctx context.Context
 //
 // A flag that dropped both would satisfy the request-only case on its own, so
 // the assertion in every pass is the pair: what went, and what stayed.
-func (r *BrunoTests) ReportWithoutBodiesOmitsBothBodies(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:519:1)
+func (r *BrunoTests) ReportWithoutBodiesOmitsBothBodies(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:527:1)
 	if r.reportWithoutBodiesOmitsBothBodies != nil {
 		return nil
 	}
@@ -721,7 +804,7 @@ func (r *BrunoTests) ReportWithoutBodiesOmitsBothBodies(ctx context.Context) err
 // The name is given in lower case against a header the collection spells
 // Authorization, because bru matches case-insensitively and a caller should not
 // have to know how the collection capitalised it.
-func (r *BrunoTests) ReportWithoutNamedHeaderKeepsTheOthers(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:493:1)
+func (r *BrunoTests) ReportWithoutNamedHeaderKeepsTheOthers(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:501:1)
 	if r.reportWithoutNamedHeaderKeepsTheOthers != nil {
 		return nil
 	}
@@ -733,7 +816,7 @@ func (r *BrunoTests) ReportWithoutNamedHeaderKeepsTheOthers(ctx context.Context)
 // RunFailsOnAssertionFailure checks that exit 1 — a failing request, test or
 // assertion — is an error, and that the error carries bru's own account of
 // what failed rather than just the exit code.
-func (r *BrunoTests) RunFailsOnAssertionFailure(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:151:1)
+func (r *BrunoTests) RunFailsOnAssertionFailure(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:159:1)
 	if r.runFailsOnAssertionFailure != nil {
 		return nil
 	}
@@ -744,7 +827,7 @@ func (r *BrunoTests) RunFailsOnAssertionFailure(ctx context.Context) error { // 
 
 // RunPassesAgainstBoundService checks the whole point of the module: a
 // collection whose environment names a bound service reaches it and passes.
-func (r *BrunoTests) RunPassesAgainstBoundService(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:119:1)
+func (r *BrunoTests) RunPassesAgainstBoundService(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:127:1)
 	if r.runPassesAgainstBoundService != nil {
 		return nil
 	}
@@ -756,7 +839,7 @@ func (r *BrunoTests) RunPassesAgainstBoundService(ctx context.Context) error { /
 // RunShouldNotBeCached checks that two identical Runs each reach the service.
 // A collection run hits a live API, so a cached pass would report a
 // now-broken API as green.
-func (r *BrunoTests) RunShouldNotBeCached(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:207:1)
+func (r *BrunoTests) RunShouldNotBeCached(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:215:1)
 	if r.runShouldNotBeCached != nil {
 		return nil
 	}
@@ -778,7 +861,7 @@ func (r *BrunoTests) RunShouldNotBeCached(ctx context.Context) error { // bruno-
 // command line" can actually be checked. That script needs the developer
 // sandbox — the safe one has no process — which is what makes WithSandbox
 // part of this test.
-func (r *BrunoTests) SecretVarIsNotOnArgv(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:627:1)
+func (r *BrunoTests) SecretVarIsNotOnArgv(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:635:1)
 	if r.secretVarIsNotOnArgv != nil {
 		return nil
 	}
@@ -803,7 +886,7 @@ func (r *BrunoTests) SecretVarIsNotOnArgv(ctx context.Context) error { // bruno-
 // narrower. The module knows the value is sensitive; it does not know where the
 // collection interpolated it, and a partial redaction would be a promise it
 // cannot keep.
-func (r *BrunoTests) SecretVarIsRedactedFromReportsByDefault(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:375:1)
+func (r *BrunoTests) SecretVarIsRedactedFromReportsByDefault(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:383:1)
 	if r.secretVarIsRedactedFromReportsByDefault != nil {
 		return nil
 	}
@@ -820,7 +903,7 @@ func (r *BrunoTests) SecretVarIsRedactedFromReportsByDefault(ctx context.Context
 // against a named CA. `--ignore-truststore` is evaluated in combination with
 // `--cacert` only, so on its own it is a flag that does nothing. Neither is a
 // non-zero exit, which is why they are the module's to catch.
-func (r *BrunoTests) TLSControlsAreValidated(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1580:1)
+func (r *BrunoTests) TLSControlsAreValidated(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:1712:1)
 	if r.tlsControlsAreValidated != nil {
 		return nil
 	}
@@ -833,7 +916,7 @@ func (r *BrunoTests) TLSControlsAreValidated(ctx context.Context) error { // bru
 // bru exits 6 when the named environment does not exist; conflating that with
 // exit 1 would make "you typo'd the environment name" read as "your API is
 // broken".
-func (r *BrunoTests) UnknownEnvironmentIsRejected(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:181:1)
+func (r *BrunoTests) UnknownEnvironmentIsRejected(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:189:1)
 	if r.unknownEnvironmentIsRejected != nil {
 		return nil
 	}
@@ -846,7 +929,7 @@ func (r *BrunoTests) UnknownEnvironmentIsRejected(ctx context.Context) error { /
 // release the module pins. The Debian variant is not cosmetic — it is the
 // escape hatch for the Alpine image's musl/OpenSSL TLS failures — so it has
 // to be a tag that exists and ships the same CLI.
-func (r *BrunoTests) VersionReportsPinnedRelease(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:104:1)
+func (r *BrunoTests) VersionReportsPinnedRelease(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:112:1)
 	if r.versionReportsPinnedRelease != nil {
 		return nil
 	}
@@ -859,7 +942,7 @@ func (r *BrunoTests) VersionReportsPinnedRelease(ctx context.Context) error { //
 // selected environment declares. The fixture puts the variable in the request
 // path, so the responder records which of the two won rather than the module
 // having to trust bru's summary.
-func (r *BrunoTests) WithVarOverridesEnvironmentValue(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:587:1)
+func (r *BrunoTests) WithVarOverridesEnvironmentValue(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:595:1)
 	if r.withVarOverridesEnvironmentValue != nil {
 		return nil
 	}
@@ -872,7 +955,7 @@ func (r *BrunoTests) WithVarOverridesEnvironmentValue(ctx context.Context) error
 // refused. The builders have no error return, so the finding belongs to the
 // run — and a blank name renders a flag that consumes whatever follows it,
 // which is a redaction that silently applies to nothing.
-func (r *BrunoTests) WithoutHeadersRejectsBlankName(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:565:1)
+func (r *BrunoTests) WithoutHeadersRejectsBlankName(ctx context.Context) error { // bruno-tests (../../../daggerverse/bruno/tests/main.go:573:1)
 	if r.withoutHeadersRejectsBlankName != nil {
 		return nil
 	}
@@ -890,7 +973,7 @@ func (r *BrunoTests) AsNode() Node {
 }
 
 // Create or update a binding of type BrunoTests in the environment
-func (r *Env) WithBrunoTestsInput(name string, value *BrunoTests, description string) *Env { // bruno-tests (../../../daggerverse/bruno/tests/main.go:33:6)
+func (r *Env) WithBrunoTestsInput(name string, value *BrunoTests, description string) *Env { // bruno-tests (../../../daggerverse/bruno/tests/main.go:37:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withBrunoTestsInput")
 	q = q.Arg("name", name)
@@ -903,7 +986,7 @@ func (r *Env) WithBrunoTestsInput(name string, value *BrunoTests, description st
 }
 
 // Declare a desired BrunoTests output to be assigned in the environment
-func (r *Env) WithBrunoTestsOutput(name string, description string) *Env { // bruno-tests (../../../daggerverse/bruno/tests/main.go:33:6)
+func (r *Env) WithBrunoTestsOutput(name string, description string) *Env { // bruno-tests (../../../daggerverse/bruno/tests/main.go:37:6)
 	q := r.query.Select("withBrunoTestsOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -917,7 +1000,7 @@ func (r *Env) WithBrunoTestsOutput(name string, description string) *Env { // br
 // test is exposed as a standalone dagger function so it can be invoked
 // individually during TDD; All wires them up for parallel execution under
 // `dagger call all`.
-func (r *Query) BrunoTests() *BrunoTests { // bruno-tests (../../../daggerverse/bruno/tests/main.go:33:6)
+func (r *Query) BrunoTests() *BrunoTests { // bruno-tests (../../../daggerverse/bruno/tests/main.go:37:6)
 	q := r.query.Select("brunoTests")
 
 	return &BrunoTests{

--- a/daggerverse/bruno/README.md
+++ b/daggerverse/bruno/README.md
@@ -126,6 +126,52 @@ from the CLI.
 or workspace not found, or an unparseable collection file), 12 and 13 (global
 environment problems), and 255 for everything else.
 
+## Data-driven runs
+
+Running a collection once against one set of values covers one case.
+`WithData(file)` runs it once per row of a data file instead, with that row's
+columns readable from every request as `{{variables}}` — so one collection
+covers the tenants, regions or payloads a suite would otherwise carry a copy of
+the same request for.
+
+```go
+collection.WithData(rows).Run(ctx)   // rows.csv → --csv-file-path
+                                     // rows.json → --json-file-path
+```
+
+```
+tenant,expectedEcho          [{"tenant": "alpha", "expectedEcho": "alpha"},
+alpha,alpha                   {"tenant": "beta",  "expectedEcho": "beta"}]
+beta,beta
+```
+
+It takes a file and not a flag plus a path because the extension already says
+which of the two `bru` wants. Nothing is read off the contents — a JSON array
+handed to `--csv-file-path` is a parse error, not a document `bru` recognises —
+so a file that is neither `.csv` nor `.json` is rejected by the run, naming
+both. `bru`'s own answer would be exit 10 or 11, which report a file that is
+sitting right there as *not found*, and only after the collection has run.
+
+Every row is an iteration, and the run is a gate over all of them: `Run` fails
+when any iteration does, and its summary is a table with a row per iteration.
+The JSON report is an array of iterations rather than a flat list of results —
+that is its shape for a plain run too, which is why the helpers in
+`tests/main.go` read it that way — and each entry carries the `iterationIndex`
+that maps it back onto a row of the data file:
+
+```json
+[{"iterationIndex": 0, "results": [...], "summary": {...}},
+ {"iterationIndex": 1, "results": [...], "summary": {...}}]
+```
+
+As of 3.4.2 the JUnit and HTML reporters write one `testsuite` per iteration but
+do not number them, so a matrix whose failure has to be attributed to a row
+wants the JSON report.
+
+`--iteration-count` and `--parallel`, which repeat a data set and run its
+iterations concurrently, are not wrapped; they stay reachable through
+`Container()`.
+
 ## Linting
 
 Bruno ships no linter, and the failure modes that leaves open are the expensive
@@ -553,6 +599,7 @@ tail.
 | `Collection.WithVar(name, value)` | `--env-var name=value`. A pair, not a map. |
 | `Collection.WithSecretVar(name, secret)` | The same override as a secret environment variable — never argv. |
 | `Collection.WithEnvFile(file)` | `--env-file`, staged outside the collection under its own `.bru`/`.json` extension. |
+| `Collection.WithData(file)` | `--csv-file-path`/`--json-file-path`, by extension; one iteration per row. |
 | `Collection.WithTags(tags)` | `--tags`; run only requests carrying one of them. |
 | `Collection.WithoutTags(tags)` | `--exclude-tags`; skip requests carrying one of them. |
 | `Collection.WithService(alias, service)` | Put a Dagger service on the run's network under `alias`. |
@@ -651,6 +698,17 @@ the default: if the two ever stop disagreeing, upstream has widened its
 redaction and this module's default has less work to do than its documentation
 claims. Every redaction test sets `WithUnredactedReport` first, so that what the
 report holds is the doing of the control under test and not of the secret.
+
+`fixtures/tenants/` is the data-driven collection, and the four files under
+`fixtures/data/` are what drive it: the same three rows as a `.csv` and as a
+`.json`, a `.txt` copy for the rejection, and a two-row set whose second row
+expects the wrong value. The rows differ from one another on purpose — a run
+that iterated the same row three times would satisfy a request count — and the
+request echoes its own row back through the responder, so a run whose variables
+never resolved fails instead of passing with a literal `{{tenant}}` in the URL.
+`FailingIterationFailsRunAndIsNamedInTheReport` swaps only the data file, which
+is what makes the failure the row's and not the collection's: the first
+iteration of that very run passes.
 
 The TLS tests get a second responder. `tests/tlsresponder.go` serves the same
 recording handler over HTTPS on 8443 — presenting a leaf signed by a CA minted

--- a/daggerverse/bruno/collection.go
+++ b/daggerverse/bruno/collection.go
@@ -19,6 +19,14 @@ const (
 	// Bruno source and dies in the grammar.
 	envFilePathPrefix = "/tmp/bruno-env-file"
 
+	// dataFilePathPrefix is the stem WithData's file is mounted under, outside
+	// the collection for the same reason the environment file is. The caller's
+	// extension is preserved because it is what selects the flag: bru reads a
+	// data file as CSV or as JSON according to which of --csv-file-path and
+	// --json-file-path it arrived under, and reads nothing at all off the
+	// contents.
+	dataFilePathPrefix = "/tmp/bruno-data-file"
+
 	// reportPathPrefix is the stem every reporter artifact is written under.
 	// It lives in /tmp because the image runs as UID 1000 and the collection
 	// is mounted root-owned: bru could not write a report beside it.
@@ -100,6 +108,8 @@ type Collection struct {
 	SecretVarValues []*dagger.Secret
 	// +private
 	EnvFile *dagger.File
+	// +private
+	DataFile *dagger.File
 	// +private
 	Tags []string
 	// +private
@@ -194,6 +204,24 @@ func (c *Collection) WithSecretVar(name string, value *dagger.Secret) *Collectio
 func (c *Collection) WithEnvFile(file *dagger.File) *Collection {
 	out := c.clone()
 	out.EnvFile = file
+	return out
+}
+
+// WithData runs the collection once per row of a data file — a CSV
+// (`--csv-file-path`) or a JSON array (`--json-file-path`) — with that row's
+// columns readable from every request as runtime variables.
+//
+// One collection then covers a matrix rather than a case: the tenants, regions
+// or payloads a suite would otherwise carry a copy of the same request for.
+// Each row is an iteration, and every reporter writes one entry per iteration.
+//
+// It takes a file rather than a flag and a path because the extension already
+// says which of the two bru wants: .csv or .json. Like the other builders it
+// has no error return, so a file that is neither is reported by the run that
+// would have read it.
+func (c *Collection) WithData(file *dagger.File) *Collection {
+	out := c.clone()
+	out.DataFile = file
 	return out
 }
 
@@ -385,21 +413,46 @@ func (c *Collection) exec(ctx context.Context, recursive bool, reportFormats []s
 	if err := c.validate(); err != nil {
 		return nil, err
 	}
-	envFile, err := c.envFilePath(ctx)
+	staged, err := c.stage(ctx)
 	if err != nil {
 		return nil, err
 	}
-	args, err := c.args(recursive, reportFormats, envFile)
+	args, err := c.args(recursive, reportFormats, staged)
 	if err != nil {
 		return nil, err
 	}
-	ctr, err := c.container(ctx, envFile)
+	ctr, err := c.container(ctx, staged)
 	if err != nil {
 		return nil, err
 	}
 	return ctr.WithExec(args, dagger.ContainerWithExecOpts{
 		Expect: dagger.ReturnTypeAny,
 	}), nil
+}
+
+// staged holds where the files that travel outside the collection are mounted,
+// resolved once so that the command line and the container cannot disagree
+// about them. Each path is empty when its file was never supplied.
+type stagedPaths struct {
+	envFile  string
+	dataFile string
+	// dataFlag is the flag dataFile is passed under, which is what makes it a
+	// CSV or a JSON data set as far as bru is concerned.
+	dataFlag string
+}
+
+// stage resolves those paths, which means reading the callers' file names —
+// hence the context, and hence this not being part of args.
+func (c *Collection) stage(ctx context.Context) (stagedPaths, error) {
+	envFile, err := c.envFilePath(ctx)
+	if err != nil {
+		return stagedPaths{}, err
+	}
+	dataFlag, dataFile, err := c.dataFilePath(ctx)
+	if err != nil {
+		return stagedPaths{}, err
+	}
+	return stagedPaths{envFile: envFile, dataFile: dataFile, dataFlag: dataFlag}, nil
 }
 
 // envFilePath is where WithEnvFile's file is mounted, keeping the extension it
@@ -425,12 +478,36 @@ func (c *Collection) envFilePath(ctx context.Context) (string, error) {
 	}
 }
 
+// dataFilePath is the flag WithData's file is passed under and where it is
+// mounted. bru splits its data files across two flags rather than sniffing the
+// contents, so the extension is what decides which one — and a file that is
+// neither is rejected here, naming both, rather than at bru's exit 10 or 11,
+// which report a file that is sitting right there as not found.
+func (c *Collection) dataFilePath(ctx context.Context) (string, string, error) {
+	if c.DataFile == nil {
+		return "", "", nil
+	}
+	name, err := c.DataFile.Name(ctx)
+	if err != nil {
+		return "", "", fmt.Errorf("WithData: read the file's name: %w", err)
+	}
+	switch ext := strings.ToLower(filepath.Ext(name)); ext {
+	case ".csv":
+		return "--csv-file-path", dataFilePathPrefix + ext, nil
+	case ".json":
+		return "--json-file-path", dataFilePathPrefix + ext, nil
+	default:
+		return "", "", fmt.Errorf(
+			"WithData: %q must be a .csv or .json file: bru reads a CSV data file with --csv-file-path and a JSON one with --json-file-path, and picks between them by extension", name)
+	}
+}
+
 // container mounts the collection at the image's own working directory and
 // wires up everything that is not a command-line flag: the bound services, the
 // secrets, which travel as environment variables precisely so they stay off
 // argv, and the TLS material the `--cacert` and `--client-cert-config` flags
 // point at.
-func (c *Collection) container(ctx context.Context, envFile string) (*dagger.Container, error) {
+func (c *Collection) container(ctx context.Context, paths stagedPaths) (*dagger.Container, error) {
 	ctr := c.Bruno.Container().
 		WithMountedDirectory(collectionDir, c.Source).
 		WithWorkdir(collectionDir).
@@ -442,13 +519,16 @@ func (c *Collection) container(ctx context.Context, envFile string) (*dagger.Con
 		ctr = ctr.WithSecretVariable(name, c.SecretVarValues[i])
 	}
 	if c.EnvFile != nil {
-		ctr = ctr.WithMountedFile(envFile, c.EnvFile)
+		ctr = ctr.WithMountedFile(paths.envFile, c.EnvFile)
+	}
+	if c.DataFile != nil {
+		ctr = ctr.WithMountedFile(paths.dataFile, c.DataFile)
 	}
 	return c.withTLS(ctx, ctr)
 }
 
 // args renders the `bru run` command line.
-func (c *Collection) args(recursive bool, reportFormats []string, envFile string) ([]string, error) {
+func (c *Collection) args(recursive bool, reportFormats []string, paths stagedPaths) ([]string, error) {
 	// The collection root is named explicitly rather than left implicit:
 	// `bru run` with no path descends into every folder whatever -r says, so
 	// without the "." the recursive parameter would only ever mean "true".
@@ -460,7 +540,10 @@ func (c *Collection) args(recursive bool, reportFormats []string, envFile string
 		args = append(args, "--env", c.Environment)
 	}
 	if c.EnvFile != nil {
-		args = append(args, "--env-file", envFile)
+		args = append(args, "--env-file", paths.envFile)
+	}
+	if c.DataFile != nil {
+		args = append(args, paths.dataFlag, paths.dataFile)
 	}
 	for i, name := range c.VarNames {
 		args = append(args, "--env-var", name+"="+c.VarValues[i])

--- a/daggerverse/bruno/dagger.gen.go
+++ b/daggerverse/bruno/dagger.gen.go
@@ -129,6 +129,7 @@ func (r Collection) MarshalJSON() ([]byte, error) {
 		SecretVarNames    []string
 		SecretVarValues   []*dagger.Secret
 		EnvFile           *dagger.File
+		DataFile          *dagger.File
 		Tags              []string
 		ExcludedTags      []string
 		ServiceAliases    []string
@@ -159,6 +160,7 @@ func (r Collection) MarshalJSON() ([]byte, error) {
 	concrete.SecretVarNames = r.SecretVarNames
 	concrete.SecretVarValues = r.SecretVarValues
 	concrete.EnvFile = r.EnvFile
+	concrete.DataFile = r.DataFile
 	concrete.Tags = r.Tags
 	concrete.ExcludedTags = r.ExcludedTags
 	concrete.ServiceAliases = r.ServiceAliases
@@ -193,6 +195,7 @@ func (r *Collection) UnmarshalJSON(bs []byte) error {
 		SecretVarNames    []string
 		SecretVarValues   []*dagger.Secret
 		EnvFile           *dagger.File
+		DataFile          *dagger.File
 		Tags              []string
 		ExcludedTags      []string
 		ServiceAliases    []string
@@ -227,6 +230,7 @@ func (r *Collection) UnmarshalJSON(bs []byte) error {
 	r.SecretVarNames = concrete.SecretVarNames
 	r.SecretVarValues = concrete.SecretVarValues
 	r.EnvFile = concrete.EnvFile
+	r.DataFile = concrete.DataFile
 	r.Tags = concrete.Tags
 	r.ExcludedTags = concrete.ExcludedTags
 	r.ServiceAliases = concrete.ServiceAliases
@@ -807,6 +811,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Collection).WithClientCert(&parent, host, cert, key, passphrase), nil
+		case "WithData":
+			var parent Collection
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var file *dagger.File
+			if inputArgs["file"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["file"]), &file)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg file", err))
+				}
+			}
+			return (*Collection).WithData(&parent, file), nil
 		case "WithDelay":
 			var parent Collection
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/bruno/tests/dagger.gen.go
+++ b/daggerverse/bruno/tests/dagger.gen.go
@@ -311,6 +311,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).ClientCertPassphraseUnlocksTheKey(&parent, ctx)
+		case "CsvDataDrivesOneRunPerRow":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).CsvDataDrivesOneRunPerRow(&parent, ctx)
+		case "DataFileWithoutKnownExtensionIsRejected":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).DataFileWithoutKnownExtensionIsRejected(&parent, ctx)
 		case "DriftIgnoresHandWrittenTests":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -318,6 +332,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).DriftIgnoresHandWrittenTests(&parent, ctx)
+		case "FailingIterationFailsRunAndIsNamedInTheReport":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).FailingIterationFailsRunAndIsNamedInTheReport(&parent, ctx)
 		case "GenerateHonoursOpenCollectionFormat":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -339,6 +360,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).GenerateRejectsUnknownFormat(&parent, ctx)
+		case "JsonDataDrivesOneRunPerRow":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).JsonDataDrivesOneRunPerRow(&parent, ctx)
 		case "JsonEnvFileKeepsItsExtension":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/bruno/tests/fixtures/data/one-bad-row.csv
+++ b/daggerverse/bruno/tests/fixtures/data/one-bad-row.csv
@@ -1,0 +1,3 @@
+tenant,expectedEcho
+alpha,alpha
+beta,not-beta

--- a/daggerverse/bruno/tests/fixtures/data/tenants.csv
+++ b/daggerverse/bruno/tests/fixtures/data/tenants.csv
@@ -1,0 +1,4 @@
+tenant,expectedEcho
+alpha,alpha
+beta,beta
+gamma,gamma

--- a/daggerverse/bruno/tests/fixtures/data/tenants.json
+++ b/daggerverse/bruno/tests/fixtures/data/tenants.json
@@ -1,0 +1,14 @@
+[
+  {
+    "tenant": "alpha",
+    "expectedEcho": "alpha"
+  },
+  {
+    "tenant": "beta",
+    "expectedEcho": "beta"
+  },
+  {
+    "tenant": "gamma",
+    "expectedEcho": "gamma"
+  }
+]

--- a/daggerverse/bruno/tests/fixtures/data/tenants.txt
+++ b/daggerverse/bruno/tests/fixtures/data/tenants.txt
@@ -1,0 +1,4 @@
+tenant,expectedEcho
+alpha,alpha
+beta,beta
+gamma,gamma

--- a/daggerverse/bruno/tests/fixtures/tenants/bruno.json
+++ b/daggerverse/bruno/tests/fixtures/tenants/bruno.json
@@ -1,0 +1,5 @@
+{
+  "version": "1",
+  "name": "tenants",
+  "type": "collection"
+}

--- a/daggerverse/bruno/tests/fixtures/tenants/echo.bru
+++ b/daggerverse/bruno/tests/fixtures/tenants/echo.bru
@@ -1,0 +1,20 @@
+meta {
+  name: echo
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/tenants/{{tenant}}
+  body: none
+  auth: none
+}
+
+headers {
+  X-Custom: {{tenant}}
+}
+
+assert {
+  res.status: eq 200
+  res.body.echo: eq {{expectedEcho}}
+}

--- a/daggerverse/bruno/tests/fixtures/tenants/environments/local.bru
+++ b/daggerverse/bruno/tests/fixtures/tenants/environments/local.bru
@@ -1,0 +1,3 @@
+vars {
+  baseUrl: http://api:8080
+}

--- a/daggerverse/bruno/tests/internal/dagger/bruno.gen.go
+++ b/daggerverse/bruno/tests/internal/dagger/bruno.gen.go
@@ -28,7 +28,7 @@ func (r *Binding) AsBrunoCi() *BrunoCi { // bruno (../../../../../daggerverse/br
 }
 
 // Retrieve the binding value, as type BrunoCollection
-func (r *Binding) AsBrunoCollection() *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:86:6)
+func (r *Binding) AsBrunoCollection() *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:94:6)
 	q := r.query.Select("asBrunoCollection")
 
 	return &BrunoCollection{
@@ -66,7 +66,7 @@ func (r *Bruno) Ci(source *Directory) *BrunoCi { // bruno (../../../../../dagger
 }
 
 // Collection binds a Bruno collection directory to the toolchain.
-func (r *Bruno) Collection(source *Directory) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:148:1)
+func (r *Bruno) Collection(source *Directory) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:158:1)
 	assertNotNil("source", source)
 	q := r.query.Select("collection")
 	q = q.Arg("source", source)
@@ -580,7 +580,7 @@ func (r *BrunoCi) AsNode() Node {
 // The input is a directory, not a lone request file: bru exits 4 when invoked
 // outside a collection root, and resolves environments/ and .env relative to
 // it.
-type BrunoCollection struct { // bruno (../../../../../daggerverse/bruno/collection.go:86:6)
+type BrunoCollection struct { // bruno (../../../../../daggerverse/bruno/collection.go:94:6)
 	query *querybuilder.Selection
 
 	checkDrift *Void
@@ -759,7 +759,7 @@ func (r *BrunoCollection) Lint(ctx context.Context, opts ...BrunoCollectionLintO
 //
 // The run is recursive, matching Run's default, so the artifact describes the
 // whole collection.
-func (r *BrunoCollection) Report(format string) *File { // bruno (../../../../../daggerverse/bruno/collection.go:334:1)
+func (r *BrunoCollection) Report(format string) *File { // bruno (../../../../../daggerverse/bruno/collection.go:362:1)
 	q := r.query.Select("report")
 	q = q.Arg("format", format)
 
@@ -778,7 +778,7 @@ type BrunoCollectionRunOpts struct {
 	//
 	//
 	// Default: true
-	Recursive bool // bruno (../../../../../daggerverse/bruno/collection.go:301:2)
+	Recursive bool // bruno (../../../../../daggerverse/bruno/collection.go:329:2)
 }
 
 // Run executes the collection and returns bru's output.
@@ -792,7 +792,7 @@ type BrunoCollectionRunOpts struct {
 // A failing Run returns no output alongside its error: a Dagger function that
 // returns an error forfeits its value. Pair it with Report when the artifact
 // matters.
-func (r *BrunoCollection) Run(ctx context.Context, opts ...BrunoCollectionRunOpts) (string, error) { // bruno (../../../../../daggerverse/bruno/collection.go:294:1)
+func (r *BrunoCollection) Run(ctx context.Context, opts ...BrunoCollectionRunOpts) (string, error) { // bruno (../../../../../daggerverse/bruno/collection.go:322:1)
 	if r.run != nil {
 		return *r.run, nil
 	}
@@ -812,7 +812,7 @@ func (r *BrunoCollection) Run(ctx context.Context, opts ...BrunoCollectionRunOpt
 
 // WithBail stops the run at the first failing request, test or assertion
 // (`--bail`) instead of working through the rest of the collection.
-func (r *BrunoCollection) WithBail() *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:267:1)
+func (r *BrunoCollection) WithBail() *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:295:1)
 	q := r.query.Select("withBail")
 
 	return &BrunoCollection{
@@ -880,9 +880,31 @@ func (r *BrunoCollection) WithClientCert(host string, cert *File, key *Secret, o
 	}
 }
 
+// WithData runs the collection once per row of a data file — a CSV
+// (`--csv-file-path`) or a JSON array (`--json-file-path`) — with that row's
+// columns readable from every request as runtime variables.
+//
+// One collection then covers a matrix rather than a case: the tenants, regions
+// or payloads a suite would otherwise carry a copy of the same request for.
+// Each row is an iteration, and every reporter writes one entry per iteration.
+//
+// It takes a file rather than a flag and a path because the extension already
+// says which of the two bru wants: .csv or .json. Like the other builders it
+// has no error return, so a file that is neither is reported by the run that
+// would have read it.
+func (r *BrunoCollection) WithData(file *File) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:222:1)
+	assertNotNil("file", file)
+	q := r.query.Select("withData")
+	q = q.Arg("file", file)
+
+	return &BrunoCollection{
+		query: q,
+	}
+}
+
 // WithDelay waits the given number of milliseconds between requests
 // (`--delay`), for a target that rate-limits.
-func (r *BrunoCollection) WithDelay(milliseconds int) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:275:1)
+func (r *BrunoCollection) WithDelay(milliseconds int) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:303:1)
 	q := r.query.Select("withDelay")
 	q = q.Arg("milliseconds", milliseconds)
 
@@ -894,7 +916,7 @@ func (r *BrunoCollection) WithDelay(milliseconds int) *BrunoCollection { // brun
 // WithEnvFile supplies an environment file (`--env-file`), a .bru or .json
 // file holding the variables for the run. It is mounted outside the
 // collection, so it never shadows a file the collection ships.
-func (r *BrunoCollection) WithEnvFile(file *File) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:194:1)
+func (r *BrunoCollection) WithEnvFile(file *File) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:204:1)
 	assertNotNil("file", file)
 	q := r.query.Select("withEnvFile")
 	q = q.Arg("file", file)
@@ -907,7 +929,7 @@ func (r *BrunoCollection) WithEnvFile(file *File) *BrunoCollection { // bruno (.
 // WithEnvironment selects the environment bru resolves variables from
 // (`--env`), by the name of the file under environments/ without its
 // extension. An unknown name is bru's exit 6, reported as a usage error.
-func (r *BrunoCollection) WithEnvironment(name string) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:155:1)
+func (r *BrunoCollection) WithEnvironment(name string) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:165:1)
 	q := r.query.Select("withEnvironment")
 	q = q.Arg("name", name)
 
@@ -924,7 +946,7 @@ func (r *BrunoCollection) WithEnvironment(name string) *BrunoCollection { // bru
 // CA: use WithCaCert for that, and WithClientCert to authenticate with a
 // certificate of the run's own. bru drops `--cacert` when `--insecure` is set,
 // so combining the two is rejected rather than quietly verifying nothing.
-func (r *BrunoCollection) WithInsecure() *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:250:1)
+func (r *BrunoCollection) WithInsecure() *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:278:1)
 	q := r.query.Select("withInsecure")
 
 	return &BrunoCollection{
@@ -941,7 +963,7 @@ func (r *BrunoCollection) WithInsecure() *BrunoCollection { // bruno (../../../.
 // A collection that says nothing runs in "safe", matching both bru's default
 // and Collection's. Like WithVar, an unknown mode is reported by the run
 // rather than here.
-func (r *BrunoCollection) WithSandbox(mode string) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:236:1)
+func (r *BrunoCollection) WithSandbox(mode string) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:264:1)
 	q := r.query.Select("withSandbox")
 	q = q.Arg("mode", mode)
 
@@ -957,7 +979,7 @@ func (r *BrunoCollection) WithSandbox(mode string) *BrunoCollection { // bruno (
 // `--env-var` places its value on the process command line. A secret is bound
 // with WithSecretVariable instead, so it appears in neither argv nor any
 // diagnostic this module echoes back.
-func (r *BrunoCollection) WithSecretVar(name string, value *Secret) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:184:1)
+func (r *BrunoCollection) WithSecretVar(name string, value *Secret) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:194:1)
 	assertNotNil("value", value)
 	q := r.query.Select("withSecretVar")
 	q = q.Arg("name", name)
@@ -971,7 +993,7 @@ func (r *BrunoCollection) WithSecretVar(name string, value *Secret) *BrunoCollec
 // WithService binds a service into the run's network under alias, so the
 // collection can reach it by that hostname. A collection is inert without a
 // target, which is why this exists at all.
-func (r *BrunoCollection) WithService(alias string, service *Service) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:220:1)
+func (r *BrunoCollection) WithService(alias string, service *Service) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:248:1)
 	assertNotNil("service", service)
 	q := r.query.Select("withService")
 	q = q.Arg("alias", alias)
@@ -984,7 +1006,7 @@ func (r *BrunoCollection) WithService(alias string, service *Service) *BrunoColl
 
 // WithTags restricts the run to requests carrying any of these tags
 // (`--tags`).
-func (r *BrunoCollection) WithTags(tags []string) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:202:1)
+func (r *BrunoCollection) WithTags(tags []string) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:230:1)
 	q := r.query.Select("withTags")
 	q = q.Arg("tags", tags)
 
@@ -996,7 +1018,7 @@ func (r *BrunoCollection) WithTags(tags []string) *BrunoCollection { // bruno (.
 // WithTestsOnly runs only the requests that carry a test or an active
 // assertion (`--tests-only`), skipping the ones that exist to set up state
 // for a human.
-func (r *BrunoCollection) WithTestsOnly() *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:259:1)
+func (r *BrunoCollection) WithTestsOnly() *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:287:1)
 	q := r.query.Select("withTestsOnly")
 
 	return &BrunoCollection{
@@ -1033,7 +1055,7 @@ func (r *BrunoCollection) WithUnredactedReport() *BrunoCollection { // bruno (..
 //
 // Validation is deferred to the run: builder methods have no error return, so
 // a bad name surfaces on the Run or Report that would have used it.
-func (r *BrunoCollection) WithVar(name string, value string) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:170:1)
+func (r *BrunoCollection) WithVar(name string, value string) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:180:1)
 	q := r.query.Select("withVar")
 	q = q.Arg("name", name)
 	q = q.Arg("value", value)
@@ -1112,7 +1134,7 @@ func (r *BrunoCollection) WithoutResponseBody() *BrunoCollection { // bruno (../
 // WithoutTags excludes requests carrying any of these tags
 // (`--exclude-tags`). It composes with WithTags: a request matching both is
 // excluded.
-func (r *BrunoCollection) WithoutTags(tags []string) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:211:1)
+func (r *BrunoCollection) WithoutTags(tags []string) *BrunoCollection { // bruno (../../../../../daggerverse/bruno/collection.go:239:1)
 	q := r.query.Select("withoutTags")
 	q = q.Arg("tags", tags)
 
@@ -1168,7 +1190,7 @@ func (r *Env) WithBrunoCiOutput(name string, description string) *Env { // bruno
 }
 
 // Create or update a binding of type BrunoCollection in the environment
-func (r *Env) WithBrunoCollectionInput(name string, value *BrunoCollection, description string) *Env { // bruno (../../../../../daggerverse/bruno/collection.go:86:6)
+func (r *Env) WithBrunoCollectionInput(name string, value *BrunoCollection, description string) *Env { // bruno (../../../../../daggerverse/bruno/collection.go:94:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withBrunoCollectionInput")
 	q = q.Arg("name", name)
@@ -1181,7 +1203,7 @@ func (r *Env) WithBrunoCollectionInput(name string, value *BrunoCollection, desc
 }
 
 // Declare a desired BrunoCollection output to be assigned in the environment
-func (r *Env) WithBrunoCollectionOutput(name string, description string) *Env { // bruno (../../../../../daggerverse/bruno/collection.go:86:6)
+func (r *Env) WithBrunoCollectionOutput(name string, description string) *Env { // bruno (../../../../../daggerverse/bruno/collection.go:94:6)
 	q := r.query.Select("withBrunoCollectionOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)

--- a/daggerverse/bruno/tests/main.go
+++ b/daggerverse/bruno/tests/main.go
@@ -28,6 +28,10 @@ const (
 	// specOperations is how many operations fixtures/petstore.yaml declares,
 	// and therefore how many requests a collection generated from it makes.
 	specOperations = 4
+
+	// dataRows is how many rows fixtures/data/tenants.csv and tenants.json each
+	// carry, and therefore how many times a collection driven by either runs.
+	dataRows = 3
 )
 
 type Tests struct{}
@@ -72,6 +76,10 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("ClientCertMaterialStaysOutOfTheCollection", t.ClientCertMaterialStaysOutOfTheCollection)
 	jobs = jobs.WithJob("CiReachesMtlsServiceBehindPrivateCa", t.CiReachesMtlsServiceBehindPrivateCa)
 	jobs = jobs.WithJob("JsonEnvFileKeepsItsExtension", t.JsonEnvFileKeepsItsExtension)
+	jobs = jobs.WithJob("CsvDataDrivesOneRunPerRow", t.CsvDataDrivesOneRunPerRow)
+	jobs = jobs.WithJob("JsonDataDrivesOneRunPerRow", t.JsonDataDrivesOneRunPerRow)
+	jobs = jobs.WithJob("FailingIterationFailsRunAndIsNamedInTheReport", t.FailingIterationFailsRunAndIsNamedInTheReport)
+	jobs = jobs.WithJob("DataFileWithoutKnownExtensionIsRejected", t.DataFileWithoutKnownExtensionIsRejected)
 	jobs = jobs.WithJob("GenerateProducesRunnableCollection", t.GenerateProducesRunnableCollection)
 	jobs = jobs.WithJob("GenerateHonoursOpenCollectionFormat", t.GenerateHonoursOpenCollectionFormat)
 	jobs = jobs.WithJob("GenerateRejectsUnknownFormat", t.GenerateRejectsUnknownFormat)
@@ -738,6 +746,130 @@ func (t *Tests) JsonEnvFileKeepsItsExtension(ctx context.Context) error {
 	}
 	if got.Count != 1 {
 		return fmt.Errorf("expected the JSON environment to resolve baseUrl and reach the service, served %d requests", got.Count)
+	}
+	return nil
+}
+
+// CsvDataDrivesOneRunPerRow checks the point of WithData: one collection, one
+// request, and a run per row of the data file.
+//
+// The count at the service is what says the rows drove iterations rather than
+// bru having accepted a flag and ignored it — a data file that was never read
+// leaves a collection that runs exactly once and passes. And the last request's
+// path is read back, because a run that iterated three times over the same row
+// would count the same.
+//
+// The tenants fixture asserts on the row as well: it echoes {{tenant}} back
+// through the responder and compares it against the row's own expectedEcho, so
+// a run whose variables did not resolve fails rather than passing with the
+// literal {{tenant}} in the URL.
+func (t *Tests) CsvDataDrivesOneRunPerRow(ctx context.Context) error {
+	return dataDrivesOneRunPerRow(ctx, "csv", fixtureFile("data/tenants.csv"))
+}
+
+// JsonDataDrivesOneRunPerRow checks the other half of WithData's one argument:
+// the same collection, the same rows and the same result, off a JSON array
+// rather than a CSV.
+//
+// It is a separate test rather than a second case in the first because the two
+// travel under different flags — bru reads nothing off the contents — so the
+// extension is the only thing standing between a JSON data file and
+// `--csv-file-path`, which would report it as not found.
+func (t *Tests) JsonDataDrivesOneRunPerRow(ctx context.Context) error {
+	return dataDrivesOneRunPerRow(ctx, "json", fixtureFile("data/tenants.json"))
+}
+
+// FailingIterationFailsRunAndIsNamedInTheReport checks the half of a
+// data-driven run that matters when the matrix is not uniform: one row out of
+// several behaving differently.
+//
+// A run over N rows is N runs of the same requests, so a gate that only looked
+// at the last of them — or at the first — would pass a suite in which one
+// tenant is broken. Run has to fail on the collection as a whole, and the report
+// has to say which row it was, or the caller is left re-running rows by hand to
+// find out.
+//
+// The fixture is the same collection the passing tests drive, with only the data
+// file swapped for one whose second row expects the wrong echo. That is what
+// makes the failure the row's and not the collection's: the first iteration of
+// this very run passes.
+func (t *Tests) FailingIterationFailsRunAndIsNamedInTheReport(ctx context.Context) error {
+	rsp, err := newResponder(ctx)
+	if err != nil {
+		return err
+	}
+	defer rsp.stop(ctx)
+
+	collection := dag.Bruno().
+		Collection(fixture("tenants")).
+		WithEnvironment("local").
+		WithData(fixtureFile("data/one-bad-row.csv")).
+		WithService(responderAlias, rsp.Svc)
+
+	_, err = collection.Run(ctx)
+	if err == nil {
+		return fmt.Errorf("expected a failing iteration to fail the whole run")
+	}
+	for _, want := range []string{"expected 'beta' to equal 'not-beta'", "Iteration"} {
+		if !strings.Contains(err.Error(), want) {
+			return fmt.Errorf("expected the error to carry bru's per-iteration summary and mention %q, got:\n%s",
+				want, head(err.Error()))
+		}
+	}
+
+	contents, err := exportContents(ctx, collection.Report("json"), "data-one-bad-row.json")
+	if err != nil {
+		return fmt.Errorf("report: %w", err)
+	}
+	report, err := iterations(contents)
+	if err != nil {
+		return err
+	}
+	if len(report) != 2 {
+		return fmt.Errorf("expected the report to describe 2 iterations, got %d:\n%s", len(report), head(contents))
+	}
+	// Which iteration failed is the assertion. A report that marked both rows
+	// failed, or marked the run failed without saying where, would leave the
+	// caller running rows by hand — so the passing row is checked too.
+	if got := report[0].failures(); len(got) != 0 {
+		return fmt.Errorf("expected iteration %d to pass, got %v", report[0].Index, got)
+	}
+	failures := report[1].failures()
+	if len(failures) != 1 {
+		return fmt.Errorf("expected iteration %d to carry 1 failed assertion, got %v", report[1].Index, failures)
+	}
+	if want := "expected 'beta' to equal 'not-beta'"; failures[0] != want {
+		return fmt.Errorf("expected the failure to be %q, got %q", want, failures[0])
+	}
+	// The index is bru's own, read off the report rather than inferred from the
+	// array's order: it is what the caller maps back onto a row of their file.
+	if report[1].Index != 1 {
+		return fmt.Errorf("expected the second iteration to report index 1, got %d", report[1].Index)
+	}
+	return nil
+}
+
+// DataFileWithoutKnownExtensionIsRejected checks that a data file bru has no
+// reader for is refused by name, and that the message names both extensions.
+//
+// The extension is the whole interface: WithData takes one file and picks
+// `--csv-file-path` or `--json-file-path` off it, so a caller holding a data
+// file with the wrong suffix has no other way to be told which two are meant.
+// bru's own answer is exit 10 or 11 — "the CSV data file was not found" for a
+// file that is sitting right there — after the collection has already been run.
+func (t *Tests) DataFileWithoutKnownExtensionIsRejected(ctx context.Context) error {
+	_, err := dag.Bruno().
+		Collection(fixture("tenants")).
+		WithEnvironment("local").
+		WithData(fixtureFile("data/tenants.txt")).
+		Run(ctx)
+	if err == nil {
+		return fmt.Errorf("expected a data file with an unreadable extension to be an error")
+	}
+	for _, want := range []string{"tenants.txt", ".csv", ".json"} {
+		if !strings.Contains(err.Error(), want) {
+			return fmt.Errorf("expected the error to mention %q, got:\n%s", want, head(err.Error()))
+		}
 	}
 	return nil
 }
@@ -2090,6 +2222,42 @@ func redactedReport(
 	return got, nil
 }
 
+// dataDrivesOneRunPerRow runs the tenants collection over one of the data
+// fixtures and checks that every row became an iteration. label distinguishes
+// the CSV pass from the JSON one; both fixtures carry the same rows, so what is
+// asserted is identical and only the flag the module picked differs.
+func dataDrivesOneRunPerRow(ctx context.Context, label string, data *dagger.File) error {
+	rsp, err := newResponder(ctx)
+	if err != nil {
+		return err
+	}
+	defer rsp.stop(ctx)
+
+	if _, err := dag.Bruno().
+		Collection(fixture("tenants")).
+		WithEnvironment("local").
+		WithData(data).
+		WithService(responderAlias, rsp.Svc).
+		Run(ctx); err != nil {
+		return fmt.Errorf("%s run: %w", label, err)
+	}
+
+	got, err := rsp.stats(ctx, "after-"+label+"-data")
+	if err != nil {
+		return err
+	}
+	if got.Count != dataRows {
+		return fmt.Errorf("expected the %s data file to drive %d iterations, but the service served %d request(s)",
+			label, dataRows, got.Count)
+	}
+	// The rows are distinguishable by design: a run that iterated the same row
+	// three times would satisfy the count.
+	if want := "/tenants/gamma"; got.Path != want {
+		return fmt.Errorf("expected the last %s iteration to request %q, got %q", label, want, got.Path)
+	}
+	return nil
+}
+
 // header looks a reported header up case-insensitively. bru writes each name
 // back the way the collection spelled it, so an exact-key lookup would be
 // asserting the fixture's capitalisation rather than what was reported.
@@ -2102,11 +2270,41 @@ func header(headers map[string]string, name string) (string, bool) {
 	return "", false
 }
 
-// reportResult is the part of one entry in bru's JSON report that the
-// redaction tests read: what the request carried and what came back.
+// reportIteration is one entry of bru's JSON report. The document is an array
+// of them: a plain run reports one, and a data-driven run one per row of the
+// data file, each carrying the index the caller maps back onto that row.
+type reportIteration struct {
+	Index   int            `json:"iterationIndex"`
+	Results []reportResult `json:"results"`
+}
+
+// failures lists the assertion errors in one iteration, which is how a report
+// says a row failed and what about it.
+func (it reportIteration) failures() []string {
+	var out []string
+	for _, result := range it.Results {
+		for _, assertion := range result.Assertions {
+			if assertion.Status != "pass" {
+				out = append(out, assertion.Error)
+			}
+		}
+	}
+	return out
+}
+
+// reportResult is the part of one entry in bru's JSON report that these tests
+// read: what the request carried, what came back, and how the assertions went.
 type reportResult struct {
-	Request  reportMessage `json:"request"`
-	Response reportMessage `json:"response"`
+	Request    reportMessage     `json:"request"`
+	Response   reportMessage     `json:"response"`
+	Assertions []reportAssertion `json:"assertionResults"`
+}
+
+// reportAssertion is one reported assertion. Error is populated only on a
+// failure, and is bru's own account of it.
+type reportAssertion struct {
+	Status string `json:"status"`
+	Error  string `json:"error"`
 }
 
 // reportMessage is one side of a reported exchange.
@@ -2121,21 +2319,25 @@ type reportMessage struct {
 	Status  int               `json:"status"`
 }
 
-// oneResult reads the single reported exchange out of a JSON report.
-//
-// The document is an array of iterations, each holding its own results, because
-// bru reports a data-driven run as one iteration per row. Every collection here
-// makes one request, so anything else means the run was not the one the test
-// set up.
-func oneResult(contents string) (reportResult, error) {
-	var iterations []struct {
-		Results []reportResult `json:"results"`
+// iterations reads a JSON report's array of iterations.
+func iterations(contents string) ([]reportIteration, error) {
+	var out []reportIteration
+	if err := json.Unmarshal([]byte(contents), &out); err != nil {
+		return nil, fmt.Errorf("parse the json report: %w\n%s", err, head(contents))
 	}
-	if err := json.Unmarshal([]byte(contents), &iterations); err != nil {
-		return reportResult{}, fmt.Errorf("parse the json report: %w\n%s", err, head(contents))
+	return out, nil
+}
+
+// oneResult reads the single reported exchange out of a JSON report. Every
+// collection outside the data tests makes one request and is driven by no data
+// file, so anything else means the run was not the one the test set up.
+func oneResult(contents string) (reportResult, error) {
+	report, err := iterations(contents)
+	if err != nil {
+		return reportResult{}, err
 	}
 	var results []reportResult
-	for _, iteration := range iterations {
+	for _, iteration := range report {
 		results = append(results, iteration.Results...)
 	}
 	if len(results) != 1 {


### PR DESCRIPTION
Closes #249.

`Collection.WithData(file)` runs a collection once per row of a data file, with
that row's columns readable from every request as `{{variables}}` — one
collection covering the tenants, regions or payloads a suite would otherwise
carry a copy of the same request for.

```go
collection.WithData(rows).Run(ctx)   // rows.csv  → --csv-file-path
                                     // rows.json → --json-file-path
```

It takes a file rather than a flag and a path because the extension already says
which of the two `bru` wants; nothing is read off the contents. A file that is
neither is rejected by the run, naming both — `bru`'s own answer is exit 10 or
11, which report a file that is sitting right there as *not found*, and only
after the collection has already run.

Internally the paths mounted outside the collection are resolved once into a
`stagedPaths`, so the command line and the container cannot disagree about them.

## Tests

Four new tests, all wired into `All`:

- `CsvDataDrivesOneRunPerRow` / `JsonDataDrivesOneRunPerRow` — the same three
  rows as a CSV and as a JSON array drive three iterations of `fixtures/tenants`.
  Counted at the recording responder rather than read out of bru's summary, and
  the last request's path is checked because a run that iterated one row three
  times would satisfy the count. The request echoes its row back through the
  responder and asserts on it, so a run whose variables never resolved fails
  instead of passing with a literal `{{tenant}}` in the URL.
- `FailingIterationFailsRunAndIsNamedInTheReport` — the same collection with
  only the data file swapped for one whose second row expects the wrong echo.
  `Run` fails on the collection as a whole, and the JSON report's
  `iterationIndex` says which row it was; the first iteration of that very run
  passes, which is what makes the failure the row's and not the collection's.
- `DataFileWithoutKnownExtensionIsRejected` — a `.txt` data file is refused by
  name before anything is run, with a message naming `.csv` and `.json`.

Measured while writing these: as of 3.4.2 the JUnit and HTML reporters write one
`testsuite` per iteration but do not number them, so a matrix whose failure has
to be attributed to a row wants the JSON report. The README says so.

## Verification

- `dagger -m daggerverse/bruno/tests call all` — green
- `dagger -m ci call generated` — green (bindings regenerated in
  `daggerverse/bruno`, `daggerverse/bruno/tests` and the root `ci` module)
- `with-data` is listed by `dagger call collection --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)