### PR TITLE
story(issue-307): run the schema-registry group on the JVM image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,23 +32,6 @@ env:
   # re-reading daggerverse/workspace-ci/README.md.
   MEMO_TTL_SECONDS: "86400"
 
-  # Modules whose checks must each get their own leg even when everything runs.
-  # The run-everything path otherwise emits one coarse leg per module, which shares
-  # one engine on one runner — free when a module's checks share their containers
-  # (13 grafana-stack checks land in ~1m30s), wrong when each check boots a stack
-  # of its own.
-  #
-  # kafka/tests is the latter: its five checks bring up five different Kafka
-  # distributions, 87 brokers/controllers/registries in one engine. Under that load
-  # a broker loses the race to reach its KRaft controller and dies (#307), which
-  # failed 3 of 3 attempts of one run here while the same check has not failed on
-  # main in 20 runs. Splitting it restores main's layout: five legs, five runners,
-  # five engines.
-  #
-  # Each name costs one module load in the list job, so this stays a short list of
-  # modules that need it rather than every module with more than one check.
-  SPLIT_MODULES: "daggerverse/kafka/tests"
-
   # Per-leg check-step budgets in minutes; anything unlisted gets the planner's
   # default of 6, which fits a leg that runs a single check and — since a module's
   # checks run concurrently and share their container builds — most coarse legs too.
@@ -62,14 +45,19 @@ env:
   #   daggerverse/workspace-ci declares that same whole-workspace `generated` as
   #                            its own check, so its coarse leg repeats the sweep;
   #                            measured at 5m12s against the 6m default.
+  #   daggerverse/kafka/tests  is the exception to "most coarse legs too": its
+  #                            five checks boot five different Kafka
+  #                            distributions rather than sharing containers, so
+  #                            the leg pays for all five. Measured at 8m45s and
+  #                            9m18s across two runs of this layout.
   #
   # A module key covers that module's coarse leg AND its per-check legs, since a
-  # coarse leg's name *is* the module directory (#306). Neither key above names a
-  # module that also produces per-check legs worth tightening, so nothing here is
-  # bound more loosely than it needs to be.
+  # coarse leg's name *is* the module directory (#306). None of the keys above
+  # name a module that also produces per-check legs worth tightening, so nothing
+  # here is bound more loosely than it needs to be.
   CHECK_TIMEOUTS: >-
     {".": 15, ".:generated-self-test": 8, ".:selection-self-test": 2,
-    "daggerverse/workspace-ci": 15}
+    "daggerverse/workspace-ci": 15, "daggerverse/kafka/tests": 15}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -174,7 +162,6 @@ jobs:
         run: |
           set -euo pipefail
           jobs="$(dagger -m daggerverse/workspace-ci call \
-            --split-modules="$SPLIT_MODULES" \
             --timeouts="$CHECK_TIMEOUTS" \
             --memo-token=env:GH_TOKEN \
             --memo-repo="$GITHUB_REPOSITORY" \

--- a/daggerverse/kafka/cluster_kafka.go
+++ b/daggerverse/kafka/cluster_kafka.go
@@ -54,10 +54,27 @@ type Cluster struct {
 // (with a brand-new CA the previous invocation's franz-go client doesn't
 // trust) every time the test calls another method on the chain.
 //
-// The GraalVM-compiled image has been observed to flake during the broker
-// `setup` step under load — see Dagger Cloud trace
-// `377f2e176c4f0e9844cb7f958c1e911b`. If you need the JVM image instead,
-// use `ApacheCluster()`.
+// The GraalVM-compiled image segfaults at startup under load. It happens
+// immediately after the entrypoint's `===> Launching`, in class
+// initialization, before Kafka logs anything of its own:
+//
+//	[ [ SegfaultHandler caught a segfault ... ] ] si_signo: 11
+//	  com.oracle.svm.core.posix.headers.Pwd.getpwuid
+//	  com.oracle.svm.core.posix.PosixSystemPropertiesSupport.userHomeValue
+//	  com.oracle.svm.core.jdk.SystemPropertiesSupport.userHome
+//	  kafka.docker.KafkaDockerWrapper.main
+//
+// and the container exits 1. It hits controllers as readily as brokers — the
+// two runs it has been caught in took a controller each: Dagger Cloud traces
+// `377f2e176c4f0e9844cb7f958c1e911b` and the run behind #307. Note the string
+// to grep for is `SegfaultHandler caught a segfault`; SubstrateVM prints
+// neither `SIGSEGV` nor `Segmentation fault`.
+//
+// Nothing here can prevent it — the frames are all `com.oracle.svm.core.*`,
+// i.e. the AOT image's own substitutions for `user.home`. Use `ApacheCluster()`
+// if a node dying at startup would cost you more than the JVM's slower cold
+// start; that image runs the same Scala wrapper on HotSpot, which has no such
+// code path.
 //
 // +cache="session"
 func (k *Kafka) ApacheNativeCluster(

--- a/daggerverse/kafka/tests/internal/dagger/kafka.gen.go
+++ b/daggerverse/kafka/tests/internal/dagger/kafka.gen.go
@@ -424,16 +424,16 @@ func (r *Kafka) WithGraphQLQuery(q *querybuilder.Selection) *Kafka {
 type KafkaApacheClusterOpts struct {
 
 	// Default: 1
-	Controllers int // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:98:2)
+	Controllers int // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:115:2)
 
 	// Default: 1
-	Brokers int // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:100:2)
+	Brokers int // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:117:2)
 
 	// Default: "docker.io"
-	Registry string // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:102:2)
+	Registry string // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:119:2)
 
 	// Default: "4.2.0"
-	Tag string // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:104:2)
+	Tag string // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:121:2)
 }
 
 // ApacheCluster spins up a KRaft Kafka cluster of the requested size with
@@ -448,7 +448,7 @@ type KafkaApacheClusterOpts struct {
 // been observed to segfault during broker startup — see Dagger Cloud
 // trace `377f2e176c4f0e9844cb7f958c1e911b`. Prefer this constructor
 // whenever startup robustness matters more than cold-start latency.
-func (r *Kafka) ApacheCluster(clusterId string, clientListenerSecurity *KafkaServerSecurity, opts ...KafkaApacheClusterOpts) *KafkaCluster { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:94:1)
+func (r *Kafka) ApacheCluster(clusterId string, clientListenerSecurity *KafkaServerSecurity, opts ...KafkaApacheClusterOpts) *KafkaCluster { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:111:1)
 	assertNotNil("clientListenerSecurity", clientListenerSecurity)
 	q := r.query.Select("apacheCluster")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -481,16 +481,16 @@ func (r *Kafka) ApacheCluster(clusterId string, clientListenerSecurity *KafkaSer
 type KafkaApacheNativeClusterOpts struct {
 
 	// Default: 1
-	Controllers int // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:67:2)
+	Controllers int // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:84:2)
 
 	// Default: 1
-	Brokers int // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:69:2)
+	Brokers int // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:86:2)
 
 	// Default: "docker.io"
-	Registry string // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:71:2)
+	Registry string // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:88:2)
 
 	// Default: "4.2.0"
-	Tag string // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:73:2)
+	Tag string // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:90:2)
 }
 
 // ApacheNativeCluster spins up a KRaft Kafka cluster of the requested
@@ -520,11 +520,28 @@ type KafkaApacheNativeClusterOpts struct {
 // so a `(with a brand-new CA the previous invocation's franz-go client doesn't
 // trust) every time the test calls another method on the chain.
 //
-// The GraalVM-compiled image has been observed to flake during the broker
-// `setup` step under load — see Dagger Cloud trace
-// `377f2e176c4f0e9844cb7f958c1e911b`. If you need the JVM image instead,
-// use `ApacheCluster()`.
-func (r *Kafka) ApacheNativeCluster(clusterId string, clientListenerSecurity *KafkaServerSecurity, opts ...KafkaApacheNativeClusterOpts) *KafkaCluster { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:63:1)
+// The GraalVM-compiled image segfaults at startup under load. It happens
+// immediately after the entrypoint's `===> Launching`, in class
+// initialization, before Kafka logs anything of its own:
+//
+//	[ [ SegfaultHandler caught a segfault ... ] ] si_signo: 11
+//	  com.oracle.svm.core.posix.headers.Pwd.getpwuid
+//	  com.oracle.svm.core.posix.PosixSystemPropertiesSupport.userHomeValue
+//	  com.oracle.svm.core.jdk.SystemPropertiesSupport.userHome
+//	  kafka.docker.KafkaDockerWrapper.main
+//
+// and the container exits 1. It hits controllers as readily as brokers — the
+// two runs it has been caught in took a controller each: Dagger Cloud traces
+// `377f2e176c4f0e9844cb7f958c1e911b` and the run behind #307. Note the string
+// to grep for is `SegfaultHandler caught a segfault`; SubstrateVM prints
+// neither `SIGSEGV` nor `Segmentation fault`.
+//
+// Nothing here can prevent it — the frames are all `com.oracle.svm.core.*`,
+// i.e. the AOT image's own substitutions for `user.home`. Use `ApacheCluster()`
+// if a node dying at startup would cost you more than the JVM's slower cold
+// start; that image runs the same Scala wrapper on HotSpot, which has no such
+// code path.
+func (r *Kafka) ApacheNativeCluster(clusterId string, clientListenerSecurity *KafkaServerSecurity, opts ...KafkaApacheNativeClusterOpts) *KafkaCluster { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:80:1)
 	assertNotNil("clientListenerSecurity", clientListenerSecurity)
 	q := r.query.Select("apacheNativeCluster")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -621,16 +638,16 @@ func (r *Kafka) Client(bootstrapServers []string, security *KafkaClientSecurity)
 type KafkaConfluentClusterOpts struct {
 
 	// Default: 1
-	Controllers int // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:129:2)
+	Controllers int // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:146:2)
 
 	// Default: 1
-	Brokers int // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:131:2)
+	Brokers int // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:148:2)
 
 	// Default: "docker.io"
-	Registry string // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:133:2)
+	Registry string // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:150:2)
 
 	// Default: "8.2.0"
-	Tag string // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:135:2)
+	Tag string // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:152:2)
 }
 
 // ConfluentCluster spins up a KRaft Kafka cluster of the requested size
@@ -645,7 +662,7 @@ type KafkaConfluentClusterOpts struct {
 // The constructor silently disables Confluent's phone-home telemetry
 // (`KAFKA_CONFLUENT_SUPPORT_METRICS_ENABLE=false`) on every broker so
 // the cluster behaves the same way the Apache variants do at startup.
-func (r *Kafka) ConfluentCluster(clusterId string, clientListenerSecurity *KafkaServerSecurity, opts ...KafkaConfluentClusterOpts) *KafkaCluster { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:125:1)
+func (r *Kafka) ConfluentCluster(clusterId string, clientListenerSecurity *KafkaServerSecurity, opts ...KafkaConfluentClusterOpts) *KafkaCluster { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:142:1)
 	assertNotNil("clientListenerSecurity", clientListenerSecurity)
 	q := r.query.Select("confluentCluster")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -1764,7 +1781,7 @@ func (r *KafkaCluster) WithGraphQLQuery(q *querybuilder.Selection) *KafkaCluster
 // same hostname BootstrapServers reports, so the container can dial brokers
 // using the same address strings as a franz-go Client returned from
 // Cluster.Client.
-func (r *KafkaCluster) BindBrokers(ctr *Container) *Container { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:401:1)
+func (r *KafkaCluster) BindBrokers(ctr *Container) *Container { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:418:1)
 	assertNotNil("ctr", ctr)
 	q := r.query.Select("bindBrokers")
 	q = q.Arg("ctr", ctr)
@@ -1776,7 +1793,7 @@ func (r *KafkaCluster) BindBrokers(ctr *Container) *Container { // kafka (../../
 
 // BootstrapServers returns the host:port pairs each broker advertises on its
 // client-facing listener.
-func (r *KafkaCluster) BootstrapServers(ctx context.Context) ([]string, error) { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:387:1)
+func (r *KafkaCluster) BootstrapServers(ctx context.Context) ([]string, error) { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:404:1)
 	q := r.query.Select("bootstrapServers")
 
 	var response []string
@@ -1787,7 +1804,7 @@ func (r *KafkaCluster) BootstrapServers(ctx context.Context) ([]string, error) {
 
 // Client starts every broker service in the cluster and returns a franz-go
 // Client wired with their bootstrap addresses.
-func (r *KafkaCluster) Client(security *KafkaClientSecurity) *KafkaClient { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:412:1)
+func (r *KafkaCluster) Client(security *KafkaClientSecurity) *KafkaClient { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:429:1)
 	assertNotNil("security", security)
 	q := r.query.Select("client")
 	q = q.Arg("security", security)
@@ -1856,7 +1873,7 @@ func (r *KafkaCluster) UnmarshalJSON(bs []byte) error {
 // cluster just run out the clock (~5 min observed in Dagger trace
 // `972bc311bf374f817b7c88481229a10c`). SIGKILL returns immediately, which
 // is all a test needs.
-func (r *KafkaCluster) Stop(ctx context.Context) error { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:361:1)
+func (r *KafkaCluster) Stop(ctx context.Context) error { // kafka (../../../../../daggerverse/kafka/cluster_kafka.go:378:1)
 	if r.stop != nil {
 		return nil
 	}

--- a/daggerverse/kafka/tests/main.go
+++ b/daggerverse/kafka/tests/main.go
@@ -12,11 +12,14 @@
 //                          contains.
 //   - tests_native.go    — ApacheNativeCluster (apache/kafka-native) cluster
 //                          helpers (freshCluster / freshTlsCluster /
-//                          freshMtlsCluster) + every test that drives the
-//                          GraalVM image (the bulk of the suite, including
-//                          shared roundTripBinaryOn).
+//                          freshMtlsCluster) + the Native group: every test
+//                          that drives the GraalVM image, including shared
+//                          roundTripBinaryOn.
 //   - tests_apache.go    — ApacheCluster (apache/kafka JVM) cluster helpers
-//                          + the three Apache-JVM round-trip tests.
+//                          (freshClusterApache / freshTlsClusterApache /
+//                          freshMtlsClusterApache) + the three Apache-JVM
+//                          round-trip tests. The SchemaRegistry group runs on
+//                          these helpers too — see its doc comment below.
 //   - tests_confluent.go — ConfluentCluster (confluentinc/cp-kafka) cluster
 //                          helpers + the three cp-kafka round-trip tests.
 //   - tests_redpanda.go  — RedpandaCluster (redpandadata/redpanda) cluster
@@ -100,10 +103,28 @@ func (t *Tests) All(
 }
 
 // SchemaRegistry runs the Schema Registry tests — ConfluentSchemaRegistry,
-// ApicurioSchemaRegistry, and KarapaceSchemaRegistry — as one group. Each test
-// owns the cluster (and, for the round-trips, the registry service) it boots,
-// so the group's only lifetime guarantee is that both are torn down once it
-// returns.
+// ApicurioSchemaRegistry, and KarapaceSchemaRegistry — plus the Avro and
+// PROTOBUF serde round-trips, as one group. Each test owns the cluster (and,
+// for the round-trips, the registry service) it boots, so the group's only
+// lifetime guarantee is that both are torn down once it returns.
+//
+// Every cluster in this group is an ApacheCluster — the apache/kafka JVM image
+// — via the freshClusterApache / freshTlsClusterApache helpers, NOT the
+// apache/kafka-native image the Native group uses. Do not switch it back for
+// the faster cold start. This is the largest group in the suite, it boots more
+// clusters than any other, and apache/kafka-native segfaults during startup:
+//
+//	===> Launching ...
+//	[ [ SegfaultHandler caught a segfault ... ] ] si_signo: 11
+//	  com.oracle.svm.core.posix.headers.Pwd.getpwuid
+//	  com.oracle.svm.core.posix.PosixSystemPropertiesSupport.userHomeValue
+//	  kafka.docker.KafkaDockerWrapper.main
+//
+// which kills whichever node drew the short straw — a controller, in the run
+// this was diagnosed from — and the group with it (#307). The crashing frames
+// are `com.oracle.svm.core.*`, so they exist only in the AOT-compiled image;
+// the JVM image cannot reach them. The native image keeps its coverage in the
+// Native group, where a crash costs one group rather than the whole suite.
 //
 // +check
 // +cache="session"

--- a/daggerverse/kafka/tests/tests_apache.go
+++ b/daggerverse/kafka/tests/tests_apache.go
@@ -12,6 +12,11 @@ import (
 // Same single-controller-single-broker plaintext topology — only the
 // underlying image differs — so it lets tests verify the JVM variant
 // without otherwise diverging from the freshCluster flow.
+//
+// It is also what the whole SchemaRegistry group runs on, rather than only the
+// three ApacheJVM tests below: see that group's doc comment in main.go for the
+// apache/kafka-native segfault that made the JVM image the right default for
+// the suite's largest group (#307).
 func freshClusterApache(ctx context.Context, kafkaImageTag string) (*dagger.KafkaCluster, error) {
 	clusterId, err := newClusterId(ctx)
 	if err != nil {

--- a/daggerverse/kafka/tests/tests_protobuf.go
+++ b/daggerverse/kafka/tests/tests_protobuf.go
@@ -245,7 +245,7 @@ func (t *Tests) ProtobufKeyFramedProduceConsumeRoundTrip(
 	// +default="4.2.0"
 	kafkaImageTag string,
 ) error {
-	cluster, err := freshCluster(ctx, kafkaImageTag)
+	cluster, err := freshClusterApache(ctx, kafkaImageTag)
 	if err != nil {
 		return fmt.Errorf("create cluster: %w", err)
 	}
@@ -366,7 +366,7 @@ func (t *Tests) ProtobufConsumeUnframedErrors(
 	// +default="4.2.0"
 	kafkaImageTag string,
 ) error {
-	cluster, err := freshCluster(ctx, kafkaImageTag)
+	cluster, err := freshClusterApache(ctx, kafkaImageTag)
 	if err != nil {
 		return fmt.Errorf("create cluster: %w", err)
 	}
@@ -422,7 +422,7 @@ func (t *Tests) ProtobufConsumeMessageIndexMismatchErrors(
 	// +default="4.2.0"
 	kafkaImageTag string,
 ) error {
-	cluster, err := freshCluster(ctx, kafkaImageTag)
+	cluster, err := freshClusterApache(ctx, kafkaImageTag)
 	if err != nil {
 		return fmt.Errorf("create cluster: %w", err)
 	}
@@ -492,7 +492,7 @@ func (t *Tests) ProtobufConsumeMessageIndexMismatchErrors(
 // messageName, consume it back, and assert the consumed value equals
 // wantCanonical and carries the registered schema id.
 func protobufRoundTrip(ctx context.Context, kafkaImageTag, messageName, inputJSON, wantCanonical string) error {
-	cluster, err := freshCluster(ctx, kafkaImageTag)
+	cluster, err := freshClusterApache(ctx, kafkaImageTag)
 	if err != nil {
 		return fmt.Errorf("create cluster: %w", err)
 	}

--- a/daggerverse/kafka/tests/tests_schema_registry.go
+++ b/daggerverse/kafka/tests/tests_schema_registry.go
@@ -27,7 +27,7 @@ func (t *Tests) SchemaRegistryRegisterLookupRoundTrip(
 	// +default="4.2.0"
 	kafkaImageTag string,
 ) error {
-	cluster, err := freshCluster(ctx, kafkaImageTag)
+	cluster, err := freshClusterApache(ctx, kafkaImageTag)
 	if err != nil {
 		return fmt.Errorf("create cluster: %w", err)
 	}
@@ -155,7 +155,7 @@ func (t *Tests) ApicurioSchemaRegistryRegisterLookupRoundTrip(
 	// +default="4.2.0"
 	kafkaImageTag string,
 ) error {
-	cluster, err := freshCluster(ctx, kafkaImageTag)
+	cluster, err := freshClusterApache(ctx, kafkaImageTag)
 	if err != nil {
 		return fmt.Errorf("create cluster: %w", err)
 	}
@@ -283,7 +283,7 @@ func (t *Tests) KarapaceSchemaRegistryRegisterLookupRoundTrip(
 	// +default="4.2.0"
 	kafkaImageTag string,
 ) error {
-	cluster, err := freshCluster(ctx, kafkaImageTag)
+	cluster, err := freshClusterApache(ctx, kafkaImageTag)
 	if err != nil {
 		return fmt.Errorf("create cluster: %w", err)
 	}
@@ -409,7 +409,7 @@ func (t *Tests) SchemaRegistryFramedProduceConsumeRoundTrip(
 	// +default="4.2.0"
 	kafkaImageTag string,
 ) error {
-	cluster, err := freshCluster(ctx, kafkaImageTag)
+	cluster, err := freshClusterApache(ctx, kafkaImageTag)
 	if err != nil {
 		return fmt.Errorf("create cluster: %w", err)
 	}
@@ -504,7 +504,7 @@ func (t *Tests) SchemaRegistryPlaintextConsumeUnframed(
 	// +default="4.2.0"
 	kafkaImageTag string,
 ) error {
-	cluster, err := freshCluster(ctx, kafkaImageTag)
+	cluster, err := freshClusterApache(ctx, kafkaImageTag)
 	if err != nil {
 		return fmt.Errorf("create cluster: %w", err)
 	}
@@ -579,7 +579,7 @@ func (t *Tests) SchemaRegistryRejectsClusterModeMismatch(
 	// +default="4.2.0"
 	kafkaImageTag string,
 ) error {
-	cluster, _, _, err := freshTlsCluster(ctx, kafkaImageTag, 1)
+	cluster, _, _, err := freshTlsClusterApache(ctx, kafkaImageTag, 1)
 	if err != nil {
 		return fmt.Errorf("create tls cluster: %w", err)
 	}
@@ -634,7 +634,7 @@ func (t *Tests) SchemaRegistryJSONFramedProduceConsumeRoundTrip(
 	// +default="4.2.0"
 	kafkaImageTag string,
 ) error {
-	cluster, err := freshCluster(ctx, kafkaImageTag)
+	cluster, err := freshClusterApache(ctx, kafkaImageTag)
 	if err != nil {
 		return fmt.Errorf("create cluster: %w", err)
 	}
@@ -760,7 +760,7 @@ func (t *Tests) AvroConsumeUnframedErrors(
 	// +default="4.2.0"
 	kafkaImageTag string,
 ) error {
-	cluster, err := freshCluster(ctx, kafkaImageTag)
+	cluster, err := freshClusterApache(ctx, kafkaImageTag)
 	if err != nil {
 		return fmt.Errorf("create cluster: %w", err)
 	}
@@ -819,7 +819,7 @@ func (t *Tests) AvroFramedProduceConsumeRoundTrip(
 	// +default="4.2.0"
 	kafkaImageTag string,
 ) error {
-	cluster, err := freshCluster(ctx, kafkaImageTag)
+	cluster, err := freshClusterApache(ctx, kafkaImageTag)
 	if err != nil {
 		return fmt.Errorf("create cluster: %w", err)
 	}
@@ -1066,7 +1066,7 @@ func (t *Tests) AvroBytesFieldRoundTrip(
 	// +default="4.2.0"
 	kafkaImageTag string,
 ) error {
-	cluster, err := freshCluster(ctx, kafkaImageTag)
+	cluster, err := freshClusterApache(ctx, kafkaImageTag)
 	if err != nil {
 		return fmt.Errorf("create cluster: %w", err)
 	}
@@ -1165,8 +1165,8 @@ func freshTlsRegistryStack(ctx context.Context, kafkaImageTag string) (
 		return nil, nil, nil, err
 	}
 	k := dag.Kafka()
-	cluster := k.ApacheNativeCluster(clusterId, k.TLSServerSecurity(caKs.Pkcs12(), caKs.Password()),
-		dagger.KafkaApacheNativeClusterOpts{Tag: kafkaImageTag, Brokers: 1})
+	cluster := k.ApacheCluster(clusterId, k.TLSServerSecurity(caKs.Pkcs12(), caKs.Password()),
+		dagger.KafkaApacheClusterOpts{Tag: kafkaImageTag, Brokers: 1})
 	srSec := k.TLSSchemaRegistrySecurity(caKs.Pkcs12(), caKs.Password())
 	clientSec := k.TLSSchemaRegistryClientSecurity(ts.Pkcs12(), ts.Password())
 	return cluster, srSec, clientSec, nil
@@ -1192,9 +1192,9 @@ func freshMtlsRegistryStack(ctx context.Context, kafkaImageTag string) (
 		return nil, nil, nil, err
 	}
 	k := dag.Kafka()
-	cluster := k.ApacheNativeCluster(clusterId,
+	cluster := k.ApacheCluster(clusterId,
 		k.MtlsServerSecurity(caKs.Pkcs12(), caKs.Password(), ts.Pkcs12(), ts.Password()),
-		dagger.KafkaApacheNativeClusterOpts{Tag: kafkaImageTag, Brokers: 1})
+		dagger.KafkaApacheClusterOpts{Tag: kafkaImageTag, Brokers: 1})
 	srSec := k.MtlsSchemaRegistrySecurity(caKs.Pkcs12(), caKs.Password(), ts.Pkcs12(), ts.Password())
 
 	clientKs, clientKsPwd, err := issueClientKeystore(ctx, ca, "sr-rest-client")
@@ -1228,8 +1228,8 @@ func freshTlsAvroStack(ctx context.Context, kafkaImageTag string) (
 		return nil, nil, nil, nil, err
 	}
 	k := dag.Kafka()
-	cluster := k.ApacheNativeCluster(clusterId, k.TLSServerSecurity(caKs.Pkcs12(), caKs.Password()),
-		dagger.KafkaApacheNativeClusterOpts{Tag: kafkaImageTag, Brokers: 1})
+	cluster := k.ApacheCluster(clusterId, k.TLSServerSecurity(caKs.Pkcs12(), caKs.Password()),
+		dagger.KafkaApacheClusterOpts{Tag: kafkaImageTag, Brokers: 1})
 	srSec := k.TLSSchemaRegistrySecurity(caKs.Pkcs12(), caKs.Password())
 	registryClientSec := k.TLSSchemaRegistryClientSecurity(ts.Pkcs12(), ts.Password())
 	wireClientSec := k.TLSClientSecurity(ts.Pkcs12(), ts.Password())
@@ -1257,9 +1257,9 @@ func freshMtlsAvroStack(ctx context.Context, kafkaImageTag string) (
 		return nil, nil, nil, nil, err
 	}
 	k := dag.Kafka()
-	cluster := k.ApacheNativeCluster(clusterId,
+	cluster := k.ApacheCluster(clusterId,
 		k.MtlsServerSecurity(caKs.Pkcs12(), caKs.Password(), ts.Pkcs12(), ts.Password()),
-		dagger.KafkaApacheNativeClusterOpts{Tag: kafkaImageTag, Brokers: 1})
+		dagger.KafkaApacheClusterOpts{Tag: kafkaImageTag, Brokers: 1})
 	srSec := k.MtlsSchemaRegistrySecurity(caKs.Pkcs12(), caKs.Password(), ts.Pkcs12(), ts.Password())
 
 	restKs, restKsPwd, err := issueClientKeystore(ctx, ca, "sr-rest-client")

--- a/daggerverse/workspace-ci/README.md
+++ b/daggerverse/workspace-ci/README.md
@@ -94,6 +94,11 @@ suite whose five checks bring up five different distributions puts **87** broker
 controllers and registries into a single engine, where a slow start becomes a
 failed one.
 
+Reach for this only once you have a leg that is genuinely too coarse rather than a
+suite that is flaky under load. devex named `daggerverse/kafka/tests` here for a
+while and then removed it: the failures turned out to be an image that segfaults at
+startup (#307), which splitting hid rather than fixed.
+
 `--split-modules` is the escape hatch: the modules it names are enumerated even
 when everything runs, so their checks get a leg each.
 


### PR DESCRIPTION
Closes #307.

## What #307 actually is

`apache/kafka-native` segfaults at startup. Right after the entrypoint's
`===> Launching`, in class initialization, before Kafka logs anything of its own:

```
===> Launching ...
[ [ SegfaultHandler caught a segfault ... ] ] si_signo: 11
  com.oracle.svm.core.posix.headers.Pwd.getpwuid
  com.oracle.svm.core.posix.PosixSystemPropertiesSupport.userHomeValue
  kafka.docker.KafkaDockerWrapper.main
```

and the container exits 1. CI run `30563257890` attempt 3 — the
`✘ exec /etc/kafka/docker/run 6.0s ERROR` the issue quotes — carries exactly one,
in `controller-1-49dff77517`. The broker lines the issue was filed on
(`RaftManager … Node 1 disconnected`) are the *consequence*: that broker's
controller had just died under it. Trace `377f2e17…`, which
`ApacheNativeCluster`'s doc comment already cited, is the same crash taking a
different controller.

It is not a timeout, a race the broker loses, or anything a readiness edge would
have prevented. An earlier revision of this PR raised the broker's KRaft
registration window on a misread span duration; that is retracted — see the
comment above.

## The change

- **The `SchemaRegistry` group runs on `ApacheCluster`** (the JVM image) via the
  existing `freshClusterApache` helpers. It is the suite's largest group and boots
  the most clusters. The crashing frames are `com.oracle.svm.core.*`, so they exist
  only in the AOT-compiled image and HotSpot cannot reach them. Native keeps its
  coverage in the `Native` group, where a crash costs one group rather than the
  suite. Measured at **1m55s** on JVM against **1m49–1m56s** on native — the JVM's
  slower cold start does not show up at this size.
- **`SPLIT_MODULES` is gone.** It was hiding this rather than fixing it. That
  returns `kafka/tests` to one coarse leg, which needs its 15-minute budget back —
  measured at **8m45s** and **9m18s** in CI under exactly this layout, against the
  planner's 6-minute default.
- `ApacheNativeCluster`'s doc comment corrected: it described this as a flake
  "during the broker `setup` step". It is a segfault, and it takes controllers as
  readily as brokers. It now also records that the string to grep for is
  `SegfaultHandler caught a segfault` — SubstrateVM prints neither `SIGSEGV` nor
  `Segmentation fault`, which is what made this hard to find.

## Verification, including what is still not green

Three runs of `dagger -m daggerverse/kafka/tests check '**'` (all five checks, one
engine, 32-core / 31GB box):

| run | result |
|---|---|
| 1 | all five green |
| 2 | **the Dagger engine was OOM-killed** — `anon-rss:14519544kB`, global OOM |
| 3 | `tests:schema-registry` failed on **#312** |

**Zero segfaults in all three**, which is what this PR is for. Neither failure is
the bug being fixed, and both are worth stating plainly:

- **Memory.** The coarse leg is memory-bound and the JVM image costs more than
  native, so moving the largest group onto it raises the peak. The engine reached
  14.5GB RSS here before the kernel killed it. GitHub-hosted runners have 16GB, so
  this leg may be tight on CI. The lever for that lives in the test module, not in
  the workflow: `Tests.All` and every group function already take a `parallel` cap
  that currently defaults to `0` (unbounded). Bounding it would cap how many
  clusters boot at once. Not done here — it is a different change.
- **#312**, the schema registry's 30s readiness bound, is still open and still
  fails this leg intermittently.

`dagger -m . call generated` is green.
