### PR TITLE
chore: enable the backlog plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,8 @@
 {
+  "enabledPlugins": {
+    "daggerverse@z5labs-devex": true,
+    "backlog@z5labs-devex": true
+  },
   "extraKnownMarketplaces": {
     "z5labs-devex": {
       "source": {
@@ -6,8 +10,5 @@
         "repo": "z5labs/devex"
       }
     }
-  },
-  "enabledPlugins": {
-    "daggerverse@z5labs-devex": true
   }
 }


### PR DESCRIPTION
Enables the `backlog` plugin from the `z5labs-devex` marketplace, added by `/plugin install backlog@z5labs-devex`.

The plugin itself landed in #323; this just turns it on for the repo so `backlog:next-issue` / `backlog:run-backlog` are available without a manual install. The reordering of keys in `.claude/settings.json` is how the plugin installer rewrote the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)