### PR TITLE
story(issue-335): make the project scope's field a per-run choice, not a config edit

### DIFF
--- a/.claude/backlog.json
+++ b/.claude/backlog.json
@@ -2,7 +2,13 @@
   "select": {
     "label": "story",
     "milestone": null,
-    "limit": 200
+    "limit": 200,
+    "project": {
+      "owner": "z5labs",
+      "number": 14,
+      "field": "Module",
+      "value": null
+    }
   },
   "dependencies": {
     "style": "native"

--- a/plugins/backlog/.claude-plugin/plugin.json
+++ b/plugins/backlog/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "backlog",
   "description": "Run a repository's story backlog unattended — one issue at a time, from selection through worktree, verification, pull request, Copilot review and label-driven auto merge",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": { "name": "z5labs" }
 }

--- a/plugins/backlog/agents/issue-worker.md
+++ b/plugins/backlog/agents/issue-worker.md
@@ -18,10 +18,12 @@ Skill tool is not granted to this agent; backlog:next-issue cannot be invoked`. 
 fallback: reconstructing the cycle from memory is how the footnotes that make it work get
 dropped.
 
-If your prompt names a project-field scope — `--project-value <value>` — carry it through to
-the skill's selection step unchanged. It is not advisory and it is not yours to widen: an
-unscoped selection picks up an issue from somewhere else in the backlog and merges it, and
-your report will read like an ordinary successful iteration.
+If your prompt names a project scope — any of `--project-value`, `--project-field`,
+`--project-owner`, `--project-number` — carry **all** of them through to the skill's selection
+step unchanged. They are not advisory and they are not yours to widen, narrow or swap: an
+unscoped selection picks up an issue from somewhere else in the backlog and merges it, and a
+selection scoped on the wrong field does the same while still looking scoped. Either way your
+report will read like an ordinary successful iteration.
 
 ## Rules that outrank anything else you conclude mid-run
 
@@ -36,8 +38,9 @@ your report will read like an ordinary successful iteration.
   the worktree and local branch you created.
 - **Do not weaken a test to make it pass**, and do not label a pull request whose review
   never completed.
-- **Do not retry selection unscoped.** If selection fails on the project scope you were
-  given, that is a `BLOCKED` report, not a reason to drop the flag.
+- **Do not retry selection unscoped, or on another scope.** If selection fails on the project
+  scope you were given, that is a `BLOCKED` report — not a reason to drop a flag, try a
+  different field or value, or edit `.claude/backlog.json` until it resolves.
 
 ## Your final message is the return value
 

--- a/plugins/backlog/assets/backlog.schema.json
+++ b/plugins/backlog/assets/backlog.schema.json
@@ -33,30 +33,31 @@
         "project": {
           "type": ["object", "null"],
           "default": null,
-          "description": "Optionally narrow the backlog to one value of a GitHub Projects v2 single-select field — \"just the workspace-ci stories\" — on a repository that groups its work by a project field rather than by labels or milestones. Absent or `null` means no such scoping, and `scripts/select-issue.sh` then makes no project API call at all. Reading a project field rather than a convention in the issue body is deliberate: the data already exists on every issue the project holds, a single-select cannot hold a typo'd value however the issue was filed (`gh issue create --body` bypasses issue templates entirely), and the value comes back as data rather than as prose to parse. The cost is that membership lives outside the repository, so a renamed field or a deleted project takes the scoping with it — acceptable because the filter is optional and its failure mode is `select-issue.sh` refusing to select, never a silent fall back to the unscoped backlog. Requires the `read:project` token scope (`gh auth refresh -s read:project`).",
+          "description": "Optionally narrow the backlog to one value of a GitHub Projects v2 single-select field — \"just the workspace-ci stories\" — on a repository that groups its work by a project field rather than by labels or milestones. Absent or `null` means no such scoping, and `scripts/select-issue.sh` then makes no project API call at all. Reading a project field rather than a convention in the issue body is deliberate: the data already exists on every issue the project holds, a single-select cannot hold a typo'd value however the issue was filed (`gh issue create --body` bypasses issue templates entirely), and the value comes back as data rather than as prose to parse. The cost is that membership lives outside the repository, so a renamed field or a deleted project takes the scoping with it — acceptable because the filter is optional and its failure mode is `select-issue.sh` refusing to select, never a silent fall back to the unscoped backlog. Requires the `read:project` token scope (`gh auth refresh -s read:project`). Every key below has a matching `select-issue.sh` flag that overrides it for one run, so a complete scope can be assembled on the command line and this whole block stays optional — including on a repository that has never carried one. What belongs here is what stays true between runs: the board, and the axis the backlog is usually grouped by.",
           "additionalProperties": false,
-          "required": ["owner", "number", "field"],
+          "required": ["owner", "number"],
           "properties": {
             "owner": {
               "type": "string",
               "minLength": 1,
-              "description": "The organisation or user login that owns the project. An organisation is tried first and a user only after GitHub reports the login is not one, because a project number is scoped to its owner."
+              "description": "The organisation or user login that owns the project. An organisation is tried first and a user only after GitHub reports the login is not one, because a project number is scoped to its owner. Required whenever this block is present, and with `number` it is the reason the block is worth having: which board the repository's work lives on is a property of the repository, not of a run. `select-issue.sh --project-owner <login>` overrides it anyway, so a repository with no block at all can still be scoped — that flag is for the one-off, not for the normal path."
             },
             "number": {
               "type": "integer",
               "minimum": 1,
-              "description": "The project number, as it appears in the project's URL (`/orgs/<owner>/projects/<number>`)."
+              "description": "The project number, as it appears in the project's URL (`/orgs/<owner>/projects/<number>`). Overridable per run by `select-issue.sh --project-number <n>`, on the same terms as `owner`."
             },
             "field": {
-              "type": "string",
+              "type": ["string", "null"],
               "minLength": 1,
-              "description": "The single-select field to read, by name — `Module`, `Area`, `Component`. It must be a single-select field: any other field type is a hard failure rather than a scope that quietly matches nothing. The name is matched exactly, and the failure names every field the project has."
+              "default": null,
+              "description": "The single-select field to read, by name — `Module`, `Area`, `Component`. It must be a single-select field: any other field type is a hard failure rather than a scope that quietly matches nothing. The name is matched exactly, and the failure names every field the project has. This is the axis the backlog is *usually* grouped by, not the only one it can be: `select-issue.sh --project-field <name>` picks another for one run, because a board routinely carries more than one single-select worth scoping by and \"work the In Progress stories\" is the same kind of request as \"work the workspace-ci stories\". Optional for that reason — a run that always names its own axis needs nothing here — but a scope with neither this nor the flag is a hard failure naming both, never a fall back to the unscoped backlog."
             },
             "value": {
               "type": ["string", "null"],
               "minLength": 1,
               "default": null,
-              "description": "The field value the backlog is restricted to, matched exactly against the field's declared options. `null` means no scoping by default — the usual setting, because \"just workspace-ci today\" is a property of one run rather than a permanent description of the backlog. `select-issue.sh --project-value <value>` overrides this per run and `--no-project-filter` clears it, so a scoped run needs no edit to this file. A value that is not one of the field's options fails with the list of options rather than selecting from an empty backlog, which would read as a drained one and stop the loop looking like success."
+              "description": "The field value the backlog is restricted to, matched exactly against the field's declared options. `null` means no scoping by default — the usual setting, because \"just workspace-ci today\" is a property of one run rather than a permanent description of the backlog. `select-issue.sh --project-value <value>` overrides this per run and `--no-project-filter` clears it, so a scoped run needs no edit to this file. `--no-project-filter` is refused alongside any other project flag: it means \"run unscoped\", so combining it with a flag that describes a scope would have to discard one of the two silently. A value that is not one of the field's options fails with the list of options rather than selecting from an empty backlog, which would read as a drained one and stop the loop looking like success."
             }
           }
         }

--- a/plugins/backlog/scripts/select-issue.sh
+++ b/plugins/backlog/scripts/select-issue.sh
@@ -2,7 +2,9 @@
 #
 # select-issue.sh — pick the next eligible backlog issue, as one call.
 #
-# Usage: select-issue.sh [--project-value <value> | --no-project-filter]
+# Usage: select-issue.sh [--project-owner <login>] [--project-number <n>]
+#                        [--project-field <name>] [--project-value <value>]
+#        select-issue.sh --no-project-filter
 #        select-issue.sh --extract <blocked-by|depends-on|none> [file]
 #        select-issue.sh --native-deps <repo> [file]
 #        select-issue.sh --project-items <repo> <field> <value> [file]
@@ -491,38 +493,76 @@ project_fetch() { # <owner> <number> <field> ; needs ERRFILE
 # today" is a property of one run, and a config-only knob would mean editing
 # .claude/backlog.json before and after every scoped run.
 #
-# Two flags rather than one with an empty-string sentinel. `--project-value ''`
+# Every piece of the scope gets a flag, for the same reason the value does. The
+# *axis* is as much a property of one run as the value on it: a board routinely
+# carries more than one single-select worth scoping by — devex's own project 14
+# has both `Status` and `Module` — and "work the In Progress stories" is the same
+# kind of request as "work the workspace-ci stories". Pinning the axis in the
+# config would make only the second one expressible.
+#
+# `--project-owner` and `--project-number` are the weakest case: they describe
+# the repository's board rather than a run, and the config stays their normal
+# home. They exist so a scope can be assembled from flags alone on a repository
+# whose config carries no `select.project` at all — without them, scoping such a
+# repository at all costs an edit and a commit to a tracked file, which is the
+# cost every flag here exists to avoid.
+#
+# Nothing new has to validate `--project-field`. `project_query` reads `fields`
+# rather than `field(name: $field)`, so an unknown name already fails the run at
+# exit 4 with the list of real field names; the flag inherits that check
+# unchanged rather than growing a second one that could disagree with it.
+#
+# Separate flags rather than one with an empty-string sentinel. `--project-value ''`
 # would have to mean "no scope", which is the same conflation `--milestone ''`
 # is avoided for below.
+OPT_PROJECT_OWNER=""
+OPT_PROJECT_OWNER_SET=0
+OPT_PROJECT_NUMBER=""
+OPT_PROJECT_NUMBER_SET=0
+OPT_PROJECT_FIELD=""
+OPT_PROJECT_FIELD_SET=0
 OPT_PROJECT_VALUE=""
 OPT_PROJECT_VALUE_SET=0
 OPT_NO_PROJECT=0
+GIVEN=""   # the project flags this run named, for the messages below
+
+USAGE='usage: select-issue.sh [--project-owner <login>] [--project-number <n>] [--project-field <name>] [--project-value <value>] | --no-project-filter'
+
+set_project_opt() { # <flag> <value>
+  [ -n "$2" ] \
+    || fail 4 "$1 needs a non-empty value; to run unscoped, pass --no-project-filter or nothing at all"
+  case "$1" in
+    --project-owner)  OPT_PROJECT_OWNER=$2;  OPT_PROJECT_OWNER_SET=1 ;;
+    --project-number) OPT_PROJECT_NUMBER=$2; OPT_PROJECT_NUMBER_SET=1 ;;
+    --project-field)  OPT_PROJECT_FIELD=$2;  OPT_PROJECT_FIELD_SET=1 ;;
+    --project-value)  OPT_PROJECT_VALUE=$2;  OPT_PROJECT_VALUE_SET=1 ;;
+  esac
+  GIVEN="$GIVEN $1"
+}
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    --project-value)
-      [ $# -ge 2 ] || fail 4 "--project-value needs a value"
-      OPT_PROJECT_VALUE=$2
-      OPT_PROJECT_VALUE_SET=1
+    --project-owner|--project-number|--project-field|--project-value)
+      [ $# -ge 2 ] || fail 4 "$1 needs a value"
+      set_project_opt "$1" "$2"
       shift 2 ;;
-    --project-value=*)
-      OPT_PROJECT_VALUE=${1#*=}
-      OPT_PROJECT_VALUE_SET=1
+    --project-owner=*|--project-number=*|--project-field=*|--project-value=*)
+      set_project_opt "${1%%=*}" "${1#*=}"
       shift ;;
     --no-project-filter)
       OPT_NO_PROJECT=1
       shift ;;
     *)
-      fail 4 "unknown argument '$1'; usage: select-issue.sh [--project-value <value> | --no-project-filter]" ;;
+      fail 4 "unknown argument '$1'; $USAGE" ;;
   esac
 done
 
-if [ "$OPT_PROJECT_VALUE_SET" -eq 1 ]; then
-  [ -n "$OPT_PROJECT_VALUE" ] \
-    || fail 4 "--project-value needs a non-empty value; to run unscoped, pass --no-project-filter or nothing at all"
-  [ "$OPT_NO_PROJECT" -eq 0 ] \
-    || fail 4 "--project-value and --no-project-filter cannot both be given"
-fi
+# `--no-project-filter` is "run unscoped", so it contradicts every flag that
+# describes a scope — not just the value. Accepting `--project-field X
+# --no-project-filter` would have to silently discard one of the two, and
+# discarding either is a run that is not the run that was asked for.
+[ "$OPT_NO_PROJECT" -eq 1 ] && [ -n "$GIVEN" ] \
+  && fail 4 "--no-project-filter cannot be combined with$GIVEN"
 
 # ----------------------------------------------------------------- config -----
 command -v gh >/dev/null 2>&1 || fail 4 "gh is not on PATH"
@@ -575,20 +615,43 @@ case "$PROJECT_KIND" in
   *) fail 4 "$CFG: select.project must be an object or null (found a $PROJECT_KIND)" ;;
 esac
 
-[ "$OPT_PROJECT_VALUE_SET" -eq 1 ] && PROJECT_VALUE=$OPT_PROJECT_VALUE
+# Piece by piece, so a run can override the axis, the value, or the board itself
+# without any of the three implying the others. A repository whose config has no
+# select.project at all assembles the whole scope here.
+[ "$OPT_PROJECT_OWNER_SET" -eq 1 ]  && PROJECT_OWNER=$OPT_PROJECT_OWNER
+[ "$OPT_PROJECT_NUMBER_SET" -eq 1 ] && PROJECT_NUMBER=$OPT_PROJECT_NUMBER
+[ "$OPT_PROJECT_FIELD_SET" -eq 1 ]  && PROJECT_FIELD=$OPT_PROJECT_FIELD
+[ "$OPT_PROJECT_VALUE_SET" -eq 1 ]  && PROJECT_VALUE=$OPT_PROJECT_VALUE
 [ "$OPT_NO_PROJECT" -eq 1 ] && PROJECT_VALUE=""
 
 # Validated up front rather than at the point of use: a scope that cannot be
 # resolved has to stop selection, not degrade it to the unscoped backlog.
+#
+# Every message names both places a piece can come from. "Add owner, number and
+# field to the config" stopped being the whole answer once each of them had a
+# flag, and a run told to edit a tracked file it does not need to edit will edit
+# it.
+MISSING=""
+[ -n "$PROJECT_OWNER" ]  || MISSING="$MISSING owner (select.project.owner or --project-owner);"
+[ -n "$PROJECT_NUMBER" ] || MISSING="$MISSING number (select.project.number or --project-number);"
+[ -n "$PROJECT_FIELD" ]  || MISSING="$MISSING field (select.project.field or --project-field);"
+
 if [ -n "$PROJECT_VALUE" ]; then
-  [ "$PROJECT_KIND" = object ] \
-    || fail 4 "a project scope of '$PROJECT_VALUE' was requested but $CFG has no select.project; add owner, number and field to it"
-  [ -n "$PROJECT_OWNER" ] || fail 4 "$CFG: select.project.owner is missing or empty"
-  [ -n "$PROJECT_FIELD" ] || fail 4 "$CFG: select.project.field is missing or empty"
+  [ -z "$MISSING" ] \
+    || fail 4 "a project scope of '$PROJECT_VALUE' was requested but the scope is incomplete; missing:${MISSING%;}"
+  NUMBER_SRC="$CFG: select.project.number"
+  [ "$OPT_PROJECT_NUMBER_SET" -eq 1 ] && NUMBER_SRC="--project-number"
   case "$PROJECT_NUMBER" in
-    ''|*[!0-9]*) fail 4 "$CFG: select.project.number must be a positive integer (found '${PROJECT_NUMBER:-null}')" ;;
-    0)           fail 4 "$CFG: select.project.number must be at least 1" ;;
+    *[!0-9]*) fail 4 "$NUMBER_SRC must be a positive integer (found '$PROJECT_NUMBER')" ;;
+    0)        fail 4 "$NUMBER_SRC must be at least 1" ;;
   esac
+elif [ -n "$GIVEN" ]; then
+  # Naming a board or an axis with nothing to match on it is not an unscoped run
+  # — it is a scoped run missing its value, and answering it with the whole
+  # backlog is the silent widening every other failure here is written to avoid.
+  # `--no-project-filter` is the way to say "unscoped", and it is refused above
+  # in combination with these flags precisely so this case cannot be ambiguous.
+  fail 4 "the project scope names$GIVEN but no value to scope by; add --project-value <value> or set select.project.value"
 fi
 
 REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null) \

--- a/plugins/backlog/scripts/select-issue_test.sh
+++ b/plugins/backlog/scripts/select-issue_test.sh
@@ -482,5 +482,168 @@ checkp_fail 'an unresolvable project is refused' z5labs/devex Module workspace-c
 checkp_fail 'an empty response is refused' z5labs/devex Module workspace-ci \
   'returned no response' ''
 
+printf '\nscope assembly\n'
+
+# Where the scope came from, as opposed to what a project response means. Every
+# case here runs the *whole* script — flags, config, the merge of the two,
+# selection — against a scratch repository and a `gh` that answers from files, so
+# the rules that decide which scope a run is under are exercised with no network
+# at all. That matters most for the case the seam above cannot reach: a complete
+# scope assembled from flags alone, against a config carrying no `select.project`.
+#
+# `dependencies.style` is `none` in every case, so the walk takes the first
+# in-scope candidate and never reads a body. Three answers are therefore
+# distinguishable — unscoped picks 288, `Module = workspace-ci` picks 291,
+# `Status = Todo` picks 302 — and each case asserts which of the three it got.
+# An assertion that could not tell a dropped scope from an applied one would pass
+# for the bug these flags are most able to introduce.
+SCRATCH=$(mktemp -d) || { printf 'cannot create a scratch directory\n' >&2; exit 1; }
+trap 'rm -rf "$SCRATCH"' EXIT
+
+git init -q "$SCRATCH/repo" >/dev/null 2>&1 \
+  || { printf 'cannot init a scratch repository\n' >&2; exit 1; }
+mkdir -p "$SCRATCH/repo/.claude" "$SCRATCH/bin" "$SCRATCH/pages"
+
+# The three gh calls this path makes, answered from files. The project response
+# is chosen by the `field=` the query was given, which is what lets a case prove
+# the flag reached the *query* rather than only the message. Anything else is a
+# loud failure: `gh issue view` would mean the dependency walk read a body under
+# style `none`.
+cat >"$SCRATCH/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+case "$1 $2" in
+  'repo view')  printf 'z5labs/devex\n' ;;
+  'issue list') cat "$STUB_ISSUES" ;;
+  'api graphql')
+    f=""
+    for a in "$@"; do case "$a" in field=*) f=${a#field=} ;; esac; done
+    if [ -n "$f" ] && [ -f "$STUB_PAGES/$f" ]; then cat "$STUB_PAGES/$f"; else cat "$STUB_PAGES/default"; fi ;;
+  *) printf 'stub gh: unexpected call: %s\n' "$*" >&2; exit 1 ;;
+esac
+STUB
+chmod +x "$SCRATCH/bin/gh"
+
+printf '288\tthe first\n291\tthe second\n302\tthe third\n' >"$SCRATCH/issues"
+
+page "[$(issue_item 288 z5labs/devex pdf),
+       $(issue_item 291 z5labs/devex workspace-ci),
+       $(issue_item 302 z5labs/devex workspace-ci)]" >"$SCRATCH/pages/Module"
+page "[$(issue_item 288 z5labs/devex Done),
+       $(issue_item 291 z5labs/devex Done),
+       $(issue_item 302 z5labs/devex Todo)]" >"$SCRATCH/pages/Status"
+# A field the project does not have still gets the project's field list back,
+# which is the whole reason `project_query` reads `fields` rather than
+# `field(name:)`.
+page '[]' >"$SCRATCH/pages/default"
+
+# run_sut <select.project json, or - for none> [args...]
+run_sut() {
+  local project=$1
+  shift
+  local block=""
+  [ "$project" = - ] || block=",
+    \"project\": $project"
+  cat >"$SCRATCH/repo/.claude/backlog.json" <<JSON
+{
+  "select": { "label": "story", "milestone": null, "limit": 200$block },
+  "dependencies": { "style": "none" },
+  "verify": ["true"],
+  "merge": { "label": "auto-merge", "workflow": "auto-merge.yaml" },
+  "review": { "required": true },
+  "worktreeDir": ".claude/worktrees"
+}
+JSON
+  RUN_OUT=$(cd "$SCRATCH/repo" && PATH="$SCRATCH/bin:$PATH" \
+    STUB_ISSUES="$SCRATCH/issues" STUB_PAGES="$SCRATCH/pages" \
+    "$SUT" "$@" 2>"$SCRATCH/err")
+  RUN_RC=$?
+  RUN_ERR=$(tr '\n' ' ' <"$SCRATCH/err")
+}
+
+# checks <name> <expected issue number> <select.project json|-> [args...]
+checks() {
+  local name=$1 want=$2
+  shift 2
+  run_sut "$@"
+  local got
+  got=$(printf '%s' "$RUN_OUT" | jq -r '.number // empty' 2>/dev/null)
+  if [ "$RUN_RC" -eq 0 ] && [ "$got" = "$want" ]; then
+    pass=$((pass + 1))
+    printf '  ok   %-58s [#%s]\n' "$name" "$got"
+  else
+    fail=$((fail + 1))
+    printf '  FAIL %-58s want [#%s] exit 0, got [%s] exit %d: %s\n' \
+      "$name" "$want" "${got:-<none>}" "$RUN_RC" "$RUN_ERR"
+  fi
+}
+
+# checks_fail <name> <substring of the message> <select.project json|-> [args...]
+checks_fail() {
+  local name=$1 want=$2
+  shift 2
+  run_sut "$@"
+  case "$RUN_ERR" in
+    *"$want"*) ;;
+    *) fail=$((fail + 1))
+       printf '  FAIL %-58s message lacks [%s]: %s\n' "$name" "$want" "$RUN_ERR"
+       return ;;
+  esac
+  if [ "$RUN_RC" -eq 4 ]; then
+    pass=$((pass + 1))
+    printf '  ok   %-58s [exit 4]\n' "$name"
+  else
+    fail=$((fail + 1))
+    printf '  FAIL %-58s want exit 4, got exit %d\n' "$name" "$RUN_RC"
+  fi
+}
+
+BOARD='{"owner":"z5labs","number":14,"field":"Status","value":null}'
+PINNED='{"owner":"z5labs","number":14,"field":"Status","value":"Todo"}'
+
+# The case the config-only design could not express at all: no select.project in
+# the file, a complete scope on the command line.
+checks 'a scope assembled from flags alone' 291 - \
+  --project-owner z5labs --project-number 14 --project-field Module --project-value workspace-ci
+
+checks 'the =value form assembles the same scope' 291 - \
+  --project-owner=z5labs --project-number=14 --project-field=Module --project-value=workspace-ci
+
+# 291 rather than 302 is the assertion: the flag reached the query, and the
+# configured Status axis did not.
+checks '--project-field overrides the configured field' 291 "$BOARD" \
+  --project-field Module --project-value workspace-ci
+
+checks '--project-value alone keeps the configured field' 302 "$BOARD" \
+  --project-value Todo
+
+checks 'a fully configured scope still needs no flags' 302 "$PINNED"
+
+checks '--no-project-filter drops the configured scope' 288 "$PINNED" \
+  --no-project-filter
+
+# The existing `fields` lookup, reached through the flag rather than the config.
+# No second code path, and no second list of field names to disagree with it.
+checks_fail 'an unknown --project-field names the fields' 'Title, Status, Module' "$BOARD" \
+  --project-field Modul --project-value workspace-ci
+
+# Each of these would otherwise be a run silently widened to another dimension,
+# or to the whole backlog. All three say which piece is missing.
+checks_fail 'a scope with nothing behind it names all three' 'owner (select.project.owner or --project-owner)' - \
+  --project-value workspace-ci
+
+checks_fail 'a config missing only the field says so' 'field (select.project.field or --project-field)' \
+  '{"owner":"z5labs","number":14}' --project-value workspace-ci
+
+checks_fail 'an axis with no value is not an unscoped run' 'no value to scope by' "$BOARD" \
+  --project-field Module
+
+checks_fail 'a scope flag and --no-project-filter is refused' 'cannot be combined with' "$BOARD" \
+  --project-field Module --no-project-filter
+
+# The message names the flag, not the config key, when the flag is where the bad
+# number came from.
+checks_fail 'a bad --project-number blames the flag' '--project-number must be a positive integer' - \
+  --project-owner z5labs --project-number fourteen --project-field Module --project-value workspace-ci
+
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/plugins/backlog/skills/next-issue/SKILL.md
+++ b/plugins/backlog/skills/next-issue/SKILL.md
@@ -93,31 +93,55 @@ you did not expect can be explained without re-running anything.
 ### Scoping the run to one project field value
 
 Some repositories group work by a single-select field on a GitHub project — `Module`, `Area`,
-`Component` — rather than by labels or milestones. Where `.claude/backlog.json` carries
-`select.project`, one run can be restricted to a single value of that field:
+`Component`, `Status` — rather than by labels or milestones. One run can be restricted to a
+single value of one such field:
 
 ```
 "${CLAUDE_PLUGIN_ROOT}/scripts/select-issue.sh" --project-value <value>
 ```
 
-Pass the flag when, and only when, you were asked for a scoped run — the user named one, or
-`backlog:run-backlog` put one in your prompt. Otherwise call the script with no arguments and
-let `select.project.value` decide, which is normally `null` and means the whole backlog.
-`--no-project-filter` is the other direction: run unscoped even though the config pins a
-value.
+A scope is four things, and each one has a flag that overrides `.claude/backlog.json` for
+this run only:
+
+| flag | overrides | when you pass it |
+| --- | --- | --- |
+| `--project-value <value>` | `select.project.value` | you were asked for a scoped run |
+| `--project-field <name>` | `select.project.field` | you were asked to scope by an axis other than the configured one — `Status` where the config says `Module` |
+| `--project-owner <login>` | `select.project.owner` | the config has no `select.project` at all, or names a different board |
+| `--project-number <n>` | `select.project.number` | same |
+
+The usual scoped call is `--project-value` alone: the config already names the board and the
+axis, and only the value is a property of this run. `--project-field` is the next most common,
+because a board routinely carries more than one single-select worth scoping by. `--project-owner`
+and `--project-number` are for the repository whose config carries no `select.project` — with
+them a complete scope can be assembled on the command line, so scoping never requires editing
+a tracked file.
+
+Pass a flag when, and only when, you were asked for that scope — the user named it, or
+`backlog:run-backlog` put it in your prompt. **Never infer one from the issues you can see.**
+With nothing asked for, call the script with no arguments and let the config decide, which
+normally means `value` is `null` and the whole backlog is in play. `--no-project-filter` is
+the other direction: run unscoped even though the config pins a value. It cannot be combined
+with any of the four flags above — "unscoped" and "scoped like this" is not a request the
+script will guess at.
 
 The scope is applied before the dependency walk, so the walk sees only in-scope issues and a
 blocker outside the scope cannot hold up the one you were asked to work.
 
-Two things to know when it fails:
+Three things to know when it fails:
 
-- It needs the **`read:project`** token scope, which `repo` does not include.
+- It needs the **`read:project`** token scope, which `repo` does not include, and it needs it
+  however the scope was assembled — a scope built entirely from flags reads the same API.
   `gh auth refresh -s read:project` grants it.
 - Every project failure is exit 4 — a token without that scope, an unknown project, a field
   that does not exist or is not a single-select, a value that is not one of the field's
-  options, `--project-value` with no `select.project` in the config. **Do not retry without
-  the flag.** Selecting from the whole backlog when a scope was asked for gets work done in
-  the wrong order, which is worse than selecting nothing; report `BLOCKED` with the message.
+  options, an axis named with no value to match on it. **Do not retry without the flag.**
+  Selecting from the whole backlog when a scope was asked for gets work done in the wrong
+  order, which is worse than selecting nothing; report `BLOCKED` with the message.
+- A scope that cannot be assembled names the piece that is missing and both places it could
+  have come from — `missing: field (select.project.field or --project-field)`. Supply it on
+  the command line. Do not edit `.claude/backlog.json` to get past it: the config describes
+  the repository's backlog, and a run is not entitled to rewrite that to describe itself.
 
 Exit 10 under a scope is not a failure — the scope is genuinely drained. Say which scope in
 the report, so a finished module reads differently from a finished backlog.
@@ -581,7 +605,8 @@ state you saw.
 
 Finish with a short status: issue number and title, pull request number and URL, check
 result, whether the pull request reached `MERGED`, and any judgment call that shaped the
-public API. If the run was scoped with `--project-value`, name the scope — an outcome from a
+public API. If the run was scoped, name the scope in full — the field as well as the value,
+because the same value can exist on more than one of a board's fields. An outcome from a
 scoped backlog says nothing about the rest of it.
 
 - When `review.required` is `true`: whether Copilot reviewed and what it flagged.
@@ -597,7 +622,8 @@ Stop and report — do not push through — if any of these happen:
 
 - `select-issue.sh` exits 4 — `.claude/backlog.json` is missing, does not parse, carries an
   unknown `dependencies.style`, has an empty `verify`, or a requested project scope could not
-  be resolved. Never re-run it without `--project-value` to get past the last of those.
+  be resolved. Never re-run it with a project flag dropped, widened or edited to get past the
+  last of those, and never edit `.claude/backlog.json` to get past it either.
 - The same CI failure survives three fix attempts.
 - Acceptance criteria are ambiguous enough that two readings produce materially different
   public APIs.

--- a/plugins/backlog/skills/run-backlog/SKILL.md
+++ b/plugins/backlog/skills/run-backlog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: run-backlog
-description: Drive a repository's story backlog unattended, one issue at a time, by spawning a fresh `issue-worker` subagent per iteration and halting on `BACKLOG EMPTY`, on `BLOCKED`, or at a bounded iteration count. Use this whenever the user wants the backlog worked continuously rather than a single issue — "run the backlog", "work through the issues", "keep taking stories until you run out", "drain the milestone", "work through the workspace-ci stories", or a `/loop` that repeats the cycle. Takes an optional integer argument setting the maximum number of iterations, and an optional `--project-value <value>` restricting the whole run to one value of the project field named by `select.project`. Skip this when the user wants exactly one issue (`backlog:next-issue`) or wants the repository bootstrapped first (`backlog:setup-backlog`).
+description: Drive a repository's story backlog unattended, one issue at a time, by spawning a fresh `issue-worker` subagent per iteration and halting on `BACKLOG EMPTY`, on `BLOCKED`, or at a bounded iteration count. Use this whenever the user wants the backlog worked continuously rather than a single issue — "run the backlog", "work through the issues", "keep taking stories until you run out", "drain the milestone", "work through the workspace-ci stories", "work the In Progress stories", or a `/loop` that repeats the cycle. Takes an optional integer argument setting the maximum number of iterations, and optional `--project-value <value>`, `--project-field <name>`, `--project-owner <login>` and `--project-number <n>` arguments restricting the whole run to one value of one single-select field on a GitHub project. Skip this when the user wants exactly one issue (`backlog:next-issue`) or wants the repository bootstrapped first (`backlog:setup-backlog`).
 allowed-tools: Agent, Bash, Read, Glob, Grep, TaskCreate, TaskUpdate, ScheduleWakeup
 ---
 
@@ -40,19 +40,40 @@ against a large backlog is not the user asking for autonomy, it is the user losi
 chance to look at the first result before the twentieth lands on top of it.
 
 And settle the **scope**. A repository that groups its work by a single-select field on a
-GitHub project — `Module`, `Area`, `Component`, named by `select.project` in the config — can
-have the whole run restricted to one value of it:
+GitHub project — `Module`, `Area`, `Component`, `Status` — can have the whole run restricted
+to one value of one such field:
 
 ```
 /run-backlog 5 --project-value workspace-ci
+/run-backlog 5 --project-field Status --project-value "In Progress"
 ```
 
-The argument order does not matter; the integer is the bound and `--project-value` is the
-scope. A user asking to "work through the workspace-ci stories" is asking for exactly this,
-and the value is theirs to give — do not infer one from the issues you can see. With no scope
-given, do not pass the flag at all and let the config decide, which normally means the whole
-backlog. Say the scope in your first message alongside the bound, because every outcome below
-is then a statement about that scope and not about the backlog.
+The argument order does not matter; the integer is the bound and everything beginning
+`--project-` is the scope. Four are accepted, and they are exactly the ones
+`scripts/select-issue.sh` takes:
+
+| argument | what it names | when the user has given you one |
+| --- | --- | --- |
+| `--project-value <value>` | the value to scope to | "work through the workspace-ci stories" |
+| `--project-field <name>` | which single-select to read it from | "work the **In Progress** stories" — a value on an axis other than the configured one |
+| `--project-owner <login>` | the board's owner | the repository's config has no `select.project`, or the user named another board |
+| `--project-number <n>` | the board's number | same |
+
+A user asking to "work through the workspace-ci stories" is asking for `--project-value`
+alone: the config already names the board and the usual axis. `--project-field` is what makes
+"work the In Progress stories" expressible without an edit to `.claude/backlog.json`, and
+`--project-owner`/`--project-number` cover the repository whose config names no board at all.
+
+**Every part of the scope is the user's to give — infer none of it.** Do not read the issues
+and guess a field, and do not guess which field a value belongs to when the user names only a
+value; if the value is not one of the configured field's options, selection fails at exit 4
+naming the real options, and that failure is the answer to report, not a prompt to try
+another field.
+
+With no scope given, pass nothing and let the config decide, which normally means the whole
+backlog. Say the scope in your first message alongside the bound — the field as well as the
+value, since the same value can exist on two of a board's fields — because every outcome
+below is then a statement about that scope and not about the backlog.
 
 ## 1. The loop
 
@@ -69,16 +90,26 @@ Agent(
 )
 ```
 
-When the run is scoped, add one more line to the prompt, with the value exactly as the user
-gave it:
+When the run is scoped, add one more line to the prompt, repeating **every** project argument
+the run was given, verbatim and in full:
 
 ```
-           This run is scoped: pass --project-value <value> to select-issue.sh at step 1.
+           This run is scoped: pass --project-field Status --project-value "In Progress"
+           to select-issue.sh at step 1.
 ```
 
-Every iteration gets it. Dropping it on one iteration does not narrow that iteration, it
-widens it to the whole backlog — the worker selects an out-of-scope issue and merges it, and
-nothing in its report will look wrong.
+Every iteration gets all of them. Dropping one does not narrow that iteration:
+
+- Drop `--project-value` and the iteration widens to the whole backlog.
+- Drop `--project-field` and the iteration either falls back to the configured axis — a
+  different dimension, quietly — or fails, depending on whether the value happens to be an
+  option on that field too. The quiet one is the danger: the worker selects an out-of-scope
+  issue and merges it, and nothing in its report will look wrong.
+- Drop `--project-owner` or `--project-number` on a repository whose config names no board
+  and the iteration fails at exit 4 — loud, but it burns an iteration on every pass.
+
+So the rule is the same for all four, and it is the one already stated for the value: the
+scope you settled at preflight goes into every prompt unchanged, or the run stops.
 
 Check the agent types available to you before the first spawn. Depending on how the plugin
 was installed the worker may be listed as `issue-worker` or as `backlog:issue-worker`; use
@@ -126,10 +157,16 @@ end.
   block is a request for a human, which is the one thing a loop cannot supply.
 - **Never widen the bound mid-run** because the backlog turned out to be longer. Finish,
   report, and let the user re-run.
-- **Never drop the scope mid-run**, and never respond to a worker that halted on a project
-  failure by re-spawning it unscoped. Both turn "work the workspace-ci stories" into "work
-  the backlog", which is the one failure a scoped run exists to prevent and the one the
-  report will not show.
+- **Never drop, widen or edit any part of the scope mid-run**, and never respond to a worker
+  that halted on a project failure by re-spawning it with a flag removed or a different field
+  or value. Dropping the value turns "work the workspace-ci stories" into "work the backlog";
+  dropping or changing the field turns it into "work some other dimension" — which is worse,
+  because it still looks scoped in the report. Both are the failure a scoped run exists to
+  prevent.
+- **Never edit `.claude/backlog.json` to make a scope resolve.** Every piece of the scope has
+  a flag, so a scope that will not assemble is a missing argument, not a missing config key.
+  Rewriting the repository's committed description of its own backlog to suit one run outlives
+  the run.
 
 ## 3. Report
 

--- a/plugins/backlog/skills/setup-backlog/SKILL.md
+++ b/plugins/backlog/skills/setup-backlog/SKILL.md
@@ -129,14 +129,21 @@ either way and let the user choose; do not switch the style on their behalf.
   `null`, which means "every open issue with the label".
 - `select.limit` — `200`.
 - `select.project` — **omit it unless the user asks.** It scopes selection to one value of a
-  single-select field on a GitHub project (`Module`, `Area`, `Component`), which is worth
-  having only where the repository actually groups its work that way; absent, selection makes
-  no project API call at all. When it is wanted, `gh project list --owner <owner>` gives the
-  number and `gh project field-list <number> --owner <owner>` gives the field names — both
+  single-select field on a GitHub project (`Module`, `Area`, `Component`, `Status`), which is
+  worth having only where the repository actually groups its work that way; absent, selection
+  makes no project API call at all. When it is wanted, `gh project list --owner <owner>` gives
+  the number and `gh project field-list <number> --owner <owner>` gives the field names — both
   need the `read:project` token scope, which `repo` does not include, so say so in the report
-  along with `gh auth refresh -s read:project`. Leave `value` as `null`: the scope belongs on
-  the run (`select-issue.sh --project-value <value>`), not on the file, because "just this
-  module today" is not a permanent description of the backlog.
+  along with `gh auth refresh -s read:project`.
+
+  Write `owner` and `number` — which board the work lives on is a property of the repository,
+  and they are the only keys the block requires. Write `field` as the axis the backlog is
+  *usually* grouped by, and leave `value` as `null`. Both of those are per-run choices that
+  `select-issue.sh --project-field <name>` and `--project-value <value>` override, because
+  neither "just this module today" nor "the In Progress ones today" is a permanent
+  description of the backlog. Every key here has such a flag, `--project-owner` and
+  `--project-number` included, so writing this block is a convenience and never a
+  prerequisite for a scoped run.
 - `merge.label` / `merge.workflow` — `auto-merge` and `auto-merge.yaml`, matching the asset
   step 3 installs. If you change either, change both, plus the `github.event.label.name`
   guard inside the workflow.


### PR DESCRIPTION
Closes #335.

#325 established that the scope belongs on the invocation as well as in config, and #331 applied that to `value` alone. `field`, `owner` and `number` stayed config-only, with all three `required` once `select.project` was present at all. Two consequences, both fixed here: switching the axis needed a config edit, and a repository with no `select.project` — devex itself — could not be scoped at all.

## The flags

`select-issue.sh` now takes `--project-field <name>`, `--project-owner <login>` and `--project-number <n>` alongside `--project-value <value>`. Each overrides its `select.project` counterpart for one run, piece by piece, so none of the three implies the others.

```
select-issue.sh --project-field Status --project-value "In Progress"
select-issue.sh --project-owner z5labs --project-number 14 --project-field Module --project-value workspace-ci
```

## The decision on `owner` and `number`

The story left open whether they get flags. **They do.** They are the weakest case for one — they describe the repository's board rather than a run, and the config stays their normal home, which is why `setup-backlog` still writes them and `select.project` still requires them when the block is present at all. But the acceptance criteria ask that a run assemble a complete scope from flags alone against a config with no `select.project`, and that is impossible without them. So they exist for the one-off: the repository that has never carried a project block, or a run against a board other than the configured one. Everything else about how they are documented steers toward the config.

`field` is the opposite: it is genuinely per-run, because a board routinely carries more than one single-select worth scoping by. devex's project 14 has both `Status` and `Module`, and "work the In Progress stories" is the same kind of request as "work the workspace-ci stories".

## No new validation for `--project-field`

`project_query` already reads `fields` rather than `field(name: $field)` — deliberately and measured, because an unknown name fails the whole query and takes the list of real names with it. So the flag inherits that check unchanged, rather than growing a second one that could disagree with it. Against the live board:

```
$ select-issue.sh --project-field Bogus --project-value x
select-issue: the project has no field named 'Bogus'; its fields are: Title, Assignees,
Status, Labels, Linked pull requests, Milestone, Repository, Reviewers, Parent issue,
Sub-issues progress, Created, Updated, Closed, Module
```

## Two things refused rather than guessed

Both are shapes the new flags made reachable, and both would otherwise have to discard half the request silently — the widening every failure in this file is written to avoid.

- **`--no-project-filter` alongside any scope flag.** "Run unscoped" and "scope it like this" is not a request worth guessing at.
- **A board or an axis named with no value to match on it.** That is a scoped run missing its value, not an unscoped run, and answering it with the whole backlog is exactly the wrong answer. `--no-project-filter` is how you say unscoped.

A scope that cannot be assembled now names the piece that is missing and *both* places it could have come from — `missing: field (select.project.field or --project-field)` — because "add owner, number and field to the config" stopped being the whole answer once each of them had a flag. A run told to edit a tracked file it does not need to edit will edit it.

The number's message names whichever source it came from, so a bad flag does not blame the config.

## Schema

`select.project` now requires only `owner` and `number`. `field` joins `value` as optional (`["string", "null"]`, default `null`), and the block stays `additionalProperties: false`. Verified against the real schema: the devex config validates, so do a missing block, an `owner`+`number`-only block and an explicit `"field": null`; a block carrying only `field` is still rejected.

## Threading and docs

`run-backlog` now accepts all four arguments and repeats **every** one of them into every worker prompt, under the rule its skill already stated for the value — with the reason each one matters spelled out, since dropping `--project-field` is the dangerous one: the iteration falls back to the configured axis quietly and still looks scoped in the report. `issue-worker` and `next-issue` carry the same rule, and both now say that editing `.claude/backlog.json` to make a scope resolve is not a way past a failure. The `read:project` requirement is documented as applying however the scope was assembled — a flag-only scope reads the same API.

## Tests

`select-issue_test.sh` gains a **scope assembly** section: 12 cases running the whole script — flags, config, the merge of the two, selection — offline, against a scratch repository and a `gh` that answers from files. The project response is keyed by the `field=` the query was given, which is what lets a case prove the flag reached the *query* and not just the message.

The fixtures are chosen so three answers are distinguishable — unscoped picks #288, `Module = workspace-ci` picks #291, `Status = Todo` picks #302 — because an assertion that could not tell a dropped scope from an applied one would pass for the bug these flags are most able to introduce. Included: a complete scope from flags alone against a config with no `select.project`, `--project-field` overriding the configured axis, `--project-value` alone still using the configured axis, and every refusal above.

62 passed, 0 failed.

## devex's own config

`.claude/backlog.json` gains `select.project` for project 14 with `field: "Module"` and `value: null`, so this repository can be run scoped without an edit. Smoke-tested live: `--project-value workspace-ci` selects #287, and `--project-field Status --project-value "In Progress"` reports `BACKLOG EMPTY` naming the scope — the axis that was previously inexpressible.

Plugin version bumped to `0.3.0`; the plugin cache is version-keyed, so without it none of this rolls out.

## Verified locally

- `plugins/backlog/scripts/select-issue_test.sh` — 62 passed, 0 failed
- `dagger check` — `ci:generated`, `ci:generated-self-test`, `ci:selection-self-test` all OK
- `bash .github/scripts/verify-affected-modules.sh` — no daggerverse module changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
