### PR TITLE
story(issue-309): render a document's pages concurrently

### DIFF
--- a/daggerverse/pdf/README.md
+++ b/daggerverse/pdf/README.md
@@ -349,6 +349,7 @@ Convert.WithDpi(dpi int) *Convert
 Convert.WithColorMode(mode ColorMode) *Convert
 Convert.WithScaleTo(pixels int) *Convert
 Convert.WithoutAnnotations() *Convert
+Convert.WithConcurrency(concurrency int) *Convert  // default: one per CPU
 
 Convert.Text(ctx, layout LayoutMode, disablePageBreaks bool) (string, error)
 Convert.Txt(ctx, layout LayoutMode, disablePageBreaks bool) (*dagger.File, error)
@@ -401,6 +402,127 @@ conv := doc.Convert().WithDpi(300).WithColorMode(dagger.PdfColorModeMono)
 png  := conv.Png()
 tiff := conv.Tiff()
 ```
+
+### One exec per page, fanned out from Go
+
+```go
+doc.Convert().WithDpi(300).WithConcurrency(8).Png()   // default: one page per CPU
+```
+
+`Png`, `Jpeg`, `Tiff`, `Svg`, `Eps` and `Html` render **one page per exec**, as
+many at a time as `WithConcurrency` allows. The bound, the scheduling, the
+fail-fast and the error message are all Go — nothing about running a conversion
+is interpreted inside a container.
+
+That is a reversal, and it is the same one [#298][i298] made in `tesseract`.
+Until #309 the raster family was a single `pdftoppm` over the whole document,
+and the vector family a page loop *inside* one exec. `pdftoppm` renders a range
+serially in one process, so an N-page document was one core for as long as it
+took, however many the machine had:
+
+| pages | one exec | one exec per page, Go fan-out |
+| --- | --- | --- |
+| 12 | 17.0s | **4.0s** |
+| 48 | 60.4s | **6.5s** |
+| 48, one page edited | 60.7s | 6.5s |
+| 48, pages 1–24 already rendered | 61.0s | **4.3s** |
+
+`dagger call document --source=… convert with-dpi --dpi=300 png entries`, median
+of three, a freshly generated document every run so nothing is a cache hit,
+32-CPU host, 300 dpi; ~1.2s of every figure is CLI startup and module load. Both
+columns produce a **byte-identical directory** — the same `sha256` — which is
+the point: concurrency is allowed to change how long a render takes and nothing
+else.
+
+The last two rows are the ones worth reading carefully, because **only one of
+them is a win, and it is not the one `tesseract` got.**
+
+- **Editing a page re-renders the whole document, in both columns.** Every
+  page's exec mounts the *same* PDF, so a change to any byte of it invalidates
+  all of them. `tesseract`'s `Batch` gets the opposite result — 50 pages, one
+  edited, 17.5s → 2.5s — because there each exec mounts *its own image file*.
+  A per-item exec only caches per item when the items are separate inputs, and
+  the pages of a PDF are not.
+- **Rendering a page range you have already rendered part of is a win.** Pages
+  1–24 followed by the whole 48 costs 4.3s against 6.4s cold, because the first
+  24 execs are hits. That is the [#300](https://github.com/z5labs/devex/issues/300)
+  sharding case: a document rendered in slices, or a slice widened after the
+  fact, no longer re-renders what it already has.
+
+Three properties the serial loop had for free, which the fan-out has to keep:
+
+- **A page that cannot be rendered fails the whole conversion**, rather than
+  going missing from a directory of a thousand, and the error names the page:
+  `Png page 7 failed (exit 99): …`.
+- **The first failure cancels the rest.** A conversion that is going to fail has
+  no reason to render the remaining pages first.
+- **The pages are assembled in page order**, off execs that finished in whatever
+  order they finished in, so the returned directory does not depend on the
+  scheduling.
+
+Those three are covered by `Pdf.RenderSchedulingSelfTest` rather than by a
+fixture, and that is not a shortcut — **poppler will not fail a page.** Measured
+against the pinned poppler 25.12, every damaged page shape is a warning on
+stderr and an exit status of 0, with a file still written: a dangling page-tree
+kid, a kid of the wrong type, a loop in the page tree, a null kid, a
+two-million-point `MediaBox`, a `MediaBox` of zero, and a resolution large enough
+to print `Bogus memory allocation size`. The only non-zero exits are for a
+document that cannot be opened at all and for a page range outside it, and both
+are caught before any page is rendered. So no document makes one page of a render
+fail, the scheduling is tested where it lives — `fanout/`, which imports no
+dagger and runs under `go test -race` — and the fail-fast exists for the
+failures poppler *does* report rather than for one this repo can demonstrate.
+
+> A blank or wrong-looking page is **not** one of the failures this catches, for
+> the same reason: poppler exits 0 for it. [`Fonts`](#fonts--the-blank-page-diagnostic-before-the-blank-page)
+> is the diagnostic for that, before the fact.
+
+[i298]: https://github.com/z5labs/devex/issues/298
+
+#### Why the default is one page per CPU
+
+`WithConcurrency` defaults to `runtime.NumCPU()`, matching `tesseract`'s `Batch`
+and the repo's guidance that a default should favour the machine the caller is
+on. Unlike `Batch` it needs no companion bound: poppler's tools are
+single-threaded, so concurrency here is concurrency and not concurrency
+multiplied by an OpenMP team.
+
+The share of a job this fixes **grows with core count rather than shrinking.**
+On the reporter's 129-page document in
+[#308](https://github.com/z5labs/devex/discussions/308), the render was ~60s on
+one core against ~30s of 14-core recognition — two thirds of the wall clock for
+a third of the CPU. The same document on a 32-CPU host is ~13s of recognition
+against an unchanged ~60s of render.
+
+**Every existing caller's cache entries churn once**, and that is a property of
+the fan-out and not of the default: one exec per page is N entries at *every*
+bound, including `WithConcurrency(1)`. The first conversion after upgrading
+re-renders; the old single entry is orphaned and expires on Dagger's usual
+7-day TTL.
+
+#### What the per-page open costs
+
+N execs each re-open the PDF and re-parse its xref, where one `pdftoppm` did
+that once. Measured inside a single container — no Dagger, so this is poppler's
+cost alone — on a 48-page document:
+
+| dpi | one process | 48 processes, serial | overhead |
+| --- | --- | --- | --- |
+| 150 | 3.72s | 4.67s | 20 ms/page |
+| 300 | 12.12s | 14.92s | 58 ms/page |
+| 600 | 43.99s | 49.78s | 121 ms/page |
+
+It is **not a fixed per-open cost**: it scales with the output's pixel count, so
+it is roughly 13–26% whatever the resolution rather than shrinking against a
+larger raster. An image-only document of the same length costs much the same
+(16 ms/page at 150, 49 ms/page at 300), so this is not the font cache being
+rebuilt — it is the per-process render state, page bitmap included, that a single
+process amortizes across pages and N processes do not.
+
+Against the ~0.47s/page a real 300-dpi page costs in #308, ~58ms is ~12% more
+CPU for the whole document — bought back many times over by the first extra core
+the fan-out uses, and the reason the trade is worth making rather than a reason
+to hesitate.
 
 ### Text and `Txt`
 
@@ -573,7 +695,7 @@ reachable, and `SvgWritesOneVectorFilePerPage` asserts the absence of a
 
 **EPS refuses multi-page outright.** `pdftocairo -eps` handed a document with a
 second page writes nothing and exits 99 with `EPS files can only contain one
-page.` The per-page loop is what turns that refusal into the whole document.
+page.` The per-page fan-out is what turns that refusal into the whole document.
 Note that an EPS's bounding box is the page's **ink**, not its media box —
 poppler crops to what is drawn, so a US Letter page with one line of text on it
 comes out a few inches wide. That is EPS's own convention (a figure carries its
@@ -584,6 +706,15 @@ disagree with the geometry `Png` reports.
 multi-page format: one document with a `%%Pages:` count and a `%%Page:` marker
 per page. A directory of one-page fragments would look tidier beside `Svg` and
 `Eps` and be individually invalid.
+
+That is also why **`Ps` is the one render that stays a single invocation**, and
+why `WithConcurrency` does nothing for it. Every other page-per-file output fans
+out an exec per page and assembles the directory afterwards; a PostScript
+document cannot be assembled that way, because concatenating the fragments is
+not the same operation as writing the document — the result needs its prologue,
+its page markers and its `%%Pages:` count rewritten, which is a PostScript editor
+and not a renderer. A caller who wants the pages rendered concurrently wants
+`Eps`, which is one page per file by definition.
 
 ### `Html` — markup with the images beside it
 
@@ -625,6 +756,16 @@ at all. `Split` is `pdfseparate`: one PDF per page, named to the same
 [page-naming contract](#page-naming--page-0001png) the render family honours,
 `page-0001.pdf` onwards. `Merge` is `pdfunite`: several PDFs concatenated into
 one.
+
+**`Split` stays one exec**, where the renders now fan out a page at a time, and
+that is a measured decision rather than an omission. Splitting is not
+rasterizing: `pdfseparate` copies page objects, at **0.8 ms/page** for the whole
+document in one invocation against 5.8 ms/page one invocation per page. A page
+that costs a millisecond does not want its own container — the Dagger exec around
+it costs two orders of magnitude more than the work — so a fan-out here would
+make `Split` slower for every document and buy nothing but cache granularity
+nobody is waiting on. `Convert.WithConcurrency` therefore does not reach it, and
+`Split` needs no bound of its own.
 
 They are **lossless** in a way no conversion is. Each split page carries the
 original page's own objects across — its text layer, its fonts, its annotations,
@@ -853,14 +994,21 @@ module's:
 image is not a page: several can sit on one page and most pages carry none.
 `Attachments` is on no list at all, its names being the document's.
 
-The families reach that contract from opposite directions. `pdftoppm` and
-`pdfseparate` name the files and this module **renames** them; for `Svg`, `Eps`
-and `Html` the module drives the page loop itself and **names them outright**,
-one invocation per page, because neither `pdftocairo` nor `pdftohtml` will
-produce a usable page-per-file set on its own. The upper bound of that loop — a
-`WithPageRange` open-ended `last`, or no range at all — is resolved from
-`pdfinfo` **inside the same exec** that renders, so the whole conversion stays
-one exec either way.
+Every render **names its pages outright**; only `Split` renames. The module
+drives the page loop itself and hands each invocation the exact file it should
+write, which is what `-singlefile` buys for the raster family — handed an output
+base, `pdftoppm` appends a page number of its own choosing, and handed
+`-singlefile` it writes exactly `<base>.<ext>`. `Split` cannot be named that way
+and goes through a rename pass instead: `pdfseparate` writes every page of a
+range in one invocation, numbered to whatever width the destination pattern
+asked for.
+
+The width comes from `PageCount`, read in **Go**, once per conversion — the
+greater of four and the digits the document's last page needs. That round trip
+is what one exec per page costs and it is the trade the fan-out makes knowingly:
+an exec that renders one page cannot compute a padding width from the files it
+finds, because it finds exactly one. It is the same `pdfinfo` `Info` runs, so a
+conversion of a document already reported on pays nothing for it.
 
 `pdfseparate` is the one that would honour a padded name if it were asked:
 handed a `page-%04d.pdf` destination pattern it zero-pads for you. It goes
@@ -868,12 +1016,12 @@ through the rename pass anyway, because a fixed width in the pattern is a width
 and not a *floor* — a document with more than 9999 pages would come out numbered
 to two widths, which is the exact ambiguity the contract exists to remove.
 
-For the raster family in particular, **this is a normalization, not
-`pdftoppm`'s own behaviour.** `pdftoppm` pads a
-page number to the width of the *document's* page count, so a 9-page document
-yields `page-1.png` and a 10-page one `page-01.png` — and a 9-page *range* of a
-12-page document yields `page-01.png` too, because the width follows the
-document rather than what was rendered.
+For the raster family in particular, **this is a contract, not `pdftoppm`'s own
+behaviour.** Left to itself `pdftoppm` pads a page number to the width of the
+*document's* page count, so a 9-page document yields `page-1.png` and a 10-page
+one `page-01.png` — and a 9-page *range* of a 12-page document yields
+`page-01.png` too, because the width follows the document rather than what was
+rendered.
 
 Lexicographic order is therefore page order **only within a single document**,
 and a consumer that sorts what it is handed — `tesseract`'s `Batch` does a bare
@@ -882,21 +1030,21 @@ hardcodes one name shape breaks on the next document. Padding to a fixed minimum
 makes the shape a contract instead of a consequence, and that is what lets this
 directory be handed to another module at all.
 
-A rename pass runs **in the same exec** as the render, so the directory never
-existed under the other names. The width is the greater of four and whatever the
-tool chose, so a document longer than four digits can express stays uniform
-rather than being truncated into ambiguity.
+`Split`'s rename pass runs **in the same exec** as the split, so its directory
+never existed under the other names.
 
 Page numbers are the **source document's**, not positions within a range, so
 `WithPageRange(4, 6)` yields `page-0004`…`page-0006`. That keeps a rendered page
-traceable back to the page it came from.
+traceable back to the page it came from. The *width* follows the whole document
+rather than the range, for the same reason: every conversion of one document
+numbers its pages the same way however it was narrowed.
 
-`-forcenum` is passed unconditionally to `pdftoppm`. On poppler 25.12 — what the
-pinned tag ships — it changes nothing, because a page number is always appended.
-It is there for a caller who overrode `alpineTag` onto an older release, where a
-single-page render was named `page.png` with no number at all, breaking the
-contract for exactly the documents most likely to be one page. The per-page
-family needs no equivalent, naming its own output.
+`-forcenum` used to be passed unconditionally to `pdftoppm`, for a caller who
+overrode `alpineTag` onto a poppler old enough to name a single-page render
+`page.png` with no number at all. It is gone, and could not have survived
+`-singlefile`: the two override rather than compose, and together they write
+`page-0007-07.png`. They answer the same worry anyway — the number is in the name
+this module chose rather than in one the tool appended, on every release.
 
 ### Why `pdftoppm` for raster and `pdftocairo` for vector
 
@@ -917,11 +1065,25 @@ transform of its inputs — the document bytes plus the flags — so Dagger's 7-
 default is correct and there is no chained-method propagation problem to worry
 about. Same posture as `tesseract`'s outputs and `kicad`.
 
+What the per-page fan-out changes is the *granularity*: a render is now one cache
+entry per page rather than one per conversion. See [One exec per page](#one-exec-per-page-fanned-out-from-go)
+for what that does and does not buy — it makes an overlapping page range cheap
+and it does **not** make an edited document cheap, because every page's exec
+mounts the same PDF.
+
 ## Follow-ups
 
 Cropping the render window and selecting odd or even pages (#272); the chained
-`Ci` builder (#273); linearize, encrypt and repair via qpdf (#274); renderer
+`Ci` builder (#273) — which will want `WithConcurrency` forwarded, the way #305
+does for `tesseract`; linearize, encrypt and repair via qpdf (#274); renderer
 fidelity and colour-profile options (#277).
+
+The per-page fan-out (#309) does **not** address intermediate size: a
+3,000-page 300-dpi directory is still gigabytes crossing a module boundary at
+once, and [#300](https://github.com/z5labs/devex/issues/300)'s `WithPageRange`
+sharding recipe is still the answer to that. What the fan-out changes for it is
+the cost: a shard of a document already partly rendered now reuses the pages it
+has.
 
 `tesseract`'s `FromPdf` was removed in favour of this module (#276): that module
 carries no rasterizer at all now, so `Png()` feeds its `Batch` directly — which

--- a/daggerverse/pdf/convert.go
+++ b/daggerverse/pdf/convert.go
@@ -3,62 +3,13 @@ package main
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"strconv"
 	"strings"
 
+	"dagger/pdf/fanout"
 	"dagger/pdf/internal/dagger"
 )
-
-// rasterArgv0 is the `$0` the raster script runs under, so the format's
-// extension reaches it as `$1` rather than being interpolated into the script
-// text.
-const rasterArgv0 = "pdf-raster"
-
-// normalizeScript renames every page the tool just wrote so its number is
-// zero-padded to a fixed width, and is the reason this directory can be handed
-// to another module at all. It is the raster renders' pass and Split's alike:
-// both write a page per file, and both leave the number unpadded for it.
-//
-// pdftoppm pads a page number to the width of the document's page count, so a
-// 9-page document yields `page-1.png` and a 10-page one `page-01.png`.
-// Lexicographic order is therefore page order within a single document and
-// nothing more: a consumer that sorts what it is given — the tesseract module's
-// Batch does a bare sort.Strings — has no way to know which width it is holding,
-// and a caller who hardcodes one name shape breaks on the next document. Padding
-// to a fixed minimum makes the shape a contract instead of a consequence.
-//
-// The width is the greater of the module's minimum and whatever pdftoppm chose,
-// so a document longer than the minimum can express stays uniform rather than
-// being truncated into ambiguity.
-//
-// It runs in the same exec as the render, so the directory this function returns
-// has never existed under the other names.
-var normalizeScript = strings.Join([]string{
-	`ext="$1"`,
-	`width=` + strconv.Itoa(minPageNumberWidth),
-	`for f in ` + pageGlob + `; do`,
-	`	[ -e "$f" ] || continue`,
-	`	n=${f##*/` + pageNamePrefix + `}`,
-	`	n=${n%."$ext"}`,
-	`	if [ ${#n} -gt "$width" ]; then width=${#n}; fi`,
-	`done`,
-	`for f in ` + pageGlob + `; do`,
-	`	[ -e "$f" ] || continue`,
-	`	n=${f##*/` + pageNamePrefix + `}`,
-	`	n=${n%."$ext"}`,
-	// Leading zeros are stripped before printf sees the number: POSIX printf
-	// reads a leading-zero argument as an octal constant, so `09` is not 9 but
-	// a diagnostic.
-	`	stripped=$(printf '%s' "$n" | sed 's/^0*//')`,
-	`	[ -n "$stripped" ] || stripped=0`,
-	`	padded=$(printf "%0${width}d" "$stripped")`,
-	`	if [ "$n" != "$padded" ]; then mv "$f" "` + outputDir + `/` + pageNamePrefix + `$padded.$ext"; fi`,
-	`done`,
-}, "\n")
-
-// pageGlob matches every page a render wrote, whatever width pdftoppm numbered
-// it to. The extension comes from `$1` so one script serves all three formats.
-const pageGlob = outputDir + `/` + pageNamePrefix + `*."$ext"`
 
 // Convert is a conversion of a bound document: the options a render reads, and
 // the outputs that read them.
@@ -88,6 +39,10 @@ type Convert struct {
 	HasScaleTo bool
 	// +private
 	HideAnnotations bool
+	// +private
+	Concurrency int
+	// +private
+	HasConcurrency bool
 }
 
 // WithDpi sets the resolution pages are rendered at, in dots per inch.
@@ -170,6 +125,40 @@ func (c *Convert) WithScaleTo(
 func (c *Convert) WithoutAnnotations() *Convert {
 	out := c.clone()
 	out.HideAnnotations = true
+	return out
+}
+
+// WithConcurrency bounds how many pages a render converts at once.
+//
+// It defaults to the number of CPUs the module can see, which is what a
+// document wants: every page is its own exec, and poppler renders a page on one
+// core whatever the machine has. A 129-page document at 300 dpi spends about a
+// minute of that one core, and the recognition it is usually rendered for
+// spends its own time across every core — so the render is a third of the CPU
+// and two thirds of the wall clock, and the share grows with core count rather
+// than shrinking.
+//
+// Unlike the tesseract module's Batch, this bound needs no companion. poppler's
+// tools are single-threaded, so concurrency here is concurrency and not
+// concurrency multiplied by an OpenMP team; the pages contend for cores the way
+// any other CPU-bound workload does.
+//
+// Pass a number to take less of the machine than the default, or 1 to render one
+// page at a time. Non-positive is rejected at output time.
+//
+// It is a scheduling bound and nothing else: the directory a conversion returns
+// is the same whatever it is set to. It is also not what decides how the results
+// cache — one exec per page is what does that, at every bound including 1.
+//
+// Ignored by Text, Txt, Bbox, Tsv and Ps, none of which renders a page at a
+// time. See Ps for why that one is a single invocation.
+func (c *Convert) WithConcurrency(
+	// Maximum number of pages to render at the same time.
+	concurrency int,
+) *Convert {
+	out := c.clone()
+	out.Concurrency = concurrency
+	out.HasConcurrency = true
 	return out
 }
 
@@ -403,6 +392,15 @@ func (c *Convert) Eps(ctx context.Context) (*dagger.Directory, error) {
 // Splitting it into a page-per-file directory would produce fragments that are
 // each individually invalid.
 //
+// That is also why this is the one render that stays a single invocation, and
+// why WithConcurrency does nothing here. Every other page-per-file output fans
+// out one exec per page and assembles the directory afterwards; a PostScript
+// document cannot be assembled that way, because concatenating the fragments is
+// not the same operation as writing the document — the result would need its
+// prologue, its page markers and its `%%Pages:` count rewritten, which is a
+// PostScript editor and not a renderer. A caller who wants the pages rendered
+// concurrently wants Eps, which is one page per file by definition.
+//
 // WithDpi governs the rasterized regions the output can still contain.
 // WithColorMode, WithScaleTo and WithoutAnnotations are ignored here and by Svg,
 // Eps and Html, and are documented no-ops rather than rejections for the same
@@ -484,11 +482,22 @@ func (c *Convert) textFlags(label string, layout LayoutMode, disablePageBreaks b
 // rasterFlags renders everything pdftoppm needs that is not the document, the
 // output base or a password.
 //
-// -forcenum is unconditional. In poppler 25.12 — what the pinned Alpine tag
-// ships — it changes nothing, because a page number is always appended. It is
-// here for the caller who overrode alpineTag onto an older release, where a
-// single-page render was named `page.png` with no number in it at all, breaking
-// the naming contract for exactly the documents most likely to be one page.
+// -singlefile is what makes the page-naming contract this module's rather than
+// poppler's. Handed an output base, pdftoppm appends a page number of its own
+// choosing and the format's extension; handed -singlefile it writes exactly
+// `<base>.<ext>` and nothing else, so a render told to produce `page-0007` does.
+// Since each invocation renders one page, that is the whole contract, and the
+// rename pass the raster family used to run afterwards is gone with it.
+//
+// -forcenum is gone for the same reason, and could not survive: it overrides
+// -singlefile rather than composing with it, so the two together write
+// `page-0007-07.png`. It existed for a caller who overrode alpineTag onto a
+// poppler old enough to name a single-page render `page.png`, and -singlefile
+// answers that case outright on every release — the number is in the name this
+// module chose, not in one the tool appended.
+//
+// The document's own range flags are deliberately not appended: the page bounds
+// are per invocation now, one page wide, and are added by raster.
 func (c *Convert) rasterFlags(label string, format rasterFormat) ([]string, error) {
 	if c.HasDpi && c.Dpi <= 0 {
 		return nil, fmt.Errorf(
@@ -505,7 +514,7 @@ func (c *Convert) rasterFlags(label string, format rasterFormat) ([]string, erro
 			label, string(c.ColorMode), colorNames())
 	}
 
-	args := []string{format.flag, "-forcenum"}
+	args := []string{format.flag, "-singlefile"}
 	// Exactly one of the two ever reaches the command line, which is what
 	// makes WithScaleTo override WithDpi here rather than inside poppler.
 	if c.HasScaleTo {
@@ -517,7 +526,7 @@ func (c *Convert) rasterFlags(label string, format rasterFormat) ([]string, erro
 	if c.HideAnnotations {
 		args = append(args, "-hide-annotations")
 	}
-	return append(args, c.Document.rangeArgs()...), nil
+	return args, nil
 }
 
 // dpi is the resolution a render runs at: what the caller asked for, or the
@@ -549,93 +558,205 @@ func (c *Convert) cairoFlags(format pageFormat) ([]string, error) {
 	return args, nil
 }
 
-// pageRender writes one file per page and returns the directory holding them.
+// pageRender writes one file per page, one exec per page, and returns the
+// directory holding them.
 //
-// The page loop runs in the container rather than here because its upper bound
-// is the document's page count, and reading that from Go would mean a second
-// round trip to fetch what the very next exec is about to open anyway. Resolving
-// it in the same shell keeps the whole conversion one exec, the way the raster
-// path's rename pass does.
+// The whole directory of each render is taken rather than the page file alone,
+// because pdftohtml writes more than the page: a page carrying images gets them
+// beside its markup under names of the tool's choosing, referenced from the
+// markup by a relative path. Selecting only what this module can name would
+// leave that markup pointing at files the returned directory does not hold.
+// Pages cannot collide in the merge — every name a render writes starts with the
+// page's own `page-NNNN` base — and they are merged in page order, so the result
+// does not depend on which exec finished first.
 func (c *Convert) pageRender(ctx context.Context, label string, format pageFormat) (*dagger.Directory, error) {
 	flags, err := c.cairoFlags(format)
 	if err != nil {
 		return nil, err
 	}
-	if err := c.Document.validateRange(ctx); err != nil {
-		return nil, err
-	}
-
-	name := pageNamePrefix + `$padded`
-	if format.namesExtension {
-		name += "." + format.ext
-	}
-	// The bounds are the loop variable, so the document's own range flags are
-	// deliberately not appended: this invocation renders exactly one page.
-	render := c.Document.command(format.tool, flags,
-		"-f", `"$p"`, "-l", `"$p"`, sourcePath, name)
-
-	res, err := c.Document.runScript(ctx, label, c.pageLoop(render))
+	pages, err := c.plan(ctx, label)
 	if err != nil {
 		return nil, err
 	}
-	return res.container.Directory(outputDir), nil
+
+	jobs := make([]pageJob, 0, len(pages))
+	for _, page := range pages {
+		// The output is named relative to the output directory, and the script
+		// works it from the inside — `cd` rather than an absolute path —
+		// because pdftohtml writes the output name it was given into every
+		// `img src` in the markup it produces. Named absolutely, it emits
+		// markup whose images only resolve on the machine that rendered them.
+		name := page.base
+		if format.namesExtension {
+			name += "." + format.ext
+		}
+		jobs = append(jobs, pageJob{
+			page: page.number,
+			script: strings.Join([]string{
+				"set -e",
+				"mkdir -p " + outputDir,
+				"cd " + outputDir,
+				c.Document.command(format.tool, flags,
+					"-f", strconv.Itoa(page.number), "-l", strconv.Itoa(page.number),
+					sourcePath, name),
+			}, "\n"),
+		})
+	}
+
+	execs, err := c.render(ctx, label, jobs)
+	if err != nil {
+		return nil, err
+	}
+	out := dag.Directory()
+	for _, exec := range execs {
+		out = out.WithDirectory("/", exec.Directory(outputDir))
+	}
+	return out, nil
 }
 
-// pageLoop is the script that runs a per-page conversion once for every page in
-// range, with `$padded` set to the page's zero-padded number.
+// page is one page of a planned conversion: its number in the source document,
+// and the padded file base every output of it is named from.
+type page struct {
+	number int
+	base   string
+}
+
+// pageJob is one page's render — the page it covers and the script that renders
+// it — carried together so a failure can name the page rather than the exec.
+type pageJob struct {
+	page   int
+	script string
+	args   []string
+}
+
+// plan resolves which pages a conversion covers and what each one's output is
+// called, and is the one place the naming contract is decided.
 //
-// It works the output directory from the inside — `cd` rather than an absolute
-// output path — because pdftohtml writes the output name it was given into every
-// `img src` in the markup it produces. Named absolutely, it emits markup whose
-// images only resolve on the machine that rendered them.
-func (c *Convert) pageLoop(render string) string {
+// It costs a PageCount round trip that the in-container page loop was written to
+// avoid, and the trade is deliberate. One exec per page cannot compute the
+// padding width from the files it finds, because each exec finds exactly one; so
+// the width moves to Go, where it needs the page count. That is one pdfinfo per
+// conversion rather than one per page, it is the same exec validateRange already
+// pays for whenever a range is set, and Dagger caches it — a second conversion of
+// the same document does not run it again.
+func (c *Convert) plan(ctx context.Context, label string) ([]page, error) {
+	if err := c.validateConcurrency(); err != nil {
+		return nil, err
+	}
+	if err := c.Document.validateRange(ctx); err != nil {
+		return nil, err
+	}
+	count, err := c.Document.pageCount(ctx, label)
+	if err != nil {
+		return nil, err
+	}
+
 	first := 1
 	if c.Document.HasRange && c.Document.FirstPage > 0 {
 		first = c.Document.FirstPage
 	}
-	last := endOfDocument
-	if c.Document.HasRange {
+	last := count
+	if c.Document.HasRange && c.Document.LastPage != endOfDocument {
 		last = c.Document.LastPage
 	}
 
-	return strings.Join([]string{
-		// set -e is what makes a page poppler cannot write stop the loop
-		// carrying its own message, rather than leaving a directory that is
-		// short a page and says nothing about it.
-		`set -e`,
-		`mkdir -p ` + outputDir,
-		`cd ` + outputDir,
-		`first=` + strconv.Itoa(first),
-		`last=` + strconv.Itoa(last),
-		// An open-ended range is resolved here rather than in Go so the page
-		// count and the render share one exec.
-		//
-		// The report is captured and parsed in two steps rather than piped
-		// straight into sed, because set -e reads the exit status of the *last*
-		// command in a pipeline. Piped, a document pdfinfo cannot open leaves
-		// sed succeeding on nothing, and the run gets as far as the page-count
-		// check below and fails there — with poppler's diagnostic still on
-		// stderr, but joined by a second message about a page count that was
-		// never the problem. Split, the script stops on pdfinfo's own status.
-		`if [ "$last" -eq ` + strconv.Itoa(endOfDocument) + ` ]; then`,
-		`	info=$(` + c.Document.command("pdfinfo", nil, sourcePath) + `)`,
-		`	last=$(printf '%s\n' "$info" | sed -n 's/^Pages:[[:space:]]*//p')`,
-		`fi`,
-		`case "$last" in`,
-		`	''|*[!0-9]*) echo "could not read the page count: $last" >&2; exit 1;;`,
-		`esac`,
-		// The width is the greater of the module's minimum and what the last
-		// page number needs, so a document longer than the minimum can express
-		// stays uniform. Same contract the raster path normalizes to.
-		`width=` + strconv.Itoa(minPageNumberWidth),
-		`if [ ${#last} -gt "$width" ]; then width=${#last}; fi`,
-		`p="$first"`,
-		`while [ "$p" -le "$last" ]; do`,
-		`	padded=$(printf "%0${width}d" "$p")`,
-		`	` + render,
-		`	p=$((p + 1))`,
-		`done`,
-	}, "\n")
+	// A conversion covering no pages would otherwise return an empty directory,
+	// which a caller reads as a document that rendered fine and had nothing in
+	// it — the same silent success EmbeddedImages refuses for a document with no
+	// images. It is not reachable through a page range, validateRange having
+	// bounded both ends against the count already; it is the floor under a
+	// document that reports having no pages at all.
+	if last < first {
+		return nil, fmt.Errorf(
+			"%s: this document reports %d page(s), so there is nothing to render",
+			label, count)
+	}
+
+	// The width follows the whole document rather than the range, so every
+	// conversion of one document numbers its pages the same way however it was
+	// narrowed — which is what makes a page traceable to the page it came from.
+	width := pageNumberWidth(count)
+	pages := make([]page, 0, last-first+1)
+	for number := first; number <= last; number++ {
+		pages = append(pages, page{
+			number: number,
+			base:   fmt.Sprintf("%s%0*d", pageNamePrefix, width, number),
+		})
+	}
+	return pages, nil
+}
+
+// pageNumberWidth is how many digits a rendered page's number is padded to: the
+// greater of the module's minimum and what the document's last page needs.
+//
+// The minimum is what makes the shape a contract rather than a consequence of
+// the document's length, and taking the greater of the two is what keeps a
+// document longer than the minimum can express uniform rather than truncating it
+// into ambiguity. See normalizeScript, which Split reaches the same contract by.
+func pageNumberWidth(count int) int {
+	return max(minPageNumberWidth, len(strconv.Itoa(count)))
+}
+
+// render runs one exec per page, at most workers() of them at a time, and
+// returns the finished execs positionally.
+//
+// The scheduling itself is the fanout package's, which imports no dagger and is
+// tested with `go test -race` — see that package for why the properties it holds
+// cannot be tested against a document instead. What is here is what makes a
+// failure readable: the page each exec covers, in the label its error carries.
+func (c *Convert) render(ctx context.Context, label string, jobs []pageJob) ([]*dagger.Container, error) {
+	execs := make([]*dagger.Container, len(jobs))
+
+	// Each unit writes only its own element, and Run does not return until every
+	// unit it started has, so the slice needs no lock of its own.
+	err := fanout.Run(ctx, c.workers(), len(jobs), func(ctx context.Context, i int) error {
+		job := jobs[i]
+		// The label carries the page, so every message this run can produce —
+		// poppler's own failure, and the module's message for an encrypted
+		// document — names the page it came from without the error being
+		// wrapped twice. Returned as it is rather than %w-wrapped: the error
+		// crosses the module boundary, which unwraps a chain back to the inner
+		// error and would drop the page's name along with it.
+		res, err := c.Document.runScript(ctx,
+			fmt.Sprintf("%s page %d", label, job.page), job.script, job.args...)
+		if err != nil {
+			return err
+		}
+		execs[i] = res.container
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return execs, nil
+}
+
+// workers is how many pages render at once: whatever WithConcurrency asked for,
+// or one per CPU the module can see.
+//
+// The default is the core count rather than one because every page is its own
+// exec now, and a single pdftoppm renders a document's pages one after another
+// on one core however many the machine has. What makes the core count safe here
+// — and needs no companion bound, unlike the tesseract module's Batch — is that
+// poppler's tools are single-threaded.
+func (c *Convert) workers() int {
+	if c.HasConcurrency {
+		return c.Concurrency
+	}
+	return max(minRenderConcurrency, runtime.NumCPU())
+}
+
+// validateConcurrency rejects a bound that would render no pages at all. It is
+// deferred to output time rather than reported from the builder because a
+// builder has no error return, which is the same reason WithDpi's check lives
+// away from WithDpi.
+func (c *Convert) validateConcurrency() error {
+	if c.HasConcurrency && c.Concurrency < minRenderConcurrency {
+		return fmt.Errorf(
+			"WithConcurrency: concurrency must be positive, got %d: pass 1 to render one page at a time, or leave it unset for one per available CPU",
+			c.Concurrency)
+	}
+	return nil
 }
 
 // geometry runs pdftotext in one of its geometry-reporting modes and returns the
@@ -664,27 +785,63 @@ func (c *Convert) geometry(ctx context.Context, label, flag, output string) (*da
 
 // raster renders the pages and returns the directory holding them, with every
 // page's number padded to a fixed width.
+//
+// One pdftoppm per page, rather than one over the whole document, is what lets
+// the pages render at the same time — poppler renders a range serially in a
+// single process, on one core whatever the machine has — and what makes the
+// results cache per page: an edited page invalidates its own render and nothing
+// else. It is the same reversal #298 made in the tesseract module, for the same
+// measured reason; see the README.
+//
+// Each page is named outright rather than renamed afterwards, -singlefile making
+// pdftoppm write exactly the file it is given. The files are selected by name
+// off the exec that produced them, in page order, so the returned directory is
+// the same whatever order the renders finished in.
 func (c *Convert) raster(ctx context.Context, label string, format rasterFormat) (*dagger.Directory, error) {
 	flags, err := c.rasterFlags(label, format)
 	if err != nil {
 		return nil, err
 	}
-	if err := c.Document.validateRange(ctx); err != nil {
-		return nil, err
-	}
-	// set -e makes a document poppler cannot open fail here, carrying its own
-	// message, rather than turning into an empty page directory a caller would
-	// read as a document with no pages in it.
-	script := strings.Join([]string{
-		"set -e",
-		"mkdir -p " + outputDir,
-		c.Document.command("pdftoppm", flags, sourcePath, pageBase),
-		normalizeScript,
-	}, "\n")
-
-	res, err := c.Document.runScript(ctx, label, script, rasterArgv0, format.ext)
+	pages, err := c.plan(ctx, label)
 	if err != nil {
 		return nil, err
 	}
-	return res.container.Directory(outputDir), nil
+
+	jobs := make([]pageJob, 0, len(pages))
+	for _, page := range pages {
+		bounds := []string{"-f", strconv.Itoa(page.number), "-l", strconv.Itoa(page.number)}
+		// set -e makes a page poppler cannot draw fail here, carrying its own
+		// message, rather than dropping a file from a directory a caller would
+		// read as a document that was short a page all along.
+		jobs = append(jobs, pageJob{
+			page: page.number,
+			script: strings.Join([]string{
+				"set -e",
+				"mkdir -p " + outputDir,
+				c.Document.command("pdftoppm", concat(flags, bounds),
+					sourcePath, outputDir+"/"+page.base),
+			}, "\n"),
+		})
+	}
+
+	execs, err := c.render(ctx, label, jobs)
+	if err != nil {
+		return nil, err
+	}
+	out := dag.Directory()
+	for i, page := range pages {
+		name := page.base + "." + format.ext
+		out = out.WithFile(name, execs[i].File(outputDir+"/"+name))
+	}
+	return out, nil
+}
+
+// concat joins two flag lists into a new slice, which appending to the first
+// would not: the flags are built once per conversion and read once per page, so
+// an append that happened to have spare capacity would let one page's bounds
+// overwrite the next one's.
+func concat(a, b []string) []string {
+	out := make([]string, 0, len(a)+len(b))
+	out = append(out, a...)
+	return append(out, b...)
 }

--- a/daggerverse/pdf/dagger.gen.go
+++ b/daggerverse/pdf/dagger.gen.go
@@ -152,6 +152,8 @@ func (r Convert) MarshalJSON() ([]byte, error) {
 		ScaleTo         int
 		HasScaleTo      bool
 		HideAnnotations bool
+		Concurrency     int
+		HasConcurrency  bool
 	}
 	concrete.Document = r.Document
 	concrete.Dpi = r.Dpi
@@ -160,6 +162,8 @@ func (r Convert) MarshalJSON() ([]byte, error) {
 	concrete.ScaleTo = r.ScaleTo
 	concrete.HasScaleTo = r.HasScaleTo
 	concrete.HideAnnotations = r.HideAnnotations
+	concrete.Concurrency = r.Concurrency
+	concrete.HasConcurrency = r.HasConcurrency
 	return json.Marshal(&concrete)
 }
 
@@ -172,6 +176,8 @@ func (r *Convert) UnmarshalJSON(bs []byte) error {
 		ScaleTo         int
 		HasScaleTo      bool
 		HideAnnotations bool
+		Concurrency     int
+		HasConcurrency  bool
 	}
 	err := json.Unmarshal(bs, &concrete)
 	if err != nil {
@@ -184,6 +190,8 @@ func (r *Convert) UnmarshalJSON(bs []byte) error {
 	r.ScaleTo = concrete.ScaleTo
 	r.HasScaleTo = concrete.HasScaleTo
 	r.HideAnnotations = concrete.HideAnnotations
+	r.Concurrency = concrete.Concurrency
+	r.HasConcurrency = concrete.HasConcurrency
 	return nil
 }
 
@@ -586,6 +594,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Convert).WithColorMode(&parent, mode), nil
+		case "WithConcurrency":
+			var parent Convert
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var concurrency int
+			if inputArgs["concurrency"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["concurrency"]), &concurrency)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg concurrency", err))
+				}
+			}
+			return (*Convert).WithConcurrency(&parent, concurrency), nil
 		case "WithDpi":
 			var parent Convert
 			err = json.Unmarshal(parentJSON, &parent)
@@ -785,6 +807,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Pdf).Merge(&parent, ctx, sources)
+		case "RenderSchedulingSelfTest":
+			var parent Pdf
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Pdf).RenderSchedulingSelfTest(&parent, ctx)
 		case "Version":
 			var parent Pdf
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/pdf/document.go
+++ b/daggerverse/pdf/document.go
@@ -136,13 +136,25 @@ func (d *Document) Info(ctx context.Context) (string, error) {
 // It is the page count of the whole document, not of a WithPageRange — which
 // is what makes it usable as the bound a range is checked against.
 func (d *Document) PageCount(ctx context.Context) (int, error) {
-	info, err := d.Info(ctx)
+	return d.pageCount(ctx, "PageCount")
+}
+
+// pageCount is PageCount under the caller's own name, which is what every
+// conversion reads the padding width from.
+//
+// The label is the caller's rather than this function's because the page count
+// is not what a caller asked for: a render that cannot open the document should
+// say so as the render, not as a report the caller never called. It is the same
+// pdfinfo invocation Info runs, so the two share a cache entry — the round trip
+// is paid once per document per session however many conversions read it.
+func (d *Document) pageCount(ctx context.Context, label string) (int, error) {
+	res, err := d.run(ctx, label, d.command("pdfinfo", nil, sourcePath))
 	if err != nil {
 		return 0, err
 	}
-	count, err := parsePageCount(info)
+	count, err := parsePageCount(strings.TrimRight(res.stdout, "\n"))
 	if err != nil {
-		return 0, fmt.Errorf("PageCount: %s", err.Error())
+		return 0, fmt.Errorf("%s: %s", label, err.Error())
 	}
 	return count, nil
 }

--- a/daggerverse/pdf/fanout/fanout.go
+++ b/daggerverse/pdf/fanout/fanout.go
@@ -1,0 +1,90 @@
+// Package fanout runs a bounded, fail-fast set of concurrent units of work,
+// which is what turns a document's pages into one render each.
+//
+// It is a package of its own, importing no dagger, for a reason that is not
+// tidiness: it is the only way these properties are covered at all. poppler will
+// not produce the failure that exercises them. Measured against poppler 25.12 —
+// what the module's pinned Alpine tag ships — a page it cannot draw is a warning
+// on stderr and an exit status of 0: a dangling page-tree kid, a kid of the
+// wrong type, a loop in the page tree, a null kid, a two-million-point MediaBox
+// and a resolution large enough to print `Bogus memory allocation size` all
+// render a file and succeed. The only non-zero exits are for a document that
+// cannot be opened at all and for a page range outside it, and both are caught
+// before any page is rendered. So no fixture makes one page of a render fail,
+// and the scheduling has to be tested where it lives instead — here, with
+// `go test -race` and no engine, and in CI through SelfCheck.
+package fanout
+
+import (
+	"context"
+	"sync"
+)
+
+// Run performs count units of work, at most workers of them at a time, and
+// returns the first error any of them reported.
+//
+// The bound is a slot channel rather than an unbounded fan-out because a
+// three-thousand-page document is three thousand containers otherwise, and
+// because a machine whose cores are already busy gains nothing from being asked
+// for more of them at once.
+//
+// The first failure cancels the rest: the context handed to run is cancelled as
+// soon as any unit fails, and a unit that has not yet taken a slot never starts.
+// Work already in flight is not interrupted beyond that cancellation — a render
+// that ignores its context runs to completion — so this bounds what is *started*
+// rather than what is finished.
+//
+// run is called with the index of its unit and may write to distinct elements of
+// a caller-owned slice without further synchronisation: no two calls share an
+// index, and Run does not return until every call it started has returned.
+func Run(ctx context.Context, workers, count int, run func(ctx context.Context, i int) error) error {
+	if workers < 1 {
+		workers = 1
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var (
+		wg    sync.WaitGroup
+		mu    sync.Mutex
+		first error
+	)
+	slots := make(chan struct{}, workers)
+
+	for i := range count {
+		wg.Go(func() {
+			select {
+			case slots <- struct{}{}:
+				defer func() { <-slots }()
+			case <-ctx.Done():
+				// Cancelled before this unit ever started. The failure that
+				// cancelled it is the one worth reporting, and it is already
+				// recorded, so this contributes nothing.
+				return
+			}
+
+			// Taking a slot is not enough to have won the race. A select whose
+			// cases are both ready picks between them at random, so a unit
+			// offered a free slot — which the failing unit has just released —
+			// takes it as readily as it observes the cancellation. Without this
+			// second look a failure stops the *queue* but still lets the units
+			// behind it start, which is the whole property this exists for.
+			if ctx.Err() != nil {
+				return
+			}
+
+			if err := run(ctx, i); err != nil {
+				mu.Lock()
+				defer mu.Unlock()
+				if first == nil {
+					first = err
+					cancel()
+				}
+			}
+		})
+	}
+	wg.Wait()
+
+	return first
+}

--- a/daggerverse/pdf/fanout/fanout_test.go
+++ b/daggerverse/pdf/fanout/fanout_test.go
@@ -1,0 +1,25 @@
+package fanout
+
+import "testing"
+
+// TestSelfCheck runs the cases the pdf module exposes as a Dagger check, so the
+// same assertions are covered here under `go test -race` — which is where the
+// scheduling itself is checked, the race detector being the only thing that sees
+// a concurrent write to a shared slot.
+func TestSelfCheck(t *testing.T) {
+	if err := SelfCheck(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestCases runs each case on its own so a failure names itself, which
+// SelfCheck's joined error cannot do as clearly from a CI log.
+func TestCases(t *testing.T) {
+	for _, c := range selfCheckCases() {
+		t.Run(c.name, func(t *testing.T) {
+			if err := c.run(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/daggerverse/pdf/fanout/selfcheck.go
+++ b/daggerverse/pdf/fanout/selfcheck.go
@@ -1,0 +1,238 @@
+package fanout
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// selfCheckTimeout bounds the cases that wait for concurrency to happen, so a
+// bound that is too narrow fails as a timeout rather than hanging CI.
+const selfCheckTimeout = 30 * time.Second
+
+// SelfCheck verifies the properties a render depends on and no fixture can
+// exercise: that every page runs, that the bound is honoured in both directions,
+// that a failure in the middle is the error reported, and that it stops the
+// pages behind it from starting. See the package comment for why this is a
+// self-check rather than a test against a document.
+//
+// It is exposed as a Dagger check so a regression fails CI. The same cases run
+// under `go test -race`, which is where the concurrency itself is checked.
+func SelfCheck() error {
+	var errs []error
+	for _, c := range selfCheckCases() {
+		if err := c.run(); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", c.name, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+type selfCheckCase struct {
+	name string
+	run  func() error
+}
+
+func selfCheckCases() []selfCheckCase {
+	return []selfCheckCase{
+		{"every unit runs exactly once, positionally", checkEveryUnitRuns},
+		{"no more than the bound run at once", checkBoundIsACeiling},
+		{"the bound is reached", checkBoundIsReached},
+		{"a failure in the middle is the error reported", checkMiddleFailureIsReported},
+		{"the first failure stops the rest from starting", checkFailureStopsTheRest},
+		{"a bound below one still renders", checkBoundBelowOne},
+	}
+}
+
+// checkEveryUnitRuns pins the property the assembled directory rests on: each
+// unit runs once, and writes to its own index.
+func checkEveryUnitRuns() error {
+	const count = 64
+
+	got := make([]int, count)
+	var runs atomic.Int64
+	err := Run(context.Background(), 8, count, func(_ context.Context, i int) error {
+		runs.Add(1)
+		got[i] = i + 1
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if n := runs.Load(); n != count {
+		return fmt.Errorf("expected %d units to run, got %d", count, n)
+	}
+	for i, v := range got {
+		if v != i+1 {
+			return fmt.Errorf("unit %d wrote %d to its slot, expected %d", i, v, i+1)
+		}
+	}
+	return nil
+}
+
+// checkBoundIsACeiling asserts the slot channel is a ceiling: never more than
+// workers units in flight at once.
+func checkBoundIsACeiling() error {
+	const (
+		workers = 3
+		count   = 40
+	)
+
+	var live, peak atomic.Int64
+	err := Run(context.Background(), workers, count, func(_ context.Context, _ int) error {
+		n := live.Add(1)
+		for {
+			max := peak.Load()
+			if n <= max || peak.CompareAndSwap(max, n) {
+				break
+			}
+		}
+		time.Sleep(time.Millisecond)
+		live.Add(-1)
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if p := peak.Load(); p > workers {
+		return fmt.Errorf("expected at most %d units in flight, saw %d", workers, p)
+	}
+	return nil
+}
+
+// checkBoundIsReached asserts the bound is also a floor — that the units really
+// do run at the same time rather than one after another, which a ceiling alone
+// would not distinguish.
+//
+// Every unit waits until all of them have arrived, so a fan-out narrower than
+// the bound cannot finish: it fails as a timeout rather than as a wrong answer.
+func checkBoundIsReached() error {
+	const workers = 4
+
+	var (
+		mu      sync.Mutex
+		arrived int
+		all     = make(chan struct{})
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), selfCheckTimeout)
+	defer cancel()
+
+	err := Run(ctx, workers, workers, func(ctx context.Context, _ int) error {
+		mu.Lock()
+		arrived++
+		if arrived == workers {
+			close(all)
+		}
+		mu.Unlock()
+
+		select {
+		case <-all:
+			return nil
+		case <-ctx.Done():
+			return fmt.Errorf("only %d of %d units ran at once", arrived, workers)
+		}
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// checkMiddleFailureIsReported is the case the page name rests on: the error the
+// caller sees is the failing unit's own, naming the page that failed rather than
+// summarising that something did.
+//
+// The unit that fails is the fourth to *run* rather than the fourth by index,
+// because which index reaches the pool first is the Go scheduler's business and
+// not this package's — goroutines contend for a slot, they do not queue in
+// order. With a bound of one that makes the case exactly deterministic: four
+// units run, the fourth fails, and none of the remaining six starts.
+func checkMiddleFailureIsReported() error {
+	const (
+		count  = 10
+		breaks = 4
+	)
+
+	var (
+		mu      sync.Mutex
+		ran     []int
+		failure error
+	)
+	err := Run(context.Background(), 1, count, func(_ context.Context, i int) error {
+		mu.Lock()
+		defer mu.Unlock()
+		ran = append(ran, i)
+		if len(ran) == breaks {
+			failure = fmt.Errorf("page %d could not be rendered", i+1)
+			return failure
+		}
+		return nil
+	})
+
+	mu.Lock()
+	defer mu.Unlock()
+	if failure == nil {
+		return fmt.Errorf("expected %d units to run, got %d", breaks, len(ran))
+	}
+	if !errors.Is(err, failure) {
+		return fmt.Errorf("expected the failing unit's own error %q, got: %v", failure, err)
+	}
+	if len(ran) != breaks {
+		return fmt.Errorf(
+			"expected the failure to stop the fan-out after %d units, got %d", breaks, len(ran))
+	}
+	return nil
+}
+
+// checkFailureStopsTheRest asserts a conversion that is going to fail does not
+// render the rest of the document first.
+//
+// Every unit fails, so which one lands first does not matter — what is asserted
+// is how many got to start at all. Nothing beyond a full pool can: a failing
+// unit records its error and cancels while it still holds its slot, so the unit
+// that inherits that slot finds the fan-out already cancelled.
+func checkFailureStopsTheRest() error {
+	const (
+		workers = 4
+		count   = 200
+	)
+
+	failure := errors.New("this page could not be rendered")
+	var entered atomic.Int64
+	err := Run(context.Background(), workers, count, func(_ context.Context, _ int) error {
+		entered.Add(1)
+		return failure
+	})
+	if !errors.Is(err, failure) {
+		return fmt.Errorf("expected a failing unit's error, got: %v", err)
+	}
+	if n := entered.Load(); n > workers {
+		return fmt.Errorf(
+			"expected at most the %d units already in flight to run, got %d of %d",
+			workers, n, count)
+	}
+	return nil
+}
+
+// checkBoundBelowOne asserts a nonsensical bound renders the document rather
+// than deadlocking on a channel of no capacity. The module rejects such a bound
+// long before this, by name; this is the floor under that.
+func checkBoundBelowOne() error {
+	const count = 5
+
+	var runs atomic.Int64
+	err := Run(context.Background(), 0, count, func(_ context.Context, _ int) error {
+		runs.Add(1)
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if n := runs.Load(); n != count {
+		return fmt.Errorf("expected %d units to run, got %d", count, n)
+	}
+	return nil
+}

--- a/daggerverse/pdf/main.go
+++ b/daggerverse/pdf/main.go
@@ -96,6 +96,7 @@ import (
 	"fmt"
 	"strings"
 
+	"dagger/pdf/fanout"
 	"dagger/pdf/internal/dagger"
 )
 
@@ -160,12 +161,11 @@ const (
 	sourcePath = workDir + "/source.pdf"
 	outputDir  = "/out"
 
-	// textOutputPath is the file Convert.Txt writes, psOutputPath the one
-	// Convert.Ps writes, and pageBase the OUTPUTBASE handed to pdftoppm — which
-	// appends a page number and the format's extension to it.
+	// textOutputPath is the file Convert.Txt writes and psOutputPath the one
+	// Convert.Ps writes. The per-page renders name their own output — see
+	// pageName — so there is no shared output base for them to derive it from.
 	textOutputPath = outputDir + "/document.txt"
 	psOutputPath   = outputDir + "/document.ps"
-	pageBase       = outputDir + "/page"
 
 	// bboxOutputPath is the file Convert.Bbox writes and tsvOutputPath the one
 	// Convert.Tsv writes. The extensions are this module's choice — pdftotext
@@ -187,13 +187,18 @@ const (
 	tsvFlag        = "-tsv"
 
 	// pageNamePrefix is the leading part of a rendered page's file name, and
-	// has to agree with pageBase: the normalization pass strips it to read the
-	// page number back out.
+	// has to agree with pageBase: Split's normalization pass strips it to read
+	// the page number back out.
 	pageNamePrefix = "page-"
 
 	// minPageNumberWidth is the digit count every rendered page's number is
-	// padded to. See normalizeScript for what it buys.
+	// padded to. See pageNumberWidth for what it buys.
 	minPageNumberWidth = 4
+
+	// minRenderConcurrency is the floor on how many pages a conversion renders
+	// at once, and so the smallest bound WithConcurrency accepts: zero pages at
+	// a time renders nothing at all.
+	minRenderConcurrency = 1
 
 	// defaultDpi is the resolution pages are rendered at when the caller names
 	// none, and is pdftoppm's own default. It is a screen-reading resolution
@@ -418,6 +423,27 @@ func (p *Pdf) Version(ctx context.Context) (string, error) {
 	// The first line is `pdftotext version <version>`; the rest is copyright.
 	first := strings.TrimSpace(strings.SplitN(strings.TrimSpace(out), "\n", 2)[0])
 	return strings.TrimSpace(strings.TrimPrefix(first, "pdftotext version")), nil
+}
+
+// RenderSchedulingSelfTest verifies the properties the per-page render fan-out
+// depends on: that every page runs, that WithConcurrency is honoured as both a
+// ceiling and a floor, that a failure partway through is the error reported, and
+// that it stops the pages behind it from starting.
+//
+// It sits on the module rather than in the test module because it checks
+// unexported scheduling, and it exists at all because no document can check it.
+// poppler does not fail a page: measured against the pinned poppler 25.12, every
+// damaged page shape — a dangling page-tree kid, a kid of the wrong type, a loop
+// in the tree, a null kid, an absurd MediaBox, an absurd resolution — is a
+// warning on stderr and an exit status of 0. So the fail-fast has no fixture
+// that would exercise it, and this is what covers it instead.
+//
+// It runs in-process and needs no container, so it is cheap enough to be a check
+// of its own.
+//
+// +check
+func (p *Pdf) RenderSchedulingSelfTest(ctx context.Context) error {
+	return fanout.SelfCheck()
 }
 
 // Document binds one PDF to the toolchain.

--- a/daggerverse/pdf/pages.go
+++ b/daggerverse/pdf/pages.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"dagger/pdf/internal/dagger"
@@ -14,11 +15,10 @@ const (
 	// refuses a pattern without one, which is how a multi-page document is
 	// allowed to write more than one file.
 	//
-	// The number goes in unpadded and is padded afterwards by normalizeScript,
-	// the same pass the raster renders go through. pdfseparate would honour a
-	// `%04d` here, but the width would then be fixed rather than a floor, and a
-	// document with more than 9999 pages would come out numbered to two
-	// different widths.
+	// The number goes in unpadded and is padded afterwards by normalizeScript.
+	// pdfseparate would honour a `%04d` here, but the width would then be fixed
+	// rather than a floor, and a document with more than 9999 pages would come
+	// out numbered to two different widths.
 	splitPattern = outputDir + "/" + pageNamePrefix + "%d.pdf"
 
 	// splitArgv0 is the `$0` the split script runs under, so the extension
@@ -36,6 +36,57 @@ const (
 	mergeInputDir = "/in"
 	mergedPath    = outputDir + "/merged.pdf"
 )
+
+// normalizeScript renames every page pdfseparate just wrote so its number is
+// zero-padded to a fixed width, and is the reason this directory can be handed
+// to another module at all.
+//
+// It is Split's alone. The render family reaches the same contract from the
+// other end: it drives the page loop from Go, so it *names* each page outright
+// and has nothing to rename — see pageName. Split cannot, pdfseparate writing
+// every page of a range in one invocation, and the number it writes being as
+// wide as the caller's destination pattern asked for.
+//
+// Padding to a fixed minimum is what makes the shape a contract instead of a
+// consequence. Lexicographic order is otherwise page order within a single
+// document and nothing more: a consumer that sorts what it is given — the
+// tesseract module's Batch does a bare sort.Strings — has no way to know which
+// width it is holding, and a caller who hardcodes one name shape breaks on the
+// next document.
+//
+// The width is the greater of the module's minimum and whatever the tool chose,
+// so a document longer than the minimum can express stays uniform rather than
+// being truncated into ambiguity.
+//
+// It runs in the same exec as the split, so the directory Split returns has
+// never existed under the other names.
+var normalizeScript = strings.Join([]string{
+	`ext="$1"`,
+	`width=` + strconv.Itoa(minPageNumberWidth),
+	`for f in ` + pageGlob + `; do`,
+	`	[ -e "$f" ] || continue`,
+	`	n=${f##*/` + pageNamePrefix + `}`,
+	`	n=${n%."$ext"}`,
+	`	if [ ${#n} -gt "$width" ]; then width=${#n}; fi`,
+	`done`,
+	`for f in ` + pageGlob + `; do`,
+	`	[ -e "$f" ] || continue`,
+	`	n=${f##*/` + pageNamePrefix + `}`,
+	`	n=${n%."$ext"}`,
+	// Leading zeros are stripped before printf sees the number: POSIX printf
+	// reads a leading-zero argument as an octal constant, so `09` is not 9 but
+	// a diagnostic.
+	`	stripped=$(printf '%s' "$n" | sed 's/^0*//')`,
+	`	[ -n "$stripped" ] || stripped=0`,
+	`	padded=$(printf "%0${width}d" "$stripped")`,
+	`	if [ "$n" != "$padded" ]; then mv "$f" "` + outputDir + `/` + pageNamePrefix + `$padded.$ext"; fi`,
+	`done`,
+}, "\n")
+
+// pageGlob matches every page the split wrote, whatever width pdfseparate
+// numbered it to. The extension comes from `$1` rather than being interpolated
+// into the script text.
+const pageGlob = outputDir + `/` + pageNamePrefix + `*."$ext"`
 
 // Split writes each page of the document to its own PDF and returns the
 // directory holding them, named `page-0001.pdf`, `page-0002.pdf`, and so on.

--- a/daggerverse/pdf/tests/dagger.gen.go
+++ b/daggerverse/pdf/tests/dagger.gen.go
@@ -472,6 +472,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).PsHoldsEveryPageInOneFile(&parent, ctx)
+		case "RenderConcurrencyAppliesToEveryPerPageFormat":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).RenderConcurrencyAppliesToEveryPerPageFormat(&parent, ctx)
+		case "RenderConcurrencyMatchesSerialOutput":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).RenderConcurrencyMatchesSerialOutput(&parent, ctx)
 		case "RenderSettingsRejectNonPositiveValues":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/pdf/tests/internal/dagger/pdf.gen.go
+++ b/daggerverse/pdf/tests/internal/dagger/pdf.gen.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Retrieve the binding value, as type Pdf
-func (r *Binding) AsPdf() *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:249:6)
+func (r *Binding) AsPdf() *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:254:6)
 	q := r.query.Select("asPdf")
 
 	return &Pdf{
@@ -20,7 +20,7 @@ func (r *Binding) AsPdf() *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:
 }
 
 // Retrieve the binding value, as type PdfConvert
-func (r *Binding) AsPdfConvert() *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:76:6)
+func (r *Binding) AsPdfConvert() *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:27:6)
 	q := r.query.Select("asPdfConvert")
 
 	return &PdfConvert{
@@ -38,7 +38,7 @@ func (r *Binding) AsPdfDocument() *PdfDocument { // pdf (../../../../../daggerve
 }
 
 // Create or update a binding of type PdfConvert in the environment
-func (r *Env) WithPdfConvertInput(name string, value *PdfConvert, description string) *Env { // pdf (../../../../../daggerverse/pdf/convert.go:76:6)
+func (r *Env) WithPdfConvertInput(name string, value *PdfConvert, description string) *Env { // pdf (../../../../../daggerverse/pdf/convert.go:27:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withPdfConvertInput")
 	q = q.Arg("name", name)
@@ -51,7 +51,7 @@ func (r *Env) WithPdfConvertInput(name string, value *PdfConvert, description st
 }
 
 // Declare a desired PdfConvert output to be assigned in the environment
-func (r *Env) WithPdfConvertOutput(name string, description string) *Env { // pdf (../../../../../daggerverse/pdf/convert.go:76:6)
+func (r *Env) WithPdfConvertOutput(name string, description string) *Env { // pdf (../../../../../daggerverse/pdf/convert.go:27:6)
 	q := r.query.Select("withPdfConvertOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -86,7 +86,7 @@ func (r *Env) WithPdfDocumentOutput(name string, description string) *Env { // p
 }
 
 // Create or update a binding of type Pdf in the environment
-func (r *Env) WithPdfInput(name string, value *Pdf, description string) *Env { // pdf (../../../../../daggerverse/pdf/main.go:249:6)
+func (r *Env) WithPdfInput(name string, value *Pdf, description string) *Env { // pdf (../../../../../daggerverse/pdf/main.go:254:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withPdfInput")
 	q = q.Arg("name", name)
@@ -99,7 +99,7 @@ func (r *Env) WithPdfInput(name string, value *Pdf, description string) *Env { /
 }
 
 // Declare a desired Pdf output to be assigned in the environment
-func (r *Env) WithPdfOutput(name string, description string) *Env { // pdf (../../../../../daggerverse/pdf/main.go:249:6)
+func (r *Env) WithPdfOutput(name string, description string) *Env { // pdf (../../../../../daggerverse/pdf/main.go:254:6)
 	q := r.query.Select("withPdfOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -113,11 +113,12 @@ func (r *Env) WithPdfOutput(name string, description string) *Env { // pdf (../.
 // carries the image coordinates and the fonts the image is built with;
 // Document hangs off it so the generated SDK surfaces conversion under
 // `dag.Pdf().Document(...)`.
-type Pdf struct { // pdf (../../../../../daggerverse/pdf/main.go:249:6)
+type Pdf struct { // pdf (../../../../../daggerverse/pdf/main.go:254:6)
 	query *querybuilder.Selection
 
-	id      *ID
-	version *string
+	id                       *ID
+	renderSchedulingSelfTest *Void
+	version                  *string
 }
 type WithPdfFunc func(r *Pdf) *Pdf
 
@@ -140,7 +141,7 @@ func (r *Pdf) WithGraphQLQuery(q *querybuilder.Selection) *Pdf {
 // reachable via `container with-exec` — as do the flags of a wrapped tool that
 // this module does not surface, `pdffonts -subst` and `pdfdetach -savefile`
 // among them.
-func (r *Pdf) Container() *Container { // pdf (../../../../../daggerverse/pdf/main.go:395:1)
+func (r *Pdf) Container() *Container { // pdf (../../../../../daggerverse/pdf/main.go:400:1)
 	q := r.query.Select("container")
 
 	return &Container{
@@ -153,7 +154,7 @@ func (r *Pdf) Container() *Container { // pdf (../../../../../daggerverse/pdf/ma
 // The boundary input is a *dagger.File rather than a *dagger.Directory: a PDF
 // resolves nothing relative to its own location, so one file is the whole unit
 // of work however many pages it carries.
-func (r *Pdf) Document(source *File) *PdfDocument { // pdf (../../../../../daggerverse/pdf/main.go:428:1)
+func (r *Pdf) Document(source *File) *PdfDocument { // pdf (../../../../../daggerverse/pdf/main.go:454:1)
 	assertNotNil("source", source)
 	q := r.query.Select("document")
 	q = q.Arg("source", source)
@@ -238,7 +239,7 @@ func (r *Pdf) UnmarshalJSON(bs []byte) error {
 // Encrypted sources are the one shape this cannot take: pdfunite has no password
 // option, so there is no argument that would let it read one. See the message a
 // run against one carries.
-func (r *Pdf) Merge(sources []*File) *File { // pdf (../../../../../daggerverse/pdf/pages.go:113:1)
+func (r *Pdf) Merge(sources []*File) *File { // pdf (../../../../../daggerverse/pdf/pages.go:164:1)
 	q := r.query.Select("merge")
 	q = q.Arg("sources", sources)
 
@@ -247,9 +248,33 @@ func (r *Pdf) Merge(sources []*File) *File { // pdf (../../../../../daggerverse/
 	}
 }
 
+// RenderSchedulingSelfTest verifies the properties the per-page render fan-out
+// depends on: that every page runs, that WithConcurrency is honoured as both a
+// ceiling and a floor, that a failure partway through is the error reported, and
+// that it stops the pages behind it from starting.
+//
+// It sits on the module rather than in the test module because it checks
+// unexported scheduling, and it exists at all because no document can check it.
+// poppler does not fail a page: measured against the pinned poppler 25.12, every
+// damaged page shape — a dangling page-tree kid, a kid of the wrong type, a loop
+// in the tree, a null kid, an absurd MediaBox, an absurd resolution — is a
+// warning on stderr and an exit status of 0. So the fail-fast has no fixture
+// that would exercise it, and this is what covers it instead.
+//
+// It runs in-process and needs no container, so it is cheap enough to be a check
+// of its own.
+func (r *Pdf) RenderSchedulingSelfTest(ctx context.Context) error { // pdf (../../../../../daggerverse/pdf/main.go:445:1)
+	if r.renderSchedulingSelfTest != nil {
+		return nil
+	}
+	q := r.query.Select("renderSchedulingSelfTest")
+
+	return q.Execute(ctx)
+}
+
 // Version returns the poppler release the assembled image ships, as the bare
 // version number reported by `pdftotext -v`.
-func (r *Pdf) Version(ctx context.Context) (string, error) { // pdf (../../../../../daggerverse/pdf/main.go:408:1)
+func (r *Pdf) Version(ctx context.Context) (string, error) { // pdf (../../../../../daggerverse/pdf/main.go:413:1)
 	if r.version != nil {
 		return *r.version, nil
 	}
@@ -275,7 +300,7 @@ func (r *Pdf) Version(ctx context.Context) (string, error) { // pdf (../../../..
 // why the credentials are not simply userinfo in the WithApkRepository URL,
 // which would put them in /etc/apk/repositories and in every apk error
 // message that quotes it.
-func (r *Pdf) WithApkAuth(credentials *Secret) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:356:1)
+func (r *Pdf) WithApkAuth(credentials *Secret) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:361:1)
 	assertNotNil("credentials", credentials)
 	q := r.query.Select("withApkAuth")
 	q = q.Arg("credentials", credentials)
@@ -298,7 +323,7 @@ func (r *Pdf) WithApkAuth(credentials *Secret) *Pdf { // pdf (../../../../../dag
 // Repeatable, for a mirror set signed by more than one key. It is a *File
 // rather than a *Secret because a public key is not a credential: it is meant
 // to be in the image, and WithApkAuth is the option for the part that is not.
-func (r *Pdf) WithApkKey(key *File) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:333:1)
+func (r *Pdf) WithApkKey(key *File) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:338:1)
 	assertNotNil("key", key)
 	q := r.query.Select("withApkKey")
 	q = q.Arg("key", key)
@@ -328,7 +353,7 @@ func (r *Pdf) WithApkKey(key *File) *Pdf { // pdf (../../../../../daggerverse/pd
 // call per component. A repository's index is signed, so pair this with
 // WithApkKey unless the mirror is signed by a key the base image already
 // trusts.
-func (r *Pdf) WithApkRepository(url string) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:305:1)
+func (r *Pdf) WithApkRepository(url string) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:310:1)
 	q := r.query.Select("withApkRepository")
 	q = q.Arg("url", url)
 
@@ -352,7 +377,7 @@ func (r *Pdf) WithApkRepository(url string) *Pdf { // pdf (../../../../../dagger
 // /etc/fonts/fonts.conf tells fontconfig to scan, so the faces in it are
 // indistinguishable from packaged ones as far as poppler is concerned. It is
 // mounted rather than copied so a large family does not become an image layer.
-func (r *Pdf) WithFonts(dir *Directory) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:380:1)
+func (r *Pdf) WithFonts(dir *Directory) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:385:1)
 	assertNotNil("dir", dir)
 	q := r.query.Select("withFonts")
 	q = q.Arg("dir", dir)
@@ -383,7 +408,7 @@ func (r *Pdf) AsNode() Node {
 // documented no-ops there rather than rejections: a DPI set before asking for
 // text is inapplicable rather than wrong, unlike a bound past the end of the
 // document, which is always a mistake.
-type PdfConvert struct { // pdf (../../../../../daggerverse/pdf/convert.go:76:6)
+type PdfConvert struct { // pdf (../../../../../daggerverse/pdf/convert.go:27:6)
 	query *querybuilder.Selection
 
 	id   *ID
@@ -409,7 +434,7 @@ type PdfConvertBboxOpts struct {
 	//
 	// Add the block and line boxes poppler groups the words into.
 	//
-	WithLayout bool // pdf (../../../../../daggerverse/pdf/convert.go:279:2)
+	WithLayout bool // pdf (../../../../../daggerverse/pdf/convert.go:268:2)
 }
 
 // Bbox returns the document's text layer as an XHTML report carrying a bounding
@@ -441,7 +466,7 @@ type PdfConvertBboxOpts struct {
 // The render options are ignored, this being an extraction and not a render, and
 // so is LayoutMode: the report's structure is poppler's own and is not the text's
 // reading order. WithPageRange narrows it.
-func (r *PdfConvert) Bbox(opts ...PdfConvertBboxOpts) *File { // pdf (../../../../../daggerverse/pdf/convert.go:275:1)
+func (r *PdfConvert) Bbox(opts ...PdfConvertBboxOpts) *File { // pdf (../../../../../daggerverse/pdf/convert.go:264:1)
 	q := r.query.Select("bbox")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `withLayout` optional argument
@@ -473,7 +498,7 @@ func (r *PdfConvert) Bbox(opts ...PdfConvertBboxOpts) *File { // pdf (../../../.
 //
 // WithDpi governs rasterized regions; WithColorMode, WithScaleTo and
 // WithoutAnnotations are ignored: see the note on Ps.
-func (r *PdfConvert) Eps() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:394:1)
+func (r *PdfConvert) Eps() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:383:1)
 	q := r.query.Select("eps")
 
 	return &Directory{
@@ -500,7 +525,7 @@ func (r *PdfConvert) Eps() *Directory { // pdf (../../../../../daggerverse/pdf/c
 //
 // Every render option is ignored, pdftohtml having no resolution, colour or
 // annotation switch of any kind. WithPageRange narrows it like everything else.
-func (r *PdfConvert) HTML() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:456:1)
+func (r *PdfConvert) HTML() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:454:1)
 	q := r.query.Select("html")
 
 	return &Directory{
@@ -564,7 +589,7 @@ func (r *PdfConvert) UnmarshalJSON(bs []byte) error {
 // Lossy, so it is the format for a preview a human looks at rather than for
 // input another program measures: the artefacts a flat page compresses into sit
 // exactly where thin strokes are, which is where OCR reads.
-func (r *PdfConvert) Jpeg() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:337:1)
+func (r *PdfConvert) Jpeg() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:326:1)
 	q := r.query.Select("jpeg")
 
 	return &Directory{
@@ -578,7 +603,7 @@ func (r *PdfConvert) Jpeg() *Directory { // pdf (../../../../../daggerverse/pdf/
 // PNG is the format to hand another module: it is lossless, so nothing
 // downstream is reading compression artefacts as page content, and it is what
 // every image library reads without a codec question.
-func (r *PdfConvert) Png() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:326:1)
+func (r *PdfConvert) Png() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:315:1)
 	q := r.query.Select("png")
 
 	return &Directory{
@@ -594,6 +619,15 @@ func (r *PdfConvert) Png() *Directory { // pdf (../../../../../daggerverse/pdf/c
 // Splitting it into a page-per-file directory would produce fragments that are
 // each individually invalid.
 //
+// That is also why this is the one render that stays a single invocation, and
+// why WithConcurrency does nothing here. Every other page-per-file output fans
+// out one exec per page and assembles the directory afterwards; a PostScript
+// document cannot be assembled that way, because concatenating the fragments is
+// not the same operation as writing the document — the result would need its
+// prologue, its page markers and its `%%Pages:` count rewritten, which is a
+// PostScript editor and not a renderer. A caller who wants the pages rendered
+// concurrently wants Eps, which is one page per file by definition.
+//
 // WithDpi governs the rasterized regions the output can still contain.
 // WithColorMode, WithScaleTo and WithoutAnnotations are ignored here and by Svg,
 // Eps and Html, and are documented no-ops rather than rejections for the same
@@ -602,7 +636,7 @@ func (r *PdfConvert) Png() *Directory { // pdf (../../../../../daggerverse/pdf/c
 // are dropped rather than forwarded because poppler does not ignore them — it
 // exits non-zero with `-mono may only be used with the -png, -jpeg, or -tiff
 // output options`, and `-hide-annotations` is not a pdftocairo option at all.
-func (r *PdfConvert) Ps() *File { // pdf (../../../../../daggerverse/pdf/convert.go:414:1)
+func (r *PdfConvert) Ps() *File { // pdf (../../../../../daggerverse/pdf/convert.go:412:1)
 	q := r.query.Select("ps")
 
 	return &File{
@@ -630,7 +664,7 @@ func (r *PdfConvert) Ps() *File { // pdf (../../../../../daggerverse/pdf/convert
 // WithDpi governs the rasterized regions a page can still contain — an embedded
 // photograph has no vector form to keep. WithColorMode, WithScaleTo and
 // WithoutAnnotations are ignored: see the note on Ps.
-func (r *PdfConvert) Svg() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:372:1)
+func (r *PdfConvert) Svg() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:361:1)
 	q := r.query.Select("svg")
 
 	return &Directory{
@@ -644,11 +678,11 @@ type PdfConvertTextOpts struct {
 	// How much of the page's physical arrangement survives into the text.
 	// Defaults to reading order.
 	//
-	Layout PdfLayoutMode // pdf (../../../../../daggerverse/pdf/convert.go:193:2)
+	Layout PdfLayoutMode // pdf (../../../../../daggerverse/pdf/convert.go:182:2)
 	//
 	// Emit no form feed between pages.
 	//
-	DisablePageBreaks bool // pdf (../../../../../daggerverse/pdf/convert.go:196:2)
+	DisablePageBreaks bool // pdf (../../../../../daggerverse/pdf/convert.go:185:2)
 }
 
 // Text returns the document's text layer as a string.
@@ -663,7 +697,7 @@ type PdfConvertTextOpts struct {
 // Pages are separated by a form feed (U+000C), including after the last one,
 // which is pdftotext's own convention. Pass disablePageBreaks to drop them, for
 // a consumer that wants one flat stream of text.
-func (r *PdfConvert) Text(ctx context.Context, opts ...PdfConvertTextOpts) (string, error) { // pdf (../../../../../daggerverse/pdf/convert.go:188:1)
+func (r *PdfConvert) Text(ctx context.Context, opts ...PdfConvertTextOpts) (string, error) { // pdf (../../../../../daggerverse/pdf/convert.go:177:1)
 	if r.text != nil {
 		return *r.text, nil
 	}
@@ -692,7 +726,7 @@ func (r *PdfConvert) Text(ctx context.Context, opts ...PdfConvertTextOpts) (stri
 // It is the format the document-imaging world already speaks, and the one to
 // pair with MONO: a bilevel TIFF is what a scanner emits and what an archive
 // expects.
-func (r *PdfConvert) Tiff() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:348:1)
+func (r *PdfConvert) Tiff() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:337:1)
 	q := r.query.Select("tiff")
 
 	return &Directory{
@@ -728,7 +762,7 @@ func (r *PdfConvert) Tiff() *Directory { // pdf (../../../../../daggerverse/pdf/
 // A page with no text layer yields its page row and no word rows rather than a
 // failure, the same boundary Text and Bbox draw. The render options are ignored,
 // as is LayoutMode. WithPageRange narrows it.
-func (r *PdfConvert) Tsv() *File { // pdf (../../../../../daggerverse/pdf/convert.go:316:1)
+func (r *PdfConvert) Tsv() *File { // pdf (../../../../../daggerverse/pdf/convert.go:305:1)
 	q := r.query.Select("tsv")
 
 	return &File{
@@ -742,11 +776,11 @@ type PdfConvertTxtOpts struct {
 	// How much of the page's physical arrangement survives into the text.
 	// Defaults to reading order.
 	//
-	Layout PdfLayoutMode // pdf (../../../../../daggerverse/pdf/convert.go:223:2)
+	Layout PdfLayoutMode // pdf (../../../../../daggerverse/pdf/convert.go:212:2)
 	//
 	// Emit no form feed between pages.
 	//
-	DisablePageBreaks bool // pdf (../../../../../daggerverse/pdf/convert.go:226:2)
+	DisablePageBreaks bool // pdf (../../../../../daggerverse/pdf/convert.go:215:2)
 }
 
 // Txt returns the same text Text returns, as a file rather than a string.
@@ -754,7 +788,7 @@ type PdfConvertTxtOpts struct {
 // Which of the two to reach for is plumbing and nothing more: a file composes
 // with whatever consumes files — another module, an export, a directory being
 // assembled — without the bytes passing through the caller.
-func (r *PdfConvert) Txt(opts ...PdfConvertTxtOpts) *File { // pdf (../../../../../daggerverse/pdf/convert.go:218:1)
+func (r *PdfConvert) Txt(opts ...PdfConvertTxtOpts) *File { // pdf (../../../../../daggerverse/pdf/convert.go:207:1)
 	q := r.query.Select("txt")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `layout` optional argument
@@ -780,9 +814,42 @@ func (r *PdfConvert) Txt(opts ...PdfConvertTxtOpts) *File { // pdf (../../../../
 // threshold a colour image itself.
 //
 // Ignored by Text and Txt.
-func (r *PdfConvert) WithColorMode(mode PdfColorMode) *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:124:1)
+func (r *PdfConvert) WithColorMode(mode PdfColorMode) *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:79:1)
 	q := r.query.Select("withColorMode")
 	q = q.Arg("mode", mode)
+
+	return &PdfConvert{
+		query: q,
+	}
+}
+
+// WithConcurrency bounds how many pages a render converts at once.
+//
+// It defaults to the number of CPUs the module can see, which is what a
+// document wants: every page is its own exec, and poppler renders a page on one
+// core whatever the machine has. A 129-page document at 300 dpi spends about a
+// minute of that one core, and the recognition it is usually rendered for
+// spends its own time across every core — so the render is a third of the CPU
+// and two thirds of the wall clock, and the share grows with core count rather
+// than shrinking.
+//
+// Unlike the tesseract module's Batch, this bound needs no companion. poppler's
+// tools are single-threaded, so concurrency here is concurrency and not
+// concurrency multiplied by an OpenMP team; the pages contend for cores the way
+// any other CPU-bound workload does.
+//
+// Pass a number to take less of the machine than the default, or 1 to render one
+// page at a time. Non-positive is rejected at output time.
+//
+// It is a scheduling bound and nothing else: the directory a conversion returns
+// is the same whatever it is set to. It is also not what decides how the results
+// cache — one exec per page is what does that, at every bound including 1.
+//
+// Ignored by Text, Txt, Bbox, Tsv and Ps, none of which renders a page at a
+// time. See Ps for why that one is a single invocation.
+func (r *PdfConvert) WithConcurrency(concurrency int) *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:155:1)
+	q := r.query.Select("withConcurrency")
+	q = q.Arg("concurrency", concurrency)
 
 	return &PdfConvert{
 		query: q,
@@ -802,7 +869,7 @@ func (r *PdfConvert) WithColorMode(mode PdfColorMode) *PdfConvert { // pdf (../.
 // Ignored by Text and Txt, which read a text layer rather than rendering
 // anything. Overridden by WithScaleTo, which fixes the output's pixel
 // dimensions directly.
-func (r *PdfConvert) WithDpi(dpi int) *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:106:1)
+func (r *PdfConvert) WithDpi(dpi int) *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:61:1)
 	q := r.query.Select("withDpi")
 	q = q.Arg("dpi", dpi)
 
@@ -825,7 +892,7 @@ func (r *PdfConvert) WithDpi(dpi int) *PdfConvert { // pdf (../../../../../dagge
 // is on the page, which is every OCR and measurement case.
 //
 // Ignored by Text and Txt.
-func (r *PdfConvert) WithScaleTo(pixels int) *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:147:1)
+func (r *PdfConvert) WithScaleTo(pixels int) *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:102:1)
 	q := r.query.Select("withScaleTo")
 	q = q.Arg("pixels", pixels)
 
@@ -846,7 +913,7 @@ func (r *PdfConvert) WithScaleTo(pixels int) *PdfConvert { // pdf (../../../../.
 // could ever turn annotations off.
 //
 // Ignored by Text and Txt.
-func (r *PdfConvert) WithoutAnnotations() *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:170:1)
+func (r *PdfConvert) WithoutAnnotations() *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:125:1)
 	q := r.query.Select("withoutAnnotations")
 
 	return &PdfConvert{
@@ -944,7 +1011,7 @@ func (r *PdfDocument) Attachments() *Directory { // pdf (../../../../../daggerve
 // nothing about the PDF — and because it is what lets one bound document, with
 // its passwords and its page range settled, fan out into several differently
 // configured conversions.
-func (r *PdfDocument) Convert() *PdfConvert { // pdf (../../../../../daggerverse/pdf/document.go:281:1)
+func (r *PdfDocument) Convert() *PdfConvert { // pdf (../../../../../daggerverse/pdf/document.go:293:1)
 	q := r.query.Select("convert")
 
 	return &PdfConvert{
@@ -1038,7 +1105,7 @@ func (r *PdfDocument) EmbeddedImages(format PdfImageFormat) *Directory { // pdf 
 // through 3. Which substitute poppler would actually choose for an unembedded
 // face is a different question, answered by `pdffonts -subst`, and reachable
 // through Container.
-func (r *PdfDocument) Fonts(ctx context.Context) (string, error) { // pdf (../../../../../daggerverse/pdf/document.go:175:1)
+func (r *PdfDocument) Fonts(ctx context.Context) (string, error) { // pdf (../../../../../daggerverse/pdf/document.go:187:1)
 	if r.fonts != nil {
 		return *r.fonts, nil
 	}
@@ -1137,7 +1204,7 @@ func (r *PdfDocument) Info(ctx context.Context) (string, error) { // pdf (../../
 //
 // WithPageRange does not narrow it, the packet being a property of the document
 // rather than of any page — the same reason it does not narrow Info.
-func (r *PdfDocument) Metadata(ctx context.Context) (string, error) { // pdf (../../../../../daggerverse/pdf/document.go:206:1)
+func (r *PdfDocument) Metadata(ctx context.Context) (string, error) { // pdf (../../../../../daggerverse/pdf/document.go:218:1)
 	if r.metadata != nil {
 		return *r.metadata, nil
 	}
@@ -1195,7 +1262,7 @@ func (r *PdfDocument) PageCount(ctx context.Context) (int, error) { // pdf (../.
 // ranges of the file rather than pages, and pdfsig has no page bounds at all.
 // The passwords do reach it, an encrypted document being one it has to open like
 // any other.
-func (r *PdfDocument) Signatures(ctx context.Context) (string, error) { // pdf (../../../../../daggerverse/pdf/document.go:247:1)
+func (r *PdfDocument) Signatures(ctx context.Context) (string, error) { // pdf (../../../../../daggerverse/pdf/document.go:259:1)
 	if r.signatures != nil {
 		return *r.signatures, nil
 	}
@@ -1226,7 +1293,7 @@ func (r *PdfDocument) Signatures(ctx context.Context) (string, error) { // pdf (
 // WithPageRange narrows it. The passwords do not reach it: pdfseparate has no
 // password option at all, so an encrypted document is one it cannot open however
 // the document was bound — see the message a run against one carries.
-func (r *PdfDocument) Split() *Directory { // pdf (../../../../../daggerverse/pdf/pages.go:59:1)
+func (r *PdfDocument) Split() *Directory { // pdf (../../../../../daggerverse/pdf/pages.go:110:1)
 	q := r.query.Select("split")
 
 	return &Directory{
@@ -1330,18 +1397,18 @@ type PdfOpts struct {
 	//
 	//
 	// Default: "docker.io"
-	Registry string // pdf (../../../../../daggerverse/pdf/main.go:271:2)
+	Registry string // pdf (../../../../../daggerverse/pdf/main.go:276:2)
 	//
 	// Tag of the alpine image the toolchain is assembled on.
 	//
 	//
 	// Default: "3.24"
-	AlpineTag string // pdf (../../../../../daggerverse/pdf/main.go:274:2)
+	AlpineTag string // pdf (../../../../../daggerverse/pdf/main.go:279:2)
 }
 
 // New returns a Pdf module backed by <registry>/library/alpine:<tag> with
 // poppler-utils and a substitute font family installed.
-func (r *Query) Pdf(opts ...PdfOpts) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:266:1)
+func (r *Query) Pdf(opts ...PdfOpts) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:271:1)
 	q := r.query.Select("pdf")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `registry` optional argument

--- a/daggerverse/pdf/tests/main.go
+++ b/daggerverse/pdf/tests/main.go
@@ -344,6 +344,9 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("PageRangeOpenEndedRunsToTheLastPage", t.PageRangeOpenEndedRunsToTheLastPage)
 	jobs = jobs.WithJob("PageRangeRejectsInvalidBounds", t.PageRangeRejectsInvalidBounds)
 
+	jobs = jobs.WithJob("RenderConcurrencyMatchesSerialOutput", t.RenderConcurrencyMatchesSerialOutput)
+	jobs = jobs.WithJob("RenderConcurrencyAppliesToEveryPerPageFormat", t.RenderConcurrencyAppliesToEveryPerPageFormat)
+
 	jobs = jobs.WithJob("PngNamesEveryPageWithFourDigits", t.PngNamesEveryPageWithFourDigits)
 	jobs = jobs.WithJob("PngNarrowedRangeKeepsFourDigitNames", t.PngNarrowedRangeKeepsFourDigitNames)
 	jobs = jobs.WithJob("PngSinglePageIsStillNumbered", t.PngSinglePageIsStillNumbered)
@@ -2888,6 +2891,121 @@ func (t *Tests) JpegAndTiffFollowTheSameContract(ctx context.Context) error {
 	return nil
 }
 
+// RenderConcurrencyMatchesSerialOutput asserts a document rendered several pages
+// at a time produces exactly what the same document produces one page at a time,
+// and that a bound that would render nothing is refused.
+//
+// Byte equality is the whole promise of the knob: concurrency is allowed to
+// change how long a render takes and nothing else. What it pins now that every
+// page is its own exec is the *assembly* — the pages are collected in page order
+// off execs that finished in whatever order they finished in, so a directory
+// that came out right only because the work happened to be serial would fail
+// here. The digest covers the names and the bytes together.
+//
+// A bound wider than the document is included because it is the ordinary case
+// for a short document on a large machine: the default is one page per CPU, and
+// most documents are shorter than the core count.
+func (t *Tests) RenderConcurrencyMatchesSerialOutput(ctx context.Context) error {
+	conv := pdf().Document(fixture(ledgerPdf)).Convert()
+
+	serial := conv.WithConcurrency(1).Png()
+	serialDigest, err := serial.Digest(ctx)
+	if err != nil {
+		return fmt.Errorf("Png one page at a time: %w", err)
+	}
+	if got, err := serial.Entries(ctx); err != nil {
+		return fmt.Errorf("Png one page at a time: %w", err)
+	} else if err := assertPageNames(got, pageNames("png", 1, ledgerPages)); err != nil {
+		return fmt.Errorf("one page at a time: %s", err.Error())
+	}
+
+	for _, tc := range []struct {
+		name string
+		dir  *dagger.Directory
+	}{
+		{"unset, one per CPU", conv.Png()},
+		{"four at a time", conv.WithConcurrency(4).Png()},
+		{"wider than the document", conv.WithConcurrency(ledgerPages * 4).Png()},
+	} {
+		digest, err := tc.dir.Digest(ctx)
+		if err != nil {
+			return fmt.Errorf("Png %s: %w", tc.name, err)
+		}
+		if digest != serialDigest {
+			return fmt.Errorf(
+				"expected Png %s to be byte-identical to the serial render, got digest %s against %s",
+				tc.name, digest, serialDigest)
+		}
+	}
+
+	// A single-page range under a bound wider than the range is the shape a
+	// fan-out is most likely to get wrong — one unit of work, many workers —
+	// and it is also the shape that stopped being a whole-document render.
+	single, err := pdf().Document(fixture(ledgerPdf)).
+		WithPageRange(7, 7).Convert().WithConcurrency(8).Png().Entries(ctx)
+	if err != nil {
+		return fmt.Errorf("Png of a single-page range: %w", err)
+	}
+	if err := assertPageNames(single, pageNames("png", 7, 7)); err != nil {
+		return fmt.Errorf("single-page range: %s", err.Error())
+	}
+
+	// Zero workers would render nothing at all, which is a directory of missing
+	// pages rather than a failure, so it is refused by name.
+	for _, n := range []int{0, -2} {
+		_, err := conv.WithConcurrency(n).Png().Entries(ctx)
+		if err == nil {
+			return fmt.Errorf("expected concurrency %d to be rejected, got nil", n)
+		}
+		for _, want := range []string{"WithConcurrency", "concurrency must be positive", strconv.Itoa(n)} {
+			if !strings.Contains(err.Error(), want) {
+				return fmt.Errorf("expected the error for concurrency %d to mention %q, got: %v", n, want, err)
+			}
+		}
+	}
+	return nil
+}
+
+// RenderConcurrencyAppliesToEveryPerPageFormat asserts the bound reaches the
+// vector family too, and that the pages those formats write are assembled the
+// same way whatever the scheduling did.
+//
+// Html is the one worth checking rather than assuming. Its pages are not the
+// only thing in the directory — a page carrying images gets them beside its
+// markup under pdftohtml's own names — so it is the format whose assembly takes
+// the whole of each render's output rather than one named file, and the format
+// where a fan-out could plausibly lose or collide a file.
+func (t *Tests) RenderConcurrencyAppliesToEveryPerPageFormat(ctx context.Context) error {
+	for _, tc := range []struct {
+		name   string
+		render func(*dagger.PdfConvert) *dagger.Directory
+	}{
+		{"Svg", func(c *dagger.PdfConvert) *dagger.Directory { return c.Svg() }},
+		{"Eps", func(c *dagger.PdfConvert) *dagger.Directory { return c.Eps() }},
+		// HTML rather than Html: the generated bindings uppercase the acronym.
+		{"Html", func(c *dagger.PdfConvert) *dagger.Directory { return c.HTML() }},
+	} {
+		// galleryPdf carries images on its pages, which is what makes the Html
+		// case cover more than the markup.
+		conv := pdf().Document(fixture(galleryPdf)).Convert()
+
+		serial, err := tc.render(conv.WithConcurrency(1)).Digest(ctx)
+		if err != nil {
+			return fmt.Errorf("%s one page at a time: %w", tc.name, err)
+		}
+		concurrent, err := tc.render(conv.WithConcurrency(4)).Digest(ctx)
+		if err != nil {
+			return fmt.Errorf("%s four at a time: %w", tc.name, err)
+		}
+		if serial != concurrent {
+			return fmt.Errorf(
+				"expected %s to be byte-identical whatever the scheduling, got digest %s against %s",
+				tc.name, concurrent, serial)
+		}
+	}
+	return nil
+}
+
 // SplitWritesOnePdfPerPage asserts Split turns a twelve-page document into
 // twelve one-page PDFs named to the same contract every render family member
 // honours.
@@ -3234,12 +3352,11 @@ func (t *Tests) EncryptedDocumentNeedsThePassword(ctx context.Context) error {
 		}
 	}
 
-	// The per-page formats reach poppler by a different route than PageCount
-	// does — they resolve the document's page count inside the same exec that
-	// renders, from a shell rather than from Go — and an encrypted document has
-	// to be refused just as clearly along it. Without this the whole per-page
-	// family's encryption behaviour would rest on the raster path's assertion,
-	// which does not exercise that shell at all.
+	// Every render resolves the page count before it can name a page, so an
+	// encrypted document is refused there rather than by a render that failed.
+	// That is the message a caller sees, and it has to name the encryption
+	// rather than the page count it happened to be reading — the report is not
+	// what they asked for.
 	_, err = pdf().Document(encrypted).Convert().Svg().Entries(ctx)
 	if err == nil {
 		return fmt.Errorf("expected Svg on an encrypted document to be refused without a password")

--- a/daggerverse/tesseract/tests/internal/dagger/pdf.gen.go
+++ b/daggerverse/tesseract/tests/internal/dagger/pdf.gen.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Retrieve the binding value, as type Pdf
-func (r *Binding) AsPdf() *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:249:6)
+func (r *Binding) AsPdf() *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:254:6)
 	q := r.query.Select("asPdf")
 
 	return &Pdf{
@@ -20,7 +20,7 @@ func (r *Binding) AsPdf() *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:
 }
 
 // Retrieve the binding value, as type PdfConvert
-func (r *Binding) AsPdfConvert() *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:76:6)
+func (r *Binding) AsPdfConvert() *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:27:6)
 	q := r.query.Select("asPdfConvert")
 
 	return &PdfConvert{
@@ -38,7 +38,7 @@ func (r *Binding) AsPdfDocument() *PdfDocument { // pdf (../../../../../daggerve
 }
 
 // Create or update a binding of type PdfConvert in the environment
-func (r *Env) WithPdfConvertInput(name string, value *PdfConvert, description string) *Env { // pdf (../../../../../daggerverse/pdf/convert.go:76:6)
+func (r *Env) WithPdfConvertInput(name string, value *PdfConvert, description string) *Env { // pdf (../../../../../daggerverse/pdf/convert.go:27:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withPdfConvertInput")
 	q = q.Arg("name", name)
@@ -51,7 +51,7 @@ func (r *Env) WithPdfConvertInput(name string, value *PdfConvert, description st
 }
 
 // Declare a desired PdfConvert output to be assigned in the environment
-func (r *Env) WithPdfConvertOutput(name string, description string) *Env { // pdf (../../../../../daggerverse/pdf/convert.go:76:6)
+func (r *Env) WithPdfConvertOutput(name string, description string) *Env { // pdf (../../../../../daggerverse/pdf/convert.go:27:6)
 	q := r.query.Select("withPdfConvertOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -86,7 +86,7 @@ func (r *Env) WithPdfDocumentOutput(name string, description string) *Env { // p
 }
 
 // Create or update a binding of type Pdf in the environment
-func (r *Env) WithPdfInput(name string, value *Pdf, description string) *Env { // pdf (../../../../../daggerverse/pdf/main.go:249:6)
+func (r *Env) WithPdfInput(name string, value *Pdf, description string) *Env { // pdf (../../../../../daggerverse/pdf/main.go:254:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withPdfInput")
 	q = q.Arg("name", name)
@@ -99,7 +99,7 @@ func (r *Env) WithPdfInput(name string, value *Pdf, description string) *Env { /
 }
 
 // Declare a desired Pdf output to be assigned in the environment
-func (r *Env) WithPdfOutput(name string, description string) *Env { // pdf (../../../../../daggerverse/pdf/main.go:249:6)
+func (r *Env) WithPdfOutput(name string, description string) *Env { // pdf (../../../../../daggerverse/pdf/main.go:254:6)
 	q := r.query.Select("withPdfOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -113,11 +113,12 @@ func (r *Env) WithPdfOutput(name string, description string) *Env { // pdf (../.
 // carries the image coordinates and the fonts the image is built with;
 // Document hangs off it so the generated SDK surfaces conversion under
 // `dag.Pdf().Document(...)`.
-type Pdf struct { // pdf (../../../../../daggerverse/pdf/main.go:249:6)
+type Pdf struct { // pdf (../../../../../daggerverse/pdf/main.go:254:6)
 	query *querybuilder.Selection
 
-	id      *ID
-	version *string
+	id                       *ID
+	renderSchedulingSelfTest *Void
+	version                  *string
 }
 type WithPdfFunc func(r *Pdf) *Pdf
 
@@ -140,7 +141,7 @@ func (r *Pdf) WithGraphQLQuery(q *querybuilder.Selection) *Pdf {
 // reachable via `container with-exec` — as do the flags of a wrapped tool that
 // this module does not surface, `pdffonts -subst` and `pdfdetach -savefile`
 // among them.
-func (r *Pdf) Container() *Container { // pdf (../../../../../daggerverse/pdf/main.go:395:1)
+func (r *Pdf) Container() *Container { // pdf (../../../../../daggerverse/pdf/main.go:400:1)
 	q := r.query.Select("container")
 
 	return &Container{
@@ -153,7 +154,7 @@ func (r *Pdf) Container() *Container { // pdf (../../../../../daggerverse/pdf/ma
 // The boundary input is a *dagger.File rather than a *dagger.Directory: a PDF
 // resolves nothing relative to its own location, so one file is the whole unit
 // of work however many pages it carries.
-func (r *Pdf) Document(source *File) *PdfDocument { // pdf (../../../../../daggerverse/pdf/main.go:428:1)
+func (r *Pdf) Document(source *File) *PdfDocument { // pdf (../../../../../daggerverse/pdf/main.go:454:1)
 	assertNotNil("source", source)
 	q := r.query.Select("document")
 	q = q.Arg("source", source)
@@ -238,7 +239,7 @@ func (r *Pdf) UnmarshalJSON(bs []byte) error {
 // Encrypted sources are the one shape this cannot take: pdfunite has no password
 // option, so there is no argument that would let it read one. See the message a
 // run against one carries.
-func (r *Pdf) Merge(sources []*File) *File { // pdf (../../../../../daggerverse/pdf/pages.go:113:1)
+func (r *Pdf) Merge(sources []*File) *File { // pdf (../../../../../daggerverse/pdf/pages.go:164:1)
 	q := r.query.Select("merge")
 	q = q.Arg("sources", sources)
 
@@ -247,9 +248,33 @@ func (r *Pdf) Merge(sources []*File) *File { // pdf (../../../../../daggerverse/
 	}
 }
 
+// RenderSchedulingSelfTest verifies the properties the per-page render fan-out
+// depends on: that every page runs, that WithConcurrency is honoured as both a
+// ceiling and a floor, that a failure partway through is the error reported, and
+// that it stops the pages behind it from starting.
+//
+// It sits on the module rather than in the test module because it checks
+// unexported scheduling, and it exists at all because no document can check it.
+// poppler does not fail a page: measured against the pinned poppler 25.12, every
+// damaged page shape — a dangling page-tree kid, a kid of the wrong type, a loop
+// in the tree, a null kid, an absurd MediaBox, an absurd resolution — is a
+// warning on stderr and an exit status of 0. So the fail-fast has no fixture
+// that would exercise it, and this is what covers it instead.
+//
+// It runs in-process and needs no container, so it is cheap enough to be a check
+// of its own.
+func (r *Pdf) RenderSchedulingSelfTest(ctx context.Context) error { // pdf (../../../../../daggerverse/pdf/main.go:445:1)
+	if r.renderSchedulingSelfTest != nil {
+		return nil
+	}
+	q := r.query.Select("renderSchedulingSelfTest")
+
+	return q.Execute(ctx)
+}
+
 // Version returns the poppler release the assembled image ships, as the bare
 // version number reported by `pdftotext -v`.
-func (r *Pdf) Version(ctx context.Context) (string, error) { // pdf (../../../../../daggerverse/pdf/main.go:408:1)
+func (r *Pdf) Version(ctx context.Context) (string, error) { // pdf (../../../../../daggerverse/pdf/main.go:413:1)
 	if r.version != nil {
 		return *r.version, nil
 	}
@@ -275,7 +300,7 @@ func (r *Pdf) Version(ctx context.Context) (string, error) { // pdf (../../../..
 // why the credentials are not simply userinfo in the WithApkRepository URL,
 // which would put them in /etc/apk/repositories and in every apk error
 // message that quotes it.
-func (r *Pdf) WithApkAuth(credentials *Secret) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:356:1)
+func (r *Pdf) WithApkAuth(credentials *Secret) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:361:1)
 	assertNotNil("credentials", credentials)
 	q := r.query.Select("withApkAuth")
 	q = q.Arg("credentials", credentials)
@@ -298,7 +323,7 @@ func (r *Pdf) WithApkAuth(credentials *Secret) *Pdf { // pdf (../../../../../dag
 // Repeatable, for a mirror set signed by more than one key. It is a *File
 // rather than a *Secret because a public key is not a credential: it is meant
 // to be in the image, and WithApkAuth is the option for the part that is not.
-func (r *Pdf) WithApkKey(key *File) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:333:1)
+func (r *Pdf) WithApkKey(key *File) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:338:1)
 	assertNotNil("key", key)
 	q := r.query.Select("withApkKey")
 	q = q.Arg("key", key)
@@ -328,7 +353,7 @@ func (r *Pdf) WithApkKey(key *File) *Pdf { // pdf (../../../../../daggerverse/pd
 // call per component. A repository's index is signed, so pair this with
 // WithApkKey unless the mirror is signed by a key the base image already
 // trusts.
-func (r *Pdf) WithApkRepository(url string) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:305:1)
+func (r *Pdf) WithApkRepository(url string) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:310:1)
 	q := r.query.Select("withApkRepository")
 	q = q.Arg("url", url)
 
@@ -352,7 +377,7 @@ func (r *Pdf) WithApkRepository(url string) *Pdf { // pdf (../../../../../dagger
 // /etc/fonts/fonts.conf tells fontconfig to scan, so the faces in it are
 // indistinguishable from packaged ones as far as poppler is concerned. It is
 // mounted rather than copied so a large family does not become an image layer.
-func (r *Pdf) WithFonts(dir *Directory) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:380:1)
+func (r *Pdf) WithFonts(dir *Directory) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:385:1)
 	assertNotNil("dir", dir)
 	q := r.query.Select("withFonts")
 	q = q.Arg("dir", dir)
@@ -383,7 +408,7 @@ func (r *Pdf) AsNode() Node {
 // documented no-ops there rather than rejections: a DPI set before asking for
 // text is inapplicable rather than wrong, unlike a bound past the end of the
 // document, which is always a mistake.
-type PdfConvert struct { // pdf (../../../../../daggerverse/pdf/convert.go:76:6)
+type PdfConvert struct { // pdf (../../../../../daggerverse/pdf/convert.go:27:6)
 	query *querybuilder.Selection
 
 	id   *ID
@@ -409,7 +434,7 @@ type PdfConvertBboxOpts struct {
 	//
 	// Add the block and line boxes poppler groups the words into.
 	//
-	WithLayout bool // pdf (../../../../../daggerverse/pdf/convert.go:279:2)
+	WithLayout bool // pdf (../../../../../daggerverse/pdf/convert.go:268:2)
 }
 
 // Bbox returns the document's text layer as an XHTML report carrying a bounding
@@ -441,7 +466,7 @@ type PdfConvertBboxOpts struct {
 // The render options are ignored, this being an extraction and not a render, and
 // so is LayoutMode: the report's structure is poppler's own and is not the text's
 // reading order. WithPageRange narrows it.
-func (r *PdfConvert) Bbox(opts ...PdfConvertBboxOpts) *File { // pdf (../../../../../daggerverse/pdf/convert.go:275:1)
+func (r *PdfConvert) Bbox(opts ...PdfConvertBboxOpts) *File { // pdf (../../../../../daggerverse/pdf/convert.go:264:1)
 	q := r.query.Select("bbox")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `withLayout` optional argument
@@ -473,7 +498,7 @@ func (r *PdfConvert) Bbox(opts ...PdfConvertBboxOpts) *File { // pdf (../../../.
 //
 // WithDpi governs rasterized regions; WithColorMode, WithScaleTo and
 // WithoutAnnotations are ignored: see the note on Ps.
-func (r *PdfConvert) Eps() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:394:1)
+func (r *PdfConvert) Eps() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:383:1)
 	q := r.query.Select("eps")
 
 	return &Directory{
@@ -500,7 +525,7 @@ func (r *PdfConvert) Eps() *Directory { // pdf (../../../../../daggerverse/pdf/c
 //
 // Every render option is ignored, pdftohtml having no resolution, colour or
 // annotation switch of any kind. WithPageRange narrows it like everything else.
-func (r *PdfConvert) HTML() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:456:1)
+func (r *PdfConvert) HTML() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:454:1)
 	q := r.query.Select("html")
 
 	return &Directory{
@@ -564,7 +589,7 @@ func (r *PdfConvert) UnmarshalJSON(bs []byte) error {
 // Lossy, so it is the format for a preview a human looks at rather than for
 // input another program measures: the artefacts a flat page compresses into sit
 // exactly where thin strokes are, which is where OCR reads.
-func (r *PdfConvert) Jpeg() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:337:1)
+func (r *PdfConvert) Jpeg() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:326:1)
 	q := r.query.Select("jpeg")
 
 	return &Directory{
@@ -578,7 +603,7 @@ func (r *PdfConvert) Jpeg() *Directory { // pdf (../../../../../daggerverse/pdf/
 // PNG is the format to hand another module: it is lossless, so nothing
 // downstream is reading compression artefacts as page content, and it is what
 // every image library reads without a codec question.
-func (r *PdfConvert) Png() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:326:1)
+func (r *PdfConvert) Png() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:315:1)
 	q := r.query.Select("png")
 
 	return &Directory{
@@ -594,6 +619,15 @@ func (r *PdfConvert) Png() *Directory { // pdf (../../../../../daggerverse/pdf/c
 // Splitting it into a page-per-file directory would produce fragments that are
 // each individually invalid.
 //
+// That is also why this is the one render that stays a single invocation, and
+// why WithConcurrency does nothing here. Every other page-per-file output fans
+// out one exec per page and assembles the directory afterwards; a PostScript
+// document cannot be assembled that way, because concatenating the fragments is
+// not the same operation as writing the document — the result would need its
+// prologue, its page markers and its `%%Pages:` count rewritten, which is a
+// PostScript editor and not a renderer. A caller who wants the pages rendered
+// concurrently wants Eps, which is one page per file by definition.
+//
 // WithDpi governs the rasterized regions the output can still contain.
 // WithColorMode, WithScaleTo and WithoutAnnotations are ignored here and by Svg,
 // Eps and Html, and are documented no-ops rather than rejections for the same
@@ -602,7 +636,7 @@ func (r *PdfConvert) Png() *Directory { // pdf (../../../../../daggerverse/pdf/c
 // are dropped rather than forwarded because poppler does not ignore them — it
 // exits non-zero with `-mono may only be used with the -png, -jpeg, or -tiff
 // output options`, and `-hide-annotations` is not a pdftocairo option at all.
-func (r *PdfConvert) Ps() *File { // pdf (../../../../../daggerverse/pdf/convert.go:414:1)
+func (r *PdfConvert) Ps() *File { // pdf (../../../../../daggerverse/pdf/convert.go:412:1)
 	q := r.query.Select("ps")
 
 	return &File{
@@ -630,7 +664,7 @@ func (r *PdfConvert) Ps() *File { // pdf (../../../../../daggerverse/pdf/convert
 // WithDpi governs the rasterized regions a page can still contain — an embedded
 // photograph has no vector form to keep. WithColorMode, WithScaleTo and
 // WithoutAnnotations are ignored: see the note on Ps.
-func (r *PdfConvert) Svg() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:372:1)
+func (r *PdfConvert) Svg() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:361:1)
 	q := r.query.Select("svg")
 
 	return &Directory{
@@ -644,11 +678,11 @@ type PdfConvertTextOpts struct {
 	// How much of the page's physical arrangement survives into the text.
 	// Defaults to reading order.
 	//
-	Layout PdfLayoutMode // pdf (../../../../../daggerverse/pdf/convert.go:193:2)
+	Layout PdfLayoutMode // pdf (../../../../../daggerverse/pdf/convert.go:182:2)
 	//
 	// Emit no form feed between pages.
 	//
-	DisablePageBreaks bool // pdf (../../../../../daggerverse/pdf/convert.go:196:2)
+	DisablePageBreaks bool // pdf (../../../../../daggerverse/pdf/convert.go:185:2)
 }
 
 // Text returns the document's text layer as a string.
@@ -663,7 +697,7 @@ type PdfConvertTextOpts struct {
 // Pages are separated by a form feed (U+000C), including after the last one,
 // which is pdftotext's own convention. Pass disablePageBreaks to drop them, for
 // a consumer that wants one flat stream of text.
-func (r *PdfConvert) Text(ctx context.Context, opts ...PdfConvertTextOpts) (string, error) { // pdf (../../../../../daggerverse/pdf/convert.go:188:1)
+func (r *PdfConvert) Text(ctx context.Context, opts ...PdfConvertTextOpts) (string, error) { // pdf (../../../../../daggerverse/pdf/convert.go:177:1)
 	if r.text != nil {
 		return *r.text, nil
 	}
@@ -692,7 +726,7 @@ func (r *PdfConvert) Text(ctx context.Context, opts ...PdfConvertTextOpts) (stri
 // It is the format the document-imaging world already speaks, and the one to
 // pair with MONO: a bilevel TIFF is what a scanner emits and what an archive
 // expects.
-func (r *PdfConvert) Tiff() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:348:1)
+func (r *PdfConvert) Tiff() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:337:1)
 	q := r.query.Select("tiff")
 
 	return &Directory{
@@ -728,7 +762,7 @@ func (r *PdfConvert) Tiff() *Directory { // pdf (../../../../../daggerverse/pdf/
 // A page with no text layer yields its page row and no word rows rather than a
 // failure, the same boundary Text and Bbox draw. The render options are ignored,
 // as is LayoutMode. WithPageRange narrows it.
-func (r *PdfConvert) Tsv() *File { // pdf (../../../../../daggerverse/pdf/convert.go:316:1)
+func (r *PdfConvert) Tsv() *File { // pdf (../../../../../daggerverse/pdf/convert.go:305:1)
 	q := r.query.Select("tsv")
 
 	return &File{
@@ -742,11 +776,11 @@ type PdfConvertTxtOpts struct {
 	// How much of the page's physical arrangement survives into the text.
 	// Defaults to reading order.
 	//
-	Layout PdfLayoutMode // pdf (../../../../../daggerverse/pdf/convert.go:223:2)
+	Layout PdfLayoutMode // pdf (../../../../../daggerverse/pdf/convert.go:212:2)
 	//
 	// Emit no form feed between pages.
 	//
-	DisablePageBreaks bool // pdf (../../../../../daggerverse/pdf/convert.go:226:2)
+	DisablePageBreaks bool // pdf (../../../../../daggerverse/pdf/convert.go:215:2)
 }
 
 // Txt returns the same text Text returns, as a file rather than a string.
@@ -754,7 +788,7 @@ type PdfConvertTxtOpts struct {
 // Which of the two to reach for is plumbing and nothing more: a file composes
 // with whatever consumes files — another module, an export, a directory being
 // assembled — without the bytes passing through the caller.
-func (r *PdfConvert) Txt(opts ...PdfConvertTxtOpts) *File { // pdf (../../../../../daggerverse/pdf/convert.go:218:1)
+func (r *PdfConvert) Txt(opts ...PdfConvertTxtOpts) *File { // pdf (../../../../../daggerverse/pdf/convert.go:207:1)
 	q := r.query.Select("txt")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `layout` optional argument
@@ -780,9 +814,42 @@ func (r *PdfConvert) Txt(opts ...PdfConvertTxtOpts) *File { // pdf (../../../../
 // threshold a colour image itself.
 //
 // Ignored by Text and Txt.
-func (r *PdfConvert) WithColorMode(mode PdfColorMode) *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:124:1)
+func (r *PdfConvert) WithColorMode(mode PdfColorMode) *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:79:1)
 	q := r.query.Select("withColorMode")
 	q = q.Arg("mode", mode)
+
+	return &PdfConvert{
+		query: q,
+	}
+}
+
+// WithConcurrency bounds how many pages a render converts at once.
+//
+// It defaults to the number of CPUs the module can see, which is what a
+// document wants: every page is its own exec, and poppler renders a page on one
+// core whatever the machine has. A 129-page document at 300 dpi spends about a
+// minute of that one core, and the recognition it is usually rendered for
+// spends its own time across every core — so the render is a third of the CPU
+// and two thirds of the wall clock, and the share grows with core count rather
+// than shrinking.
+//
+// Unlike the tesseract module's Batch, this bound needs no companion. poppler's
+// tools are single-threaded, so concurrency here is concurrency and not
+// concurrency multiplied by an OpenMP team; the pages contend for cores the way
+// any other CPU-bound workload does.
+//
+// Pass a number to take less of the machine than the default, or 1 to render one
+// page at a time. Non-positive is rejected at output time.
+//
+// It is a scheduling bound and nothing else: the directory a conversion returns
+// is the same whatever it is set to. It is also not what decides how the results
+// cache — one exec per page is what does that, at every bound including 1.
+//
+// Ignored by Text, Txt, Bbox, Tsv and Ps, none of which renders a page at a
+// time. See Ps for why that one is a single invocation.
+func (r *PdfConvert) WithConcurrency(concurrency int) *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:155:1)
+	q := r.query.Select("withConcurrency")
+	q = q.Arg("concurrency", concurrency)
 
 	return &PdfConvert{
 		query: q,
@@ -802,7 +869,7 @@ func (r *PdfConvert) WithColorMode(mode PdfColorMode) *PdfConvert { // pdf (../.
 // Ignored by Text and Txt, which read a text layer rather than rendering
 // anything. Overridden by WithScaleTo, which fixes the output's pixel
 // dimensions directly.
-func (r *PdfConvert) WithDpi(dpi int) *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:106:1)
+func (r *PdfConvert) WithDpi(dpi int) *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:61:1)
 	q := r.query.Select("withDpi")
 	q = q.Arg("dpi", dpi)
 
@@ -825,7 +892,7 @@ func (r *PdfConvert) WithDpi(dpi int) *PdfConvert { // pdf (../../../../../dagge
 // is on the page, which is every OCR and measurement case.
 //
 // Ignored by Text and Txt.
-func (r *PdfConvert) WithScaleTo(pixels int) *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:147:1)
+func (r *PdfConvert) WithScaleTo(pixels int) *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:102:1)
 	q := r.query.Select("withScaleTo")
 	q = q.Arg("pixels", pixels)
 
@@ -846,7 +913,7 @@ func (r *PdfConvert) WithScaleTo(pixels int) *PdfConvert { // pdf (../../../../.
 // could ever turn annotations off.
 //
 // Ignored by Text and Txt.
-func (r *PdfConvert) WithoutAnnotations() *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:170:1)
+func (r *PdfConvert) WithoutAnnotations() *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:125:1)
 	q := r.query.Select("withoutAnnotations")
 
 	return &PdfConvert{
@@ -944,7 +1011,7 @@ func (r *PdfDocument) Attachments() *Directory { // pdf (../../../../../daggerve
 // nothing about the PDF — and because it is what lets one bound document, with
 // its passwords and its page range settled, fan out into several differently
 // configured conversions.
-func (r *PdfDocument) Convert() *PdfConvert { // pdf (../../../../../daggerverse/pdf/document.go:281:1)
+func (r *PdfDocument) Convert() *PdfConvert { // pdf (../../../../../daggerverse/pdf/document.go:293:1)
 	q := r.query.Select("convert")
 
 	return &PdfConvert{
@@ -1038,7 +1105,7 @@ func (r *PdfDocument) EmbeddedImages(format PdfImageFormat) *Directory { // pdf 
 // through 3. Which substitute poppler would actually choose for an unembedded
 // face is a different question, answered by `pdffonts -subst`, and reachable
 // through Container.
-func (r *PdfDocument) Fonts(ctx context.Context) (string, error) { // pdf (../../../../../daggerverse/pdf/document.go:175:1)
+func (r *PdfDocument) Fonts(ctx context.Context) (string, error) { // pdf (../../../../../daggerverse/pdf/document.go:187:1)
 	if r.fonts != nil {
 		return *r.fonts, nil
 	}
@@ -1137,7 +1204,7 @@ func (r *PdfDocument) Info(ctx context.Context) (string, error) { // pdf (../../
 //
 // WithPageRange does not narrow it, the packet being a property of the document
 // rather than of any page — the same reason it does not narrow Info.
-func (r *PdfDocument) Metadata(ctx context.Context) (string, error) { // pdf (../../../../../daggerverse/pdf/document.go:206:1)
+func (r *PdfDocument) Metadata(ctx context.Context) (string, error) { // pdf (../../../../../daggerverse/pdf/document.go:218:1)
 	if r.metadata != nil {
 		return *r.metadata, nil
 	}
@@ -1195,7 +1262,7 @@ func (r *PdfDocument) PageCount(ctx context.Context) (int, error) { // pdf (../.
 // ranges of the file rather than pages, and pdfsig has no page bounds at all.
 // The passwords do reach it, an encrypted document being one it has to open like
 // any other.
-func (r *PdfDocument) Signatures(ctx context.Context) (string, error) { // pdf (../../../../../daggerverse/pdf/document.go:247:1)
+func (r *PdfDocument) Signatures(ctx context.Context) (string, error) { // pdf (../../../../../daggerverse/pdf/document.go:259:1)
 	if r.signatures != nil {
 		return *r.signatures, nil
 	}
@@ -1226,7 +1293,7 @@ func (r *PdfDocument) Signatures(ctx context.Context) (string, error) { // pdf (
 // WithPageRange narrows it. The passwords do not reach it: pdfseparate has no
 // password option at all, so an encrypted document is one it cannot open however
 // the document was bound — see the message a run against one carries.
-func (r *PdfDocument) Split() *Directory { // pdf (../../../../../daggerverse/pdf/pages.go:59:1)
+func (r *PdfDocument) Split() *Directory { // pdf (../../../../../daggerverse/pdf/pages.go:110:1)
 	q := r.query.Select("split")
 
 	return &Directory{
@@ -1330,18 +1397,18 @@ type PdfOpts struct {
 	//
 	//
 	// Default: "docker.io"
-	Registry string // pdf (../../../../../daggerverse/pdf/main.go:271:2)
+	Registry string // pdf (../../../../../daggerverse/pdf/main.go:276:2)
 	//
 	// Tag of the alpine image the toolchain is assembled on.
 	//
 	//
 	// Default: "3.24"
-	AlpineTag string // pdf (../../../../../daggerverse/pdf/main.go:274:2)
+	AlpineTag string // pdf (../../../../../daggerverse/pdf/main.go:279:2)
 }
 
 // New returns a Pdf module backed by <registry>/library/alpine:<tag> with
 // poppler-utils and a substitute font family installed.
-func (r *Query) Pdf(opts ...PdfOpts) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:266:1)
+func (r *Query) Pdf(opts ...PdfOpts) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:271:1)
 	q := r.query.Select("pdf")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `registry` optional argument


### PR DESCRIPTION
Closes #309.

`Png`, `Jpeg`, `Tiff`, `Svg`, `Eps` and `Html` now render **one page per exec**,
fanned out from Go and bounded by `Convert.WithConcurrency`. The raster family
was a single `pdftoppm` over the whole document; the vector family looped per
page *inside* one exec. Both were serial, because poppler renders a range on one
core however many the machine has.

## Measured

48 pages at 300 dpi, 32-CPU host, median of three, a freshly generated document
every run so nothing is a cache hit:

| pages | one exec | one exec per page, Go fan-out |
| --- | --- | --- |
| 12 | 17.0s | **4.0s** |
| 48 | 60.4s | **6.5s** |
| 48, one page edited | 60.7s | 6.5s |
| 48, pages 1–24 already rendered | 61.0s | **4.3s** |

Both columns produce a **byte-identical directory** — same `sha256`, checked
against the pre-change code directly.

The per-page open costs 20 ms/page at 150 dpi, 58 ms at 300, 121 ms at 600
(measured in one container, no Dagger). It is not a fixed cost — it scales with
output pixels, so it stays ~13–26% rather than shrinking against a bigger raster.
Against the ~0.47s/page a real 300-dpi page costs in #308 that is ~12% more CPU
for the document, bought back by the first extra core.

## Two findings I did not smooth over

**The "one page edited" win does not transfer from #298.** The issue expected it
to. It cannot: every page's exec mounts the *same* PDF, so changing any byte of
it invalidates all of them — `tesseract`'s `Batch` gets 17.5s → 2.5s there only
because each exec mounts its own image file. What per-page caching *does* buy is
an overlapping page range (row four above), which is #300's sharding case.

**poppler will not fail a page.** I tried nine damaged fixture shapes — dangling
page-tree kid, kid of the wrong type, loop in the tree, null kid, `/Count` over-
and understated, two-million-point `MediaBox`, zero `MediaBox`, absurd `-r`.
Every one warns on stderr and **exits 0 with a file written**; the only non-zero
exits are for a document that cannot be opened and a page range outside it, both
caught before any page renders. So the fail-fast has no fixture that would
exercise it, and the scheduling lives in `fanout/` instead — no dagger import,
`go test -race`, and checked in CI by `Pdf.RenderSchedulingSelfTest`.

That test found a real bug: `select` picks at random when both a free slot and a
cancelled context are ready, so the first failure stopped the *queue* but let the
pages behind it start anyway. `tesseract/batch.go` has the same shape and the
same behaviour — worth a follow-up if you want it, but I left it alone here.

## Scope

- `Ps` stays one invocation — PostScript is multi-page and its fragments cannot
  be concatenated back into a document. Documented on the function.
- **`Split` stays one exec, and I did not file the follow-up** the issue offered
  as an alternative, because measuring it argued the other way: `pdfseparate`
  copies page objects at 0.8 ms/page against 5.8 ms/page one invocation per page,
  so a container per page would cost ~100× the work it wraps. Recorded in the
  README as a decision. Say the word if you would rather have the issue anyway.
- `-forcenum` is gone: `-singlefile` names each page outright, and the two
  override rather than compose (together they write `page-0007-07.png`).
- The padding width moves to Go, costing one `PageCount` per conversion — one
  `pdfinfo`, shared with `Info`'s cache entry.

`Ci` forwarding (#273) is untouched, as the issue expected.

## Verified locally

`dagger -m daggerverse/pdf/tests call all`, `dagger -m ci call generated`,
`go test -race -count=10 ./fanout/...`, and
`tesseract/tests call pdf-module-pages-batch-into-one-searchable-pdf` for the
downstream `Png()` → `Batch` flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
