### PR TITLE
story(issue-328): let a GoApp stamp its binary at build time

### DIFF
--- a/daggerverse/go/README.md
+++ b/daggerverse/go/README.md
@@ -22,7 +22,7 @@ and use that version; if no directive is present the image falls back to
 | Name | Purpose |
 |---|---|
 | `Container(source)` | Prepared base container — escape hatch when a Go command isn't covered by the typed helpers. Returns `*Container` lazily; the underlying constructor takes ctx + returns error in source so go.mod inspection can run. |
-| `Build(source, pkg, output, flags)` | `go build -o /out/[output] ...`; returns `/out` as a `*Directory`. `pkg` defaults to `./...`. |
+| `Build(source, pkg, output, trimpath, strip, stamps, tags, platform, disableCgo)` | `go build -o /out/[output] ...`; returns `/out` as a `*Directory`. `pkg` defaults to `./...`. Every flag is a named input — see [Build flags](#build-flags). |
 | `Test(source, pkg, race, flags)` | `go test -count=1 [-race] ...`; returns combined stdout. |
 | `Vet(source, pkg)` | `go vet pkg`. |
 | `Fmt(source)` | `gofmt -l -d .`; non-empty diff is also returned as an error. |
@@ -36,6 +36,33 @@ and use that version; if no directive is present the image falls back to
 | `Env()` | `go env`. |
 | `ToolVersion()` | `go version`. |
 | `Ci(source)` | Returns a `Ci` builder for staged pipelines (parallel checks → build). `Run` returns the built binary as a `*File`. |
+
+## Build flags
+
+`Build` takes no `flags []string`. Every flag it can pass is a named input
+with its own doc comment, so `dagger functions` describes what each one does
+to the output, the module validates them, and no caller has to re-learn a
+spelling:
+
+| Input | Effect |
+|---|---|
+| `trimpath` | `-trimpath` — the output no longer depends on where it was compiled. |
+| `strip` | `-ldflags "-s -w"` — no symbol table, no DWARF. |
+| `stamps` | `-ldflags "-X importpath.Name=value"` per element. |
+| `tags` | `-tags a,b,c`. |
+| `platform` | `GOOS`/`GOARCH` for a cross-compile, as `GOOS/GOARCH[/variant]`. |
+| `disableCgo` | `CGO_ENABLED=0`. |
+
+`stamps` elements are `importpath.Name=value`; only the first `=` splits name
+from value, so a value may contain `=`. An element with no `=`, or an empty
+name, is rejected with a message naming it. A value containing whitespace is
+quoted for you, since `cmd/go` splits the `-ldflags` value on whitespace.
+
+There is deliberately no raw-flag escape hatch on `Build`: if a flag is worth
+passing it is worth naming, and a bag of strings can be neither validated nor
+documented. `Container(source)` remains the escape hatch for anything not
+named above — it hands back the prepared container to run any `go build`
+invocation you like.
 
 ## CLI quick reference
 
@@ -59,6 +86,14 @@ g := dag.Go() // or dag.Go(dagger.GoOpts{Version: "1.23"})
 
 // Build returns the /out directory containing the produced binaries.
 out := g.Build(src, dagger.GoBuildOpts{Pkg: "./...", Output: "myapp"})
+
+// A release build: static, reproducible, and told its own version.
+rel := g.Build(src, dagger.GoBuildOpts{
+    Pkg: ".", Output: "myapp",
+    Trimpath: true, Strip: true, DisableCgo: true,
+    Platform: "linux/arm64",
+    Stamps:   []string{"main.version=v1.2.3"},
+})
 
 // Test returns combined stdout.
 stdout, err := g.Test(ctx, src, dagger.GoTestOpts{Race: true})

--- a/daggerverse/go/dagger.gen.go
+++ b/daggerverse/go/dagger.gen.go
@@ -374,14 +374,49 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg output", err))
 				}
 			}
-			var flags []string
-			if inputArgs["flags"] != nil {
-				err = json.Unmarshal([]byte(inputArgs["flags"]), &flags)
+			var trimpath bool
+			if inputArgs["trimpath"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["trimpath"]), &trimpath)
 				if err != nil {
-					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg flags", err))
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg trimpath", err))
 				}
 			}
-			return (*Go).Build(&parent, ctx, source, pkg, output, flags)
+			var strip bool
+			if inputArgs["strip"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["strip"]), &strip)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg strip", err))
+				}
+			}
+			var stamps []string
+			if inputArgs["stamps"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["stamps"]), &stamps)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg stamps", err))
+				}
+			}
+			var tags []string
+			if inputArgs["tags"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["tags"]), &tags)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg tags", err))
+				}
+			}
+			var platform string
+			if inputArgs["platform"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["platform"]), &platform)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg platform", err))
+				}
+			}
+			var disableCgo bool
+			if inputArgs["disableCgo"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["disableCgo"]), &disableCgo)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg disableCgo", err))
+				}
+			}
+			return (*Go).Build(&parent, ctx, source, pkg, output, trimpath, strip, stamps, tags, platform, disableCgo)
 		case "Ci":
 			var parent Go
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/go/examples/go/internal/dagger/go.gen.go
+++ b/daggerverse/go/examples/go/internal/dagger/go.gen.go
@@ -102,20 +102,70 @@ func (r *Go) WithGraphQLQuery(q *querybuilder.Selection) *Go {
 
 // GoBuildOpts contains options for Go.Build
 type GoBuildOpts struct {
-
+	//
+	// Package(s) to build, in `go build` package-list syntax.
+	//
+	//
 	// Default: "./..."
-	Pkg string // go (../../../../../../daggerverse/go/main.go:230:2)
-
-	Output string // go (../../../../../../daggerverse/go/main.go:232:2)
-
-	Flags []string // go (../../../../../../daggerverse/go/main.go:234:2)
+	Pkg string // go (../../../../../../daggerverse/go/main.go:240:2)
+	//
+	// Name of the binary written under /out. Empty means `-o /out/`, which
+	// lets go build name each binary after its main package.
+	//
+	Output string // go (../../../../../../daggerverse/go/main.go:245:2)
+	//
+	// Pass -trimpath: strip the build's local file system paths out of the
+	// binary, so the output does not depend on where it was compiled.
+	//
+	Trimpath bool // go (../../../../../../daggerverse/go/main.go:250:2)
+	//
+	// Pass -ldflags "-s -w": drop the symbol table and the DWARF debug
+	// info. Smaller binary, no usable stack symbolization or debugger.
+	//
+	Strip bool // go (../../../../../../daggerverse/go/main.go:255:2)
+	//
+	// Link-time variable assignments, each `importpath.Name=value`,
+	// rendered as `-ldflags "-X importpath.Name=value"`. This is how a
+	// binary learns its own version or commit. Only the first `=` splits
+	// name from value, so a value may itself contain `=`. An element with
+	// no `=`, or with an empty name, is rejected. The linker silently
+	// ignores a stamp naming a variable that does not exist, or one that
+	// is not a package-level string.
+	//
+	Stamps []string // go (../../../../../../daggerverse/go/main.go:265:2)
+	//
+	// Build tags, passed as `-tags a,b,c`. Selects which `//go:build`
+	// files are compiled in.
+	//
+	Tags []string // go (../../../../../../daggerverse/go/main.go:270:2)
+	//
+	// Target platform as `GOOS/GOARCH[/variant]`, e.g. "linux/arm64".
+	// Sets GOOS and GOARCH for a cross-compile; empty builds for the
+	// toolchain container's own platform. Any variant segment is ignored —
+	// GOARM/GOAMD64 are left unset.
+	//
+	Platform string // go (../../../../../../daggerverse/go/main.go:277:2)
+	//
+	// Set CGO_ENABLED=0. Produces a statically linked binary with no libc
+	// dependency, which is what a scratch image needs, at the cost of the
+	// cgo-backed net and os/user implementations.
+	//
+	DisableCgo bool // go (../../../../../../daggerverse/go/main.go:283:2)
 }
 
-// Build runs `go build -o /out/[output] [flags] pkg` against the supplied
-// source and returns /out as a *dagger.Directory. pkg defaults to `./...`;
-// when output is empty, `-o /out/` is used so go build picks names per its
-// own rules (one binary per main package).
-func (r *Go) Build(source *Directory, opts ...GoBuildOpts) *Directory { // go (../../../../../../daggerverse/go/main.go:226:1)
+// Build runs `go build` against the supplied source and returns /out as a
+// *dagger.Directory. pkg defaults to `./...`; when output is empty, `-o
+// /out/` is used so go build picks names per its own rules (one binary per
+// main package).
+//
+// Every flag this function can pass is a named input with its own doc
+// comment, so `dagger functions` describes what each one does to the
+// output. There is deliberately no raw `flags []string` escape hatch: a bag
+// of strings cannot be validated, cannot be documented per flag, and makes
+// every caller re-learn the same spellings. Container() is the escape hatch
+// for anything not named here — it hands back the prepared container so a
+// caller can run whatever `go build` invocation it likes.
+func (r *Go) Build(source *Directory, opts ...GoBuildOpts) *Directory { // go (../../../../../../daggerverse/go/main.go:234:1)
 	assertNotNil("source", source)
 	q := r.query.Select("build")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -127,9 +177,29 @@ func (r *Go) Build(source *Directory, opts ...GoBuildOpts) *Directory { // go (.
 		if !querybuilder.IsZeroValue(opts[i].Output) {
 			q = q.Arg("output", opts[i].Output)
 		}
-		// `flags` optional argument
-		if !querybuilder.IsZeroValue(opts[i].Flags) {
-			q = q.Arg("flags", opts[i].Flags)
+		// `trimpath` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Trimpath) {
+			q = q.Arg("trimpath", opts[i].Trimpath)
+		}
+		// `strip` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Strip) {
+			q = q.Arg("strip", opts[i].Strip)
+		}
+		// `stamps` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Stamps) {
+			q = q.Arg("stamps", opts[i].Stamps)
+		}
+		// `tags` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Tags) {
+			q = q.Arg("tags", opts[i].Tags)
+		}
+		// `platform` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Platform) {
+			q = q.Arg("platform", opts[i].Platform)
+		}
+		// `disableCgo` optional argument
+		if !querybuilder.IsZeroValue(opts[i].DisableCgo) {
+			q = q.Arg("disableCgo", opts[i].DisableCgo)
 		}
 	}
 	q = q.Arg("source", source)
@@ -170,7 +240,7 @@ func (r *Go) Container(source *Directory) *Container { // go (../../../../../../
 }
 
 // Env runs `go env` in a source-less base container and returns its stdout.
-func (r *Go) Env(ctx context.Context) (string, error) { // go (../../../../../../daggerverse/go/main.go:319:1)
+func (r *Go) Env(ctx context.Context) (string, error) { // go (../../../../../../daggerverse/go/main.go:448:1)
 	if r.env != nil {
 		return *r.env, nil
 	}
@@ -185,7 +255,7 @@ func (r *Go) Env(ctx context.Context) (string, error) { // go (../../../../../..
 // Fmt runs `gofmt -l -d .` against the supplied source. Returns the diff
 // of any unformatted files; non-empty output is also returned as an error so
 // CI fails fast on formatting violations.
-func (r *Go) Fmt(ctx context.Context, source *Directory) (string, error) { // go (../../../../../../daggerverse/go/main.go:283:1)
+func (r *Go) Fmt(ctx context.Context, source *Directory) (string, error) { // go (../../../../../../daggerverse/go/main.go:412:1)
 	assertNotNil("source", source)
 	if r.fmt != nil {
 		return *r.fmt, nil
@@ -360,17 +430,17 @@ func (r *Go) Run(ctx context.Context, source *Directory, pkg string, opts ...GoR
 type GoTestOpts struct {
 
 	// Default: "./..."
-	Pkg string // go (../../../../../../daggerverse/go/main.go:259:2)
+	Pkg string // go (../../../../../../daggerverse/go/main.go:388:2)
 
-	Race bool // go (../../../../../../daggerverse/go/main.go:261:2)
+	Race bool // go (../../../../../../daggerverse/go/main.go:390:2)
 
-	Flags []string // go (../../../../../../daggerverse/go/main.go:263:2)
+	Flags []string // go (../../../../../../daggerverse/go/main.go:392:2)
 }
 
 // Test runs `go test -count=1 [-race] [flags] pkg` against the supplied
 // source and returns the combined stdout. -count=1 is always passed to
 // bypass Go's internal test cache.
-func (r *Go) Test(ctx context.Context, source *Directory, opts ...GoTestOpts) (string, error) { // go (../../../../../../daggerverse/go/main.go:255:1)
+func (r *Go) Test(ctx context.Context, source *Directory, opts ...GoTestOpts) (string, error) { // go (../../../../../../daggerverse/go/main.go:384:1)
 	assertNotNil("source", source)
 	if r.test != nil {
 		return *r.test, nil
@@ -400,7 +470,7 @@ func (r *Go) Test(ctx context.Context, source *Directory, opts ...GoTestOpts) (s
 
 // ToolVersion runs `go version` in a source-less base container and returns
 // the trimmed output (e.g. "go version go1.23.0 linux/amd64").
-func (r *Go) ToolVersion(ctx context.Context) (string, error) { // go (../../../../../../daggerverse/go/main.go:327:1)
+func (r *Go) ToolVersion(ctx context.Context) (string, error) { // go (../../../../../../daggerverse/go/main.go:456:1)
 	if r.toolVersion != nil {
 		return *r.toolVersion, nil
 	}
@@ -431,12 +501,12 @@ func (r *Go) Version(ctx context.Context) (string, error) { // go (../../../../.
 type GoVetOpts struct {
 
 	// Default: "./..."
-	Pkg string // go (../../../../../../daggerverse/go/main.go:306:2)
+	Pkg string // go (../../../../../../daggerverse/go/main.go:435:2)
 }
 
 // Vet runs `go vet pkg` against the supplied source. pkg defaults to
 // `./...`. Returns a non-nil error when vet reports any issue.
-func (r *Go) Vet(ctx context.Context, source *Directory, opts ...GoVetOpts) error { // go (../../../../../../daggerverse/go/main.go:302:1)
+func (r *Go) Vet(ctx context.Context, source *Directory, opts ...GoVetOpts) error { // go (../../../../../../daggerverse/go/main.go:431:1)
 	assertNotNil("source", source)
 	if r.vet != nil {
 		return nil

--- a/daggerverse/go/main.go
+++ b/daggerverse/go/main.go
@@ -217,34 +217,163 @@ func (g *Go) Run(
 	return ctr.WithExec(cmd).Stdout(ctx)
 }
 
-// Build runs `go build -o /out/[output] [flags] pkg` against the supplied
-// source and returns /out as a *dagger.Directory. pkg defaults to `./...`;
-// when output is empty, `-o /out/` is used so go build picks names per its
-// own rules (one binary per main package).
+// Build runs `go build` against the supplied source and returns /out as a
+// *dagger.Directory. pkg defaults to `./...`; when output is empty, `-o
+// /out/` is used so go build picks names per its own rules (one binary per
+// main package).
+//
+// Every flag this function can pass is a named input with its own doc
+// comment, so `dagger functions` describes what each one does to the
+// output. There is deliberately no raw `flags []string` escape hatch: a bag
+// of strings cannot be validated, cannot be documented per flag, and makes
+// every caller re-learn the same spellings. Container() is the escape hatch
+// for anything not named here — it hands back the prepared container so a
+// caller can run whatever `go build` invocation it likes.
 //
 // +cache="session"
 func (g *Go) Build(
 	ctx context.Context,
 	source *dagger.Directory,
+	// Package(s) to build, in `go build` package-list syntax.
+	//
 	// +default="./..."
 	pkg string,
+	// Name of the binary written under /out. Empty means `-o /out/`, which
+	// lets go build name each binary after its main package.
+	//
 	// +optional
 	output string,
+	// Pass -trimpath: strip the build's local file system paths out of the
+	// binary, so the output does not depend on where it was compiled.
+	//
 	// +optional
-	flags []string,
+	trimpath bool,
+	// Pass -ldflags "-s -w": drop the symbol table and the DWARF debug
+	// info. Smaller binary, no usable stack symbolization or debugger.
+	//
+	// +optional
+	strip bool,
+	// Link-time variable assignments, each `importpath.Name=value`,
+	// rendered as `-ldflags "-X importpath.Name=value"`. This is how a
+	// binary learns its own version or commit. Only the first `=` splits
+	// name from value, so a value may itself contain `=`. An element with
+	// no `=`, or with an empty name, is rejected. The linker silently
+	// ignores a stamp naming a variable that does not exist, or one that
+	// is not a package-level string.
+	//
+	// +optional
+	stamps []string,
+	// Build tags, passed as `-tags a,b,c`. Selects which `//go:build`
+	// files are compiled in.
+	//
+	// +optional
+	tags []string,
+	// Target platform as `GOOS/GOARCH[/variant]`, e.g. "linux/arm64".
+	// Sets GOOS and GOARCH for a cross-compile; empty builds for the
+	// toolchain container's own platform. Any variant segment is ignored —
+	// GOARM/GOAMD64 are left unset.
+	//
+	// +optional
+	platform string,
+	// Set CGO_ENABLED=0. Produces a statically linked binary with no libc
+	// dependency, which is what a scratch image needs, at the cost of the
+	// cgo-backed net and os/user implementations.
+	//
+	// +optional
+	disableCgo bool,
 ) (*dagger.Directory, error) {
+	ldflags, err := renderLdflags(strip, stamps)
+	if err != nil {
+		return nil, err
+	}
 	ctr, err := g.Container(ctx, source)
 	if err != nil {
 		return nil, err
+	}
+	if platform != "" {
+		goos, goarch, err := parseBuildPlatform(platform)
+		if err != nil {
+			return nil, err
+		}
+		ctr = ctr.
+			WithEnvVariable("GOOS", goos).
+			WithEnvVariable("GOARCH", goarch)
+	}
+	if disableCgo {
+		ctr = ctr.WithEnvVariable("CGO_ENABLED", "0")
 	}
 	target := "/out/"
 	if output != "" {
 		target = "/out/" + output
 	}
-	args := []string{"go", "build", "-o", target}
-	args = append(args, flags...)
-	args = append(args, pkg)
+	args := []string{"go", "build"}
+	if trimpath {
+		args = append(args, "-trimpath")
+	}
+	if len(tags) > 0 {
+		args = append(args, "-tags", strings.Join(tags, ","))
+	}
+	if ldflags != "" {
+		args = append(args, "-ldflags", ldflags)
+	}
+	args = append(args, "-o", target, pkg)
 	return ctr.WithExec(args).Directory("/out"), nil
+}
+
+// renderLdflags builds the single `-ldflags` argument from the strip switch
+// and the -X stamps. Returns "" when neither is requested, so the caller can
+// leave -ldflags off the command line entirely.
+func renderLdflags(strip bool, stamps []string) (string, error) {
+	var parts []string
+	if strip {
+		parts = append(parts, "-s", "-w")
+	}
+	for _, stamp := range stamps {
+		// IndexByte, not a split: everything after the first `=` is the
+		// value, so a value containing `=` reaches the linker intact.
+		i := strings.IndexByte(stamp, '=')
+		if i < 0 {
+			return "", fmt.Errorf("Build: stamp %q is not in importpath.Name=value form: no %q", stamp, "=")
+		}
+		if i == 0 {
+			return "", fmt.Errorf("Build: stamp %q has an empty importpath.Name before %q", stamp, "=")
+		}
+		quoted, err := quoteLdflag(stamp)
+		if err != nil {
+			return "", err
+		}
+		parts = append(parts, "-X", quoted)
+	}
+	return strings.Join(parts, " "), nil
+}
+
+// quoteLdflag makes tok survive cmd/go's -ldflags splitting. cmd/go splits
+// the -ldflags value on whitespace, honouring single and double quotes but
+// no escape sequences — so a stamp value containing a space has to be
+// wrapped, and one containing both quote characters cannot be represented
+// at all and is rejected rather than silently truncated.
+func quoteLdflag(tok string) (string, error) {
+	if !strings.ContainsAny(tok, " \t\n'\"") {
+		return tok, nil
+	}
+	if !strings.Contains(tok, "'") {
+		return "'" + tok + "'", nil
+	}
+	if !strings.Contains(tok, `"`) {
+		return `"` + tok + `"`, nil
+	}
+	return "", fmt.Errorf("Build: stamp %q contains both quote characters, which -ldflags cannot express", tok)
+}
+
+// parseBuildPlatform splits a platform string ("goos/goarch" or
+// "goos/goarch/variant") into GOOS and GOARCH. Segments past the first two
+// are accepted and ignored.
+func parseBuildPlatform(p string) (goos, goarch string, err error) {
+	parts := strings.Split(p, "/")
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("Build: invalid platform %q (expected GOOS/GOARCH[/variant])", p)
+	}
+	return parts[0], parts[1], nil
 }
 
 // Test runs `go test -count=1 [-race] [flags] pkg` against the supplied

--- a/daggerverse/go/tests/dagger.gen.go
+++ b/daggerverse/go/tests/dagger.gen.go
@@ -241,6 +241,90 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Tests).BuildMultipkgDotSlashEllipsis(&parent, ctx, goImageTag)
+		case "BuildPlatformCrossCompiles":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var goImageTag string
+			if inputArgs["goImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["goImageTag"]), &goImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg goImageTag", err))
+				}
+			}
+			return nil, (*Tests).BuildPlatformCrossCompiles(&parent, ctx, goImageTag)
+		case "BuildRejectsMalformedStamps":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var goImageTag string
+			if inputArgs["goImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["goImageTag"]), &goImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg goImageTag", err))
+				}
+			}
+			return nil, (*Tests).BuildRejectsMalformedStamps(&parent, ctx, goImageTag)
+		case "BuildStampsReachTheBinary":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var goImageTag string
+			if inputArgs["goImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["goImageTag"]), &goImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg goImageTag", err))
+				}
+			}
+			return nil, (*Tests).BuildStampsReachTheBinary(&parent, ctx, goImageTag)
+		case "BuildStripShrinksTheBinary":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var goImageTag string
+			if inputArgs["goImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["goImageTag"]), &goImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg goImageTag", err))
+				}
+			}
+			return nil, (*Tests).BuildStripShrinksTheBinary(&parent, ctx, goImageTag)
+		case "BuildTagsSelectTaggedFiles":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var goImageTag string
+			if inputArgs["goImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["goImageTag"]), &goImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg goImageTag", err))
+				}
+			}
+			return nil, (*Tests).BuildTagsSelectTaggedFiles(&parent, ctx, goImageTag)
+		case "BuildTrimpathRemovesSourcePaths":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var goImageTag string
+			if inputArgs["goImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["goImageTag"]), &goImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg goImageTag", err))
+				}
+			}
+			return nil, (*Tests).BuildTrimpathRemovesSourcePaths(&parent, ctx, goImageTag)
 		case "CiCheckRunsEnabledChecksAndSkipsBuild":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/go/tests/fixtures/stamped/flavor_fancy.go
+++ b/daggerverse/go/tests/fixtures/stamped/flavor_fancy.go
@@ -1,0 +1,5 @@
+//go:build fancy
+
+package main
+
+const flavor = "fancy"

--- a/daggerverse/go/tests/fixtures/stamped/flavor_plain.go
+++ b/daggerverse/go/tests/fixtures/stamped/flavor_plain.go
@@ -1,0 +1,5 @@
+//go:build !fancy
+
+package main
+
+const flavor = "plain"

--- a/daggerverse/go/tests/fixtures/stamped/go.mod
+++ b/daggerverse/go/tests/fixtures/stamped/go.mod
@@ -1,0 +1,3 @@
+module example.com/stamped
+
+go 1.23

--- a/daggerverse/go/tests/fixtures/stamped/main.go
+++ b/daggerverse/go/tests/fixtures/stamped/main.go
@@ -1,0 +1,13 @@
+package main
+
+import "fmt"
+
+// version and commit are package-level string vars so `-ldflags -X` can
+// assign them at link time. The defaults are what an unstamped build
+// reports.
+var (
+	version = "dev"
+	commit  = "none"
+)
+
+func main() { fmt.Printf("version=%s commit=%s flavor=%s\n", version, commit, flavor) }

--- a/daggerverse/go/tests/internal/dagger/go.gen.go
+++ b/daggerverse/go/tests/internal/dagger/go.gen.go
@@ -102,20 +102,70 @@ func (r *Go) WithGraphQLQuery(q *querybuilder.Selection) *Go {
 
 // GoBuildOpts contains options for Go.Build
 type GoBuildOpts struct {
-
+	//
+	// Package(s) to build, in `go build` package-list syntax.
+	//
+	//
 	// Default: "./..."
-	Pkg string // go (../../../../../daggerverse/go/main.go:230:2)
-
-	Output string // go (../../../../../daggerverse/go/main.go:232:2)
-
-	Flags []string // go (../../../../../daggerverse/go/main.go:234:2)
+	Pkg string // go (../../../../../daggerverse/go/main.go:240:2)
+	//
+	// Name of the binary written under /out. Empty means `-o /out/`, which
+	// lets go build name each binary after its main package.
+	//
+	Output string // go (../../../../../daggerverse/go/main.go:245:2)
+	//
+	// Pass -trimpath: strip the build's local file system paths out of the
+	// binary, so the output does not depend on where it was compiled.
+	//
+	Trimpath bool // go (../../../../../daggerverse/go/main.go:250:2)
+	//
+	// Pass -ldflags "-s -w": drop the symbol table and the DWARF debug
+	// info. Smaller binary, no usable stack symbolization or debugger.
+	//
+	Strip bool // go (../../../../../daggerverse/go/main.go:255:2)
+	//
+	// Link-time variable assignments, each `importpath.Name=value`,
+	// rendered as `-ldflags "-X importpath.Name=value"`. This is how a
+	// binary learns its own version or commit. Only the first `=` splits
+	// name from value, so a value may itself contain `=`. An element with
+	// no `=`, or with an empty name, is rejected. The linker silently
+	// ignores a stamp naming a variable that does not exist, or one that
+	// is not a package-level string.
+	//
+	Stamps []string // go (../../../../../daggerverse/go/main.go:265:2)
+	//
+	// Build tags, passed as `-tags a,b,c`. Selects which `//go:build`
+	// files are compiled in.
+	//
+	Tags []string // go (../../../../../daggerverse/go/main.go:270:2)
+	//
+	// Target platform as `GOOS/GOARCH[/variant]`, e.g. "linux/arm64".
+	// Sets GOOS and GOARCH for a cross-compile; empty builds for the
+	// toolchain container's own platform. Any variant segment is ignored —
+	// GOARM/GOAMD64 are left unset.
+	//
+	Platform string // go (../../../../../daggerverse/go/main.go:277:2)
+	//
+	// Set CGO_ENABLED=0. Produces a statically linked binary with no libc
+	// dependency, which is what a scratch image needs, at the cost of the
+	// cgo-backed net and os/user implementations.
+	//
+	DisableCgo bool // go (../../../../../daggerverse/go/main.go:283:2)
 }
 
-// Build runs `go build -o /out/[output] [flags] pkg` against the supplied
-// source and returns /out as a *dagger.Directory. pkg defaults to `./...`;
-// when output is empty, `-o /out/` is used so go build picks names per its
-// own rules (one binary per main package).
-func (r *Go) Build(source *Directory, opts ...GoBuildOpts) *Directory { // go (../../../../../daggerverse/go/main.go:226:1)
+// Build runs `go build` against the supplied source and returns /out as a
+// *dagger.Directory. pkg defaults to `./...`; when output is empty, `-o
+// /out/` is used so go build picks names per its own rules (one binary per
+// main package).
+//
+// Every flag this function can pass is a named input with its own doc
+// comment, so `dagger functions` describes what each one does to the
+// output. There is deliberately no raw `flags []string` escape hatch: a bag
+// of strings cannot be validated, cannot be documented per flag, and makes
+// every caller re-learn the same spellings. Container() is the escape hatch
+// for anything not named here — it hands back the prepared container so a
+// caller can run whatever `go build` invocation it likes.
+func (r *Go) Build(source *Directory, opts ...GoBuildOpts) *Directory { // go (../../../../../daggerverse/go/main.go:234:1)
 	assertNotNil("source", source)
 	q := r.query.Select("build")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -127,9 +177,29 @@ func (r *Go) Build(source *Directory, opts ...GoBuildOpts) *Directory { // go (.
 		if !querybuilder.IsZeroValue(opts[i].Output) {
 			q = q.Arg("output", opts[i].Output)
 		}
-		// `flags` optional argument
-		if !querybuilder.IsZeroValue(opts[i].Flags) {
-			q = q.Arg("flags", opts[i].Flags)
+		// `trimpath` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Trimpath) {
+			q = q.Arg("trimpath", opts[i].Trimpath)
+		}
+		// `strip` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Strip) {
+			q = q.Arg("strip", opts[i].Strip)
+		}
+		// `stamps` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Stamps) {
+			q = q.Arg("stamps", opts[i].Stamps)
+		}
+		// `tags` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Tags) {
+			q = q.Arg("tags", opts[i].Tags)
+		}
+		// `platform` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Platform) {
+			q = q.Arg("platform", opts[i].Platform)
+		}
+		// `disableCgo` optional argument
+		if !querybuilder.IsZeroValue(opts[i].DisableCgo) {
+			q = q.Arg("disableCgo", opts[i].DisableCgo)
 		}
 	}
 	q = q.Arg("source", source)
@@ -170,7 +240,7 @@ func (r *Go) Container(source *Directory) *Container { // go (../../../../../dag
 }
 
 // Env runs `go env` in a source-less base container and returns its stdout.
-func (r *Go) Env(ctx context.Context) (string, error) { // go (../../../../../daggerverse/go/main.go:319:1)
+func (r *Go) Env(ctx context.Context) (string, error) { // go (../../../../../daggerverse/go/main.go:448:1)
 	if r.env != nil {
 		return *r.env, nil
 	}
@@ -185,7 +255,7 @@ func (r *Go) Env(ctx context.Context) (string, error) { // go (../../../../../da
 // Fmt runs `gofmt -l -d .` against the supplied source. Returns the diff
 // of any unformatted files; non-empty output is also returned as an error so
 // CI fails fast on formatting violations.
-func (r *Go) Fmt(ctx context.Context, source *Directory) (string, error) { // go (../../../../../daggerverse/go/main.go:283:1)
+func (r *Go) Fmt(ctx context.Context, source *Directory) (string, error) { // go (../../../../../daggerverse/go/main.go:412:1)
 	assertNotNil("source", source)
 	if r.fmt != nil {
 		return *r.fmt, nil
@@ -360,17 +430,17 @@ func (r *Go) Run(ctx context.Context, source *Directory, pkg string, opts ...GoR
 type GoTestOpts struct {
 
 	// Default: "./..."
-	Pkg string // go (../../../../../daggerverse/go/main.go:259:2)
+	Pkg string // go (../../../../../daggerverse/go/main.go:388:2)
 
-	Race bool // go (../../../../../daggerverse/go/main.go:261:2)
+	Race bool // go (../../../../../daggerverse/go/main.go:390:2)
 
-	Flags []string // go (../../../../../daggerverse/go/main.go:263:2)
+	Flags []string // go (../../../../../daggerverse/go/main.go:392:2)
 }
 
 // Test runs `go test -count=1 [-race] [flags] pkg` against the supplied
 // source and returns the combined stdout. -count=1 is always passed to
 // bypass Go's internal test cache.
-func (r *Go) Test(ctx context.Context, source *Directory, opts ...GoTestOpts) (string, error) { // go (../../../../../daggerverse/go/main.go:255:1)
+func (r *Go) Test(ctx context.Context, source *Directory, opts ...GoTestOpts) (string, error) { // go (../../../../../daggerverse/go/main.go:384:1)
 	assertNotNil("source", source)
 	if r.test != nil {
 		return *r.test, nil
@@ -400,7 +470,7 @@ func (r *Go) Test(ctx context.Context, source *Directory, opts ...GoTestOpts) (s
 
 // ToolVersion runs `go version` in a source-less base container and returns
 // the trimmed output (e.g. "go version go1.23.0 linux/amd64").
-func (r *Go) ToolVersion(ctx context.Context) (string, error) { // go (../../../../../daggerverse/go/main.go:327:1)
+func (r *Go) ToolVersion(ctx context.Context) (string, error) { // go (../../../../../daggerverse/go/main.go:456:1)
 	if r.toolVersion != nil {
 		return *r.toolVersion, nil
 	}
@@ -431,12 +501,12 @@ func (r *Go) Version(ctx context.Context) (string, error) { // go (../../../../.
 type GoVetOpts struct {
 
 	// Default: "./..."
-	Pkg string // go (../../../../../daggerverse/go/main.go:306:2)
+	Pkg string // go (../../../../../daggerverse/go/main.go:435:2)
 }
 
 // Vet runs `go vet pkg` against the supplied source. pkg defaults to
 // `./...`. Returns a non-nil error when vet reports any issue.
-func (r *Go) Vet(ctx context.Context, source *Directory, opts ...GoVetOpts) error { // go (../../../../../daggerverse/go/main.go:302:1)
+func (r *Go) Vet(ctx context.Context, source *Directory, opts ...GoVetOpts) error { // go (../../../../../daggerverse/go/main.go:431:1)
 	assertNotNil("source", source)
 	if r.vet != nil {
 		return nil

--- a/daggerverse/go/tests/main.go
+++ b/daggerverse/go/tests/main.go
@@ -94,6 +94,24 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("BuildMultipkgDotSlashEllipsis", func(ctx context.Context) error {
 		return t.BuildMultipkgDotSlashEllipsis(ctx, goImageTag)
 	})
+	jobs = jobs.WithJob("BuildRejectsMalformedStamps", func(ctx context.Context) error {
+		return t.BuildRejectsMalformedStamps(ctx, goImageTag)
+	})
+	jobs = jobs.WithJob("BuildStampsReachTheBinary", func(ctx context.Context) error {
+		return t.BuildStampsReachTheBinary(ctx, goImageTag)
+	})
+	jobs = jobs.WithJob("BuildTagsSelectTaggedFiles", func(ctx context.Context) error {
+		return t.BuildTagsSelectTaggedFiles(ctx, goImageTag)
+	})
+	jobs = jobs.WithJob("BuildTrimpathRemovesSourcePaths", func(ctx context.Context) error {
+		return t.BuildTrimpathRemovesSourcePaths(ctx, goImageTag)
+	})
+	jobs = jobs.WithJob("BuildStripShrinksTheBinary", func(ctx context.Context) error {
+		return t.BuildStripShrinksTheBinary(ctx, goImageTag)
+	})
+	jobs = jobs.WithJob("BuildPlatformCrossCompiles", func(ctx context.Context) error {
+		return t.BuildPlatformCrossCompiles(ctx, goImageTag)
+	})
 	jobs = jobs.WithJob("TestMultipkgPkgArgVariants", func(ctx context.Context) error {
 		return t.TestMultipkgPkgArgVariants(ctx, goImageTag)
 	})
@@ -392,6 +410,183 @@ func (t *Tests) CiRunHelloDefaultsProduceModuleNameBinary(ctx context.Context, g
 // helloDir returns the on-disk hello fixture as a *dagger.Directory.
 func helloDir() *dagger.Directory {
 	return dag.CurrentModule().Source().Directory("fixtures/hello")
+}
+
+// stampedDir returns the stamped fixture: a main package whose version and
+// commit are package-level vars for `-X` to assign, and whose flavor
+// constant is selected by the `fancy` build tag.
+func stampedDir() *dagger.Directory {
+	return dag.CurrentModule().Source().Directory("fixtures/stamped")
+}
+
+// alpineImage is the minimal container built binaries are executed in.
+// ":latest" is a moving target, so the tag is pinned.
+const alpineImage = "alpine:3.22"
+
+// runBuiltBinary executes a freshly built linux binary in a minimal
+// container and returns its stdout.
+func runBuiltBinary(ctx context.Context, bin *dagger.File) (string, error) {
+	return dag.Container().From(alpineImage).
+		WithFile("/bin/app", bin, dagger.ContainerWithFileOpts{Permissions: 0o755}).
+		WithExec([]string{"/bin/app"}).
+		Stdout(ctx)
+}
+
+// BuildRejectsMalformedStamps asserts Build rejects a stamp with no "=" and
+// a stamp whose importpath.Name is empty, and that each message names the
+// offending element rather than reporting a generic parse failure.
+func (t *Tests) BuildRejectsMalformedStamps(ctx context.Context, goImageTag string) error {
+	for _, stamp := range []string{"main.version", "=v1.0.0"} {
+		_, err := dag.Go(dagger.GoOpts{Version: goImageTag}).
+			Build(stampedDir(), dagger.GoBuildOpts{
+				Pkg:    ".",
+				Output: "stamped",
+				Stamps: []string{stamp},
+			}).
+			Entries(ctx)
+		if err == nil {
+			return fmt.Errorf("expected Build to reject stamp %q, got nil error", stamp)
+		}
+		if !strings.Contains(err.Error(), stamp) {
+			return fmt.Errorf("expected error for stamp %q to name it, got: %s", stamp, err.Error())
+		}
+	}
+	return nil
+}
+
+// BuildStampsReachTheBinary asserts -X stamps are applied and that a stamp
+// value containing "=" arrives unmangled: only the first "=" separates the
+// variable name from its value.
+func (t *Tests) BuildStampsReachTheBinary(ctx context.Context, goImageTag string) error {
+	out := dag.Go(dagger.GoOpts{Version: goImageTag}).Build(stampedDir(), dagger.GoBuildOpts{
+		Pkg:        ".",
+		Output:     "stamped",
+		Trimpath:   true,
+		Strip:      true,
+		DisableCgo: true,
+		Stamps:     []string{"main.version=v1.2.3", "main.commit=sha=deadbeef"},
+	})
+	got, err := runBuiltBinary(ctx, out.File("stamped"))
+	if err != nil {
+		return fmt.Errorf("run stamped binary: %w", err)
+	}
+	const want = "version=v1.2.3 commit=sha=deadbeef flavor=plain\n"
+	if got != want {
+		return fmt.Errorf("expected %q, got %q", want, got)
+	}
+	return nil
+}
+
+// BuildTagsSelectTaggedFiles asserts tags reaches `go build -tags`: the
+// stamped fixture reports flavor=fancy only when the `fancy` tag is set.
+func (t *Tests) BuildTagsSelectTaggedFiles(ctx context.Context, goImageTag string) error {
+	out := dag.Go(dagger.GoOpts{Version: goImageTag}).Build(stampedDir(), dagger.GoBuildOpts{
+		Pkg:        ".",
+		Output:     "stamped",
+		DisableCgo: true,
+		Tags:       []string{"fancy"},
+	})
+	got, err := runBuiltBinary(ctx, out.File("stamped"))
+	if err != nil {
+		return fmt.Errorf("run tagged binary: %w", err)
+	}
+	if !strings.Contains(got, "flavor=fancy") {
+		return fmt.Errorf("expected flavor=fancy with the fancy tag, got %q", got)
+	}
+	return nil
+}
+
+// BuildTrimpathRemovesSourcePaths asserts trimpath reaches `go build
+// -trimpath`: the build's own /src mount point is recorded in an untrimmed
+// binary and absent from a trimmed one.
+func (t *Tests) BuildTrimpathRemovesSourcePaths(ctx context.Context, goImageTag string) error {
+	for _, tc := range []struct {
+		trimpath bool
+		want     bool
+	}{
+		{trimpath: false, want: true},
+		{trimpath: true, want: false},
+	} {
+		out := dag.Go(dagger.GoOpts{Version: goImageTag}).Build(stampedDir(), dagger.GoBuildOpts{
+			Pkg:        ".",
+			Output:     "stamped",
+			DisableCgo: true,
+			Trimpath:   tc.trimpath,
+		})
+		found, err := binaryContains(ctx, out.File("stamped"), "/src/main.go")
+		if err != nil {
+			return fmt.Errorf("scan binary (trimpath=%v): %w", tc.trimpath, err)
+		}
+		if found != tc.want {
+			return fmt.Errorf("trimpath=%v: expected /src/main.go present=%v, got %v", tc.trimpath, tc.want, found)
+		}
+	}
+	return nil
+}
+
+// BuildStripShrinksTheBinary asserts strip reaches `go build -ldflags "-s
+// -w"`: dropping the symbol table and DWARF info makes the output smaller.
+func (t *Tests) BuildStripShrinksTheBinary(ctx context.Context, goImageTag string) error {
+	sizes := make(map[bool]int, 2)
+	for _, strip := range []bool{false, true} {
+		out := dag.Go(dagger.GoOpts{Version: goImageTag}).Build(stampedDir(), dagger.GoBuildOpts{
+			Pkg:        ".",
+			Output:     "stamped",
+			DisableCgo: true,
+			Strip:      strip,
+		})
+		size, err := out.File("stamped").Size(ctx)
+		if err != nil {
+			return fmt.Errorf("size (strip=%v): %w", strip, err)
+		}
+		sizes[strip] = size
+	}
+	if sizes[true] >= sizes[false] {
+		return fmt.Errorf("expected stripped binary to be smaller, got %d stripped vs %d unstripped", sizes[true], sizes[false])
+	}
+	return nil
+}
+
+// BuildPlatformCrossCompiles asserts platform reaches GOOS/GOARCH: the
+// binary built for linux/arm64 carries the aarch64 machine type in its ELF
+// header (e_machine == 0xb7 at offset 18), which an amd64 build does not.
+func (t *Tests) BuildPlatformCrossCompiles(ctx context.Context, goImageTag string) error {
+	for _, tc := range []struct{ platform, wantMachine string }{
+		{"linux/arm64", "b7"},
+		{"linux/amd64", "3e"},
+	} {
+		out := dag.Go(dagger.GoOpts{Version: goImageTag}).Build(stampedDir(), dagger.GoBuildOpts{
+			Pkg:        ".",
+			Output:     "stamped",
+			DisableCgo: true,
+			Platform:   tc.platform,
+		})
+		got, err := dag.Container().From(alpineImage).
+			WithFile("/bin/app", out.File("stamped")).
+			WithExec([]string{"od", "-An", "-t", "x1", "-j", "18", "-N", "1", "/bin/app"}).
+			Stdout(ctx)
+		if err != nil {
+			return fmt.Errorf("read ELF header (%s): %w", tc.platform, err)
+		}
+		if strings.TrimSpace(got) != tc.wantMachine {
+			return fmt.Errorf("%s: expected e_machine %q, got %q", tc.platform, tc.wantMachine, strings.TrimSpace(got))
+		}
+	}
+	return nil
+}
+
+// binaryContains reports whether the raw bytes of bin contain needle.
+// grep -a treats the binary as text so a match is reported rather than
+// swallowed by the "binary file matches" shortcut.
+func binaryContains(ctx context.Context, bin *dagger.File, needle string) (bool, error) {
+	out, err := dag.Container().From(alpineImage).
+		WithFile("/bin/app", bin).
+		WithExec([]string{"sh", "-c", `grep -a -q -- "$1" /bin/app && echo yes || echo no`, "sh", needle}).
+		Stdout(ctx)
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(out) == "yes", nil
 }
 
 // multipkgDir returns the multi-package fixture (main + pkg/foo subpackage).

--- a/daggerverse/z5labs/builder.go
+++ b/daggerverse/z5labs/builder.go
@@ -9,7 +9,9 @@ import (
 
 // Builder produces the same image GoApp.Ci would publish, single-arch
 // (host platform). Used for local development to verify the artifact
-// before pushing.
+// before pushing. Both of its functions route through the same
+// per-platform build Ci uses, so the binary carries the same version and
+// commit stamp and a local build is the same artifact.
 type Builder struct {
 	// +private
 	App *GoApp

--- a/daggerverse/z5labs/goapp.go
+++ b/daggerverse/z5labs/goapp.go
@@ -325,19 +325,79 @@ func (a *GoApp) resolvedPkg() string {
 // buildBinaryForPlatform cross-compiles source against platform
 // (formatted "<goos>/<goarch>") and returns the resulting binary as a
 // *dagger.File. CGO is disabled and the binary is built with -trimpath
-// and -s -w for reproducibility and size.
-func (a *GoApp) buildBinaryForPlatform(_ context.Context, platform, binaryName string) (*dagger.File, error) {
-	goos, goarch, err := parsePlatform(platform)
+// and -s -w for reproducibility and size, and stamped with the version
+// and commit derived from HEAD.
+//
+// Stamping happens here, in the per-variant compile, and nowhere else:
+// Ci collapses its per-platform images into a single manifest list
+// before publishing, so a stamp applied at the image or publish layer
+// would be applied once to an artifact that already merged the variants.
+func (a *GoApp) buildBinaryForPlatform(ctx context.Context, platform, binaryName string) (*dagger.File, error) {
+	// Validate here rather than leaving it to Go.Build: Build's error
+	// surfaces only when the returned directory is evaluated, which is
+	// several steps further from the caller that supplied the platform.
+	if _, _, err := parsePlatform(platform); err != nil {
+		return nil, err
+	}
+	version, commit, err := a.stampValues(ctx)
 	if err != nil {
 		return nil, err
 	}
-	out := "/out/" + binaryName
-	ctr := dag.Go().Container(a.Source).
-		WithEnvVariable("GOOS", goos).
-		WithEnvVariable("GOARCH", goarch).
-		WithEnvVariable("CGO_ENABLED", "0").
-		WithExec([]string{"go", "build", "-trimpath", "-ldflags", "-s -w", "-o", out, a.resolvedPkg()})
-	return ctr.File(out), nil
+	return dag.Go().Build(a.Source, dagger.GoBuildOpts{
+		Pkg:        a.resolvedPkg(),
+		Output:     binaryName,
+		Trimpath:   true,
+		Strip:      true,
+		DisableCgo: true,
+		Platform:   platform,
+		Stamps: []string{
+			stampVersionVar + "=" + version,
+			stampCommitVar + "=" + commit,
+		},
+	}).File(binaryName), nil
+}
+
+// stampVersionVar and stampCommitVar are the linker symbols every binary
+// GoApp builds is stamped with. They are fixed by the module rather than
+// chosen per application, so every z5labs Go application answers "which
+// build am I running" the same way.
+const (
+	stampVersionVar = "main.version"
+	stampCommitVar  = "main.commit"
+)
+
+// stampValues returns the version and commit stamped into every binary
+// this GoApp builds, both derived from HEAD and from nothing else.
+//
+// version follows the same rule as imageTagFor, so a binary's reported
+// version and the tag of the image carrying it agree by construction: a
+// tag pointing at HEAD gives the stripped tag name, anything else gives
+// "<shortSha>-<isoCommitTime>". The refs are read unfiltered — publishOn
+// decides what gets published, not what gets stamped, so a build that
+// will never publish is stamped exactly like one that will.
+//
+// commit is the short HEAD SHA. Both values are functions of the commit
+// alone, which is what makes two builds of one commit byte-identical.
+func (a *GoApp) stampValues(ctx context.Context) (version, commit string, err error) {
+	shortSha, commitISO, err := a.shortShaAndCommitTime(ctx)
+	if err != nil {
+		return "", "", fmt.Errorf("could not derive build stamp from source: %v", err)
+	}
+	refs, err := a.collectRefs(ctx)
+	if err != nil {
+		return "", "", fmt.Errorf("could not derive build stamp from source: %v", err)
+	}
+	for _, ref := range refs {
+		if !strings.HasPrefix(ref, "refs/tags/") {
+			continue
+		}
+		tag, ok := imageTagFor(ref, shortSha, commitISO)
+		if !ok {
+			continue
+		}
+		return tag, shortSha, nil
+	}
+	return shortSha + "-" + commitISO, shortSha, nil
 }
 
 // imageForPlatform packages binary as a scratch image pinned to

--- a/daggerverse/z5labs/internal/dagger/go.gen.go
+++ b/daggerverse/z5labs/internal/dagger/go.gen.go
@@ -102,20 +102,70 @@ func (r *Go) WithGraphQLQuery(q *querybuilder.Selection) *Go {
 
 // GoBuildOpts contains options for Go.Build
 type GoBuildOpts struct {
-
+	//
+	// Package(s) to build, in `go build` package-list syntax.
+	//
+	//
 	// Default: "./..."
-	Pkg string // go (../../../../daggerverse/go/main.go:230:2)
-
-	Output string // go (../../../../daggerverse/go/main.go:232:2)
-
-	Flags []string // go (../../../../daggerverse/go/main.go:234:2)
+	Pkg string // go (../../../../daggerverse/go/main.go:240:2)
+	//
+	// Name of the binary written under /out. Empty means `-o /out/`, which
+	// lets go build name each binary after its main package.
+	//
+	Output string // go (../../../../daggerverse/go/main.go:245:2)
+	//
+	// Pass -trimpath: strip the build's local file system paths out of the
+	// binary, so the output does not depend on where it was compiled.
+	//
+	Trimpath bool // go (../../../../daggerverse/go/main.go:250:2)
+	//
+	// Pass -ldflags "-s -w": drop the symbol table and the DWARF debug
+	// info. Smaller binary, no usable stack symbolization or debugger.
+	//
+	Strip bool // go (../../../../daggerverse/go/main.go:255:2)
+	//
+	// Link-time variable assignments, each `importpath.Name=value`,
+	// rendered as `-ldflags "-X importpath.Name=value"`. This is how a
+	// binary learns its own version or commit. Only the first `=` splits
+	// name from value, so a value may itself contain `=`. An element with
+	// no `=`, or with an empty name, is rejected. The linker silently
+	// ignores a stamp naming a variable that does not exist, or one that
+	// is not a package-level string.
+	//
+	Stamps []string // go (../../../../daggerverse/go/main.go:265:2)
+	//
+	// Build tags, passed as `-tags a,b,c`. Selects which `//go:build`
+	// files are compiled in.
+	//
+	Tags []string // go (../../../../daggerverse/go/main.go:270:2)
+	//
+	// Target platform as `GOOS/GOARCH[/variant]`, e.g. "linux/arm64".
+	// Sets GOOS and GOARCH for a cross-compile; empty builds for the
+	// toolchain container's own platform. Any variant segment is ignored —
+	// GOARM/GOAMD64 are left unset.
+	//
+	Platform string // go (../../../../daggerverse/go/main.go:277:2)
+	//
+	// Set CGO_ENABLED=0. Produces a statically linked binary with no libc
+	// dependency, which is what a scratch image needs, at the cost of the
+	// cgo-backed net and os/user implementations.
+	//
+	DisableCgo bool // go (../../../../daggerverse/go/main.go:283:2)
 }
 
-// Build runs `go build -o /out/[output] [flags] pkg` against the supplied
-// source and returns /out as a *dagger.Directory. pkg defaults to `./...`;
-// when output is empty, `-o /out/` is used so go build picks names per its
-// own rules (one binary per main package).
-func (r *Go) Build(source *Directory, opts ...GoBuildOpts) *Directory { // go (../../../../daggerverse/go/main.go:226:1)
+// Build runs `go build` against the supplied source and returns /out as a
+// *dagger.Directory. pkg defaults to `./...`; when output is empty, `-o
+// /out/` is used so go build picks names per its own rules (one binary per
+// main package).
+//
+// Every flag this function can pass is a named input with its own doc
+// comment, so `dagger functions` describes what each one does to the
+// output. There is deliberately no raw `flags []string` escape hatch: a bag
+// of strings cannot be validated, cannot be documented per flag, and makes
+// every caller re-learn the same spellings. Container() is the escape hatch
+// for anything not named here — it hands back the prepared container so a
+// caller can run whatever `go build` invocation it likes.
+func (r *Go) Build(source *Directory, opts ...GoBuildOpts) *Directory { // go (../../../../daggerverse/go/main.go:234:1)
 	assertNotNil("source", source)
 	q := r.query.Select("build")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -127,9 +177,29 @@ func (r *Go) Build(source *Directory, opts ...GoBuildOpts) *Directory { // go (.
 		if !querybuilder.IsZeroValue(opts[i].Output) {
 			q = q.Arg("output", opts[i].Output)
 		}
-		// `flags` optional argument
-		if !querybuilder.IsZeroValue(opts[i].Flags) {
-			q = q.Arg("flags", opts[i].Flags)
+		// `trimpath` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Trimpath) {
+			q = q.Arg("trimpath", opts[i].Trimpath)
+		}
+		// `strip` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Strip) {
+			q = q.Arg("strip", opts[i].Strip)
+		}
+		// `stamps` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Stamps) {
+			q = q.Arg("stamps", opts[i].Stamps)
+		}
+		// `tags` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Tags) {
+			q = q.Arg("tags", opts[i].Tags)
+		}
+		// `platform` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Platform) {
+			q = q.Arg("platform", opts[i].Platform)
+		}
+		// `disableCgo` optional argument
+		if !querybuilder.IsZeroValue(opts[i].DisableCgo) {
+			q = q.Arg("disableCgo", opts[i].DisableCgo)
 		}
 	}
 	q = q.Arg("source", source)
@@ -170,7 +240,7 @@ func (r *Go) Container(source *Directory) *Container { // go (../../../../dagger
 }
 
 // Env runs `go env` in a source-less base container and returns its stdout.
-func (r *Go) Env(ctx context.Context) (string, error) { // go (../../../../daggerverse/go/main.go:319:1)
+func (r *Go) Env(ctx context.Context) (string, error) { // go (../../../../daggerverse/go/main.go:448:1)
 	if r.env != nil {
 		return *r.env, nil
 	}
@@ -185,7 +255,7 @@ func (r *Go) Env(ctx context.Context) (string, error) { // go (../../../../dagge
 // Fmt runs `gofmt -l -d .` against the supplied source. Returns the diff
 // of any unformatted files; non-empty output is also returned as an error so
 // CI fails fast on formatting violations.
-func (r *Go) Fmt(ctx context.Context, source *Directory) (string, error) { // go (../../../../daggerverse/go/main.go:283:1)
+func (r *Go) Fmt(ctx context.Context, source *Directory) (string, error) { // go (../../../../daggerverse/go/main.go:412:1)
 	assertNotNil("source", source)
 	if r.fmt != nil {
 		return *r.fmt, nil
@@ -360,17 +430,17 @@ func (r *Go) Run(ctx context.Context, source *Directory, pkg string, opts ...GoR
 type GoTestOpts struct {
 
 	// Default: "./..."
-	Pkg string // go (../../../../daggerverse/go/main.go:259:2)
+	Pkg string // go (../../../../daggerverse/go/main.go:388:2)
 
-	Race bool // go (../../../../daggerverse/go/main.go:261:2)
+	Race bool // go (../../../../daggerverse/go/main.go:390:2)
 
-	Flags []string // go (../../../../daggerverse/go/main.go:263:2)
+	Flags []string // go (../../../../daggerverse/go/main.go:392:2)
 }
 
 // Test runs `go test -count=1 [-race] [flags] pkg` against the supplied
 // source and returns the combined stdout. -count=1 is always passed to
 // bypass Go's internal test cache.
-func (r *Go) Test(ctx context.Context, source *Directory, opts ...GoTestOpts) (string, error) { // go (../../../../daggerverse/go/main.go:255:1)
+func (r *Go) Test(ctx context.Context, source *Directory, opts ...GoTestOpts) (string, error) { // go (../../../../daggerverse/go/main.go:384:1)
 	assertNotNil("source", source)
 	if r.test != nil {
 		return *r.test, nil
@@ -400,7 +470,7 @@ func (r *Go) Test(ctx context.Context, source *Directory, opts ...GoTestOpts) (s
 
 // ToolVersion runs `go version` in a source-less base container and returns
 // the trimmed output (e.g. "go version go1.23.0 linux/amd64").
-func (r *Go) ToolVersion(ctx context.Context) (string, error) { // go (../../../../daggerverse/go/main.go:327:1)
+func (r *Go) ToolVersion(ctx context.Context) (string, error) { // go (../../../../daggerverse/go/main.go:456:1)
 	if r.toolVersion != nil {
 		return *r.toolVersion, nil
 	}
@@ -431,12 +501,12 @@ func (r *Go) Version(ctx context.Context) (string, error) { // go (../../../../d
 type GoVetOpts struct {
 
 	// Default: "./..."
-	Pkg string // go (../../../../daggerverse/go/main.go:306:2)
+	Pkg string // go (../../../../daggerverse/go/main.go:435:2)
 }
 
 // Vet runs `go vet pkg` against the supplied source. pkg defaults to
 // `./...`. Returns a non-nil error when vet reports any issue.
-func (r *Go) Vet(ctx context.Context, source *Directory, opts ...GoVetOpts) error { // go (../../../../daggerverse/go/main.go:302:1)
+func (r *Go) Vet(ctx context.Context, source *Directory, opts ...GoVetOpts) error { // go (../../../../daggerverse/go/main.go:431:1)
 	assertNotNil("source", source)
 	if r.vet != nil {
 		return nil

--- a/daggerverse/z5labs/main.go
+++ b/daggerverse/z5labs/main.go
@@ -20,6 +20,25 @@ type Z5labs struct{}
 // Go application. Call Ci to run checks + multi-arch build + conditional
 // publish, or Builder to produce the same image single-arch locally.
 //
+// Every binary GoApp builds is stamped at link time with the version and
+// the commit it was built from, so an application can answer "which build
+// am I running" without a second build definition beside this one. Declare
+// these two package-level vars in your main package and they are filled in:
+//
+//	var (
+//		version = "dev"
+//		commit  = "none"
+//	)
+//
+// The names are fixed by the module — `main.version` and `main.commit` —
+// and the values are taken from HEAD, never from a parameter. A tag
+// pointing at HEAD gives version the stripped tag name; anything else
+// gives "<shortSha>-<isoCommitTime>", the same rule the published image
+// tag follows, so the two agree by construction. commit is the short HEAD
+// SHA. Because both are functions of the commit alone, two builds of one
+// commit are byte-identical; there is no caller-supplied value that could
+// break that. Source without git metadata at HEAD is an error.
+//
 // publishOn is a regex evaluated against source repo's HEAD refs (after
 // normalizing `refs/remotes/origin/X` → `refs/heads/X`); matches trigger
 // publish. When registry is set, auth is required.

--- a/daggerverse/z5labs/tests/dagger.gen.go
+++ b/daggerverse/z5labs/tests/dagger.gen.go
@@ -220,6 +220,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).BuilderContainerProducesScratchImageWithBinary(&parent, ctx)
+		case "GoAppBuildFailsWithoutGitMetadata":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).GoAppBuildFailsWithoutGitMetadata(&parent, ctx)
 		case "GoAppCiErrorsWhenPublishOnMatchesButCredsMissing":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -262,6 +269,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).GoAppCiPublishesToAllMatchingTags(&parent, ctx)
+		case "GoAppCiRebuildIsByteIdenticalPerPlatform":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).GoAppCiRebuildIsByteIdenticalPerPlatform(&parent, ctx)
 		case "GoAppCiRejectsMissingGitDir":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -276,6 +290,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).GoAppCiSkipsPublishWhenNoRefMatches(&parent, ctx)
+		case "GoAppCiStampedBinaryMatchesImageTagAndBuilder":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).GoAppCiStampedBinaryMatchesImageTagAndBuilder(&parent, ctx)
+		case "GoAppCiStampsEveryPlatformVariant":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).GoAppCiStampsEveryPlatformVariant(&parent, ctx)
 		case "GoAppCiTagBeatsBranch":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -283,6 +311,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).GoAppCiTagBeatsBranch(&parent, ctx)
+		case "GoAppStampsWhenPublishOnDoesNotMatch":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).GoAppStampsWhenPublishOnDoesNotMatch(&parent, ctx)
 		case "GoLibCiFailsForFailingTest":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/z5labs/tests/fixtures/stamped/go.mod
+++ b/daggerverse/z5labs/tests/fixtures/stamped/go.mod
@@ -1,0 +1,3 @@
+module example.com/stamped
+
+go 1.23

--- a/daggerverse/z5labs/tests/fixtures/stamped/main.go
+++ b/daggerverse/z5labs/tests/fixtures/stamped/main.go
@@ -1,0 +1,12 @@
+package main
+
+import "fmt"
+
+// version and commit are the two package-level vars GoApp stamps at link
+// time. The defaults are what an unstamped build would report.
+var (
+	version = "dev"
+	commit  = "none"
+)
+
+func main() { fmt.Printf("version=%s commit=%s\n", version, commit) }

--- a/daggerverse/z5labs/tests/internal/dagger/go.gen.go
+++ b/daggerverse/z5labs/tests/internal/dagger/go.gen.go
@@ -102,20 +102,70 @@ func (r *Go) WithGraphQLQuery(q *querybuilder.Selection) *Go {
 
 // GoBuildOpts contains options for Go.Build
 type GoBuildOpts struct {
-
+	//
+	// Package(s) to build, in `go build` package-list syntax.
+	//
+	//
 	// Default: "./..."
-	Pkg string // go (../../../../../daggerverse/go/main.go:230:2)
-
-	Output string // go (../../../../../daggerverse/go/main.go:232:2)
-
-	Flags []string // go (../../../../../daggerverse/go/main.go:234:2)
+	Pkg string // go (../../../../../daggerverse/go/main.go:240:2)
+	//
+	// Name of the binary written under /out. Empty means `-o /out/`, which
+	// lets go build name each binary after its main package.
+	//
+	Output string // go (../../../../../daggerverse/go/main.go:245:2)
+	//
+	// Pass -trimpath: strip the build's local file system paths out of the
+	// binary, so the output does not depend on where it was compiled.
+	//
+	Trimpath bool // go (../../../../../daggerverse/go/main.go:250:2)
+	//
+	// Pass -ldflags "-s -w": drop the symbol table and the DWARF debug
+	// info. Smaller binary, no usable stack symbolization or debugger.
+	//
+	Strip bool // go (../../../../../daggerverse/go/main.go:255:2)
+	//
+	// Link-time variable assignments, each `importpath.Name=value`,
+	// rendered as `-ldflags "-X importpath.Name=value"`. This is how a
+	// binary learns its own version or commit. Only the first `=` splits
+	// name from value, so a value may itself contain `=`. An element with
+	// no `=`, or with an empty name, is rejected. The linker silently
+	// ignores a stamp naming a variable that does not exist, or one that
+	// is not a package-level string.
+	//
+	Stamps []string // go (../../../../../daggerverse/go/main.go:265:2)
+	//
+	// Build tags, passed as `-tags a,b,c`. Selects which `//go:build`
+	// files are compiled in.
+	//
+	Tags []string // go (../../../../../daggerverse/go/main.go:270:2)
+	//
+	// Target platform as `GOOS/GOARCH[/variant]`, e.g. "linux/arm64".
+	// Sets GOOS and GOARCH for a cross-compile; empty builds for the
+	// toolchain container's own platform. Any variant segment is ignored —
+	// GOARM/GOAMD64 are left unset.
+	//
+	Platform string // go (../../../../../daggerverse/go/main.go:277:2)
+	//
+	// Set CGO_ENABLED=0. Produces a statically linked binary with no libc
+	// dependency, which is what a scratch image needs, at the cost of the
+	// cgo-backed net and os/user implementations.
+	//
+	DisableCgo bool // go (../../../../../daggerverse/go/main.go:283:2)
 }
 
-// Build runs `go build -o /out/[output] [flags] pkg` against the supplied
-// source and returns /out as a *dagger.Directory. pkg defaults to `./...`;
-// when output is empty, `-o /out/` is used so go build picks names per its
-// own rules (one binary per main package).
-func (r *Go) Build(source *Directory, opts ...GoBuildOpts) *Directory { // go (../../../../../daggerverse/go/main.go:226:1)
+// Build runs `go build` against the supplied source and returns /out as a
+// *dagger.Directory. pkg defaults to `./...`; when output is empty, `-o
+// /out/` is used so go build picks names per its own rules (one binary per
+// main package).
+//
+// Every flag this function can pass is a named input with its own doc
+// comment, so `dagger functions` describes what each one does to the
+// output. There is deliberately no raw `flags []string` escape hatch: a bag
+// of strings cannot be validated, cannot be documented per flag, and makes
+// every caller re-learn the same spellings. Container() is the escape hatch
+// for anything not named here — it hands back the prepared container so a
+// caller can run whatever `go build` invocation it likes.
+func (r *Go) Build(source *Directory, opts ...GoBuildOpts) *Directory { // go (../../../../../daggerverse/go/main.go:234:1)
 	assertNotNil("source", source)
 	q := r.query.Select("build")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -127,9 +177,29 @@ func (r *Go) Build(source *Directory, opts ...GoBuildOpts) *Directory { // go (.
 		if !querybuilder.IsZeroValue(opts[i].Output) {
 			q = q.Arg("output", opts[i].Output)
 		}
-		// `flags` optional argument
-		if !querybuilder.IsZeroValue(opts[i].Flags) {
-			q = q.Arg("flags", opts[i].Flags)
+		// `trimpath` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Trimpath) {
+			q = q.Arg("trimpath", opts[i].Trimpath)
+		}
+		// `strip` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Strip) {
+			q = q.Arg("strip", opts[i].Strip)
+		}
+		// `stamps` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Stamps) {
+			q = q.Arg("stamps", opts[i].Stamps)
+		}
+		// `tags` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Tags) {
+			q = q.Arg("tags", opts[i].Tags)
+		}
+		// `platform` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Platform) {
+			q = q.Arg("platform", opts[i].Platform)
+		}
+		// `disableCgo` optional argument
+		if !querybuilder.IsZeroValue(opts[i].DisableCgo) {
+			q = q.Arg("disableCgo", opts[i].DisableCgo)
 		}
 	}
 	q = q.Arg("source", source)
@@ -170,7 +240,7 @@ func (r *Go) Container(source *Directory) *Container { // go (../../../../../dag
 }
 
 // Env runs `go env` in a source-less base container and returns its stdout.
-func (r *Go) Env(ctx context.Context) (string, error) { // go (../../../../../daggerverse/go/main.go:319:1)
+func (r *Go) Env(ctx context.Context) (string, error) { // go (../../../../../daggerverse/go/main.go:448:1)
 	if r.env != nil {
 		return *r.env, nil
 	}
@@ -185,7 +255,7 @@ func (r *Go) Env(ctx context.Context) (string, error) { // go (../../../../../da
 // Fmt runs `gofmt -l -d .` against the supplied source. Returns the diff
 // of any unformatted files; non-empty output is also returned as an error so
 // CI fails fast on formatting violations.
-func (r *Go) Fmt(ctx context.Context, source *Directory) (string, error) { // go (../../../../../daggerverse/go/main.go:283:1)
+func (r *Go) Fmt(ctx context.Context, source *Directory) (string, error) { // go (../../../../../daggerverse/go/main.go:412:1)
 	assertNotNil("source", source)
 	if r.fmt != nil {
 		return *r.fmt, nil
@@ -360,17 +430,17 @@ func (r *Go) Run(ctx context.Context, source *Directory, pkg string, opts ...GoR
 type GoTestOpts struct {
 
 	// Default: "./..."
-	Pkg string // go (../../../../../daggerverse/go/main.go:259:2)
+	Pkg string // go (../../../../../daggerverse/go/main.go:388:2)
 
-	Race bool // go (../../../../../daggerverse/go/main.go:261:2)
+	Race bool // go (../../../../../daggerverse/go/main.go:390:2)
 
-	Flags []string // go (../../../../../daggerverse/go/main.go:263:2)
+	Flags []string // go (../../../../../daggerverse/go/main.go:392:2)
 }
 
 // Test runs `go test -count=1 [-race] [flags] pkg` against the supplied
 // source and returns the combined stdout. -count=1 is always passed to
 // bypass Go's internal test cache.
-func (r *Go) Test(ctx context.Context, source *Directory, opts ...GoTestOpts) (string, error) { // go (../../../../../daggerverse/go/main.go:255:1)
+func (r *Go) Test(ctx context.Context, source *Directory, opts ...GoTestOpts) (string, error) { // go (../../../../../daggerverse/go/main.go:384:1)
 	assertNotNil("source", source)
 	if r.test != nil {
 		return *r.test, nil
@@ -400,7 +470,7 @@ func (r *Go) Test(ctx context.Context, source *Directory, opts ...GoTestOpts) (s
 
 // ToolVersion runs `go version` in a source-less base container and returns
 // the trimmed output (e.g. "go version go1.23.0 linux/amd64").
-func (r *Go) ToolVersion(ctx context.Context) (string, error) { // go (../../../../../daggerverse/go/main.go:327:1)
+func (r *Go) ToolVersion(ctx context.Context) (string, error) { // go (../../../../../daggerverse/go/main.go:456:1)
 	if r.toolVersion != nil {
 		return *r.toolVersion, nil
 	}
@@ -431,12 +501,12 @@ func (r *Go) Version(ctx context.Context) (string, error) { // go (../../../../.
 type GoVetOpts struct {
 
 	// Default: "./..."
-	Pkg string // go (../../../../../daggerverse/go/main.go:306:2)
+	Pkg string // go (../../../../../daggerverse/go/main.go:435:2)
 }
 
 // Vet runs `go vet pkg` against the supplied source. pkg defaults to
 // `./...`. Returns a non-nil error when vet reports any issue.
-func (r *Go) Vet(ctx context.Context, source *Directory, opts ...GoVetOpts) error { // go (../../../../../daggerverse/go/main.go:302:1)
+func (r *Go) Vet(ctx context.Context, source *Directory, opts ...GoVetOpts) error { // go (../../../../../daggerverse/go/main.go:431:1)
 	assertNotNil("source", source)
 	if r.vet != nil {
 		return nil

--- a/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
+++ b/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
@@ -19,7 +19,7 @@ func (r *Binding) AsZ5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5l
 }
 
 // Retrieve the binding value, as type Z5LabsBuilder
-func (r *Binding) AsZ5LabsBuilder() *Z5LabsBuilder { // z5labs (../../../../../daggerverse/z5labs/builder.go:13:6)
+func (r *Binding) AsZ5LabsBuilder() *Z5LabsBuilder { // z5labs (../../../../../daggerverse/z5labs/builder.go:15:6)
 	q := r.query.Select("asZ5LabsBuilder")
 
 	return &Z5LabsBuilder{
@@ -46,7 +46,7 @@ func (r *Binding) AsZ5LabsGoLib() *Z5LabsGoLib { // z5labs (../../../../../dagge
 }
 
 // Create or update a binding of type Z5LabsBuilder in the environment
-func (r *Env) WithZ5LabsBuilderInput(name string, value *Z5LabsBuilder, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/builder.go:13:6)
+func (r *Env) WithZ5LabsBuilderInput(name string, value *Z5LabsBuilder, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/builder.go:15:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withZ5LabsBuilderInput")
 	q = q.Arg("name", name)
@@ -59,7 +59,7 @@ func (r *Env) WithZ5LabsBuilderInput(name string, value *Z5LabsBuilder, descript
 }
 
 // Declare a desired Z5LabsBuilder output to be assigned in the environment
-func (r *Env) WithZ5LabsBuilderOutput(name string, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/builder.go:13:6)
+func (r *Env) WithZ5LabsBuilderOutput(name string, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/builder.go:15:6)
 	q := r.query.Select("withZ5LabsBuilderOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -169,29 +169,48 @@ func (r *Z5Labs) WithGraphQLQuery(q *querybuilder.Selection) *Z5Labs {
 type Z5LabsGoAppOpts struct {
 
 	// Default: "."
-	Pkg string // z5labs (../../../../../daggerverse/z5labs/main.go:37:2)
+	Pkg string // z5labs (../../../../../daggerverse/z5labs/main.go:56:2)
 
-	BinaryName string // z5labs (../../../../../daggerverse/z5labs/main.go:39:2)
+	BinaryName string // z5labs (../../../../../daggerverse/z5labs/main.go:58:2)
 
 	// Default: "^refs/heads/main$"
-	PublishOn string // z5labs (../../../../../daggerverse/z5labs/main.go:42:2)
+	PublishOn string // z5labs (../../../../../daggerverse/z5labs/main.go:61:2)
 
-	Registry string // z5labs (../../../../../daggerverse/z5labs/main.go:44:2)
+	Registry string // z5labs (../../../../../daggerverse/z5labs/main.go:63:2)
 
 	// Default: "ci"
-	AuthUsername string // z5labs (../../../../../daggerverse/z5labs/main.go:47:2)
+	AuthUsername string // z5labs (../../../../../daggerverse/z5labs/main.go:66:2)
 
-	Auth *Secret // z5labs (../../../../../daggerverse/z5labs/main.go:49:2)
+	Auth *Secret // z5labs (../../../../../daggerverse/z5labs/main.go:68:2)
 
-	LintConfig *File // z5labs (../../../../../daggerverse/z5labs/main.go:51:2)
+	LintConfig *File // z5labs (../../../../../daggerverse/z5labs/main.go:70:2)
 
-	Platforms []string // z5labs (../../../../../daggerverse/z5labs/main.go:53:2)
+	Platforms []string // z5labs (../../../../../daggerverse/z5labs/main.go:72:2)
 
-	RegistryService *Service // z5labs (../../../../../daggerverse/z5labs/main.go:55:2)
+	RegistryService *Service // z5labs (../../../../../daggerverse/z5labs/main.go:74:2)
 }
 
 // GoApp wires up an opinionated CI/release pipeline for a `package main`
 // Go application. Call Ci to run checks + multi-arch buildpublish, or Builder to produce the same image single-arch locally.
+//
+// Every binary GoApp builds is stamped at link time with the version and
+// the commit it was built from, so an application can answer "which build
+// am I running" without a second build definition beside this one. Declare
+// these two package-level vars in your main package and they are filled in:
+//
+//	var (
+//		version = "dev"
+//		commit  = "none"
+//	)
+//
+// The names are fixed by the module — `main.version` and `main.commit` —
+// and the values are taken from HEAD, never from a parameter. A tag
+// pointing at HEAD gives version the stripped tag name; anything else
+// gives "<shortSha>-<isoCommitTime>", the same rule the published image
+// tag follows, so the two agree by construction. commit is the short HEAD
+// SHA. Because both are functions of the commit alone, two builds of one
+// commit are byte-identical; there is no caller-supplied value that could
+// break that. Source without git metadata at HEAD is an error.
 //
 // publishOn is a regex evaluated against source repo's HEAD refs (after
 // normalizing `refs/remotes/origin/X` → `refs/heads/X`); matches trigger
@@ -203,7 +222,7 @@ type Z5LabsGoAppOpts struct {
 // publishing container — used by tests against a local registry:2
 // service and by callers whose private registry is itself a Dagger
 // service.
-func (r *Z5Labs) GoApp(source *Directory, opts ...Z5LabsGoAppOpts) *Z5LabsGoApp { // z5labs (../../../../../daggerverse/z5labs/main.go:33:1)
+func (r *Z5Labs) GoApp(source *Directory, opts ...Z5LabsGoAppOpts) *Z5LabsGoApp { // z5labs (../../../../../daggerverse/z5labs/main.go:52:1)
 	assertNotNil("source", source)
 	q := r.query.Select("goApp")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -253,12 +272,12 @@ func (r *Z5Labs) GoApp(source *Directory, opts ...Z5LabsGoAppOpts) *Z5LabsGoApp 
 
 // Z5LabsGoLibOpts contains options for Z5Labs.GoLib
 type Z5LabsGoLibOpts struct {
-	LintConfig *File // z5labs (../../../../../daggerverse/z5labs/main.go:79:2)
+	LintConfig *File // z5labs (../../../../../daggerverse/z5labs/main.go:98:2)
 }
 
 // GoLib wires up the checks-only pipeline for a Go library. v1 has no
 // publish equivalent for libraries.
-func (r *Z5Labs) GoLib(source *Directory, opts ...Z5LabsGoLibOpts) *Z5LabsGoLib { // z5labs (../../../../../daggerverse/z5labs/main.go:76:1)
+func (r *Z5Labs) GoLib(source *Directory, opts ...Z5LabsGoLibOpts) *Z5LabsGoLib { // z5labs (../../../../../daggerverse/z5labs/main.go:95:1)
 	assertNotNil("source", source)
 	q := r.query.Select("goLib")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -333,8 +352,10 @@ func (r *Z5Labs) AsNode() Node {
 
 // Builder produces the same image GoApp.Ci would publish, single-arch
 // (host platform). Used for local development to verify the artifact
-// before pushing.
-type Z5LabsBuilder struct { // z5labs (../../../../../daggerverse/z5labs/builder.go:13:6)
+// before pushing. Both of its functions route through the same
+// per-platform build Ci uses, so the binary carries the same version and
+// commit stamp and a local build is the same artifact.
+type Z5LabsBuilder struct { // z5labs (../../../../../daggerverse/z5labs/builder.go:15:6)
 	query *querybuilder.Selection
 
 	id *ID
@@ -347,7 +368,7 @@ func (r *Z5LabsBuilder) WithGraphQLQuery(q *querybuilder.Selection) *Z5LabsBuild
 }
 
 // Binary returns the host-platform compiled binary as a *dagger.File.
-func (r *Z5LabsBuilder) Binary() *File { // z5labs (../../../../../daggerverse/z5labs/builder.go:38:1)
+func (r *Z5LabsBuilder) Binary() *File { // z5labs (../../../../../daggerverse/z5labs/builder.go:40:1)
 	q := r.query.Select("binary")
 
 	return &File{
@@ -357,7 +378,7 @@ func (r *Z5LabsBuilder) Binary() *File { // z5labs (../../../../../daggerverse/z
 
 // Container returns the host-platform scratch image containing the
 // compiled binary at /app/<binaryName> with that path as entrypoint.
-func (r *Z5LabsBuilder) Container() *Container { // z5labs (../../../../../daggerverse/z5labs/builder.go:22:1)
+func (r *Z5LabsBuilder) Container() *Container { // z5labs (../../../../../daggerverse/z5labs/builder.go:24:1)
 	q := r.query.Select("container")
 
 	return &Container{

--- a/daggerverse/z5labs/tests/main.go
+++ b/daggerverse/z5labs/tests/main.go
@@ -7,6 +7,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -22,6 +23,55 @@ const registryAlias = "registry"
 // curlImage matches the pin used by the other test modules in this
 // repo (envoy, otel, grafana-stack). ":latest" is a moving target.
 const curlImage = "curlimages/curl:8.10.1"
+
+// skopeoImage matches the pin the module itself publishes with. Tests use
+// skopeo to read individual platform variants back out of the registry.
+const skopeoImage = "quay.io/skopeo/stable:v1.22.2"
+
+// hostPlatform is the platform Builder builds for. Test module code runs
+// in a linux container on the engine, so runtime.GOARCH here is the
+// engine's architecture — the same one Builder resolves.
+func hostPlatform() string { return "linux/" + runtime.GOARCH }
+
+// hostArch is hostPlatform's GOARCH component, as skopeo's
+// --override-arch spells it.
+func hostArch() string { return runtime.GOARCH }
+
+// pullVariant pulls the given platform's variant of image:tag out of the
+// local registry and imports it as a container, so a test can look at the
+// exact bytes that were published for that platform.
+//
+// skopeo rather than Container.From: an image reference resolves in the
+// engine's BuildKit context, which does not see this session's service
+// bindings, while skopeo running inside a service-bound container does.
+// The password is a plain env var rather than a secret on purpose —
+// Dagger excludes secret values from cache keys, and this exec must not
+// be served from an earlier session's registry.
+//
+// Import resolves the archive against the container's platform, which
+// defaults to the engine's; a foreign-architecture variant is invisible
+// unless the container is created for that platform explicitly.
+// nonce varies this pull's cache key. Pass a distinct value when a test
+// pulls the same tag more than once and needs the later pulls to be real
+// pulls rather than the first one's cached result.
+func pullVariant(svc *dagger.Service, host, user, pwd, image, tag, platform, nonce string) *dagger.Container {
+	arch := platform
+	if _, a, ok := strings.Cut(platform, "/"); ok {
+		arch = a
+	}
+	ref := fmt.Sprintf("docker://%s:5000/%s:%s", host, image, tag)
+	tarball := dag.Container().From(skopeoImage).
+		WithServiceBinding(host, svc).
+		WithEnvVariable("NONCE", nonce).
+		WithEnvVariable("REGISTRY_USERNAME", user).
+		WithEnvVariable("REGISTRY_PASSWORD", pwd).
+		WithExec([]string{"sh", "-c",
+			`skopeo copy --src-tls-verify=false --override-os linux --override-arch "$1" --src-creds="$REGISTRY_USERNAME:$REGISTRY_PASSWORD" "$2" docker-archive:/img.tar`,
+			"sh", arch, ref,
+		}).
+		File("/img.tar")
+	return dag.Container(dagger.ContainerOpts{Platform: dagger.Platform(platform)}).Import(tarball)
+}
 
 type Tests struct{}
 
@@ -55,6 +105,11 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("GoAppCiPublishesToAllMatchingTags", t.GoAppCiPublishesToAllMatchingTags)
 	jobs = jobs.WithJob("GoAppCiNormalizesRemoteOriginRefs", t.GoAppCiNormalizesRemoteOriginRefs)
 	jobs = jobs.WithJob("GoAppCiTagBeatsBranch", t.GoAppCiTagBeatsBranch)
+	jobs = jobs.WithJob("GoAppBuildFailsWithoutGitMetadata", t.GoAppBuildFailsWithoutGitMetadata)
+	jobs = jobs.WithJob("GoAppStampsWhenPublishOnDoesNotMatch", t.GoAppStampsWhenPublishOnDoesNotMatch)
+	jobs = jobs.WithJob("GoAppCiStampedBinaryMatchesImageTagAndBuilder", t.GoAppCiStampedBinaryMatchesImageTagAndBuilder)
+	jobs = jobs.WithJob("GoAppCiStampsEveryPlatformVariant", t.GoAppCiStampsEveryPlatformVariant)
+	jobs = jobs.WithJob("GoAppCiRebuildIsByteIdenticalPerPlatform", t.GoAppCiRebuildIsByteIdenticalPerPlatform)
 
 	return jobs.Run(ctx)
 }
@@ -481,9 +536,14 @@ func (t *Tests) GoAppCiRejectsMissingGitDir(ctx context.Context) error {
 
 // BuilderContainerProducesScratchImageWithBinary asserts that
 // Builder.Container produces a scratch image whose entrypoint runs the
-// embedded binary and prints "hello".
+// embedded binary and prints "hello". The source is git-backed because
+// every build derives its stamp from HEAD.
 func (t *Tests) BuilderContainerProducesScratchImageWithBinary(ctx context.Context) error {
-	ctr := dag.Z5Labs().GoApp(helloDir()).Builder().Container()
+	src, err := gitFixture(ctx, helloDir(), "main", nil)
+	if err != nil {
+		return fmt.Errorf("gitFixture: %v", err)
+	}
+	ctr := dag.Z5Labs().GoApp(src).Builder().Container()
 	out, err := ctr.
 		WithExec([]string{}, dagger.ContainerWithExecOpts{UseEntrypoint: true}).
 		Stdout(ctx)
@@ -497,9 +557,14 @@ func (t *Tests) BuilderContainerProducesScratchImageWithBinary(ctx context.Conte
 }
 
 // BuilderBinaryProducesCompiledBinary asserts that Builder.Binary
-// returns a non-empty file named after the go.mod module basename.
+// returns a non-empty file named after the go.mod module basename. The
+// source is git-backed because every build derives its stamp from HEAD.
 func (t *Tests) BuilderBinaryProducesCompiledBinary(ctx context.Context) error {
-	bin := dag.Z5Labs().GoApp(helloDir()).Builder().Binary()
+	src, err := gitFixture(ctx, helloDir(), "main", nil)
+	if err != nil {
+		return fmt.Errorf("gitFixture: %v", err)
+	}
+	bin := dag.Z5Labs().GoApp(src).Builder().Binary()
 	size, err := bin.Size(ctx)
 	if err != nil {
 		return fmt.Errorf("Builder.Binary.Size: %w", err)
@@ -534,6 +599,340 @@ func (t *Tests) GoLibCiFailsForFailingTest(ctx context.Context) error {
 // helloDir returns the on-disk hello (app) fixture.
 func helloDir() *dagger.Directory {
 	return dag.CurrentModule().Source().Directory("fixtures/hello")
+}
+
+// stampedDir returns the stamped (app) fixture: a main package that
+// declares the two package-level vars GoApp stamps and prints them.
+func stampedDir() *dagger.Directory {
+	return dag.CurrentModule().Source().Directory("fixtures/stamped")
+}
+
+// headShortSha returns `git rev-parse --short HEAD` for a git-backed
+// source, so a test can compare the stamp against the commit it came from.
+func headShortSha(ctx context.Context, src *dagger.Directory) (string, error) {
+	out, err := dag.Go().Container(src).
+		WithExec([]string{"git", "rev-parse", "--short", "HEAD"}).
+		Stdout(ctx)
+	if err != nil {
+		return "", fmt.Errorf("git rev-parse: %v", err)
+	}
+	return strings.TrimSpace(out), nil
+}
+
+// stampOf runs the stamped fixture's entrypoint in ctr and returns the
+// version and commit it reports.
+func stampOf(ctx context.Context, ctr *dagger.Container) (version, commit string, err error) {
+	out, err := ctr.
+		WithExec([]string{}, dagger.ContainerWithExecOpts{UseEntrypoint: true}).
+		Stdout(ctx)
+	if err != nil {
+		return "", "", fmt.Errorf("run stamped binary: %v", err)
+	}
+	return parseStampLine(out)
+}
+
+// parseStampLine parses the stamped fixture's single line of output,
+// "version=<v> commit=<c>". Neither value can contain a space: commit is a
+// short SHA and version is either a docker-tag-sanitized tag name or
+// "<shortSha>-<isoCommitTime>".
+func parseStampLine(out string) (version, commit string, err error) {
+	fields := strings.Fields(strings.TrimSpace(out))
+	if len(fields) != 2 {
+		return "", "", fmt.Errorf("unexpected stamp output %q", out)
+	}
+	version, okV := strings.CutPrefix(fields[0], "version=")
+	commit, okC := strings.CutPrefix(fields[1], "commit=")
+	if !okV || !okC {
+		return "", "", fmt.Errorf("unexpected stamp output %q", out)
+	}
+	return version, commit, nil
+}
+
+// alpineImage is the minimal container a built binary is inspected in.
+// ":latest" is a moving target, so the tag is pinned.
+const alpineImage = "alpine:3.22"
+
+// binaryContains reports whether the raw bytes of bin contain needle.
+// grep -a treats the binary as text so a match is reported rather than
+// collapsed into "binary file matches".
+func binaryContains(ctx context.Context, bin *dagger.File, needle string) (bool, error) {
+	out, err := dag.Container().From(alpineImage).
+		WithFile("/bin/app", bin).
+		WithExec([]string{"sh", "-c", `grep -a -q -- "$1" /bin/app && echo yes || echo no`, "sh", needle}).
+		Stdout(ctx)
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(out) == "yes", nil
+}
+
+// GoAppCiStampsEveryPlatformVariant asserts a multi-platform build stamps
+// every variant. Ci collapses its per-platform images into a single
+// manifest list before publishing, so a stamp applied at the image or
+// publish layer would land on an artifact whose variants have already been
+// merged; only a stamp applied in the per-variant compile reaches them
+// all. Each variant is therefore pulled back individually: the one
+// matching the engine's architecture is executed, and the foreign one —
+// which cannot be executed here — is searched for the stamped bytes.
+func (t *Tests) GoAppCiStampsEveryPlatformVariant(ctx context.Context) error {
+	const tag = "v9.9.9"
+	src, err := gitFixture(ctx, stampedDir(), "main", []string{tag})
+	if err != nil {
+		return fmt.Errorf("gitFixture: %v", err)
+	}
+	svc, pwdHex, secret, err := localRegistry(ctx)
+	if err != nil {
+		return err
+	}
+	const host = registryAlias
+	platforms := []string{"linux/amd64", "linux/arm64"}
+	err = dag.Z5Labs().GoApp(src, dagger.Z5LabsGoAppOpts{
+		PublishOn:       "^refs/tags/v.+",
+		Registry:        host + ":5000",
+		AuthUsername:    "ci",
+		Auth:            secret,
+		RegistryService: svc,
+		Platforms:       platforms,
+	}).Ci(ctx)
+	if err != nil {
+		return fmt.Errorf("Ci: %v", err)
+	}
+	sha, err := headShortSha(ctx, src)
+	if err != nil {
+		return err
+	}
+	for _, p := range platforms {
+		variant := pullVariant(svc, host, "ci", pwdHex, "stamped", tag, p, "")
+		if p == hostPlatform() {
+			version, commit, err := stampOf(ctx, variant)
+			if err != nil {
+				return fmt.Errorf("%s: %v", p, err)
+			}
+			if version != tag || commit != sha {
+				return fmt.Errorf("%s: expected version=%q commit=%q, got version=%q commit=%q", p, tag, sha, version, commit)
+			}
+			continue
+		}
+		for _, want := range []string{tag, sha} {
+			found, err := binaryContains(ctx, variant.File("/app/stamped"), want)
+			if err != nil {
+				return fmt.Errorf("%s: scan binary: %v", p, err)
+			}
+			if !found {
+				return fmt.Errorf("%s: expected the binary to carry %q", p, want)
+			}
+		}
+		// Negative control: a scan that answers yes to everything
+		// would make the two assertions above vacuous.
+		found, err := binaryContains(ctx, variant.File("/app/stamped"), "v0.0.0-never-stamped")
+		if err != nil {
+			return fmt.Errorf("%s: scan binary: %v", p, err)
+		}
+		if found {
+			return fmt.Errorf("%s: binary scan reports a string that was never stamped", p)
+		}
+	}
+	return nil
+}
+
+// pinnedGitFixture overlays a git repo whose commit is a pure function of
+// the fixture's contents: the author and committer dates are pinned, so
+// two calls produce the same commit SHA and therefore the same stamp.
+//
+// nonce varies the exec's cache key so the two calls really are two
+// separate git invocations rather than one cached result — otherwise a
+// reproducibility assertion would be comparing an artifact against itself.
+func pinnedGitFixture(ctx context.Context, base *dagger.Directory, branch, nonce string) (*dagger.Directory, error) {
+	const commitDate = "2024-01-02T03:04:05+00:00"
+	ctr := dag.Go().Container(base).
+		WithEnvVariable("NONCE", nonce).
+		WithEnvVariable("GIT_AUTHOR_NAME", "CI").
+		WithEnvVariable("GIT_AUTHOR_EMAIL", "ci@example.com").
+		WithEnvVariable("GIT_AUTHOR_DATE", commitDate).
+		WithEnvVariable("GIT_COMMITTER_NAME", "CI").
+		WithEnvVariable("GIT_COMMITTER_EMAIL", "ci@example.com").
+		WithEnvVariable("GIT_COMMITTER_DATE", commitDate).
+		WithExec([]string{"git", "init", "--initial-branch=" + branch, "."}).
+		WithExec([]string{"git", "add", "."}).
+		WithExec([]string{"git", "commit", "-m", "initial"})
+	if _, err := ctr.Sync(ctx); err != nil {
+		return nil, err
+	}
+	return ctr.Directory("/src"), nil
+}
+
+// GoAppCiRebuildIsByteIdenticalPerPlatform asserts building one commit
+// twice produces byte-identical binaries for every platform. The two runs
+// build from independently created working trees of the same commit, so
+// each is a real compile rather than a cache hit on the first — what makes
+// them agree is that both the stamp and everything else in the link line
+// are functions of the commit alone.
+func (t *Tests) GoAppCiRebuildIsByteIdenticalPerPlatform(ctx context.Context) error {
+	svc, pwdHex, secret, err := localRegistry(ctx)
+	if err != nil {
+		return err
+	}
+	const host = registryAlias
+	platforms := []string{"linux/amd64", "linux/arm64"}
+	runs := make([]map[string]string, 0, 2)
+	imageTag := ""
+	for _, nonce := range []string{"run-a", "run-b"} {
+		src, err := pinnedGitFixture(ctx, stampedDir(), "main", nonce)
+		if err != nil {
+			return fmt.Errorf("pinnedGitFixture %s: %v", nonce, err)
+		}
+		err = dag.Z5Labs().GoApp(src, dagger.Z5LabsGoAppOpts{
+			PublishOn:       "^refs/heads/main$",
+			Registry:        host + ":5000",
+			AuthUsername:    "ci",
+			Auth:            secret,
+			RegistryService: svc,
+			Platforms:       platforms,
+		}).Ci(ctx)
+		if err != nil {
+			return fmt.Errorf("Ci %s: %v", nonce, err)
+		}
+		tags, err := listTags(ctx, svc, host, "ci", pwdHex, "stamped")
+		if err != nil {
+			return fmt.Errorf("listTags %s: %v", nonce, err)
+		}
+		if len(tags) != 1 {
+			return fmt.Errorf("%s: expected exactly 1 published tag, got %v", nonce, tags)
+		}
+		if imageTag == "" {
+			imageTag = tags[0]
+		} else if tags[0] != imageTag {
+			return fmt.Errorf("expected both runs to publish tag %q, second run published %q", imageTag, tags[0])
+		}
+		// Digest eagerly: the next run overwrites this tag.
+		digests := make(map[string]string, len(platforms))
+		for _, p := range platforms {
+			d, err := pullVariant(svc, host, "ci", pwdHex, "stamped", imageTag, p, nonce).
+				File("/app/stamped").
+				Digest(ctx, dagger.FileDigestOpts{ExcludeMetadata: true})
+			if err != nil {
+				return fmt.Errorf("%s %s: digest: %v", nonce, p, err)
+			}
+			digests[p] = d
+		}
+		runs = append(runs, digests)
+	}
+	for _, p := range platforms {
+		if runs[0][p] != runs[1][p] {
+			return fmt.Errorf("%s: expected byte-identical rebuild, got %q then %q", p, runs[0][p], runs[1][p])
+		}
+	}
+	return nil
+}
+
+// GoAppCiStampedBinaryMatchesImageTagAndBuilder asserts three things about
+// a binary Ci built, by pulling it back out of the registry and running
+// it: it reports a version and a commit at all; its version is exactly the
+// tag of the image carrying it, which is what makes the two agree by
+// construction on the branch rule "<shortSha>-<isoCommitTime>"; and
+// Builder produces the identical stamp, so a local build is the same
+// artifact.
+func (t *Tests) GoAppCiStampedBinaryMatchesImageTagAndBuilder(ctx context.Context) error {
+	src, err := gitFixture(ctx, stampedDir(), "main", nil)
+	if err != nil {
+		return fmt.Errorf("gitFixture: %v", err)
+	}
+	svc, pwdHex, secret, err := localRegistry(ctx)
+	if err != nil {
+		return err
+	}
+	const host = registryAlias
+	app := dag.Z5Labs().GoApp(src, dagger.Z5LabsGoAppOpts{
+		PublishOn:       "^refs/heads/main$",
+		Registry:        host + ":5000",
+		AuthUsername:    "ci",
+		Auth:            secret,
+		RegistryService: svc,
+		Platforms:       []string{hostPlatform()},
+	})
+	if err := app.Ci(ctx); err != nil {
+		return fmt.Errorf("Ci: %v", err)
+	}
+	tags, err := listTags(ctx, svc, host, "ci", pwdHex, "stamped")
+	if err != nil {
+		return fmt.Errorf("listTags: %v", err)
+	}
+	if len(tags) != 1 {
+		return fmt.Errorf("expected exactly 1 published tag, got %v", tags)
+	}
+	imageTag := tags[0]
+
+	version, commit, err := stampOf(ctx, pullVariant(svc, host, "ci", pwdHex, "stamped", imageTag, hostPlatform(), ""))
+	if err != nil {
+		return err
+	}
+	sha, err := headShortSha(ctx, src)
+	if err != nil {
+		return err
+	}
+	if commit != sha {
+		return fmt.Errorf("expected commit stamp %q, got %q", sha, commit)
+	}
+	if version != imageTag {
+		return fmt.Errorf("expected stamped version to equal image tag %q, got %q", imageTag, version)
+	}
+
+	localVersion, localCommit, err := stampOf(ctx, app.Builder().Container())
+	if err != nil {
+		return fmt.Errorf("Builder: %v", err)
+	}
+	if localVersion != version || localCommit != commit {
+		return fmt.Errorf(
+			"expected Builder to stamp as Ci did (version=%q commit=%q), got version=%q commit=%q",
+			version, commit, localVersion, localCommit,
+		)
+	}
+	return nil
+}
+
+// GoAppStampsWhenPublishOnDoesNotMatch asserts stamping is not gated on
+// publishOn: a build from a branch the publish filter rejects still
+// carries a version and commit derived from HEAD.
+func (t *Tests) GoAppStampsWhenPublishOnDoesNotMatch(ctx context.Context) error {
+	src, err := gitFixture(ctx, stampedDir(), "feature/x", nil)
+	if err != nil {
+		return fmt.Errorf("gitFixture: %v", err)
+	}
+	app := dag.Z5Labs().GoApp(src, dagger.Z5LabsGoAppOpts{
+		PublishOn: "^refs/heads/main$",
+	})
+	version, commit, err := stampOf(ctx, app.Builder().Container())
+	if err != nil {
+		return err
+	}
+	sha, err := headShortSha(ctx, src)
+	if err != nil {
+		return err
+	}
+	if commit != sha {
+		return fmt.Errorf("expected commit stamp %q, got %q", sha, commit)
+	}
+	// The branch rule: "<shortSha>-<isoCommitTime>". "dev" is the
+	// fixture's own default, i.e. an unstamped build.
+	if !strings.HasPrefix(version, sha+"-") {
+		return fmt.Errorf("expected version stamp to start with %q, got %q", sha+"-", version)
+	}
+	return nil
+}
+
+// GoAppBuildFailsWithoutGitMetadata asserts a source with no git metadata
+// at HEAD fails with a message about the stamp rather than leaking a bare
+// git error. Builder is the path that reaches the build without Ci's
+// working-tree precondition.
+func (t *Tests) GoAppBuildFailsWithoutGitMetadata(ctx context.Context) error {
+	_, err := dag.Z5Labs().GoApp(stampedDir()).Builder().Binary().Size(ctx)
+	if err == nil {
+		return fmt.Errorf("expected Builder.Binary to error without git metadata, got nil")
+	}
+	if !strings.Contains(err.Error(), "could not derive build stamp") {
+		return fmt.Errorf("expected a stamp-derivation message, got: %s", err.Error())
+	}
+	return nil
 }
 
 // helloLibDir returns the on-disk hello-lib fixture (library variant).


### PR DESCRIPTION
Closes #328.

Two changes, one per module, following the agreed shape in
https://github.com/z5labs/devex/issues/328#issuecomment-5186879126.

## `go`: the build flags become named inputs

`Go.Build`'s `flags []string` is gone. Every flag it can pass is now an input
in its own right with a doc comment describing its effect on the output, so
`dagger functions` documents them and the module can validate them:
`trimpath`, `strip`, `stamps`, `tags`, `platform`, `disableCgo`.

`stamps` are `-X importpath.Name=value` pairs rendered by the module. Only the
first `=` splits name from value, so a value may contain `=`; an element with
no `=`, or an empty name, is rejected with a message naming it. Values
containing whitespace are quoted, since `cmd/go` splits the `-ldflags` value on
whitespace and would otherwise silently truncate one. No input is a
`+default=true` bool — every one is optional and off by default, which is also
what keeps `Build` a faithful `go build` wrapper: the opinions live in
`z5labs`, not here.

**The escape hatch does not survive, and the doc comment says so.** If a flag
is worth passing it is worth naming; `Container(source)` remains the escape
hatch for anything not named, since it hands back the prepared container. The
two flags the issue discussion listed but this PR does not implement — `-race`
and `-buildmode` — are #343, not a silent omission.

## `z5labs`: always stamp, from values it already has

`Z5labs.GoApp`'s signature is unchanged: no `ldflags`, no `version`, no
`commit`. Every binary it builds is stamped with `main.version` and
`main.commit`, derived from HEAD and from nothing else — a tag at HEAD gives
the stripped tag name, anything else gives `<shortSha>-<isoCommitTime>`, the
same rule `imageTagFor` follows, so the binary's version and the tag of the
image carrying it agree by construction. The refs are read unfiltered, so
`publishOn` decides what publishes, not what stamps.

`buildBinaryForPlatform` now routes through the typed `Go.Build` and the
hand-written link line is deleted. Stamping happens there, in the per-variant
compile, because `Ci` merges its variants into one manifest list before
publishing. Source without git metadata at HEAD now fails with a
stamp-derivation message rather than a bare git error — which is a behaviour
change for `Builder`, whose two existing tests moved to git-backed fixtures.

## Verification

Local: `dagger check`, `bash .github/scripts/verify-affected-modules.sh`,
`dagger -m ci call generated`, and both suites via `dagger call all`.

New tests. In `go`: malformed stamps rejected by name; a stamp value containing
`=` reaching the binary intact; tags selecting a `//go:build` file; `-trimpath`
removing `/src` paths; `-s -w` shrinking the output; `platform` producing an
aarch64 ELF header. In `z5labs`: a `Ci`-built binary pulled back out of the
registry and **run**, reporting a version equal to its own image tag and a
commit equal to HEAD's short SHA, with `Builder` stamping identically; every
variant of a two-platform build stamped, each pulled individually rather than
inspected after the merge (with a negative control, so the binary scan cannot
pass vacuously); stamping on a branch `publishOn` rejects; the missing-git
message; and one commit built twice from independently created working trees
producing byte-identical binaries for both platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
