### PR TITLE
story(issue-298): recognise a batch's images concurrently

### DIFF
--- a/ci/internal/dagger/tesseract-tests.gen.go
+++ b/ci/internal/dagger/tesseract-tests.gen.go
@@ -68,6 +68,8 @@ type TesseractTests struct { // tesseract-tests (../../../daggerverse/tesseract/
 	apkRepositoryInstallsFromPrivateMirror          *Void
 	apkRepositoryReplacesImageDefaults              *Void
 	authenticatedRepositoryIsRejectedWithoutApkAuth *Void
+	batchConcurrencyMatchesSerialOutput             *Void
+	batchConcurrencyReportsFailingImage             *Void
 	batchDefaultGlobSkipsNonImages                  *Void
 	batchExportProducesEveryFormatPerImage          *Void
 	batchGlobSelectsFiles                           *Void
@@ -161,7 +163,7 @@ func (r *TesseractTests) All(ctx context.Context, opts ...TesseractTestsAllOpts)
 // AltoIsValidXml asserts the ALTO renderer emits well-formed XML in the ALTO
 // namespace, since its consumers are schema-driven archive tooling that will
 // reject anything else outright.
-func (r *TesseractTests) AltoIsValidXML(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:361:1)
+func (r *TesseractTests) AltoIsValidXML(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:363:1)
 	if r.altoIsValidXml != nil {
 		return nil
 	}
@@ -244,6 +246,48 @@ func (r *TesseractTests) AuthenticatedRepositoryIsRejectedWithoutApkAuth(ctx con
 	return q.Execute(ctx)
 }
 
+// BatchConcurrencyMatchesSerialOutput asserts a batch recognised several
+// images at a time produces exactly what the same batch produces one at a
+// time, and that a bound that would recognise nothing is refused.
+//
+// Byte equality is the whole promise of the knob: recognition of one image has
+// nothing to say about recognition of another, so concurrency is allowed to
+// change how long a batch takes and nothing else. The digest covers the layout
+// too, which is what pins the mirrored directories being created before the
+// parallel pass rather than raced for inside it — two images share `scans/` and
+// two share `scans/deep/`, so with four workers every directory here has two
+// candidates to create it.
+func (r *TesseractTests) BatchConcurrencyMatchesSerialOutput(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1271:1)
+	if r.batchConcurrencyMatchesSerialOutput != nil {
+		return nil
+	}
+	q := r.query.Select("batchConcurrencyMatchesSerialOutput")
+
+	return q.Execute(ctx)
+}
+
+// BatchConcurrencyReportsFailingImage asserts a page tesseract cannot read
+// fails the whole batch — recognised one at a time or four at a time — with a
+// message that names the page and carries tesseract's own complaint about it.
+//
+// Failing loudly is what the serial loop got from `set -e` for free, and it is
+// the half of a parallel rewrite that is easy to lose: a runner that reports
+// only its own exit status turns an unreadable page into a batch that
+// "succeeded" with one artifact quietly missing from a thousand.
+//
+// Naming the page has to be the runner's own doing. tesseract handed a file
+// leptonica will not decode falls back to reading it as a list of image paths,
+// so its message names the file's first *line* rather than the file — here,
+// the words in the fake PNG.
+func (r *TesseractTests) BatchConcurrencyReportsFailingImage(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1342:1)
+	if r.batchConcurrencyReportsFailingImage != nil {
+		return nil
+	}
+	q := r.query.Select("batchConcurrencyReportsFailingImage")
+
+	return q.Execute(ctx)
+}
+
 // BatchDefaultGlobSkipsNonImages asserts the default glob takes the images out
 // of a real scan folder and leaves the rest alone.
 //
@@ -251,7 +295,7 @@ func (r *TesseractTests) AuthenticatedRepositoryIsRejectedWithoutApkAuth(ctx con
 // them are pages. Handing one to tesseract is not a no-op — leptonica fails to
 // decode it and the run dies — so "ignored by default" is what makes pointing
 // Batch at an existing directory work at all.
-func (r *TesseractTests) BatchDefaultGlobSkipsNonImages(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1019:1)
+func (r *TesseractTests) BatchDefaultGlobSkipsNonImages(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1021:1)
 	if r.batchDefaultGlobSkipsNonImages != nil {
 		return nil
 	}
@@ -267,7 +311,7 @@ func (r *TesseractTests) BatchDefaultGlobSkipsNonImages(ctx context.Context) err
 // would render one concatenated artifact per *format* — a single .txt with
 // form-feed page breaks and a single multi-page PDF — with no way to tell which
 // page produced what.
-func (r *TesseractTests) BatchExportProducesEveryFormatPerImage(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1115:1)
+func (r *TesseractTests) BatchExportProducesEveryFormatPerImage(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1117:1)
 	if r.batchExportProducesEveryFormatPerImage != nil {
 		return nil
 	}
@@ -283,7 +327,7 @@ func (r *TesseractTests) BatchExportProducesEveryFormatPerImage(ctx context.Cont
 // be indistinguishable from a batch that ran and found no text, so a typo in a
 // pattern would surface much later as missing output rather than here as a bad
 // glob.
-func (r *TesseractTests) BatchGlobSelectsFiles(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1063:1)
+func (r *TesseractTests) BatchGlobSelectsFiles(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1065:1)
 	if r.batchGlobSelectsFiles != nil {
 		return nil
 	}
@@ -300,7 +344,7 @@ func (r *TesseractTests) BatchGlobSelectsFiles(ctx context.Context) error { // t
 // directory of `result-1.txt`, `result-2.txt` would force every caller to
 // rebuild the correspondence between page and text that the input directory
 // already expressed.
-func (r *TesseractTests) BatchMirrorsInputLayout(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:985:1)
+func (r *TesseractTests) BatchMirrorsInputLayout(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:987:1)
 	if r.batchMirrorsInputLayout != nil {
 		return nil
 	}
@@ -316,7 +360,7 @@ func (r *TesseractTests) BatchMirrorsInputLayout(ctx context.Context) error { //
 // A collision is the subtle one: `a.png` and `a.jpg` in one folder both render
 // onto `a.txt`, so the second silently overwrites the first and the batch looks
 // like it succeeded with one page missing.
-func (r *TesseractTests) BatchRejectsAmbiguousInput(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1227:1)
+func (r *TesseractTests) BatchRejectsAmbiguousInput(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1229:1)
 	if r.batchRejectsAmbiguousInput != nil {
 		return nil
 	}
@@ -332,7 +376,7 @@ func (r *TesseractTests) BatchRejectsAmbiguousInput(ctx context.Context) error {
 // It covers both halves: an option that has to reach tesseract for every image
 // in the run, and the deferred validation that has to reject a bad option
 // before any of them are recognised.
-func (r *TesseractTests) BatchSharesDocumentOptions(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1161:1)
+func (r *TesseractTests) BatchSharesDocumentOptions(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1163:1)
 	if r.batchSharesDocumentOptions != nil {
 		return nil
 	}
@@ -344,7 +388,7 @@ func (r *TesseractTests) BatchSharesDocumentOptions(ctx context.Context) error {
 // BoxReportsCharacterBoxes asserts the box renderer descends to the character
 // level, which is the level nothing else this module offers reaches: hOCR and
 // TSV stop at the word.
-func (r *TesseractTests) BoxReportsCharacterBoxes(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1522:1)
+func (r *TesseractTests) BoxReportsCharacterBoxes(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1636:1)
 	if r.boxReportsCharacterBoxes != nil {
 		return nil
 	}
@@ -362,7 +406,7 @@ func (r *TesseractTests) BoxReportsCharacterBoxes(ctx context.Context) error { /
 // and that makes "did it actually look?" the thing worth testing. A Check that
 // short-circuited when no threshold was set would be a green build over a
 // directory of files tesseract cannot read at all.
-func (r *TesseractTests) CiCheckRunsTheGateWithoutArtifacts(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1378:1)
+func (r *TesseractTests) CiCheckRunsTheGateWithoutArtifacts(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1492:1)
 	if r.ciCheckRunsTheGateWithoutArtifacts != nil {
 		return nil
 	}
@@ -380,7 +424,7 @@ func (r *TesseractTests) CiCheckRunsTheGateWithoutArtifacts(ctx context.Context)
 // for PDFs did not ask for a TSV beside every page, and would find one in the
 // archive they published. A caller who did ask for TSV keeps it, which is the
 // half that catches a filter written as "drop every TSV".
-func (r *TesseractTests) CiGateKeepsItsTsvOutOfTheOutput(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1414:1)
+func (r *TesseractTests) CiGateKeepsItsTsvOutOfTheOutput(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1528:1)
 	if r.ciGateKeepsItsTsvOutOfTheOutput != nil {
 		return nil
 	}
@@ -398,7 +442,7 @@ func (r *TesseractTests) CiGateKeepsItsTsvOutOfTheOutput(ctx context.Context) er
 // proves it, because the check that produces it lives on the shared option set
 // and could only fire if the value got there. It also fires before recognition,
 // so a wrong-language pipeline costs a message rather than a batch.
-func (r *TesseractTests) CiLanguageReachesRecognition(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1462:1)
+func (r *TesseractTests) CiLanguageReachesRecognition(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1576:1)
 	if r.ciLanguageReachesRecognition != nil {
 		return nil
 	}
@@ -420,7 +464,7 @@ func (r *TesseractTests) CiLanguageReachesRecognition(ctx context.Context) error
 // that has to be earned: one clean scan and one blank page under a threshold
 // only the blank page misses. A gate that failed the batch as a whole would be
 // telling the caller to go and diff a hundred TSVs.
-func (r *TesseractTests) CiMinConfidenceGatesTheRun(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1322:1)
+func (r *TesseractTests) CiMinConfidenceGatesTheRun(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1436:1)
 	if r.ciMinConfidenceGatesTheRun != nil {
 		return nil
 	}
@@ -440,7 +484,7 @@ func (r *TesseractTests) CiMinConfidenceGatesTheRun(ctx context.Context) error {
 // It is checked through Check rather than Run because that is where a
 // misconfiguration costs the most to discover late: Check is the call a PR gate
 // makes, and its whole answer is the error it returns.
-func (r *TesseractTests) CiRejectsUnusableThreshold(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1500:1)
+func (r *TesseractTests) CiRejectsUnusableThreshold(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1614:1)
 	if r.ciRejectsUnusableThreshold != nil {
 		return nil
 	}
@@ -456,7 +500,7 @@ func (r *TesseractTests) CiRejectsUnusableThreshold(ctx context.Context) error {
 // WithFormats was called would look like a broken directory rather than an
 // unconfigured one, so an unconfigured Ci renders plain text — the format
 // tesseract itself produces when no renderer is named.
-func (r *TesseractTests) CiRunProducesEnabledFormats(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1267:1)
+func (r *TesseractTests) CiRunProducesEnabledFormats(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1381:1)
 	if r.ciRunProducesEnabledFormats != nil {
 		return nil
 	}
@@ -486,7 +530,7 @@ func (r *TesseractTests) DefaultApkConfigurationIsUntouched(ctx context.Context)
 // English and nothing else. The base apk package carries no language data at
 // all, so an empty default would produce an image that cannot recognise
 // anything.
-func (r *TesseractTests) DefaultLanguagesInstallEnglish(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:238:1)
+func (r *TesseractTests) DefaultLanguagesInstallEnglish(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:240:1)
 	if r.defaultLanguagesInstallEnglish != nil {
 		return nil
 	}
@@ -499,7 +543,7 @@ func (r *TesseractTests) DefaultLanguagesInstallEnglish(ctx context.Context) err
 // formats. That the artifacts arrive in a single directory lifted off a single
 // exec is what proves they came from one recognition pass rather than six: the
 // per-format functions each run their own.
-func (r *TesseractTests) ExportProducesEveryRequestedFormat(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:432:1)
+func (r *TesseractTests) ExportProducesEveryRequestedFormat(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:434:1)
 	if r.exportProducesEveryRequestedFormat != nil {
 		return nil
 	}
@@ -516,7 +560,7 @@ func (r *TesseractTests) ExportProducesEveryRequestedFormat(ctx context.Context)
 // Letter, 612x792 points, so a page rasterized at D dots per inch is exactly
 // 612*D/72 by 792*D/72 pixels. Asserting on the pixels rather than on the flag
 // is what makes this a test of the rasterizer rather than of argv.
-func (r *TesseractTests) FromPdfDpiSetsRasterResolution(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:847:1)
+func (r *TesseractTests) FromPdfDpiSetsRasterResolution(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:849:1)
 	if r.fromPdfDpiSetsRasterResolution != nil {
 		return nil
 	}
@@ -538,7 +582,7 @@ func (r *TesseractTests) FromPdfDpiSetsRasterResolution(ctx context.Context) err
 // Each format is therefore checked for its own per-page structure rather than
 // for mere existence: three page elements, three page numbers, three PDF
 // pages. A renderer that kept only one page would still produce a file.
-func (r *TesseractTests) FromPdfExportRendersEveryFormatAsOneDocument(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:897:1)
+func (r *TesseractTests) FromPdfExportRendersEveryFormatAsOneDocument(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:899:1)
 	if r.fromPdfExportRendersEveryFormatAsOneDocument != nil {
 		return nil
 	}
@@ -555,7 +599,7 @@ func (r *TesseractTests) FromPdfExportRendersEveryFormatAsOneDocument(ctx contex
 // writes one file per page and the recognition pass reads them from a list, so
 // a sorting bug — page-10 before page-2, say — would still produce text for
 // every page and still look like a success.
-func (r *TesseractTests) FromPdfRecognizesEveryPageInOrder(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:831:1)
+func (r *TesseractTests) FromPdfRecognizesEveryPageInOrder(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:833:1)
 	if r.fromPdfRecognizesEveryPageInOrder != nil {
 		return nil
 	}
@@ -566,7 +610,7 @@ func (r *TesseractTests) FromPdfRecognizesEveryPageInOrder(ctx context.Context) 
 
 // HocrContainsWordBoxes asserts hOCR carries the per-word geometry that is the
 // whole reason to ask for it rather than plain text.
-func (r *TesseractTests) HocrContainsWordBoxes(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:338:1)
+func (r *TesseractTests) HocrContainsWordBoxes(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:340:1)
 	if r.hocrContainsWordBoxes != nil {
 		return nil
 	}
@@ -631,7 +675,7 @@ func (r *TesseractTests) UnmarshalJSON(bs []byte) error {
 // is that no member is dead: LEGACY and LEGACY_LSTM only work because Alpine
 // packages the *combined* tessdata models. A rebuild against tessdata_fast or
 // tessdata_best would strip the legacy data and this is where that shows up.
-func (r *TesseractTests) LstmEngineRecognizesFixture(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:579:1)
+func (r *TesseractTests) LstmEngineRecognizesFixture(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:581:1)
 	if r.lstmEngineRecognizesFixture != nil {
 		return nil
 	}
@@ -648,7 +692,7 @@ func (r *TesseractTests) LstmEngineRecognizesFixture(ctx context.Context) error 
 // it, because that is what a sample is *for*: the file pairs the line's pixels
 // with the characters they are supposed to be, and a sample built against the
 // wrong text trains the model to be wrong without ever failing.
-func (r *TesseractTests) LstmTrainBuildsTrainingSample(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1578:1)
+func (r *TesseractTests) LstmTrainBuildsTrainingSample(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1692:1)
 	if r.lstmTrainBuildsTrainingSample != nil {
 		return nil
 	}
@@ -660,7 +704,7 @@ func (r *TesseractTests) LstmTrainBuildsTrainingSample(ctx context.Context) erro
 // MalformedParameterNameIsRejected asserts an empty parameter name, and one
 // carrying its own `=`, are refused. `-c` takes `name=value`, so an embedded
 // `=` would quietly set a different variable to a different value.
-func (r *TesseractTests) MalformedParameterNameIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:775:1)
+func (r *TesseractTests) MalformedParameterNameIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:777:1)
 	if r.malformedParameterNameIsRejected != nil {
 		return nil
 	}
@@ -672,7 +716,7 @@ func (r *TesseractTests) MalformedParameterNameIsRejected(ctx context.Context) e
 // NonPositiveDpiIsRejected asserts a zero or negative resolution is refused
 // rather than handed to tesseract, which would take it as a real measurement
 // and scale its analysis by it.
-func (r *TesseractTests) NonPositiveDpiIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:801:1)
+func (r *TesseractTests) NonPositiveDpiIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:803:1)
 	if r.nonPositiveDpiIsRejected != nil {
 		return nil
 	}
@@ -691,7 +735,7 @@ func (r *TesseractTests) NonPositiveDpiIsRejected(ctx context.Context) error { /
 // works at all: without it, anything running several recognitions at once has
 // no way to stop each pass claiming every core, which cost this very suite
 // nine minutes on a four-core runner (#226).
-func (r *TesseractTests) OmpThreadLimitBoundsOpenMp(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:275:1)
+func (r *TesseractTests) OmpThreadLimitBoundsOpenMp(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:277:1)
 	if r.ompThreadLimitBoundsOpenMp != nil {
 		return nil
 	}
@@ -703,7 +747,7 @@ func (r *TesseractTests) OmpThreadLimitBoundsOpenMp(ctx context.Context) error {
 // OsdDetectsRotation asserts orientation detection reads the quarter-turn in
 // the rotated fixture and reports the rotation that would undo it, while the
 // upright fixture reports no rotation at all.
-func (r *TesseractTests) OsdDetectsRotation(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:658:1)
+func (r *TesseractTests) OsdDetectsRotation(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:660:1)
 	if r.osdDetectsRotation != nil {
 		return nil
 	}
@@ -715,7 +759,7 @@ func (r *TesseractTests) OsdDetectsRotation(ctx context.Context) error { // tess
 // OsdWithoutOsdDataIsRejected asserts orientation detection on an image built
 // without the osd model names the fix rather than failing inside tesseract,
 // which would report a missing traineddata file.
-func (r *TesseractTests) OsdWithoutOsdDataIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:739:1)
+func (r *TesseractTests) OsdWithoutOsdDataIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:741:1)
 	if r.osdWithoutOsdDataIsRejected != nil {
 		return nil
 	}
@@ -727,7 +771,7 @@ func (r *TesseractTests) OsdWithoutOsdDataIsRejected(ctx context.Context) error 
 // PdfHasPdfMagic asserts the searchable-PDF renderer emits a real PDF. The
 // bytes go through the filesystem rather than File.Contents, which mangles
 // non-UTF-8 data.
-func (r *TesseractTests) PdfHasPdfMagic(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:414:1)
+func (r *TesseractTests) PdfHasPdfMagic(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:416:1)
 	if r.pdfHasPdfMagic != nil {
 		return nil
 	}
@@ -743,7 +787,7 @@ func (r *TesseractTests) PdfHasPdfMagic(ctx context.Context) error { // tesserac
 // The error has to name FromPdf, which is the whole difference between an
 // error that ends the caller's afternoon and one that ends their next line of
 // code: rasterizing is no longer something they have to go and arrange.
-func (r *TesseractTests) PdfInputIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:759:1)
+func (r *TesseractTests) PdfInputIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:761:1)
 	if r.pdfInputIsRejected != nil {
 		return nil
 	}
@@ -756,7 +800,7 @@ func (r *TesseractTests) PdfInputIsRejected(ctx context.Context) error { // tess
 // recognised comes back, and that it is the processed one rather than the
 // source: the fixture goes in as a PNG and this comes out as a TIFF, which is
 // the observable half of "this is a derivative, not your file".
-func (r *TesseractTests) ProcessedImagesReturnsThresholdedTiff(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1558:1)
+func (r *TesseractTests) ProcessedImagesReturnsThresholdedTiff(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1672:1)
 	if r.processedImagesReturnsThresholdedTiff != nil {
 		return nil
 	}
@@ -768,7 +812,7 @@ func (r *TesseractTests) ProcessedImagesReturnsThresholdedTiff(ctx context.Conte
 // RequestedLanguagesAreInstalled asserts every requested language lands in the
 // image as its own apk package, including "osd", which is a detection model
 // rather than a recognition language.
-func (r *TesseractTests) RequestedLanguagesAreInstalled(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:252:1)
+func (r *TesseractTests) RequestedLanguagesAreInstalled(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:254:1)
 	if r.requestedLanguagesAreInstalled != nil {
 		return nil
 	}
@@ -782,7 +826,7 @@ func (r *TesseractTests) RequestedLanguagesAreInstalled(ctx context.Context) err
 // that finds the lines, so it returns far less than the default mode does —
 // which is the observable proof the flag was passed, without asserting on
 // whatever garbage the constrained mode happens to produce.
-func (r *TesseractTests) SingleWordPageSegReturnsFewerWords(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:553:1)
+func (r *TesseractTests) SingleWordPageSegReturnsFewerWords(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:555:1)
 	if r.singleWordPageSegReturnsFewerWords != nil {
 		return nil
 	}
@@ -795,7 +839,7 @@ func (r *TesseractTests) SingleWordPageSegReturnsFewerWords(ctx context.Context)
 // mounting a tessdata directory adds the models it holds and nothing else, so a
 // language neither half carries is rejected the same way it was before, with
 // both halves listed and both ways of adding one named.
-func (r *TesseractTests) TessdataDoesNotAdmitUnknownLanguage(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:719:1)
+func (r *TesseractTests) TessdataDoesNotAdmitUnknownLanguage(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:721:1)
 	if r.tessdataDoesNotAdmitUnknownLanguage != nil {
 		return nil
 	}
@@ -821,7 +865,7 @@ func (r *TesseractTests) TessdataDoesNotAdmitUnknownLanguage(ctx context.Context
 // configfiles, and pdf.ttf is what the PDF renderer draws its invisible text
 // layer with. Pointed at the caller's directory alone, every renderer breaks
 // and every packaged language disappears.
-func (r *TesseractTests) TessdataModelIsSelectable(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:485:1)
+func (r *TesseractTests) TessdataModelIsSelectable(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:487:1)
 	if r.tessdataModelIsSelectable != nil {
 		return nil
 	}
@@ -837,7 +881,7 @@ func (r *TesseractTests) TessdataModelIsSelectable(ctx context.Context) error { 
 // answered from the requested package set alone. A supplied osd.traineddata
 // would have been refused by this module while sitting right there in the
 // image, which is the failure mode this pins.
-func (r *TesseractTests) TessdataSuppliesOsdModel(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:531:1)
+func (r *TesseractTests) TessdataSuppliesOsdModel(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:533:1)
 	if r.tessdataSuppliesOsdModel != nil {
 		return nil
 	}
@@ -848,7 +892,7 @@ func (r *TesseractTests) TessdataSuppliesOsdModel(ctx context.Context) error { /
 
 // TextRecognizesFixture asserts the shortest path — image in, string out —
 // reproduces every line the fixture renders.
-func (r *TesseractTests) TextRecognizesFixture(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:309:1)
+func (r *TesseractTests) TextRecognizesFixture(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:311:1)
 	if r.textRecognizesFixture != nil {
 		return nil
 	}
@@ -866,7 +910,7 @@ func (r *TesseractTests) TextRecognizesFixture(ctx context.Context) error { // t
 // off-by-one ones: the run stops one image short, or one transcription is
 // saved under the wrong stem. "Something is unpaired" sends the caller to diff
 // two file listings; "line-3.png has no ground truth" does not.
-func (r *TesseractTests) TrainingPairsImagesWithGroundTruth(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1632:1)
+func (r *TesseractTests) TrainingPairsImagesWithGroundTruth(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1746:1)
 	if r.trainingPairsImagesWithGroundTruth != nil {
 		return nil
 	}
@@ -889,7 +933,7 @@ func (r *TesseractTests) TrainingPairsImagesWithGroundTruth(ctx context.Context)
 // what that default is for is precisely this: a bound low enough that a
 // training run belongs in a test suite. If it ever stops being, this test is
 // where that shows up.
-func (r *TesseractTests) TrainingProducesUsableModel(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1788:1)
+func (r *TesseractTests) TrainingProducesUsableModel(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1902:1)
 	if r.trainingProducesUsableModel != nil {
 		return nil
 	}
@@ -904,7 +948,7 @@ func (r *TesseractTests) TrainingProducesUsableModel(ctx context.Context) error 
 // A training run is the most expensive thing this module does, so the cost of
 // finding out late is not a slow error message — it is minutes of a machine
 // arriving at a failure that was visible from the outside the whole time.
-func (r *TesseractTests) TrainingRejectsUnusableInput(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1692:1)
+func (r *TesseractTests) TrainingRejectsUnusableInput(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1806:1)
 	if r.trainingRejectsUnusableInput != nil {
 		return nil
 	}
@@ -922,7 +966,7 @@ func (r *TesseractTests) TrainingRejectsUnusableInput(ctx context.Context) error
 // loads, recognises, and lists as a language like any other — and lstmtraining
 // says only "eng.lstm is an integer (fast) model", which names neither the
 // float models nor how to get one onto the image.
-func (r *TesseractTests) TrainingRequiresFloatBaseModel(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1757:1)
+func (r *TesseractTests) TrainingRequiresFloatBaseModel(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1871:1)
 	if r.trainingRequiresFloatBaseModel != nil {
 		return nil
 	}
@@ -934,7 +978,7 @@ func (r *TesseractTests) TrainingRequiresFloatBaseModel(ctx context.Context) err
 // TsvHasHeaderAndWordRows asserts the TSV renderer emits its column header and
 // descends all the way to word-level rows (level 5), which is the level
 // carrying the text and its confidence.
-func (r *TesseractTests) TsvHasHeaderAndWordRows(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:380:1)
+func (r *TesseractTests) TsvHasHeaderAndWordRows(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:382:1)
 	if r.tsvHasHeaderAndWordRows != nil {
 		return nil
 	}
@@ -945,7 +989,7 @@ func (r *TesseractTests) TsvHasHeaderAndWordRows(ctx context.Context) error { //
 
 // TxtFileMatchesText asserts the txt renderer and the stdout path agree, so
 // choosing a file over a string is purely a plumbing decision.
-func (r *TesseractTests) TxtFileMatchesText(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:319:1)
+func (r *TesseractTests) TxtFileMatchesText(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:321:1)
 	if r.txtFileMatchesText != nil {
 		return nil
 	}
@@ -958,7 +1002,7 @@ func (r *TesseractTests) TxtFileMatchesText(ctx context.Context) error { // tess
 // rejected with the installed set named. tesseract's own failure talks about
 // traineddata paths and TESSDATA_PREFIX, which says nothing about the fact
 // that languages are chosen on New.
-func (r *TesseractTests) UnknownLanguageIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:687:1)
+func (r *TesseractTests) UnknownLanguageIsRejected(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:689:1)
 	if r.unknownLanguageIsRejected != nil {
 		return nil
 	}
@@ -974,7 +1018,7 @@ func (r *TesseractTests) UnknownLanguageIsRejected(ctx context.Context) error { 
 // and exits 0, so a typo would otherwise be indistinguishable from a setting
 // that simply had no effect. The same test pins the other half: a real
 // parameter still goes through, so the check is not just rejecting everything.
-func (r *TesseractTests) UnknownParameterFails(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:605:1)
+func (r *TesseractTests) UnknownParameterFails(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:607:1)
 	if r.unknownParameterFails != nil {
 		return nil
 	}
@@ -1014,7 +1058,7 @@ func (r *TesseractTests) UntrustedIndexIsRejectedWithoutApkKey(ctx context.Conte
 // a dictionary hint on an already-clean fixture is not reliably observable.
 // What this does catch is a wrong mount path or a flag emitted in the wrong
 // position, either of which turns the whole run into a usage error.
-func (r *TesseractTests) UserWordsFileIsAccepted(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:641:1)
+func (r *TesseractTests) UserWordsFileIsAccepted(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:643:1)
 	if r.userWordsFileIsAccepted != nil {
 		return nil
 	}
@@ -1026,7 +1070,7 @@ func (r *TesseractTests) UserWordsFileIsAccepted(ctx context.Context) error { //
 // VersionReportsTesseractFive asserts the assembled image ships the tesseract
 // release Alpine's community repository carries, so a base-tag bump that
 // silently changes major version fails here rather than in recognition.
-func (r *TesseractTests) VersionReportsTesseractFive(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:223:1)
+func (r *TesseractTests) VersionReportsTesseractFive(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:225:1)
 	if r.versionReportsTesseractFive != nil {
 		return nil
 	}

--- a/ci/internal/dagger/tesseract-tests.gen.go
+++ b/ci/internal/dagger/tesseract-tests.gen.go
@@ -250,13 +250,13 @@ func (r *TesseractTests) AuthenticatedRepositoryIsRejectedWithoutApkAuth(ctx con
 // images at a time produces exactly what the same batch produces one at a
 // time, and that a bound that would recognise nothing is refused.
 //
-// Byte equality is the whole promise of the knob: recognition of one image has
-// nothing to say about recognition of another, so concurrency is allowed to
-// change how long a batch takes and nothing else. The digest covers the layout
-// too, which is what pins the mirrored directories being created before the
-// parallel pass rather than raced for inside it — two images share `scans/` and
-// two share `scans/deep/`, so with four workers every directory here has two
-// candidates to create it.
+// Byte equality is the whole promise of the knob: concurrency is allowed to
+// change how long a batch takes and nothing else. What it pins now that the
+// fan-out is Go and each image is its own exec is the *assembly* — the artifacts
+// are collected in sorted order off execs that finished in whatever order they
+// finished in, so a directory that came out right only because the work
+// happened to be serial would fail here. The digest covers the mirrored layout
+// too, nested directories and all.
 func (r *TesseractTests) BatchConcurrencyMatchesSerialOutput(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1271:1)
 	if r.batchConcurrencyMatchesSerialOutput != nil {
 		return nil
@@ -270,16 +270,17 @@ func (r *TesseractTests) BatchConcurrencyMatchesSerialOutput(ctx context.Context
 // fails the whole batch — recognised one at a time or four at a time — with a
 // message that names the page and carries tesseract's own complaint about it.
 //
-// Failing loudly is what the serial loop got from `set -e` for free, and it is
-// the half of a parallel rewrite that is easy to lose: a runner that reports
-// only its own exit status turns an unreadable page into a batch that
-// "succeeded" with one artifact quietly missing from a thousand.
+// Failing loudly is the half of a parallel rewrite that is easy to lose: a
+// runner that reports only its own exit status turns an unreadable page into a
+// batch that "succeeded" with one artifact quietly missing from a thousand.
 //
-// Naming the page has to be the runner's own doing. tesseract handed a file
+// Naming the page has to be the batch's own doing. tesseract handed a file
 // leptonica will not decode falls back to reading it as a list of image paths,
 // so its message names the file's first *line* rather than the file — here,
-// the words in the fake PNG.
-func (r *TesseractTests) BatchConcurrencyReportsFailingImage(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1342:1)
+// the words in the fake PNG. Two of the good pages recognise fine either side
+// of it, so what is asserted is a failure that survives its siblings
+// succeeding.
+func (r *TesseractTests) BatchConcurrencyReportsFailingImage(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1343:1)
 	if r.batchConcurrencyReportsFailingImage != nil {
 		return nil
 	}
@@ -388,7 +389,7 @@ func (r *TesseractTests) BatchSharesDocumentOptions(ctx context.Context) error {
 // BoxReportsCharacterBoxes asserts the box renderer descends to the character
 // level, which is the level nothing else this module offers reaches: hOCR and
 // TSV stop at the word.
-func (r *TesseractTests) BoxReportsCharacterBoxes(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1636:1)
+func (r *TesseractTests) BoxReportsCharacterBoxes(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1637:1)
 	if r.boxReportsCharacterBoxes != nil {
 		return nil
 	}
@@ -406,7 +407,7 @@ func (r *TesseractTests) BoxReportsCharacterBoxes(ctx context.Context) error { /
 // and that makes "did it actually look?" the thing worth testing. A Check that
 // short-circuited when no threshold was set would be a green build over a
 // directory of files tesseract cannot read at all.
-func (r *TesseractTests) CiCheckRunsTheGateWithoutArtifacts(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1492:1)
+func (r *TesseractTests) CiCheckRunsTheGateWithoutArtifacts(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1493:1)
 	if r.ciCheckRunsTheGateWithoutArtifacts != nil {
 		return nil
 	}
@@ -424,7 +425,7 @@ func (r *TesseractTests) CiCheckRunsTheGateWithoutArtifacts(ctx context.Context)
 // for PDFs did not ask for a TSV beside every page, and would find one in the
 // archive they published. A caller who did ask for TSV keeps it, which is the
 // half that catches a filter written as "drop every TSV".
-func (r *TesseractTests) CiGateKeepsItsTsvOutOfTheOutput(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1528:1)
+func (r *TesseractTests) CiGateKeepsItsTsvOutOfTheOutput(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1529:1)
 	if r.ciGateKeepsItsTsvOutOfTheOutput != nil {
 		return nil
 	}
@@ -442,7 +443,7 @@ func (r *TesseractTests) CiGateKeepsItsTsvOutOfTheOutput(ctx context.Context) er
 // proves it, because the check that produces it lives on the shared option set
 // and could only fire if the value got there. It also fires before recognition,
 // so a wrong-language pipeline costs a message rather than a batch.
-func (r *TesseractTests) CiLanguageReachesRecognition(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1576:1)
+func (r *TesseractTests) CiLanguageReachesRecognition(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1577:1)
 	if r.ciLanguageReachesRecognition != nil {
 		return nil
 	}
@@ -464,7 +465,7 @@ func (r *TesseractTests) CiLanguageReachesRecognition(ctx context.Context) error
 // that has to be earned: one clean scan and one blank page under a threshold
 // only the blank page misses. A gate that failed the batch as a whole would be
 // telling the caller to go and diff a hundred TSVs.
-func (r *TesseractTests) CiMinConfidenceGatesTheRun(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1436:1)
+func (r *TesseractTests) CiMinConfidenceGatesTheRun(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1437:1)
 	if r.ciMinConfidenceGatesTheRun != nil {
 		return nil
 	}
@@ -484,7 +485,7 @@ func (r *TesseractTests) CiMinConfidenceGatesTheRun(ctx context.Context) error {
 // It is checked through Check rather than Run because that is where a
 // misconfiguration costs the most to discover late: Check is the call a PR gate
 // makes, and its whole answer is the error it returns.
-func (r *TesseractTests) CiRejectsUnusableThreshold(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1614:1)
+func (r *TesseractTests) CiRejectsUnusableThreshold(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1615:1)
 	if r.ciRejectsUnusableThreshold != nil {
 		return nil
 	}
@@ -500,7 +501,7 @@ func (r *TesseractTests) CiRejectsUnusableThreshold(ctx context.Context) error {
 // WithFormats was called would look like a broken directory rather than an
 // unconfigured one, so an unconfigured Ci renders plain text — the format
 // tesseract itself produces when no renderer is named.
-func (r *TesseractTests) CiRunProducesEnabledFormats(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1381:1)
+func (r *TesseractTests) CiRunProducesEnabledFormats(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1382:1)
 	if r.ciRunProducesEnabledFormats != nil {
 		return nil
 	}
@@ -692,7 +693,7 @@ func (r *TesseractTests) LstmEngineRecognizesFixture(ctx context.Context) error 
 // it, because that is what a sample is *for*: the file pairs the line's pixels
 // with the characters they are supposed to be, and a sample built against the
 // wrong text trains the model to be wrong without ever failing.
-func (r *TesseractTests) LstmTrainBuildsTrainingSample(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1692:1)
+func (r *TesseractTests) LstmTrainBuildsTrainingSample(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1693:1)
 	if r.lstmTrainBuildsTrainingSample != nil {
 		return nil
 	}
@@ -800,7 +801,7 @@ func (r *TesseractTests) PdfInputIsRejected(ctx context.Context) error { // tess
 // recognised comes back, and that it is the processed one rather than the
 // source: the fixture goes in as a PNG and this comes out as a TIFF, which is
 // the observable half of "this is a derivative, not your file".
-func (r *TesseractTests) ProcessedImagesReturnsThresholdedTiff(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1672:1)
+func (r *TesseractTests) ProcessedImagesReturnsThresholdedTiff(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1673:1)
 	if r.processedImagesReturnsThresholdedTiff != nil {
 		return nil
 	}
@@ -910,7 +911,7 @@ func (r *TesseractTests) TextRecognizesFixture(ctx context.Context) error { // t
 // off-by-one ones: the run stops one image short, or one transcription is
 // saved under the wrong stem. "Something is unpaired" sends the caller to diff
 // two file listings; "line-3.png has no ground truth" does not.
-func (r *TesseractTests) TrainingPairsImagesWithGroundTruth(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1746:1)
+func (r *TesseractTests) TrainingPairsImagesWithGroundTruth(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1747:1)
 	if r.trainingPairsImagesWithGroundTruth != nil {
 		return nil
 	}
@@ -933,7 +934,7 @@ func (r *TesseractTests) TrainingPairsImagesWithGroundTruth(ctx context.Context)
 // what that default is for is precisely this: a bound low enough that a
 // training run belongs in a test suite. If it ever stops being, this test is
 // where that shows up.
-func (r *TesseractTests) TrainingProducesUsableModel(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1902:1)
+func (r *TesseractTests) TrainingProducesUsableModel(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1903:1)
 	if r.trainingProducesUsableModel != nil {
 		return nil
 	}
@@ -948,7 +949,7 @@ func (r *TesseractTests) TrainingProducesUsableModel(ctx context.Context) error 
 // A training run is the most expensive thing this module does, so the cost of
 // finding out late is not a slow error message — it is minutes of a machine
 // arriving at a failure that was visible from the outside the whole time.
-func (r *TesseractTests) TrainingRejectsUnusableInput(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1806:1)
+func (r *TesseractTests) TrainingRejectsUnusableInput(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1807:1)
 	if r.trainingRejectsUnusableInput != nil {
 		return nil
 	}
@@ -966,7 +967,7 @@ func (r *TesseractTests) TrainingRejectsUnusableInput(ctx context.Context) error
 // loads, recognises, and lists as a language like any other — and lstmtraining
 // says only "eng.lstm is an integer (fast) model", which names neither the
 // float models nor how to get one onto the image.
-func (r *TesseractTests) TrainingRequiresFloatBaseModel(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1871:1)
+func (r *TesseractTests) TrainingRequiresFloatBaseModel(ctx context.Context) error { // tesseract-tests (../../../daggerverse/tesseract/tests/main.go:1872:1)
 	if r.trainingRequiresFloatBaseModel != nil {
 		return nil
 	}

--- a/daggerverse/tesseract/README.md
+++ b/daggerverse/tesseract/README.md
@@ -197,30 +197,32 @@ still share the package fetch. A negative value is rejected on `New` — libgomp
 reads an unparseable `OMP_THREAD_LIMIT` as absent and silently goes back to one
 thread per CPU, the opposite of what was asked for.
 
-**A batch already has more than one image.** `Batch.WithConcurrency` runs N of
-them at a time inside the one exec, and pairs itself with the bound rather than
-leaving two knobs to reconcile by hand. Eleven copies of the four-line test
-fixture through `Batch.Export`, four CPUs — the same fixture and CPU count as
-the oversubscription table above, not the full page the two before it use:
+**A batch already has more than one image, so it answers this itself.**
+`Batch.WithConcurrency` defaults to one recognition per CPU, and recognising
+more than one at a time also caps that batch's OpenMP at one thread per
+process. Eleven copies of the four-line fixture, four pinned CPUs, timed
+against tesseract directly rather than through the module — the same fixture
+and CPU count as the oversubscription table above, not the full page the two
+before it use:
 
-| `WithConcurrency` | `OMP_THREAD_LIMIT` | wall | CPU |
+| concurrent passes | `OMP_THREAD_LIMIT` | wall | CPU |
 | --- | --- | --- | --- |
-| unset — 1 | the image's, unset | 3.37s | 5.78s |
-| 4 | `1`, on the exec | 1.24s | 4.21s |
-| 8 | `1`, on the exec | 1.18s | 4.25s |
-| 11 | `1`, on the exec | **1.05s** | 4.12s |
-| 4 | the image's, unset | **3m36.8s** | 14m24s |
+| 1 | unset | 3.37s | 5.78s |
+| 4 | `1` | 1.24s | 4.21s |
+| 8 | `1` | 1.18s | 4.25s |
+| 11 | `1` | **1.05s** | 4.12s |
+| 4 | unset | **3m36.8s** | 14m24s |
 
-The last row is the whole reason concurrency implies the bound: it is the same
-four workers as the second row, inheriting an unbounded image, 174x apart. A
-caller who reaches for concurrency without having read anything about libgomp
-lands on the second row rather than the last. `WithConcurrency(11)` landing on
-the 1.06s the oversubscription table reports for eleven bare concurrent
-processes is the other half of it — the runner itself costs nothing.
+The last row is the whole reason concurrency implies the bound: same four
+passes as the second row, threads unbounded, 174x apart. A caller who reaches
+for concurrency without having read anything about libgomp would otherwise land
+there. (What `Batch` costs on top of these numbers is a separate question, and a
+separate measurement, in [One exec per image](#one-exec-per-image-fanned-out-from-go).)
 
-An `ompThreadLimit` named on `New` is left alone, because it was named. The
-automatic bound is a `WithEnvVariable` on that one batch's exec, so the image
-keeps whatever it had and every other caller's recognition is untouched.
+An `ompThreadLimit` named on `New` is left alone, because it was named.
+Otherwise the bound rides on a copy of the module the batch makes for itself, so
+the caller's image keeps whatever it had, every other caller's recognition is
+untouched, and both images still share the package fetch.
 
 ## Toolchain
 
@@ -360,7 +362,7 @@ fine-tuning.
 Tesseract.Batch(source *dagger.Directory) *Batch
 
 Batch.WithGlob(pattern string) *Batch          // default: the image extensions below
-Batch.WithConcurrency(concurrency int) *Batch  // default: 1
+Batch.WithConcurrency(concurrency int) *Batch  // default: one per CPU
 Batch.WithLanguage(lang string) *Batch         // …and the six other Document builders
 Batch.Files(ctx) ([]string, error)
 Batch.Export(ctx, formats []Format) (*dagger.Directory, error)
@@ -384,49 +386,69 @@ of all for PDF. (That behaviour is not useless — it is precisely what the page
 of one PDF want, and `FromPdf` below is built on it. It is just not what a
 folder of independent scans wants.)
 
-So the batch is one container **exec** rather than one tesseract **process**: the
-exec loops over a manifest, recognising each image onto its own output base. That
-collapses the part that actually costs anything in Dagger — a `WithExec`, its
-mounts and its cache lookup, per page — to one, while each page keeps its own
-artifacts. The loop reaches flags and configfiles through `"$@"` rather than
-string interpolation, so no value needs escaping.
+So a batch is its images recognised as **`Document`s** — one exec each, each
+mounting its own image, each rendering its own artifact set — and what runs
+several of them at a time is Go.
 
-### `WithConcurrency` — how many at once inside that exec
-
-Collapsing the exec was only half the cost. The recognitions themselves ran one
-after another, and recognition is where all the time is. `WithConcurrency`
-bounds how many of them run at the same time — still inside the one exec, still
-one artifact set per image.
+### One exec per image, fanned out from Go
 
 ```go
-tess.Batch(scans).WithConcurrency(4).Export(ctx, formats)
+tess.Batch(scans).WithConcurrency(8).Export(ctx, formats)   // default: one per CPU
 ```
 
-**The default is 1**, unchanged from before the knob existed, and a non-positive
-bound is refused at output time rather than quietly recognising nothing. Above 1
-it also caps OpenMP at one thread per process *for that exec* — see [OpenMP
-fan-out](#openmp-fan-out--ompthreadlimit) for the measured reason, which is that
-concurrency multiplied by threads is the one shape slower than doing nothing. An
-`ompThreadLimit` named on `New` wins; nothing is set on the image either way.
+`Batch.Export` resolves the glob, builds a `Document` per match, and runs them
+through a slot channel bounded by `WithConcurrency`. The bound, the scheduling,
+the fail-fast and the error message are all `batch.go` — nothing about running a
+batch is interpreted inside a container, so all of it is typed, reviewable and
+debuggable the same way the rest of the module is.
 
-Two things the serial loop got for free and the runner has to keep:
+That is a reversal. Until #298 the batch was **one** exec looping a
+tab-separated manifest in `sh`, on the argument that the exec — its mounts, its
+cache lookup — was the expensive part and should be paid once per directory
+rather than once per page. Measured end-to-end, it is not:
+
+| pages | one exec, `sh` loop | one exec per image, Go fan-out |
+| --- | --- | --- |
+| 11 | 5.5s | **2.8s** |
+| 50 | 17.5s | **5.0s** |
+| 50, one page edited | 17.5s | **2.5s** |
+
+`dagger call batch --source=… export --formats=TXT entries`, median of three,
+cold inputs each run, 32-CPU host; ~1.7s of every figure is CLI startup and
+module load. The one-exec column is the manifest loop recognising one image at a
+time, which is what it did, threads unbounded; the Go column is the default —
+one recognition per CPU, one OpenMP thread each.
+
+The last row is the one that does not close with more cores. The old exec
+mounted the whole source directory, so editing any page invalidated the mount
+and re-recognised **all fifty**; a per-image exec keys on that image, so the
+other forty-nine are cache hits. For a corpus that grows or gets corrected a
+page at a time, that is the difference between a re-run and a re-do.
+
+Three properties the serial loop had for free, which the fan-out has to keep:
 
 - **A page that cannot be read still fails the batch**, rather than going
-  missing from a thousand results. Each recognition's output is captured and
-  reported as one block naming its image — `xargs -P` would answer a failed
-  child with its own exit 123, which names nothing, and tesseract's own message
-  often cannot name it either: handed a file leptonica will not decode, it falls
-  back to reading it as a list of image paths and reports the *contents* of the
-  first line as the file it could not open. The first failure raises a stop flag
-  every worker checks, so the run does not recognise the remaining pages first.
-- **Output directories are created in one serial pass** before any recognition
-  starts. Several images share a directory, and two workers creating
-  `scans/deep` at the same moment is a race worth not having.
+  missing from a thousand results, and the error names the page — tesseract's
+  own message often cannot, because handed a file leptonica will not decode it
+  falls back to reading the file as a list of image paths and reports the
+  *contents* of the first line as the file it could not open.
+- **The first failure cancels the rest.** A batch that is going to fail has no
+  reason to recognise the remaining pages first.
+- **The artifacts are assembled in sorted order**, off execs that finished in
+  whatever order they finished in, so the returned directory does not depend on
+  the scheduling.
 
-Work is partitioned round-robin over the manifest, so a worker knows which
-records are its own without coordinating with anyone. Somewhere around the core
-count is the number to pass; past that each process is already single-threaded
-and there is little left to win.
+What it no longer has to do is protect a record format: file names with tabs or
+newlines in them were rejected when a manifest had to carry them, and are
+ordinary inputs now.
+
+Recognising more than one image at a time also caps OpenMP at one thread per
+process, unless an `ompThreadLimit` was named on `New` — see [OpenMP
+fan-out](#openmp-fan-out--ompthreadlimit) for the measured reason, which is that
+concurrency multiplied by threads is the one shape slower than doing nothing.
+The bound rides on a copy of the module rather than the caller's, so nothing
+else built from the same `Tesseract` sees it, and the two images still share the
+package fetch.
 
 ### Which files take part
 
@@ -718,7 +740,7 @@ letting tesseract fail in its own vocabulary.
 | a `Batch` glob matching nothing | an empty directory is indistinguishable from a batch that ran and found no text, so a typo would surface much later as missing output |
 | a `Batch` source holding no images | same, but the fix is `WithGlob` rather than the pattern, so the message names the default extension set |
 | two `Batch` inputs sharing an output base | `a.png` and `a.jpg` both render onto `a.txt`; the second silently overwrites the first and the run looks like it succeeded with a page missing |
-| a `Batch` file name containing a tab or newline | the manifest is tab-separated and newline-delimited, so the loop would recognise the wrong file |
+| a `Training` file name containing a tab or newline | its manifest is tab-separated and newline-delimited, so the sample-building loop would act on the wrong file. `Batch` needed this too until its manifest went away |
 | a `Training` image with no `.gt.txt`, or a `.gt.txt` with no image | training directories are assembled by script and fail off-by-one; "something is unpaired" sends the caller to diff two file listings, the file's name does not |
 | two `Training` images pairing with one `.gt.txt` | `a.png` and `a.jpg` would build two samples from one transcription, and only one `.box` |
 | a `Training` `.gt.txt` that is empty or holds several lines | the box claims the whole image renders exactly this text; against a two-line image that is false in a way training cannot recover from — the network is shown two lines of pixels and told they are one line of characters |
@@ -741,6 +763,13 @@ and there is no chained-method propagation problem to worry about. `Container`,
 `Version`, `Langs` and `Parameters` take `+cache="session"` per `kicad`, because
 a floating Alpine tag can resolve differently across sessions.
 
+What *is* worth knowing is the granularity underneath those functions. A `Batch`
+recognises each image in its own exec mounting only that image, so the engine
+caches per page: the second export of a fifty-page folder with one page edited
+re-recognises one page. `Training` is the opposite by nature — one exec for the
+whole run, one cache entry, see [One exec, one cache entry](#one-exec-one-cache-entry)
+— because a fine-tune is not separable into per-sample work.
+
 ## Follow-ups
 
 An `examples/go` cookbook (#224); evaluation against a held-out set (#231);
@@ -756,6 +785,12 @@ whole intake folder has no single answer for them. A caller who needs one is
 configuring a `Batch`, not a CI. `WithGlob` is absent for the same reason from
 the other direction: the default takes the images and leaves the manifests, which
 is what pointing this at an existing scan folder should do.
+
+`WithConcurrency` is not in that category — it changes how long the same run
+takes and nothing about how a scan is read — but `Ci` still does not forward it,
+because it inherits the default (one recognition per CPU) and narrowing that is
+a different request. #305 is the open question of whether it should, given `Run`
+makes two batch passes that may want different answers.
 
 Batch OCR over a directory (#220) and PDF-input rasterization (#221) both
 landed — see above. `Batch` still deliberately does not expose the concatenated

--- a/daggerverse/tesseract/README.md
+++ b/daggerverse/tesseract/README.md
@@ -197,6 +197,31 @@ still share the package fetch. A negative value is rejected on `New` — libgomp
 reads an unparseable `OMP_THREAD_LIMIT` as absent and silently goes back to one
 thread per CPU, the opposite of what was asked for.
 
+**A batch already has more than one image.** `Batch.WithConcurrency` runs N of
+them at a time inside the one exec, and pairs itself with the bound rather than
+leaving two knobs to reconcile by hand. Eleven copies of the four-line test
+fixture through `Batch.Export`, four CPUs — the same fixture and CPU count as
+the oversubscription table above, not the full page the two before it use:
+
+| `WithConcurrency` | `OMP_THREAD_LIMIT` | wall | CPU |
+| --- | --- | --- | --- |
+| unset — 1 | the image's, unset | 3.37s | 5.78s |
+| 4 | `1`, on the exec | 1.24s | 4.21s |
+| 8 | `1`, on the exec | 1.18s | 4.25s |
+| 11 | `1`, on the exec | **1.05s** | 4.12s |
+| 4 | the image's, unset | **3m36.8s** | 14m24s |
+
+The last row is the whole reason concurrency implies the bound: it is the same
+four workers as the second row, inheriting an unbounded image, 174x apart. A
+caller who reaches for concurrency without having read anything about libgomp
+lands on the second row rather than the last. `WithConcurrency(11)` landing on
+the 1.06s the oversubscription table reports for eleven bare concurrent
+processes is the other half of it — the runner itself costs nothing.
+
+An `ompThreadLimit` named on `New` is left alone, because it was named. The
+automatic bound is a `WithEnvVariable` on that one batch's exec, so the image
+keeps whatever it had and every other caller's recognition is untouched.
+
 ## Toolchain
 
 ```go
@@ -334,8 +359,9 @@ fine-tuning.
 ```go
 Tesseract.Batch(source *dagger.Directory) *Batch
 
-Batch.WithGlob(pattern string) *Batch    // default: the image extensions below
-Batch.WithLanguage(lang string) *Batch   // …and the six other Document builders
+Batch.WithGlob(pattern string) *Batch          // default: the image extensions below
+Batch.WithConcurrency(concurrency int) *Batch  // default: 1
+Batch.WithLanguage(lang string) *Batch         // …and the six other Document builders
 Batch.Files(ctx) ([]string, error)
 Batch.Export(ctx, formats []Format) (*dagger.Directory, error)
 ```
@@ -364,6 +390,43 @@ collapses the part that actually costs anything in Dagger — a `WithExec`, its
 mounts and its cache lookup, per page — to one, while each page keeps its own
 artifacts. The loop reaches flags and configfiles through `"$@"` rather than
 string interpolation, so no value needs escaping.
+
+### `WithConcurrency` — how many at once inside that exec
+
+Collapsing the exec was only half the cost. The recognitions themselves ran one
+after another, and recognition is where all the time is. `WithConcurrency`
+bounds how many of them run at the same time — still inside the one exec, still
+one artifact set per image.
+
+```go
+tess.Batch(scans).WithConcurrency(4).Export(ctx, formats)
+```
+
+**The default is 1**, unchanged from before the knob existed, and a non-positive
+bound is refused at output time rather than quietly recognising nothing. Above 1
+it also caps OpenMP at one thread per process *for that exec* — see [OpenMP
+fan-out](#openmp-fan-out--ompthreadlimit) for the measured reason, which is that
+concurrency multiplied by threads is the one shape slower than doing nothing. An
+`ompThreadLimit` named on `New` wins; nothing is set on the image either way.
+
+Two things the serial loop got for free and the runner has to keep:
+
+- **A page that cannot be read still fails the batch**, rather than going
+  missing from a thousand results. Each recognition's output is captured and
+  reported as one block naming its image — `xargs -P` would answer a failed
+  child with its own exit 123, which names nothing, and tesseract's own message
+  often cannot name it either: handed a file leptonica will not decode, it falls
+  back to reading it as a list of image paths and reports the *contents* of the
+  first line as the file it could not open. The first failure raises a stop flag
+  every worker checks, so the run does not recognise the remaining pages first.
+- **Output directories are created in one serial pass** before any recognition
+  starts. Several images share a directory, and two workers creating
+  `scans/deep` at the same moment is a race worth not having.
+
+Work is partitioned round-robin over the manifest, so a worker knows which
+records are its own without coordinating with anyone. Somewhere around the core
+count is the number to pass; past that each process is already single-threaded
+and there is little left to win.
 
 ### Which files take part
 

--- a/daggerverse/tesseract/batch.go
+++ b/daggerverse/tesseract/batch.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path"
 	"sort"
+	"strconv"
 	"strings"
 
 	"dagger/tesseract/internal/dagger"
@@ -16,18 +17,93 @@ import (
 // from needing any escaping at all.
 const batchArgv0 = "tesseract-batch"
 
-// batchScript is the whole of the batch mechanism: read one record per image,
-// create its output directory, recognise it.
+// batchScriptTemplate is the whole of the batch mechanism: one serial pass
+// creating every output directory, then N concurrent passes over the same
+// manifest, each recognising the records whose index it owns.
 //
-// `set -e` aborts on the first failure, so a page tesseract cannot read fails
-// the run carrying its own message instead of going quietly missing from the
-// results. IFS is a literal tab, so a file name with spaces survives the read;
-// checkManifestSafe rejects the tabs and newlines that would not.
-const batchScript = `set -e
-while IFS="` + "\t" + `" read -r src out dir; do
+// The directories are created up front rather than in the recognition pass
+// because several images share one: two workers creating `scans/deep` at the
+// same moment is a race, and creating them all while nothing is running costs
+// one mkdir per record and removes it.
+//
+// Round-robin over record index is what partitions the work, so a worker knows
+// which records are its own without coordinating with the others — the manifest
+// is read once per worker and nothing is popped from a shared queue. `xargs -P`
+// would schedule better on records of uneven cost, but it answers a failed
+// child with its own exit 123 and names nothing, and naming the image that
+// failed is the whole of what the serial loop's `set -e` used to do for free.
+//
+// Each recognition's output is captured rather than streamed, so a failure
+// reports as one block naming its image instead of interleaving with whatever
+// the other workers are writing. tesseract's own message frequently cannot name
+// it: handed a file leptonica will not decode, tesseract falls back to reading
+// it as a list of image paths and reports the *contents* of the first line as
+// the file it could not open.
+//
+// The first failure touches the stop file, which every worker checks before its
+// next image, so a batch that is already going to fail stops within one image
+// per worker rather than recognising the remaining thousand pages first.
+//
+// IFS is a literal tab, so a file name with spaces survives the read;
+// checkManifestSafe rejects the tabs and newlines that would not. Every
+// recognition flag reaches the workers as `"$@"`, which is why the function
+// takes its slot as `$1` and shifts it off.
+const batchScriptTemplate = `set -e
+mkdir -p @FAILURES@
+
+while IFS="	" read -r src out dir; do
 	mkdir -p "$dir"
-	tesseract "$src" "$out" "$@"
-done < ` + batchManifestPath
+done < @MANIFEST@
+
+recognise() {
+	slot=$1
+	shift
+	index=0
+	while IFS="	" read -r src out dir; do
+		if [ $((index % @WORKERS@)) -eq "$slot" ]; then
+			if [ -e @STOP@ ]; then
+				return 1
+			fi
+			if ! output=$(tesseract "$src" "$out" "$@" 2>&1); then
+				printf '%s:\n%s\n' "$src" "$output" >> "@FAILURES@/$slot"
+				: > @STOP@
+				return 1
+			fi
+		fi
+		index=$((index + 1))
+	done < @MANIFEST@
+}
+
+slot=0
+pids=""
+while [ "$slot" -lt @WORKERS@ ]; do
+	recognise "$slot" "$@" &
+	pids="$pids $!"
+	slot=$((slot + 1))
+done
+
+failed=0
+for pid in $pids; do
+	wait "$pid" || failed=1
+done
+
+if [ "$failed" -ne 0 ]; then
+	cat @FAILURES@/* >&2
+	exit 1
+fi`
+
+// batchScript renders the template for a given number of workers. The
+// substitutions are container paths this module owns and an integer it has
+// already validated, so none of them can carry anything the shell would have to
+// be protected from — unlike the recognition flags, which stay in `"$@"`.
+func batchScript(workers int) string {
+	return strings.NewReplacer(
+		"@MANIFEST@", batchManifestPath,
+		"@FAILURES@", batchFailureDir,
+		"@STOP@", batchStopFile,
+		"@WORKERS@", strconv.Itoa(workers),
+	).Replace(batchScriptTemplate)
+}
 
 // imageExtensions is what the default glob accepts, lower-cased for a
 // case-insensitive comparison. It is the set this image can actually decode:
@@ -53,6 +129,10 @@ type Batch struct {
 	// +private
 	Glob string
 	// +private
+	Concurrency int
+	// +private
+	HasConcurrency bool
+	// +private
 	Options options
 }
 
@@ -69,6 +149,38 @@ type Batch struct {
 func (b *Batch) WithGlob(pattern string) *Batch {
 	out := *b
 	out.Glob = pattern
+	return &out
+}
+
+// WithConcurrency bounds how many images the batch recognises at once. The
+// default is one, which is what a batch has always done.
+//
+// Recognition is where a batch spends its time, and it is the one thing the
+// serial loop does not collapse: N independent images recognised one after
+// another. Processes are how tesseract parallelises well — eleven pages on four
+// CPUs take 3.37s one at a time and 1.05s eleven at a time, ~90% efficiency
+// where its own OpenMP manages 33%, because those regions sit inside the LSTM
+// inner loops and do not amortize.
+//
+// A bound above one therefore also caps OpenMP at one thread per process for
+// this batch's exec, unless the caller named an explicit ompThreadLimit on New,
+// which is left alone. Concurrency multiplied by per-process threads rather
+// than bounded by cores is the one shape that is slower than doing nothing:
+// those same four workers on an unbounded image take 3m36.8s against 1.24s
+// bounded, 174x. The bound is set on the exec rather than on the image, so
+// nothing else built from the same Tesseract sees it and two batches differing
+// only in concurrency still share the package fetch.
+//
+// Somewhere around the core count is the number to pass; more processes than
+// cores buys little once each is single-threaded. Non-positive is rejected at
+// output time.
+func (b *Batch) WithConcurrency(
+	// Maximum number of images to recognise at the same time.
+	concurrency int,
+) *Batch {
+	out := *b
+	out.Concurrency = concurrency
+	out.HasConcurrency = true
 	return &out
 }
 
@@ -115,7 +227,8 @@ func (b *Batch) WithUserPatterns(patterns *dagger.File) *Batch {
 }
 
 // Files lists the images the batch will recognise, as paths relative to the
-// source directory root, in the order they are processed.
+// source directory root, sorted — which is the order they are recognised in
+// until WithConcurrency deals them out to several workers at once.
 //
 // It answers the question a glob always raises — did that pattern pick up what
 // I meant? — without paying for the recognition, and it fails on an empty match
@@ -135,7 +248,8 @@ func (b *Batch) Files(ctx context.Context) ([]string, error) {
 // multi-page PDF) and offers no way to get the per-image files this returns.
 // So the exec loops over the manifest instead, which keeps the expensive part
 // — a container exec, its mounts and its cache lookup, per page — collapsed to
-// one, while each image still gets its own output base.
+// one, while each image still gets its own output base. How many of those
+// recognitions run at once inside that one exec is WithConcurrency.
 func (b *Batch) Export(
 	ctx context.Context,
 	// Output formats to render for each image in the batch.
@@ -143,6 +257,9 @@ func (b *Batch) Export(
 ) (*dagger.Directory, error) {
 	configs, err := selectFormats(formats)
 	if err != nil {
+		return nil, err
+	}
+	if err := b.validateConcurrency(); err != nil {
 		return nil, err
 	}
 	sources, err := b.matches(ctx)
@@ -161,7 +278,7 @@ func (b *Batch) Export(
 		return nil, err
 	}
 
-	args := append([]string{"sh", "-c", batchScript, batchArgv0}, flags...)
+	args := append([]string{"sh", "-c", batchScript(b.workers()), batchArgv0}, flags...)
 	exec, err := execTesseract(ctx, b.container(manifest), append(args, configs...))
 	if err != nil {
 		return nil, err
@@ -179,10 +296,43 @@ func (b *Batch) with(opts options) *Batch {
 
 // container mounts the source directory and the manifest the exec loops over,
 // alongside whatever the options bring with them.
+//
+// A concurrent batch also bounds OpenMP here, on the exec rather than on the
+// image: concurrency multiplied by per-process threads is the shape that
+// collapses (see WithConcurrency), and one thread per process is the only one
+// worth running. An ompThreadLimit the caller named on New is theirs and is
+// left alone — it is already on the image, and overriding it would ignore the
+// one instruction on the subject this module was given.
 func (b *Batch) container(manifest *dagger.File) *dagger.Container {
-	return b.Options.mount(b.Tesseract.Container().
+	ctr := b.Tesseract.Container().
 		WithMountedDirectory(batchSourceDir, b.Source).
-		WithMountedFile(batchManifestPath, manifest))
+		WithMountedFile(batchManifestPath, manifest)
+	if b.workers() > 1 && b.Tesseract.OmpThreadLimit == hostCpuOmpThreadLimit {
+		ctr = ctr.WithEnvVariable(ompThreadLimitEnv, strconv.Itoa(concurrentOmpThreadLimit))
+	}
+	return b.Options.mount(ctr)
+}
+
+// workers is how many tesseract processes one Export runs at once: whatever
+// WithConcurrency asked for, or one.
+func (b *Batch) workers() int {
+	if !b.HasConcurrency {
+		return defaultBatchConcurrency
+	}
+	return b.Concurrency
+}
+
+// validateConcurrency rejects a bound that would run no images at all. It is
+// deferred to output time rather than reported from the builder because a
+// builder has no error return, which is the same reason WithDpi's check lives
+// away from WithDpi.
+func (b *Batch) validateConcurrency() error {
+	if b.HasConcurrency && b.Concurrency < defaultBatchConcurrency {
+		return fmt.Errorf(
+			"WithConcurrency: concurrency must be positive, got %d: pass 1 to recognise one image at a time, which is what leaving it unset does",
+			b.Concurrency)
+	}
+	return nil
 }
 
 // matches resolves the glob into the sorted list of images to recognise, and

--- a/daggerverse/tesseract/batch.go
+++ b/daggerverse/tesseract/batch.go
@@ -4,106 +4,13 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"runtime"
 	"sort"
-	"strconv"
 	"strings"
+	"sync"
 
 	"dagger/tesseract/internal/dagger"
 )
-
-// batchArgv0 is the `$0` the batch loop runs under. Every recognition flag and
-// configfile reaches the loop as `"$@"` rather than being interpolated into the
-// script, which is what keeps a parameter value with a space or a quote in it
-// from needing any escaping at all.
-const batchArgv0 = "tesseract-batch"
-
-// batchScriptTemplate is the whole of the batch mechanism: one serial pass
-// creating every output directory, then N concurrent passes over the same
-// manifest, each recognising the records whose index it owns.
-//
-// The directories are created up front rather than in the recognition pass
-// because several images share one: two workers creating `scans/deep` at the
-// same moment is a race, and creating them all while nothing is running costs
-// one mkdir per record and removes it.
-//
-// Round-robin over record index is what partitions the work, so a worker knows
-// which records are its own without coordinating with the others — the manifest
-// is read once per worker and nothing is popped from a shared queue. `xargs -P`
-// would schedule better on records of uneven cost, but it answers a failed
-// child with its own exit 123 and names nothing, and naming the image that
-// failed is the whole of what the serial loop's `set -e` used to do for free.
-//
-// Each recognition's output is captured rather than streamed, so a failure
-// reports as one block naming its image instead of interleaving with whatever
-// the other workers are writing. tesseract's own message frequently cannot name
-// it: handed a file leptonica will not decode, tesseract falls back to reading
-// it as a list of image paths and reports the *contents* of the first line as
-// the file it could not open.
-//
-// The first failure touches the stop file, which every worker checks before its
-// next image, so a batch that is already going to fail stops within one image
-// per worker rather than recognising the remaining thousand pages first.
-//
-// IFS is a literal tab, so a file name with spaces survives the read;
-// checkManifestSafe rejects the tabs and newlines that would not. Every
-// recognition flag reaches the workers as `"$@"`, which is why the function
-// takes its slot as `$1` and shifts it off.
-const batchScriptTemplate = `set -e
-mkdir -p @FAILURES@
-
-while IFS="	" read -r src out dir; do
-	mkdir -p "$dir"
-done < @MANIFEST@
-
-recognise() {
-	slot=$1
-	shift
-	index=0
-	while IFS="	" read -r src out dir; do
-		if [ $((index % @WORKERS@)) -eq "$slot" ]; then
-			if [ -e @STOP@ ]; then
-				return 1
-			fi
-			if ! output=$(tesseract "$src" "$out" "$@" 2>&1); then
-				printf '%s:\n%s\n' "$src" "$output" >> "@FAILURES@/$slot"
-				: > @STOP@
-				return 1
-			fi
-		fi
-		index=$((index + 1))
-	done < @MANIFEST@
-}
-
-slot=0
-pids=""
-while [ "$slot" -lt @WORKERS@ ]; do
-	recognise "$slot" "$@" &
-	pids="$pids $!"
-	slot=$((slot + 1))
-done
-
-failed=0
-for pid in $pids; do
-	wait "$pid" || failed=1
-done
-
-if [ "$failed" -ne 0 ]; then
-	cat @FAILURES@/* >&2
-	exit 1
-fi`
-
-// batchScript renders the template for a given number of workers. The
-// substitutions are container paths this module owns and an integer it has
-// already validated, so none of them can carry anything the shell would have to
-// be protected from — unlike the recognition flags, which stay in `"$@"`.
-func batchScript(workers int) string {
-	return strings.NewReplacer(
-		"@MANIFEST@", batchManifestPath,
-		"@FAILURES@", batchFailureDir,
-		"@STOP@", batchStopFile,
-		"@WORKERS@", strconv.Itoa(workers),
-	).Replace(batchScriptTemplate)
-}
 
 // imageExtensions is what the default glob accepts, lower-cased for a
 // case-insensitive comparison. It is the set this image can actually decode:
@@ -121,6 +28,13 @@ var imageExtensions = []string{
 // Batch is a directory of images plus the recognition options that apply to
 // all of them. It carries the same options type Document does, so the two
 // cannot drift: every With* here forwards to the shared builder.
+//
+// It is also built out of Document rather than merely resembling one. Each
+// matched image is recognised as its own Document — its own exec, its own
+// mounts, its own cache entry — and what runs several of them at a time is Go,
+// not a runner inside a container. That is what keeps the scheduling, the
+// bound and the failure reporting in a language with types and a debugger,
+// instead of in a shell script mounted into an image.
 type Batch struct {
 	// +private
 	Tesseract *Tesseract
@@ -152,28 +66,25 @@ func (b *Batch) WithGlob(pattern string) *Batch {
 	return &out
 }
 
-// WithConcurrency bounds how many images the batch recognises at once. The
-// default is one, which is what a batch has always done.
+// WithConcurrency bounds how many images the batch recognises at once.
 //
-// Recognition is where a batch spends its time, and it is the one thing the
-// serial loop does not collapse: N independent images recognised one after
-// another. Processes are how tesseract parallelises well — eleven pages on four
-// CPUs take 3.37s one at a time and 1.05s eleven at a time, ~90% efficiency
-// where its own OpenMP manages 33%, because those regions sit inside the LSTM
-// inner loops and do not amortize.
+// It defaults to the number of CPUs the module can see, which is what a batch
+// wants: every image is its own exec, and recognising them one at a time would
+// pay that overhead N times for none of the parallelism it buys. Processes are
+// how tesseract parallelises well — eleven pages on four CPUs take 3.37s one at
+// a time and 1.05s eleven at a time, ~90% efficiency where its own OpenMP
+// manages 33%, because those regions sit inside the LSTM inner loops and do not
+// amortize.
 //
-// A bound above one therefore also caps OpenMP at one thread per process for
-// this batch's exec, unless the caller named an explicit ompThreadLimit on New,
-// which is left alone. Concurrency multiplied by per-process threads rather
-// than bounded by cores is the one shape that is slower than doing nothing:
-// those same four workers on an unbounded image take 3m36.8s against 1.24s
-// bounded, 174x. The bound is set on the exec rather than on the image, so
-// nothing else built from the same Tesseract sees it and two batches differing
-// only in concurrency still share the package fetch.
+// Recognising more than one at a time therefore also caps OpenMP at one thread
+// per process, unless the caller named an explicit ompThreadLimit on New, which
+// is left alone. Concurrency multiplied by per-process threads rather than
+// bounded by cores is the one shape that is slower than doing nothing: four
+// concurrent unbounded passes on four CPUs take 3m36.8s against 1.24s bounded,
+// 174x.
 //
-// Somewhere around the core count is the number to pass; more processes than
-// cores buys little once each is single-threaded. Non-positive is rejected at
-// output time.
+// Pass a number to take less of the machine than the default, or 1 to recognise
+// one image at a time. Non-positive is rejected at output time.
 func (b *Batch) WithConcurrency(
 	// Maximum number of images to recognise at the same time.
 	concurrency int,
@@ -227,8 +138,10 @@ func (b *Batch) WithUserPatterns(patterns *dagger.File) *Batch {
 }
 
 // Files lists the images the batch will recognise, as paths relative to the
-// source directory root, sorted — which is the order they are recognised in
-// until WithConcurrency deals them out to several workers at once.
+// source directory root, sorted. Sorted is not the order they are recognised
+// in — they run several at a time — but it is the order their artifacts are
+// assembled in, so the returned directory is the same whatever the scheduling
+// did.
 //
 // It answers the question a glob always raises — did that pattern pick up what
 // I meant? — without paying for the recognition, and it fails on an empty match
@@ -241,21 +154,24 @@ func (b *Batch) Files(ctx context.Context) ([]string, error) {
 // input layout, with one artifact per requested format per image: `scans/a.png`
 // becomes `scans/a.txt` alongside `scans/a.pdf`.
 //
-// The whole batch is one container exec. tesseract's own list-file mode — a
-// text file of image paths as the FILE argument — is not what does that here,
-// because it treats the list as one multi-page *document*: it renders a single
-// concatenated artifact set (one .txt with form-feed page breaks, one
-// multi-page PDF) and offers no way to get the per-image files this returns.
-// So the exec loops over the manifest instead, which keeps the expensive part
-// — a container exec, its mounts and its cache lookup, per page — collapsed to
-// one, while each image still gets its own output base. How many of those
-// recognitions run at once inside that one exec is WithConcurrency.
+// Each image is recognised on its own, as its own exec, WithConcurrency of them
+// at a time. tesseract's own list-file mode — a text file of image paths as the
+// FILE argument — is not what a batch wants, because it treats the list as one
+// multi-page *document*: it renders a single concatenated artifact set (one .txt
+// with form-feed page breaks, one multi-page PDF) and offers no way to get the
+// per-image files this returns.
+//
+// One exec per image is what makes the results cache per image too: an edited
+// page invalidates its own recognition and nothing else, which is the whole
+// difference for a corpus that grows a page at a time. It costs one exec's
+// overhead per page instead of per batch — see the README for what that is
+// worth measured — and it is the shape that lets the fan-out live in Go.
 func (b *Batch) Export(
 	ctx context.Context,
 	// Output formats to render for each image in the batch.
 	formats []Format,
 ) (*dagger.Directory, error) {
-	configs, err := selectFormats(formats)
+	selected, err := selectedFormats(formats)
 	if err != nil {
 		return nil, err
 	}
@@ -266,24 +182,119 @@ func (b *Batch) Export(
 	if err != nil {
 		return nil, err
 	}
+	// Validated once here rather than per image: the checks are the same for
+	// every recognition in the batch, and a bad option should be reported as
+	// itself instead of as a failure of whichever page happened to run first.
 	if err := b.Options.validate(ctx, b.Tesseract); err != nil {
 		return nil, err
 	}
-	manifest, err := batchManifest(sources)
-	if err != nil {
-		return nil, err
-	}
-	flags, err := b.Options.flags(b.Tesseract)
+
+	execs, err := b.recognise(ctx, sources, formatConfigs(selected))
 	if err != nil {
 		return nil, err
 	}
 
-	args := append([]string{"sh", "-c", batchScript(b.workers()), batchArgv0}, flags...)
-	exec, err := execTesseract(ctx, b.container(manifest), append(args, configs...))
-	if err != nil {
-		return nil, err
+	// Assembling the mirrored directory is pure graph-building — every
+	// recognition has already run — so it is one WithFile per artifact, in a
+	// fixed order, off the exec that produced it.
+	out := dag.Directory()
+	for i, source := range sources {
+		base := outputBaseFor(source)
+		for _, format := range selected {
+			ext := formatTable[format].ext
+			out = out.WithFile(base+ext, execs[i].File(outputBase+ext))
+		}
 	}
-	return exec.Directory(outputDir), nil
+	return out, nil
+}
+
+// recognise runs one exec per image, at most workers() of them at a time, and
+// returns the finished execs positionally.
+//
+// The bound is a slot channel rather than an unbounded fan-out because a
+// thousand pages is a thousand containers otherwise, and because recognition
+// that is already using every core gains nothing from being asked for more of
+// them at once.
+//
+// The first failure cancels the rest: a batch that is going to fail has no
+// reason to recognise the remaining pages first, and the error it reports names
+// the image. tesseract's own message usually cannot — handed a file leptonica
+// will not decode, it falls back to reading the file as a list of image paths
+// and reports the *contents* of its first line as the file it could not open.
+func (b *Batch) recognise(ctx context.Context, sources []string, configs []string) ([]*dagger.Container, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var (
+		wg    sync.WaitGroup
+		mu    sync.Mutex
+		first error
+	)
+	execs := make([]*dagger.Container, len(sources))
+	slots := make(chan struct{}, b.workers())
+
+	for i, source := range sources {
+		wg.Go(func() {
+			select {
+			case slots <- struct{}{}:
+				defer func() { <-slots }()
+			case <-ctx.Done():
+				return
+			}
+
+			exec, err := b.document(source).run(ctx, outputBase, configs...)
+
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				// Formatted rather than %w-wrapped: the error crosses the
+				// module boundary, which unwraps a chain back to the inner
+				// error and would drop the image's name along with it.
+				if first == nil {
+					first = fmt.Errorf("Batch: %q: %v", source, err)
+					cancel()
+				}
+				return
+			}
+			execs[i] = exec
+		})
+	}
+	wg.Wait()
+
+	if first != nil {
+		return nil, first
+	}
+	return execs, nil
+}
+
+// document binds one matched image to the toolchain as the Document it is, so
+// the two units of work share their execution as well as their option set: a
+// batch is its images recognised as Documents, several at a time.
+func (b *Batch) document(source string) *Document {
+	return &Document{
+		Tesseract: b.toolchain(),
+		Source:    b.Source.File(source),
+		Options:   b.Options,
+	}
+}
+
+// toolchain is the module the batch's recognitions run on: the caller's, or a
+// copy bounded to one OpenMP thread when several of them run at once.
+//
+// Concurrency multiplied by per-process threads rather than bounded by cores is
+// the one shape slower than doing nothing (see WithConcurrency), and one thread
+// per process is the fast shape outright. The bound rides on a copy of the
+// module rather than on the caller's, so nothing else built from the same
+// Tesseract sees it; it is applied after `apk add`, so the two images still
+// share the package fetch. An ompThreadLimit the caller named on New is theirs
+// and is left alone.
+func (b *Batch) toolchain() *Tesseract {
+	if b.workers() <= minBatchConcurrency || b.Tesseract.OmpThreadLimit != hostCpuOmpThreadLimit {
+		return b.Tesseract
+	}
+	out := b.Tesseract.clone()
+	out.OmpThreadLimit = concurrentOmpThreadLimit
+	return out
 }
 
 // with returns a copy of the batch carrying a new option set, which is what
@@ -294,32 +305,21 @@ func (b *Batch) with(opts options) *Batch {
 	return &out
 }
 
-// container mounts the source directory and the manifest the exec loops over,
-// alongside whatever the options bring with them.
+// workers is how many recognitions run at once: whatever WithConcurrency asked
+// for, or one per CPU the module can see.
 //
-// A concurrent batch also bounds OpenMP here, on the exec rather than on the
-// image: concurrency multiplied by per-process threads is the shape that
-// collapses (see WithConcurrency), and one thread per process is the only one
-// worth running. An ompThreadLimit the caller named on New is theirs and is
-// left alone — it is already on the image, and overriding it would ignore the
-// one instruction on the subject this module was given.
-func (b *Batch) container(manifest *dagger.File) *dagger.Container {
-	ctr := b.Tesseract.Container().
-		WithMountedDirectory(batchSourceDir, b.Source).
-		WithMountedFile(batchManifestPath, manifest)
-	if b.workers() > 1 && b.Tesseract.OmpThreadLimit == hostCpuOmpThreadLimit {
-		ctr = ctr.WithEnvVariable(ompThreadLimitEnv, strconv.Itoa(concurrentOmpThreadLimit))
-	}
-	return b.Options.mount(ctr)
-}
-
-// workers is how many tesseract processes one Export runs at once: whatever
-// WithConcurrency asked for, or one.
+// The default is the core count rather than one because every image is its own
+// exec now: recognising them one at a time would pay that exec's overhead N
+// times over and spend none of the parallelism it bought. What makes the core
+// count safe is toolchain's OpenMP bound — see WithConcurrency.
 func (b *Batch) workers() int {
-	if !b.HasConcurrency {
-		return defaultBatchConcurrency
+	if b.HasConcurrency {
+		return b.Concurrency
 	}
-	return b.Concurrency
+	if cpus := runtime.NumCPU(); cpus > minBatchConcurrency {
+		return cpus
+	}
+	return minBatchConcurrency
 }
 
 // validateConcurrency rejects a bound that would run no images at all. It is
@@ -327,9 +327,9 @@ func (b *Batch) workers() int {
 // builder has no error return, which is the same reason WithDpi's check lives
 // away from WithDpi.
 func (b *Batch) validateConcurrency() error {
-	if b.HasConcurrency && b.Concurrency < defaultBatchConcurrency {
+	if b.HasConcurrency && b.Concurrency < minBatchConcurrency {
 		return fmt.Errorf(
-			"WithConcurrency: concurrency must be positive, got %d: pass 1 to recognise one image at a time, which is what leaving it unset does",
+			"WithConcurrency: concurrency must be positive, got %d: pass 1 to recognise one image at a time, or leave it unset for one per available CPU",
 			b.Concurrency)
 	}
 	return nil
@@ -365,9 +365,6 @@ func (b *Batch) matches(ctx context.Context) ([]string, error) {
 		}
 		if err := rejectPdf(p); err != nil {
 			return nil, fmt.Errorf("Batch: %w", err)
-		}
-		if err := checkManifestSafe(p); err != nil {
-			return nil, fmt.Errorf("Batch: %w: rename it, or recognise it on its own with Document", err)
 		}
 		sources = append(sources, p)
 	}
@@ -414,32 +411,6 @@ func checkOutputCollisions(sources []string) error {
 		seen[base] = p
 	}
 	return nil
-}
-
-// checkManifestSafe rejects a path the tab-separated manifest cannot carry
-// unambiguously. Spaces are fine — the loops split on tabs alone — but a tab or
-// a newline in a file name would be read as a field or record boundary and act
-// on the wrong file. Batch and Training share the manifest shape and therefore
-// share the check; each adds its own way out of it.
-func checkManifestSafe(p string) error {
-	if strings.ContainsAny(p, "\t\n") {
-		return fmt.Errorf("file name %q contains a tab or newline, which the manifest cannot represent", p)
-	}
-	return nil
-}
-
-// batchManifest renders the file the exec loops over: one record per image,
-// holding the source path, the output base and the directory to create for it.
-// All three are absolute container paths, resolved here rather than in the
-// shell so the loop needs no path arithmetic of its own.
-func batchManifest(sources []string) (*dagger.File, error) {
-	var sb strings.Builder
-	for _, p := range sources {
-		out := outputDir + "/" + outputBaseFor(p)
-		fmt.Fprintf(&sb, "%s\t%s\t%s\n", batchSourceDir+"/"+p, out, path.Dir(out))
-	}
-	name := path.Base(batchManifestPath)
-	return dag.Directory().WithNewFile(name, sb.String()).File(name), nil
 }
 
 // outputBaseFor maps an input path onto the output base that mirrors it, by

--- a/daggerverse/tesseract/dagger.gen.go
+++ b/daggerverse/tesseract/dagger.gen.go
@@ -109,24 +109,30 @@ func (r *Tesseract) UnmarshalJSON(bs []byte) error {
 
 func (r Batch) MarshalJSON() ([]byte, error) {
 	var concrete struct {
-		Tesseract *Tesseract
-		Source    *dagger.Directory
-		Glob      string
-		Options   options
+		Tesseract      *Tesseract
+		Source         *dagger.Directory
+		Glob           string
+		Concurrency    int
+		HasConcurrency bool
+		Options        options
 	}
 	concrete.Tesseract = r.Tesseract
 	concrete.Source = r.Source
 	concrete.Glob = r.Glob
+	concrete.Concurrency = r.Concurrency
+	concrete.HasConcurrency = r.HasConcurrency
 	concrete.Options = r.Options
 	return json.Marshal(&concrete)
 }
 
 func (r *Batch) UnmarshalJSON(bs []byte) error {
 	var concrete struct {
-		Tesseract *Tesseract
-		Source    *dagger.Directory
-		Glob      string
-		Options   options
+		Tesseract      *Tesseract
+		Source         *dagger.Directory
+		Glob           string
+		Concurrency    int
+		HasConcurrency bool
+		Options        options
 	}
 	err := json.Unmarshal(bs, &concrete)
 	if err != nil {
@@ -135,6 +141,8 @@ func (r *Batch) UnmarshalJSON(bs []byte) error {
 	r.Tesseract = concrete.Tesseract
 	r.Source = concrete.Source
 	r.Glob = concrete.Glob
+	r.Concurrency = concrete.Concurrency
+	r.HasConcurrency = concrete.HasConcurrency
 	r.Options = concrete.Options
 	return nil
 }
@@ -585,6 +593,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return (*Batch).Files(&parent, ctx)
+		case "WithConcurrency":
+			var parent Batch
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var concurrency int
+			if inputArgs["concurrency"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["concurrency"]), &concurrency)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg concurrency", err))
+				}
+			}
+			return (*Batch).WithConcurrency(&parent, concurrency), nil
 		case "WithDpi":
 			var parent Batch
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/tesseract/document.go
+++ b/daggerverse/tesseract/document.go
@@ -293,10 +293,11 @@ func (d *Document) renderSpec(ctx context.Context, spec formatSpec) (*dagger.Fil
 	return exec.File(outputBase + spec.ext), nil
 }
 
-// selectFormats validates the requested set and returns the CONFIGFILE words
-// in a fixed order, de-duplicated so the same format twice does not render
-// twice.
-func selectFormats(formats []Format) ([]string, error) {
+// selectedFormats validates the requested set and returns it in a fixed order,
+// de-duplicated so the same format twice does not render twice. Batch takes the
+// formats themselves, because it names each artifact after the image that
+// produced it and therefore needs the extensions as well as the configfiles.
+func selectedFormats(formats []Format) ([]Format, error) {
 	if len(formats) == 0 {
 		return nil, fmt.Errorf("Export: at least one format is required: must be one of %s", formatNames())
 	}
@@ -307,13 +308,33 @@ func selectFormats(formats []Format) ([]string, error) {
 		}
 		want[f] = struct{}{}
 	}
-	configs := make([]string, 0, len(want))
+	selected := make([]Format, 0, len(want))
 	for _, f := range formatOrder {
 		if _, ok := want[f]; ok {
-			configs = append(configs, formatTable[f].config)
+			selected = append(selected, f)
 		}
 	}
-	return configs, nil
+	return selected, nil
+}
+
+// formatConfigs is the CONFIGFILE word each format is selected by, which is
+// what recognition takes as its trailing arguments.
+func formatConfigs(formats []Format) []string {
+	configs := make([]string, 0, len(formats))
+	for _, f := range formats {
+		configs = append(configs, formatTable[f].config)
+	}
+	return configs
+}
+
+// selectFormats validates the requested set and returns the CONFIGFILE words
+// in a fixed order.
+func selectFormats(formats []Format) ([]string, error) {
+	selected, err := selectedFormats(formats)
+	if err != nil {
+		return nil, err
+	}
+	return formatConfigs(selected), nil
 }
 
 // with returns a copy of the document carrying a new option set, which is what
@@ -372,6 +393,11 @@ func execTool(ctx context.Context, ctr *dagger.Container, args []string, tool st
 // A rasterized PDF mounts its whole page directory, at the path the page list
 // names its entries by — the list holds absolute paths, so this mount and the
 // one the rasterizer wrote them under have to agree.
+//
+// The output directory arrives as an empty directory rather than as a `mkdir`
+// exec. tesseract will not create it and the difference is one exec per
+// recognition — invisible on one document, and doubled work on a batch, which
+// runs one of these per image.
 func (d *Document) container(source string) *dagger.Container {
 	ctr := d.Tesseract.Container()
 	if d.Pages != nil {
@@ -379,7 +405,7 @@ func (d *Document) container(source string) *dagger.Container {
 	} else {
 		ctr = ctr.WithMountedFile(source, d.Source)
 	}
-	return d.Options.mount(ctr.WithExec([]string{"mkdir", "-p", outputDir}))
+	return d.Options.mount(ctr.WithDirectory(outputDir, dag.Directory()))
 }
 
 // validate reports every deferred builder check and returns the path the

--- a/daggerverse/tesseract/main.go
+++ b/daggerverse/tesseract/main.go
@@ -43,9 +43,8 @@
 //     builder, one piece of argv and one deferred check per option, so the two
 //     units of work cannot drift apart.
 //   - document.go  — *Document, one image in and one artifact set out.
-//   - batch.go     — *Batch, a directory in and a mirrored directory out, all
-//     of it in a single container exec, as many recognitions wide as
-//     WithConcurrency asked for.
+//   - batch.go     — *Batch, a directory in and a mirrored directory out, one
+//     Document per image, WithConcurrency of them recognised at a time.
 //   - ci.go        — *Ci, a batch plus a confidence gate, for the repo that
 //     wants its whole document pipeline as one declarative call.
 //   - pdf.go       — FromPdf, the rasterizer that turns a PDF into pages a
@@ -118,24 +117,10 @@ const (
 	userWordsPath    = workDir + "/user-words.txt"
 	userPatternsPath = workDir + "/user-patterns.txt"
 
-	// batchSourceDir is where Batch mounts the caller's directory, and
-	// batchManifestPath the record list its exec loops over. Both sit beside
-	// the single-document mounts rather than replacing them, so the user word
-	// and pattern lists land in the same place for either unit of work.
-	batchSourceDir    = workDir + "/batch"
-	batchManifestPath = workDir + "/batch.tsv"
-
-	// batchFailureDir collects one report per worker that hit a failure, and
-	// batchStopFile is the flag the first of them raises to stop the rest.
-	// Both sit outside outputDir: they are how the run reports itself, not
-	// artifacts, and the caller exports that directory.
-	batchFailureDir = "/batch-failures"
-	batchStopFile   = "/batch-stop"
-
-	// defaultBatchConcurrency is how many images a batch recognises at once
-	// when WithConcurrency named no bound: one, which is what a batch did
-	// before the bound existed.
-	defaultBatchConcurrency = 1
+	// minBatchConcurrency is the floor on how many images a batch recognises
+	// at once, and therefore the answer on a single-CPU host. Batch.workers
+	// defaults to the core count above it.
+	minBatchConcurrency = 1
 
 	// defaultBatchGlob matches every path in the source directory. It is not
 	// the whole default: what actually narrows a batch to images is the

--- a/daggerverse/tesseract/main.go
+++ b/daggerverse/tesseract/main.go
@@ -44,7 +44,8 @@
 //     units of work cannot drift apart.
 //   - document.go  — *Document, one image in and one artifact set out.
 //   - batch.go     — *Batch, a directory in and a mirrored directory out, all
-//     of it in a single container exec.
+//     of it in a single container exec, as many recognitions wide as
+//     WithConcurrency asked for.
 //   - ci.go        — *Ci, a batch plus a confidence gate, for the repo that
 //     wants its whole document pipeline as one declarative call.
 //   - pdf.go       — FromPdf, the rasterizer that turns a PDF into pages a
@@ -123,6 +124,18 @@ const (
 	// and pattern lists land in the same place for either unit of work.
 	batchSourceDir    = workDir + "/batch"
 	batchManifestPath = workDir + "/batch.tsv"
+
+	// batchFailureDir collects one report per worker that hit a failure, and
+	// batchStopFile is the flag the first of them raises to stop the rest.
+	// Both sit outside outputDir: they are how the run reports itself, not
+	// artifacts, and the caller exports that directory.
+	batchFailureDir = "/batch-failures"
+	batchStopFile   = "/batch-stop"
+
+	// defaultBatchConcurrency is how many images a batch recognises at once
+	// when WithConcurrency named no bound: one, which is what a batch did
+	// before the bound existed.
+	defaultBatchConcurrency = 1
 
 	// defaultBatchGlob matches every path in the source directory. It is not
 	// the whole default: what actually narrows a batch to images is the
@@ -245,6 +258,12 @@ const (
 	// caller who wants the whole box — and the wrong one as soon as several
 	// recognitions share the cores, which is what the bound exists for.
 	hostCpuOmpThreadLimit = 0
+
+	// concurrentOmpThreadLimit is the bound a concurrent batch applies to its
+	// own exec. One thread per process is not a compromise between the two
+	// kinds of parallelism: it is the fast shape outright, and the only one
+	// that does not multiply concurrency by the core count.
+	concurrentOmpThreadLimit = 1
 )
 
 // Tesseract is the root namespace for every exported function in this module.

--- a/daggerverse/tesseract/tests/dagger.gen.go
+++ b/daggerverse/tesseract/tests/dagger.gen.go
@@ -248,6 +248,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).AuthenticatedRepositoryIsRejectedWithoutApkAuth(&parent, ctx)
+		case "BatchConcurrencyMatchesSerialOutput":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).BatchConcurrencyMatchesSerialOutput(&parent, ctx)
+		case "BatchConcurrencyReportsFailingImage":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).BatchConcurrencyReportsFailingImage(&parent, ctx)
 		case "BatchDefaultGlobSkipsNonImages":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/tesseract/tests/internal/dagger/tesseract.gen.go
+++ b/daggerverse/tesseract/tests/internal/dagger/tesseract.gen.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Retrieve the binding value, as type Tesseract
-func (r *Binding) AsTesseract() *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:254:6)
+func (r *Binding) AsTesseract() *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:273:6)
 	q := r.query.Select("asTesseract")
 
 	return &Tesseract{
@@ -20,7 +20,7 @@ func (r *Binding) AsTesseract() *Tesseract { // tesseract (../../../../../dagger
 }
 
 // Retrieve the binding value, as type TesseractBatch
-func (r *Binding) AsTesseractBatch() *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:48:6)
+func (r *Binding) AsTesseractBatch() *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:124:6)
 	q := r.query.Select("asTesseractBatch")
 
 	return &TesseractBatch{
@@ -56,7 +56,7 @@ func (r *Binding) AsTesseractTraining() *TesseractTraining { // tesseract (../..
 }
 
 // Create or update a binding of type TesseractBatch in the environment
-func (r *Env) WithTesseractBatchInput(name string, value *TesseractBatch, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/batch.go:48:6)
+func (r *Env) WithTesseractBatchInput(name string, value *TesseractBatch, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/batch.go:124:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withTesseractBatchInput")
 	q = q.Arg("name", name)
@@ -69,7 +69,7 @@ func (r *Env) WithTesseractBatchInput(name string, value *TesseractBatch, descri
 }
 
 // Declare a desired TesseractBatch output to be assigned in the environment
-func (r *Env) WithTesseractBatchOutput(name string, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/batch.go:48:6)
+func (r *Env) WithTesseractBatchOutput(name string, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/batch.go:124:6)
 	q := r.query.Select("withTesseractBatchOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -128,7 +128,7 @@ func (r *Env) WithTesseractDocumentOutput(name string, description string) *Env 
 }
 
 // Create or update a binding of type Tesseract in the environment
-func (r *Env) WithTesseractInput(name string, value *Tesseract, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/main.go:254:6)
+func (r *Env) WithTesseractInput(name string, value *Tesseract, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/main.go:273:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withTesseractInput")
 	q = q.Arg("name", name)
@@ -141,7 +141,7 @@ func (r *Env) WithTesseractInput(name string, value *Tesseract, description stri
 }
 
 // Declare a desired Tesseract output to be assigned in the environment
-func (r *Env) WithTesseractOutput(name string, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/main.go:254:6)
+func (r *Env) WithTesseractOutput(name string, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/main.go:273:6)
 	q := r.query.Select("withTesseractOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -184,18 +184,18 @@ type TesseractOpts struct {
 	//
 	//
 	// Default: "docker.io"
-	Registry string // tesseract (../../../../../daggerverse/tesseract/main.go:280:2)
+	Registry string // tesseract (../../../../../daggerverse/tesseract/main.go:299:2)
 	//
 	// Tag of the alpine image the toolchain is assembled on.
 	//
 	//
 	// Default: "3.24"
-	AlpineTag string // tesseract (../../../../../daggerverse/tesseract/main.go:283:2)
+	AlpineTag string // tesseract (../../../../../daggerverse/tesseract/main.go:302:2)
 	//
 	// Language codes to install, one apk package each. Empty installs "eng".
 	// "osd" is not a recognition language but is required by Document.Osd.
 	//
-	Languages []string // tesseract (../../../../../daggerverse/tesseract/main.go:287:2)
+	Languages []string // tesseract (../../../../../daggerverse/tesseract/main.go:306:2)
 	//
 	// Upper bound on the OpenMP threads tesseract may use, set on the
 	// assembled image as OMP_THREAD_LIMIT. Unset, tesseract uses one thread
@@ -206,12 +206,12 @@ type TesseractOpts struct {
 	// slowdown reports (tesseract-ocr/tesseract#2611, #1171, #263). One
 	// thread per pass is the usual setting there.
 	//
-	OmpThreadLimit int // tesseract (../../../../../daggerverse/tesseract/main.go:297:2)
+	OmpThreadLimit int // tesseract (../../../../../daggerverse/tesseract/main.go:316:2)
 }
 
 // New returns a Tesseract module backed by <registry>/library/alpine:<tag>
 // with tesseract-ocr and one language package per requested language.
-func (r *Query) Tesseract(opts ...TesseractOpts) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:275:1)
+func (r *Query) Tesseract(opts ...TesseractOpts) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:294:1)
 	q := r.query.Select("tesseract")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `registry` optional argument
@@ -241,7 +241,7 @@ func (r *Query) Tesseract(opts ...TesseractOpts) *Tesseract { // tesseract (../.
 // It carries the image coordinates and the language set the image is built
 // with; Document hangs off it so the generated SDK surfaces recognition under
 // `dag.Tesseract().Document(...)`.
-type Tesseract struct { // tesseract (../../../../../daggerverse/tesseract/main.go:254:6)
+type Tesseract struct { // tesseract (../../../../../daggerverse/tesseract/main.go:273:6)
 	query *querybuilder.Selection
 
 	id         *ID
@@ -271,7 +271,7 @@ func (r *Tesseract) WithGraphQLQuery(q *querybuilder.Selection) *Tesseract {
 // with whatever reads the results the same way the input directory was
 // composed. Which files take part is a glob, defaulting to the image
 // extensions leptonica can read.
-func (r *Tesseract) Batch(source *Directory) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/main.go:519:1)
+func (r *Tesseract) Batch(source *Directory) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/main.go:538:1)
 	assertNotNil("source", source)
 	q := r.query.Select("batch")
 	q = q.Arg("source", source)
@@ -301,7 +301,7 @@ func (r *Tesseract) Ci(source *Directory) *TesseractCi { // tesseract (../../../
 //
 // A requested OpenMP bound lives here rather than on the recognition
 // invocation so everything reached through this escape hatch inherits it too.
-func (r *Tesseract) Container() *Container { // tesseract (../../../../../daggerverse/tesseract/main.go:431:1)
+func (r *Tesseract) Container() *Container { // tesseract (../../../../../daggerverse/tesseract/main.go:450:1)
 	q := r.query.Select("container")
 
 	return &Container{
@@ -314,7 +314,7 @@ func (r *Tesseract) Container() *Container { // tesseract (../../../../../dagger
 // The boundary input is a *dagger.File rather than a *dagger.Directory, unlike
 // the kicad module's Project: tesseract resolves nothing relative to its input,
 // so one image — including a multi-page TIFF — is the whole unit of work.
-func (r *Tesseract) Document(source *File) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/main.go:507:1)
+func (r *Tesseract) Document(source *File) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/main.go:526:1)
 	assertNotNil("source", source)
 	q := r.query.Select("document")
 	q = q.Arg("source", source)
@@ -419,7 +419,7 @@ func (r *Tesseract) UnmarshalJSON(bs []byte) error {
 // `tesseract --list-langs`: the packaged languages and any model WithTessdata
 // added, as one set. This is what Document.WithLanguage validates against, and
 // it includes "osd" when that model was installed or supplied.
-func (r *Tesseract) Langs(ctx context.Context) ([]string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:477:1)
+func (r *Tesseract) Langs(ctx context.Context) ([]string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:496:1)
 	q := r.query.Select("langs")
 
 	var response []string
@@ -431,7 +431,7 @@ func (r *Tesseract) Langs(ctx context.Context) ([]string, error) { // tesseract 
 // Parameters returns tesseract's control-variable table — every name, its
 // default value and a one-line description — as `tesseract --print-parameters`
 // prints it. These are the names Document.WithParameter accepts.
-func (r *Tesseract) Parameters(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:492:1)
+func (r *Tesseract) Parameters(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:511:1)
 	if r.parameters != nil {
 		return *r.parameters, nil
 	}
@@ -455,7 +455,7 @@ func (r *Tesseract) Parameters(ctx context.Context) (string, error) { // tessera
 //
 // The model it produces pairs directly with WithTessdata, so a fine-tune and
 // the recognition that uses it are two calls on the same module.
-func (r *Tesseract) Training(source *Directory) *TesseractTraining { // tesseract (../../../../../daggerverse/tesseract/main.go:535:1)
+func (r *Tesseract) Training(source *Directory) *TesseractTraining { // tesseract (../../../../../daggerverse/tesseract/main.go:554:1)
 	assertNotNil("source", source)
 	q := r.query.Select("training")
 	q = q.Arg("source", source)
@@ -467,7 +467,7 @@ func (r *Tesseract) Training(source *Directory) *TesseractTraining { // tesserac
 
 // Version returns the tesseract release the assembled image ships, as the
 // bare version number reported by `tesseract --version`.
-func (r *Tesseract) Version(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:458:1)
+func (r *Tesseract) Version(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:477:1)
 	if r.version != nil {
 		return *r.version, nil
 	}
@@ -493,7 +493,7 @@ func (r *Tesseract) Version(ctx context.Context) (string, error) { // tesseract 
 // why the credentials are not simply userinfo in the WithApkRepository URL,
 // which would put them in /etc/apk/repositories and in every apk error message
 // that quotes it.
-func (r *Tesseract) WithApkAuth(credentials *Secret) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:413:1)
+func (r *Tesseract) WithApkAuth(credentials *Secret) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:432:1)
 	assertNotNil("credentials", credentials)
 	q := r.query.Select("withApkAuth")
 	q = q.Arg("credentials", credentials)
@@ -516,7 +516,7 @@ func (r *Tesseract) WithApkAuth(credentials *Secret) *Tesseract { // tesseract (
 // Repeatable, for a mirror set signed by more than one key. It is a *File
 // rather than a *Secret because a public key is not a credential: it is meant
 // to be in the image, and WithApkAuth is the option for the part that is not.
-func (r *Tesseract) WithApkKey(key *File) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:390:1)
+func (r *Tesseract) WithApkKey(key *File) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:409:1)
 	assertNotNil("key", key)
 	q := r.query.Select("withApkKey")
 	q = q.Arg("key", key)
@@ -546,7 +546,7 @@ func (r *Tesseract) WithApkKey(key *File) *Tesseract { // tesseract (../../../..
 // call per component. A repository's index is signed, so pair this with
 // WithApkKey unless the mirror is signed by a key the base image already
 // trusts.
-func (r *Tesseract) WithApkRepository(url string) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:362:1)
+func (r *Tesseract) WithApkRepository(url string) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:381:1)
 	q := r.query.Select("withApkRepository")
 	q = q.Arg("url", url)
 
@@ -570,7 +570,7 @@ func (r *Tesseract) WithApkRepository(url string) *Tesseract { // tesseract (../
 // renderer configfiles and the font the PDF renderer needs. A caller-supplied
 // model wins over a packaged one of the same name, which is what makes
 // replacing the stock `eng` with a fine-tuned one work.
-func (r *Tesseract) WithTessdata(dir *Directory) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:333:1)
+func (r *Tesseract) WithTessdata(dir *Directory) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:352:1)
 	assertNotNil("dir", dir)
 	q := r.query.Select("withTessdata")
 	q = q.Arg("dir", dir)
@@ -591,7 +591,7 @@ func (r *Tesseract) AsNode() Node {
 // Batch is a directory of images plus the recognition options that apply to
 // all of them. It carries the same options type Document does, so the two
 // cannot drift: every With* here forwards to the shared builder.
-type TesseractBatch struct { // tesseract (../../../../../daggerverse/tesseract/batch.go:48:6)
+type TesseractBatch struct { // tesseract (../../../../../daggerverse/tesseract/batch.go:124:6)
 	query *querybuilder.Selection
 
 	id *ID
@@ -622,8 +622,9 @@ func (r *TesseractBatch) WithGraphQLQuery(q *querybuilder.Selection) *TesseractB
 // multi-page PDF) and offers no way to get the per-image files this returns.
 // So the exec loops over the manifest instead, which keeps the expensive part
 // — a container exec, its mounts and its cache lookup, per page — collapsed to
-// one, while each image still gets its own output base.
-func (r *TesseractBatch) Export(formats []TesseractFormat) *Directory { // tesseract (../../../../../daggerverse/tesseract/batch.go:139:1)
+// one, while each image still gets its own output base. How many of those
+// recognitions run at once inside that one exec is WithConcurrency.
+func (r *TesseractBatch) Export(formats []TesseractFormat) *Directory { // tesseract (../../../../../daggerverse/tesseract/batch.go:253:1)
 	q := r.query.Select("export")
 	q = q.Arg("formats", formats)
 
@@ -633,12 +634,13 @@ func (r *TesseractBatch) Export(formats []TesseractFormat) *Directory { // tesse
 }
 
 // Files lists the images the batch will recognise, as paths relative to the
-// source directory root, in the order they are processed.
+// source directory root, sorted — which is the order they are recognised in
+// until WithConcurrency deals them out to several workers at once.
 //
 // It answers the question a glob always raises — did that pattern pick up what
 // I meant? — without paying for the recognition, and it fails on an empty match
 // exactly as Export does.
-func (r *TesseractBatch) Files(ctx context.Context) ([]string, error) { // tesseract (../../../../../daggerverse/tesseract/batch.go:123:1)
+func (r *TesseractBatch) Files(ctx context.Context) ([]string, error) { // tesseract (../../../../../daggerverse/tesseract/batch.go:236:1)
 	q := r.query.Select("files")
 
 	var response []string
@@ -696,9 +698,40 @@ func (r *TesseractBatch) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
+// WithConcurrency bounds how many images the batch recognises at once. The
+// default is one, which is what a batch has always done.
+//
+// Recognition is where a batch spends its time, and it is the one thing the
+// serial loop does not collapse: N independent images recognised one after
+// another. Processes are how tesseract parallelises well — eleven pages on four
+// CPUs take 3.37s one at a time and 1.05s eleven at a time, ~90% efficiency
+// where its own OpenMP manages 33%, because those regions sit inside the LSTM
+// inner loops and do not amortize.
+//
+// A bound above one therefore also caps OpenMP at one thread per process for
+// this batch's exec, unless the caller named an explicit ompThreadLimit on New,
+// which is left alone. Concurrency multiplied by per-process threads rather
+// than bounded by cores is the one shape that is slower than doing nothing:
+// those same four workers on an unbounded image take 3m36.8s against 1.24s
+// bounded, 174x. The bound is set on the exec rather than on the image, so
+// nothing else built from the same Tesseract sees it and two batches differing
+// only in concurrency still share the package fetch.
+//
+// Somewhere around the core count is the number to pass; more processes than
+// cores buys little once each is single-threaded. Non-positive is rejected at
+// output time.
+func (r *TesseractBatch) WithConcurrency(concurrency int) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:177:1)
+	q := r.query.Select("withConcurrency")
+	q = q.Arg("concurrency", concurrency)
+
+	return &TesseractBatch{
+		query: q,
+	}
+}
+
 // WithDpi declares the source resolution (`--dpi`) for every image in the
 // batch. See Document.WithDpi.
-func (r *TesseractBatch) WithDpi(dpi int) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:95:1)
+func (r *TesseractBatch) WithDpi(dpi int) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:207:1)
 	q := r.query.Select("withDpi")
 	q = q.Arg("dpi", dpi)
 
@@ -709,7 +742,7 @@ func (r *TesseractBatch) WithDpi(dpi int) *TesseractBatch { // tesseract (../../
 
 // WithEngine selects the OCR engine (`--oem`) for every image in the batch.
 // See Document.WithEngine.
-func (r *TesseractBatch) WithEngine(mode TesseractEngineMode) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:89:1)
+func (r *TesseractBatch) WithEngine(mode TesseractEngineMode) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:201:1)
 	q := r.query.Select("withEngine")
 	q = q.Arg("mode", mode)
 
@@ -728,7 +761,7 @@ func (r *TesseractBatch) WithEngine(mode TesseractEngineMode) *TesseractBatch { 
 // directory, and leptonica sniffs content rather than trusting extensions, so
 // `**/*.scan` is a reasonable thing to ask for. PDFs stay rejected either way,
 // because leptonica genuinely cannot read them.
-func (r *TesseractBatch) WithGlob(pattern string) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:69:1)
+func (r *TesseractBatch) WithGlob(pattern string) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:149:1)
 	q := r.query.Select("withGlob")
 	q = q.Arg("pattern", pattern)
 
@@ -739,7 +772,7 @@ func (r *TesseractBatch) WithGlob(pattern string) *TesseractBatch { // tesseract
 
 // WithLanguage selects the recognition language (`-l`) for every image in the
 // batch. See Document.WithLanguage.
-func (r *TesseractBatch) WithLanguage(lang string) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:77:1)
+func (r *TesseractBatch) WithLanguage(lang string) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:189:1)
 	q := r.query.Select("withLanguage")
 	q = q.Arg("lang", lang)
 
@@ -750,7 +783,7 @@ func (r *TesseractBatch) WithLanguage(lang string) *TesseractBatch { // tesserac
 
 // WithPageSegmentation sets how much layout analysis precedes recognition
 // (`--psm`) for every image in the batch. See Document.WithPageSegmentation.
-func (r *TesseractBatch) WithPageSegmentation(mode TesseractPageSegMode) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:83:1)
+func (r *TesseractBatch) WithPageSegmentation(mode TesseractPageSegMode) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:195:1)
 	q := r.query.Select("withPageSegmentation")
 	q = q.Arg("mode", mode)
 
@@ -761,7 +794,7 @@ func (r *TesseractBatch) WithPageSegmentation(mode TesseractPageSegMode) *Tesser
 
 // WithParameter sets one of tesseract's control variables (`-c name=value`)
 // for every image in the batch. See Document.WithParameter.
-func (r *TesseractBatch) WithParameter(name string, value string) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:101:1)
+func (r *TesseractBatch) WithParameter(name string, value string) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:213:1)
 	q := r.query.Select("withParameter")
 	q = q.Arg("name", name)
 	q = q.Arg("value", value)
@@ -773,7 +806,7 @@ func (r *TesseractBatch) WithParameter(name string, value string) *TesseractBatc
 
 // WithUserPatterns supplies a pattern list (`--user-patterns`) for every image
 // in the batch. See Document.WithUserPatterns.
-func (r *TesseractBatch) WithUserPatterns(patterns *File) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:113:1)
+func (r *TesseractBatch) WithUserPatterns(patterns *File) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:225:1)
 	assertNotNil("patterns", patterns)
 	q := r.query.Select("withUserPatterns")
 	q = q.Arg("patterns", patterns)
@@ -785,7 +818,7 @@ func (r *TesseractBatch) WithUserPatterns(patterns *File) *TesseractBatch { // t
 
 // WithUserWords supplies a word list (`--user-words`) for every image in the
 // batch. See Document.WithUserWords.
-func (r *TesseractBatch) WithUserWords(words *File) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:107:1)
+func (r *TesseractBatch) WithUserWords(words *File) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:219:1)
 	assertNotNil("words", words)
 	q := r.query.Select("withUserWords")
 	q = q.Arg("words", words)

--- a/daggerverse/tesseract/tests/internal/dagger/tesseract.gen.go
+++ b/daggerverse/tesseract/tests/internal/dagger/tesseract.gen.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Retrieve the binding value, as type Tesseract
-func (r *Binding) AsTesseract() *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:273:6)
+func (r *Binding) AsTesseract() *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:258:6)
 	q := r.query.Select("asTesseract")
 
 	return &Tesseract{
@@ -20,7 +20,7 @@ func (r *Binding) AsTesseract() *Tesseract { // tesseract (../../../../../dagger
 }
 
 // Retrieve the binding value, as type TesseractBatch
-func (r *Binding) AsTesseractBatch() *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:124:6)
+func (r *Binding) AsTesseractBatch() *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:38:6)
 	q := r.query.Select("asTesseractBatch")
 
 	return &TesseractBatch{
@@ -56,7 +56,7 @@ func (r *Binding) AsTesseractTraining() *TesseractTraining { // tesseract (../..
 }
 
 // Create or update a binding of type TesseractBatch in the environment
-func (r *Env) WithTesseractBatchInput(name string, value *TesseractBatch, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/batch.go:124:6)
+func (r *Env) WithTesseractBatchInput(name string, value *TesseractBatch, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/batch.go:38:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withTesseractBatchInput")
 	q = q.Arg("name", name)
@@ -69,7 +69,7 @@ func (r *Env) WithTesseractBatchInput(name string, value *TesseractBatch, descri
 }
 
 // Declare a desired TesseractBatch output to be assigned in the environment
-func (r *Env) WithTesseractBatchOutput(name string, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/batch.go:124:6)
+func (r *Env) WithTesseractBatchOutput(name string, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/batch.go:38:6)
 	q := r.query.Select("withTesseractBatchOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -128,7 +128,7 @@ func (r *Env) WithTesseractDocumentOutput(name string, description string) *Env 
 }
 
 // Create or update a binding of type Tesseract in the environment
-func (r *Env) WithTesseractInput(name string, value *Tesseract, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/main.go:273:6)
+func (r *Env) WithTesseractInput(name string, value *Tesseract, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/main.go:258:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withTesseractInput")
 	q = q.Arg("name", name)
@@ -141,7 +141,7 @@ func (r *Env) WithTesseractInput(name string, value *Tesseract, description stri
 }
 
 // Declare a desired Tesseract output to be assigned in the environment
-func (r *Env) WithTesseractOutput(name string, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/main.go:273:6)
+func (r *Env) WithTesseractOutput(name string, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/main.go:258:6)
 	q := r.query.Select("withTesseractOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -184,18 +184,18 @@ type TesseractOpts struct {
 	//
 	//
 	// Default: "docker.io"
-	Registry string // tesseract (../../../../../daggerverse/tesseract/main.go:299:2)
+	Registry string // tesseract (../../../../../daggerverse/tesseract/main.go:284:2)
 	//
 	// Tag of the alpine image the toolchain is assembled on.
 	//
 	//
 	// Default: "3.24"
-	AlpineTag string // tesseract (../../../../../daggerverse/tesseract/main.go:302:2)
+	AlpineTag string // tesseract (../../../../../daggerverse/tesseract/main.go:287:2)
 	//
 	// Language codes to install, one apk package each. Empty installs "eng".
 	// "osd" is not a recognition language but is required by Document.Osd.
 	//
-	Languages []string // tesseract (../../../../../daggerverse/tesseract/main.go:306:2)
+	Languages []string // tesseract (../../../../../daggerverse/tesseract/main.go:291:2)
 	//
 	// Upper bound on the OpenMP threads tesseract may use, set on the
 	// assembled image as OMP_THREAD_LIMIT. Unset, tesseract uses one thread
@@ -206,12 +206,12 @@ type TesseractOpts struct {
 	// slowdown reports (tesseract-ocr/tesseract#2611, #1171, #263). One
 	// thread per pass is the usual setting there.
 	//
-	OmpThreadLimit int // tesseract (../../../../../daggerverse/tesseract/main.go:316:2)
+	OmpThreadLimit int // tesseract (../../../../../daggerverse/tesseract/main.go:301:2)
 }
 
 // New returns a Tesseract module backed by <registry>/library/alpine:<tag>
 // with tesseract-ocr and one language package per requested language.
-func (r *Query) Tesseract(opts ...TesseractOpts) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:294:1)
+func (r *Query) Tesseract(opts ...TesseractOpts) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:279:1)
 	q := r.query.Select("tesseract")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `registry` optional argument
@@ -241,7 +241,7 @@ func (r *Query) Tesseract(opts ...TesseractOpts) *Tesseract { // tesseract (../.
 // It carries the image coordinates and the language set the image is built
 // with; Document hangs off it so the generated SDK surfaces recognition under
 // `dag.Tesseract().Document(...)`.
-type Tesseract struct { // tesseract (../../../../../daggerverse/tesseract/main.go:273:6)
+type Tesseract struct { // tesseract (../../../../../daggerverse/tesseract/main.go:258:6)
 	query *querybuilder.Selection
 
 	id         *ID
@@ -271,7 +271,7 @@ func (r *Tesseract) WithGraphQLQuery(q *querybuilder.Selection) *Tesseract {
 // with whatever reads the results the same way the input directory was
 // composed. Which files take part is a glob, defaulting to the image
 // extensions leptonica can read.
-func (r *Tesseract) Batch(source *Directory) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/main.go:538:1)
+func (r *Tesseract) Batch(source *Directory) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/main.go:523:1)
 	assertNotNil("source", source)
 	q := r.query.Select("batch")
 	q = q.Arg("source", source)
@@ -301,7 +301,7 @@ func (r *Tesseract) Ci(source *Directory) *TesseractCi { // tesseract (../../../
 //
 // A requested OpenMP bound lives here rather than on the recognition
 // invocation so everything reached through this escape hatch inherits it too.
-func (r *Tesseract) Container() *Container { // tesseract (../../../../../daggerverse/tesseract/main.go:450:1)
+func (r *Tesseract) Container() *Container { // tesseract (../../../../../daggerverse/tesseract/main.go:435:1)
 	q := r.query.Select("container")
 
 	return &Container{
@@ -314,7 +314,7 @@ func (r *Tesseract) Container() *Container { // tesseract (../../../../../dagger
 // The boundary input is a *dagger.File rather than a *dagger.Directory, unlike
 // the kicad module's Project: tesseract resolves nothing relative to its input,
 // so one image — including a multi-page TIFF — is the whole unit of work.
-func (r *Tesseract) Document(source *File) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/main.go:526:1)
+func (r *Tesseract) Document(source *File) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/main.go:511:1)
 	assertNotNil("source", source)
 	q := r.query.Select("document")
 	q = q.Arg("source", source)
@@ -419,7 +419,7 @@ func (r *Tesseract) UnmarshalJSON(bs []byte) error {
 // `tesseract --list-langs`: the packaged languages and any model WithTessdata
 // added, as one set. This is what Document.WithLanguage validates against, and
 // it includes "osd" when that model was installed or supplied.
-func (r *Tesseract) Langs(ctx context.Context) ([]string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:496:1)
+func (r *Tesseract) Langs(ctx context.Context) ([]string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:481:1)
 	q := r.query.Select("langs")
 
 	var response []string
@@ -431,7 +431,7 @@ func (r *Tesseract) Langs(ctx context.Context) ([]string, error) { // tesseract 
 // Parameters returns tesseract's control-variable table — every name, its
 // default value and a one-line description — as `tesseract --print-parameters`
 // prints it. These are the names Document.WithParameter accepts.
-func (r *Tesseract) Parameters(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:511:1)
+func (r *Tesseract) Parameters(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:496:1)
 	if r.parameters != nil {
 		return *r.parameters, nil
 	}
@@ -455,7 +455,7 @@ func (r *Tesseract) Parameters(ctx context.Context) (string, error) { // tessera
 //
 // The model it produces pairs directly with WithTessdata, so a fine-tune and
 // the recognition that uses it are two calls on the same module.
-func (r *Tesseract) Training(source *Directory) *TesseractTraining { // tesseract (../../../../../daggerverse/tesseract/main.go:554:1)
+func (r *Tesseract) Training(source *Directory) *TesseractTraining { // tesseract (../../../../../daggerverse/tesseract/main.go:539:1)
 	assertNotNil("source", source)
 	q := r.query.Select("training")
 	q = q.Arg("source", source)
@@ -467,7 +467,7 @@ func (r *Tesseract) Training(source *Directory) *TesseractTraining { // tesserac
 
 // Version returns the tesseract release the assembled image ships, as the
 // bare version number reported by `tesseract --version`.
-func (r *Tesseract) Version(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:477:1)
+func (r *Tesseract) Version(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:462:1)
 	if r.version != nil {
 		return *r.version, nil
 	}
@@ -493,7 +493,7 @@ func (r *Tesseract) Version(ctx context.Context) (string, error) { // tesseract 
 // why the credentials are not simply userinfo in the WithApkRepository URL,
 // which would put them in /etc/apk/repositories and in every apk error message
 // that quotes it.
-func (r *Tesseract) WithApkAuth(credentials *Secret) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:432:1)
+func (r *Tesseract) WithApkAuth(credentials *Secret) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:417:1)
 	assertNotNil("credentials", credentials)
 	q := r.query.Select("withApkAuth")
 	q = q.Arg("credentials", credentials)
@@ -516,7 +516,7 @@ func (r *Tesseract) WithApkAuth(credentials *Secret) *Tesseract { // tesseract (
 // Repeatable, for a mirror set signed by more than one key. It is a *File
 // rather than a *Secret because a public key is not a credential: it is meant
 // to be in the image, and WithApkAuth is the option for the part that is not.
-func (r *Tesseract) WithApkKey(key *File) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:409:1)
+func (r *Tesseract) WithApkKey(key *File) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:394:1)
 	assertNotNil("key", key)
 	q := r.query.Select("withApkKey")
 	q = q.Arg("key", key)
@@ -546,7 +546,7 @@ func (r *Tesseract) WithApkKey(key *File) *Tesseract { // tesseract (../../../..
 // call per component. A repository's index is signed, so pair this with
 // WithApkKey unless the mirror is signed by a key the base image already
 // trusts.
-func (r *Tesseract) WithApkRepository(url string) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:381:1)
+func (r *Tesseract) WithApkRepository(url string) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:366:1)
 	q := r.query.Select("withApkRepository")
 	q = q.Arg("url", url)
 
@@ -570,7 +570,7 @@ func (r *Tesseract) WithApkRepository(url string) *Tesseract { // tesseract (../
 // renderer configfiles and the font the PDF renderer needs. A caller-supplied
 // model wins over a packaged one of the same name, which is what makes
 // replacing the stock `eng` with a fine-tuned one work.
-func (r *Tesseract) WithTessdata(dir *Directory) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:352:1)
+func (r *Tesseract) WithTessdata(dir *Directory) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:337:1)
 	assertNotNil("dir", dir)
 	q := r.query.Select("withTessdata")
 	q = q.Arg("dir", dir)
@@ -591,7 +591,14 @@ func (r *Tesseract) AsNode() Node {
 // Batch is a directory of images plus the recognition options that apply to
 // all of them. It carries the same options type Document does, so the two
 // cannot drift: every With* here forwards to the shared builder.
-type TesseractBatch struct { // tesseract (../../../../../daggerverse/tesseract/batch.go:124:6)
+//
+// It is also built out of Document rather than merely resembling one. Each
+// matched image is recognised as its own Document — its own exec, its own
+// mounts, its own cache entry — and what runs several of them at a time is Go,
+// not a runner inside a container. That is what keeps the scheduling, the
+// bound and the failure reporting in a language with types and a debugger,
+// instead of in a shell script mounted into an image.
+type TesseractBatch struct { // tesseract (../../../../../daggerverse/tesseract/batch.go:38:6)
 	query *querybuilder.Selection
 
 	id *ID
@@ -615,16 +622,19 @@ func (r *TesseractBatch) WithGraphQLQuery(q *querybuilder.Selection) *TesseractB
 // input layout, with one artifact per requested format per image: `scans/a.png`
 // becomes `scans/a.txt` alongside `scans/a.pdf`.
 //
-// The whole batch is one container exec. tesseract's own list-file mode — a
-// text file of image paths as the FILE argument — is not what does that here,
-// because it treats the list as one multi-page *document*: it renders a single
-// concatenated artifact set (one .txt with form-feed page breaks, one
-// multi-page PDF) and offers no way to get the per-image files this returns.
-// So the exec loops over the manifest instead, which keeps the expensive part
-// — a container exec, its mounts and its cache lookup, per page — collapsed to
-// one, while each image still gets its own output base. How many of those
-// recognitions run at once inside that one exec is WithConcurrency.
-func (r *TesseractBatch) Export(formats []TesseractFormat) *Directory { // tesseract (../../../../../daggerverse/tesseract/batch.go:253:1)
+// Each image is recognised on its own, as its own exec, WithConcurrency of them
+// at a time. tesseract's own list-file mode — a text file of image paths as the
+// FILE argument — is not what a batch wants, because it treats the list as one
+// multi-page *document*: it renders a single concatenated artifact set (one .txt
+// with form-feed page breaks, one multi-page PDF) and offers no way to get the
+// per-image files this returns.
+//
+// One exec per image is what makes the results cache per image too: an edited
+// page invalidates its own recognition and nothing else, which is the whole
+// difference for a corpus that grows a page at a time. It costs one exec's
+// overhead per page instead of per batch — see the README for what that is
+// worth measured — and it is the shape that lets the fan-out live in Go.
+func (r *TesseractBatch) Export(formats []TesseractFormat) *Directory { // tesseract (../../../../../daggerverse/tesseract/batch.go:169:1)
 	q := r.query.Select("export")
 	q = q.Arg("formats", formats)
 
@@ -634,13 +644,15 @@ func (r *TesseractBatch) Export(formats []TesseractFormat) *Directory { // tesse
 }
 
 // Files lists the images the batch will recognise, as paths relative to the
-// source directory root, sorted — which is the order they are recognised in
-// until WithConcurrency deals them out to several workers at once.
+// source directory root, sorted. Sorted is not the order they are recognised
+// in — they run several at a time — but it is the order their artifacts are
+// assembled in, so the returned directory is the same whatever the scheduling
+// did.
 //
 // It answers the question a glob always raises — did that pattern pick up what
 // I meant? — without paying for the recognition, and it fails on an empty match
 // exactly as Export does.
-func (r *TesseractBatch) Files(ctx context.Context) ([]string, error) { // tesseract (../../../../../daggerverse/tesseract/batch.go:236:1)
+func (r *TesseractBatch) Files(ctx context.Context) ([]string, error) { // tesseract (../../../../../daggerverse/tesseract/batch.go:149:1)
 	q := r.query.Select("files")
 
 	var response []string
@@ -698,29 +710,26 @@ func (r *TesseractBatch) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
-// WithConcurrency bounds how many images the batch recognises at once. The
-// default is one, which is what a batch has always done.
+// WithConcurrency bounds how many images the batch recognises at once.
 //
-// Recognition is where a batch spends its time, and it is the one thing the
-// serial loop does not collapse: N independent images recognised one after
-// another. Processes are how tesseract parallelises well — eleven pages on four
-// CPUs take 3.37s one at a time and 1.05s eleven at a time, ~90% efficiency
-// where its own OpenMP manages 33%, because those regions sit inside the LSTM
-// inner loops and do not amortize.
+// It defaults to the number of CPUs the module can see, which is what a batch
+// wants: every image is its own exec, and recognising them one at a time would
+// pay that overhead N times for none of the parallelism it buys. Processes are
+// how tesseract parallelises well — eleven pages on four CPUs take 3.37s one at
+// a time and 1.05s eleven at a time, ~90% efficiency where its own OpenMP
+// manages 33%, because those regions sit inside the LSTM inner loops and do not
+// amortize.
 //
-// A bound above one therefore also caps OpenMP at one thread per process for
-// this batch's exec, unless the caller named an explicit ompThreadLimit on New,
-// which is left alone. Concurrency multiplied by per-process threads rather
-// than bounded by cores is the one shape that is slower than doing nothing:
-// those same four workers on an unbounded image take 3m36.8s against 1.24s
-// bounded, 174x. The bound is set on the exec rather than on the image, so
-// nothing else built from the same Tesseract sees it and two batches differing
-// only in concurrency still share the package fetch.
+// Recognising more than one at a time therefore also caps OpenMP at one thread
+// per process, unless the caller named an explicit ompThreadLimit on New, which
+// is left alone. Concurrency multiplied by per-process threads rather than
+// bounded by cores is the one shape that is slower than doing nothing: four
+// concurrent unbounded passes on four CPUs take 3m36.8s against 1.24s bounded,
+// 174x.
 //
-// Somewhere around the core count is the number to pass; more processes than
-// cores buys little once each is single-threaded. Non-positive is rejected at
-// output time.
-func (r *TesseractBatch) WithConcurrency(concurrency int) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:177:1)
+// Pass a number to take less of the machine than the default, or 1 to recognise
+// one image at a time. Non-positive is rejected at output time.
+func (r *TesseractBatch) WithConcurrency(concurrency int) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:88:1)
 	q := r.query.Select("withConcurrency")
 	q = q.Arg("concurrency", concurrency)
 
@@ -731,7 +740,7 @@ func (r *TesseractBatch) WithConcurrency(concurrency int) *TesseractBatch { // t
 
 // WithDpi declares the source resolution (`--dpi`) for every image in the
 // batch. See Document.WithDpi.
-func (r *TesseractBatch) WithDpi(dpi int) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:207:1)
+func (r *TesseractBatch) WithDpi(dpi int) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:118:1)
 	q := r.query.Select("withDpi")
 	q = q.Arg("dpi", dpi)
 
@@ -742,7 +751,7 @@ func (r *TesseractBatch) WithDpi(dpi int) *TesseractBatch { // tesseract (../../
 
 // WithEngine selects the OCR engine (`--oem`) for every image in the batch.
 // See Document.WithEngine.
-func (r *TesseractBatch) WithEngine(mode TesseractEngineMode) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:201:1)
+func (r *TesseractBatch) WithEngine(mode TesseractEngineMode) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:112:1)
 	q := r.query.Select("withEngine")
 	q = q.Arg("mode", mode)
 
@@ -761,7 +770,7 @@ func (r *TesseractBatch) WithEngine(mode TesseractEngineMode) *TesseractBatch { 
 // directory, and leptonica sniffs content rather than trusting extensions, so
 // `**/*.scan` is a reasonable thing to ask for. PDFs stay rejected either way,
 // because leptonica genuinely cannot read them.
-func (r *TesseractBatch) WithGlob(pattern string) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:149:1)
+func (r *TesseractBatch) WithGlob(pattern string) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:63:1)
 	q := r.query.Select("withGlob")
 	q = q.Arg("pattern", pattern)
 
@@ -772,7 +781,7 @@ func (r *TesseractBatch) WithGlob(pattern string) *TesseractBatch { // tesseract
 
 // WithLanguage selects the recognition language (`-l`) for every image in the
 // batch. See Document.WithLanguage.
-func (r *TesseractBatch) WithLanguage(lang string) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:189:1)
+func (r *TesseractBatch) WithLanguage(lang string) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:100:1)
 	q := r.query.Select("withLanguage")
 	q = q.Arg("lang", lang)
 
@@ -783,7 +792,7 @@ func (r *TesseractBatch) WithLanguage(lang string) *TesseractBatch { // tesserac
 
 // WithPageSegmentation sets how much layout analysis precedes recognition
 // (`--psm`) for every image in the batch. See Document.WithPageSegmentation.
-func (r *TesseractBatch) WithPageSegmentation(mode TesseractPageSegMode) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:195:1)
+func (r *TesseractBatch) WithPageSegmentation(mode TesseractPageSegMode) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:106:1)
 	q := r.query.Select("withPageSegmentation")
 	q = q.Arg("mode", mode)
 
@@ -794,7 +803,7 @@ func (r *TesseractBatch) WithPageSegmentation(mode TesseractPageSegMode) *Tesser
 
 // WithParameter sets one of tesseract's control variables (`-c name=value`)
 // for every image in the batch. See Document.WithParameter.
-func (r *TesseractBatch) WithParameter(name string, value string) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:213:1)
+func (r *TesseractBatch) WithParameter(name string, value string) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:124:1)
 	q := r.query.Select("withParameter")
 	q = q.Arg("name", name)
 	q = q.Arg("value", value)
@@ -806,7 +815,7 @@ func (r *TesseractBatch) WithParameter(name string, value string) *TesseractBatc
 
 // WithUserPatterns supplies a pattern list (`--user-patterns`) for every image
 // in the batch. See Document.WithUserPatterns.
-func (r *TesseractBatch) WithUserPatterns(patterns *File) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:225:1)
+func (r *TesseractBatch) WithUserPatterns(patterns *File) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:136:1)
 	assertNotNil("patterns", patterns)
 	q := r.query.Select("withUserPatterns")
 	q = q.Arg("patterns", patterns)
@@ -818,7 +827,7 @@ func (r *TesseractBatch) WithUserPatterns(patterns *File) *TesseractBatch { // t
 
 // WithUserWords supplies a word list (`--user-words`) for every image in the
 // batch. See Document.WithUserWords.
-func (r *TesseractBatch) WithUserWords(words *File) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:219:1)
+func (r *TesseractBatch) WithUserWords(words *File) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:130:1)
 	assertNotNil("words", words)
 	q := r.query.Select("withUserWords")
 	q = q.Arg("words", words)

--- a/daggerverse/tesseract/tests/main.go
+++ b/daggerverse/tesseract/tests/main.go
@@ -1261,13 +1261,13 @@ func (t *Tests) BatchRejectsAmbiguousInput(ctx context.Context) error {
 // images at a time produces exactly what the same batch produces one at a
 // time, and that a bound that would recognise nothing is refused.
 //
-// Byte equality is the whole promise of the knob: recognition of one image has
-// nothing to say about recognition of another, so concurrency is allowed to
-// change how long a batch takes and nothing else. The digest covers the layout
-// too, which is what pins the mirrored directories being created before the
-// parallel pass rather than raced for inside it — two images share `scans/` and
-// two share `scans/deep/`, so with four workers every directory here has two
-// candidates to create it.
+// Byte equality is the whole promise of the knob: concurrency is allowed to
+// change how long a batch takes and nothing else. What it pins now that the
+// fan-out is Go and each image is its own exec is the *assembly* — the artifacts
+// are collected in sorted order off execs that finished in whatever order they
+// finished in, so a directory that came out right only because the work
+// happened to be serial would fail here. The digest covers the mirrored layout
+// too, nested directories and all.
 func (t *Tests) BatchConcurrencyMatchesSerialOutput(ctx context.Context) error {
 	source := dag.Directory().
 		WithFile("scans/page-1.png", fixture(sentencePng)).
@@ -1330,15 +1330,16 @@ func (t *Tests) BatchConcurrencyMatchesSerialOutput(ctx context.Context) error {
 // fails the whole batch — recognised one at a time or four at a time — with a
 // message that names the page and carries tesseract's own complaint about it.
 //
-// Failing loudly is what the serial loop got from `set -e` for free, and it is
-// the half of a parallel rewrite that is easy to lose: a runner that reports
-// only its own exit status turns an unreadable page into a batch that
-// "succeeded" with one artifact quietly missing from a thousand.
+// Failing loudly is the half of a parallel rewrite that is easy to lose: a
+// runner that reports only its own exit status turns an unreadable page into a
+// batch that "succeeded" with one artifact quietly missing from a thousand.
 //
-// Naming the page has to be the runner's own doing. tesseract handed a file
+// Naming the page has to be the batch's own doing. tesseract handed a file
 // leptonica will not decode falls back to reading it as a list of image paths,
 // so its message names the file's first *line* rather than the file — here,
-// the words in the fake PNG.
+// the words in the fake PNG. Two of the good pages recognise fine either side
+// of it, so what is asserted is a failure that survives its siblings
+// succeeding.
 func (t *Tests) BatchConcurrencyReportsFailingImage(ctx context.Context) error {
 	source := dag.Directory().
 		WithFile("scans/page-1.png", fixture(sentencePng)).

--- a/daggerverse/tesseract/tests/main.go
+++ b/daggerverse/tesseract/tests/main.go
@@ -171,6 +171,8 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("BatchExportProducesEveryFormatPerImage", t.BatchExportProducesEveryFormatPerImage)
 	jobs = jobs.WithJob("BatchSharesDocumentOptions", t.BatchSharesDocumentOptions)
 	jobs = jobs.WithJob("BatchRejectsAmbiguousInput", t.BatchRejectsAmbiguousInput)
+	jobs = jobs.WithJob("BatchConcurrencyMatchesSerialOutput", t.BatchConcurrencyMatchesSerialOutput)
+	jobs = jobs.WithJob("BatchConcurrencyReportsFailingImage", t.BatchConcurrencyReportsFailingImage)
 
 	jobs = jobs.WithJob("CiRunProducesEnabledFormats", t.CiRunProducesEnabledFormats)
 	jobs = jobs.WithJob("CiMinConfidenceGatesTheRun", t.CiMinConfidenceGatesTheRun)
@@ -1250,6 +1252,118 @@ func (t *Tests) BatchRejectsAmbiguousInput(ctx context.Context) error {
 	for _, want := range []string{"scan.pdf", "leptonica", "rasterize"} {
 		if !strings.Contains(err.Error(), want) {
 			return fmt.Errorf("expected the error to mention %q, got: %v", want, err)
+		}
+	}
+	return nil
+}
+
+// BatchConcurrencyMatchesSerialOutput asserts a batch recognised several
+// images at a time produces exactly what the same batch produces one at a
+// time, and that a bound that would recognise nothing is refused.
+//
+// Byte equality is the whole promise of the knob: recognition of one image has
+// nothing to say about recognition of another, so concurrency is allowed to
+// change how long a batch takes and nothing else. The digest covers the layout
+// too, which is what pins the mirrored directories being created before the
+// parallel pass rather than raced for inside it — two images share `scans/` and
+// two share `scans/deep/`, so with four workers every directory here has two
+// candidates to create it.
+func (t *Tests) BatchConcurrencyMatchesSerialOutput(ctx context.Context) error {
+	source := dag.Directory().
+		WithFile("scans/page-1.png", fixture(sentencePng)).
+		WithFile("scans/page-2.png", fixture(sentencePng)).
+		WithFile("scans/deep/page-3.png", fixture(sentencePng)).
+		WithFile("scans/deep/page-4.png", fixture(sentencePng))
+	batch := ocr().Batch(source)
+	formats := []dagger.TesseractFormat{dagger.TesseractFormatTxt, dagger.TesseractFormatTsv}
+
+	serial := batch.Export(formats)
+	concurrent := batch.WithConcurrency(4).Export(formats)
+
+	entries, err := concurrent.Glob(ctx, "**/*")
+	if err != nil {
+		return fmt.Errorf("Export with concurrency: %w", err)
+	}
+	want := []string{
+		"scans/", "scans/deep/",
+		"scans/deep/page-3.tsv", "scans/deep/page-3.txt",
+		"scans/deep/page-4.tsv", "scans/deep/page-4.txt",
+		"scans/page-1.tsv", "scans/page-1.txt",
+		"scans/page-2.tsv", "scans/page-2.txt",
+	}
+	sort.Strings(entries)
+	if !reflect.DeepEqual(entries, want) {
+		return fmt.Errorf("expected a concurrent batch to mirror the input as %v, got %v", want, entries)
+	}
+
+	serialDigest, err := serial.Digest(ctx)
+	if err != nil {
+		return fmt.Errorf("Export without concurrency: %w", err)
+	}
+	concurrentDigest, err := concurrent.Digest(ctx)
+	if err != nil {
+		return fmt.Errorf("Export with concurrency: %w", err)
+	}
+	if serialDigest != concurrentDigest {
+		return fmt.Errorf(
+			"expected a concurrent batch to produce byte-identical artifacts, got digest %s against the serial run's %s",
+			concurrentDigest, serialDigest)
+	}
+
+	// Zero workers would recognise nothing at all, which is a directory of
+	// missing artifacts rather than a failure, so it is refused by name.
+	for _, n := range []int{0, -2} {
+		_, err := batch.WithConcurrency(n).Export(formats).Entries(ctx)
+		if err == nil {
+			return fmt.Errorf("expected concurrency %d to be rejected, got nil", n)
+		}
+		for _, want := range []string{"WithConcurrency", "concurrency must be positive", strconv.Itoa(n)} {
+			if !strings.Contains(err.Error(), want) {
+				return fmt.Errorf("expected the error for concurrency %d to mention %q, got: %v", n, want, err)
+			}
+		}
+	}
+	return nil
+}
+
+// BatchConcurrencyReportsFailingImage asserts a page tesseract cannot read
+// fails the whole batch — recognised one at a time or four at a time — with a
+// message that names the page and carries tesseract's own complaint about it.
+//
+// Failing loudly is what the serial loop got from `set -e` for free, and it is
+// the half of a parallel rewrite that is easy to lose: a runner that reports
+// only its own exit status turns an unreadable page into a batch that
+// "succeeded" with one artifact quietly missing from a thousand.
+//
+// Naming the page has to be the runner's own doing. tesseract handed a file
+// leptonica will not decode falls back to reading it as a list of image paths,
+// so its message names the file's first *line* rather than the file — here,
+// the words in the fake PNG.
+func (t *Tests) BatchConcurrencyReportsFailingImage(ctx context.Context) error {
+	source := dag.Directory().
+		WithFile("scans/page-1.png", fixture(sentencePng)).
+		WithFile("scans/page-2.png", fixture(sentencePng)).
+		WithFile("scans/deep/page-3.png", fixture(sentencePng)).
+		WithNewFile("scans/torn.png", "not an image at all\n")
+	batch := ocr().Batch(source)
+
+	for _, tc := range []struct {
+		name  string
+		batch *dagger.TesseractBatch
+	}{
+		{"one at a time", batch},
+		{"four at a time", batch.WithConcurrency(4)},
+	} {
+		_, err := tc.batch.
+			Export([]dagger.TesseractFormat{dagger.TesseractFormatTxt}).
+			Entries(ctx)
+		if err == nil {
+			return fmt.Errorf("expected an unreadable image to fail the batch %s, got nil", tc.name)
+		}
+		for _, want := range []string{"scans/torn.png", "cannot be read", "Error during processing"} {
+			if !strings.Contains(err.Error(), want) {
+				return fmt.Errorf("expected the failure %s to mention %q, got: %v", tc.name, want, err)
+			}
 		}
 	}
 	return nil

--- a/daggerverse/tesseract/training.go
+++ b/daggerverse/tesseract/training.go
@@ -320,6 +320,22 @@ func (tr *Training) iterations() (int, error) {
 	return tr.Iterations, nil
 }
 
+// checkManifestSafe rejects a path the tab-separated manifest cannot carry
+// unambiguously. Spaces are fine — the sample-building loop splits on tabs
+// alone — but a tab or a newline in a file name would be read as a field or
+// record boundary and act on the wrong file.
+//
+// Batch used to share this check and no longer needs it: it recognises each
+// image as its own exec with its own mount, so there is no record format left
+// for a file name to break. Training still assembles one, and one shell loop
+// reads it.
+func checkManifestSafe(p string) error {
+	if strings.ContainsAny(p, "\t\n") {
+		return fmt.Errorf("file name %q contains a tab or newline, which the manifest cannot represent", p)
+	}
+	return nil
+}
+
 // pairs resolves the source directory into the training samples it holds, and
 // reports every reason it is not a training set: an image with no ground
 // truth, a ground truth with no image, two images that would share one, or


### PR DESCRIPTION
Closes #298

`Batch.Export` recognised its images one after another. This makes them
concurrent, and does the fan-out **in Go** — one exec per image, bounded by a
slot channel in `batch.go` — rather than in a runner inside a single container.

```go
tess.Batch(scans).Export(ctx, formats)                     // one recognition per CPU
tess.Batch(scans).WithConcurrency(8).Export(ctx, formats)  // or fewer
```

## What changed

| | before | after |
| --- | --- | --- |
| execs | one, mounting the whole source directory | one per image, mounting that image |
| loop | a tab-separated manifest read by `sh` | a `Document` per match, run from Go |
| bound | — | `WithConcurrency`, default one per CPU |
| failure | `set -e` inside the exec | first error cancels the rest, named in Go |

The first commit on this branch bounded a `sh` worker pool inside the one exec,
because #298 fixed that shape as a constraint. Review pushed back: the point of
writing a Dagger module in Go is not to maintain scripts, and per-image execs
were never actually ruled out — a batch already runs one tesseract *process* per
image, it just shared one exec. The second commit is that rewrite.

## Measured

The one-exec shape was justified on the claim that an exec's mounts and cache
lookup are the expensive part and belong once per directory. End to end, they
are not:

| pages | one exec, `sh` loop | one exec per image, Go fan-out |
| --- | --- | --- |
| 11 | 5.5s | **2.8s** |
| 50 | 17.5s | **5.0s** |
| 50, one page edited | 17.5s | **2.5s** |

`dagger call batch --source=… export --formats=TXT entries`, median of three,
cold inputs each run (a per-run nonce appended to every PNG), 32-CPU host;
~1.7s of every figure is CLI startup and module load. The `sh` column was
measured against this branch's first commit at concurrency 1 — one exec, one
recognition at a time, threads unbounded — and the Go column is the new default.

The last row is the one more cores never fix. The old exec mounted the whole
source directory, so editing any page invalidated the mount and re-recognised
all fifty; a per-image exec keys on its own image, so the other forty-nine are
cache hits.

## Kept

- **A page that cannot be read still fails the batch**, and the error names it.
  tesseract's own message usually cannot: handed a file leptonica will not
  decode, it falls back to reading the file as a list of image paths and reports
  the *contents* of the first line as the file it could not open.
- **The first failure cancels the rest** — a doomed batch does not recognise the
  remaining pages first.
- **Deterministic assembly**: artifacts are collected in sorted order off execs
  that finished in whatever order they finished in.
- **The OpenMP bound.** Recognising more than one at a time caps OpenMP at one
  thread per process unless `New` named an `ompThreadLimit`; four concurrent
  unbounded passes on four CPUs are 3m36.8s against 1.24s bounded, 174x. It now
  rides on a copy of the module the batch makes for itself, so it reaches every
  exec in the fan-out and still leaves the caller's image alone.

## Dropped

- The manifest, and with it the rejection of file names carrying tabs or
  newlines — those are ordinary inputs now. `Training` still assembles one and
  keeps the check.
- The `mkdir -p /out` exec per recognition, replaced by an empty directory:
  invisible on one document, doubled exec count on a batch.

## Tests

`BatchConcurrencyMatchesSerialOutput` (byte-identical `Directory.Digest` and
mirrored layout however the work was scheduled; non-positive bounds refused by
name) and `BatchConcurrencyReportsFailingImage` (an unreadable page fails the
batch one at a time and four at a time, naming the page, while its siblings
succeed). The five existing `Batch` tests and the six `Ci` tests pass unchanged,
which is the check that the mirrored layout and per-image artifacts really are
the same.

## Verification

- `dagger -m daggerverse/tesseract/tests call all` — green
- `dagger -m ci call generated` — OK (bindings regenerated in module, tests and root)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vcWUX4saisKPt3PYEAdVh