### PR TITLE
story(issue-325): scope issue selection by a GitHub project field

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -19,11 +19,11 @@ answer it, label for auto merge, close the issue, clean up — then stops.
 so each issue starts from clean context, and halts on `BACKLOG EMPTY`, on
 `BLOCKED`, or at a bounded iteration count.
 
-Nothing repository-specific lives in the skills. Six knobs live in
-`.claude/backlog.json` — which label and milestone form the backlog, how issue
-bodies declare dependencies, the commands that must pass before a pull request
-opens, the merge label and workflow, whether a review is required, and where
-worktrees go — described by
+Nothing repository-specific lives in the skills. The knobs live in
+`.claude/backlog.json` — which label, milestone and optional project field value
+form the backlog, how issue bodies declare dependencies, the commands that must
+pass before a pull request opens, the merge label and workflow, whether a review
+is required, and where worktrees go — described by
 [`assets/backlog.schema.json`](backlog/assets/backlog.schema.json). The repo
 slug and default branch are deliberately *not* among them: they are read from
 `gh repo view`, so a fork or a rename cannot leave the config describing a
@@ -51,6 +51,16 @@ took the real dependencies below it with it. Three of those made an issue
 rather than not at all. Those bodies are now
 [`scripts/select-issue_test.sh`](backlog/scripts/select-issue_test.sh), which
 needs no network.
+
+The same script can narrow the backlog to one value of a single-select field on
+a GitHub project — `--project-value workspace-ci` on a repository that groups
+its work by `Module` — for repositories where the axis worth working along is
+one the label and milestone filters cannot see. The value is read over GraphQL
+as a `ProjectV2ItemFieldSingleSelectValue`, checked against the field's declared
+options so a typo cannot resolve to an empty backlog, and intersected with this
+repository's issues because an org-level project spans repositories. Every way
+it can fail is exit 4: falling back to the unfiltered backlog when a scope was
+asked for is the same class of failure as a silently eligible issue.
 
 The review gate is
 [`scripts/await-review.sh`](backlog/scripts/await-review.sh) — request, wait,

--- a/plugins/backlog/agents/issue-worker.md
+++ b/plugins/backlog/agents/issue-worker.md
@@ -18,6 +18,11 @@ Skill tool is not granted to this agent; backlog:next-issue cannot be invoked`. 
 fallback: reconstructing the cycle from memory is how the footnotes that make it work get
 dropped.
 
+If your prompt names a project-field scope — `--project-value <value>` — carry it through to
+the skill's selection step unchanged. It is not advisory and it is not yours to widen: an
+unscoped selection picks up an issue from somewhere else in the backlog and merges it, and
+your report will read like an ordinary successful iteration.
+
 ## Rules that outrank anything else you conclude mid-run
 
 - **Exactly one issue.** When the cycle finishes, you stop. Do not pick up a second issue,
@@ -31,6 +36,8 @@ dropped.
   the worktree and local branch you created.
 - **Do not weaken a test to make it pass**, and do not label a pull request whose review
   never completed.
+- **Do not retry selection unscoped.** If selection fails on the project scope you were
+  given, that is a `BLOCKED` report, not a reason to drop the flag.
 
 ## Your final message is the return value
 

--- a/plugins/backlog/assets/backlog.schema.json
+++ b/plugins/backlog/assets/backlog.schema.json
@@ -28,7 +28,37 @@
           "type": "integer",
           "minimum": 1,
           "default": 200,
-          "description": "The `--limit` passed to `gh issue list`. Always passed explicitly: gh's default page size is 30, and on a backlog larger than that the eligible issues simply fall off the end of the list without any error."
+          "description": "The `--limit` passed to `gh issue list`. Always passed explicitly: gh's default page size is 30, and on a backlog larger than that the eligible issues simply fall off the end of the list without any error. It bounds the *label* query, so it also bounds what `select.project` can then narrow: on a backlog longer than this, an in-scope issue can fall off the end before the project scope is ever applied."
+        },
+        "project": {
+          "type": ["object", "null"],
+          "default": null,
+          "description": "Optionally narrow the backlog to one value of a GitHub Projects v2 single-select field — \"just the workspace-ci stories\" — on a repository that groups its work by a project field rather than by labels or milestones. Absent or `null` means no such scoping, and `scripts/select-issue.sh` then makes no project API call at all. Reading a project field rather than a convention in the issue body is deliberate: the data already exists on every issue the project holds, a single-select cannot hold a typo'd value however the issue was filed (`gh issue create --body` bypasses issue templates entirely), and the value comes back as data rather than as prose to parse. The cost is that membership lives outside the repository, so a renamed field or a deleted project takes the scoping with it — acceptable because the filter is optional and its failure mode is `select-issue.sh` refusing to select, never a silent fall back to the unscoped backlog. Requires the `read:project` token scope (`gh auth refresh -s read:project`).",
+          "additionalProperties": false,
+          "required": ["owner", "number", "field"],
+          "properties": {
+            "owner": {
+              "type": "string",
+              "minLength": 1,
+              "description": "The organisation or user login that owns the project. An organisation is tried first and a user only after GitHub reports the login is not one, because a project number is scoped to its owner."
+            },
+            "number": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "The project number, as it appears in the project's URL (`/orgs/<owner>/projects/<number>`)."
+            },
+            "field": {
+              "type": "string",
+              "minLength": 1,
+              "description": "The single-select field to read, by name — `Module`, `Area`, `Component`. It must be a single-select field: any other field type is a hard failure rather than a scope that quietly matches nothing. The name is matched exactly, and the failure names every field the project has."
+            },
+            "value": {
+              "type": ["string", "null"],
+              "minLength": 1,
+              "default": null,
+              "description": "The field value the backlog is restricted to, matched exactly against the field's declared options. `null` means no scoping by default — the usual setting, because \"just workspace-ci today\" is a property of one run rather than a permanent description of the backlog. `select-issue.sh --project-value <value>` overrides this per run and `--no-project-filter` clears it, so a scoped run needs no edit to this file. A value that is not one of the field's options fails with the list of options rather than selecting from an empty backlog, which would read as a drained one and stop the loop looking like success."
+            }
+          }
         }
       }
     },

--- a/plugins/backlog/scripts/select-issue.sh
+++ b/plugins/backlog/scripts/select-issue.sh
@@ -2,8 +2,9 @@
 #
 # select-issue.sh — pick the next eligible backlog issue, as one call.
 #
-# Usage: select-issue.sh
+# Usage: select-issue.sh [--project-value <value> | --no-project-filter]
 #        select-issue.sh --extract <blocked-by|depends-on|none> [file]
+#        select-issue.sh --project-items <repo> <field> <value> [file]
 #
 # Why this is a script and not a numbered step.
 #
@@ -33,10 +34,17 @@
 # and printing one reference per line. It needs no network, which is what lets
 # `select-issue_test.sh` hold the fixture corpus these bugs came from.
 #
+# `--project-items` is the same seam for the project scope below: it reads the
+# GraphQL pages from a file or stdin and prints the in-scope issue numbers, so
+# every rule about what counts as in scope is exercised by the test without a
+# network call.
+#
 # Exit codes:
 #   0   an issue was selected; stdout is {"number":N,"title":"..."}
-#   4   usage or precondition failure (no gh/jq/git, or the config is unusable)
-#   10  BACKLOG EMPTY — no open issue carries the label (and milestone)
+#   4   usage or precondition failure (no gh/jq/git, the config is unusable, or
+#       a requested project scope could not be resolved)
+#   10  BACKLOG EMPTY — no open issue carries the label (and milestone, and
+#       project field value)
 #   11  BLOCKED — open issues remain and none is eligible
 
 set -uo pipefail
@@ -185,7 +193,212 @@ if [ "${1:-}" = --extract ]; then
   exit 0
 fi
 
-[ $# -eq 0 ] || fail 4 "usage: select-issue.sh [--extract <style> [file]]"
+# ---------------------------------------------------------------- project -----
+# Optional scoping by one value of a GitHub Projects v2 single-select field —
+# "just the workspace-ci stories today". Label and milestone are the only other
+# axes the backlog can be narrowed on, and neither models the grouping a project
+# board already holds.
+#
+# Read as a *field value*, over GraphQL, rather than any of the alternatives:
+#
+#   * `gh project item-list --format json` flattens custom fields into
+#     lowercased top-level keys. That shape is undocumented, it collides as soon
+#     as two fields differ only by case or punctuation, and a rename upstream
+#     changes it silently. `ProjectV2ItemFieldSingleSelectValue` is the schema
+#     type and says what it is.
+#   * A convention in the issue body would need a template change and a backfill
+#     of every open issue before it filtered anything, and it inherits every
+#     parsing failure mode documented above this line. A single-select cannot
+#     hold a typo'd value, and the project enforces that however the issue was
+#     filed — including `gh issue create --body`, which bypasses templates.
+#
+# Two things this deliberately does not trust:
+#
+#   * An org-level project spans repositories, so its items are intersected with
+#     this repository's issues rather than taken as-is. Without that, `#42` in a
+#     sibling repository selects issue 42 here.
+#   * The requested value is checked against the field's declared options before
+#     anything is filtered. A typo would otherwise match no item and read as an
+#     empty backlog — and an empty backlog stops the loop quietly, which is the
+#     failure that looks like success.
+#
+# Every failure here is exit 4, never a silent fall-through to the unscoped
+# backlog. Selecting from the whole backlog when a scope was asked for is the
+# one wrong answer that gets work done in the wrong order rather than not at
+# all, which is the same standard the dependency walk below is held to.
+
+# The field is found in `fields` rather than asked for by `field(name: $field)`.
+# Measured: an unknown name makes `field(name:)` fail the *whole query* — `Could
+# not resolve to a Unions::ProjectV2FieldConfiguration with the name Module` —
+# so the response that would have carried the list of real field names is the
+# one thing a typo cannot get you. `fieldValueByName` is the opposite and
+# returns null for a name that does not exist, which is why the item side can
+# keep using it.
+project_query() { # <organization|user>
+  cat <<QUERY
+query(\$owner: String!, \$number: Int!, \$field: String!, \$endCursor: String) {
+  $1(login: \$owner) {
+    projectV2(number: \$number) {
+      title
+      fields(first: 100) {
+        nodes {
+          __typename
+          ... on ProjectV2FieldCommon { name }
+          ... on ProjectV2SingleSelectField { options { name } }
+        }
+      }
+      items(first: 100, after: \$endCursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          content {
+            __typename
+            ... on Issue { number repository { nameWithOwner } }
+          }
+          fieldValueByName(name: \$field) {
+            __typename
+            ... on ProjectV2ItemFieldSingleSelectValue { name }
+          }
+        }
+      }
+    }
+  }
+}
+QUERY
+}
+
+# `gh api graphql --paginate` prints one whole response per page, concatenated,
+# which `jq -s` reads as a stream of documents. The owner may be an organisation
+# or a user and the query root differs, so `proj` accepts either and every page
+# that resolved to neither drops out.
+PROJECT_JQ_DEF='
+def proj: (.data.organization // .data.user) | .projectV2?;
+def pages: [ .[] | proj ] | map(select(. != null));
+def thefield: ((pages[0].fields.nodes // []) | map(select(.name == $field)) | .[0]) // null;
+'
+
+# Prints one in-scope issue number per line. Reads the pages on stdin so the
+# test can hold them as fixtures; the network lives in project_fetch alone.
+project_items() { # <repo> <field> <value>
+  local repo=$1 field=$2 want=$3
+  local pages typename known options options_msg
+
+  pages=$(cat)
+  [ -n "$pages" ] || fail 4 "the project query returned no response for field '$field'"
+
+  typename=$(printf '%s' "$pages" | jq -s -r --arg field "$field" "$PROJECT_JQ_DEF"'
+    if (pages | length) == 0 then "NO-PROJECT" else (thefield.__typename // "NO-FIELD") end') \
+    || fail 4 "the project query response does not parse as JSON"
+
+  case "$typename" in
+    NO-PROJECT)
+      fail 4 "no project was returned; check select.project.owner and select.project.number" ;;
+    NO-FIELD)
+      known=$(printf '%s' "$pages" | jq -s -r --arg field "$field" "$PROJECT_JQ_DEF"'
+        (pages[0].fields.nodes // []) | map(.name // empty) | join(", ")')
+      fail 4 "the project has no field named '$field'${known:+; its fields are: $known}" ;;
+    ProjectV2SingleSelectField) ;;
+    *)
+      fail 4 "project field '$field' is a $typename, not a single-select field; only a single-select field can scope the backlog" ;;
+  esac
+
+  options=$(printf '%s' "$pages" | jq -s -r --arg field "$field" "$PROJECT_JQ_DEF"'thefield.options[]?.name')
+  # Exact match, and the options list is what says so. Matching loosely would
+  # make `Workspace-CI` and `workspace-ci` the same request against a field that
+  # considers them two different options, or none.
+  if ! printf '%s\n' "$options" | grep -qxF -- "$want"; then
+    options_msg=$(printf '%s' "$options" | tr '\n' ',')
+    fail 4 "project field '$field' has no option '$want'; its options are: ${options_msg%,}"
+  fi
+
+  printf '%s' "$pages" | jq -s -r --arg field "$field" --arg repo "$repo" --arg want "$want" "$PROJECT_JQ_DEF"'
+    [ pages[].items.nodes[]? ]
+    | map(select(
+        .content.__typename == "Issue"
+        and .content.repository.nameWithOwner == $repo
+        and .fieldValueByName.__typename == "ProjectV2ItemFieldSingleSelectValue"
+        and .fieldValueByName.name == $want))
+    | map(.content.number) | unique | .[]' \
+    || fail 4 "the project query response could not be read for field '$field'"
+}
+
+if [ "${1:-}" = --project-items ]; then
+  command -v jq >/dev/null 2>&1 || fail 4 "jq is not on PATH"
+  [ $# -ge 4 ] || fail 4 "usage: select-issue.sh --project-items <repo> <field> <value> [file]"
+  if [ -n "${5:-}" ]; then project_items "$2" "$3" "$4" <"$5"; else project_items "$2" "$3" "$4"; fi
+  exit 0
+fi
+
+# The organisation root is tried first and the user root only after GitHub says
+# the login is not an organisation, because a project number is scoped to its
+# owner: guessing the wrong root would report "no such project" for a project
+# that exists.
+#
+# gh's stderr goes to a file rather than into the captured output, which would
+# corrupt the JSON. The caller owns that file: this runs inside a command
+# substitution, whose subshell does not run the EXIT trap and cannot hand a path
+# back to be cleaned up.
+PROJECT_ERRFILE=""
+trap '[ -n "$PROJECT_ERRFILE" ] && rm -f "$PROJECT_ERRFILE"; true' EXIT
+
+project_fetch() { # <owner> <number> <field> ; needs PROJECT_ERRFILE
+  local owner=$1 number=$2 field=$3
+  local root out rc message
+
+  for root in organization user; do
+    out=$(gh api graphql --paginate \
+            -F owner="$owner" -F number="$number" -F field="$field" \
+            -f query="$(project_query "$root")" 2>"$PROJECT_ERRFILE")
+    rc=$?
+    if [ "$rc" -eq 0 ]; then printf '%s' "$out"; return 0; fi
+    if grep -qiE 'read:project|not been granted|INSUFFICIENT_SCOPES' "$PROJECT_ERRFILE"; then
+      note "$(cat "$PROJECT_ERRFILE")"
+      fail 4 "the GitHub token cannot read projects; run 'gh auth refresh -s read:project' and retry"
+    fi
+    grep -qiE 'could not resolve to an organization' "$PROJECT_ERRFILE" && continue
+    break
+  done
+
+  message=$(tr '\n' ' ' <"$PROJECT_ERRFILE")
+  fail 4 "cannot read project number $number owned by '$owner': ${message:-gh api graphql failed}"
+}
+
+# ------------------------------------------------------------------- args -----
+# The scope belongs on the invocation as much as in the config: "just workspace-ci
+# today" is a property of one run, and a config-only knob would mean editing
+# .claude/backlog.json before and after every scoped run.
+#
+# Two flags rather than one with an empty-string sentinel. `--project-value ''`
+# would have to mean "no scope", which is the same conflation `--milestone ''`
+# is avoided for below.
+OPT_PROJECT_VALUE=""
+OPT_PROJECT_VALUE_SET=0
+OPT_NO_PROJECT=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --project-value)
+      [ $# -ge 2 ] || fail 4 "--project-value needs a value"
+      OPT_PROJECT_VALUE=$2
+      OPT_PROJECT_VALUE_SET=1
+      shift 2 ;;
+    --project-value=*)
+      OPT_PROJECT_VALUE=${1#*=}
+      OPT_PROJECT_VALUE_SET=1
+      shift ;;
+    --no-project-filter)
+      OPT_NO_PROJECT=1
+      shift ;;
+    *)
+      fail 4 "unknown argument '$1'; usage: select-issue.sh [--project-value <value> | --no-project-filter]" ;;
+  esac
+done
+
+if [ "$OPT_PROJECT_VALUE_SET" -eq 1 ]; then
+  [ -n "$OPT_PROJECT_VALUE" ] \
+    || fail 4 "--project-value needs a non-empty value; to run unscoped, pass --no-project-filter or nothing at all"
+  [ "$OPT_NO_PROJECT" -eq 0 ] \
+    || fail 4 "--project-value and --no-project-filter cannot both be given"
+fi
 
 # ----------------------------------------------------------------- config -----
 command -v gh >/dev/null 2>&1 || fail 4 "gh is not on PATH"
@@ -201,6 +414,7 @@ jq -e . "$CFG" >/dev/null 2>&1 || fail 4 "$CFG does not parse as JSON"
 LABEL=$(jq -r '.select.label // ""' "$CFG")
 MILESTONE=$(jq -r '.select.milestone // ""' "$CFG")
 LIMIT=$(jq -r '.select.limit // ""' "$CFG")
+PROJECT_KIND=$(jq -r 'if (.select.project // null) == null then "absent" else (.select.project | type) end' "$CFG")
 STYLE=$(jq -r '.dependencies.style // ""' "$CFG")
 VERIFY_N=$(jq -r 'if (.verify | type) == "array" then (.verify | length) else -1 end' "$CFG")
 
@@ -218,6 +432,40 @@ esac
 # nothing local ever looked at, and selection is the first chance to say so.
 [ "$VERIFY_N" -ge 1 ] 2>/dev/null \
   || fail 4 "$CFG: verify must be a non-empty array of commands; run backlog:setup-backlog"
+
+# The scope is whatever the config pins, unless this run says otherwise. Absent
+# from both, no project call is made at all and selection is exactly what it was
+# before this filter existed.
+PROJECT_OWNER=""
+PROJECT_NUMBER=""
+PROJECT_FIELD=""
+PROJECT_VALUE=""
+case "$PROJECT_KIND" in
+  absent) ;;
+  object)
+    PROJECT_OWNER=$(jq -r '.select.project.owner // ""' "$CFG")
+    PROJECT_NUMBER=$(jq -r '.select.project.number // ""' "$CFG")
+    PROJECT_FIELD=$(jq -r '.select.project.field // ""' "$CFG")
+    PROJECT_VALUE=$(jq -r '.select.project.value // ""' "$CFG")
+    ;;
+  *) fail 4 "$CFG: select.project must be an object or null (found a $PROJECT_KIND)" ;;
+esac
+
+[ "$OPT_PROJECT_VALUE_SET" -eq 1 ] && PROJECT_VALUE=$OPT_PROJECT_VALUE
+[ "$OPT_NO_PROJECT" -eq 1 ] && PROJECT_VALUE=""
+
+# Validated up front rather than at the point of use: a scope that cannot be
+# resolved has to stop selection, not degrade it to the unscoped backlog.
+if [ -n "$PROJECT_VALUE" ]; then
+  [ "$PROJECT_KIND" = object ] \
+    || fail 4 "a project scope of '$PROJECT_VALUE' was requested but $CFG has no select.project; add owner, number and field to it"
+  [ -n "$PROJECT_OWNER" ] || fail 4 "$CFG: select.project.owner is missing or empty"
+  [ -n "$PROJECT_FIELD" ] || fail 4 "$CFG: select.project.field is missing or empty"
+  case "$PROJECT_NUMBER" in
+    ''|*[!0-9]*) fail 4 "$CFG: select.project.number must be a positive integer (found '${PROJECT_NUMBER:-null}')" ;;
+    0)           fail 4 "$CFG: select.project.number must be at least 1" ;;
+  esac
+fi
 
 REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null) \
   || fail 4 "cannot resolve the repository slug from gh"
@@ -238,10 +486,41 @@ CANDIDATES=$(gh issue list "${LIST_ARGS[@]}" \
   --json number,title --jq 'sort_by(.number)[] | "\(.number)\t\(.title)"') \
   || fail 4 "gh issue list failed for $REPO"
 
+SCOPE_NOTE=""
+[ -n "$PROJECT_VALUE" ] && SCOPE_NOTE=" with $PROJECT_FIELD = '$PROJECT_VALUE' in project $PROJECT_OWNER/$PROJECT_NUMBER"
+
 if [ -z "$CANDIDATES" ]; then
   printf 'BACKLOG EMPTY\n'
   note "no open issue in $REPO carries the label '$LABEL'${MILESTONE:+ in milestone '$MILESTONE'}"
   exit 10
+fi
+
+# ---------------------------------------------------------------- scoping -----
+# Applied before the dependency walk, so the walk sees only in-scope issues and
+# cannot be held up by a blocker outside the scope it was asked for.
+#
+# The limit above still bounds the *label* query, not this one: on a backlog
+# longer than select.limit, an in-scope issue can fall off the end before the
+# scope is ever applied. That is why the limit defaults to 200 rather than to
+# gh's page size of 30.
+if [ -n "$PROJECT_VALUE" ]; then
+  # `|| exit $?` on both: a `fail` inside a command substitution exits only the
+  # subshell, and without this the script would carry on with an empty scope —
+  # which is the unscoped-selection failure this whole section exists to make
+  # impossible.
+  PROJECT_ERRFILE=$(mktemp) || fail 4 "cannot create a temporary file for the project query"
+  PROJECT_PAGES=$(project_fetch "$PROJECT_OWNER" "$PROJECT_NUMBER" "$PROJECT_FIELD") || exit $?
+  IN_SCOPE=$(project_items "$REPO" "$PROJECT_FIELD" "$PROJECT_VALUE" <<<"$PROJECT_PAGES") || exit $?
+
+  CANDIDATES=$(awk -F'\t' 'NR == FNR { if ($0 != "") keep[$0] = 1; next } ($1 in keep)' \
+    <(printf '%s\n' "$IN_SCOPE") <(printf '%s\n' "$CANDIDATES"))
+
+  if [ -z "$CANDIDATES" ]; then
+    printf 'BACKLOG EMPTY\n'
+    note "no open issue in $REPO carries the label '$LABEL'${MILESTONE:+ in milestone '$MILESTONE'}$SCOPE_NOTE"
+    exit 10
+  fi
+  note "project scope leaves $(printf '%s\n' "$CANDIDATES" | grep -c .) candidate(s)$SCOPE_NOTE"
 fi
 
 # --------------------------------------------------------------- eligible -----
@@ -308,6 +587,6 @@ while IFS=$'\t' read -r NUM TITLE; do
 # escape.
 done < <(printf '%s\n' "$CANDIDATES")
 
-printf 'BLOCKED — every open issue carrying the label '\''%s'\'' has an unmet dependency:\n' "$LABEL"
+printf 'BLOCKED — every open issue carrying the label '\''%s'\''%s has an unmet dependency:\n' "$LABEL" "$SCOPE_NOTE"
 printf '%s' "$REASONS"
 exit 11

--- a/plugins/backlog/scripts/select-issue_test.sh
+++ b/plugins/backlog/scripts/select-issue_test.sh
@@ -1,13 +1,21 @@
 #!/usr/bin/env bash
 #
-# select-issue_test.sh — the fixture corpus for select-issue.sh's extraction.
+# select-issue_test.sh — the fixture corpus for select-issue.sh.
 #
-# Every case below is an issue body that a real backlog can contain. The ones
-# marked REGRESSION were extracted wrongly by the awk/sed/grep pipelines this
-# script replaced, back when they lived in `skills/next-issue/SKILL.md` as prose
-# for an agent to retype and check against a table by eye. Three of them
-# produced a *silently eligible* issue, which is the failure that gets work done
-# in the wrong order rather than not at all.
+# Two halves, both offline.
+#
+# **Extraction.** Every case is an issue body that a real backlog can contain.
+# The ones marked REGRESSION were extracted wrongly by the awk/sed/grep
+# pipelines this script replaced, back when they lived in
+# `skills/next-issue/SKILL.md` as prose for an agent to retype and check against
+# a table by eye. Three of them produced a *silently eligible* issue, which is
+# the failure that gets work done in the wrong order rather than not at all.
+#
+# **Project scoping.** Every case is a GraphQL response `gh api graphql
+# --paginate` can return for the project query, fed to `--project-items`. The
+# failures matter as much as the matches here: a scope that resolves to nothing
+# and a scope that was never applied both look like an ordinary backlog from the
+# outside, so each one has to be an exit 4 rather than an empty answer.
 #
 # Run: plugins/backlog/scripts/select-issue_test.sh
 # Exit 0 when every case matches, 1 otherwise.
@@ -211,6 +219,134 @@ check 'parses nothing' none '' \
 - #12
 
 Depends on #17.'
+
+printf '\nproject scoping\n'
+
+# One GraphQL page, built around the item list under test. The field list and
+# the query root are the two things individual cases vary, so both are
+# arguments. The shape is what `gh api graphql` really returns — the fields are
+# read out of `fields` because `field(name:)` fails the whole query on a name
+# that does not exist, taking the list of real names with it.
+FIELDS='[{"__typename":"ProjectV2Field","name":"Title"},
+         {"__typename":"ProjectV2SingleSelectField","name":"Status","options":[{"name":"Todo"},{"name":"Done"}]},
+         {"__typename":"ProjectV2SingleSelectField","name":"Module","options":[{"name":"workspace-ci"},{"name":"pdf"}]}]'
+
+page() { # <items json array> [fields json array] [organization|user]
+  printf '{"data":{"%s":{"projectV2":{"title":"devex",' "${3:-organization}"
+  printf '"fields":{"nodes":%s},' "${2:-$FIELDS}"
+  printf '"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":%s}}}}}' "$1"
+}
+
+issue_item() { # <number> <repo> <field value, or - for none>
+  local value='null'
+  [ "$3" = - ] || value="{\"__typename\":\"ProjectV2ItemFieldSingleSelectValue\",\"name\":\"$3\"}"
+  printf '{"content":{"__typename":"Issue","number":%s,"repository":{"nameWithOwner":"%s"}},"fieldValueByName":%s}' \
+    "$1" "$2" "$value"
+}
+
+# checkp <name> <repo> <field> <value> <expected numbers, space separated> <pages>
+checkp() {
+  local name=$1 repo=$2 field=$3 value=$4 want=$5 pages=$6 got rc
+  got=$(printf '%s' "$pages" | "$SUT" --project-items "$repo" "$field" "$value" 2>/dev/null)
+  rc=$?
+  got=$(printf '%s' "$got" | tr '\n' ' ')
+  got=${got% }
+  if [ "$rc" -eq 0 ] && [ "$got" = "$want" ]; then
+    pass=$((pass + 1))
+    printf '  ok   %-58s [%s]\n' "$name" "${got:-<none>}"
+  else
+    fail=$((fail + 1))
+    printf '  FAIL %-58s want [%s] exit 0, got [%s] exit %d\n' "$name" "$want" "$got" "$rc"
+  fi
+}
+
+# checkp_fail <name> <repo> <field> <value> <substring of the message> <pages>
+checkp_fail() {
+  local name=$1 repo=$2 field=$3 value=$4 want=$5 pages=$6 err rc
+  err=$(printf '%s' "$pages" | "$SUT" --project-items "$repo" "$field" "$value" 2>&1 >/dev/null)
+  rc=$?
+  case "$err" in
+    *"$want"*) ;;
+    *) fail=$((fail + 1))
+       printf '  FAIL %-58s message lacks [%s]: %s\n' "$name" "$want" "$err"
+       return ;;
+  esac
+  if [ "$rc" -eq 4 ]; then
+    pass=$((pass + 1))
+    printf '  ok   %-58s [exit 4]\n' "$name"
+  else
+    fail=$((fail + 1))
+    printf '  FAIL %-58s want exit 4, got exit %d\n' "$name" "$rc"
+  fi
+}
+
+checkp 'the requested value, and only it' z5labs/devex Module workspace-ci '288 291' \
+  "$(page "[$(issue_item 288 z5labs/devex workspace-ci),
+            $(issue_item 302 z5labs/devex pdf),
+            $(issue_item 291 z5labs/devex workspace-ci)]")"
+
+# An org-level project spans repositories. Trusting its items as-is would select
+# issue 288 in *this* repository because a sibling repository's 288 is in scope.
+checkp 'another repository is not this one' z5labs/devex Module workspace-ci '291' \
+  "$(page "[$(issue_item 288 z5labs/other workspace-ci),
+            $(issue_item 291 z5labs/devex workspace-ci)]")"
+
+# A project holds draft issues and pull requests too. Neither has an issue
+# number in this repository, and a draft's `content` carries no `number` at all.
+checkp 'draft issues and pull requests are skipped' z5labs/devex Module workspace-ci '291' \
+  "$(page '[{"content":{"__typename":"DraftIssue"},"fieldValueByName":{"__typename":"ProjectV2ItemFieldSingleSelectValue","name":"workspace-ci"}},
+            {"content":{"__typename":"PullRequest","number":304,"repository":{"nameWithOwner":"z5labs/devex"}},"fieldValueByName":{"__typename":"ProjectV2ItemFieldSingleSelectValue","name":"workspace-ci"}},
+            '"$(issue_item 291 z5labs/devex workspace-ci)"']')"
+
+# An item that was never given a value for the field is out of scope, not in it.
+checkp 'an unset field value is out of scope' z5labs/devex Module workspace-ci '291' \
+  "$(page "[$(issue_item 288 z5labs/devex -),
+            $(issue_item 291 z5labs/devex workspace-ci)]")"
+
+# Defensive: only a single-select value is read. A value of any other type on a
+# field that has since been retyped must not match by carrying the right `name`.
+checkp 'only a single-select value counts' z5labs/devex Module workspace-ci '291' \
+  "$(page '[{"content":{"__typename":"Issue","number":288,"repository":{"nameWithOwner":"z5labs/devex"}},"fieldValueByName":{"__typename":"ProjectV2ItemFieldTextValue","name":"workspace-ci"}},
+            '"$(issue_item 291 z5labs/devex workspace-ci)"']')"
+
+# `--paginate` prints one whole response per page, concatenated. Reading only
+# the first would silently drop every item past 100 — a scoped backlog that
+# looks short rather than one that errors.
+checkp 'every page contributes, deduped' z5labs/devex Module workspace-ci '288 291 306' \
+  "$(page "[$(issue_item 288 z5labs/devex workspace-ci),
+            $(issue_item 291 z5labs/devex workspace-ci)]")
+$(page "[$(issue_item 291 z5labs/devex workspace-ci),
+            $(issue_item 306 z5labs/devex workspace-ci)]")"
+
+# A project can be owned by a user rather than an organisation, and the query
+# root differs. Both responses have to read the same.
+checkp 'a user-owned project reads the same' z5labs/devex Module workspace-ci '291' \
+  "$(page "[$(issue_item 291 z5labs/devex workspace-ci)]" "$FIELDS" user)"
+
+checkp 'no items at all is an empty scope, not an error' z5labs/devex Module workspace-ci '' \
+  "$(page '[]')"
+
+# The four failures. Each one would otherwise resolve to an empty candidate set,
+# which reads as a drained backlog and stops the loop looking like success.
+checkp_fail 'a typo in the value names the options' z5labs/devex Module Workspace-CI \
+  'workspace-ci,pdf' \
+  "$(page "[$(issue_item 291 z5labs/devex workspace-ci)]")"
+
+checkp_fail 'an unknown field names the fields' z5labs/devex Modul workspace-ci \
+  'Title, Status, Module' \
+  "$(page "[$(issue_item 291 z5labs/devex workspace-ci)]")"
+
+checkp_fail 'a field of the wrong type is refused' z5labs/devex Module workspace-ci \
+  'not a single-select field' \
+  "$(page "[$(issue_item 291 z5labs/devex workspace-ci)]" \
+          '[{"__typename":"ProjectV2Field","name":"Module"}]')"
+
+checkp_fail 'an unresolvable project is refused' z5labs/devex Module workspace-ci \
+  'no project was returned' \
+  '{"data":{"organization":{"projectV2":null}}}'
+
+checkp_fail 'an empty response is refused' z5labs/devex Module workspace-ci \
+  'returned no response' ''
 
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/plugins/backlog/skills/next-issue/SKILL.md
+++ b/plugins/backlog/skills/next-issue/SKILL.md
@@ -13,9 +13,9 @@ You never run `gh pr merge`. You label the pull request and GitHub merges it, ga
 default branch's protection rules; see step 9.
 
 Nothing about the repository is written into this skill. The repository slug and default
-branch are read from the repository itself (step 0); the label, milestone, dependency
-convention, verify commands, merge label and worktree directory are read from
-`.claude/backlog.json`.
+branch are read from the repository itself (step 0); the label, milestone, optional project
+scope, dependency convention, verify commands, merge label and worktree directory are read
+from `.claude/backlog.json`.
 
 ## 0. Load the configuration
 
@@ -37,18 +37,18 @@ Do not invent defaults and carry on. A guessed label selects the wrong issues an
 verify list opens red pull requests, and both failures look like the repository's fault
 rather than the config's.
 
-The six keys, and what each is used for:
+What each key is used for:
 
 | key | used at |
 | --- | --- |
-| `select.label`, `select.milestone`, `select.limit` | step 1 — read by `select-issue.sh`, not by you |
+| `select.label`, `select.milestone`, `select.limit`, `select.project` | step 1 — read by `select-issue.sh`, not by you |
 | `dependencies.style` | step 1 — same |
 | `verify` | step 4, the commands that gate the pull request |
 | `merge.label`, `merge.workflow` | step 9, handing the merge to GitHub |
 | `review.required` | steps 7 and 8, whether Copilot gates the merge |
 | `worktreeDir` | steps 2 and 10, where the worktree lives |
 
-Read the file for the four keys you use directly. The first four rows belong to step 1's
+Read the file for the four keys you use directly. The first three rows belong to step 1's
 script, which re-reads and validates them itself — including rejecting an empty `verify`,
 which parses fine and would otherwise surface as a pull request nothing local ever checked.
 
@@ -84,11 +84,43 @@ exit code:
 | 0 | `{"number":N,"title":"…"}` | that is your issue — continue to step 2 |
 | 10 | `BACKLOG EMPTY` | print that line and stop. Do nothing else. |
 | 11 | `BLOCKED — …`, then a line per issue naming what holds it | print it and stop |
-| 4 | a message naming the problem | `BLOCKED`. The config or the environment is wrong, not the backlog — usually `.claude/backlog.json` is missing, unparseable, carries an unknown `dependencies.style`, or has an empty `verify`. Point at `backlog:setup-backlog`. |
+| 4 | a message naming the problem | `BLOCKED`. The config or the environment is wrong, not the backlog — usually `.claude/backlog.json` is missing, unparseable, carries an unknown `dependencies.style`, or has an empty `verify`. A requested project scope that could not be resolved lands here too; see below. Point at `backlog:setup-backlog`. |
 
 The script walks candidates in ascending number order and takes the first whose every
 declared dependency is `CLOSED`. Its per-candidate reasoning goes to stderr, so a selection
 you did not expect can be explained without re-running anything.
+
+### Scoping the run to one project field value
+
+Some repositories group work by a single-select field on a GitHub project — `Module`, `Area`,
+`Component` — rather than by labels or milestones. Where `.claude/backlog.json` carries
+`select.project`, one run can be restricted to a single value of that field:
+
+```
+"${CLAUDE_PLUGIN_ROOT}/scripts/select-issue.sh" --project-value <value>
+```
+
+Pass the flag when, and only when, you were asked for a scoped run — the user named one, or
+`backlog:run-backlog` put one in your prompt. Otherwise call the script with no arguments and
+let `select.project.value` decide, which is normally `null` and means the whole backlog.
+`--no-project-filter` is the other direction: run unscoped even though the config pins a
+value.
+
+The scope is applied before the dependency walk, so the walk sees only in-scope issues and a
+blocker outside the scope cannot hold up the one you were asked to work.
+
+Two things to know when it fails:
+
+- It needs the **`read:project`** token scope, which `repo` does not include.
+  `gh auth refresh -s read:project` grants it.
+- Every project failure is exit 4 — a token without that scope, an unknown project, a field
+  that does not exist or is not a single-select, a value that is not one of the field's
+  options, `--project-value` with no `select.project` in the config. **Do not retry without
+  the flag.** Selecting from the whole backlog when a scope was asked for gets work done in
+  the wrong order, which is worse than selecting nothing; report `BLOCKED` with the message.
+
+Exit 10 under a scope is not a failure — the scope is genuinely drained. Say which scope in
+the report, so a finished module reads differently from a finished backlog.
 
 **Do not reconstruct any of this by hand**, and do not fall back to `gh issue list` plus your
 own body parsing if the call fails. That fallback is where this step's history lives: the
@@ -531,7 +563,8 @@ state you saw.
 
 Finish with a short status: issue number and title, pull request number and URL, check
 result, whether the pull request reached `MERGED`, and any judgment call that shaped the
-public API.
+public API. If the run was scoped with `--project-value`, name the scope — an outcome from a
+scoped backlog says nothing about the rest of it.
 
 - When `review.required` is `true`: whether Copilot reviewed and what it flagged.
 - When `review.required` is `false`: say plainly that **the pull request merged without a
@@ -545,7 +578,8 @@ If you stopped early, say exactly where and why, beginning the report with `BLOC
 Stop and report — do not push through — if any of these happen:
 
 - `select-issue.sh` exits 4 — `.claude/backlog.json` is missing, does not parse, carries an
-  unknown `dependencies.style`, or has an empty `verify`.
+  unknown `dependencies.style`, has an empty `verify`, or a requested project scope could not
+  be resolved. Never re-run it without `--project-value` to get past the last of those.
 - The same CI failure survives three fix attempts.
 - Acceptance criteria are ambiguous enough that two readings produce materially different
   public APIs.

--- a/plugins/backlog/skills/run-backlog/SKILL.md
+++ b/plugins/backlog/skills/run-backlog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: run-backlog
-description: Drive a repository's story backlog unattended, one issue at a time, by spawning a fresh `issue-worker` subagent per iteration and halting on `BACKLOG EMPTY`, on `BLOCKED`, or at a bounded iteration count. Use this whenever the user wants the backlog worked continuously rather than a single issue — "run the backlog", "work through the issues", "keep taking stories until you run out", "drain the milestone", or a `/loop` that repeats the cycle. Takes an optional integer argument setting the maximum number of iterations. Skip this when the user wants exactly one issue (`backlog:next-issue`) or wants the repository bootstrapped first (`backlog:setup-backlog`).
+description: Drive a repository's story backlog unattended, one issue at a time, by spawning a fresh `issue-worker` subagent per iteration and halting on `BACKLOG EMPTY`, on `BLOCKED`, or at a bounded iteration count. Use this whenever the user wants the backlog worked continuously rather than a single issue — "run the backlog", "work through the issues", "keep taking stories until you run out", "drain the milestone", "work through the workspace-ci stories", or a `/loop` that repeats the cycle. Takes an optional integer argument setting the maximum number of iterations, and an optional `--project-value <value>` restricting the whole run to one value of the project field named by `select.project`. Skip this when the user wants exactly one issue (`backlog:next-issue`) or wants the repository bootstrapped first (`backlog:setup-backlog`).
 allowed-tools: Agent, Bash, Read, Glob, Grep, TaskCreate, TaskUpdate, ScheduleWakeup
 ---
 
@@ -29,12 +29,30 @@ Run these once, before the first iteration, and stop if any fails:
    changes you did not make are a stop condition for the cycle, so they are a stop condition
    for the loop; report what is dirty and let the user decide.
 3. **Auth.** `gh auth status`. An expired token turns every iteration into the same
-   opaque failure.
+   opaque failure. If this run is scoped (below), the scopes it prints must include
+   **`read:project`** — `repo` does not imply it, and without it every iteration fails
+   identically at selection. `gh auth refresh -s read:project` grants it; report and stop
+   rather than dropping the scope and running the whole backlog.
 
 Also settle the **bound** now. It is the skill's argument when one was given; otherwise
 default to **10** iterations. Say the number in your first message. An unbounded loop
 against a large backlog is not the user asking for autonomy, it is the user losing the
 chance to look at the first result before the twentieth lands on top of it.
+
+And settle the **scope**. A repository that groups its work by a single-select field on a
+GitHub project — `Module`, `Area`, `Component`, named by `select.project` in the config — can
+have the whole run restricted to one value of it:
+
+```
+/run-backlog 5 --project-value workspace-ci
+```
+
+The argument order does not matter; the integer is the bound and `--project-value` is the
+scope. A user asking to "work through the workspace-ci stories" is asking for exactly this,
+and the value is theirs to give — do not infer one from the issues you can see. With no scope
+given, do not pass the flag at all and let the config decide, which normally means the whole
+backlog. Say the scope in your first message alongside the bound, because every outcome below
+is then a statement about that scope and not about the backlog.
 
 ## 1. The loop
 
@@ -50,6 +68,17 @@ Agent(
            first line unchanged — BACKLOG EMPTY or BLOCKED where the skill calls for it."
 )
 ```
+
+When the run is scoped, add one more line to the prompt, with the value exactly as the user
+gave it:
+
+```
+           This run is scoped: pass --project-value <value> to select-issue.sh at step 1.
+```
+
+Every iteration gets it. Dropping it on one iteration does not narrow that iteration, it
+widens it to the whole backlog — the worker selects an out-of-scope issue and merges it, and
+nothing in its report will look wrong.
 
 Check the agent types available to you before the first spawn. Depending on how the plugin
 was installed the worker may be listed as `issue-worker` or as `backlog:issue-worker`; use
@@ -67,7 +96,7 @@ Read the worker's final message and act on its first line:
 
 | first line | do |
 | --- | --- |
-| `BACKLOG EMPTY` | **Halt.** The backlog holds no matching open issues. This is success, not failure. |
+| `BACKLOG EMPTY` | **Halt.** The backlog holds no matching open issues. This is success, not failure. Under a scope it means *that scope* is drained, and the rest of the backlog is untouched — say which. |
 | `BLOCKED …` | **Halt.** Report the worker's reason verbatim. |
 | anything else | Record a one-line outcome and continue to the next iteration. |
 
@@ -97,12 +126,17 @@ end.
   block is a request for a human, which is the one thing a loop cannot supply.
 - **Never widen the bound mid-run** because the backlog turned out to be longer. Finish,
   report, and let the user re-run.
+- **Never drop the scope mid-run**, and never respond to a worker that halted on a project
+  failure by re-spawning it unscoped. Both turn "work the workspace-ci stories" into "work
+  the backlog", which is the one failure a scoped run exists to prevent and the one the
+  report will not show.
 
 ## 3. Report
 
-Close with the iteration table, the reason the loop stopped in its own words
-(`BACKLOG EMPTY`, `BLOCKED`, bound reached, worker failure), and — if anything merged
-without a review because `review.required` is `false` — that fact, once, for the whole run.
+Close with the iteration table, the scope the run was under if it had one, the reason the
+loop stopped in its own words (`BACKLOG EMPTY`, `BLOCKED`, bound reached, worker failure),
+and — if anything merged without a review because `review.required` is `false` — that fact,
+once, for the whole run.
 
 ## Running it on a schedule
 

--- a/plugins/backlog/skills/setup-backlog/SKILL.md
+++ b/plugins/backlog/skills/setup-backlog/SKILL.md
@@ -104,6 +104,15 @@ sample — and getting it wrong means work happens in the wrong order rather tha
   Exactly one open milestone with open issues is a reasonable inference; anything else is
   `null`, which means "every open issue with the label".
 - `select.limit` — `200`.
+- `select.project` — **omit it unless the user asks.** It scopes selection to one value of a
+  single-select field on a GitHub project (`Module`, `Area`, `Component`), which is worth
+  having only where the repository actually groups its work that way; absent, selection makes
+  no project API call at all. When it is wanted, `gh project list --owner <owner>` gives the
+  number and `gh project field-list <number> --owner <owner>` gives the field names — both
+  need the `read:project` token scope, which `repo` does not include, so say so in the report
+  along with `gh auth refresh -s read:project`. Leave `value` as `null`: the scope belongs on
+  the run (`select-issue.sh --project-value <value>`), not on the file, because "just this
+  module today" is not a permanent description of the backlog.
 - `merge.label` / `merge.workflow` — `auto-merge` and `auto-merge.yaml`, matching the asset
   step 3 installs. If you change either, change both, plus the `github.event.label.name`
   guard inside the workflow.


### PR DESCRIPTION
Closes #325

Adds an optional fourth selection filter to the backlog cycle: one value of a single-select
field on a GitHub project. On devex that is `Module` in org project 14, so
`--project-value workspace-ci` now answers "just the workspace-ci stories" without
restructuring labels or milestones around a grouping the project already models.

## Acceptance criteria

- [x] **`select-issue.sh` can restrict candidates to issues whose project field holds a given
      value, applied before the dependency walk.** `select.project` (`owner`, `number`,
      `field`, optional `value`) in `.claude/backlog.json`. The intersection happens
      immediately after `gh issue list` and before the eligibility walk, so the walk sees only
      in-scope issues and a blocker outside the scope cannot hold up work inside it.
- [x] **The filter is optional; with no project configured, selection behaves exactly as
      today and makes no project API call.** Verified with a `gh` stub on `PATH` that exits 99
      on any `api graphql` call: unscoped runs and `--no-project-filter` both select normally,
      a scoped run fails 4.
- [x] **`run-backlog` and `next-issue` accept a per-run override.** `--project-value <value>`
      overrides `select.project.value`; `--no-project-filter` clears it. Two flags rather than
      one with an empty-string sentinel, which would have to conflate "no scope" with a value.
      `run-backlog` takes the flag alongside its bound and passes it into every worker prompt;
      `issue-worker` is told to carry it through and never to retry unscoped.
- [x] **The config shape is added to `backlog.schema.json`, which stays
      `additionalProperties: false`.** Validated with `jsonschema` 4.23 against nine configs:
      absent/null/full/valueless project all valid; a missing `field`, `number: 0`, an unknown
      key inside `project`, an unknown key in `select`, and an unknown top-level key all
      invalid.
- [x] **The value is read via GraphQL `ProjectV2ItemFieldSingleSelectValue`, not
      `gh project item-list --format json`.** `fieldValueByName(name:)` per item, with
      `--paginate` over 100-item pages.
- [x] **Items are intersected with this repository's issues.** An org-level project spans
      repositories, so `z5labs/other#288` cannot select `#288` here. Covered by a fixture, and
      draft issues and pull requests drop out the same way.
- [x] **A token missing `project` scope, an unknown project, or an unknown field or value
      fails with a clear message and exit 4.** Every project failure is exit 4 and there is no
      path that falls back to the unscoped backlog. The scope is also validated *before* the
      walk, and a `fail` inside a command substitution is explicitly propagated with
      `|| exit $?` — without which the script would have carried on with an empty scope, which
      is exactly the failure this is meant to make impossible.
- [x] **Covered by `select-issue_test.sh`, without network.** `--project-items` exposes the
      projection alone, reading GraphQL pages from a file or stdin. 13 new cases, 39 passing
      in total.
- [x] **`run-backlog` and `next-issue` document the flag and the required token scope.**
      Both name `read:project` and `gh auth refresh -s read:project`; `run-backlog`'s preflight
      checks for the scope before starting a scoped loop, so it fails once rather than
      identically on every iteration.

## Judgment calls

**The field is found in `fields`, not asked for by `field(name: $field)`.** Measured against
the real API: an unknown field name makes `field(name:)` fail the *whole query* — `Could not
resolve to a Unions::ProjectV2FieldConfiguration with the name Module` — so the response that
would have carried the list of real field names is the one thing a typo cannot get you.
`fieldValueByName` is the opposite and returns `null` for a name that does not exist, so the
item side still uses it. The error now names every field the project has.

**The requested value is checked against the field's declared options before anything is
filtered.** A typo would otherwise match no item and resolve to an empty candidate set, which
prints `BACKLOG EMPTY` and stops the loop looking like success. Matching is exact for the same
reason: `Workspace-CI` and `workspace-ci` are two different requests against a field that
holds one of them.

**The organisation root is tried first and the user root only on `Could not resolve to an
Organization`.** A project number is scoped to its owner, so guessing the wrong root would
report "no such project" for a project that exists.

**`select.project.value` may be pinned in config but is expected to be `null`.** The scope
belongs on the invocation — a config-only knob would mean editing `.claude/backlog.json`
before and after every scoped run. `setup-backlog` is told to omit `select.project` unless
asked and to leave `value` null.

## Verified

- `plugins/backlog/scripts/select-issue_test.sh` — 39 passed, 0 failed.
- `bash -n` on both scripts; `jq -e .` on the schema.
- The GraphQL query run live against `z5labs` project 14, paginated: the projection returns
  `286 287 288 289 291 306` for `Module = workspace-ci`, and end-to-end selection under a
  temporary `.claude/backlog.json` picks `#287` from five in-scope open candidates — the
  workspace-ci set the issue names.
- Failure paths exercised live: unknown value (names all 30 options), unknown field, wrong
  field type, unresolvable project, `--project-value` with no `select.project`, both flags
  together, an unknown flag, and a drained scope (`--project-value zig` → exit 10).
- No temp-file leak: `gh`'s stderr file is created by the caller, because a command
  substitution's subshell never runs the `EXIT` trap and cannot hand a path back. Checked
  `/tmp` entry count across a successful and a failing scoped run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
