### PR TITLE
story(issue-334): stop the cycle busy-waiting on its own Monitor calls

### DIFF
--- a/plugins/backlog/.claude-plugin/plugin.json
+++ b/plugins/backlog/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "backlog",
   "description": "Run a repository's story backlog unattended — one issue at a time, from selection through worktree, verification, pull request, Copilot review and label-driven auto merge",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": { "name": "z5labs" }
 }

--- a/plugins/backlog/agents/issue-worker.md
+++ b/plugins/backlog/agents/issue-worker.md
@@ -34,6 +34,15 @@ your report will read like an ordinary successful iteration.
   one iteration later, where nothing points back at the cause.
 - **Never delete a remote branch.** The merge workflow owns remote cleanup. Clean up only
   the worktree and local branch you created.
+- **Never busy-wait on a `Monitor` call.** The cycle's three long waits — CI checks, the
+  Copilot review, the merge — are each one `Monitor` call, and its result comes back to you
+  on its own. Once a wait is armed your turn is over: no no-op `sleep` Bash calls to pass the
+  time, and no reading, `cat`-ing or `tail`-ing a wait's output file, log or task record to
+  see how a monitor that has not reported yet is getting on. Neither makes the wait finish
+  sooner and both cost a full turn each; one measured iteration burned a quarter of its
+  tokens that way. Where a wait needs a precondition, put it inside the monitored command as
+  `until <precondition>; do sleep 5; done; <blocking command>`, which the skill spells out at
+  step 6.
 - **Do not weaken a test to make it pass**, and do not label a pull request whose review
   never completed.
 - **Do not retry selection unscoped.** If selection fails on the project scope you were

--- a/plugins/backlog/skills/next-issue/SKILL.md
+++ b/plugins/backlog/skills/next-issue/SKILL.md
@@ -297,19 +297,64 @@ CI outlasts the Bash tool — the call is killed mid-wait, and a wait that never
 exactly like a pull request whose checks failed. Every wait in this cycle goes through
 `Monitor` for that reason; step 7 and step 10 are the same.
 
-Do **not** use Bash `run_in_background` either. It has been observed exiting immediately
-without ever polling, which looks like a completed wait and reports whatever the first sample
-happened to be.
+Set `timeout_ms` to cover the monitored command's own wait. It defaults to five minutes,
+while the scripts steps 7 and 10 monitor wait up to ten, so `660000` covers every wait in
+this cycle with room to spare. A monitor killed halfway through a wait that would have
+succeeded reads as a failed wait.
+
+### Waiting is not something you do
+
+This is the first of the cycle's three waits, and the rule is the same for all of them.
+
+A `Monitor` call is the wait. Its result comes back to you on its own — the command's output
+arrives as notifications and its exit is reported when it ends — so there is nothing to
+collect, nothing to check, and nothing you can do that makes it arrive sooner. Once the wait
+is armed, **your turn is over.** The next thing you do is read what came back.
+
+Two improvisations have been measured on real runs, and both are forbidden by name:
+
+- **No no-op `sleep` Bash calls to pass the time.** `sleep 0.5; echo ok` and its variants
+  advance nothing — the monitored command is a separate process and it is not waiting on you
+  — while each one costs a full assistant turn. One measured iteration spent 106 turns, about
+  a quarter of its entire token cost, on that loop to buy under a minute of real waiting; the
+  two iterations either side of it spent 0 and 2.
+- **No peeking.** Do not `Read`, `cat` or `tail` a wait's output file, log or task record to
+  see how a `Monitor` that has not reported yet is getting on, and do not re-run the
+  underlying command by hand to check on it. Its output reaches you in full when it ends.
+
+The `Bash` tool's own description states the same rule from the other side: *foreground
+`sleep` is blocked; use `Monitor` with an until-loop to wait on a condition.*
+
+And do **not** reach for Bash `run_in_background` when a wait feels unreliable. It is not a
+more observable `Monitor`; it is a wait that has been observed exiting immediately without
+ever polling, reporting whatever the first sample happened to be as though the wait had
+completed. `Monitor` is the tool that actually waits. Where a wait needs a precondition, the
+precondition goes inside the monitored command — see `no checks reported` below — never into
+a turn of your own.
 
 - Exit 0 → green, continue.
 - Failure → read the logs (`gh run view <id> --log-failed`), fix, push, and re-watch. After
   **three** failed attempts on the same root cause, stop and report instead of looping.
-- `no checks reported` → nothing gates this pull request. Workflows queue for a few seconds
-  after a push, so re-check once after a short wait before concluding anything. If there
-  are still none, do not silently treat it as a pass: record `no checks reported` in the
-  report and continue. This is the same gap `backlog:setup-backlog` reports when the default
-  branch has no required status check, seen from the other side — with no required check,
-  the label in step 9 merges the pull request the instant it lands.
+- `no checks reported` → most often the workflows have not been created yet; runs queue for a
+  few seconds after a push. Do not re-check by hand and do not sleep between checks. Put the
+  precondition inside the `Monitor` command, so one call waits for the checks to appear and
+  then watches them:
+
+  ```
+  until gh pr checks <pr> --repo <repo> >/dev/null 2>&1; do sleep 5; done; gh pr checks <pr> --repo <repo> --watch --fail-fast
+  ```
+
+  `until <precondition>; do sleep 5; done; <blocking command>` is the sanctioned shape for
+  every "wait for X to exist, then wait for X to finish" in this cycle. The `sleep` is inside
+  the monitored command rather than in a turn of yours, and the whole wait costs one call.
+  `timeout_ms` bounds it, so a precondition that never becomes true ends the monitor instead
+  of hanging the cycle.
+
+  If that call ends with the checks still unreported, nothing gates this pull request. Do not
+  silently treat it as a pass: record `no checks reported` in the report and continue. This is
+  the same gap `backlog:setup-backlog` reports when the default branch has no required status
+  check, seen from the other side — with no required check, the label in step 9 merges the
+  pull request the instant it lands.
 
 ## 7. The Copilot review — one call
 
@@ -317,8 +362,11 @@ happened to be.
 Nothing here is optional when it is `true`.
 
 Requesting the review, waiting for it, and deciding whether what landed *is* a review are one
-call. Pass it as the `command` of a `Monitor` call — the wait runs up to ten minutes, past the
-Bash tool's ceiling — and not to Bash with `run_in_background`:
+call. Pass it as the `command` of a `Monitor` call with `timeout_ms` of `660000` — the wait
+runs up to ten minutes, past both the Bash tool's ceiling and `Monitor`'s default — and not to
+Bash with `run_in_background`. This is the longest wait in the cycle and the one that has
+attracted busy-waiting; step 6's rule holds unchanged here. Arm it, end your turn, and read
+the exit code when it arrives:
 
 ```
 "${CLAUDE_PLUGIN_ROOT}/scripts/await-review.sh" <pr>
@@ -359,7 +407,9 @@ debugging session:
   hard-coded.
 - The wait polls the **timeline**, not `pulls/<pr>/reviews`. The reviews endpoint has been
   seen empty for forty minutes after Copilot had in fact submitted, so polling it times out
-  on a pull request that *was* reviewed.
+  on a pull request that *was* reviewed. That is why the polling lives in the script and is
+  aimed at the timeline; a check of your own, against whichever endpoint, is the mistake this
+  finding is made of.
 - `--paginate`, because the timeline returns thirty events per page and a pull request with a
   few pushes and check runs pushes the `reviewed` event off page one.
 - A case-insensitive `copilot` login filter, without which the repository owner glancing at
@@ -368,6 +418,11 @@ debugging session:
 Re-running is safe: a Copilot review already on the pull request is classified and returned
 without requesting another, and the newest review wins, so an old decline sitting beside a
 newer completed review is not misread.
+
+Every finding above is a reason the wait is *inside* a script rather than in your hands. None
+of them is a reason to look in on the script while it runs — a review that has not landed yet
+reads exactly like one that never will, from your side, and the script is the thing that can
+tell those apart. Re-run it after an exit 2; do not check on it before one.
 
 ## 8. Address the review
 
@@ -473,7 +528,15 @@ gh run list --repo <repo> --workflow <merge.workflow> --branch issue-<n> --limit
 that workflow in the whole repository — anyone labelling another pull request while yours is
 queued hands you their result, and it reads as a verdict on yours.
 
-Wait for it to leave `queued` and `in_progress`. A `success` conclusion with the pull
+If it has not completed, waiting for it is a `Monitor` call in the form step 6 gives, not a
+sequence of Bash calls of your own:
+
+```
+until [ "$(gh run list --repo <repo> --workflow <merge.workflow> --branch issue-<n> --limit 1 --json status --jq '.[0].status // ""')" = completed ]; do sleep 5; done
+gh run list --repo <repo> --workflow <merge.workflow> --branch issue-<n> --limit 1 --json conclusion --jq '.[0].conclusion'
+```
+
+A `success` conclusion with the pull
 request still open means auto merge is armed and waiting on a check. A `failure` conclusion
 means the workflow itself is broken — report it, with the output of
 `gh run view <id> --log-failed`, rather than falling back to a manual merge, which is what
@@ -483,8 +546,11 @@ this whole step exists to avoid.
 
 Everything after the label is mechanism, not judgment: wait for the merge, close the issue,
 verify it closed, drop the worktree, delete the local branch. Run it as one script rather
-than as five steps. Pass it as the `command` of a `Monitor` call — the wait runs up to ten
-minutes, past the Bash tool's ceiling — and not to Bash with `run_in_background`:
+than as five steps. Pass it as the `command` of a `Monitor` call with `timeout_ms` of
+`660000` — the wait runs up to ten minutes, past both the Bash tool's ceiling and `Monitor`'s
+default — and not to Bash with `run_in_background`. Step 6's rule holds here too: arm it, end
+your turn, and read the exit code when it arrives. Do not sleep, and do not read the pull
+request or the worktree to see how far it has got.
 
 ```
 "${CLAUDE_PLUGIN_ROOT}/scripts/finish-issue.sh" <n> <pr> issue-<n>

--- a/plugins/backlog/skills/run-backlog/SKILL.md
+++ b/plugins/backlog/skills/run-backlog/SKILL.md
@@ -110,9 +110,29 @@ Also halt if:
 - The bound is reached. Say so plainly: a loop that stopped at its bound with work left is a
   different outcome from a drained backlog, and the user's next move differs.
 
-Record per iteration: issue number and title, pull request number, and merged / blocked.
-Nothing else. Keep the running list short enough that you can still see all of it at the
-end.
+Record per iteration: issue number and title, pull request number, merged / blocked, and the
+token cost the agent result reports for that worker. Nothing else. Keep the running list
+short enough that you can still see all of it at the end.
+
+### What an iteration should cost
+
+A worker that takes one story from selection to a merged pull request costs roughly
+**300–375k tokens** and 300–390 assistant turns, at about a thousand tokens a turn. Three
+consecutive iterations measured against a real repository came in at 370k / 346k / 405k.
+
+The third one did not do more work. It **busy-waited**: filled the time while a `Monitor`
+wait was outstanding with no-op `sleep` Bash calls and with reads of the wait's output file,
+106 turns of them out of 419 — about 100k tokens, a quarter of the iteration, spent to buy
+under a minute of real waiting. The two either side of it spent 0 and 2 turns that way on
+comparable work, and nothing in the three reports distinguished them.
+
+So an iteration well past the band is a wait that was watched rather than an issue that was
+large.
+
+`backlog:next-issue` forbids both improvisations by name at step 6 and `issue-worker` repeats
+the rule, so a worker doing it is a worker that departed from the cycle. Name it in the
+report when the table shows it: the iteration count and the outcomes look identical either
+way, and the cost column is the only place a run that regressed is visible.
 
 ## 2. What you never do yourself
 
@@ -137,6 +157,10 @@ Close with the iteration table, the scope the run was under if it had one, the r
 loop stopped in its own words (`BACKLOG EMPTY`, `BLOCKED`, bound reached, worker failure),
 and — if anything merged without a review because `review.required` is `false` — that fact,
 once, for the whole run.
+
+The table carries the token cost per iteration, so keep that column in the closing report
+rather than summarising it away. It is what makes the next run comparable to this one, and
+the only signal that separates an expensive iteration from a busy-waiting one.
 
 ## Running it on a schedule
 


### PR DESCRIPTION
Closes #334

The cycle routed every long wait through `Monitor` but never said what a worker should do
*while* one is outstanding, and workers filled the gap with a poll loop — 106 turns in one
measured iteration, about a quarter of its tokens, to buy under a minute of real waiting.
This states the contract, forbids the two observed improvisations by name, and gives the
`until`-precondition form the same worker independently discovered.

## Acceptance criteria

- [x] **`next-issue` states the `Monitor` contract once, where the first `Monitor` call is
      introduced.** New "Waiting is not something you do" section in step 6, flagged there as
      the rule for all three of the cycle's waits. Steps 7 and 10 point back at it rather than
      restating it.
- [x] **The two improvisations are forbidden by name** — no-op `sleep` Bash calls used to pass
      the time, and reading/`cat`-ing/`tail`-ing a wait's output file, log or task record to
      peek at a `Monitor` that has not reported. Each is its own bullet, with the measured cost.
- [x] **Step 6 gives the `until <precondition>; do sleep 5; done; <blocking command>` form**
      inside the `Monitor` command, replacing "re-check once after a short wait". The form is
      named in prose as the sanctioned shape for every wait-for-X-then-wait-for-X-to-finish in
      the cycle.
- [x] **Both existing warnings kept and reworded.** `run_in_background` is now framed as "not a
      more observable `Monitor`" — a wait that does not wait — rather than as an unreliability
      to compensate for. Step 7's timeline/`pulls/reviews` finding gains a closing clause: it is
      why the polling lives in the script, not a reason to look in on it.
- [x] **`agents/issue-worker.md` carries the same rule**, as a rule in the section that
      outranks anything the worker concludes mid-run, so a worker that never reads past the
      agent definition still has it.
- [x] **`run-backlog` records the expected per-iteration cost** (~300–375k tokens, 300–390
      turns, with the three measured iterations), names busy-waiting as what inflates it, adds
      the token cost to the per-iteration record and keeps that column in the closing report.

## Judgment calls

**"Blocks" vs "the result comes back on its own."** The criterion asked for the skill to say a
`Monitor` call *blocks* the cycle. It does not, literally: `Monitor` arms a background watch and
returns, and the command's output and exit arrive later as notifications. Writing "it blocks"
would have been falsified on the worker's first wait — plausibly the very thing that convinced
one to start checking. The skill instead says the wait's result comes back on its own, that
nothing the worker does makes it arrive sooner, and that **once a wait is armed the turn is
over**, which is the behaviour the criterion is after and is true as written.

**Two additions beyond the listed criteria**, both in the same territory and both cheap:

- `Monitor`'s `timeout_ms` defaults to five minutes; `await-review.sh` and `finish-issue.sh`
  each wait up to ten (`POLL_COUNT=40` × `POLL_SECONDS=15`). A default-timeout monitor is killed
  halfway through a wait that would have succeeded, which reads as a failed wait — exactly the
  kind of thing that teaches a worker not to trust the tool. Steps 6, 7 and 10 now say `660000`.
- Step 9's `OPEN not-armed` path said "wait for it to leave `queued` and `in_progress`" with no
  mechanism, which is the same unstated-wait defect one step further on. It now gives the
  `until` form as a `Monitor` call.

**Plugin version** bumped `0.2.0` → `0.3.0`; plugin caches are version-keyed, so without it the
prose does not reach an installed copy.

## Verification

Both `verify` commands from `.claude/backlog.json`, from inside the worktree:

- `dagger check` — exit 0, all legs OK.
- `bash .github/scripts/verify-affected-modules.sh` — `no daggerverse module changed against
  origin/main` (this change is plugin markdown and one JSON version field).
