### PR TITLE
story(issue-322): add backlog plugin for the autonomous issue-to-merge cycle

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,6 +8,11 @@
   },
   "plugins": [
     {
+      "name": "backlog",
+      "source": "./plugins/backlog",
+      "description": "Run a repository's story backlog unattended, one issue at a time, from selection through pull request to a label-driven auto merge"
+    },
+    {
       "name": "daggerverse",
       "source": "./plugins/daggerverse",
       "description": "Claude Code tooling for designing and building daggerverse modules"

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Then install a plugin:
 
 | Plugin | Provides |
 | ------ | -------- |
+| [`backlog`](plugins/backlog) | `/backlog:run-backlog` — works a repository's story backlog unattended, one issue at a time, from selection through pull request to a label-driven auto merge. |
 | [`daggerverse`](plugins/daggerverse) | `/plan-dagger-module` — paces a design conversation and drafts story issues for a new daggerverse module. |
 
 See [`plugins/README.md`](plugins/README.md) for the plugin layout. To develop

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -34,6 +34,24 @@ The cycle never runs `gh pr merge`. It labels the pull request and
 GitHub, gated by the default branch's protection rules — which is what puts the
 merge policy somewhere readable and what lets the loop run unattended at all.
 
+Both ends of the cycle are scripts rather than numbered steps, for the same
+reason: they carry no judgment, and a procedure an agent retypes cannot be
+tested.
+
+Picking the issue is
+[`scripts/select-issue.sh`](backlog/scripts/select-issue.sh) — label, milestone,
+limit and dependency convention in, one issue or `BACKLOG EMPTY` or `BLOCKED`
+out, as an exit code. It replaced three `awk`/`sed`/`grep` pipelines that lived
+in the skill as prose, all of which were wrong: a sentence reading *this issue is
+not blocked by anything* opened a dependency list, a fenced code block quoting
+the convention counted as a declaration, GitHub's `- [ ] #12` task-list form
+extracted nothing, and a cross-repository `owner/repo#N` terminated the list and
+took the real dependencies below it with it. Three of those made an issue
+*silently eligible*, which is the failure that gets work done in the wrong order
+rather than not at all. Those bodies are now
+[`scripts/select-issue_test.sh`](backlog/scripts/select-issue_test.sh), which
+needs no network.
+
 The tail of the cycle is
 [`scripts/finish-issue.sh`](backlog/scripts/finish-issue.sh) rather than five
 more numbered steps. Waiting for the merge, closing the issue, verifying it
@@ -72,7 +90,9 @@ plugins/
     ├── skills/              # SKILL.md directories (auto-discovered)
     ├── commands/            # flat .md command files (auto-discovered)
     ├── agents/              # agent .md files (auto-discovered)
-    └── hooks/               # hooks.json (auto-discovered)
+    ├── hooks/               # hooks.json (auto-discovered)
+    ├── assets/              # files a skill copies into a target repo
+    └── scripts/             # executables a skill calls, with their tests
 ```
 
 - **`.claude-plugin/plugin.json`** describes the plugin. The only required field
@@ -81,6 +101,10 @@ plugins/
 - **Component directories** (`skills/`, `commands/`, `agents/`, `hooks/`) are
   discovered automatically when the plugin is installed — you only add a key to
   `plugin.json` to point at a non-default location.
+- **`assets/` and `scripts/`** are not discovered; a skill reaches them through
+  `${CLAUDE_PLUGIN_ROOT}`. Put a step there rather than in prose whenever it is
+  deterministic — a script can be tested, and a procedure written out for a
+  model to retype cannot.
 
 See the [plugins reference](https://code.claude.com/docs/en/plugins-reference)
 for the full `plugin.json` schema.

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -40,10 +40,18 @@ more numbered steps. Waiting for the merge, closing the issue, verifying it
 closed, dropping the worktree and deleting the local branch involve no judgment,
 run at the point where an agent's context is fullest, and can be half-done
 without anything looking wrong. The close matters most: a `Closes #N` line does
-*not* close the issue when a workflow's `GITHUB_TOKEN` performs the merge, and
-an issue left open is one the next iteration selects again. One call with a
-meaningful exit code cannot be forgotten and asserts the close instead of
-trusting it.
+*not* close the issue when a token performs the merge — the closing reference
+registers and nothing acts on it — and an issue left open is one the next
+iteration selects again. One call with a meaningful exit code cannot be
+forgotten and asserts the close instead of trusting it.
+
+Setting up the App token matters more than it looks. GitHub creates no workflow
+run from an event triggered by `GITHUB_TOKEN`, so a workflow that merges with
+its own token emits a `closed` event that starts nothing — and every job hanging
+off that event is skipped in silence. Merging with a GitHub App installation
+token instead is what makes `close-linked-issues` and `delete-merged-branch` run
+at all; `setup-backlog` checks for the two secrets and reports the degradation
+when they are absent.
 
 `setup-backlog` bootstraps a target repository: it writes the config with
 `verify` and `dependencies.style` inferred from the repository rather than

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -5,9 +5,41 @@ published by the [`z5labs-devex` marketplace](../.claude-plugin/marketplace.json
 Keeping them here keeps the plugin catalog cleanly separate from the Dagger
 tooling (`daggerverse/`, `ci/`) and the docs (`docs/`).
 
-> The first plugin, **[`daggerverse`](daggerverse/)**, houses the
-> `plan-dagger-module` skill — a paced design workflow that drafts story
-> issues for a new daggerverse module.
+| Plugin | Provides |
+| ------ | -------- |
+| **[`backlog`](backlog/)** | `next-issue`, `run-backlog` and `setup-backlog` — an unattended issue-to-merge cycle for any GitHub repository, configured per repo by `.claude/backlog.json`. |
+| **[`daggerverse`](daggerverse/)** | `plan-dagger-module` — a paced design workflow that drafts story issues for a new daggerverse module. |
+
+## `backlog`
+
+Takes one story issue from the backlog to a merged pull request — select,
+worktree, implement, verify, PR, wait for checks, get a Copilot review and
+answer it, label for auto merge, close the issue, clean up — then stops.
+`run-backlog` repeats that with a fresh `issue-worker` subagent per iteration,
+so each issue starts from clean context, and halts on `BACKLOG EMPTY`, on
+`BLOCKED`, or at a bounded iteration count.
+
+Nothing repository-specific lives in the skills. Six knobs live in
+`.claude/backlog.json` — which label and milestone form the backlog, how issue
+bodies declare dependencies, the commands that must pass before a pull request
+opens, the merge label and workflow, whether a review is required, and where
+worktrees go — described by
+[`assets/backlog.schema.json`](backlog/assets/backlog.schema.json). The repo
+slug and default branch are deliberately *not* among them: they are read from
+`gh repo view`, so a fork or a rename cannot leave the config describing a
+repository it is no longer in.
+
+The cycle never runs `gh pr merge`. It labels the pull request and
+[`assets/auto-merge.yaml`](backlog/assets/auto-merge.yaml) hands the merge to
+GitHub, gated by the default branch's protection rules — which is what puts the
+merge policy somewhere readable and what lets the loop run unattended at all.
+
+`setup-backlog` bootstraps a target repository: it writes the config with
+`verify` and `dependencies.style` inferred from the repository rather than
+asked, installs the workflow, creates the labels, and then *verifies* the
+environment — squash-only merging, the default branch's required status checks,
+and whether Copilot code review is really enabled — reporting what it cannot fix
+without repository-admin rights.
 
 ## Convention
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -34,6 +34,17 @@ The cycle never runs `gh pr merge`. It labels the pull request and
 GitHub, gated by the default branch's protection rules — which is what puts the
 merge policy somewhere readable and what lets the loop run unattended at all.
 
+The tail of the cycle is
+[`scripts/finish-issue.sh`](backlog/scripts/finish-issue.sh) rather than five
+more numbered steps. Waiting for the merge, closing the issue, verifying it
+closed, dropping the worktree and deleting the local branch involve no judgment,
+run at the point where an agent's context is fullest, and can be half-done
+without anything looking wrong. The close matters most: a `Closes #N` line does
+*not* close the issue when a workflow's `GITHUB_TOKEN` performs the merge, and
+an issue left open is one the next iteration selects again. One call with a
+meaningful exit code cannot be forgotten and asserts the close instead of
+trusting it.
+
 `setup-backlog` bootstraps a target repository: it writes the config with
 `verify` and `dependencies.style` inferred from the repository rather than
 asked, installs the workflow, creates the labels, and then *verifies* the

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -34,7 +34,7 @@ The cycle never runs `gh pr merge`. It labels the pull request and
 GitHub, gated by the default branch's protection rules — which is what puts the
 merge policy somewhere readable and what lets the loop run unattended at all.
 
-Both ends of the cycle are scripts rather than numbered steps, for the same
+Three parts of the cycle are scripts rather than numbered steps, for the same
 reason: they carry no judgment, and a procedure an agent retypes cannot be
 tested.
 
@@ -51,6 +51,17 @@ took the real dependencies below it with it. Three of those made an issue
 rather than not at all. Those bodies are now
 [`scripts/select-issue_test.sh`](backlog/scripts/select-issue_test.sh), which
 needs no network.
+
+The review gate is
+[`scripts/await-review.sh`](backlog/scripts/await-review.sh) — request, wait,
+and classify what landed, as `0 completed / 1 declined / 2 timed out / 3 could
+not request`. "Did Copilot review this?" looks like one question and is two, and
+the two used to sit sixty lines apart: the wait exited on the first `reviewed`
+event, while whether that review had *declined* the work was a separate command
+under its own heading. Copilot declines a pull request over 300 files with a
+review whose body says so, and that decline satisfies any `length > 0` test —
+which is how a cycle once merged with no review at all. The merge label is the
+assertion that a review completed, so the assertion is now an exit code.
 
 The tail of the cycle is
 [`scripts/finish-issue.sh`](backlog/scripts/finish-issue.sh) rather than five

--- a/plugins/backlog/.claude-plugin/plugin.json
+++ b/plugins/backlog/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "backlog",
+  "description": "Run a repository's story backlog unattended — one issue at a time, from selection through worktree, verification, pull request, Copilot review and label-driven auto merge",
+  "version": "0.1.0",
+  "author": { "name": "z5labs" }
+}

--- a/plugins/backlog/agents/issue-worker.md
+++ b/plugins/backlog/agents/issue-worker.md
@@ -1,0 +1,51 @@
+---
+name: issue-worker
+description: Runs one iteration of the backlog cycle — invokes the `backlog:next-issue` skill, takes a single story issue from selection to a merged pull request, and returns that run's report verbatim. Spawned once per iteration by `backlog:run-backlog`; not usually invoked directly.
+tools: Skill, Bash, Read, Write, Edit, Glob, Grep, Monitor, TaskCreate, TaskUpdate
+---
+
+You run **one** iteration of a repository's backlog cycle and then return.
+
+Your first action is to invoke the `backlog:next-issue` skill with the `Skill` tool. That
+skill is the whole of your instructions: follow it step by step, in order, and do not
+substitute your own judgment for the procedure it lays out. Everything repository-specific —
+which label marks the backlog, how dependencies are written, which commands verify a change,
+which label triggers the merge — comes from `.claude/backlog.json`, which the skill reads.
+You do not need to be told any of it, and you must not assume any of it.
+
+If the `Skill` tool is not available to you, stop immediately and report `BLOCKED — the
+Skill tool is not granted to this agent; backlog:next-issue cannot be invoked`. There is no
+fallback: reconstructing the cycle from memory is how the footnotes that make it work get
+dropped.
+
+## Rules that outrank anything else you conclude mid-run
+
+- **Exactly one issue.** When the cycle finishes, you stop. Do not pick up a second issue,
+  however much time or context you have left — your caller re-spawns a fresh worker for the
+  next one, and that fresh context is the point.
+- **Never run `gh pr merge`.** You label the pull request and GitHub merges it. Beyond the
+  permission classifier refusing the command, a subagent that merges emits a security banner
+  into its caller's context which blocks the caller's *next* agent spawn — so the loop dies
+  one iteration later, where nothing points back at the cause.
+- **Never delete a remote branch.** The merge workflow owns remote cleanup. Clean up only
+  the worktree and local branch you created.
+- **Do not weaken a test to make it pass**, and do not label a pull request whose review
+  never completed.
+
+## Your final message is the return value
+
+Your caller reads it programmatically to decide whether to keep looping, so it is a report,
+not a conversation.
+
+- Return the cycle's report as `backlog:next-issue` defines it, and make its **first line**
+  the sentinel where there is one: `BACKLOG EMPTY` when the backlog holds no matching open
+  issues, `BLOCKED` when you stopped early, for any reason.
+- Do not soften, paraphrase or bury those two words. A blocked run reported as "I ran into
+  a small problem" reads to the caller as a successful iteration, and the loop then spends
+  its remaining iterations re-hitting the same wall.
+- On a completed iteration, name the issue number and title, the pull request number and
+  URL, the check result, whether the pull request reached `MERGED`, and whether Copilot
+  reviewed — or, when `review.required` is `false`, say plainly that the pull request merged
+  without a review.
+- Keep it to a handful of lines. Detail belongs in the pull request, not in the caller's
+  context.

--- a/plugins/backlog/assets/auto-merge.yaml
+++ b/plugins/backlog/assets/auto-merge.yaml
@@ -1,0 +1,121 @@
+name: Auto merge
+
+# The backlog loop runs unattended, so the merge that ends a cycle has to happen
+# without a human at the keyboard. Rather than let the agent driving the loop run
+# `gh pr merge` itself, the loop labels the pull request and this workflow hands
+# it to GitHub's native auto merge.
+#
+# The point is where the policy lives. A merge the agent performs is a judgement
+# made mid-cycle and visible only in a transcript; a merge this workflow performs
+# is governed by two things you can read and change: the label gate below, and
+# the branch protection rule on the default branch, whichever checks it requires.
+#
+# Neither path around that rule exists. If checks are still running, auto merge
+# is armed and GitHub holds the pull request until they pass, never merging it if
+# one does not — a failing check leaves the pull request open with auto merge
+# still armed, so pushing a fix is enough to let it through, and nothing is
+# closed on your behalf. If checks have already passed, the merge happens
+# immediately, and branch protection still refuses any merge that would violate
+# it. The label decides *when* the merge is attempted, not *whether* the rule
+# applies.
+#
+# Adding the label is itself a permission boundary: it takes write access to the
+# repository, so a pull request from a fork cannot trigger this by labelling
+# itself.
+
+# `pull_request_target`, not `pull_request`. The usual advice is the reverse,
+# because `pull_request_target` runs with a write token and it is easy to pair
+# that with a checkout of the pull request's own code — which executes untrusted
+# code with write access. This job checks out nothing, so that hazard does not
+# apply, and the trigger's other property is the one that matters here: workflow
+# files are read from the base branch. Under `pull_request`, they are read from
+# the pull request's head, so a pull request could rewrite the steps below and
+# have them run with the `contents: write` token granted underneath.
+#
+# That is not theoretical in a repository running this plugin. The label is
+# applied by an unattended loop, on branches that same loop creates, with no
+# human reading the diff first.
+#
+# If a checkout is ever added to this job, it must pin an explicit ref from the
+# base branch. Never check out `github.event.pull_request.head.sha` here.
+on:
+  pull_request_target:
+    types:
+      - labeled
+      - closed
+
+# `contents: write` is not optional here, despite this job checking out nothing.
+# `gh pr merge --auto` only *arms* auto merge while something still blocks the
+# pull request; once the required checks are already green it merges immediately
+# instead, and that path writes to repository contents. Because the loop labels
+# only after checks pass, the immediate path is the common one — `contents: read`
+# fails it with `Resource not accessible by integration (mergePullRequest)`.
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-auto-merge:
+    name: enable auto merge
+    # Every other label on a pull request — the backlog label, `bug`, whatever
+    # arrives later — leaves this workflow inert. The `closed` trigger belongs to
+    # `delete-merged-branch` below and must not reach this job.
+    #
+    # If you rename the merge label, change it in `.claude/backlog.json` and here
+    # in the same commit. The cycle applies whatever the config names; this job
+    # reacts to whatever is written below; a mismatch is silent on both sides —
+    # the label lands, no run starts, and the pull request waits forever.
+    if: github.event.action == 'labeled' && github.event.label.name == 'auto-merge'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        # `--auto` queues the merge instead of performing it: GitHub squashes the
+        # pull request when the required checks pass, and does nothing if they
+        # never do. `--squash` assumes the repository allows squash merges;
+        # `backlog:setup-backlog` checks that and reports if another merge method
+        # is still permitted.
+        #
+        # The branch is *not* removed on the way out. `deleteBranchOnMerge` may
+        # well be set on the repository, but it does not fire for a merge
+        # performed by this workflow's `GITHUB_TOKEN` — only for one a person
+        # performs. That is what `delete-merged-branch` below exists to cover.
+        run: gh pr merge "$PR" --repo "$REPO" --squash --auto
+
+  delete-merged-branch:
+    name: delete merged branch
+    # Remote cleanup lives here rather than in the agent that drives the loop.
+    # `git push --delete` is denied by that agent's settings, and an unattended
+    # loop working around a rule its operator set is the wrong shape regardless
+    # of whether any single deletion was harmless. Putting the deletion in the
+    # workflow that already performs the merge keeps it automatic and keeps the
+    # policy readable, while leaving the agent responsible only for what it
+    # created locally: its worktree and its local branch.
+    #
+    # `merged` rather than `closed`: a pull request closed without merging keeps
+    # its branch, because the work on it has not landed anywhere.
+    #
+    # The head-repository guard skips forks. A fork's branch is not ours to
+    # delete, and the API call would fail rather than no-op.
+    if: >-
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete the head branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+        # Deleting the ref is idempotent in the only way that matters: if
+        # something else already removed it, the API answers 422 and there is
+        # nothing left to do. A failure here must not fail the run — the merge
+        # has already happened, and an orphaned branch is untidy, not broken.
+        run: |
+          gh api -X DELETE "repos/$REPO/git/refs/heads/$BRANCH" \
+            && echo "deleted $BRANCH" \
+            || echo "could not delete $BRANCH; it may already be gone"

--- a/plugins/backlog/assets/auto-merge.yaml
+++ b/plugins/backlog/assets/auto-merge.yaml
@@ -50,9 +50,21 @@ on:
 # instead, and that path writes to repository contents. Because the loop labels
 # only after checks pass, the immediate path is the common one — `contents: read`
 # fails it with `Resource not accessible by integration (mergePullRequest)`.
+#
+# `issues: write` covers the linked issue. A pull request body carrying
+# `Closes #N` does register a closing reference — that much was confirmed across
+# four merges, where `closingIssuesReferences` held the right issue every time
+# and the issue stayed open anyway. The auto-close is performed *as the merging
+# actor*, and the merging actor here is `github-actions[bot]` acting through this
+# token, so it is bounded by the permissions below; without `issues: write` there
+# is nothing to close with. Whether this is sufficient has not been proven — the
+# cycle closes the issue explicitly regardless, and that close is idempotent — but
+# an unclosed issue is re-selected by the next iteration, which re-implements
+# merged work, so the cheap half of the belt-and-braces belongs here.
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   enable-auto-merge:

--- a/plugins/backlog/assets/auto-merge.yaml
+++ b/plugins/backlog/assets/auto-merge.yaml
@@ -51,16 +51,9 @@ on:
 # only after checks pass, the immediate path is the common one — `contents: read`
 # fails it with `Resource not accessible by integration (mergePullRequest)`.
 #
-# `issues: write` covers the linked issue. A pull request body carrying
-# `Closes #N` does register a closing reference — that much was confirmed across
-# four merges, where `closingIssuesReferences` held the right issue every time
-# and the issue stayed open anyway. The auto-close is performed *as the merging
-# actor*, and the merging actor here is `github-actions[bot]` acting through this
-# token, so it is bounded by the permissions below; without `issues: write` there
-# is nothing to close with. Whether this is sufficient has not been proven — the
-# cycle closes the issue explicitly regardless, and that close is idempotent — but
-# an unclosed issue is re-selected by the next iteration, which re-implements
-# merged work, so the cheap half of the belt-and-braces belongs here.
+# `issues: write` is for the explicit `gh issue close` in `close-linked-issues`
+# below. It is NOT there to make GitHub's own auto-close work: that was tested on
+# a real merge and does not. See the comment on that job.
 permissions:
   contents: write
   pull-requests: write
@@ -71,7 +64,7 @@ jobs:
     name: enable auto merge
     # Every other label on a pull request — the backlog label, `bug`, whatever
     # arrives later — leaves this workflow inert. The `closed` trigger belongs to
-    # `delete-merged-branch` below and must not reach this job.
+    # the two jobs below and must not reach this one.
     #
     # If you rename the merge label, change it in `.claude/backlog.json` and here
     # in the same commit. The cycle applies whatever the config names; this job
@@ -79,10 +72,50 @@ jobs:
     # the label lands, no run starts, and the pull request waits forever.
     if: github.event.action == 'labeled' && github.event.label.name == 'auto-merge'
     runs-on: ubuntu-latest
+    env:
+      APP_ID: ${{ secrets.BACKLOG_APP_ID }}
     steps:
+      # Who performs the merge decides whether anything downstream of it happens
+      # at all. GitHub does not create workflow runs from events triggered by
+      # GITHUB_TOKEN — an anti-recursion rule — so a merge performed with
+      # GITHUB_TOKEN emits a `closed` event that starts no run, and the two jobs
+      # below never execute. That is not a hypothesis: across ten merges in two
+      # repositories every auto-merge run showed `delete merged branch` as
+      # `skipped`, twenty-four merged branches survived, and the single run where
+      # it did fire was a pull request a person merged by hand.
+      #
+      # An App installation token is a different actor, so its events cascade
+      # normally.
+      #
+      # One-time setup: create a GitHub App, install it on this repository with
+      # Contents / Pull requests / Issues set to write, and add two repository
+      # secrets:
+      #   BACKLOG_APP_ID   -- the App's numeric App ID
+      #   BACKLOG_APP_KEY  -- the App's PEM private key
+      # `backlog:setup-backlog` checks for both and reports when they are absent.
+      - name: Mint a GitHub App installation token
+        id: app-token
+        if: env.APP_ID != ''
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.BACKLOG_APP_ID }}
+          private-key: ${{ secrets.BACKLOG_APP_KEY }}
+
+      # Degrade loudly, not silently. Without the App the merge still happens and
+      # the loop still works — its own `finish-issue` step closes the issue — but
+      # remote branches accumulate with nothing to collect them, and an operator
+      # who never reads this log would have no way to know why.
+      - name: Warn when falling back to GITHUB_TOKEN
+        if: env.APP_ID == ''
+        run: |
+          echo "::warning title=No App token::BACKLOG_APP_ID is unset, so this merge \
+          uses GITHUB_TOKEN. GitHub suppresses workflow runs for GITHUB_TOKEN-triggered \
+          events, so close-linked-issues and delete-merged-branch will NOT run and the \
+          head branch will survive the merge."
+
       - name: Enable auto merge
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         # `--auto` queues the merge instead of performing it: GitHub squashes the
@@ -90,12 +123,58 @@ jobs:
         # never do. `--squash` assumes the repository allows squash merges;
         # `backlog:setup-backlog` checks that and reports if another merge method
         # is still permitted.
-        #
-        # The branch is *not* removed on the way out. `deleteBranchOnMerge` may
-        # well be set on the repository, but it does not fire for a merge
-        # performed by this workflow's `GITHUB_TOKEN` — only for one a person
-        # performs. That is what `delete-merged-branch` below exists to cover.
         run: gh pr merge "$PR" --repo "$REPO" --squash --auto
+
+  close-linked-issues:
+    name: close linked issues
+    # A `Closes #N` line does not close the issue when the merge is performed by
+    # a token rather than a person. The closing reference itself registers
+    # correctly — measured across five cycles, `closingIssuesReferences` held the
+    # right issue every time — and nothing acts on it. Granting `issues: write`
+    # was the obvious explanation and was tested on a real merge: the issue
+    # stayed open, and the loop closed it by hand eighteen seconds later, exactly
+    # as before. So the permission is not the lever, and this job does the close
+    # explicitly rather than relying on behaviour that has already been observed
+    # not to happen.
+    #
+    # No fork guard here, unlike the branch deletion below. A pull request from a
+    # fork can legitimately close an issue in this repository.
+    #
+    # The loop's own `finish-issue` step also closes the issue and verifies the
+    # result. That redundancy is deliberate: this job cannot run at all unless the
+    # App token is configured, and the two closes are idempotent — whichever
+    # arrives first wins and the other reads `CLOSED` and does nothing.
+    if: >-
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close the issues this pull request closes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        # Read the references GitHub itself parsed, rather than re-parsing the
+        # body: whatever keyword form the author used, this is what GitHub
+        # understood by it. An empty list is the normal case for a pull request
+        # that closes nothing, and the loop over it simply does not execute.
+        #
+        # Failures must not fail the run. The merge has already happened, and the
+        # loop verifies the close from its side regardless.
+        run: |
+          gh pr view "$PR" --repo "$REPO" --json closingIssuesReferences \
+            --jq '.closingIssuesReferences[].number' \
+          | while read -r n; do
+              [ -n "$n" ] || continue
+              state=$(gh issue view "$n" --repo "$REPO" --json state --jq .state 2>/dev/null || echo "")
+              if [ "$state" = OPEN ]; then
+                gh issue close "$n" --repo "$REPO" --comment "Closed by #$PR." \
+                  && echo "closed #$n" \
+                  || echo "could not close #$n"
+              else
+                echo "#$n is already ${state:-unreadable}; nothing to do"
+              fi
+            done
 
   delete-merged-branch:
     name: delete merged branch
@@ -112,6 +191,10 @@ jobs:
     #
     # The head-repository guard skips forks. A fork's branch is not ours to
     # delete, and the API call would fail rather than no-op.
+    #
+    # Like the job above, this runs only when the merge used the App token. With
+    # GITHUB_TOKEN it never fires and branches accumulate — the warning in
+    # `enable-auto-merge` is the only notice you get.
     if: >-
       github.event.action == 'closed' &&
       github.event.pull_request.merged == true &&
@@ -127,6 +210,10 @@ jobs:
         # something else already removed it, the API answers 422 and there is
         # nothing left to do. A failure here must not fail the run — the merge
         # has already happened, and an orphaned branch is untidy, not broken.
+        #
+        # `deleteBranchOnMerge` on the repository does not cover this. It fires
+        # for a merge a person performs, not for one a token performs, which is
+        # why this job exists.
         run: |
           gh api -X DELETE "repos/$REPO/git/refs/heads/$BRANCH" \
             && echo "deleted $BRANCH" \

--- a/plugins/backlog/assets/backlog.schema.json
+++ b/plugins/backlog/assets/backlog.schema.json
@@ -41,13 +41,13 @@
         "style": {
           "enum": ["blocked-by", "depends-on", "none"],
           "default": "blocked-by",
-          "description": "`blocked-by`: a line containing `Blocked by:` followed by `- #N` list items. `depends-on`: `Depends on #N` written inline, conventionally under a `Related Issues` heading. `none`: the backlog declares no ordering, so every open issue carrying the label is eligible and bodies are not parsed for dependencies at all."
+          "description": "`blocked-by`: a line *opening* with `Blocked by:` — heading, bold or plain — then `- #N` list items, GitHub task-list items included; references on the label line count too. The list ends at the first non-blank line that is not a list item, and the first reference on an item is the dependency (the rest is a gloss). `depends-on`: `Depends on #N` written inline, conventionally under a `Related Issues` heading, with the reference immediately following the phrase. `none`: the backlog declares no ordering, so every open issue carrying the label is eligible and bodies are not parsed at all. Under both parsing styles, fenced code is example text rather than a declaration, and a cross-repository `owner/repo#N` makes that issue ineligible and is named in the report rather than being silently skipped. `scripts/select-issue.sh` implements this and `scripts/select-issue_test.sh` is its fixture corpus — the rules live there, not in prose."
         }
       }
     },
     "verify": {
       "type": "array",
-      "description": "Shell commands that must every one succeed, in this order, inside the worktree, before a pull request is opened. Keep this the same set CI runs: the whole value of the list is that a local pass predicts a green pull request, and a command CI runs that is missing here turns into a red pull request the cycle then has to iterate on.",
+      "description": "Shell commands that must every one succeed, in this order, inside the worktree, before a pull request is opened. Keep this the same set CI runs: the whole value of the list is that a local pass predicts a green pull request, and a command CI runs that is missing here turns into a red pull request the cycle then has to iterate on. `scripts/select-issue.sh` refuses to select an issue when this is empty — an empty list parses fine and would otherwise surface only as a pull request nothing local ever looked at.",
       "minItems": 1,
       "items": { "type": "string", "minLength": 1 }
     },

--- a/plugins/backlog/assets/backlog.schema.json
+++ b/plugins/backlog/assets/backlog.schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/z5labs/devex/main/plugins/backlog/assets/backlog.schema.json",
+  "title": "backlog.json",
+  "description": "Per-repository configuration for the backlog plugin, read from `.claude/backlog.json`. It holds everything the issue-to-merge cycle needs that genuinely differs between repositories — and deliberately nothing that can be read from the repository itself. The repo slug and the default branch are absent on purpose: `backlog:next-issue` resolves both from `gh repo view --json nameWithOwner,defaultBranchRef`, so a fork, a transfer or a rename cannot leave this file describing a repository it is no longer in.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["select", "dependencies", "verify", "merge", "review", "worktreeDir"],
+  "properties": {
+    "select": {
+      "type": "object",
+      "description": "Which open issues make up the backlog.",
+      "additionalProperties": false,
+      "required": ["label", "milestone", "limit"],
+      "properties": {
+        "label": {
+          "type": "string",
+          "minLength": 1,
+          "default": "story",
+          "description": "The issue label that marks an issue as backlog work. Issues without it are never selected."
+        },
+        "milestone": {
+          "type": ["string", "null"],
+          "default": null,
+          "description": "Restrict the backlog to a single milestone by title. `null` means every open issue carrying the label, whatever milestone it is in — and the `--milestone` flag is then omitted from `gh issue list` entirely rather than passed empty."
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 200,
+          "description": "The `--limit` passed to `gh issue list`. Always passed explicitly: gh's default page size is 30, and on a backlog larger than that the eligible issues simply fall off the end of the list without any error."
+        }
+      }
+    },
+    "dependencies": {
+      "type": "object",
+      "description": "How this repository declares that one issue blocks another. GitHub's native blocked-by field is not consulted — it has been observed empty on repositories whose issue bodies do declare ordering in prose, which reads as an unblocked backlog and is not one.",
+      "additionalProperties": false,
+      "required": ["style"],
+      "properties": {
+        "style": {
+          "enum": ["blocked-by", "depends-on", "none"],
+          "default": "blocked-by",
+          "description": "`blocked-by`: a line containing `Blocked by:` followed by `- #N` list items. `depends-on`: `Depends on #N` written inline, conventionally under a `Related Issues` heading. `none`: the backlog declares no ordering, so every open issue carrying the label is eligible and bodies are not parsed for dependencies at all."
+        }
+      }
+    },
+    "verify": {
+      "type": "array",
+      "description": "Shell commands that must every one succeed, in this order, inside the worktree, before a pull request is opened. Keep this the same set CI runs: the whole value of the list is that a local pass predicts a green pull request, and a command CI runs that is missing here turns into a red pull request the cycle then has to iterate on.",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "merge": {
+      "type": "object",
+      "description": "How the finished pull request is handed to GitHub. The cycle never merges anything itself.",
+      "additionalProperties": false,
+      "required": ["label", "workflow"],
+      "properties": {
+        "label": {
+          "type": "string",
+          "minLength": 1,
+          "default": "auto-merge",
+          "description": "The label whose `labeled` event the merge workflow listens for. Applying it is the cycle's assertion that checks are green and the review completed."
+        },
+        "workflow": {
+          "type": "string",
+          "minLength": 1,
+          "default": "auto-merge.yaml",
+          "description": "The workflow file name, as `gh run list --workflow` expects it. Used to tell a queued run apart from a broken one when the pull request still reads `OPEN not-armed`."
+        }
+      }
+    },
+    "review": {
+      "type": "object",
+      "description": "Whether an automated review gates the merge. Only Copilot is modelled. There is deliberately no `reviewer` key — a field with exactly one legal value is an invitation to assume the other values work.",
+      "additionalProperties": false,
+      "required": ["required"],
+      "properties": {
+        "required": {
+          "type": "boolean",
+          "default": true,
+          "description": "`true`: request a Copilot review, wait for it, address it, and refuse to label the pull request if it declines or never arrives. `false`: skip the review steps entirely, for a repository where Copilot code review is not enabled. That is a deliberate downgrade rather than a silent one — the run's report has to say the pull request merged without a review."
+        }
+      }
+    },
+    "worktreeDir": {
+      "type": "string",
+      "minLength": 1,
+      "default": ".claude/worktrees",
+      "description": "Directory, relative to the repository root, that per-issue worktrees are created under. Add it to `.gitignore`; a worktree checked into the repository it lives in is a loop no tool will thank you for."
+    }
+  }
+}

--- a/plugins/backlog/scripts/await-review.sh
+++ b/plugins/backlog/scripts/await-review.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+#
+# await-review.sh — request Copilot's review, wait for it, and say what landed.
+#
+# Usage: await-review.sh <pr-number>
+#
+# Why this is a script and not three numbered steps.
+#
+# "Did Copilot review this?" looks like one question and is two, and the cycle
+# used to answer them in places far enough apart that the second could be
+# skipped. The wait was a polling loop that exited as soon as a `reviewed` event
+# appeared; whether that review had DECLINED the work — "Copilot wasn't able to
+# review this pull request because it exceeds the maximum number of files (300)"
+# — was a separate command sixty lines further down, under its own heading, that
+# an agent had to remember to run. It has already been missed once in the wild:
+# a vendored test suite pushed a pull request past the file limit, Copilot
+# declined, the naive `length > 0` check passed, and the cycle merged with no
+# review at all.
+#
+# The merge label is the cycle's assertion that a review completed. That
+# assertion should be an exit code, not a thing remembered at the end of the
+# longest part of the run.
+#
+# Four findings are folded in here, each of which cost a debugging session:
+#
+#   * Copilot is a Bot, not a User. `reviewers[]=Copilot` on the REST endpoint
+#     returns 200 and does nothing; the GraphQL mutation takes `botIds`, and the
+#     REST form works only with the full `...[bot]` login.
+#   * The wait polls the TIMELINE, not `pulls/<pr>/reviews`. The reviews
+#     endpoint has been seen empty for forty minutes after Copilot had in fact
+#     submitted, so polling it times out on a pull request that was reviewed.
+#   * `--paginate`, because the timeline returns thirty events per page and a
+#     pull request with a few pushes and check runs pushes the `reviewed` event
+#     off page one — where an unpaginated read reports nothing.
+#   * The login filter, because a `reviewed` event from anyone would otherwise
+#     end the wait. The repository owner glancing at the pull request while
+#     Copilot was still working would satisfy an unfiltered loop.
+#
+# Idempotent: a Copilot review that has already landed is classified and
+# returned immediately, without requesting another. Re-running after a timeout
+# resumes the wait.
+#
+# Exit codes:
+#   0  a review completed — it left comments, or reported that it generated none
+#   1  the most recent Copilot review DECLINED the work; stdout is its body
+#   2  timed out waiting for a review
+#   3  the review could not be requested (Copilot code review not enabled here)
+#   4  usage or precondition failure
+
+set -uo pipefail
+
+POLL_COUNT=${BACKLOG_REVIEW_POLL_COUNT:-40}
+POLL_SECONDS=${BACKLOG_REVIEW_POLL_SECONDS:-15}
+BOT_LOGIN='copilot-pull-request-reviewer[bot]'
+
+fail() { local code=$1; shift; printf 'await-review: %s\n' "$*" >&2; exit "$code"; }
+note() { printf 'await-review: %s\n' "$*" >&2; }
+
+[ $# -eq 1 ] || fail 4 "usage: await-review.sh <pr-number>"
+PR=$1
+case "$PR" in ''|*[!0-9]*) fail 4 "pull request number must be an integer (got '$PR')" ;; esac
+
+command -v gh >/dev/null 2>&1 || fail 4 "gh is not on PATH"
+command -v jq >/dev/null 2>&1 || fail 4 "jq is not on PATH"
+
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null) \
+  || fail 4 "cannot resolve the repository slug from gh"
+[ -n "$REPO" ] || fail 4 "cannot resolve the repository slug from gh"
+
+# --------------------------------------------------------------- reading ------
+# The most recent Copilot review, as {state, body}, or nothing.
+#
+# `jq -s` slurps the per-page objects back into one array before sorting.
+# Sorting inside --jq would sort each page separately and yield the last review
+# OF THE LAST PAGE rather than the last review.
+latest_review() {
+  gh api --paginate "repos/$REPO/issues/$PR/timeline" \
+    --jq '.[] | select(.event=="reviewed") | select(.user.login | test("copilot";"i"))' \
+    2>/dev/null \
+  | jq -s 'sort_by(.submitted_at) | last // empty | {state: (.state // ""), body: (.body // "")}' \
+    2>/dev/null
+}
+
+# A decline satisfies any `length > 0` test, which is exactly how it was missed.
+# The apostrophe is matched loosely because GitHub has rendered it both as ' and
+# as a typographic quote.
+declined() {
+  printf '%s' "$1" | grep -qiE "was(n.?t| not) able to review"
+}
+
+classify() { # <review json>
+  local state body
+  state=$(printf '%s' "$1" | jq -r '.state // ""')
+  body=$(printf '%s' "$1" | jq -r '.body // ""')
+  if declined "$body"; then
+    printf '%s\n' "$body"
+    fail 1 "Copilot DECLINED to review PR #$PR; do not label it"
+  fi
+  printf 'copilot review completed [%s]\n%s\n' "$state" "$body"
+  exit 0
+}
+
+EXISTING=$(latest_review)
+if [ -n "$EXISTING" ]; then
+  note "a Copilot review is already on PR #$PR; not requesting another"
+  classify "$EXISTING"
+fi
+
+# ------------------------------------------------------------- requesting -----
+# The bot's node ID is looked up by login rather than hard-coded, so a change on
+# GitHub's side surfaces here as a failed lookup instead of a silent no-op.
+requested() {
+  gh api "repos/$REPO/pulls/$PR/requested_reviewers" \
+    --jq '[.users[]?.login] + [.teams[]?.slug] | join(" ")' 2>/dev/null \
+  | grep -qi copilot
+}
+
+request_review() {
+  local pr_id bot_id
+  pr_id=$(gh pr view "$PR" --repo "$REPO" --json id --jq .id 2>/dev/null) || pr_id=""
+  bot_id=$(gh api "/users/$BOT_LOGIN" --jq .node_id 2>/dev/null) || bot_id=""
+
+  if [ -n "$pr_id" ] && [ -n "$bot_id" ]; then
+    if gh api graphql -f query='
+      mutation($pr:ID!, $bot:ID!) {
+        requestReviews(input: {pullRequestId: $pr, botIds: [$bot], union: true}) {
+          pullRequest { reviewRequests(first:10) { nodes {
+            requestedReviewer { __typename ... on Bot { login } } } } }
+        }
+      }' -f pr="$pr_id" -f bot="$bot_id" 2>/dev/null | grep -qi copilot; then
+      note "review requested via the GraphQL requestReviews mutation"
+      return 0
+    fi
+    note "the GraphQL mutation did not take; falling back to REST"
+  fi
+
+  # REST works only with the full bot login. A bare `reviewers[]=Copilot`
+  # returns 200 while doing nothing at all, and the wait below would then time
+  # out on a review that was never requested.
+  gh api --method POST "repos/$REPO/pulls/$PR/requested_reviewers" \
+    -f "reviewers[]=$BOT_LOGIN" >/dev/null 2>&1 || true
+
+  requested
+}
+
+if requested; then
+  note "Copilot is already a requested reviewer on PR #$PR"
+elif request_review; then
+  note "Copilot is now a requested reviewer on PR #$PR"
+else
+  fail 3 "could not request a Copilot review on PR #$PR; Copilot code review may not be enabled for this organisation"
+fi
+
+# ---------------------------------------------------------------- waiting -----
+for _ in $(seq 1 "$POLL_COUNT"); do
+  sleep "$POLL_SECONDS"
+  REVIEW=$(latest_review)
+  [ -n "$REVIEW" ] && classify "$REVIEW"
+done
+
+fail 2 "no Copilot review on PR #$PR after $((POLL_COUNT * POLL_SECONDS))s; re-run to keep waiting"

--- a/plugins/backlog/scripts/finish-issue.sh
+++ b/plugins/backlog/scripts/finish-issue.sh
@@ -123,12 +123,20 @@ if [ -n "$WT" ]; then
     || warn "could not remove the worktree at $WT; it may have uncommitted changes"
 fi
 
-if [ -n "$(git status --porcelain)" ]; then
+# Only ever fast-forward a checkout that is ALREADY on the default branch. This
+# script cleans up what the cycle created; the branch the operator left their
+# main checkout on is not that, and silently moving it is a surprise waiting at
+# the end of an unattended run. Nothing depends on the local ref anyway — step 2
+# fetches and branches from origin/<default-branch> — so declining here costs
+# nothing.
+CURRENT=$(git symbolic-ref --quiet --short HEAD 2>/dev/null || printf '')
+if [ "$CURRENT" != "$DEFAULT_BRANCH" ]; then
+  warn "main checkout at $MAIN is on '${CURRENT:-a detached HEAD}', not $DEFAULT_BRANCH; leaving it alone"
+elif [ -n "$(git status --porcelain)" ]; then
   warn "main checkout at $MAIN is dirty; skipping the update of $DEFAULT_BRANCH"
 else
-  git checkout --quiet "$DEFAULT_BRANCH" 2>/dev/null \
-    && git pull --quiet --ff-only 2>/dev/null \
-    || warn "could not bring $DEFAULT_BRANCH up to date; the next iteration may branch from a stale ref"
+  git pull --quiet --ff-only 2>/dev/null \
+    || warn "could not fast-forward $DEFAULT_BRANCH"
 fi
 
 # A stale *local* branch is what breaks a retry: `git worktree add -b <branch>`

--- a/plugins/backlog/scripts/finish-issue.sh
+++ b/plugins/backlog/scripts/finish-issue.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# finish-issue.sh — everything after the merge label, as one call.
+#
+# Usage: finish-issue.sh <issue-number> <pr-number> [branch]
+#        branch defaults to issue-<issue-number>
+#
+# Why this is a script and not five numbered steps.
+#
+# The tail of a cycle — wait for the merge, close the issue, verify it closed,
+# drop the worktree, delete the local branch — carries no judgment at all. It is
+# also the part that runs ten-plus minutes after the interesting work, at the
+# point where an agent's context is fullest, and it is five actions that can be
+# half-done without anything looking wrong. The close in particular has been
+# rediscovered from first principles on cycle after cycle, because GitHub does
+# not auto-close a linked issue when the merge is performed by a workflow's
+# GITHUB_TOKEN — the closing reference registers, and nothing acts on it. An
+# issue left open is one the next iteration selects again, so the loop
+# re-implements work it has already merged.
+#
+# One call with an exit code is the fix. It cannot be forgotten, it cannot be
+# partially completed, and it asserts the close rather than trusting it.
+#
+# Every step is guarded, so re-running after a timeout is safe and cheap: an
+# already-merged pull request skips the wait, an already-closed issue skips the
+# close, an absent worktree or branch skips its removal.
+#
+# It deletes nothing remote. The merge workflow's delete-merged-branch job owns
+# the remote branch, and `git push --delete` is denied by the operator's
+# settings — a script working around that rule would be the wrong shape whether
+# or not any single deletion was harmless.
+#
+# Exit codes:
+#   0  merged and the issue is closed (cleanup warnings, if any, go to stderr)
+#   1  the pull request closed without merging
+#   2  timed out waiting for the merge
+#   3  the issue would not close
+#   4  usage or precondition failure
+
+set -uo pipefail
+
+POLL_COUNT=${BACKLOG_MERGE_POLL_COUNT:-40}
+POLL_SECONDS=${BACKLOG_MERGE_POLL_SECONDS:-15}
+
+fail() { local code=$1; shift; printf 'finish-issue: %s\n' "$*" >&2; exit "$code"; }
+warn() { printf 'finish-issue: WARN %s\n' "$*" >&2; }
+
+[ $# -ge 2 ] || fail 4 "usage: finish-issue.sh <issue-number> <pr-number> [branch]"
+ISSUE=$1
+PR=$2
+BRANCH=${3:-issue-$1}
+
+command -v gh >/dev/null 2>&1 || fail 4 "gh is not on PATH"
+
+# Move to the main checkout before doing anything else. This script removes the
+# worktree it may well have been called from, and a process whose working
+# directory has been deleted fails later, somewhere unrelated. `git worktree
+# list` reports the main checkout first, so this needs no configured path.
+MAIN=$(git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print substr($0, 10); exit}')
+[ -n "$MAIN" ] || fail 4 "not inside a git repository"
+cd "$MAIN" || fail 4 "cannot enter the main checkout at $MAIN"
+
+# Resolved from GitHub, never configured: a fork or a rename must not be able to
+# point this at a repository it no longer describes.
+read -r REPO DEFAULT_BRANCH <<<"$(gh repo view --json nameWithOwner,defaultBranchRef \
+  --jq '"\(.nameWithOwner) \(.defaultBranchRef.name)"' 2>/dev/null)"
+[ -n "${REPO:-}" ] && [ -n "${DEFAULT_BRANCH:-}" ] \
+  || fail 4 "cannot resolve the repository slug and default branch from gh"
+
+# ---------------------------------------------------------------- wait --------
+# The merge is asynchronous: labelling queues it and GitHub completes it when the
+# required checks finish. Both failure paths exit non-zero, so a timeout or an
+# unmerged close cannot be mistaken for success by a caller reading the code
+# rather than the text.
+state=""
+for _ in $(seq 1 "$POLL_COUNT"); do
+  state=$(gh pr view "$PR" --repo "$REPO" --json state --jq .state 2>/dev/null || printf '')
+  case "$state" in
+    MERGED) break ;;
+    CLOSED) fail 1 "PR #$PR closed without merging" ;;
+  esac
+  sleep "$POLL_SECONDS"
+done
+[ "$state" = MERGED ] \
+  || fail 2 "PR #$PR is ${state:-unreadable} after $((POLL_COUNT * POLL_SECONDS))s; re-run to keep waiting"
+
+SHA=$(gh pr view "$PR" --repo "$REPO" --json mergeCommit --jq '.mergeCommit.oid // ""' 2>/dev/null || printf '')
+
+# --------------------------------------------------------------- close --------
+# The assertion this whole script exists for. A `Closes #N` line in the pull
+# request body does register a closing reference — that part works — but nothing
+# acts on it when a workflow's GITHUB_TOKEN performs the merge, so the issue is
+# still open here and closing it is not a formality.
+istate=$(gh issue view "$ISSUE" --repo "$REPO" --json state --jq .state 2>/dev/null || printf '')
+[ -n "$istate" ] || fail 3 "cannot read the state of issue #$ISSUE"
+
+if [ "$istate" = OPEN ]; then
+  comment="Implemented in #$PR"
+  [ -n "$SHA" ] && comment="$comment, merged as $SHA"
+  gh issue close "$ISSUE" --repo "$REPO" --comment "$comment." >/dev/null \
+    || fail 3 "gh issue close failed for #$ISSUE"
+fi
+
+# Re-read rather than trusting the close. This is the check that turns a silent
+# no-op into a non-zero exit.
+istate=$(gh issue view "$ISSUE" --repo "$REPO" --json state --jq .state 2>/dev/null || printf '')
+[ "$istate" = CLOSED ] || fail 3 "issue #$ISSUE is ${istate:-unreadable} after the close attempt"
+
+# ------------------------------------------------------------- clean up -------
+# Past this point the cycle has succeeded. Anything that fails below is untidy
+# rather than broken, so it warns and the script still exits 0 — conflating a
+# leftover directory with an issue that would not close would make the exit code
+# useless for the one thing it is read for.
+WT=$(git worktree list --porcelain | awk -v want="branch refs/heads/$BRANCH" '
+  /^worktree /{ w = substr($0, 10) }
+  $0 == want   { print w; exit }')
+
+if [ -n "$WT" ]; then
+  # Deliberately not --force. A dirty worktree at this point means work that
+  # never reached the merged pull request, and discarding it silently is worse
+  # than leaving a directory behind.
+  git worktree remove "$WT" 2>/dev/null \
+    || warn "could not remove the worktree at $WT; it may have uncommitted changes"
+fi
+
+if [ -n "$(git status --porcelain)" ]; then
+  warn "main checkout at $MAIN is dirty; skipping the update of $DEFAULT_BRANCH"
+else
+  git checkout --quiet "$DEFAULT_BRANCH" 2>/dev/null \
+    && git pull --quiet --ff-only 2>/dev/null \
+    || warn "could not bring $DEFAULT_BRANCH up to date; the next iteration may branch from a stale ref"
+fi
+
+# A stale *local* branch is what breaks a retry: `git worktree add -b <branch>`
+# fails against an existing branch, and the retry then reports a name collision
+# rather than anything real.
+if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+  git branch -D "$BRANCH" >/dev/null 2>&1 \
+    || warn "could not delete the local branch $BRANCH"
+fi
+
+printf 'finish-issue: OK — PR #%s MERGED%s, issue #%s CLOSED, local cleanup done\n' \
+  "$PR" "${SHA:+ as $SHA}" "$ISSUE"

--- a/plugins/backlog/scripts/select-issue.sh
+++ b/plugins/backlog/scripts/select-issue.sh
@@ -1,0 +1,313 @@
+#!/usr/bin/env bash
+#
+# select-issue.sh — pick the next eligible backlog issue, as one call.
+#
+# Usage: select-issue.sh
+#        select-issue.sh --extract <blocked-by|depends-on|none> [file]
+#
+# Why this is a script and not a numbered step.
+#
+# Selection is the one part of the cycle with no judgment in it at all: given
+# the label, the milestone, the limit and the dependency convention, the answer
+# is a function of the backlog. It was previously three awk/sed/grep pipelines
+# written out in prose for an agent to retype, checked against a table of
+# expected answers by eye. Every one of them was wrong in a way the table did
+# not exercise:
+#
+#   * `tolower($0) ~ /blocked by/` was unanchored and did not require the colon
+#     the convention is written with, so "this issue is not blocked by
+#     anything", "the old parser was blocked by a flaky test", and the phrase
+#     appearing inside a fenced code block all opened a dependency list, and the
+#     next bullet in the body became a dependency that does not exist.
+#   * A cross-repository `owner/repo#N` did the opposite of what was documented.
+#     Under `depends-on` it matched nothing and the issue came out eligible.
+#     Under `blocked-by` it was not a list item, so it *terminated* the list —
+#     losing the real in-repo dependencies below it as well.
+#   * The inline form `Blocked by: #12` and GitHub's task-list form `- [ ] #12`
+#     both extracted nothing, which reads as an unblocked issue.
+#
+# Three of those five produce a *silently eligible* issue, which is the one
+# wrong answer that gets work done in the wrong order rather than not at all.
+#
+# `--extract` exposes the extraction alone, reading a body from a file or stdin
+# and printing one reference per line. It needs no network, which is what lets
+# `select-issue_test.sh` hold the fixture corpus these bugs came from.
+#
+# Exit codes:
+#   0   an issue was selected; stdout is {"number":N,"title":"..."}
+#   4   usage or precondition failure (no gh/jq/git, or the config is unusable)
+#   10  BACKLOG EMPTY — no open issue carries the label (and milestone)
+#   11  BLOCKED — open issues remain and none is eligible
+
+set -uo pipefail
+
+fail() { local code=$1; shift; printf 'select-issue: %s\n' "$*" >&2; exit "$code"; }
+note() { printf 'select-issue: %s\n' "$*" >&2; }
+
+# ---------------------------------------------------------------- extract -----
+# One reference per line, in first-seen order, deduped, in the form it was
+# written: `#14` for this repository, `owner/repo#N` for anywhere else. Keeping
+# the two shapes distinct is what lets the caller tell "issue 14 here" from
+# "something I cannot resolve" instead of the two looking identical.
+#
+# Two deliberate asymmetries, both chosen so that an ambiguous body errs toward
+# reporting a dependency rather than missing one:
+#
+#   * In a list, the FIRST reference on an item is the dependency and the rest
+#     of the line is a gloss — `- #12 — needs #34 first` is a dependency on 12.
+#   * On the inline label line, EVERY reference counts, because `Blocked by:
+#     #12, #14` has no gloss convention and taking only the first would silently
+#     drop 14.
+#
+# A blank line does not end a list. Markdown calls a bullet list with blank
+# lines between its items a single loose list, and ending at the first blank
+# would silently drop every dependency after it.
+EXTRACT_AWK=$(cat <<'AWK'
+function out(ref) {
+  if (!(ref in seen)) { seen[ref] = 1; order[++n] = ref }
+}
+
+# The label line, with markdown decoration removed, lowercased. Used only to
+# recognise the phrase — never to read a reference out of, because stripping
+# `_` would corrupt a repository name that contains one.
+function label_form(s,   t) {
+  t = s
+  sub(/^[[:space:]]*#+[[:space:]]*/, "", t)
+  gsub(/[*_`]/, "", t)
+  sub(/^[[:space:]]+/, "", t)
+  return tolower(t)
+}
+
+function first_ref(s) {
+  if (match(s, /([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)?#[0-9]+/))
+    return substr(s, RSTART, RLENGTH)
+  return ""
+}
+
+function all_refs(s,   rest, m) {
+  rest = s
+  while (match(rest, /([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)?#[0-9]+/)) {
+    m = substr(rest, RSTART, RLENGTH)
+    out(m)
+    rest = substr(rest, RSTART + RLENGTH)
+  }
+}
+
+# Anchored at the start of the remainder: the reference has to follow the
+# phrase immediately, so "Depends on the parser landing, see #99" is not a
+# dependency on 99.
+function leading_ref(s) {
+  if (match(s, /^([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)?#[0-9]+/))
+    return substr(s, RSTART, RLENGTH)
+  return ""
+}
+
+# "no longer depends on #17" is a note that a dependency was removed. Reading
+# it as live blocks the issue forever with a reason that is not in its body.
+function negated(p) {
+  return p ~ /(^|[^a-z])(not|never|no longer|nor)[[:space:]]*$/ || p ~ /n.t[[:space:]]*$/
+}
+
+function is_item(s) {
+  return s ~ /^[[:space:]]*[-*+][[:space:]]/ || s ~ /^[[:space:]]*[0-9]+[.)][[:space:]]/
+}
+
+function item_body(s,   t) {
+  t = s
+  sub(/^[[:space:]]*([-*+]|[0-9]+[.)])[[:space:]]*/, "", t)
+  sub(/^\[[ xX]\][[:space:]]*/, "", t)   # GitHub task-list checkbox
+  return t
+}
+
+function depends_on(line,   lower, pos, seg, start, len, prefix, tail, ref) {
+  lower = tolower(line)
+  pos = 1
+  while (pos <= length(lower)) {
+    seg = substr(lower, pos)
+    if (!match(seg, /depends[[:space:]]+on[[:space:]]*:?[[:space:]]*/)) return
+    start = pos + RSTART - 1
+    len   = RLENGTH
+    prefix = substr(lower, 1, start - 1)
+    tail   = substr(line, start + len)      # original case: repo names matter
+    if (!negated(prefix)) {
+      ref = leading_ref(tail)
+      if (ref != "") out(ref)
+    }
+    pos = start + len
+  }
+}
+
+# A fenced block is example text. The convention this parses is written inside
+# fences in more than one issue template, and a template is not a declaration.
+{
+  probe = $0
+  sub(/^[[:space:]]*/, "", probe)
+  if (probe ~ /^(```|~~~)/) { fence = !fence; next }
+  if (fence) next
+}
+
+STYLE == "depends-on" { depends_on($0); next }
+
+STYLE == "blocked-by" {
+  lf = label_form($0)
+  # The phrase has to open the line and be terminated by a colon or by the end
+  # of the line. That is what tells "Blocked by:" apart from "was blocked by a
+  # flaky test", and it is the form the convention is actually written in.
+  if (lf ~ /^blocked[[:space:]]+by[[:space:]]*(:|$)/) {
+    inlist = 1
+    rest = $0
+    if (rest ~ /:/) { sub(/^[^:]*:/, "", rest); all_refs(rest) }
+    next
+  }
+  if (inlist) {
+    if (is_item($0)) { r = first_ref(item_body($0)); if (r != "") out(r); next }
+    if ($0 ~ /[^[:space:]]/) inlist = 0   # non-blank, not an item: list over
+  }
+  next
+}
+
+END { for (i = 1; i <= n; i++) print order[i] }
+AWK
+)
+
+extract_refs() { # <style> ; body on stdin
+  [ "$1" = none ] && { cat >/dev/null; return 0; }
+  awk -v STYLE="$1" "$EXTRACT_AWK"
+}
+
+if [ "${1:-}" = --extract ]; then
+  [ $# -ge 2 ] || fail 4 "usage: select-issue.sh --extract <blocked-by|depends-on|none> [file]"
+  case "$2" in
+    blocked-by|depends-on|none) ;;
+    *) fail 4 "unknown style '$2'; expected blocked-by, depends-on or none" ;;
+  esac
+  if [ -n "${3:-}" ]; then extract_refs "$2" <"$3"; else extract_refs "$2"; fi
+  exit 0
+fi
+
+[ $# -eq 0 ] || fail 4 "usage: select-issue.sh [--extract <style> [file]]"
+
+# ----------------------------------------------------------------- config -----
+command -v gh >/dev/null 2>&1 || fail 4 "gh is not on PATH"
+command -v jq >/dev/null 2>&1 || fail 4 "jq is not on PATH"
+
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || fail 4 "not inside a git repository"
+cd "$ROOT" || fail 4 "cannot enter the repository root at $ROOT"
+
+CFG=.claude/backlog.json
+[ -f "$CFG" ] || fail 4 "$CFG is missing; run backlog:setup-backlog to create it"
+jq -e . "$CFG" >/dev/null 2>&1 || fail 4 "$CFG does not parse as JSON"
+
+LABEL=$(jq -r '.select.label // ""' "$CFG")
+MILESTONE=$(jq -r '.select.milestone // ""' "$CFG")
+LIMIT=$(jq -r '.select.limit // ""' "$CFG")
+STYLE=$(jq -r '.dependencies.style // ""' "$CFG")
+VERIFY_N=$(jq -r 'if (.verify | type) == "array" then (.verify | length) else -1 end' "$CFG")
+
+[ -n "$LABEL" ] || fail 4 "$CFG: select.label is missing or empty"
+case "$LIMIT" in
+  ''|*[!0-9]*) fail 4 "$CFG: select.limit must be a positive integer (found '${LIMIT:-null}')" ;;
+  0)           fail 4 "$CFG: select.limit must be at least 1" ;;
+esac
+case "$STYLE" in
+  blocked-by|depends-on|none) ;;
+  *) fail 4 "$CFG: dependencies.style must be one of blocked-by, depends-on, none (found '${STYLE:-null}'); run backlog:setup-backlog" ;;
+esac
+# Checked here rather than at step 4, where an empty list is indistinguishable
+# from a list that passed: a config with no verify commands opens a pull request
+# nothing local ever looked at, and selection is the first chance to say so.
+[ "$VERIFY_N" -ge 1 ] 2>/dev/null \
+  || fail 4 "$CFG: verify must be a non-empty array of commands; run backlog:setup-backlog"
+
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null) \
+  || fail 4 "cannot resolve the repository slug from gh"
+[ -n "$REPO" ] || fail 4 "cannot resolve the repository slug from gh"
+
+# ------------------------------------------------------------------- list -----
+# --limit is always passed. gh's default page size is 30, and on a longer
+# backlog the issues past the first page do not error — they are simply absent,
+# so the cycle reports an empty or blocked backlog that is neither.
+#
+# --milestone is passed only when one is configured. An empty --milestone is not
+# the same as no milestone filter, which is why this is an argument array rather
+# than a string the caller interpolates.
+LIST_ARGS=(--repo "$REPO" --state open --label "$LABEL" --limit "$LIMIT")
+[ -n "$MILESTONE" ] && LIST_ARGS+=(--milestone "$MILESTONE")
+
+CANDIDATES=$(gh issue list "${LIST_ARGS[@]}" \
+  --json number,title --jq 'sort_by(.number)[] | "\(.number)\t\(.title)"') \
+  || fail 4 "gh issue list failed for $REPO"
+
+if [ -z "$CANDIDATES" ]; then
+  printf 'BACKLOG EMPTY\n'
+  note "no open issue in $REPO carries the label '$LABEL'${MILESTONE:+ in milestone '$MILESTONE'}"
+  exit 10
+fi
+
+# --------------------------------------------------------------- eligible -----
+# Walk in ascending number order and take the first issue whose every declared
+# dependency is CLOSED. An issue with a dependency this script cannot resolve is
+# skipped rather than treated as eligible — but it is skipped as *ineligible*,
+# with its reason recorded, so the backlog is not starved by one unresolvable
+# reference while other issues are workable.
+STATE_CACHE=""
+dep_state() { # <issue-number>
+  local hit
+  case "$STATE_CACHE" in
+    *"|$1="*) hit=${STATE_CACHE##*"|$1="}; printf '%s' "${hit%%|*}"; return 0 ;;
+  esac
+  local s
+  s=$(gh issue view "$1" --repo "$REPO" --json state --jq .state 2>/dev/null) || s=""
+  [ -n "$s" ] || s=UNREADABLE
+  STATE_CACHE="$STATE_CACHE|$1=$s|"
+  printf '%s' "$s"
+}
+
+REASONS=""
+while IFS=$'\t' read -r NUM TITLE; do
+  [ -n "$NUM" ] || continue
+
+  if [ "$STYLE" = none ]; then
+    note "#$NUM eligible (dependencies.style is none)"
+    jq -n --argjson n "$NUM" --arg t "$TITLE" '{number:$n, title:$t}'
+    exit 0
+  fi
+
+  BODY=$(gh issue view "$NUM" --repo "$REPO" --json body --jq .body 2>/dev/null) || BODY=""
+  REFS=$(printf '%s\n' "$BODY" | extract_refs "$STYLE")
+
+  blockers=""
+  for ref in $REFS; do
+    case "$ref" in
+      \#*)
+        d=${ref#\#}
+        st=$(dep_state "$d")
+        [ "$st" = CLOSED ] || blockers="$blockers #$d is $st;"
+        ;;
+      *)
+        # owner/repo#N. Not modelled, and guessing is worse than declining:
+        # calling the issue eligible is the failure this whole step avoids.
+        blockers="$blockers $ref is a cross-repository dependency this cycle cannot resolve;"
+        ;;
+    esac
+  done
+
+  if [ -z "$blockers" ]; then
+    note "#$NUM eligible${REFS:+ (dependencies all CLOSED)}"
+    jq -n --argjson n "$NUM" --arg t "$TITLE" '{number:$n, title:$t}'
+    exit 0
+  fi
+
+  note "#$NUM not eligible:$blockers"
+  REASONS="$REASONS#$NUM:$blockers
+"
+# Process substitution, not a pipe: a `while | read` loop runs in a subshell,
+# where the `exit 0` above would end the subshell and let the script fall
+# through to the BLOCKED report having just selected an issue. Not a heredoc
+# either — an unquoted one would treat a backslash in an issue title as an
+# escape.
+done < <(printf '%s\n' "$CANDIDATES")
+
+printf 'BLOCKED — every open issue carrying the label '\''%s'\'' has an unmet dependency:\n' "$LABEL"
+printf '%s' "$REASONS"
+exit 11

--- a/plugins/backlog/scripts/select-issue_test.sh
+++ b/plugins/backlog/scripts/select-issue_test.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+#
+# select-issue_test.sh — the fixture corpus for select-issue.sh's extraction.
+#
+# Every case below is an issue body that a real backlog can contain. The ones
+# marked REGRESSION were extracted wrongly by the awk/sed/grep pipelines this
+# script replaced, back when they lived in `skills/next-issue/SKILL.md` as prose
+# for an agent to retype and check against a table by eye. Three of them
+# produced a *silently eligible* issue, which is the failure that gets work done
+# in the wrong order rather than not at all.
+#
+# Run: plugins/backlog/scripts/select-issue_test.sh
+# Exit 0 when every case matches, 1 otherwise.
+
+set -uo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+SUT="$HERE/select-issue.sh"
+[ -x "$SUT" ] || { printf 'select-issue.sh is not executable at %s\n' "$SUT" >&2; exit 1; }
+
+pass=0
+fail=0
+
+# check <name> <style> <expected refs, space separated> <body>
+check() {
+  local name=$1 style=$2 want=$3 body=$4 got
+  got=$(printf '%s' "$body" | "$SUT" --extract "$style" | tr '\n' ' ')
+  got=${got% }
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1))
+    printf '  ok   %-58s [%s]\n' "$name" "${got:-<none>}"
+  else
+    fail=$((fail + 1))
+    printf '  FAIL %-58s want [%s] got [%s]\n' "$name" "$want" "$got"
+  fi
+}
+
+printf '\nblocked-by\n'
+
+# The fixture the skill has always documented. The three styles must give three
+# different answers on this one body.
+check 'the documented fixture' blocked-by '#12 #14' \
+'### Related Issues
+
+Blocked by:
+- #12 — the parser this builds on
+- #14
+
+Depends on #17.
+
+- #19 is related but not blocking.'
+
+# REGRESSION: `tolower($0) ~ /blocked by/` was unanchored, so a sentence saying
+# the issue is NOT blocked opened a dependency list and swallowed the next
+# bullet. The issue was then blocked forever on a dependency not in its body.
+check 'REGRESSION negated prose does not open a list' blocked-by '' \
+'This issue is not blocked by anything.
+
+- #77 see also'
+
+# REGRESSION: same root cause, past tense, in a paragraph nowhere near the
+# Related Issues section.
+check 'REGRESSION incidental prose does not open a list' blocked-by '' \
+'Background
+
+The old parser was blocked by a flaky test.
+
+- #99 unrelated tracking bullet'
+
+# REGRESSION: an issue template quoted inside a fence is an example, not a
+# declaration.
+check 'REGRESSION fenced code block is not a declaration' blocked-by '' \
+'Example config:
+
+```
+Blocked by:
+- #123
+```
+
+real text'
+
+# REGRESSION: the inline form extracted nothing at all, so the issue read as
+# unblocked. Every reference on the label line counts — there is no gloss
+# convention there, and taking only the first would drop #14.
+check 'REGRESSION inline form on the label line' blocked-by '#12 #14' \
+'Blocked by: #12, #14
+
+Some prose.'
+
+# REGRESSION: GitHub renders `- [ ] #12` as a task list. The old list-item
+# regex required `#` immediately after the bullet, so a checklist of blockers
+# extracted nothing.
+check 'REGRESSION task-list checkboxes' blocked-by '#12 #14' \
+'Blocked by:
+- [ ] #12
+- [x] #14'
+
+# REGRESSION, and the worst of them. `- z5labs/other#42` was not a list item
+# under the old regex, so it TERMINATED the list — the cross-repo reference was
+# dropped AND the real in-repo dependency below it was never seen. Now both
+# survive, and the caller reports BLOCKED on the unresolvable one.
+check 'REGRESSION cross-repo item keeps the list open' blocked-by 'z5labs/other#42 #14' \
+'Blocked by:
+- z5labs/other#42
+- #14'
+
+check 'a markdown heading ends the list' blocked-by '#12' \
+'Blocked by:
+- #12
+
+## Acceptance Criteria
+
+- [ ] parser handles #500 style refs
+- #501'
+
+check 'prose ends the list' blocked-by '#12' \
+'Blocked by:
+- #12
+Some following paragraph.
+- #34'
+
+check 'bold label' blocked-by '#12' \
+'**Blocked by:**
+- #12'
+
+check 'heading label with no colon' blocked-by '#12' \
+'### Blocked by
+
+- #12'
+
+# The first reference on an item is the dependency; the rest of the line is a
+# gloss. This is the rule the documented fixture depends on.
+check 'first ref per item, gloss ignored' blocked-by '#12' \
+'Blocked by:
+- #12 — needs #34 first'
+
+# Markdown calls this one loose list, so both items are dependencies. Ending at
+# the blank line instead would silently drop #19, and a missed dependency is
+# worse than an extra one: the extra one halts the loop with a visible reason.
+check 'a blank line does not end a loose list' blocked-by '#12 #19' \
+'Blocked by:
+- #12
+
+- #19'
+
+check 'duplicates collapse, order preserved' blocked-by '#14 #12' \
+'Blocked by:
+- #14
+- #12
+- #14'
+
+check 'no label at all' blocked-by '' \
+'Just an ordinary issue body with a reference to #5 in it.'
+
+printf '\ndepends-on\n'
+
+check 'the documented fixture' depends-on '#17' \
+'### Related Issues
+
+Blocked by:
+- #12 — the parser this builds on
+- #14
+
+Depends on #17.
+
+- #19 is related but not blocking.'
+
+# REGRESSION: `grep -oiE '"'"'depends on[[:space:]]*#[0-9]+'"'"'` matched a
+# cross-repo reference nowhere, so the issue came out eligible with an
+# unresolved dependency.
+check 'REGRESSION cross-repo reference is reported' depends-on 'z5labs/other#42' \
+'Depends on z5labs/other#42'
+
+# REGRESSION: a note that a dependency was removed is not a dependency.
+check 'REGRESSION no longer depends on' depends-on '' \
+'This no longer depends on #17 since #20 landed.'
+
+check 'REGRESSION never depends on' depends-on '' \
+'This never depends on #17.'
+
+check 'REGRESSION fenced code block is not a declaration' depends-on '' \
+'For example:
+
+```
+Depends on #123
+```'
+
+check 'colon form' depends-on '#17' 'Depends on: #17'
+
+check 'case insensitive' depends-on '#17' 'depends on #17'
+
+check 'several, deduped in order' depends-on '#17 #20' \
+'Depends on #17 for the schema.
+
+Also depends on #20, and depends on #17 again.'
+
+# The reference has to follow the phrase. A sentence that merely mentions an
+# issue later on is not declaring a dependency on it.
+check 'non-adjacent reference is not a dependency' depends-on '' \
+'Depends on the parser landing, see #99 for context.'
+
+check 'blocked-by list items carry no depends-on phrase' depends-on '' \
+'Blocked by:
+- #12
+- #14'
+
+printf '\nnone\n'
+
+check 'parses nothing' none '' \
+'Blocked by:
+- #12
+
+Depends on #17.'
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/plugins/backlog/skills/next-issue/SKILL.md
+++ b/plugins/backlog/skills/next-issue/SKILL.md
@@ -245,6 +245,24 @@ The pull request body must include `Closes #<n>`, the acceptance criteria checke
 one, a note on any judgment call that shaped the public API, and how it was verified. Keep
 the standard attribution your harness adds to commits and pull request bodies.
 
+Then assert that the closing reference actually registered:
+
+```
+gh pr view <pr> --repo <repo> --json closingIssuesReferences \
+  --jq '[.closingIssuesReferences[].number]'
+```
+
+It must contain `<n>`. An empty array means GitHub did not parse the keyword — usually
+because the line is missing, misspelled, or names a cross-repository issue — and the link is
+established at creation time, so fixing the body later is the moment to re-check.
+
+This check costs one call and it is diagnostic, not preventive. It is expected to *pass* and
+for the issue to stay open anyway after the merge: the reference registers correctly and
+nothing acts on it when a workflow's `GITHUB_TOKEN` performs the merge, which is why step 10
+closes the issue explicitly. Running it here is what separates those two failures — a link
+that never formed from a link nothing honoured — instead of leaving them to look identical
+ten minutes later.
+
 ## 6. Wait for checks
 
 Do not foreground a `sleep` loop. Either use `gh pr checks <pr> --watch --fail-fast`, or
@@ -487,86 +505,84 @@ means the workflow itself is broken — report it, with the output of
 `gh run view <id> --log-failed`, rather than falling back to a manual merge, which is what
 this whole step exists to avoid.
 
-## 10. Wait for the merge, then clean up
+## 10. Finish — one call
 
-The merge is asynchronous: labelling queues it, and GitHub completes it when the checks
-finish. Wait for it before touching the worktree. Pass the script below as the `command` of
-a `Monitor` call — not to Bash with `run_in_background`:
+Everything after the label is mechanism, not judgment: wait for the merge, close the issue,
+verify it closed, drop the worktree, delete the local branch. Run it as one script rather
+than as five steps. Pass it as the `command` of a `Monitor` call — the wait runs up to ten
+minutes, past the Bash tool's ceiling — and not to Bash with `run_in_background`:
 
 ```
-for i in $(seq 1 40); do
-  s=$(gh pr view <pr> --json state -q .state 2>/dev/null || echo "")
-  case "$s" in
-    MERGED) echo "PR <pr> MERGED"; exit 0;;
-    CLOSED) echo "PR <pr> CLOSED without merging"; exit 1;;
-  esac
-  sleep 15
-done
-echo "PR <pr> still OPEN after 10m"; exit 1
+"${CLAUDE_PLUGIN_ROOT}/scripts/finish-issue.sh" <n> <pr> issue-<n>
 ```
 
-Both failure paths exit non-zero so an unmerged close or a timeout cannot be mistaken for
-success by anything that reads the exit code rather than the emitted line.
+Read its exit code. It is the assertion, and each value means one thing:
 
-If a required check fails, auto merge stays armed and the pull request stays open; fix the
-failure, push, and it merges when the rerun is green. If it stays `OPEN` with nothing
-running, report it rather than merging by hand.
+| exit | meaning | what you do |
+| --- | --- | --- |
+| 0 | merged, issue confirmed `CLOSED`, local cleanup done | continue to the report |
+| 1 | the pull request closed without merging | `BLOCKED`, naming the pull request |
+| 2 | timed out waiting for the merge | re-run it; it resumes. If it times out again with nothing running, `BLOCKED` |
+| 3 | the issue would not close | `BLOCKED` — this is the one that makes the next iteration redo merged work |
+| 4 | usage or precondition failure | `BLOCKED`; the plugin or the environment is wrong, not the pull request |
 
-**Never delete the remote branch.** The `delete-merged-branch` job in
-`.github/workflows/<merge.workflow>` owns remote cleanup; leave it to do its job. `git push
---delete` is denied by the operator's settings, and a subagent must not work around that
-rule. Clean up only what you created locally: your own worktree and your own local branch.
+Warnings on stderr (`WARN`) are untidiness, not failure — a worktree that would not remove,
+a main checkout too dirty to update. Repeat them in the report and carry on.
 
-`deleteBranchOnMerge` on the repository does **not** cover this. It fires for a merge a
-person performs, not for one the auto merge workflow performs with its `GITHUB_TOKEN`, which
+Re-running after a timeout is safe: every step is guarded, so an already-merged pull request
+skips the wait, an already-closed issue skips the close, and an absent worktree or branch
+skips its removal.
+
+### Why this is a script
+
+Three of those steps have been rediscovered from first principles on cycle after cycle, and
+the close is the expensive one. **A `Closes #<n>` line does not close the issue when a
+workflow's `GITHUB_TOKEN` performs the merge.** Across four consecutive merges the closing
+reference registered correctly every time — step 5's assertion would have passed on all
+four — and every issue stayed open until an agent noticed and closed it by hand. The
+auto-close is performed as the merging actor, and that actor is `github-actions[bot]`, so it
+is bounded by the workflow's `permissions:` block; the workflow this plugin installs grants
+`issues: write` for that reason, and whether that is sufficient is not yet proven.
+
+So the explicit close stays either way, and it is not a formality: an issue left open is one
+the next invocation of this skill selects again, so the loop re-implements work it has
+already merged. Putting it behind an exit code is what stops it depending on an agent
+remembering, at the very end of the longest part of the cycle, a fact that is invisible
+unless you go looking for it.
+
+The script also **deletes nothing remote.** The `delete-merged-branch` job in
+`.github/workflows/<merge.workflow>` owns remote cleanup; `git push --delete` is denied by
+the operator's settings, and neither an agent nor a script should work around that rule.
+Note that `deleteBranchOnMerge` on the repository does not cover this either — it fires for
+a merge a person performs, not for one the workflow performs with its `GITHUB_TOKEN`, which
 is why that job exists at all. If a branch outlives its merge, the fix belongs in the
-workflow, not in a `git push` here.
+workflow.
 
-### Close the issue
+### If the script is unavailable
 
-Once the state really is `MERGED`, one thing the repository normally does on your behalf
-will not have happened: a merge performed by the workflow's `GITHUB_TOKEN` does not close
-the issue the way a merge performed by a person does. A `Closes #<n>` line in the pull
-request body has been observed not closing it. It is not a formality — an issue left open is
-one the next invocation of this skill selects again, so the loop re-implements work it has
-already merged:
+Running interactively without the plugin root set, do the same five things by hand, in this
+order, and check the state after the close rather than assuming it:
 
 ```
-gh issue view <n> --json state -q .state
-```
-
-If that says `OPEN`, close it explicitly, and say in the comment which pull request did the
-work so the trail is not just a bare state change:
-
-```
-gh issue close <n> --repo <repo> --comment "Implemented in #<pr>, merged as <sha>."
-```
-
-Re-read the state afterwards and confirm it is `CLOSED` before moving on.
-
-### Drop the worktree
-
-```
-git worktree remove <worktreeDir>/issue-<n>
-```
-
-Then bring the main checkout up to date so the next iteration branches from the merged
-state, and delete your own local branch. `git worktree list` reports the main checkout
-first, so this needs no hard-coded path:
-
-```
-MAIN=$(git worktree list --porcelain | head -1 | cut -d' ' -f2-)
-git -C "$MAIN" checkout <default-branch>
-git -C "$MAIN" pull
-git -C "$MAIN" branch -D issue-<n>
+# 1. wait for MERGED (Monitor); CLOSED without merging and a timeout are both failures
+# 2. gh issue view <n> --repo <repo> --json state -q .state
+# 3. if OPEN: gh issue close <n> --repo <repo> --comment "Implemented in #<pr>, merged as <sha>."
+# 4. re-read the state and confirm CLOSED
+# 5. git worktree remove <worktreeDir>/issue-<n>
+#    MAIN=$(git worktree list --porcelain | head -1 | cut -d' ' -f2-)
+#    git -C "$MAIN" checkout <default-branch> && git -C "$MAIN" pull --ff-only
+#    git -C "$MAIN" branch -D issue-<n>
 ```
 
 A stale *local* branch is what breaks a retry — `git worktree add -b issue-<n>` fails
 against an existing branch, and the retry then reports `BLOCKED` on a name collision rather
 than on anything real. The remote side needs nothing from you.
 
-If the pull request did not merge, leave the worktree in place and report `BLOCKED` with the
-pull request number and the last state you saw.
+If a required check fails, auto merge stays armed and the pull request stays open; fix the
+failure, push, and it merges when the rerun is green. If it stays `OPEN` with nothing
+running, report it rather than merging by hand. If the pull request did not merge at all,
+leave the worktree in place and report `BLOCKED` with the pull request number and the last
+state you saw.
 
 ## Report
 

--- a/plugins/backlog/skills/next-issue/SKILL.md
+++ b/plugins/backlog/skills/next-issue/SKILL.md
@@ -41,12 +41,16 @@ The six keys, and what each is used for:
 
 | key | used at |
 | --- | --- |
-| `select.label`, `select.milestone`, `select.limit` | step 1, listing the backlog |
-| `dependencies.style` | step 1, deciding eligibility |
+| `select.label`, `select.milestone`, `select.limit` | step 1 — read by `select-issue.sh`, not by you |
+| `dependencies.style` | step 1 — same |
 | `verify` | step 4, the commands that gate the pull request |
 | `merge.label`, `merge.workflow` | step 9, handing the merge to GitHub |
 | `review.required` | steps 7 and 8, whether Copilot gates the merge |
 | `worktreeDir` | steps 2 and 10, where the worktree lives |
+
+Read the file for the four keys you use directly. The first four rows belong to step 1's
+script, which re-reads and validates them itself — including rejecting an empty `verify`,
+which parses fine and would otherwise surface as a pull request nothing local ever checked.
 
 `${CLAUDE_PLUGIN_ROOT}/assets/backlog.schema.json` is the schema; read it if a key looks
 wrong.
@@ -65,100 +69,67 @@ next command. Note the values down and substitute them literally into the comman
 or re-derive them inside the same command. Every `<repo>` and `<default-branch>` in this
 document is one of those two values.
 
-## 1. Pick the issue
+## 1. Pick the issue — one call
 
-List the backlog. Pass `--milestone` **only** when `select.milestone` is not null — an
-empty `--milestone` is not the same as no milestone filter:
-
-```
-gh issue list --state open --label "<select.label>" --limit <select.limit> \
-  [--milestone "<select.milestone>"] --json number,title --jq 'sort_by(.number)[]'
-```
-
-`--limit` is always passed. gh's default page size is 30, and on a backlog larger than that
-the issues past the first page do not error — they are simply not in the list, so the cycle
-reports an empty or blocked backlog that is neither.
-
-Walk the list in ascending number order. For each candidate, read its body
-(`gh issue view <n> --json body --jq .body`) and extract its dependencies according to
-`dependencies.style`. An issue is *eligible* only when every issue it names is CLOSED:
+Selection carries no judgment: given the label, the milestone, the limit and the dependency
+convention, the answer is a function of the backlog. So it is one call, and the answer is an
+exit code:
 
 ```
-gh issue view <N> --json state --jq .state
+"${CLAUDE_PLUGIN_ROOT}/scripts/select-issue.sh"
 ```
 
-Take the lowest-numbered eligible issue.
+| exit | stdout | what you do |
+| --- | --- | --- |
+| 0 | `{"number":N,"title":"…"}` | that is your issue — continue to step 2 |
+| 10 | `BACKLOG EMPTY` | print that line and stop. Do nothing else. |
+| 11 | `BLOCKED — …`, then a line per issue naming what holds it | print it and stop |
+| 4 | a message naming the problem | `BLOCKED`. The config or the environment is wrong, not the backlog — usually `.claude/backlog.json` is missing, unparseable, carries an unknown `dependencies.style`, or has an empty `verify`. Point at `backlog:setup-backlog`. |
 
-- If no open issues match the label (and milestone, when set), print `BACKLOG EMPTY` and
-  stop. Do nothing else.
-- If open issues remain but none are eligible, print `BLOCKED` plus which dependency is
-  holding things up, and stop.
+The script walks candidates in ascending number order and takes the first whose every
+declared dependency is `CLOSED`. Its per-candidate reasoning goes to stderr, so a selection
+you did not expect can be explained without re-running anything.
 
-### Reading dependencies
+**Do not reconstruct any of this by hand**, and do not fall back to `gh issue list` plus your
+own body parsing if the call fails. That fallback is where this step's history lives: the
+extraction used to be three `awk`/`sed`/`grep` pipelines written out here for you to retype,
+and every one of them was wrong — a sentence reading `this issue is not blocked by anything`
+opened a dependency list, a fenced code block quoting the convention counted as a
+declaration, GitHub's `- [ ] #12` task-list form extracted nothing, and a cross-repository
+`owner/repo#N` silently terminated the list, dropping the real dependencies below it.
+`scripts/select-issue_test.sh` is the fixture corpus those came from; a change to the rules
+belongs there, not here.
 
-GitHub's native blocked-by field is **not** consulted. It has been observed empty on
-repositories whose issue bodies do declare ordering in prose, and an empty native field
-reads as an unblocked backlog, which is the one wrong answer that causes work to be done in
-the wrong order rather than not at all.
+### The conventions it reads
 
-`dependencies.style` is one of exactly three values. Anything else is a configuration
-error: stop, and report — beginning with `BLOCKED` — that `dependencies.style` must be one
-of `blocked-by`, `depends-on` or `none`, naming the value that was found and pointing at
-`backlog:setup-backlog`.
+Useful when you are *writing* an issue body, and what `backlog:setup-backlog` infers
+`dependencies.style` from. GitHub's own native blocked-by field is **not** consulted: it has
+been observed empty on repositories whose issue bodies do declare ordering in prose, and an
+empty native field reads as an unblocked backlog — the one wrong answer that gets work done
+in the wrong order rather than not at all.
 
-**`blocked-by`** — a line containing `Blocked by:` followed by `- #N` list items. The list
-ends at the first non-empty line that is not a list item:
+**`blocked-by`** — a line that *opens* with `Blocked by:` (a heading, bold, or plain), then
+`- #N` list items. The phrase has to start the line and end at a colon or the line end, which
+is what tells a declaration apart from prose that merely mentions being blocked. References
+on the label line itself count too, so `Blocked by: #12, #14` works. The list ends at the
+first non-blank line that is not a list item — a blank line does not end it, because Markdown
+calls a bullet list with blank lines between its items a single loose list. On each item the
+**first** reference is the dependency and the rest is a gloss, so `- #12 — needs #34 first`
+contributes 12 and not 34.
 
-```
-gh issue view <n> --json body --jq .body | awk '
-  tolower($0) ~ /blocked by/                       { inlist = 1; next }
-  inlist && /^[[:space:]]*[-*][[:space:]]*#[0-9]+/ { print; next }
-  inlist && NF                                     { inlist = 0 }
-' | sed -nE 's/^[[:space:]]*[-*][[:space:]]*#([0-9]+).*/\1/p'
-```
+**`depends-on`** — `Depends on #N` written inline, conventionally under a `Related Issues`
+heading. The reference has to follow the phrase immediately, so `Depends on the parser
+landing, see #99` is not a dependency on 99. A phrase negated in the same clause — `no longer
+depends on #17` — is a note that a dependency was removed, not a live one.
 
-The `sed` takes the **first** `#N` on each list item and nothing after it, so a trailing
-gloss like `- #12 — needs #34 first` contributes 12 and not 34.
+**`none`** — the backlog declares no ordering. Bodies are not parsed at all; every open issue
+carrying the label is eligible and the lowest-numbered one wins.
 
-**`depends-on`** — `Depends on #N`, written inline, conventionally under a `Related Issues`
-heading. There is no list structure to track, so match the phrase directly, case
-insensitively:
-
-```
-gh issue view <n> --json body --jq .body \
-  | grep -oiE 'depends on[[:space:]]*#[0-9]+' | grep -oE '[0-9]+'
-```
-
-**`none`** — the backlog declares no ordering. Do not parse the body for dependencies at
-all; every open issue carrying the label is eligible, and the lowest-numbered one wins.
-
-A bare `#N` means an issue in this repository. A cross-repository `owner/repo#N` is not
-modelled: treat it as a dependency you cannot resolve, and report `BLOCKED` naming it,
-rather than skipping it and calling the issue eligible.
-
-### Fixture
-
-The three styles must give three different answers on the same body. Against this one:
-
-```markdown
-### Related Issues
-
-Blocked by:
-- #12 — the parser this builds on
-- #14
-
-Depends on #17.
-
-- #19 is related but not blocking.
-```
-
-| `dependencies.style` | selects |
-| --- | --- |
-| `blocked-by` | 12, 14 — the list ends at `Depends on #17.`, which is neither blank nor a list item, so `- #19` is out of the list and not a dependency |
-| `depends-on` | 17 — the `Blocked by:` list items carry no phrase to match |
-| `none` | nothing; the issue is eligible on sight |
-
-If your extraction disagrees with that table on this body, the extraction is wrong.
+Under both parsing styles, text inside a ``` or `~~~` fence is example text, not a
+declaration. A bare `#N` means an issue in this repository. A cross-repository `owner/repo#N`
+is not modelled: it makes *that issue* ineligible and is named in the report, rather than
+being skipped and the issue called eligible — but the walk continues, so one unresolvable
+reference does not starve a backlog whose other issues are workable.
 
 ### Read the issue
 
@@ -618,8 +589,8 @@ If you stopped early, say exactly where and why, beginning the report with `BLOC
 
 Stop and report — do not push through — if any of these happen:
 
-- `.claude/backlog.json` is missing, does not parse, or carries an unknown
-  `dependencies.style`.
+- `select-issue.sh` exits 4 — `.claude/backlog.json` is missing, does not parse, carries an
+  unknown `dependencies.style`, or has an empty `verify`.
 - The same CI failure survives three fix attempts.
 - Acceptance criteria are ambiguous enough that two readings produce materially different
   public APIs.

--- a/plugins/backlog/skills/next-issue/SKILL.md
+++ b/plugins/backlog/skills/next-issue/SKILL.md
@@ -536,27 +536,44 @@ skips its removal.
 ### Why this is a script
 
 Three of those steps have been rediscovered from first principles on cycle after cycle, and
-the close is the expensive one. **A `Closes #<n>` line does not close the issue when a
-workflow's `GITHUB_TOKEN` performs the merge.** Across four consecutive merges the closing
+the close is the expensive one. **A `Closes #<n>` line does not close the issue when a token
+rather than a person performs the merge.** Across five consecutive merges the closing
 reference registered correctly every time — step 5's assertion would have passed on all
-four — and every issue stayed open until an agent noticed and closed it by hand. The
-auto-close is performed as the merging actor, and that actor is `github-actions[bot]`, so it
-is bounded by the workflow's `permissions:` block; the workflow this plugin installs grants
-`issues: write` for that reason, and whether that is sufficient is not yet proven.
+five — and every issue stayed open until an agent noticed and closed it by hand.
 
-So the explicit close stays either way, and it is not a formality: an issue left open is one
-the next invocation of this skill selects again, so the loop re-implements work it has
-already merged. Putting it behind an exit code is what stops it depending on an agent
-remembering, at the very end of the longest part of the cycle, a fact that is invisible
-unless you go looking for it.
+Granting the merge workflow `issues: write` is the obvious explanation, and it was tested on
+a real merge: the issue still did not close, and the loop closed it by hand eighteen seconds
+later exactly as before. That explanation is **refuted**; the mechanism remains unknown.
 
-The script also **deletes nothing remote.** The `delete-merged-branch` job in
-`.github/workflows/<merge.workflow>` owns remote cleanup; `git push --delete` is denied by
-the operator's settings, and neither an agent nor a script should work around that rule.
-Note that `deleteBranchOnMerge` on the repository does not cover this either — it fires for
-a merge a person performs, not for one the workflow performs with its `GITHUB_TOKEN`, which
-is why that job exists at all. If a branch outlives its merge, the fix belongs in the
-workflow.
+So this close is not a backstop for something that usually works — for a long time it was
+the *only* thing closing these issues, and an issue left open is one the next invocation of
+this skill selects again, so the loop re-implements work it has already merged. Putting it
+behind an exit code is what stops it depending on an agent remembering, at the very end of
+the longest part of the cycle, a fact that is invisible unless you go looking for it.
+
+The workflow this plugin installs now also closes linked issues explicitly, in a
+`close-linked-issues` job. Both closes are idempotent — whichever arrives first wins and the
+other reads `CLOSED` and does nothing — and the redundancy is deliberate, because that job
+runs only when the repository is set up as below.
+
+### The remote branch, and what it depends on
+
+The script **deletes nothing remote.** `git push --delete` is denied by the operator's
+settings, and neither an agent nor a script should work around that rule; the
+`delete-merged-branch` job in `.github/workflows/<merge.workflow>` owns remote cleanup.
+
+That job only fires if the merge was performed by a **GitHub App installation token**.
+GitHub does not create workflow runs from events triggered by `GITHUB_TOKEN`, so a merge
+performed with `GITHUB_TOKEN` emits a `closed` event that starts no run — and both the
+branch deletion and the issue close above are skipped. Measured, not inferred: across ten
+merges in two repositories every auto-merge run showed that job `skipped` and twenty-four
+merged branches survived, while the one run where it did fire belonged to a pull request a
+person merged by hand.
+
+`backlog:setup-backlog` checks for the App secrets and reports when they are missing. If
+they are, expect merged branches to accumulate; say so in the report rather than deleting
+one, and note that `deleteBranchOnMerge` on the repository does not cover it either — that
+fires for a merge a person performs.
 
 ### If the script is unavailable
 

--- a/plugins/backlog/skills/next-issue/SKILL.md
+++ b/plugins/backlog/skills/next-issue/SKILL.md
@@ -1,0 +1,601 @@
+---
+name: next-issue
+description: Take exactly one eligible story issue from the backlog through the full development cycle — select it, branch a worktree, implement the acceptance criteria, run the repository's verify commands, open a pull request, wait for checks, get a Copilot review and answer it, then label the pull request for GitHub to auto merge, close the issue and clean up. Use this whenever the user asks to "work the backlog", "take the next issue", "do the next story", "pick up the next ticket", or runs the backlog loop; it is also what the `issue-worker` agent invokes on every iteration of `backlog:run-backlog`. Everything repository-specific comes from `.claude/backlog.json`. Skip this when the user names a specific issue to explore rather than to land, or when they want the backlog bootstrapped rather than worked — that is `backlog:setup-backlog`.
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Monitor, TaskCreate, TaskUpdate, EnterWorktree, ExitWorktree
+---
+
+# next-issue
+
+Take **exactly one** issue from backlog to a merged pull request, then stop. Do not start a
+second issue in the same invocation — the loop re-invokes this skill for the next one.
+
+You never run `gh pr merge`. You label the pull request and GitHub merges it, gated by the
+default branch's protection rules; see step 9.
+
+Nothing about the repository is written into this skill. The repository slug and default
+branch are read from the repository itself (step 0); the label, milestone, dependency
+convention, verify commands, merge label and worktree directory are read from
+`.claude/backlog.json`.
+
+## 0. Load the configuration
+
+Two reads, in this order. Both must succeed before anything else happens.
+
+**The config.** `.claude/backlog.json`, relative to the repository root:
+
+```
+jq . .claude/backlog.json
+```
+
+If the file is absent, or `jq` exits non-zero on it, **stop**. Report, beginning with
+`BLOCKED`:
+
+> `BLOCKED` — `.claude/backlog.json` is missing (or does not parse). Run
+> `backlog:setup-backlog` to create it.
+
+Do not invent defaults and carry on. A guessed label selects the wrong issues and a guessed
+verify list opens red pull requests, and both failures look like the repository's fault
+rather than the config's.
+
+The six keys, and what each is used for:
+
+| key | used at |
+| --- | --- |
+| `select.label`, `select.milestone`, `select.limit` | step 1, listing the backlog |
+| `dependencies.style` | step 1, deciding eligibility |
+| `verify` | step 4, the commands that gate the pull request |
+| `merge.label`, `merge.workflow` | step 9, handing the merge to GitHub |
+| `review.required` | steps 7 and 8, whether Copilot gates the merge |
+| `worktreeDir` | steps 2 and 10, where the worktree lives |
+
+`${CLAUDE_PLUGIN_ROOT}/assets/backlog.schema.json` is the schema; read it if a key looks
+wrong.
+
+**The repository.** Slug and default branch come from GitHub, not from the config — a fork
+or a rename must not be able to leave a stale slug pointing the cycle at someone else's
+repository:
+
+```
+read -r REPO DEFAULT_BRANCH <<<"$(gh repo view --json nameWithOwner,defaultBranchRef \
+  --jq '"\(.nameWithOwner) \(.defaultBranchRef.name)"')"
+```
+
+Shell state does not survive between Bash calls, so those two variables are gone by your
+next command. Note the values down and substitute them literally into the commands below,
+or re-derive them inside the same command. Every `<repo>` and `<default-branch>` in this
+document is one of those two values.
+
+## 1. Pick the issue
+
+List the backlog. Pass `--milestone` **only** when `select.milestone` is not null — an
+empty `--milestone` is not the same as no milestone filter:
+
+```
+gh issue list --state open --label "<select.label>" --limit <select.limit> \
+  [--milestone "<select.milestone>"] --json number,title --jq 'sort_by(.number)[]'
+```
+
+`--limit` is always passed. gh's default page size is 30, and on a backlog larger than that
+the issues past the first page do not error — they are simply not in the list, so the cycle
+reports an empty or blocked backlog that is neither.
+
+Walk the list in ascending number order. For each candidate, read its body
+(`gh issue view <n> --json body --jq .body`) and extract its dependencies according to
+`dependencies.style`. An issue is *eligible* only when every issue it names is CLOSED:
+
+```
+gh issue view <N> --json state --jq .state
+```
+
+Take the lowest-numbered eligible issue.
+
+- If no open issues match the label (and milestone, when set), print `BACKLOG EMPTY` and
+  stop. Do nothing else.
+- If open issues remain but none are eligible, print `BLOCKED` plus which dependency is
+  holding things up, and stop.
+
+### Reading dependencies
+
+GitHub's native blocked-by field is **not** consulted. It has been observed empty on
+repositories whose issue bodies do declare ordering in prose, and an empty native field
+reads as an unblocked backlog, which is the one wrong answer that causes work to be done in
+the wrong order rather than not at all.
+
+`dependencies.style` is one of exactly three values. Anything else is a configuration
+error: stop, and report — beginning with `BLOCKED` — that `dependencies.style` must be one
+of `blocked-by`, `depends-on` or `none`, naming the value that was found and pointing at
+`backlog:setup-backlog`.
+
+**`blocked-by`** — a line containing `Blocked by:` followed by `- #N` list items. The list
+ends at the first non-empty line that is not a list item:
+
+```
+gh issue view <n> --json body --jq .body | awk '
+  tolower($0) ~ /blocked by/                       { inlist = 1; next }
+  inlist && /^[[:space:]]*[-*][[:space:]]*#[0-9]+/ { print; next }
+  inlist && NF                                     { inlist = 0 }
+' | sed -nE 's/^[[:space:]]*[-*][[:space:]]*#([0-9]+).*/\1/p'
+```
+
+The `sed` takes the **first** `#N` on each list item and nothing after it, so a trailing
+gloss like `- #12 — needs #34 first` contributes 12 and not 34.
+
+**`depends-on`** — `Depends on #N`, written inline, conventionally under a `Related Issues`
+heading. There is no list structure to track, so match the phrase directly, case
+insensitively:
+
+```
+gh issue view <n> --json body --jq .body \
+  | grep -oiE 'depends on[[:space:]]*#[0-9]+' | grep -oE '[0-9]+'
+```
+
+**`none`** — the backlog declares no ordering. Do not parse the body for dependencies at
+all; every open issue carrying the label is eligible, and the lowest-numbered one wins.
+
+A bare `#N` means an issue in this repository. A cross-repository `owner/repo#N` is not
+modelled: treat it as a dependency you cannot resolve, and report `BLOCKED` naming it,
+rather than skipping it and calling the issue eligible.
+
+### Fixture
+
+The three styles must give three different answers on the same body. Against this one:
+
+```markdown
+### Related Issues
+
+Blocked by:
+- #12 — the parser this builds on
+- #14
+
+Depends on #17.
+
+- #19 is related but not blocking.
+```
+
+| `dependencies.style` | selects |
+| --- | --- |
+| `blocked-by` | 12, 14 — the list ends at `Depends on #17.`, which is neither blank nor a list item, so `- #19` is out of the list and not a dependency |
+| `depends-on` | 17 — the `Blocked by:` list items carry no phrase to match |
+| `none` | nothing; the issue is eligible on sight |
+
+If your extraction disagrees with that table on this body, the extraction is wrong.
+
+### Read the issue
+
+Read the whole issue body. The **Acceptance Criteria** checklist is the spec — every box
+must be genuinely satisfied before you open the pull request.
+
+## 2. Worktree
+
+Branch a fresh worktree from the remote default branch:
+
+```
+git fetch origin
+git worktree add -b issue-<n> <worktreeDir>/issue-<n> origin/<default-branch>
+```
+
+Then work by absolute path inside that directory. Confirm with
+`git -C <worktreeDir>/issue-<n> rev-parse --abbrev-ref HEAD` and
+`git -C <worktreeDir>/issue-<n> log --oneline -3`.
+
+Branch from `origin/<default-branch>`, not from the local one: the main checkout is
+routinely behind, because earlier iterations merge through GitHub rather than locally, and
+branching from a stale local ref reimplements work that already landed or conflicts with
+it.
+
+Never commit, branch, or open a pull request from the main checkout — the directory holding
+`<worktreeDir>/`, which `git worktree list` reports first.
+
+Avoid bare `git stash` and `git stash pop`. The stash stack is shared across every worktree
+of the repository, so a pop can restore work belonging to another session entirely. Set
+work aside with a temporary commit instead.
+
+> Running this interactively, outside the loop, `EnterWorktree(name: "issue-<n>")` and
+> `ExitWorktree(action: "remove")` do the same job with less typing. They are unavailable
+> to a subagent running with a working-directory override, which is exactly how
+> `backlog:run-backlog` invokes this skill — so the git commands above are the path that
+> actually runs, and the tools are the convenience.
+
+If the repository root has a `CLAUDE.md`, read it now, along with any `CLAUDE.md` in the
+package you are about to touch. It holds the implementation conventions this repository's
+issues assume.
+
+## 3. Implement
+
+Work through the acceptance criteria in order. Follow the conventions already established
+in the repository — the package layout, naming and test style of code that has already
+landed — rather than inventing new ones. Where the issue names a structural model, mirror
+that.
+
+Write tests alongside the implementation, in the style the repository already uses.
+
+## 4. Verify locally
+
+Run every command in `verify`, in order, from inside the worktree. All must pass before you
+go further. This is the same set CI runs, so a local failure is a guaranteed red pull
+request:
+
+```
+<verify[0]>
+<verify[1]>
+...
+```
+
+Some verify commands report a problem by printing rather than by exiting non-zero — a
+formatter listing the files it would rewrite is the usual case. For those, **non-empty
+output is the failure.** Fix what it lists rather than reading the exit code and moving on.
+
+If a test fails, fix the code — never weaken the test to make it pass. If the acceptance
+criteria and a passing test genuinely conflict, stop and report rather than guessing.
+
+A verify command that fails because the *tool* is stale rather than because the code is
+wrong is not a code defect; fix the tool and say so in the report rather than editing
+around it.
+
+## 5. Commit and open the pull request
+
+```
+git add -A
+git commit -m "<type>(<scope>): <summary>"   # match the issue title's prefix
+git push -u origin HEAD
+gh pr create --title "<issue title>" --body "<body>"
+```
+
+The pull request body must include `Closes #<n>`, the acceptance criteria checked off one by
+one, a note on any judgment call that shaped the public API, and how it was verified. Keep
+the standard attribution your harness adds to commits and pull request bodies.
+
+## 6. Wait for checks
+
+Do not foreground a `sleep` loop. Either use `gh pr checks <pr> --watch --fail-fast`, or
+poll with `Monitor`.
+
+Do **not** use Bash `run_in_background` for a wait loop. It has been observed exiting
+immediately without ever polling, which looks like a completed wait and reports whatever the
+first sample happened to be. `Monitor` is the tool for every wait in this cycle.
+
+- Exit 0 → green, continue.
+- Failure → read the logs (`gh run view <id> --log-failed`), fix, push, and re-watch. After
+  **three** failed attempts on the same root cause, stop and report instead of looping.
+- `no checks reported` → nothing gates this pull request. Workflows queue for a few seconds
+  after a push, so re-check once after a short wait before concluding anything. If there
+  are still none, do not silently treat it as a pass: record `no checks reported` in the
+  report and continue. This is the same gap `backlog:setup-backlog` reports when the default
+  branch has no required status check, seen from the other side — with no required check,
+  the label in step 9 merges the pull request the instant it lands.
+
+## 7. Request the Copilot review
+
+**If `review.required` is `false`, skip this step and step 8 entirely** and go to step 9.
+Nothing here is optional when it is `true`.
+
+Copilot is a **Bot**, not a User. Two things follow. The login is
+`copilot-pull-request-reviewer[bot]`, and passing a bare `reviewers[]=Copilot` to the REST
+endpoint `POST /pulls/<pr>/requested_reviewers` returns 200 while silently doing nothing —
+`requested_reviewers` stays empty and the wait below then times out on a review that was
+never requested.
+
+The GraphQL mutation is the reliable path. It takes `botIds`, not `reviewers`:
+
+```
+PR_ID=$(gh pr view <pr> --json id --jq .id)
+BOT_ID=$(gh api '/users/copilot-pull-request-reviewer[bot]' --jq .node_id)
+gh api graphql -f query='
+mutation($pr:ID!, $bot:ID!) {
+  requestReviews(input: {pullRequestId: $pr, botIds: [$bot], union: true}) {
+    pullRequest { reviewRequests(first:10) { nodes {
+      requestedReviewer { __typename ... on Bot { login } } } } }
+  }
+}' -f pr="$PR_ID" -f bot="$BOT_ID"
+```
+
+The bot ID is looked up by login rather than hard-coded. Confirm the response lists
+`copilot-pull-request-reviewer` under `reviewRequests` — an empty list means the request did
+not take.
+
+REST also works *provided the full bot login is used*, and is a reasonable fallback if the
+mutation errors:
+
+```
+gh api --method POST repos/<repo>/pulls/<pr>/requested_reviewers \
+  -f "reviewers[]=copilot-pull-request-reviewer[bot]" -q '.number'
+```
+
+Either way, confirm the login appears in `requested_reviewers` before you start waiting.
+
+### Wait for the review to land
+
+Pass this as the `command` of a `Monitor` call — not to Bash with `run_in_background`, for
+the reason in step 6:
+
+```
+for i in $(seq 1 40); do
+  n=$(gh api --paginate repos/<repo>/issues/<pr>/timeline \
+        --jq '.[]|select(.event=="reviewed")
+              |select(.user.login|test("copilot";"i"))|.id' 2>/dev/null | wc -l)
+  if [ "$n" -gt 0 ]; then echo "copilot review landed"; exit 0; fi
+  sleep 15
+done
+echo "copilot review timed out"; exit 1
+```
+
+Two filters, both load bearing.
+
+`--paginate`, because the timeline returns thirty events per page by default, and a pull
+request that saw several pushes, check runs and comments will push the `reviewed` event off
+the first page — where an unpaginated read reports zero and the loop times out on a reviewed
+pull request, which is the exact failure this step exists to avoid. Counting `.id` lines
+rather than taking a `length` per page is what makes the count work across pages.
+
+The `copilot` login filter, because a `reviewed` event from *anyone* would otherwise end the
+wait. The repository owner reviewing a pull request while Copilot was still working would
+satisfy this loop, and step 9 would then be deciding on a review that never arrived. The
+gate is specifically that Copilot completed; the wait has to be specific in the same way.
+Matching is case-insensitive on purpose — the timeline reports this reviewer as `Copilot`
+while the `pulls/` endpoints report `copilot-pull-request-reviewer[bot]`.
+
+The wait polls the **timeline**, not `pulls/<pr>/reviews`. The reviews endpoint — and the
+equivalent GraphQL query — have been seen returning an empty array for as long as forty
+minutes after Copilot had in fact submitted, while the timeline showed it immediately.
+Polling the reviews endpoint therefore produces a timeout on a pull request that was
+reviewed, and that reads as a missing review rather than as the API lagging.
+
+**Never report `BLOCKED` for a missing review without checking the timeline first:**
+
+```
+gh api --paginate repos/<repo>/issues/<pr>/timeline \
+  --jq '.[]|select(.event=="reviewed")|select(.user.login|test("copilot";"i"))' \
+  | jq -s 'sort_by(.submitted_at)|last|{user:.user.login,state,body}'
+```
+
+Same two filters, for the same two reasons — without the login filter this returns whichever
+review is newest, which after a human comment is not Copilot's. And `jq -s` because it
+slurps the per-page objects back into one array before sorting: sorting inside `--jq` would
+sort each page separately and give you the last review *of the last page*, not the last
+review.
+
+### A non-empty reviews array does not mean the pull request was reviewed
+
+Copilot posts a review whose body **declines** the work — most often `"Copilot wasn't able
+to review this pull request because it exceeds the maximum number of files (300)"` — and
+that decline satisfies a naive `length > 0` test. Check the body before treating the review
+as real.
+
+Read the **most recent** Copilot review only. Reruns and pushed fixes leave older reviews in
+the array, so an earlier decline sitting beside a later completed review — or the reverse —
+is easy to misread:
+
+```
+gh api repos/<repo>/pulls/<pr>/reviews \
+  --jq '[.[] | select(.user.login | test("copilot";"i"))]
+        | sort_by(.submitted_at) | last | .body // "no copilot review"'
+```
+
+A body matching `wasn't able to review` is a **declined** review, not a completed one. This
+has been seen in the wild: vendored test suites pushed a pull request past the 300-file
+limit, Copilot declined, the `length > 0` check passed, and the cycle merged with no review
+at all.
+
+If the review is declined, times out, or the request itself errors (Copilot code review not
+enabled for the organisation), the cycle does **not** label the pull request — see step 9.
+
+## 8. Address the review
+
+**Skipped entirely when `review.required` is `false`.**
+
+Pull both the summary review and the inline comments — a review whose body says it
+`generated no comments` still counts as having reviewed:
+
+```
+gh api repos/<repo>/pulls/<pr>/reviews  --jq '.[] | "\(.user.login) [\(.state)]\n\(.body)"'
+gh api repos/<repo>/pulls/<pr>/comments --jq '.[] | "[\(.id)] \(.path):\(.line)\n\(.body)"'
+```
+
+If the reviews endpoint is still lagging (step 7), read the body from the timeline instead —
+the `reviewed` events carry the same `state` and `body`. An empty result here is a stale
+endpoint, not an absent review.
+
+Use judgment. Fix what is a real defect or a genuine improvement. Where a comment is wrong
+or does not apply, reply on the thread explaining why rather than making the change — do not
+silently ignore it, and do not change correct code just to clear a comment.
+
+```
+gh api --method POST repos/<repo>/pulls/<pr>/comments/<comment-id>/replies \
+  -f body="<reply>" -q '.id'
+```
+
+The `pulls/<pr>/` segment belongs there. Copilot has claimed that the route is
+`pulls/comments/<comment-id>/replies` and that the form above 404s; it is wrong, and the
+reply rebutting it was posted with the command exactly as written. The shorter path is the
+`GET`/`PATCH`/`DELETE` route for a single review comment, not the reply route.
+
+If you push fixes, go back to step 6 and let checks re-run before labelling.
+
+## 9. Label the pull request — never merge it yourself
+
+**Do not run `gh pr merge`.** Not with `--auto`, not without. Two separate things break.
+The permission classifier stops an agent merging to the default branch, so the command
+fails. And a *subagent* that merges emits a security banner into its caller's context which
+blocks the caller's next agent spawn — killing the loop on its second iteration, one
+iteration after the mistake, where the cause is no longer visible.
+
+Hand the merge to GitHub instead:
+
+```
+gh pr edit <pr> --add-label <merge.label>
+```
+
+`.github/workflows/<merge.workflow>` picks up the `labeled` event and enables native auto
+merge. GitHub squash-merges the pull request once every required status check passes — or
+immediately, if they have already passed — and leaves it open if one fails.
+
+Apply the label only when **both** hold:
+
+1. Checks are green, and
+2. **either** `review.required` is `false`, **or** a Copilot review actually **completed** —
+   it either left comments (every one now addressed or answered) or reported that it
+   generated none.
+
+This is not a formality to route around: the label **is** the assertion that you verified
+both conditions, and adding it without having done so is the same failure as merging
+unreviewed work by hand. Condition 1 is enforced by branch protection whatever you do;
+condition 2 is enforced by nothing but you.
+
+Keeping the merge in a workflow puts the policy somewhere it can be read and changed — the
+label gate plus the branch protection rule — rather than in a decision made mid-cycle and
+visible only in a transcript. It is also what lets the loop run unattended: an agent merging
+on its own is blocked, and labelling is not.
+
+When `review.required` is `true`, a review that was declined, never arrived, or was never
+requested because the request errored is **not** a completed review. Do **not** label the
+pull request. Leave it open, leave the worktree in place, and stop with a report beginning
+`BLOCKED` that names the pull request and why the review is missing, so the user can tell a
+pull request that needs a human look from one that merged on its own. Sending unreviewed
+work to the default branch is the one step of this cycle that is not yours to take
+unilaterally.
+
+If the pull request is unreviewable because it exceeds the 300-file limit, say so in the
+`BLOCKED` report and suggest how the work could be split; do not label it anyway.
+
+### Confirm the label was acted on
+
+There are **two** successful outcomes, and checking only for an armed auto merge request
+will report a false failure on the more common one:
+
+```
+gh pr view <pr> --json state,autoMergeRequest -q '"\(.state) \(.autoMergeRequest.enabledAt // "not-armed")"'
+```
+
+- `MERGED …` — already merged. `gh pr merge --auto` merges immediately when the required
+  checks have already passed, and since this cycle labels only after they pass, this is the
+  usual result. `not-armed` beside `MERGED` is correct, not a fault.
+- `OPEN <timestamp>` — auto merge is armed and waiting on a check still running.
+- `OPEN not-armed` — **usually just means the workflow has not started yet.** The run is
+  queued for a few seconds after the label lands, and reading the pull request immediately
+  will show this every time. It is not evidence of a failure on its own.
+
+Do not conclude anything from `OPEN not-armed` until the workflow run has actually finished.
+The run list is what disambiguates:
+
+```
+gh run list --repo <repo> --workflow <merge.workflow> --limit 1
+```
+
+Wait for it to leave `queued` and `in_progress`. A `success` conclusion with the pull
+request still open means auto merge is armed and waiting on a check. A `failure` conclusion
+means the workflow itself is broken — report it, with the output of
+`gh run view <id> --log-failed`, rather than falling back to a manual merge, which is what
+this whole step exists to avoid.
+
+## 10. Wait for the merge, then clean up
+
+The merge is asynchronous: labelling queues it, and GitHub completes it when the checks
+finish. Wait for it before touching the worktree. Pass the script below as the `command` of
+a `Monitor` call — not to Bash with `run_in_background`:
+
+```
+for i in $(seq 1 40); do
+  s=$(gh pr view <pr> --json state -q .state 2>/dev/null || echo "")
+  case "$s" in
+    MERGED) echo "PR <pr> MERGED"; exit 0;;
+    CLOSED) echo "PR <pr> CLOSED without merging"; exit 1;;
+  esac
+  sleep 15
+done
+echo "PR <pr> still OPEN after 10m"; exit 1
+```
+
+Both failure paths exit non-zero so an unmerged close or a timeout cannot be mistaken for
+success by anything that reads the exit code rather than the emitted line.
+
+If a required check fails, auto merge stays armed and the pull request stays open; fix the
+failure, push, and it merges when the rerun is green. If it stays `OPEN` with nothing
+running, report it rather than merging by hand.
+
+**Never delete the remote branch.** The `delete-merged-branch` job in
+`.github/workflows/<merge.workflow>` owns remote cleanup; leave it to do its job. `git push
+--delete` is denied by the operator's settings, and a subagent must not work around that
+rule. Clean up only what you created locally: your own worktree and your own local branch.
+
+`deleteBranchOnMerge` on the repository does **not** cover this. It fires for a merge a
+person performs, not for one the auto merge workflow performs with its `GITHUB_TOKEN`, which
+is why that job exists at all. If a branch outlives its merge, the fix belongs in the
+workflow, not in a `git push` here.
+
+### Close the issue
+
+Once the state really is `MERGED`, one thing the repository normally does on your behalf
+will not have happened: a merge performed by the workflow's `GITHUB_TOKEN` does not close
+the issue the way a merge performed by a person does. A `Closes #<n>` line in the pull
+request body has been observed not closing it. It is not a formality — an issue left open is
+one the next invocation of this skill selects again, so the loop re-implements work it has
+already merged:
+
+```
+gh issue view <n> --json state -q .state
+```
+
+If that says `OPEN`, close it explicitly, and say in the comment which pull request did the
+work so the trail is not just a bare state change:
+
+```
+gh issue close <n> --repo <repo> --comment "Implemented in #<pr>, merged as <sha>."
+```
+
+Re-read the state afterwards and confirm it is `CLOSED` before moving on.
+
+### Drop the worktree
+
+```
+git worktree remove <worktreeDir>/issue-<n>
+```
+
+Then bring the main checkout up to date so the next iteration branches from the merged
+state, and delete your own local branch. `git worktree list` reports the main checkout
+first, so this needs no hard-coded path:
+
+```
+MAIN=$(git worktree list --porcelain | head -1 | cut -d' ' -f2-)
+git -C "$MAIN" checkout <default-branch>
+git -C "$MAIN" pull
+git -C "$MAIN" branch -D issue-<n>
+```
+
+A stale *local* branch is what breaks a retry — `git worktree add -b issue-<n>` fails
+against an existing branch, and the retry then reports `BLOCKED` on a name collision rather
+than on anything real. The remote side needs nothing from you.
+
+If the pull request did not merge, leave the worktree in place and report `BLOCKED` with the
+pull request number and the last state you saw.
+
+## Report
+
+Finish with a short status: issue number and title, pull request number and URL, check
+result, whether the pull request reached `MERGED`, and any judgment call that shaped the
+public API.
+
+- When `review.required` is `true`: whether Copilot reviewed and what it flagged.
+- When `review.required` is `false`: say plainly that **the pull request merged without a
+  review**, because `review.required` is `false`. Do not leave that to be inferred from the
+  absence of a review line.
+
+If you stopped early, say exactly where and why, beginning the report with `BLOCKED`.
+
+## Stop conditions
+
+Stop and report — do not push through — if any of these happen:
+
+- `.claude/backlog.json` is missing, does not parse, or carries an unknown
+  `dependencies.style`.
+- The same CI failure survives three fix attempts.
+- Acceptance criteria are ambiguous enough that two readings produce materially different
+  public APIs.
+- Landing the pull request would require a force-push, a branch-protection override, or
+  discarding someone else's commits.
+- `git status` in the main checkout is dirty with changes you did not make.
+- `review.required` is `true` and the Copilot review declined, timed out, or was never
+  requested successfully.
+
+When you stop for one of these, begin the report with `BLOCKED` so the caller can tell a
+halted cycle from a finished one at a glance. `backlog:run-backlog` halts the loop on that
+word.

--- a/plugins/backlog/skills/next-issue/SKILL.md
+++ b/plugins/backlog/skills/next-issue/SKILL.md
@@ -236,12 +236,20 @@ ten minutes later.
 
 ## 6. Wait for checks
 
-Do not foreground a `sleep` loop. Either use `gh pr checks <pr> --watch --fail-fast`, or
-poll with `Monitor`.
+Pass this as the `command` of a `Monitor` call:
 
-Do **not** use Bash `run_in_background` for a wait loop. It has been observed exiting
-immediately without ever polling, which looks like a completed wait and reports whatever the
-first sample happened to be. `Monitor` is the tool for every wait in this cycle.
+```
+gh pr checks <pr> --repo <repo> --watch --fail-fast
+```
+
+**Not to Bash.** `--watch` blocks until every check finishes, which on a repository with real
+CI outlasts the Bash tool — the call is killed mid-wait, and a wait that never finished looks
+exactly like a pull request whose checks failed. Every wait in this cycle goes through
+`Monitor` for that reason; step 7 and step 10 are the same.
+
+Do **not** use Bash `run_in_background` either. It has been observed exiting immediately
+without ever polling, which looks like a completed wait and reports whatever the first sample
+happened to be.
 
 - Exit 0 → green, continue.
 - Failure → read the logs (`gh run view <id> --log-failed`), fix, push, and re-watch. After
@@ -253,136 +261,79 @@ first sample happened to be. `Monitor` is the tool for every wait in this cycle.
   branch has no required status check, seen from the other side — with no required check,
   the label in step 9 merges the pull request the instant it lands.
 
-## 7. Request the Copilot review
+## 7. The Copilot review — one call
 
 **If `review.required` is `false`, skip this step and step 8 entirely** and go to step 9.
 Nothing here is optional when it is `true`.
 
-Copilot is a **Bot**, not a User. Two things follow. The login is
-`copilot-pull-request-reviewer[bot]`, and passing a bare `reviewers[]=Copilot` to the REST
-endpoint `POST /pulls/<pr>/requested_reviewers` returns 200 while silently doing nothing —
-`requested_reviewers` stays empty and the wait below then times out on a review that was
-never requested.
-
-The GraphQL mutation is the reliable path. It takes `botIds`, not `reviewers`:
+Requesting the review, waiting for it, and deciding whether what landed *is* a review are one
+call. Pass it as the `command` of a `Monitor` call — the wait runs up to ten minutes, past the
+Bash tool's ceiling — and not to Bash with `run_in_background`:
 
 ```
-PR_ID=$(gh pr view <pr> --json id --jq .id)
-BOT_ID=$(gh api '/users/copilot-pull-request-reviewer[bot]' --jq .node_id)
-gh api graphql -f query='
-mutation($pr:ID!, $bot:ID!) {
-  requestReviews(input: {pullRequestId: $pr, botIds: [$bot], union: true}) {
-    pullRequest { reviewRequests(first:10) { nodes {
-      requestedReviewer { __typename ... on Bot { login } } } } }
-  }
-}' -f pr="$PR_ID" -f bot="$BOT_ID"
+"${CLAUDE_PLUGIN_ROOT}/scripts/await-review.sh" <pr>
 ```
 
-The bot ID is looked up by login rather than hard-coded. Confirm the response lists
-`copilot-pull-request-reviewer` under `reviewRequests` — an empty list means the request did
-not take.
+| exit | meaning | what you do |
+| --- | --- | --- |
+| 0 | a review **completed** — it left comments, or reported it generated none. stdout is its body | continue to step 8 |
+| 1 | the most recent review **declined** the work; stdout is why | `BLOCKED`, and do **not** label. If it is the 300-file limit, say so and suggest how the work could be split |
+| 2 | timed out waiting | re-run it; it resumes. If it times out again, `BLOCKED` |
+| 3 | the review could not be requested — Copilot code review is probably not enabled for this organisation | `BLOCKED`, naming that |
+| 4 | usage or precondition failure | `BLOCKED`; the plugin or the environment is wrong, not the pull request |
 
-REST also works *provided the full bot login is used*, and is a reasonable fallback if the
-mutation errors:
+**Only exit 0 lets you label the pull request in step 9.**
 
-```
-gh api --method POST repos/<repo>/pulls/<pr>/requested_reviewers \
-  -f "reviewers[]=copilot-pull-request-reviewer[bot]" -q '.number'
-```
+### Why this is a script
 
-Either way, confirm the login appears in `requested_reviewers` before you start waiting.
+"Did Copilot review this?" looks like one question and is two, and the cycle used to answer
+them in places far enough apart that the second could be skipped. The wait was a polling loop
+that exited on the first `reviewed` event; whether that review had *declined* the work was a
+separate command sixty lines further down, under its own heading. Copilot posts a review
+whose body declines — most often `"Copilot wasn't able to review this pull request because it
+exceeds the maximum number of files (300)"` — and that decline satisfies any `length > 0`
+test. It has been missed in the wild: a vendored test suite pushed a pull request past the
+limit, Copilot declined, the check passed, and the cycle merged with no review at all.
 
-### Wait for the review to land
+The label in step 9 **is** the assertion that a review completed. Making it an exit code is
+what stops that assertion depending on an agent remembering a second question at the very end
+of the longest part of the cycle.
 
-Pass this as the `command` of a `Monitor` call — not to Bash with `run_in_background`, for
-the reason in step 6:
+Four findings live inside the script rather than in prose here, each of which cost a
+debugging session:
 
-```
-for i in $(seq 1 40); do
-  n=$(gh api --paginate repos/<repo>/issues/<pr>/timeline \
-        --jq '.[]|select(.event=="reviewed")
-              |select(.user.login|test("copilot";"i"))|.id' 2>/dev/null | wc -l)
-  if [ "$n" -gt 0 ]; then echo "copilot review landed"; exit 0; fi
-  sleep 15
-done
-echo "copilot review timed out"; exit 1
-```
+- Copilot is a **Bot**, not a User. The GraphQL mutation takes `botIds`; a bare
+  `reviewers[]=Copilot` on the REST endpoint returns 200 while doing nothing, and the wait
+  then times out on a review that was never requested. REST works only with the full
+  `copilot-pull-request-reviewer[bot]` login. The bot's node ID is looked up rather than
+  hard-coded.
+- The wait polls the **timeline**, not `pulls/<pr>/reviews`. The reviews endpoint has been
+  seen empty for forty minutes after Copilot had in fact submitted, so polling it times out
+  on a pull request that *was* reviewed.
+- `--paginate`, because the timeline returns thirty events per page and a pull request with a
+  few pushes and check runs pushes the `reviewed` event off page one.
+- A case-insensitive `copilot` login filter, without which the repository owner glancing at
+  the pull request ends the wait and step 9 decides on a review that never arrived.
 
-Two filters, both load bearing.
-
-`--paginate`, because the timeline returns thirty events per page by default, and a pull
-request that saw several pushes, check runs and comments will push the `reviewed` event off
-the first page — where an unpaginated read reports zero and the loop times out on a reviewed
-pull request, which is the exact failure this step exists to avoid. Counting `.id` lines
-rather than taking a `length` per page is what makes the count work across pages.
-
-The `copilot` login filter, because a `reviewed` event from *anyone* would otherwise end the
-wait. The repository owner reviewing a pull request while Copilot was still working would
-satisfy this loop, and step 9 would then be deciding on a review that never arrived. The
-gate is specifically that Copilot completed; the wait has to be specific in the same way.
-Matching is case-insensitive on purpose — the timeline reports this reviewer as `Copilot`
-while the `pulls/` endpoints report `copilot-pull-request-reviewer[bot]`.
-
-The wait polls the **timeline**, not `pulls/<pr>/reviews`. The reviews endpoint — and the
-equivalent GraphQL query — have been seen returning an empty array for as long as forty
-minutes after Copilot had in fact submitted, while the timeline showed it immediately.
-Polling the reviews endpoint therefore produces a timeout on a pull request that was
-reviewed, and that reads as a missing review rather than as the API lagging.
-
-**Never report `BLOCKED` for a missing review without checking the timeline first:**
-
-```
-gh api --paginate repos/<repo>/issues/<pr>/timeline \
-  --jq '.[]|select(.event=="reviewed")|select(.user.login|test("copilot";"i"))' \
-  | jq -s 'sort_by(.submitted_at)|last|{user:.user.login,state,body}'
-```
-
-Same two filters, for the same two reasons — without the login filter this returns whichever
-review is newest, which after a human comment is not Copilot's. And `jq -s` because it
-slurps the per-page objects back into one array before sorting: sorting inside `--jq` would
-sort each page separately and give you the last review *of the last page*, not the last
-review.
-
-### A non-empty reviews array does not mean the pull request was reviewed
-
-Copilot posts a review whose body **declines** the work — most often `"Copilot wasn't able
-to review this pull request because it exceeds the maximum number of files (300)"` — and
-that decline satisfies a naive `length > 0` test. Check the body before treating the review
-as real.
-
-Read the **most recent** Copilot review only. Reruns and pushed fixes leave older reviews in
-the array, so an earlier decline sitting beside a later completed review — or the reverse —
-is easy to misread:
-
-```
-gh api repos/<repo>/pulls/<pr>/reviews \
-  --jq '[.[] | select(.user.login | test("copilot";"i"))]
-        | sort_by(.submitted_at) | last | .body // "no copilot review"'
-```
-
-A body matching `wasn't able to review` is a **declined** review, not a completed one. This
-has been seen in the wild: vendored test suites pushed a pull request past the 300-file
-limit, Copilot declined, the `length > 0` check passed, and the cycle merged with no review
-at all.
-
-If the review is declined, times out, or the request itself errors (Copilot code review not
-enabled for the organisation), the cycle does **not** label the pull request — see step 9.
+Re-running is safe: a Copilot review already on the pull request is classified and returned
+without requesting another, and the newest review wins, so an old decline sitting beside a
+newer completed review is not misread.
 
 ## 8. Address the review
 
 **Skipped entirely when `review.required` is `false`.**
 
-Pull both the summary review and the inline comments — a review whose body says it
-`generated no comments` still counts as having reviewed:
+Step 7 already printed the summary body on stdout. What it does not carry is the inline
+comments, which is what you are here for:
 
 ```
-gh api repos/<repo>/pulls/<pr>/reviews  --jq '.[] | "\(.user.login) [\(.state)]\n\(.body)"'
 gh api repos/<repo>/pulls/<pr>/comments --jq '.[] | "[\(.id)] \(.path):\(.line)\n\(.body)"'
 ```
 
-If the reviews endpoint is still lagging (step 7), read the body from the timeline instead —
-the `reviewed` events carry the same `state` and `body`. An empty result here is a stale
-endpoint, not an absent review.
+An empty result is normal — a review whose body says it `generated no comments` still counts
+as having reviewed, and step 7 exited 0 on it. If you want the summary again, take it from
+step 7's output rather than from `pulls/<pr>/reviews`, which lags (see step 7) and will
+happily return an empty array for a review that landed.
 
 Use judgment. Fix what is a real defect or a genuine improvement. Where a comment is wrong
 or does not apply, reply on the thread explaining why rather than making the change — do not
@@ -421,9 +372,8 @@ immediately, if they have already passed — and leaves it open if one fails.
 Apply the label only when **both** hold:
 
 1. Checks are green, and
-2. **either** `review.required` is `false`, **or** a Copilot review actually **completed** —
-   it either left comments (every one now addressed or answered) or reported that it
-   generated none.
+2. **either** `review.required` is `false`, **or** step 7 exited **0** — a review actually
+   completed, and every comment it left is now addressed or answered.
 
 This is not a formality to route around: the label **is** the assertion that you verified
 both conditions, and adding it without having done so is the same failure as merging
@@ -435,9 +385,8 @@ label gate plus the branch protection rule — rather than in a decision made mi
 visible only in a transcript. It is also what lets the loop run unattended: an agent merging
 on its own is blocked, and labelling is not.
 
-When `review.required` is `true`, a review that was declined, never arrived, or was never
-requested because the request errored is **not** a completed review. Do **not** label the
-pull request. Leave it open, leave the worktree in place, and stop with a report beginning
+When `review.required` is `true`, any exit from step 7 other than 0 — declined (1), timed out
+(2), never requested (3) — is **not** a completed review. Do **not** label the pull request. Leave it open, leave the worktree in place, and stop with a report beginning
 `BLOCKED` that names the pull request and why the review is missing, so the user can tell a
 pull request that needs a human look from one that merged on its own. Sending unreviewed
 work to the default branch is the one step of this cycle that is not yours to take
@@ -467,8 +416,12 @@ Do not conclude anything from `OPEN not-armed` until the workflow run has actual
 The run list is what disambiguates:
 
 ```
-gh run list --repo <repo> --workflow <merge.workflow> --limit 1
+gh run list --repo <repo> --workflow <merge.workflow> --branch issue-<n> --limit 1
 ```
+
+`--branch` is what makes this your run. Without it, `--limit 1` is the most recent run of
+that workflow in the whole repository — anyone labelling another pull request while yours is
+queued hands you their result, and it reads as a verdict on yours.
 
 Wait for it to leave `queued` and `in_progress`. A `success` conclusion with the pull
 request still open means auto merge is armed and waiting on a check. A `failure` conclusion
@@ -558,8 +511,10 @@ order, and check the state after the close rather than assuming it:
 # 4. re-read the state and confirm CLOSED
 # 5. git worktree remove <worktreeDir>/issue-<n>
 #    MAIN=$(git worktree list --porcelain | head -1 | cut -d' ' -f2-)
-#    git -C "$MAIN" checkout <default-branch> && git -C "$MAIN" pull --ff-only
 #    git -C "$MAIN" branch -D issue-<n>
+#    # fast-forward the main checkout ONLY if it is already on <default-branch>;
+#    # moving the branch the operator left it on is not this cycle's to do, and
+#    # step 2 branches from origin/<default-branch> regardless
 ```
 
 A stale *local* branch is what breaks a retry — `git worktree add -b issue-<n>` fails
@@ -597,8 +552,8 @@ Stop and report — do not push through — if any of these happen:
 - Landing the pull request would require a force-push, a branch-protection override, or
   discarding someone else's commits.
 - `git status` in the main checkout is dirty with changes you did not make.
-- `review.required` is `true` and the Copilot review declined, timed out, or was never
-  requested successfully.
+- `review.required` is `true` and `await-review.sh` exited non-zero — the review declined,
+  timed out, or could not be requested.
 
 When you stop for one of these, begin the report with `BLOCKED` so the caller can tell a
 halted cycle from a finished one at a glance. `backlog:run-backlog` halts the loop on that

--- a/plugins/backlog/skills/run-backlog/SKILL.md
+++ b/plugins/backlog/skills/run-backlog/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: run-backlog
+description: Drive a repository's story backlog unattended, one issue at a time, by spawning a fresh `issue-worker` subagent per iteration and halting on `BACKLOG EMPTY`, on `BLOCKED`, or at a bounded iteration count. Use this whenever the user wants the backlog worked continuously rather than a single issue — "run the backlog", "work through the issues", "keep taking stories until you run out", "drain the milestone", or a `/loop` that repeats the cycle. Takes an optional integer argument setting the maximum number of iterations. Skip this when the user wants exactly one issue (`backlog:next-issue`) or wants the repository bootstrapped first (`backlog:setup-backlog`).
+allowed-tools: Agent, Bash, Read, Glob, Grep, TaskCreate, TaskUpdate, ScheduleWakeup
+---
+
+# run-backlog
+
+Work the backlog until it is empty, something blocks, or the iteration bound is reached.
+
+You are the driver, not the worker. Every iteration is done by a **fresh subagent** and none
+of it happens in your context.
+
+That is the whole design, and it is not an optimisation. One issue's implementation — the
+files read, the tests written, the CI logs, the review thread — is far more context than the
+decision "keep going or stop" needs. Working an issue yourself gets you three or four
+iterations in before the context that made the first one go well has been squeezed out by
+the details of the third. A subagent per iteration means iteration twelve starts as clean as
+iteration one, and all you ever hold is a list of one-line outcomes.
+
+## 0. Preflight
+
+Run these once, before the first iteration, and stop if any fails:
+
+1. **Config present.** `jq . .claude/backlog.json`. If it is missing or does not parse,
+   stop and say so, naming `backlog:setup-backlog`. Do not start a loop that will fail
+   identically on every iteration.
+2. **Main checkout clean.** `git status --porcelain` in the repository root. Uncommitted
+   changes you did not make are a stop condition for the cycle, so they are a stop condition
+   for the loop; report what is dirty and let the user decide.
+3. **Auth.** `gh auth status`. An expired token turns every iteration into the same
+   opaque failure.
+
+Also settle the **bound** now. It is the skill's argument when one was given; otherwise
+default to **10** iterations. Say the number in your first message. An unbounded loop
+against a large backlog is not the user asking for autonomy, it is the user losing the
+chance to look at the first result before the twentieth lands on top of it.
+
+## 1. The loop
+
+For each iteration up to the bound:
+
+```
+Agent(
+  subagent_type: "issue-worker",
+  description: "backlog iteration <i>",
+  prompt: "Run one iteration of the backlog cycle in <absolute path to the repository root>.
+           Invoke the backlog:next-issue skill and follow it exactly. Take exactly one issue
+           end to end, then stop. Return the cycle's report as your final message, with its
+           first line unchanged — BACKLOG EMPTY or BLOCKED where the skill calls for it."
+)
+```
+
+Check the agent types available to you before the first spawn. Depending on how the plugin
+was installed the worker may be listed as `issue-worker` or as `backlog:issue-worker`; use
+the name exactly as listed. If neither is present the plugin's `agents/` directory was not
+picked up — stop and say so rather than falling back to a general-purpose agent, which will
+not have the `Skill` tool and cannot invoke the cycle at all.
+
+Give the worker the repository root as an **absolute path**. It runs with a working-directory
+override, which is why `EnterWorktree` is unavailable to it and why `backlog:next-issue`
+leads with plain `git worktree add`.
+
+### After each iteration
+
+Read the worker's final message and act on its first line:
+
+| first line | do |
+| --- | --- |
+| `BACKLOG EMPTY` | **Halt.** The backlog holds no matching open issues. This is success, not failure. |
+| `BLOCKED …` | **Halt.** Report the worker's reason verbatim. |
+| anything else | Record a one-line outcome and continue to the next iteration. |
+
+Also halt if:
+
+- The worker returns nothing, errors, or is skipped. A silent worker is not an empty
+  backlog, and treating it as one hides a broken plugin install behind a clean finish.
+- Two consecutive iterations report the same issue number. That means the issue did not
+  close — the cycle would re-implement merged work on every remaining iteration. Report it;
+  the cause is usually a merge that did not land, or the explicit issue close being skipped.
+- The bound is reached. Say so plainly: a loop that stopped at its bound with work left is a
+  different outcome from a drained backlog, and the user's next move differs.
+
+Record per iteration: issue number and title, pull request number, and merged / blocked.
+Nothing else. Keep the running list short enough that you can still see all of it at the
+end.
+
+## 2. What you never do yourself
+
+- **Never run `gh pr merge`**, and never work an issue yourself when a worker fails. Beyond
+  the permission classifier refusing an agent-driven merge, a subagent that merges emits a
+  security banner into its caller's context which blocks the caller's next agent spawn.
+  That is your context and your next spawn: the loop dies on the *following* iteration, with
+  nothing at that point pointing back at the merge. If a worker's report suggests it merged
+  by hand, halt and say so — the next spawn is likely to fail regardless.
+- **Never implement the issue in your own context** when the worker reports `BLOCKED`. The
+  block is a request for a human, which is the one thing a loop cannot supply.
+- **Never widen the bound mid-run** because the backlog turned out to be longer. Finish,
+  report, and let the user re-run.
+
+## 3. Report
+
+Close with the iteration table, the reason the loop stopped in its own words
+(`BACKLOG EMPTY`, `BLOCKED`, bound reached, worker failure), and — if anything merged
+without a review because `review.required` is `false` — that fact, once, for the whole run.
+
+## Running it on a schedule
+
+`/loop` is the usual driver: it re-invokes this skill on an interval, and each invocation
+does its own bounded pass. Keep the bound small when looping, so the two levels of
+repetition do not multiply into an unattended run nobody has read the start of.
+
+The permission allow-list `backlog:setup-backlog` offers is what lets an unattended run
+proceed without a prompt on every `gh` call. Without it the loop stalls on the first
+permission dialog and looks like a hang.

--- a/plugins/backlog/skills/setup-backlog/SKILL.md
+++ b/plugins/backlog/skills/setup-backlog/SKILL.md
@@ -1,0 +1,356 @@
+---
+name: setup-backlog
+description: Bootstrap a repository for the unattended backlog cycle and verify the environment it depends on — write `.claude/backlog.json` with the label, dependency convention and verify commands inferred from the repository, install the auto-merge workflow, create the backlog and merge labels, and check squash-only merging, the default branch's required status checks and whether Copilot code review is actually enabled. Use this whenever the user wants to set up, bootstrap, install, onboard or enable the backlog loop on a repository, when `backlog:next-issue` stops because `.claude/backlog.json` is missing, or when the user wants to know why an unattended run keeps stalling. Skip this when the repository is already configured and the user simply wants work done — that is `backlog:next-issue` or `backlog:run-backlog`.
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
+---
+
+# setup-backlog
+
+Get a repository ready to run its backlog unattended, and — the half that actually saves
+time — check the things that will otherwise fail three iterations into an unattended run
+before anyone notices.
+
+Copying a workflow file in is easy. The failures that cost a run are environmental: Copilot
+code review not enabled for the organisation, a merge method other than squash still
+allowed, a default branch with no required status check so the merge label lands the pull
+request instantly and unverified. Those are the point of steps 4 and 5, and several of them
+you can only *report*, because fixing them takes repository-admin rights this agent does not
+have.
+
+Work through the steps in order and finish with one report covering all of them.
+
+## 0. Preflight
+
+```
+git rev-parse --show-toplevel
+gh auth status
+read -r REPO DEFAULT_BRANCH <<<"$(gh repo view --json nameWithOwner,defaultBranchRef \
+  --jq '"\(.nameWithOwner) \(.defaultBranchRef.name)"')"
+```
+
+Everything below runs from the repository root. `<repo>` and `<default-branch>` are those
+two values — resolved from GitHub, never written into any file this skill produces.
+
+Check the token's scopes in the `gh auth status` output while you are here. Pushing a file
+under `.github/workflows/` requires the `workflow` scope; without it step 3's file writes
+fine and the push that carries it is rejected, which is a confusing place to discover it.
+
+## 1. Infer the configuration
+
+Do not interview the user for what the repository already says.
+
+### `verify`
+
+**CI wins.** Read `.github/workflows/*.y*ml` and take the commands the pull request workflow
+actually runs. The entire value of this list is that a local pass predicts a green pull
+request, so a command CI runs that is missing here becomes a red pull request the cycle then
+iterates on, and a command here that CI does not run is wasted time on every iteration.
+
+Where CI is unreadable or absent, fall back on what the repository is built from. Union the
+rows that match, and dedupe:
+
+| detector | fallback commands |
+| --- | --- |
+| `go.mod` | `go build ./...`, `go vet ./...`, `go test -race ./...`, `gofmt -l .` |
+| `dagger.json` | `dagger functions` — it loads and type-checks the module, which is the cheap smoke test; prefer whatever `dagger call` CI runs |
+| `package.json` | the subset of `lint`, `test`, `build` that actually exists in `.scripts`, as `npm run <name>` (`npm test` for `test`) |
+
+Two extras worth catching from CI rather than from the fallback table, because they are
+common and neither is implied by `go.mod`: a linter run as its own job (`staticcheck ./...`,
+`golangci-lint run`), and a tool with a version floor. If CI pins a tool version, say so in
+the report — a stale local binary failing on a version mismatch is not a code defect, and an
+unattended run will otherwise spend its three fix attempts on it.
+
+### `dependencies.style`
+
+Read an actual issue body. Do not ask.
+
+```
+gh issue list --state open --limit 20 --json number --jq '.[].number'
+```
+
+Fetch a handful of those bodies (`gh issue view <n> --json body --jq .body`) and look for
+which convention is in use:
+
+- A line containing `Blocked by:` followed by `- #N` items → `blocked-by`.
+- `Depends on #N` written inline → `depends-on`.
+- Neither, across every body you read → `none`.
+
+Say in the report which issues you read and what you concluded. `none` inferred from a
+backlog that has simply not declared any ordering *yet* is the one inference worth
+double-checking with the user, because it is indistinguishable from a convention you did not
+sample — and getting it wrong means work happens in the wrong order rather than not at all.
+
+### The rest
+
+- `select.label` — the label the backlog uses. `gh label list --json name --jq '.[].name'`;
+  if `story` exists, take it. If the repository clearly uses another (`feature`, `task`),
+  take that and say so. If none exists, `story`, and step 4 creates it.
+- `select.milestone` — `gh api repos/<repo>/milestones --jq '.[] | "\(.title) \(.open_issues)"'`.
+  Exactly one open milestone with open issues is a reasonable inference; anything else is
+  `null`, which means "every open issue with the label".
+- `select.limit` — `200`.
+- `merge.label` / `merge.workflow` — `auto-merge` and `auto-merge.yaml`, matching the asset
+  step 3 installs. If you change either, change both, plus the `github.event.label.name`
+  guard inside the workflow.
+- `review.required` — `true` unless step 5 finds Copilot code review is not enabled; see
+  there.
+- `worktreeDir` — `.claude/worktrees`.
+
+Write the result to `.claude/backlog.json`, validated against
+`${CLAUDE_PLUGIN_ROOT}/assets/backlog.schema.json`. Neither the repository slug nor the
+default branch goes in it — `backlog:next-issue` reads both from `gh repo view`, so a fork
+or a rename cannot leave the config describing a repository it is no longer in.
+
+If `.claude/backlog.json` already exists, do not overwrite it. Diff your inference against
+it, report the differences, and let the user decide.
+
+Add `worktreeDir` to `.gitignore` if it is not covered already.
+
+## 2. Never hard-code the repository anywhere
+
+Worth stating once because it is the failure mode this plugin exists to remove: nothing this
+step writes — not the config, not the workflow, not the labels — carries the repository name,
+the default branch name, or a check name. Every one of those is resolved at run time. A
+config that names its own repository is a config that survives a rename by describing the
+wrong thing.
+
+## 3. Install the merge workflow
+
+```
+cp "${CLAUDE_PLUGIN_ROOT}/assets/auto-merge.yaml" .github/workflows/auto-merge.yaml
+```
+
+**Refuse to clobber.** If `.github/workflows/auto-merge.yaml` already exists, do not copy
+over it. Diff the two and report:
+
+```
+diff -u .github/workflows/auto-merge.yaml "${CLAUDE_PLUGIN_ROOT}/assets/auto-merge.yaml"
+```
+
+Identical → nothing to do, say so. Different → show the diff and let the user choose. The
+existing file may carry a local change that matters, and the comments in the asset are the
+reasoning behind every clause in it — silently replacing one with the other destroys
+whichever of the two was the considered version.
+
+Do not commit or push. Leave the file in the working tree and say in the report that it
+needs a commit, and that pushing it needs the `workflow` token scope from step 0.
+
+## 4. Create the labels
+
+Both must exist before the cycle runs: the backlog label is what selects issues, and the
+merge label is what the workflow's `labeled` guard matches. A missing merge label is
+especially quiet — `gh pr edit --add-label` fails, or creates it and no workflow reacts.
+
+Idempotent, so re-running this skill is safe:
+
+```
+gh label list --json name --jq '.[].name'
+```
+
+Create only what is missing:
+
+```
+gh label create <select.label> --description "Backlog work item" --color 0E8A16
+gh label create <merge.label>  --description "Hand this pull request to the auto merge workflow" --color 1D76DB
+```
+
+Report each as created or already present. `gh label create` on an existing label exits
+non-zero with `already exists`; that is a no-op, not a failure, but check the list first
+rather than swallowing errors.
+
+## 5. Verify the environment
+
+This is the half that cannot be fixed by writing a file. Run all of it, report all of it,
+and mark each result **ok**, **needs a change**, or **needs admin rights**.
+
+A `403` is **needs admin rights**, not a failure. It means the endpoint exists and the token
+cannot read it — report the check as unverified and name what the user needs to look at.
+Reporting it as a failure sends someone chasing a problem that may not be there.
+
+### Squash-only merging
+
+```
+gh repo view --json squashMergeAllowed,mergeCommitAllowed,rebaseMergeAllowed,deleteBranchOnMerge
+```
+
+- `squashMergeAllowed: false` → **needs a change**, and it is load bearing: the workflow runs
+  `gh pr merge --squash --auto`, which fails outright.
+- `mergeCommitAllowed` or `rebaseMergeAllowed` true → hygiene. The workflow always squashes,
+  so nothing breaks; it just means a human can land history in another shape.
+- `deleteBranchOnMerge` either way → note it and move on. It does **not** cover this cycle:
+  it fires for a merge a person performs, not for one the workflow performs with its
+  `GITHUB_TOKEN`, which is exactly why the workflow carries its own `delete-merged-branch`
+  job.
+
+### Required status checks on the default branch
+
+Two mechanisms can impose them, and a repository can use either. Check **both** — finding
+nothing in one is not evidence of nothing.
+
+Classic branch protection (admin-only to read):
+
+```
+gh api repos/<repo>/branches/<default-branch>/protection \
+  --jq '.required_status_checks.contexts'
+```
+
+Rulesets — `rules/branches` returns the rules *in effect* for a branch and needs no admin
+rights, which makes it the one to lead with:
+
+```
+gh api repos/<repo>/rules/branches/<default-branch> \
+  --jq '[.[] | select(.type=="required_status_checks")
+        | .parameters.required_status_checks[].context]'
+```
+
+- Checks found in either → **ok**. Name them.
+- `403` on protection with an empty ruleset result → **needs admin rights**. Say the check
+  is unverified.
+- Nothing anywhere, both readable → **needs a change**, and explain the consequence rather
+  than just the fact: with no required check, the merge label arms auto merge and GitHub
+  merges the pull request immediately, so the cycle's own local verification is the only
+  thing that ever looked at the code.
+
+### Copilot code review
+
+**There is no reliable API for whether Copilot code review is enabled.** Say that plainly in
+the report — an inference presented as a lookup is worse than no check at all, because it
+retires the question.
+
+Infer from what the repository shows. A single repo-wide call for the fast positive:
+
+```
+gh api --paginate "repos/<repo>/pulls/comments?per_page=100" \
+  --jq '[.[] | select(.user.login|test("copilot";"i"))] | length'
+```
+
+A non-zero count is proof it has worked here. Zero is not proof of the opposite: a review
+that generated no comments leaves none behind. Check recent pull request timelines too —
+`reviewed` events survive a comment-free review:
+
+```
+for pr in $(gh pr list --state all --limit 5 --json number --jq '.[].number'); do
+  gh api --paginate "repos/<repo>/issues/$pr/timeline" \
+    --jq '.[]|select(.event=="reviewed")|select(.user.login|test("copilot";"i"))|.user.login'
+done
+```
+
+Report the verdict with its basis attached — "inferred from N recent pull requests", not
+"enabled". On a repository with few or no pull requests there is nothing to infer from; say
+that instead of guessing, and note that the definitive test is the first real cycle, where
+`backlog:next-issue` requests a review and either gets one or reports `BLOCKED`.
+
+If the evidence says Copilot does not review here, that is what `review.required: false` is
+for. Offer it explicitly as a downgrade, not a default: with it, pull requests merge with no
+review at all, and every run says so in its report.
+
+## 6. Offer the permission allow-list
+
+An unattended loop that stops on a permission dialog looks like a hang. The allow-list is
+what prevents it.
+
+It belongs in **`~/.claude/settings.json`**, not in the repository. This list is not
+repository-specific, it is *operator*-specific — the same `git`, `gh` and worktree calls on
+every repository the operator runs the loop against. Per-repository copies are how two
+repositories running the identical cycle ended up with different rules, and how a finding
+learned on one stayed on one.
+
+**Ask before writing it**, showing the entries. Only write `~/.claude/settings.json` on
+explicit confirmation, and merge into the existing `permissions.allow` / `permissions.deny`
+arrays rather than replacing them — that file is the operator's, and it governs every
+project they open. If they decline, offer the repository's `.claude/settings.json` instead
+and say what that costs: the next repository starts from nothing again.
+
+Core list, language-agnostic:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Read", "Glob", "Grep", "Agent", "Skill",
+      "Monitor", "TaskCreate", "TaskUpdate", "ScheduleWakeup",
+      "EnterWorktree", "ExitWorktree",
+      "Edit(**)",
+      "Bash(git status*)", "Bash(git diff*)", "Bash(git log*)", "Bash(git show*)",
+      "Bash(git add*)", "Bash(git commit*)", "Bash(git checkout*)", "Bash(git switch*)",
+      "Bash(git branch*)", "Bash(git fetch*)", "Bash(git pull*)", "Bash(git push*)",
+      "Bash(git rebase*)", "Bash(git merge*)", "Bash(git worktree*)", "Bash(git remote*)",
+      "Bash(git rev-parse*)",
+      "Bash(gh issue*)", "Bash(gh pr*)", "Bash(gh run*)", "Bash(gh api*)",
+      "Bash(gh repo view*)", "Bash(gh label*)", "Bash(gh workflow*)", "Bash(gh auth status*)",
+      "Bash(ls*)", "Bash(mkdir*)", "Bash(jq*)", "Bash(rg*)", "Bash(find*)", "Bash(diff*)"
+    ],
+    "deny": [
+      "Bash(git push --force*)", "Bash(git push -f*)", "Bash(git push --delete*)",
+      "Bash(git stash*)",
+      "Bash(gh repo delete*)", "Bash(gh repo archive*)",
+      "Bash(gh api --method DELETE*)", "Bash(gh api -X DELETE*)",
+      "Bash(gh auth logout*)", "Bash(gh auth token*)",
+      "Bash(rm -rf*)"
+    ]
+  }
+}
+```
+
+Then append only the toolchain entries the `verify` list from step 1 actually needs — `go
+build*`, `go test*`, `gofmt*`, `npm*`, `dagger*`, a linter. Granting a language's toolchain
+to an operator who does not write that language is noise in the file they read most.
+
+Three entries carry a reason, because each of them was a difference between two repositories
+running this same cycle:
+
+- **`Bash(git stash*)` is denied.** The stash stack is shared across every worktree of a
+  repository, so a pop can restore work belonging to another session. An unattended loop is
+  precisely the caller that will not notice. Set work aside with a temporary commit.
+- **`Bash(git push --delete*)` is denied**, and the merge workflow's `delete-merged-branch`
+  job does remote cleanup instead. An unattended loop working around a rule its operator set
+  is the wrong shape regardless of whether any single deletion was harmless.
+- **`Skill` is granted.** Without it the `issue-worker` agent cannot invoke
+  `backlog:next-issue` at all, and the failure surfaces as a subagent that returns having
+  done nothing.
+
+`gh api --method DELETE` is denied while `gh api` is allowed, and the order matters: deny
+rules win, so the broad allow does not reopen the narrow deny.
+
+### The per-repository half
+
+One thing genuinely does stay per-repository, in `.claude/settings.local.json`: the
+operator's statement that *this* repository's loop is authorised to run unattended. Without
+it, a subagent reporting that it landed a pull request with no human approval can read as a
+policy violation and cause the following iterations to be denied.
+
+Show the user this and let them decide — do not write it for them. It is an authorisation,
+and an agent writing its own authorisation is not one:
+
+```json
+{
+  "permissions": {
+    "autoMode": {
+      "allow": [
+        "$defaults",
+        "The backlog loop in this repository is authorized by the repository owner to run unattended. Spawning a subagent per story issue is expected. Landing a pull request once CI passes and Copilot's automated review has landed is the intended workflow: no human approval is required on these pull requests by design, and their absence is not a reason to block. A subagent reporting that it landed such a pull request without human review is reporting the expected outcome, not a policy violation, and must not cause subsequent iterations to be denied."
+      ]
+    }
+  }
+}
+```
+
+## 7. Report
+
+One report, covering:
+
+1. `.claude/backlog.json` — written, or diffed against an existing one. Show the inferred
+   `verify` and `dependencies.style` with the evidence each came from.
+2. The workflow — copied, identical, or differing (with the diff).
+3. Labels — created or already present.
+4. The environment table: squash-only, required status checks, Copilot. Each **ok**,
+   **needs a change**, or **needs admin rights**, with the consequence spelled out for
+   anything not ok.
+5. Permissions — written where, or declined.
+6. What is left for a human: the commit and push of the workflow file (and the `workflow`
+   token scope it needs), anything needing admin rights, and the `autoMode` statement if
+   they want one.
+
+Finish by naming the next step: `backlog:run-backlog` to work the backlog, or
+`backlog:next-issue` for a single issue.

--- a/plugins/backlog/skills/setup-backlog/SKILL.md
+++ b/plugins/backlog/skills/setup-backlog/SKILL.md
@@ -133,13 +133,14 @@ existing file may carry a local change that matters, and the comments in the ass
 reasoning behind every clause in it — silently replacing one with the other destroys
 whichever of the two was the considered version.
 
-One diff line is worth calling out by name: **`issues: write` in the `permissions:` block.**
-An older copy of this workflow grants only `contents: write` and `pull-requests: write`, and
-on that copy a merge does not close the linked issue even though the pull request's
-`closingIssuesReferences` registered correctly — the auto-close runs as
-`github-actions[bot]` and is bounded by that block. The cycle closes the issue explicitly
-regardless, so this is the cheap half of a belt and braces rather than the fix; recommend it
-in the report when the existing file lacks it.
+Two differences are worth calling out by name if the existing file is an older copy:
+
+- **No `close-linked-issues` job.** A `Closes #N` line does not close the issue when a token
+  performs the merge, even though `closingIssuesReferences` registers correctly. Granting
+  `issues: write` was tested as the explanation on a real merge and did not fix it, so the
+  asset closes linked issues with an explicit `gh issue close` instead.
+- **No `Mint a GitHub App installation token` step.** This is the load-bearing one; see the
+  App check in step 5.
 
 Do not commit or push. Leave the file in the working tree and say in the report that it
 needs a commit, and that pushing it needs the `workflow` token scope from step 0.
@@ -175,6 +176,44 @@ and mark each result **ok**, **needs a change**, or **needs admin rights**.
 A `403` is **needs admin rights**, not a failure. It means the endpoint exists and the token
 cannot read it — report the check as unverified and name what the user needs to look at.
 Reporting it as a failure sends someone chasing a problem that may not be there.
+
+### The App token — check this one first
+
+Everything the merge workflow does *after* the merge depends on it. GitHub does not create
+workflow runs from events triggered by `GITHUB_TOKEN`, so when the workflow merges with its
+own token the resulting `closed` event starts no run at all: `close-linked-issues` and
+`delete-merged-branch` are both skipped, silently, every time. Measured across ten merges in
+two repositories — every run showed the branch job `skipped`, twenty-four merged branches
+survived, and the only run where it fired was a pull request a person had merged by hand.
+
+An App installation token is a different actor, so its events cascade normally.
+
+```
+gh secret list --repo <repo> --json name --jq '[.[].name]'
+```
+
+`BACKLOG_APP_ID` and `BACKLOG_APP_KEY` must both be present. A `403` here is **needs admin
+rights**, not a failure.
+
+When they are missing, report it as **needs a change** with the consequence stated — merged
+branches will accumulate with nothing to collect them, and the linked-issue close falls
+entirely to the cycle's own `finish-issue` step — and give the setup, which needs a human:
+
+1. Create a GitHub App (any account you control; it does not need to be public).
+2. Install it on this repository with **Contents**, **Pull requests** and **Issues** set to
+   **Read and write**.
+3. Add its App ID as `BACKLOG_APP_ID` and its PEM private key as `BACKLOG_APP_KEY`.
+
+The loop still works without it. Nothing merges unreviewed and no issue goes unclosed — the
+cycle's own close covers that — so this is a degradation, not a blocker. Report it as one.
+
+Check the symptom directly too, since it is the thing an operator will actually notice:
+
+```
+gh api --paginate repos/<repo>/branches --jq '.[].name' | wc -l
+```
+
+A pile of branches named after already-merged issues is this problem, not untidiness.
 
 ### Squash-only merging
 

--- a/plugins/backlog/skills/setup-backlog/SKILL.md
+++ b/plugins/backlog/skills/setup-backlog/SKILL.md
@@ -72,9 +72,23 @@ gh issue list --state open --limit 20 --json number --jq '.[].number'
 Fetch a handful of those bodies (`gh issue view <n> --json body --jq .body`) and look for
 which convention is in use:
 
-- A line containing `Blocked by:` followed by `- #N` items → `blocked-by`.
+- A line opening with `Blocked by:` followed by `- #N` items → `blocked-by`.
 - `Depends on #N` written inline → `depends-on`.
 - Neither, across every body you read → `none`.
+
+Confirm the guess against the extractor the cycle will actually use, rather than against
+your reading of the body — they are not the same thing, and the one that decides eligibility
+is the extractor:
+
+```
+gh issue view <n> --json body --jq .body \
+  | "${CLAUDE_PLUGIN_ROOT}/scripts/select-issue.sh" --extract <style>
+```
+
+It prints one reference per line — `#14` for this repository, `owner/repo#N` for anywhere
+else — and nothing when the convention is absent. A style that extracts nothing from bodies
+that plainly declare ordering means the repository uses a third convention neither value
+models; say so rather than picking the closer of the two.
 
 Say in the report which issues you read and what you concluded. `none` inferred from a
 backlog that has simply not declared any ordering *yet* is the one inference worth

--- a/plugins/backlog/skills/setup-backlog/SKILL.md
+++ b/plugins/backlog/skills/setup-backlog/SKILL.md
@@ -133,6 +133,14 @@ existing file may carry a local change that matters, and the comments in the ass
 reasoning behind every clause in it — silently replacing one with the other destroys
 whichever of the two was the considered version.
 
+One diff line is worth calling out by name: **`issues: write` in the `permissions:` block.**
+An older copy of this workflow grants only `contents: write` and `pull-requests: write`, and
+on that copy a merge does not close the linked issue even though the pull request's
+`closingIssuesReferences` registered correctly — the auto-close runs as
+`github-actions[bot]` and is bounded by that block. The cycle closes the issue explicitly
+regardless, so this is the cheap half of a belt and braces rather than the fix; recommend it
+in the report when the existing file lacks it.
+
 Do not commit or push. Leave the file in the working tree and say in the report that it
 needs a commit, and that pushing it needs the `workflow` token scope from step 0.
 


### PR DESCRIPTION
Closes #322

`z5labs/dfcad` and `z5labs/rdf-go` each carry a ~450-line `.claude/commands/next-issue.md`
driving an unattended backlog loop. The two files are the same document — every difference
is a knob — and the duplication has already drifted, leaving the finding that *a subagent
running `gh pr merge` emits a security banner that kills the caller's next spawn* living in
exactly one repo. This packages the cycle as a plugin so a third repo installs the flow
rather than copying it and re-learning the footnotes.

## Layout

```
plugins/backlog/
  .claude-plugin/plugin.json
  skills/next-issue/SKILL.md       # one issue, end to end
  skills/run-backlog/SKILL.md      # the loop driver
  skills/setup-backlog/SKILL.md    # bootstrap and verify a target repo
  agents/issue-worker.md
  assets/auto-merge.yaml
  assets/backlog.schema.json
```

## Notes on judgment calls

- **The schema forbids a repo slug.** `additionalProperties: false` at the root means a
  `repo` key is a validation error, not just an unused one — the "resolve it from
  `gh repo view`" decision is enforced structurally rather than by prose. Same mechanism
  keeps `review.reviewer` out.
- **Drift resolved, with reasons attached.** `Bash(git stash*)` is **denied** (dfcad allowed
  it): the stash stack is shared across worktrees and an unattended loop is exactly the
  caller that will not notice a pop restoring another session's work. `ScheduleWakeup`,
  `Monitor`, `TaskCreate` and the worktree tools are all granted — the union, since the
  split between the two repos was accidental.
- **`verify` inference leads with CI, not with `go.mod`.** The list's whole value is that a
  local pass predicts a green PR, so what CI actually runs beats what the language implies;
  the detector table is the fallback.
- **The `autoMode` authorization statement stays per-repo and is *shown*, not written.** It
  is the operator authorizing their own loop; an agent writing its own authorization is not
  one. It was previously only in dfcad's `settings.local.json`.
- **A cross-repo `owner/repo#N` dependency is `BLOCKED`, not ignored.** Silently skipping an
  unresolvable dependency is the one wrong answer that gets work done in the wrong order.

## Verified

- `marketplace.json`, `plugin.json`, `backlog.schema.json` parse; `auto-merge.yaml` parses
  and keeps both jobs.
- The schema is a valid Draft 2020-12 schema, accepts the documented example config, and
  rejects an unknown `dependencies.style`, a `review.reviewer` key, a smuggled-in repo slug,
  and an empty `verify`.
- The three `dependencies.style` extractions were run against the fixture body in the skill
  and produce exactly the table's answers — `blocked-by` → 12, 14 (the list terminates at
  the non-list line, so `- #19` is excluded); `depends-on` → 17; and the gloss guard yields
  `12` from `- #12 — needs #34 first`.
- `gh repo view --json nameWithOwner,defaultBranchRef` and the non-admin
  `repos/<slug>/rules/branches/<branch>` ruleset query both run clean against this repo.
- Every Copilot finding from the source commands greps present in `next-issue`; no repo
  slug, branch literal, milestone or build command appears anywhere under `plugins/backlog/`.

## Not verified here

The last acceptance criterion — installing into a fresh repo and taking a real issue to a
merged PR with no hand-editing — needs a live third repository and a real unattended run.
It is the acceptance test for whether the generalisation held, and per the issue it belongs
with the dfcad/rdf-go migrations that follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)