### PR TITLE
story(issue-327): configure devex to run its own backlog loop

### DIFF
--- a/.claude/backlog.json
+++ b/.claude/backlog.json
@@ -1,0 +1,22 @@
+{
+  "select": {
+    "label": "story",
+    "milestone": null,
+    "limit": 200
+  },
+  "dependencies": {
+    "style": "native"
+  },
+  "verify": [
+    "dagger check",
+    "b=\"origin/$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)\"; for m in $(git diff --name-only \"$b...HEAD\" -- 'daggerverse/*' | cut -d/ -f1,2 | sort -u); do dagger -m \"$m\" check || exit 1; if [ -d \"$m/tests\" ]; then dagger -m \"$m/tests\" check || exit 1; fi; done"
+  ],
+  "merge": {
+    "label": "auto-merge",
+    "workflow": "auto-merge.yaml"
+  },
+  "review": {
+    "required": true
+  },
+  "worktreeDir": ".claude/worktrees"
+}

--- a/.claude/backlog.json
+++ b/.claude/backlog.json
@@ -9,7 +9,7 @@
   },
   "verify": [
     "dagger check",
-    "b=\"origin/$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)\"; for m in $(git diff --name-only \"$b...HEAD\" -- 'daggerverse/*' | cut -d/ -f1,2 | sort -u); do dagger -m \"$m\" check || exit 1; if [ -d \"$m/tests\" ]; then dagger -m \"$m/tests\" check || exit 1; fi; done"
+    "bash .github/scripts/verify-affected-modules.sh"
   ],
   "merge": {
     "label": "auto-merge",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,9 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(bash .github/scripts/verify-affected-modules.sh)"
+    ]
+  },
   "enabledPlugins": {
     "daggerverse@z5labs-devex": true,
     "backlog@z5labs-devex": true

--- a/.github/ISSUE_TEMPLATE/story.yaml
+++ b/.github/ISSUE_TEMPLATE/story.yaml
@@ -1,6 +1,7 @@
 name: Story
 description: Represents stories
 title: "story(subject): short description"
+labels: ["story"]
 body:
   - type: textarea
     id: description

--- a/.github/scripts/verify-affected-modules.sh
+++ b/.github/scripts/verify-affected-modules.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# verify-affected-modules.sh — run the checks CI would run for this branch's
+# daggerverse changes, from inside a worktree.
+#
+# The second half of `verify` in .claude/backlog.json. The first half is
+# `dagger check`, the root module's three checks, which the planner always runs
+# and never memoizes. This is everything else a worktree can reproduce.
+#
+# Why not just ask the planner. `.github/workflows/ci.yml` gets its whole matrix
+# from one `dagger -m daggerverse/workspace-ci call plan`, and that is the
+# authority on which legs a change needs. It reads the change set out of a real
+# `.git` directory — and in a git worktree `.git` is a file pointing elsewhere,
+# so the planner cannot see the history at all. The backlog cycle runs only in
+# worktrees. That leaves this approximation.
+#
+# What it does NOT reproduce, stated so nobody discovers it as a surprise: the
+# planner's dependency closure. A change to a module that some *other* module
+# depends on runs that other module's checks in CI and not here. Adding closure
+# would mean a second planner to keep in agreement with the first, which is the
+# thing workspace-ci exists to avoid.
+#
+# Why this is a file rather than a string in backlog.json: a command the loop
+# runs unattended has to match a permission rule, and a rule cannot match a
+# command that opens with a shell assignment. It also gets to carry these
+# comments.
+
+set -uo pipefail
+
+# The default branch is resolved rather than named. A rename must not leave this
+# diffing against a branch that no longer exists.
+default_branch=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name) || exit 1
+base="origin/${default_branch}"
+
+# `cut -f1,2` collapses daggerverse/<m>/... and daggerverse/<m>/tests/... to the
+# same daggerverse/<m>, so a change to either runs both suites below.
+modules=$(git diff --name-only "${base}...HEAD" -- 'daggerverse/*' | cut -d/ -f1,2 | sort -u)
+
+if [ -z "$modules" ]; then
+  echo "verify-affected-modules: no daggerverse module changed against ${base}"
+  exit 0
+fi
+
+for module in $modules; do
+  echo "verify-affected-modules: ${module}"
+  # A module that declares no checks of its own exits 0 with an empty check
+  # list, so this is safe to run unconditionally.
+  dagger -m "$module" check || exit 1
+  if [ -d "${module}/tests" ]; then
+    dagger -m "${module}/tests" check || exit 1
+  fi
+done

--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -1,0 +1,220 @@
+name: Auto merge
+
+# The backlog loop runs unattended, so the merge that ends a cycle has to happen
+# without a human at the keyboard. Rather than let the agent driving the loop run
+# `gh pr merge` itself, the loop labels the pull request and this workflow hands
+# it to GitHub's native auto merge.
+#
+# The point is where the policy lives. A merge the agent performs is a judgement
+# made mid-cycle and visible only in a transcript; a merge this workflow performs
+# is governed by two things you can read and change: the label gate below, and
+# the branch protection rule on the default branch, whichever checks it requires.
+#
+# Neither path around that rule exists. If checks are still running, auto merge
+# is armed and GitHub holds the pull request until they pass, never merging it if
+# one does not — a failing check leaves the pull request open with auto merge
+# still armed, so pushing a fix is enough to let it through, and nothing is
+# closed on your behalf. If checks have already passed, the merge happens
+# immediately, and branch protection still refuses any merge that would violate
+# it. The label decides *when* the merge is attempted, not *whether* the rule
+# applies.
+#
+# Adding the label is itself a permission boundary: it takes write access to the
+# repository, so a pull request from a fork cannot trigger this by labelling
+# itself.
+
+# `pull_request_target`, not `pull_request`. The usual advice is the reverse,
+# because `pull_request_target` runs with a write token and it is easy to pair
+# that with a checkout of the pull request's own code — which executes untrusted
+# code with write access. This job checks out nothing, so that hazard does not
+# apply, and the trigger's other property is the one that matters here: workflow
+# files are read from the base branch. Under `pull_request`, they are read from
+# the pull request's head, so a pull request could rewrite the steps below and
+# have them run with the `contents: write` token granted underneath.
+#
+# That is not theoretical in a repository running this plugin. The label is
+# applied by an unattended loop, on branches that same loop creates, with no
+# human reading the diff first.
+#
+# If a checkout is ever added to this job, it must pin an explicit ref from the
+# base branch. Never check out `github.event.pull_request.head.sha` here.
+on:
+  pull_request_target:
+    types:
+      - labeled
+      - closed
+
+# `contents: write` is not optional here, despite this job checking out nothing.
+# `gh pr merge --auto` only *arms* auto merge while something still blocks the
+# pull request; once the required checks are already green it merges immediately
+# instead, and that path writes to repository contents. Because the loop labels
+# only after checks pass, the immediate path is the common one — `contents: read`
+# fails it with `Resource not accessible by integration (mergePullRequest)`.
+#
+# `issues: write` is for the explicit `gh issue close` in `close-linked-issues`
+# below. It is NOT there to make GitHub's own auto-close work: that was tested on
+# a real merge and does not. See the comment on that job.
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  enable-auto-merge:
+    name: enable auto merge
+    # Every other label on a pull request — the backlog label, `bug`, whatever
+    # arrives later — leaves this workflow inert. The `closed` trigger belongs to
+    # the two jobs below and must not reach this one.
+    #
+    # If you rename the merge label, change it in `.claude/backlog.json` and here
+    # in the same commit. The cycle applies whatever the config names; this job
+    # reacts to whatever is written below; a mismatch is silent on both sides —
+    # the label lands, no run starts, and the pull request waits forever.
+    if: github.event.action == 'labeled' && github.event.label.name == 'auto-merge'
+    runs-on: ubuntu-latest
+    env:
+      APP_ID: ${{ secrets.BACKLOG_APP_ID }}
+    steps:
+      # Who performs the merge decides whether anything downstream of it happens
+      # at all. GitHub does not create workflow runs from events triggered by
+      # GITHUB_TOKEN — an anti-recursion rule — so a merge performed with
+      # GITHUB_TOKEN emits a `closed` event that starts no run, and the two jobs
+      # below never execute. That is not a hypothesis: across ten merges in two
+      # repositories every auto-merge run showed `delete merged branch` as
+      # `skipped`, twenty-four merged branches survived, and the single run where
+      # it did fire was a pull request a person merged by hand.
+      #
+      # An App installation token is a different actor, so its events cascade
+      # normally.
+      #
+      # One-time setup: create a GitHub App, install it on this repository with
+      # Contents / Pull requests / Issues set to write, and add two repository
+      # secrets:
+      #   BACKLOG_APP_ID   -- the App's numeric App ID
+      #   BACKLOG_APP_KEY  -- the App's PEM private key
+      # `backlog:setup-backlog` checks for both and reports when they are absent.
+      - name: Mint a GitHub App installation token
+        id: app-token
+        if: env.APP_ID != ''
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.BACKLOG_APP_ID }}
+          private-key: ${{ secrets.BACKLOG_APP_KEY }}
+
+      # Degrade loudly, not silently. Without the App the merge still happens and
+      # the loop still works — its own `finish-issue` step closes the issue — but
+      # remote branches accumulate with nothing to collect them, and an operator
+      # who never reads this log would have no way to know why.
+      - name: Warn when falling back to GITHUB_TOKEN
+        if: env.APP_ID == ''
+        run: |
+          echo "::warning title=No App token::BACKLOG_APP_ID is unset, so this merge \
+          uses GITHUB_TOKEN. GitHub suppresses workflow runs for GITHUB_TOKEN-triggered \
+          events, so close-linked-issues and delete-merged-branch will NOT run and the \
+          head branch will survive the merge."
+
+      - name: Enable auto merge
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        # `--auto` queues the merge instead of performing it: GitHub squashes the
+        # pull request when the required checks pass, and does nothing if they
+        # never do. `--squash` assumes the repository allows squash merges;
+        # `backlog:setup-backlog` checks that and reports if another merge method
+        # is still permitted.
+        run: gh pr merge "$PR" --repo "$REPO" --squash --auto
+
+  close-linked-issues:
+    name: close linked issues
+    # A `Closes #N` line does not close the issue when the merge is performed by
+    # a token rather than a person. The closing reference itself registers
+    # correctly — measured across five cycles, `closingIssuesReferences` held the
+    # right issue every time — and nothing acts on it. Granting `issues: write`
+    # was the obvious explanation and was tested on a real merge: the issue
+    # stayed open, and the loop closed it by hand eighteen seconds later, exactly
+    # as before. So the permission is not the lever, and this job does the close
+    # explicitly rather than relying on behaviour that has already been observed
+    # not to happen.
+    #
+    # No fork guard here, unlike the branch deletion below. A pull request from a
+    # fork can legitimately close an issue in this repository.
+    #
+    # The loop's own `finish-issue` step also closes the issue and verifies the
+    # result. That redundancy is deliberate: this job cannot run at all unless the
+    # App token is configured, and the two closes are idempotent — whichever
+    # arrives first wins and the other reads `CLOSED` and does nothing.
+    if: >-
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close the issues this pull request closes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        # Read the references GitHub itself parsed, rather than re-parsing the
+        # body: whatever keyword form the author used, this is what GitHub
+        # understood by it. An empty list is the normal case for a pull request
+        # that closes nothing, and the loop over it simply does not execute.
+        #
+        # Failures must not fail the run. The merge has already happened, and the
+        # loop verifies the close from its side regardless.
+        run: |
+          gh pr view "$PR" --repo "$REPO" --json closingIssuesReferences \
+            --jq '.closingIssuesReferences[].number' \
+          | while read -r n; do
+              [ -n "$n" ] || continue
+              state=$(gh issue view "$n" --repo "$REPO" --json state --jq .state 2>/dev/null || echo "")
+              if [ "$state" = OPEN ]; then
+                gh issue close "$n" --repo "$REPO" --comment "Closed by #$PR." \
+                  && echo "closed #$n" \
+                  || echo "could not close #$n"
+              else
+                echo "#$n is already ${state:-unreadable}; nothing to do"
+              fi
+            done
+
+  delete-merged-branch:
+    name: delete merged branch
+    # Remote cleanup lives here rather than in the agent that drives the loop.
+    # `git push --delete` is denied by that agent's settings, and an unattended
+    # loop working around a rule its operator set is the wrong shape regardless
+    # of whether any single deletion was harmless. Putting the deletion in the
+    # workflow that already performs the merge keeps it automatic and keeps the
+    # policy readable, while leaving the agent responsible only for what it
+    # created locally: its worktree and its local branch.
+    #
+    # `merged` rather than `closed`: a pull request closed without merging keeps
+    # its branch, because the work on it has not landed anywhere.
+    #
+    # The head-repository guard skips forks. A fork's branch is not ours to
+    # delete, and the API call would fail rather than no-op.
+    #
+    # Like the job above, this runs only when the merge used the App token. With
+    # GITHUB_TOKEN it never fires and branches accumulate — the warning in
+    # `enable-auto-merge` is the only notice you get.
+    if: >-
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete the head branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+        # Deleting the ref is idempotent in the only way that matters: if
+        # something else already removed it, the API answers 422 and there is
+        # nothing left to do. A failure here must not fail the run — the merge
+        # has already happened, and an orphaned branch is untidy, not broken.
+        #
+        # `deleteBranchOnMerge` on the repository does not cover this. It fires
+        # for a merge a person performs, not for one a token performs, which is
+        # why this job exists.
+        run: |
+          gh api -X DELETE "repos/$REPO/git/refs/heads/$BRANCH" \
+            && echo "deleted $BRANCH" \
+            || echo "could not delete $BRANCH; it may already be gone"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Per-issue worktrees created by the backlog loop (`worktreeDir` in
+# .claude/backlog.json). They live inside the repository so a run can find
+# them without a path outside it, which means the repository has to be told
+# not to track its own checkouts: an untracked worktree reads as a dirty tree,
+# and a dirty tree is one of the cycle's stop conditions.
+.claude/worktrees/

--- a/plugins/backlog/.claude-plugin/plugin.json
+++ b/plugins/backlog/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "backlog",
   "description": "Run a repository's story backlog unattended — one issue at a time, from selection through worktree, verification, pull request, Copilot review and label-driven auto merge",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": { "name": "z5labs" }
 }


### PR DESCRIPTION
Closes #327.

`backlog:setup-backlog` run against this repository. Everything it wrote is in the
diff; everything it could only *check* is below.

## What is in the diff

| file | why |
| --- | --- |
| `.claude/backlog.json` | the config; validated against `plugins/backlog/assets/backlog.schema.json` |
| `.gitignore` | new file — the repository had none, so `.claude/worktrees/` was untracked rather than ignored, and an untracked worktree reads as a dirty tree, which is one of the cycle's stop conditions |
| `.github/workflows/auto-merge.yaml` | copied verbatim from `plugins/backlog/assets/auto-merge.yaml`; nothing existed at that path |
| `.github/ISSUE_TEMPLATE/story.yaml` | `labels: ["story"]`, matching dfcad, rdf-go and sexpr-go |
| `plugins/backlog/.claude-plugin/plugin.json` | `0.1.0` → `0.2.0`, see below |

### `verify`

```
dagger check
bash .github/scripts/verify-affected-modules.sh
```

There is no single command that reproduces a CI run here, because `ci.yml` asks
`daggerverse/workspace-ci` for a change-aware plan and runs its legs. The two
above are the halves of that a worktree can run:

- `dagger check` is the root module's three checks — the set the planner always
  runs and never memoizes. ~1m warm.
- The script runs the checks for each `daggerverse/<m>` the branch touched and
  that module's `tests/` sibling. It resolves the default branch from
  `gh repo view` rather than naming it, so a rename cannot leave it diffing
  against a branch that is gone.

The second one is a file rather than a string in `backlog.json` for a reason
worth stating: a command the loop runs unattended has to match a permission
rule, and no rule can match a command that opens with a shell assignment — which
the inline form did. It would have prompted on every iteration, at exactly the
point the loop is meant to be autonomous. `.claude/settings.json` allows that
one command, which keeps the operator-wide list free of anything
repository-shaped.

Two limits, stated rather than discovered later:

- **No dependency closure.** A change to a module that some *other* module
  depends on runs that other module's checks only in CI. Reimplementing the
  planner's closure here would be a second planner to keep in agreement with the
  first.
- **The planner itself cannot run from a worktree.** `.git` is a file there and
  it reads the change set out of a real `.git` directly, so `plan` is not usable
  as a verify command in the one place the cycle runs.

Both commands were run on this branch and pass. The script is correctly a no-op
here (no `daggerverse/` paths changed), so both halves were checked separately:
its module derivation against `HEAD~6...HEAD`, which yields `daggerverse/pdf`
and `daggerverse/tesseract`, and a copy pinned to `daggerverse/random`, which
ran that module's checks and its `tests:all` suite.

### The plugin version bump

Not cosmetic, and the reason it is in this pull request. Plugin caches are keyed
by version (`~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/`), and the
version was left at `0.1.0` through both #331 and #332. So every installed copy
was still being served the 0.1.0 content, which has neither `select.project` nor
`native` and fails a config declaring the latter with:

```
select-issue: .claude/backlog.json: dependencies.style must be one of blocked-by, depends-on, none (found 'native')
```

Which is to say the config this issue asks for could not have been read by any
installed copy of the plugin. `/plugin marketplace update` does not fix it; a new
version number does.

## Dependencies: what got a typed edge, and what did not

`dependencies.style` is `native`. Both body-parsing styles extract nothing from
this repository's `Related Issues` prose, so the edges were written as GitHub's
typed dependencies. The judgment the issue asks to be reviewable is here.

The dividing line: **an edge means "this cannot be built until that lands"**, not
"this is where that came from". Most of the prose is the latter.

### Edges written — 26, across 16 issues

| blocked | blocked by | the prose it came from |
| --- | --- | --- |
| #316 | #315, #321 | `Follows #315` — and #321 says outright it "blocks the sweep story for #315", having been filed to stop #316 copying `pdf`'s fan-out instead of depending on it |
| #317 #318 #319 #320 | #315 | `Follows #315` — the openscad module does not exist yet, so nothing can be added to it |
| #255 #257 #258 #259 | #254 | `Builds on #254` — same, for the ssdd module |
| #256 | #254, #255 | `Builds on #254. Delta content depends on the amend/supersede story` (= #255) |
| #261 | #254, #256, #257 | `Builds on #254 and #256`, and #257 describes itself as "precondition for the OCI publishing story" |
| #262 #264 | #254, #255, #256 | `Builds on #254, #255 and #256` |
| #263 | #254, #256 | `Builds on #254 and #256` |
| #300 | #299 | `Depends on #298 and #299 for the two calls it recommends` — #298 is closed |
| #87 | #86 | `Builds on #86 (Kind backend in the kubernetes module)` |

### Deliberately left unblocked

- **Provenance, not ordering.** `Follow-up to #286` (#291, #287, #288, #289,
  #306), `Surfaced while designing #254` (#260), `Surfaced during design of the
  main story` (#259's second sentence), `Follows #266` (#272, #273, #274, #277),
  `Deferred from #222` (#231). Converting these into blocking edges would stall
  the backlog behind issues that never needed to land first — and in most cases
  behind issues that are already closed.
- **Every reference whose target is closed.** #286, #266, #276, #241, #218,
  #298, #309, #322, #323, #234, #131, #141, #43, #142, #223, #238, #242, #243,
  #130, #149, #222 are all closed, so #301's "which must land first", #132's
  "Blocked by #131" and #150's "Depends on / unblocked by #141" describe
  ordering that has already happened.
- **#329 → #328.** The only judgment call I would flag for a second opinion.
  #329's acceptance criteria say binaries must carry "any `ldflags` from #328",
  but the Related Issues line is `Relates to #328` — the weakest of the four
  phrasings this repository uses, and deliberately not `Builds on`. The clause
  reads as conditional, so #329 is left eligible. If the intent was that #328
  lands first, one `gh issue edit 329 --add-blocked-by 328` settles it.
- **#252 → #247.** "gets more precise parameter extraction once the full grammar
  lands" is an improvement afterwards, not a precondition.
- **#263 and #261's non-issue blockers.** "Blocked on the system spec
  representation, which is deferred upstream" and "Blocked on #257 *if* the
  target registry lacks referrers support" — the first names no issue in this
  repository; the second is covered by #257's own precondition claim.
- **Cross-repository.** #328, #329 and #330 say `Blocks z5labs/dfcad#63/64/65` —
  outbound only. No `owner/repo#N` blocker was created, which matters because
  the selector treats a cross-repository blocker as making that issue ineligible.

### The `story` label

Applied to 52 issues: every open issue whose title opens `story(` and which does
not carry `bug`. That excludes #147 (`story(daggerverse): fix kafka
SchemaRegistry BindTo` — titled as a story, labelled `bug`, and an
investigation rather than a scoped change), #307, #312 and #162.

Selection was then run end to end against the new config and reads the backlog
correctly:

```
$ plugins/backlog/scripts/select-issue.sh
select-issue: #60 eligible
{"number": 60, "title": "story(kafka): add examples/go/ cookbook module showcasing kafka usage"}
```

## Environment verification

| check | verdict | detail |
| --- | --- | --- |
| Squash-only merging | **ok** | `squashMergeAllowed: true`, merge-commit and rebase both `false`. `deleteBranchOnMerge: true` — note that this does *not* cover the loop: it fires for a merge a person performs, not one the workflow performs, which is why the workflow carries its own `delete-merged-branch` job. |
| Copilot code review | **ok** | 257 review comments authored by Copilot across this repository's pull requests. Proof, not inference. `review.required` stays `true`. |
| Labels | **ok** | `story` and `auto-merge` both created (neither existed). |
| Required status checks on `main` | **was a change, now ok** | Nothing existed in either mechanism: `rules/branches/main` returned `[]` and `branches/main/protection` returned 404 *Branch not protected*, both readable, so a real absence rather than a permissions gap. Fixed during this run — see below. |
| GitHub App token | **needs a change** | `gh secret list` returns `[]`: neither `BACKLOG_APP_ID` nor `BACKLOG_APP_KEY` is set. |

### Required status checks — the one that matters

With no required check, `gh pr merge --squash --auto` does not arm anything: it
merges immediately. The loop labels a pull request the moment its own local
verify passes, so **CI would never be consulted** and the local run would be the
only thing that ever looked at the code.

`ci.yml` already anticipates this and names the check to require:

> Because the run matrix is dynamic […] the per-leg check names cannot be
> required directly: a skipped leg would leave its required check pending
> forever. Require ONLY "CI Gate" in branch protection instead.

So the fix is a ruleset requiring exactly `CI Gate`, and it was created with the
repository owner's go-ahead: ruleset `20420888`, *default branch: require CI
Gate*, `enforcement: active`, scoped to `~DEFAULT_BRANCH` rather than to a branch
name so a rename cannot orphan it. `strict_required_status_checks_policy` is
`false` — requiring every branch to be up to date would force a rebase per
merge for no benefit under a memoized, change-aware CI. Readback:

```
$ gh api repos/z5labs/devex/rules/branches/main \
    --jq '[.[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context]'
["CI Gate"]
```

This pull request is the first one it applies to.

### The App token — a degradation, not a blocker

Without it the workflow merges with `GITHUB_TOKEN`, and GitHub creates no
workflow run from a `GITHUB_TOKEN`-triggered event — so `close-linked-issues` and
`delete-merged-branch` are silently skipped on every merge. The workflow warns
loudly in its log rather than failing, the merge still happens, and the cycle's
own `finish-issue` still closes the issue. What is lost is remote branch cleanup.
The repository currently has 4 branches, so nothing has accumulated yet.

Setup, when wanted: create a GitHub App, install it here with **Contents**,
**Pull requests** and **Issues** at read-and-write, and add its App ID as
`BACKLOG_APP_ID` and its PEM private key as `BACKLOG_APP_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
