### PR TITLE
story(daggerverse): name the last two Go.Build flags — -race and -buildmode

### DIFF
--- a/daggerverse/go/README.md
+++ b/daggerverse/go/README.md
@@ -22,7 +22,7 @@ and use that version; if no directive is present the image falls back to
 | Name | Purpose |
 |---|---|
 | `Container(source)` | Prepared base container — escape hatch when a Go command isn't covered by the typed helpers. Returns `*Container` lazily; the underlying constructor takes ctx + returns error in source so go.mod inspection can run. |
-| `Build(source, pkg, output, trimpath, strip, stamps, tags, platform, disableCgo)` | `go build -o /out/[output] ...`; returns `/out` as a `*Directory`. `pkg` defaults to `./...`. Every flag is a named input — see [Build flags](#build-flags). |
+| `Build(source, pkg, artifactName, trimpath, strip, stamps, tags, platform, disableCgo, race, buildmode)` | `go build -o /out/[artifactName] ...`; returns `/out` as a `*Directory`. `pkg` defaults to `./...`. Every flag is a named input — see [Build flags](#build-flags). |
 | `Test(source, pkg, race, flags)` | `go test -count=1 [-race] ...`; returns combined stdout. |
 | `Vet(source, pkg)` | `go vet pkg`. |
 | `Fmt(source)` | `gofmt -l -d .`; non-empty diff is also returned as an error. |
@@ -52,11 +52,53 @@ spelling:
 | `tags` | `-tags a,b,c`. |
 | `platform` | `GOOS`/`GOARCH` for a cross-compile, as `GOOS/GOARCH[/variant]`. |
 | `disableCgo` | `CGO_ENABLED=0`. |
+| `race` | `-race` — links Go's data-race detector into the output. |
+| `buildmode` | `-buildmode=<mode>` — what the linker emits, as a `BuildMode` enum. |
 
 `stamps` elements are `importpath.Name=value`; only the first `=` splits name
 from value, so a value may contain `=`. An element with no `=`, or an empty
 name, is rejected with a message naming it. A value containing whitespace is
 quoted for you, since `cmd/go` splits the `-ldflags` value on whitespace.
+
+`race` costs roughly 2-20x the CPU and 5-10x the memory of an ordinary build,
+so the result is a binary for an integration test rather than one to ship. It
+needs cgo, which makes two pairings worth knowing:
+
+- **`race` with `disableCgo` is rejected** with a message naming both, rather
+  than left for the linker to fail on. `-race` links the race runtime through
+  cgo, so `CGO_ENABLED=0` cannot work; pass one or the other.
+- **`race` with `platform`** needs a C cross-compiler for the target in the
+  toolchain image. The `golang` image ships one for its own platform only, so
+  a race-enabled cross-compile fails there — use `Container(source)` with an
+  image that has the cross toolchain.
+
+`buildmode` is a `BuildMode` enum rather than a string because the set is
+closed and each member has a different output shape. Members surface as
+`ARCHIVE`, `C_ARCHIVE`, `C_SHARED`, `EXE`, `PIE` and `PLUGIN` — the Dagger Go
+SDK derives each name from the constant identifier in SCREAMING_SNAKE_CASE, so
+`go build`'s hyphenated spellings are mapped internally rather than typed:
+
+| Member | `go build` | Emits |
+|---|---|---|
+| `ARCHIVE` | `archive` | `.a` per listed non-main package; main packages are ignored. |
+| `C_ARCHIVE` | `c-archive` | A C archive plus a generated header; only cgo `//export` functions are callable. Needs cgo. |
+| `C_SHARED` | `c-shared` | The same exported surface as `C_ARCHIVE`, linked dynamically. Needs cgo. |
+| `EXE` | `exe` | Executables, position-dependent even where PIE is the toolchain default. |
+| `PIE` | `pie` | Position independent executables, which a runtime wanting ASLR requires. |
+| `PLUGIN` | `plugin` | A shared library loadable with `plugin.Open`; host and plugin must come from the same toolchain and dependency versions. |
+
+Leaving `buildmode` unset leaves the flag off entirely, so `go build` picks its
+own default. Two of `go build`'s modes are deliberately absent: `default` is
+what omitting the input already means, and `shared` is only half a feature
+without a `-linkshared` counterpart on the consuming build, which `Build` does
+not have — use `Container(source)` if you are building against a shared std.
+
+The name written under `/out` is `artifactName`, not `output`: the Dagger CLI
+reserves `--output/-o` for exporting a call's result, and a function parameter
+called `output` collides with it badly enough that `dagger call build` fails to
+parse its own flags before running anything. `Ci.WithBuild`'s `binaryName`
+dodges the same collision; `Build`'s is not always a binary, because
+`buildmode` can make it an archive or a shared library.
 
 There is deliberately no raw-flag escape hatch on `Build`: if a flag is worth
 passing it is worth naming, and a bag of strings can be neither validated nor
@@ -77,6 +119,14 @@ dagger -m daggerverse/go call container \
 
 # Test all packages in a Go source tree
 dagger -m daggerverse/go call test --source=. --pkg=./...
+
+# Build a C archive: /out holds libgreet.a and the generated libgreet.h
+dagger -m daggerverse/go call build --source=path/to/project --pkg=. \
+    --artifact-name=libgreet.a --buildmode=C_ARCHIVE entries
+
+# Build a race-enabled binary for an integration test
+dagger -m daggerverse/go call build --source=path/to/project --pkg=. \
+    --artifact-name=myapp --race=true export --path=./out
 ```
 
 ## Go SDK quick reference
@@ -85,14 +135,25 @@ dagger -m daggerverse/go call test --source=. --pkg=./...
 g := dag.Go() // or dag.Go(dagger.GoOpts{Version: "1.23"})
 
 // Build returns the /out directory containing the produced binaries.
-out := g.Build(src, dagger.GoBuildOpts{Pkg: "./...", Output: "myapp"})
+out := g.Build(src, dagger.GoBuildOpts{Pkg: "./...", ArtifactName: "myapp"})
 
 // A release build: static, reproducible, and told its own version.
 rel := g.Build(src, dagger.GoBuildOpts{
-    Pkg: ".", Output: "myapp",
+    Pkg: ".", ArtifactName: "myapp",
     Trimpath: true, Strip: true, DisableCgo: true,
     Platform: "linux/arm64",
     Stamps:   []string{"main.version=v1.2.3"},
+})
+
+// A binary for an integration test, with the race detector linked in.
+racy := g.Build(src, dagger.GoBuildOpts{
+    Pkg: ".", ArtifactName: "myapp", Race: true,
+})
+
+// A C archive: /out holds libmyapp.a and the generated libmyapp.h.
+lib := g.Build(src, dagger.GoBuildOpts{
+    Pkg: ".", ArtifactName: "libmyapp.a",
+    Buildmode: dagger.GoBuildModeCArchive,
 })
 
 // Test returns combined stdout.

--- a/daggerverse/go/README.md
+++ b/daggerverse/go/README.md
@@ -81,11 +81,21 @@ SDK derives each name from the constant identifier in SCREAMING_SNAKE_CASE, so
 | Member | `go build` | Emits |
 |---|---|---|
 | `ARCHIVE` | `archive` | `.a` per listed non-main package; main packages are ignored. |
-| `C_ARCHIVE` | `c-archive` | A C archive plus a generated header; only cgo `//export` functions are callable. Needs cgo. |
-| `C_SHARED` | `c-shared` | The same exported surface as `C_ARCHIVE`, linked dynamically. Needs cgo. |
+| `C_ARCHIVE` | `c-archive` | A C archive plus a generated header; only cgo `//export` functions are callable. |
+| `C_SHARED` | `c-shared` | The same exported surface as `C_ARCHIVE`, linked dynamically. |
 | `EXE` | `exe` | Executables, position-dependent even where PIE is the toolchain default. |
 | `PIE` | `pie` | Position independent executables, which a runtime wanting ASLR requires. |
 | `PLUGIN` | `plugin` | A shared library loadable with `plugin.Open`; host and plugin must come from the same toolchain and dependency versions. |
+
+Only `race` is rejected alongside `disableCgo`; no buildmode is. That asymmetry
+is measured rather than assumed: `go build -race` refuses outright with `-race
+requires cgo; enable cgo by setting CGO_ENABLED=1`, whereas `c-archive` and
+`c-shared` build fine with `CGO_ENABLED=0` given a pure-Go main package. What
+needs cgo for those two is the `//export` directives in the *source*, which
+`Build` cannot inspect — so with cgo off, a package whose exports live in cgo
+files fails with `build constraints exclude all Go files`, and a pure-Go one
+yields a library exporting nothing and no generated header. Rejecting the
+pairing would break the second case, which works today.
 
 Leaving `buildmode` unset leaves the flag off entirely, so `go build` picks its
 own default. Two of `go build`'s modes are deliberately absent: `default` is

--- a/daggerverse/go/buildmode.go
+++ b/daggerverse/go/buildmode.go
@@ -36,13 +36,18 @@ const (
 	// produces nothing.
 	BuildModeArchive BuildMode = "ARCHIVE"
 	// BuildModeCArchive builds the listed main package into a C archive
-	// (`c-archive`), alongside a generated header. Only the functions
-	// carrying a cgo `//export` comment are callable. Needs cgo, so it
-	// cannot be combined with disableCgo.
+	// (`c-archive`). Only the functions carrying a cgo `//export` comment are
+	// callable, and it is those exports rather than the mode that need cgo —
+	// so this is not rejected alongside disableCgo the way race is. With cgo
+	// off, a package whose exports live in cgo files fails to build at all
+	// (`build constraints exclude all Go files`), and a pure-Go main package
+	// still produces an archive, but one exporting nothing and carrying no
+	// generated header. The archive/header pair is a consequence of having
+	// cgo exports, not of asking for this mode.
 	BuildModeCArchive BuildMode = "C_ARCHIVE"
 	// BuildModeCShared builds the listed main package into a C shared
-	// library (`c-shared`), alongside a generated header — the same exported
-	// surface as C_ARCHIVE, linked dynamically instead. Needs cgo.
+	// library (`c-shared`) — the same exported surface as C_ARCHIVE, linked
+	// dynamically instead, and with the same relationship to cgo.
 	BuildModeCShared BuildMode = "C_SHARED"
 	// BuildModeExe builds the listed main packages into executables
 	// (`exe`), forcing a position-dependent executable on a toolchain whose

--- a/daggerverse/go/buildmode.go
+++ b/daggerverse/go/buildmode.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// No const in this file aliases an enum member. An alias reads to the
+// generator as an extra member of the same enum carrying the aliased member's
+// *value*, which breaks codegen in a module that depends on this one rather
+// than in this one — so it passes `dagger develop` here and fails in the
+// dependent's.
+
+// BuildMode is what `go build -buildmode` produces: the kind of artifact the
+// linker emits, which for most of these is not an executable at all. It is an
+// enum rather than a string because the set is closed and each member has a
+// different output shape a caller has to be ready for.
+//
+// Two of `go build`'s modes are deliberately absent. `default` is what
+// omitting this input already means, so a member for it would be a second
+// spelling of the same request. `shared` is only half a feature without a
+// `-linkshared` counterpart on the consuming build, which Build does not have
+// — use Container() if you are building a shared std.
+//
+// Note on rendered names: the Dagger Go SDK derives each GraphQL enum member
+// from the *constant identifier* in SCREAMING_SNAKE_CASE, so these surface as
+// `ARCHIVE`, `C_ARCHIVE`, `C_SHARED`, `EXE`, `PIE` and `PLUGIN`. That is why
+// the `go build` spelling (`c-archive`) lives in buildModeFlags below rather
+// than in the identifier: a hyphen cannot appear in a Go identifier, so the
+// mapping has to be explicit.
+type BuildMode string
+
+const (
+	// BuildModeArchive builds the listed non-main packages into `.a` files
+	// (`archive`). Main packages are ignored, so pointing this at one
+	// produces nothing.
+	BuildModeArchive BuildMode = "ARCHIVE"
+	// BuildModeCArchive builds the listed main package into a C archive
+	// (`c-archive`), alongside a generated header. Only the functions
+	// carrying a cgo `//export` comment are callable. Needs cgo, so it
+	// cannot be combined with disableCgo.
+	BuildModeCArchive BuildMode = "C_ARCHIVE"
+	// BuildModeCShared builds the listed main package into a C shared
+	// library (`c-shared`), alongside a generated header — the same exported
+	// surface as C_ARCHIVE, linked dynamically instead. Needs cgo.
+	BuildModeCShared BuildMode = "C_SHARED"
+	// BuildModeExe builds the listed main packages into executables
+	// (`exe`), forcing a position-dependent executable on a toolchain whose
+	// default for the target is PIE.
+	BuildModeExe BuildMode = "EXE"
+	// BuildModePie builds the listed main packages into position
+	// independent executables (`pie`), which is what a hardened runtime
+	// wanting ASLR requires.
+	BuildModePie BuildMode = "PIE"
+	// BuildModePlugin builds the listed main packages into a shared library
+	// loadable at run time with `plugin.Open` (`plugin`). The plugin and
+	// its host have to be built by the same toolchain from the same
+	// dependency versions or the load fails.
+	BuildModePlugin BuildMode = "PLUGIN"
+)
+
+// buildModeFlags maps each member onto the value `go build -buildmode=` takes.
+// Presence in this table is what makes a mode legal, so a member added above
+// without an entry here is rejected rather than silently dropped.
+var buildModeFlags = map[BuildMode]string{
+	BuildModeArchive:  "archive",
+	BuildModeCArchive: "c-archive",
+	BuildModeCShared:  "c-shared",
+	BuildModeExe:      "exe",
+	BuildModePie:      "pie",
+	BuildModePlugin:   "plugin",
+}
+
+// buildModeOrder fixes the order modes are listed in a rejection message, so
+// the message does not depend on Go's map iteration order.
+var buildModeOrder = []BuildMode{
+	BuildModeArchive,
+	BuildModeCArchive,
+	BuildModeCShared,
+	BuildModeExe,
+	BuildModePie,
+	BuildModePlugin,
+}
+
+// flag returns the `-buildmode=` value for mode, or an error naming the legal
+// set. The empty mode is the caller not asking for one, which is not this
+// function's business to decide — Build checks for it before calling.
+func (mode BuildMode) flag() (string, error) {
+	if f, ok := buildModeFlags[mode]; ok {
+		return f, nil
+	}
+	legal := make([]string, 0, len(buildModeOrder))
+	for _, m := range buildModeOrder {
+		legal = append(legal, string(m))
+	}
+	return "", fmt.Errorf("Build: unknown buildmode %q (want one of %s)", string(mode), strings.Join(legal, ", "))
+}

--- a/daggerverse/go/dagger.gen.go
+++ b/daggerverse/go/dagger.gen.go
@@ -79,6 +79,68 @@ func (r *Go) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
+func (r BuildMode) IsEnum() {}
+
+func (r BuildMode) Name() string {
+	switch r {
+	case BuildModeArchive:
+		return "Archive"
+	case BuildModeCArchive:
+		return "CArchive"
+	case BuildModeCShared:
+		return "CShared"
+	case BuildModeExe:
+		return "Exe"
+	case BuildModePie:
+		return "Pie"
+	case BuildModePlugin:
+		return "Plugin"
+	}
+	return ""
+}
+
+func (r BuildMode) Value() string {
+	return string(r)
+}
+
+func (r BuildMode) MarshalJSON() ([]byte, error) {
+	if r == "" {
+		return []byte("\"\""), nil
+	}
+	name := r.Name()
+	if name == "" {
+		return nil, fmt.Errorf("invalid enum value %q", r)
+	}
+	return json.Marshal(name)
+}
+
+func (r *BuildMode) UnmarshalJSON(bs []byte) error {
+	var s string
+	err := json.Unmarshal(bs, &s)
+	if err != nil {
+		return err
+	}
+	switch s {
+	case "":
+		*r = ""
+	case "Archive":
+		*r = BuildModeArchive
+	case "CArchive":
+		*r = BuildModeCArchive
+	case "CShared":
+		*r = BuildModeCShared
+	case "Exe":
+		*r = BuildModeExe
+	case "Pie":
+		*r = BuildModePie
+	case "Plugin":
+		*r = BuildModePlugin
+	default:
+		return fmt.Errorf("invalid enum value %q", s)
+	}
+	return nil
+}
+
 func (r Ci) MarshalJSON() ([]byte, error) {
 	var concrete struct {
 		Go              *Go
@@ -367,11 +429,11 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg pkg", err))
 				}
 			}
-			var output string
-			if inputArgs["output"] != nil {
-				err = json.Unmarshal([]byte(inputArgs["output"]), &output)
+			var artifactName string
+			if inputArgs["artifactName"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["artifactName"]), &artifactName)
 				if err != nil {
-					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg output", err))
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg artifactName", err))
 				}
 			}
 			var trimpath bool
@@ -416,7 +478,21 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg disableCgo", err))
 				}
 			}
-			return (*Go).Build(&parent, ctx, source, pkg, output, trimpath, strip, stamps, tags, platform, disableCgo)
+			var race bool
+			if inputArgs["race"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["race"]), &race)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg race", err))
+				}
+			}
+			var buildmode BuildMode
+			if inputArgs["buildmode"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["buildmode"]), &buildmode)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg buildmode", err))
+				}
+			}
+			return (*Go).Build(&parent, ctx, source, pkg, artifactName, trimpath, strip, stamps, tags, platform, disableCgo, race, buildmode)
 		case "Ci":
 			var parent Go
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/go/examples/go/internal/dagger/go.gen.go
+++ b/daggerverse/go/examples/go/internal/dagger/go.gen.go
@@ -918,30 +918,35 @@ const (
 	GoBuildModeArchive GoBuildMode = "ARCHIVE" // go (../../../../../../daggerverse/go/buildmode.go:37:2)
 
 	// BuildModeCArchive builds the listed main package into a C archive
-	// (`c-archive`), alongside a generated header. Only the functions
-	// carrying a cgo `//export` comment are callable. Needs cgo, so it
-	// cannot be combined with disableCgo.
-	GoBuildModeCArchive GoBuildMode = "C_ARCHIVE" // go (../../../../../../daggerverse/go/buildmode.go:42:2)
+	// (`c-archive`). Only the functions carrying a cgo `//export` comment are
+	// callable, and it is those exports rather than the mode that need cgo —
+	// so this is not rejected alongside disableCgo the way race is. With cgo
+	// off, a package whose exports live in cgo files fails to build at all
+	// (`build constraints exclude all Go files`), and a pure-Go main package
+	// still produces an archive, but one exporting nothing and carrying no
+	// generated header. The archive/header pair is a consequence of having
+	// cgo exports, not of asking for this mode.
+	GoBuildModeCArchive GoBuildMode = "C_ARCHIVE" // go (../../../../../../daggerverse/go/buildmode.go:47:2)
 
 	// BuildModeCShared builds the listed main package into a C shared
-	// library (`c-shared`), alongside a generated header — the same exported
-	// surface as C_ARCHIVE, linked dynamically instead. Needs cgo.
-	GoBuildModeCShared GoBuildMode = "C_SHARED" // go (../../../../../../daggerverse/go/buildmode.go:46:2)
+	// library (`c-shared`) — the same exported surface as C_ARCHIVE, linked
+	// dynamically instead, and with the same relationship to cgo.
+	GoBuildModeCShared GoBuildMode = "C_SHARED" // go (../../../../../../daggerverse/go/buildmode.go:51:2)
 
 	// BuildModeExe builds the listed main packages into executables
 	// (`exe`), forcing a position-dependent executable on a toolchain whose
 	// default for the target is PIE.
-	GoBuildModeExe GoBuildMode = "EXE" // go (../../../../../../daggerverse/go/buildmode.go:50:2)
+	GoBuildModeExe GoBuildMode = "EXE" // go (../../../../../../daggerverse/go/buildmode.go:55:2)
 
 	// BuildModePie builds the listed main packages into position
 	// independent executables (`pie`), which is what a hardened runtime
 	// wanting ASLR requires.
-	GoBuildModePie GoBuildMode = "PIE" // go (../../../../../../daggerverse/go/buildmode.go:54:2)
+	GoBuildModePie GoBuildMode = "PIE" // go (../../../../../../daggerverse/go/buildmode.go:59:2)
 
 	// BuildModePlugin builds the listed main packages into a shared library
 	// loadable at run time with `plugin.Open` (`plugin`). The plugin and
 	// its host have to be built by the same toolchain from the same
 	// dependency versions or the load fails.
-	GoBuildModePlugin GoBuildMode = "PLUGIN" // go (../../../../../../daggerverse/go/buildmode.go:59:2)
+	GoBuildModePlugin GoBuildMode = "PLUGIN" // go (../../../../../../daggerverse/go/buildmode.go:64:2)
 
 )

--- a/daggerverse/go/examples/go/internal/dagger/go.gen.go
+++ b/daggerverse/go/examples/go/internal/dagger/go.gen.go
@@ -5,6 +5,7 @@ package dagger
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/dagger/querybuilder"
 )
@@ -109,20 +110,27 @@ type GoBuildOpts struct {
 	// Default: "./..."
 	Pkg string // go (../../../../../../daggerverse/go/main.go:240:2)
 	//
-	// Name of the binary written under /out. Empty means `-o /out/`, which
+	// Name of the artifact written under /out. Empty means `-o /out/`, which
 	// lets go build name each binary after its main package.
 	//
-	Output string // go (../../../../../../daggerverse/go/main.go:245:2)
+	// Named artifactName rather than output because the Dagger CLI reserves
+	// `--output/-o` for exporting a call's result: a function parameter
+	// called output collides with it, and `dagger call build` then fails to
+	// parse its own flags before it runs anything. Ci.WithBuild's
+	// binaryName dodges the same collision; this one is not always a binary,
+	// because buildmode can make it an archive or a shared library.
+	//
+	ArtifactName string // go (../../../../../../daggerverse/go/main.go:252:2)
 	//
 	// Pass -trimpath: strip the build's local file system paths out of the
 	// binary, so the output does not depend on where it was compiled.
 	//
-	Trimpath bool // go (../../../../../../daggerverse/go/main.go:250:2)
+	Trimpath bool // go (../../../../../../daggerverse/go/main.go:257:2)
 	//
 	// Pass -ldflags "-s -w": drop the symbol table and the DWARF debug
 	// info. Smaller binary, no usable stack symbolization or debugger.
 	//
-	Strip bool // go (../../../../../../daggerverse/go/main.go:255:2)
+	Strip bool // go (../../../../../../daggerverse/go/main.go:262:2)
 	//
 	// Link-time variable assignments, each `importpath.Name=value`,
 	// rendered as `-ldflags "-X importpath.Name=value"`. This is how a
@@ -132,25 +140,45 @@ type GoBuildOpts struct {
 	// ignores a stamp naming a variable that does not exist, or one that
 	// is not a package-level string.
 	//
-	Stamps []string // go (../../../../../../daggerverse/go/main.go:265:2)
+	Stamps []string // go (../../../../../../daggerverse/go/main.go:272:2)
 	//
 	// Build tags, passed as `-tags a,b,c`. Selects which `//go:build`
 	// files are compiled in.
 	//
-	Tags []string // go (../../../../../../daggerverse/go/main.go:270:2)
+	Tags []string // go (../../../../../../daggerverse/go/main.go:277:2)
 	//
 	// Target platform as `GOOS/GOARCH[/variant]`, e.g. "linux/arm64".
 	// Sets GOOS and GOARCH for a cross-compile; empty builds for the
 	// toolchain container's own platform. Any variant segment is ignored —
 	// GOARM/GOAMD64 are left unset.
 	//
-	Platform string // go (../../../../../../daggerverse/go/main.go:277:2)
+	Platform string // go (../../../../../../daggerverse/go/main.go:284:2)
 	//
 	// Set CGO_ENABLED=0. Produces a statically linked binary with no libc
 	// dependency, which is what a scratch image needs, at the cost of the
 	// cgo-backed net and os/user implementations.
 	//
-	DisableCgo bool // go (../../../../../../daggerverse/go/main.go:283:2)
+	DisableCgo bool // go (../../../../../../daggerverse/go/main.go:290:2)
+	//
+	// Pass -race: link Go's data-race detector into the output. The binary
+	// then reports racing accesses to stderr as it runs, at roughly 2-20x
+	// the CPU and 5-10x the memory of an ordinary build — so this is a
+	// binary for an integration test, not one to ship.
+	//
+	// -race requires cgo, so it cannot be combined with disableCgo (Build
+	// rejects that pairing) and it needs a C toolchain for the target: the
+	// golang image has one for its own platform, but a cross-compile via
+	// platform does not unless the toolchain image provides it.
+	//
+	Race bool // go (../../../../../../daggerverse/go/main.go:302:2)
+	//
+	// Pass -buildmode=<mode>: what the linker emits, which for most modes is
+	// not an executable. Absent leaves the flag off entirely, so `go build`
+	// picks its own default for the target — an executable for a main
+	// package, an archive for the rest. See BuildMode for what each member
+	// produces.
+	//
+	Buildmode GoBuildMode // go (../../../../../../daggerverse/go/main.go:310:2)
 }
 
 // Build runs `go build` against the supplied source and returns /out as a
@@ -173,9 +201,9 @@ func (r *Go) Build(source *Directory, opts ...GoBuildOpts) *Directory { // go (.
 		if !querybuilder.IsZeroValue(opts[i].Pkg) {
 			q = q.Arg("pkg", opts[i].Pkg)
 		}
-		// `output` optional argument
-		if !querybuilder.IsZeroValue(opts[i].Output) {
-			q = q.Arg("output", opts[i].Output)
+		// `artifactName` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ArtifactName) {
+			q = q.Arg("artifactName", opts[i].ArtifactName)
 		}
 		// `trimpath` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Trimpath) {
@@ -200,6 +228,14 @@ func (r *Go) Build(source *Directory, opts ...GoBuildOpts) *Directory { // go (.
 		// `disableCgo` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DisableCgo) {
 			q = q.Arg("disableCgo", opts[i].DisableCgo)
+		}
+		// `race` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Race) {
+			q = q.Arg("race", opts[i].Race)
+		}
+		// `buildmode` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Buildmode) {
+			q = q.Arg("buildmode", opts[i].Buildmode)
 		}
 	}
 	q = q.Arg("source", source)
@@ -240,7 +276,7 @@ func (r *Go) Container(source *Directory) *Container { // go (../../../../../../
 }
 
 // Env runs `go env` in a source-less base container and returns its stdout.
-func (r *Go) Env(ctx context.Context) (string, error) { // go (../../../../../../daggerverse/go/main.go:448:1)
+func (r *Go) Env(ctx context.Context) (string, error) { // go (../../../../../../daggerverse/go/main.go:488:1)
 	if r.env != nil {
 		return *r.env, nil
 	}
@@ -255,7 +291,7 @@ func (r *Go) Env(ctx context.Context) (string, error) { // go (../../../../../..
 // Fmt runs `gofmt -l -d .` against the supplied source. Returns the diff
 // of any unformatted files; non-empty output is also returned as an error so
 // CI fails fast on formatting violations.
-func (r *Go) Fmt(ctx context.Context, source *Directory) (string, error) { // go (../../../../../../daggerverse/go/main.go:412:1)
+func (r *Go) Fmt(ctx context.Context, source *Directory) (string, error) { // go (../../../../../../daggerverse/go/main.go:452:1)
 	assertNotNil("source", source)
 	if r.fmt != nil {
 		return *r.fmt, nil
@@ -430,17 +466,17 @@ func (r *Go) Run(ctx context.Context, source *Directory, pkg string, opts ...GoR
 type GoTestOpts struct {
 
 	// Default: "./..."
-	Pkg string // go (../../../../../../daggerverse/go/main.go:388:2)
+	Pkg string // go (../../../../../../daggerverse/go/main.go:428:2)
 
-	Race bool // go (../../../../../../daggerverse/go/main.go:390:2)
+	Race bool // go (../../../../../../daggerverse/go/main.go:430:2)
 
-	Flags []string // go (../../../../../../daggerverse/go/main.go:392:2)
+	Flags []string // go (../../../../../../daggerverse/go/main.go:432:2)
 }
 
 // Test runs `go test -count=1 [-race] [flags] pkg` against the supplied
 // source and returns the combined stdout. -count=1 is always passed to
 // bypass Go's internal test cache.
-func (r *Go) Test(ctx context.Context, source *Directory, opts ...GoTestOpts) (string, error) { // go (../../../../../../daggerverse/go/main.go:384:1)
+func (r *Go) Test(ctx context.Context, source *Directory, opts ...GoTestOpts) (string, error) { // go (../../../../../../daggerverse/go/main.go:424:1)
 	assertNotNil("source", source)
 	if r.test != nil {
 		return *r.test, nil
@@ -470,7 +506,7 @@ func (r *Go) Test(ctx context.Context, source *Directory, opts ...GoTestOpts) (s
 
 // ToolVersion runs `go version` in a source-less base container and returns
 // the trimmed output (e.g. "go version go1.23.0 linux/amd64").
-func (r *Go) ToolVersion(ctx context.Context) (string, error) { // go (../../../../../../daggerverse/go/main.go:456:1)
+func (r *Go) ToolVersion(ctx context.Context) (string, error) { // go (../../../../../../daggerverse/go/main.go:496:1)
 	if r.toolVersion != nil {
 		return *r.toolVersion, nil
 	}
@@ -501,12 +537,12 @@ func (r *Go) Version(ctx context.Context) (string, error) { // go (../../../../.
 type GoVetOpts struct {
 
 	// Default: "./..."
-	Pkg string // go (../../../../../../daggerverse/go/main.go:435:2)
+	Pkg string // go (../../../../../../daggerverse/go/main.go:475:2)
 }
 
 // Vet runs `go vet pkg` against the supplied source. pkg defaults to
 // `./...`. Returns a non-nil error when vet reports any issue.
-func (r *Go) Vet(ctx context.Context, source *Directory, opts ...GoVetOpts) error { // go (../../../../../../daggerverse/go/main.go:431:1)
+func (r *Go) Vet(ctx context.Context, source *Directory, opts ...GoVetOpts) error { // go (../../../../../../daggerverse/go/main.go:471:1)
 	assertNotNil("source", source)
 	if r.vet != nil {
 		return nil
@@ -793,3 +829,119 @@ func (r *Query) Go(opts ...GoOpts) *Go { // go (../../../../../../daggerverse/go
 		query: q,
 	}
 }
+
+// BuildMode is what `go build -buildmode` produces: the kind of artifact the
+// linker emits, which for most of these is not an executable at all. It is an
+// enum rather than a string because the set is closed and each member has a
+// different output shape a caller has to be ready for.
+//
+// Two of `go build`'s modes are deliberately absent. `default` is what
+// omitting this input already means, so a member for it would be a second
+// spelling of the same request. `shared` is only half a feature without a
+// `-linkshared` counterpart on the consuming build, which Build does not have
+// — use Container() if you are building a shared std.
+//
+// Note on rendered names: the Dagger Go SDK derives each GraphQL enum member
+// from the *constant identifier* in SCREAMING_SNAKE_CASE, so these surface as
+// `ARCHIVE`, `C_ARCHIVE`, `C_SHARED`, `EXE`, `PIE` and `PLUGIN`. That is why
+// the `go build` spelling (`c-archive`) lives in buildModeFlags below rather
+// than in the identifier: a hyphen cannot appear in a Go identifier, so the
+// mapping has to be explicit.
+type GoBuildMode string // go (../../../../../../daggerverse/go/buildmode.go:31:6)
+
+func (GoBuildMode) IsEnum() {}
+
+func (v GoBuildMode) Name() string {
+	switch v {
+	case GoBuildModeArchive:
+		return "ARCHIVE"
+	case GoBuildModeCArchive:
+		return "C_ARCHIVE"
+	case GoBuildModeCShared:
+		return "C_SHARED"
+	case GoBuildModeExe:
+		return "EXE"
+	case GoBuildModePie:
+		return "PIE"
+	case GoBuildModePlugin:
+		return "PLUGIN"
+	default:
+		return ""
+	}
+}
+
+func (v GoBuildMode) Value() string {
+	return string(v)
+}
+
+func (v *GoBuildMode) MarshalJSON() ([]byte, error) {
+	if *v == "" {
+		return []byte(`""`), nil
+	}
+	name := v.Name()
+	if name == "" {
+		return nil, fmt.Errorf("invalid enum value %q", *v)
+	}
+	return json.Marshal(name)
+}
+
+func (v *GoBuildMode) UnmarshalJSON(dt []byte) error {
+	var s string
+	if err := json.Unmarshal(dt, &s); err != nil {
+		return err
+	}
+	switch s {
+	case "":
+		*v = ""
+	case "ARCHIVE":
+		*v = GoBuildModeArchive
+	case "C_ARCHIVE":
+		*v = GoBuildModeCArchive
+	case "C_SHARED":
+		*v = GoBuildModeCShared
+	case "EXE":
+		*v = GoBuildModeExe
+	case "PIE":
+		*v = GoBuildModePie
+	case "PLUGIN":
+		*v = GoBuildModePlugin
+	default:
+		return fmt.Errorf("invalid enum value %q", s)
+	}
+	return nil
+}
+
+const (
+	// BuildModeArchive builds the listed non-main packages into `.a` files
+	// (`archive`). Main packages are ignored, so pointing this at one
+	// produces nothing.
+	GoBuildModeArchive GoBuildMode = "ARCHIVE" // go (../../../../../../daggerverse/go/buildmode.go:37:2)
+
+	// BuildModeCArchive builds the listed main package into a C archive
+	// (`c-archive`), alongside a generated header. Only the functions
+	// carrying a cgo `//export` comment are callable. Needs cgo, so it
+	// cannot be combined with disableCgo.
+	GoBuildModeCArchive GoBuildMode = "C_ARCHIVE" // go (../../../../../../daggerverse/go/buildmode.go:42:2)
+
+	// BuildModeCShared builds the listed main package into a C shared
+	// library (`c-shared`), alongside a generated header — the same exported
+	// surface as C_ARCHIVE, linked dynamically instead. Needs cgo.
+	GoBuildModeCShared GoBuildMode = "C_SHARED" // go (../../../../../../daggerverse/go/buildmode.go:46:2)
+
+	// BuildModeExe builds the listed main packages into executables
+	// (`exe`), forcing a position-dependent executable on a toolchain whose
+	// default for the target is PIE.
+	GoBuildModeExe GoBuildMode = "EXE" // go (../../../../../../daggerverse/go/buildmode.go:50:2)
+
+	// BuildModePie builds the listed main packages into position
+	// independent executables (`pie`), which is what a hardened runtime
+	// wanting ASLR requires.
+	GoBuildModePie GoBuildMode = "PIE" // go (../../../../../../daggerverse/go/buildmode.go:54:2)
+
+	// BuildModePlugin builds the listed main packages into a shared library
+	// loadable at run time with `plugin.Open` (`plugin`). The plugin and
+	// its host have to be built by the same toolchain from the same
+	// dependency versions or the load fails.
+	GoBuildModePlugin GoBuildMode = "PLUGIN" // go (../../../../../../daggerverse/go/buildmode.go:59:2)
+
+)

--- a/daggerverse/go/examples/go/main.go
+++ b/daggerverse/go/examples/go/main.go
@@ -60,7 +60,7 @@ func (m *GoExamples) BuildBinary(
 	pkg string,
 ) *dagger.File {
 	return dag.Go().
-		Build(sourceOrSample(source), dagger.GoBuildOpts{Pkg: pkg, Output: "app"}).
+		Build(sourceOrSample(source), dagger.GoBuildOpts{Pkg: pkg, ArtifactName: "app"}).
 		File("app")
 }
 

--- a/daggerverse/go/main.go
+++ b/daggerverse/go/main.go
@@ -238,11 +238,18 @@ func (g *Go) Build(
 	//
 	// +default="./..."
 	pkg string,
-	// Name of the binary written under /out. Empty means `-o /out/`, which
+	// Name of the artifact written under /out. Empty means `-o /out/`, which
 	// lets go build name each binary after its main package.
 	//
+	// Named artifactName rather than output because the Dagger CLI reserves
+	// `--output/-o` for exporting a call's result: a function parameter
+	// called output collides with it, and `dagger call build` then fails to
+	// parse its own flags before it runs anything. Ci.WithBuild's
+	// binaryName dodges the same collision; this one is not always a binary,
+	// because buildmode can make it an archive or a shared library.
+	//
 	// +optional
-	output string,
+	artifactName string,
 	// Pass -trimpath: strip the build's local file system paths out of the
 	// binary, so the output does not depend on where it was compiled.
 	//
@@ -281,7 +288,30 @@ func (g *Go) Build(
 	//
 	// +optional
 	disableCgo bool,
+	// Pass -race: link Go's data-race detector into the output. The binary
+	// then reports racing accesses to stderr as it runs, at roughly 2-20x
+	// the CPU and 5-10x the memory of an ordinary build — so this is a
+	// binary for an integration test, not one to ship.
+	//
+	// -race requires cgo, so it cannot be combined with disableCgo (Build
+	// rejects that pairing) and it needs a C toolchain for the target: the
+	// golang image has one for its own platform, but a cross-compile via
+	// platform does not unless the toolchain image provides it.
+	//
+	// +optional
+	race bool,
+	// Pass -buildmode=<mode>: what the linker emits, which for most modes is
+	// not an executable. Absent leaves the flag off entirely, so `go build`
+	// picks its own default for the target — an executable for a main
+	// package, an archive for the rest. See BuildMode for what each member
+	// produces.
+	//
+	// +optional
+	buildmode BuildMode,
 ) (*dagger.Directory, error) {
+	if race && disableCgo {
+		return nil, fmt.Errorf("Build: race and disableCgo cannot be combined: -race links the race runtime through cgo, so CGO_ENABLED=0 makes `go build -race` fail — pass one or the other")
+	}
 	ldflags, err := renderLdflags(strip, stamps)
 	if err != nil {
 		return nil, err
@@ -303,12 +333,22 @@ func (g *Go) Build(
 		ctr = ctr.WithEnvVariable("CGO_ENABLED", "0")
 	}
 	target := "/out/"
-	if output != "" {
-		target = "/out/" + output
+	if artifactName != "" {
+		target = "/out/" + artifactName
 	}
 	args := []string{"go", "build"}
 	if trimpath {
 		args = append(args, "-trimpath")
+	}
+	if race {
+		args = append(args, "-race")
+	}
+	if buildmode != "" {
+		mode, err := buildmode.flag()
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, "-buildmode="+mode)
 	}
 	if len(tags) > 0 {
 		args = append(args, "-tags", strings.Join(tags, ","))

--- a/daggerverse/go/tests/dagger.gen.go
+++ b/daggerverse/go/tests/dagger.gen.go
@@ -213,6 +213,34 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Tests).All(&parent, ctx, goImageTag, parallel)
+		case "BuildBuildmodeCArchiveProducesArchiveAndHeader":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var goImageTag string
+			if inputArgs["goImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["goImageTag"]), &goImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg goImageTag", err))
+				}
+			}
+			return nil, (*Tests).BuildBuildmodeCArchiveProducesArchiveAndHeader(&parent, ctx, goImageTag)
+		case "BuildBuildmodeMembersAllProduceOutput":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var goImageTag string
+			if inputArgs["goImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["goImageTag"]), &goImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg goImageTag", err))
+				}
+			}
+			return nil, (*Tests).BuildBuildmodeMembersAllProduceOutput(&parent, ctx, goImageTag)
 		case "BuildHelloWritesBinary":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -255,6 +283,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Tests).BuildPlatformCrossCompiles(&parent, ctx, goImageTag)
+		case "BuildRaceLinksTheDetector":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var goImageTag string
+			if inputArgs["goImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["goImageTag"]), &goImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg goImageTag", err))
+				}
+			}
+			return nil, (*Tests).BuildRaceLinksTheDetector(&parent, ctx, goImageTag)
 		case "BuildRejectsMalformedStamps":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -269,6 +311,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Tests).BuildRejectsMalformedStamps(&parent, ctx, goImageTag)
+		case "BuildRejectsRaceWithDisableCgo":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var goImageTag string
+			if inputArgs["goImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["goImageTag"]), &goImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg goImageTag", err))
+				}
+			}
+			return nil, (*Tests).BuildRejectsRaceWithDisableCgo(&parent, ctx, goImageTag)
 		case "BuildStampsReachTheBinary":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/go/tests/fixtures/carchive/go.mod
+++ b/daggerverse/go/tests/fixtures/carchive/go.mod
@@ -1,0 +1,3 @@
+module example.com/carchive
+
+go 1.23

--- a/daggerverse/go/tests/fixtures/carchive/main.go
+++ b/daggerverse/go/tests/fixtures/carchive/main.go
@@ -1,0 +1,15 @@
+// A main package whose only purpose is to be compiled with
+// -buildmode=c-archive or -buildmode=c-shared: those modes export the
+// functions carrying a cgo //export comment and ignore main, which must
+// nonetheless exist for the package to be a main package.
+package main
+
+// #include <stdlib.h>
+import "C"
+
+//export Greet
+func Greet() *C.char {
+	return C.CString("hello from go")
+}
+
+func main() {}

--- a/daggerverse/go/tests/fixtures/racy/detector_off.go
+++ b/daggerverse/go/tests/fixtures/racy/detector_off.go
@@ -1,0 +1,5 @@
+//go:build !race
+
+package main
+
+const raceDetector = "off"

--- a/daggerverse/go/tests/fixtures/racy/detector_on.go
+++ b/daggerverse/go/tests/fixtures/racy/detector_on.go
@@ -1,0 +1,5 @@
+//go:build race
+
+package main
+
+const raceDetector = "on"

--- a/daggerverse/go/tests/fixtures/racy/go.mod
+++ b/daggerverse/go/tests/fixtures/racy/go.mod
@@ -1,0 +1,3 @@
+module example.com/racy
+
+go 1.23

--- a/daggerverse/go/tests/fixtures/racy/main.go
+++ b/daggerverse/go/tests/fixtures/racy/main.go
@@ -1,0 +1,8 @@
+package main
+
+import "fmt"
+
+// The race detector is not something a program can query at runtime, so this
+// fixture reports it at build time instead: `go build -race` implies the
+// `race` build tag, which selects detector_on.go over detector_off.go.
+func main() { fmt.Printf("race=%s\n", raceDetector) }

--- a/daggerverse/go/tests/internal/dagger/go.gen.go
+++ b/daggerverse/go/tests/internal/dagger/go.gen.go
@@ -918,30 +918,35 @@ const (
 	GoBuildModeArchive GoBuildMode = "ARCHIVE" // go (../../../../../daggerverse/go/buildmode.go:37:2)
 
 	// BuildModeCArchive builds the listed main package into a C archive
-	// (`c-archive`), alongside a generated header. Only the functions
-	// carrying a cgo `//export` comment are callable. Needs cgo, so it
-	// cannot be combined with disableCgo.
-	GoBuildModeCArchive GoBuildMode = "C_ARCHIVE" // go (../../../../../daggerverse/go/buildmode.go:42:2)
+	// (`c-archive`). Only the functions carrying a cgo `//export` comment are
+	// callable, and it is those exports rather than the mode that need cgo —
+	// so this is not rejected alongside disableCgo the way race is. With cgo
+	// off, a package whose exports live in cgo files fails to build at all
+	// (`build constraints exclude all Go files`), and a pure-Go main package
+	// still produces an archive, but one exporting nothing and carrying no
+	// generated header. The archive/header pair is a consequence of having
+	// cgo exports, not of asking for this mode.
+	GoBuildModeCArchive GoBuildMode = "C_ARCHIVE" // go (../../../../../daggerverse/go/buildmode.go:47:2)
 
 	// BuildModeCShared builds the listed main package into a C shared
-	// library (`c-shared`), alongside a generated header — the same exported
-	// surface as C_ARCHIVE, linked dynamically instead. Needs cgo.
-	GoBuildModeCShared GoBuildMode = "C_SHARED" // go (../../../../../daggerverse/go/buildmode.go:46:2)
+	// library (`c-shared`) — the same exported surface as C_ARCHIVE, linked
+	// dynamically instead, and with the same relationship to cgo.
+	GoBuildModeCShared GoBuildMode = "C_SHARED" // go (../../../../../daggerverse/go/buildmode.go:51:2)
 
 	// BuildModeExe builds the listed main packages into executables
 	// (`exe`), forcing a position-dependent executable on a toolchain whose
 	// default for the target is PIE.
-	GoBuildModeExe GoBuildMode = "EXE" // go (../../../../../daggerverse/go/buildmode.go:50:2)
+	GoBuildModeExe GoBuildMode = "EXE" // go (../../../../../daggerverse/go/buildmode.go:55:2)
 
 	// BuildModePie builds the listed main packages into position
 	// independent executables (`pie`), which is what a hardened runtime
 	// wanting ASLR requires.
-	GoBuildModePie GoBuildMode = "PIE" // go (../../../../../daggerverse/go/buildmode.go:54:2)
+	GoBuildModePie GoBuildMode = "PIE" // go (../../../../../daggerverse/go/buildmode.go:59:2)
 
 	// BuildModePlugin builds the listed main packages into a shared library
 	// loadable at run time with `plugin.Open` (`plugin`). The plugin and
 	// its host have to be built by the same toolchain from the same
 	// dependency versions or the load fails.
-	GoBuildModePlugin GoBuildMode = "PLUGIN" // go (../../../../../daggerverse/go/buildmode.go:59:2)
+	GoBuildModePlugin GoBuildMode = "PLUGIN" // go (../../../../../daggerverse/go/buildmode.go:64:2)
 
 )

--- a/daggerverse/go/tests/internal/dagger/go.gen.go
+++ b/daggerverse/go/tests/internal/dagger/go.gen.go
@@ -5,6 +5,7 @@ package dagger
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/dagger/querybuilder"
 )
@@ -109,20 +110,27 @@ type GoBuildOpts struct {
 	// Default: "./..."
 	Pkg string // go (../../../../../daggerverse/go/main.go:240:2)
 	//
-	// Name of the binary written under /out. Empty means `-o /out/`, which
+	// Name of the artifact written under /out. Empty means `-o /out/`, which
 	// lets go build name each binary after its main package.
 	//
-	Output string // go (../../../../../daggerverse/go/main.go:245:2)
+	// Named artifactName rather than output because the Dagger CLI reserves
+	// `--output/-o` for exporting a call's result: a function parameter
+	// called output collides with it, and `dagger call build` then fails to
+	// parse its own flags before it runs anything. Ci.WithBuild's
+	// binaryName dodges the same collision; this one is not always a binary,
+	// because buildmode can make it an archive or a shared library.
+	//
+	ArtifactName string // go (../../../../../daggerverse/go/main.go:252:2)
 	//
 	// Pass -trimpath: strip the build's local file system paths out of the
 	// binary, so the output does not depend on where it was compiled.
 	//
-	Trimpath bool // go (../../../../../daggerverse/go/main.go:250:2)
+	Trimpath bool // go (../../../../../daggerverse/go/main.go:257:2)
 	//
 	// Pass -ldflags "-s -w": drop the symbol table and the DWARF debug
 	// info. Smaller binary, no usable stack symbolization or debugger.
 	//
-	Strip bool // go (../../../../../daggerverse/go/main.go:255:2)
+	Strip bool // go (../../../../../daggerverse/go/main.go:262:2)
 	//
 	// Link-time variable assignments, each `importpath.Name=value`,
 	// rendered as `-ldflags "-X importpath.Name=value"`. This is how a
@@ -132,25 +140,45 @@ type GoBuildOpts struct {
 	// ignores a stamp naming a variable that does not exist, or one that
 	// is not a package-level string.
 	//
-	Stamps []string // go (../../../../../daggerverse/go/main.go:265:2)
+	Stamps []string // go (../../../../../daggerverse/go/main.go:272:2)
 	//
 	// Build tags, passed as `-tags a,b,c`. Selects which `//go:build`
 	// files are compiled in.
 	//
-	Tags []string // go (../../../../../daggerverse/go/main.go:270:2)
+	Tags []string // go (../../../../../daggerverse/go/main.go:277:2)
 	//
 	// Target platform as `GOOS/GOARCH[/variant]`, e.g. "linux/arm64".
 	// Sets GOOS and GOARCH for a cross-compile; empty builds for the
 	// toolchain container's own platform. Any variant segment is ignored —
 	// GOARM/GOAMD64 are left unset.
 	//
-	Platform string // go (../../../../../daggerverse/go/main.go:277:2)
+	Platform string // go (../../../../../daggerverse/go/main.go:284:2)
 	//
 	// Set CGO_ENABLED=0. Produces a statically linked binary with no libc
 	// dependency, which is what a scratch image needs, at the cost of the
 	// cgo-backed net and os/user implementations.
 	//
-	DisableCgo bool // go (../../../../../daggerverse/go/main.go:283:2)
+	DisableCgo bool // go (../../../../../daggerverse/go/main.go:290:2)
+	//
+	// Pass -race: link Go's data-race detector into the output. The binary
+	// then reports racing accesses to stderr as it runs, at roughly 2-20x
+	// the CPU and 5-10x the memory of an ordinary build — so this is a
+	// binary for an integration test, not one to ship.
+	//
+	// -race requires cgo, so it cannot be combined with disableCgo (Build
+	// rejects that pairing) and it needs a C toolchain for the target: the
+	// golang image has one for its own platform, but a cross-compile via
+	// platform does not unless the toolchain image provides it.
+	//
+	Race bool // go (../../../../../daggerverse/go/main.go:302:2)
+	//
+	// Pass -buildmode=<mode>: what the linker emits, which for most modes is
+	// not an executable. Absent leaves the flag off entirely, so `go build`
+	// picks its own default for the target — an executable for a main
+	// package, an archive for the rest. See BuildMode for what each member
+	// produces.
+	//
+	Buildmode GoBuildMode // go (../../../../../daggerverse/go/main.go:310:2)
 }
 
 // Build runs `go build` against the supplied source and returns /out as a
@@ -173,9 +201,9 @@ func (r *Go) Build(source *Directory, opts ...GoBuildOpts) *Directory { // go (.
 		if !querybuilder.IsZeroValue(opts[i].Pkg) {
 			q = q.Arg("pkg", opts[i].Pkg)
 		}
-		// `output` optional argument
-		if !querybuilder.IsZeroValue(opts[i].Output) {
-			q = q.Arg("output", opts[i].Output)
+		// `artifactName` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ArtifactName) {
+			q = q.Arg("artifactName", opts[i].ArtifactName)
 		}
 		// `trimpath` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Trimpath) {
@@ -200,6 +228,14 @@ func (r *Go) Build(source *Directory, opts ...GoBuildOpts) *Directory { // go (.
 		// `disableCgo` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DisableCgo) {
 			q = q.Arg("disableCgo", opts[i].DisableCgo)
+		}
+		// `race` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Race) {
+			q = q.Arg("race", opts[i].Race)
+		}
+		// `buildmode` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Buildmode) {
+			q = q.Arg("buildmode", opts[i].Buildmode)
 		}
 	}
 	q = q.Arg("source", source)
@@ -240,7 +276,7 @@ func (r *Go) Container(source *Directory) *Container { // go (../../../../../dag
 }
 
 // Env runs `go env` in a source-less base container and returns its stdout.
-func (r *Go) Env(ctx context.Context) (string, error) { // go (../../../../../daggerverse/go/main.go:448:1)
+func (r *Go) Env(ctx context.Context) (string, error) { // go (../../../../../daggerverse/go/main.go:488:1)
 	if r.env != nil {
 		return *r.env, nil
 	}
@@ -255,7 +291,7 @@ func (r *Go) Env(ctx context.Context) (string, error) { // go (../../../../../da
 // Fmt runs `gofmt -l -d .` against the supplied source. Returns the diff
 // of any unformatted files; non-empty output is also returned as an error so
 // CI fails fast on formatting violations.
-func (r *Go) Fmt(ctx context.Context, source *Directory) (string, error) { // go (../../../../../daggerverse/go/main.go:412:1)
+func (r *Go) Fmt(ctx context.Context, source *Directory) (string, error) { // go (../../../../../daggerverse/go/main.go:452:1)
 	assertNotNil("source", source)
 	if r.fmt != nil {
 		return *r.fmt, nil
@@ -430,17 +466,17 @@ func (r *Go) Run(ctx context.Context, source *Directory, pkg string, opts ...GoR
 type GoTestOpts struct {
 
 	// Default: "./..."
-	Pkg string // go (../../../../../daggerverse/go/main.go:388:2)
+	Pkg string // go (../../../../../daggerverse/go/main.go:428:2)
 
-	Race bool // go (../../../../../daggerverse/go/main.go:390:2)
+	Race bool // go (../../../../../daggerverse/go/main.go:430:2)
 
-	Flags []string // go (../../../../../daggerverse/go/main.go:392:2)
+	Flags []string // go (../../../../../daggerverse/go/main.go:432:2)
 }
 
 // Test runs `go test -count=1 [-race] [flags] pkg` against the supplied
 // source and returns the combined stdout. -count=1 is always passed to
 // bypass Go's internal test cache.
-func (r *Go) Test(ctx context.Context, source *Directory, opts ...GoTestOpts) (string, error) { // go (../../../../../daggerverse/go/main.go:384:1)
+func (r *Go) Test(ctx context.Context, source *Directory, opts ...GoTestOpts) (string, error) { // go (../../../../../daggerverse/go/main.go:424:1)
 	assertNotNil("source", source)
 	if r.test != nil {
 		return *r.test, nil
@@ -470,7 +506,7 @@ func (r *Go) Test(ctx context.Context, source *Directory, opts ...GoTestOpts) (s
 
 // ToolVersion runs `go version` in a source-less base container and returns
 // the trimmed output (e.g. "go version go1.23.0 linux/amd64").
-func (r *Go) ToolVersion(ctx context.Context) (string, error) { // go (../../../../../daggerverse/go/main.go:456:1)
+func (r *Go) ToolVersion(ctx context.Context) (string, error) { // go (../../../../../daggerverse/go/main.go:496:1)
 	if r.toolVersion != nil {
 		return *r.toolVersion, nil
 	}
@@ -501,12 +537,12 @@ func (r *Go) Version(ctx context.Context) (string, error) { // go (../../../../.
 type GoVetOpts struct {
 
 	// Default: "./..."
-	Pkg string // go (../../../../../daggerverse/go/main.go:435:2)
+	Pkg string // go (../../../../../daggerverse/go/main.go:475:2)
 }
 
 // Vet runs `go vet pkg` against the supplied source. pkg defaults to
 // `./...`. Returns a non-nil error when vet reports any issue.
-func (r *Go) Vet(ctx context.Context, source *Directory, opts ...GoVetOpts) error { // go (../../../../../daggerverse/go/main.go:431:1)
+func (r *Go) Vet(ctx context.Context, source *Directory, opts ...GoVetOpts) error { // go (../../../../../daggerverse/go/main.go:471:1)
 	assertNotNil("source", source)
 	if r.vet != nil {
 		return nil
@@ -793,3 +829,119 @@ func (r *Query) Go(opts ...GoOpts) *Go { // go (../../../../../daggerverse/go/ma
 		query: q,
 	}
 }
+
+// BuildMode is what `go build -buildmode` produces: the kind of artifact the
+// linker emits, which for most of these is not an executable at all. It is an
+// enum rather than a string because the set is closed and each member has a
+// different output shape a caller has to be ready for.
+//
+// Two of `go build`'s modes are deliberately absent. `default` is what
+// omitting this input already means, so a member for it would be a second
+// spelling of the same request. `shared` is only half a feature without a
+// `-linkshared` counterpart on the consuming build, which Build does not have
+// — use Container() if you are building a shared std.
+//
+// Note on rendered names: the Dagger Go SDK derives each GraphQL enum member
+// from the *constant identifier* in SCREAMING_SNAKE_CASE, so these surface as
+// `ARCHIVE`, `C_ARCHIVE`, `C_SHARED`, `EXE`, `PIE` and `PLUGIN`. That is why
+// the `go build` spelling (`c-archive`) lives in buildModeFlags below rather
+// than in the identifier: a hyphen cannot appear in a Go identifier, so the
+// mapping has to be explicit.
+type GoBuildMode string // go (../../../../../daggerverse/go/buildmode.go:31:6)
+
+func (GoBuildMode) IsEnum() {}
+
+func (v GoBuildMode) Name() string {
+	switch v {
+	case GoBuildModeArchive:
+		return "ARCHIVE"
+	case GoBuildModeCArchive:
+		return "C_ARCHIVE"
+	case GoBuildModeCShared:
+		return "C_SHARED"
+	case GoBuildModeExe:
+		return "EXE"
+	case GoBuildModePie:
+		return "PIE"
+	case GoBuildModePlugin:
+		return "PLUGIN"
+	default:
+		return ""
+	}
+}
+
+func (v GoBuildMode) Value() string {
+	return string(v)
+}
+
+func (v *GoBuildMode) MarshalJSON() ([]byte, error) {
+	if *v == "" {
+		return []byte(`""`), nil
+	}
+	name := v.Name()
+	if name == "" {
+		return nil, fmt.Errorf("invalid enum value %q", *v)
+	}
+	return json.Marshal(name)
+}
+
+func (v *GoBuildMode) UnmarshalJSON(dt []byte) error {
+	var s string
+	if err := json.Unmarshal(dt, &s); err != nil {
+		return err
+	}
+	switch s {
+	case "":
+		*v = ""
+	case "ARCHIVE":
+		*v = GoBuildModeArchive
+	case "C_ARCHIVE":
+		*v = GoBuildModeCArchive
+	case "C_SHARED":
+		*v = GoBuildModeCShared
+	case "EXE":
+		*v = GoBuildModeExe
+	case "PIE":
+		*v = GoBuildModePie
+	case "PLUGIN":
+		*v = GoBuildModePlugin
+	default:
+		return fmt.Errorf("invalid enum value %q", s)
+	}
+	return nil
+}
+
+const (
+	// BuildModeArchive builds the listed non-main packages into `.a` files
+	// (`archive`). Main packages are ignored, so pointing this at one
+	// produces nothing.
+	GoBuildModeArchive GoBuildMode = "ARCHIVE" // go (../../../../../daggerverse/go/buildmode.go:37:2)
+
+	// BuildModeCArchive builds the listed main package into a C archive
+	// (`c-archive`), alongside a generated header. Only the functions
+	// carrying a cgo `//export` comment are callable. Needs cgo, so it
+	// cannot be combined with disableCgo.
+	GoBuildModeCArchive GoBuildMode = "C_ARCHIVE" // go (../../../../../daggerverse/go/buildmode.go:42:2)
+
+	// BuildModeCShared builds the listed main package into a C shared
+	// library (`c-shared`), alongside a generated header — the same exported
+	// surface as C_ARCHIVE, linked dynamically instead. Needs cgo.
+	GoBuildModeCShared GoBuildMode = "C_SHARED" // go (../../../../../daggerverse/go/buildmode.go:46:2)
+
+	// BuildModeExe builds the listed main packages into executables
+	// (`exe`), forcing a position-dependent executable on a toolchain whose
+	// default for the target is PIE.
+	GoBuildModeExe GoBuildMode = "EXE" // go (../../../../../daggerverse/go/buildmode.go:50:2)
+
+	// BuildModePie builds the listed main packages into position
+	// independent executables (`pie`), which is what a hardened runtime
+	// wanting ASLR requires.
+	GoBuildModePie GoBuildMode = "PIE" // go (../../../../../daggerverse/go/buildmode.go:54:2)
+
+	// BuildModePlugin builds the listed main packages into a shared library
+	// loadable at run time with `plugin.Open` (`plugin`). The plugin and
+	// its host have to be built by the same toolchain from the same
+	// dependency versions or the load fails.
+	GoBuildModePlugin GoBuildMode = "PLUGIN" // go (../../../../../daggerverse/go/buildmode.go:59:2)
+
+)

--- a/daggerverse/go/tests/main.go
+++ b/daggerverse/go/tests/main.go
@@ -112,6 +112,18 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("BuildPlatformCrossCompiles", func(ctx context.Context) error {
 		return t.BuildPlatformCrossCompiles(ctx, goImageTag)
 	})
+	jobs = jobs.WithJob("BuildRaceLinksTheDetector", func(ctx context.Context) error {
+		return t.BuildRaceLinksTheDetector(ctx, goImageTag)
+	})
+	jobs = jobs.WithJob("BuildRejectsRaceWithDisableCgo", func(ctx context.Context) error {
+		return t.BuildRejectsRaceWithDisableCgo(ctx, goImageTag)
+	})
+	jobs = jobs.WithJob("BuildBuildmodeCArchiveProducesArchiveAndHeader", func(ctx context.Context) error {
+		return t.BuildBuildmodeCArchiveProducesArchiveAndHeader(ctx, goImageTag)
+	})
+	jobs = jobs.WithJob("BuildBuildmodeMembersAllProduceOutput", func(ctx context.Context) error {
+		return t.BuildBuildmodeMembersAllProduceOutput(ctx, goImageTag)
+	})
 	jobs = jobs.WithJob("TestMultipkgPkgArgVariants", func(ctx context.Context) error {
 		return t.TestMultipkgPkgArgVariants(ctx, goImageTag)
 	})
@@ -419,6 +431,18 @@ func stampedDir() *dagger.Directory {
 	return dag.CurrentModule().Source().Directory("fixtures/stamped")
 }
 
+// carchiveDir returns the carchive fixture: a main package exporting a cgo
+// //export function, which is what -buildmode=c-archive and c-shared compile.
+func carchiveDir() *dagger.Directory {
+	return dag.CurrentModule().Source().Directory("fixtures/carchive")
+}
+
+// racyDir returns the racy fixture: a main package whose raceDetector
+// constant is selected by the `race` build tag, which `go build -race` sets.
+func racyDir() *dagger.Directory {
+	return dag.CurrentModule().Source().Directory("fixtures/racy")
+}
+
 // alpineImage is the minimal container built binaries are executed in.
 // ":latest" is a moving target, so the tag is pinned.
 const alpineImage = "alpine:3.22"
@@ -432,6 +456,20 @@ func runBuiltBinary(ctx context.Context, bin *dagger.File) (string, error) {
 		Stdout(ctx)
 }
 
+// runBuiltBinaryOnGlibc executes a freshly built binary in the same
+// glibc-based toolchain container it was compiled in, and returns its stdout.
+// A -race build links the race runtime through cgo, so its output is
+// dynamically linked against glibc and cannot run in the musl-based alpine
+// image runBuiltBinary uses. Reusing Container(source) rather than pinning a
+// second image keeps the runtime ABI matched to the build's by construction.
+func runBuiltBinaryOnGlibc(ctx context.Context, goImageTag string, source *dagger.Directory, bin *dagger.File) (string, error) {
+	return dag.Go(dagger.GoOpts{Version: goImageTag}).
+		Container(source).
+		WithFile("/bin/app", bin, dagger.ContainerWithFileOpts{Permissions: 0o755}).
+		WithExec([]string{"/bin/app"}).
+		Stdout(ctx)
+}
+
 // BuildRejectsMalformedStamps asserts Build rejects a stamp with no "=" and
 // a stamp whose importpath.Name is empty, and that each message names the
 // offending element rather than reporting a generic parse failure.
@@ -439,9 +477,9 @@ func (t *Tests) BuildRejectsMalformedStamps(ctx context.Context, goImageTag stri
 	for _, stamp := range []string{"main.version", "=v1.0.0"} {
 		_, err := dag.Go(dagger.GoOpts{Version: goImageTag}).
 			Build(stampedDir(), dagger.GoBuildOpts{
-				Pkg:    ".",
-				Output: "stamped",
-				Stamps: []string{stamp},
+				Pkg:          ".",
+				ArtifactName: "stamped",
+				Stamps:       []string{stamp},
 			}).
 			Entries(ctx)
 		if err == nil {
@@ -459,12 +497,12 @@ func (t *Tests) BuildRejectsMalformedStamps(ctx context.Context, goImageTag stri
 // variable name from its value.
 func (t *Tests) BuildStampsReachTheBinary(ctx context.Context, goImageTag string) error {
 	out := dag.Go(dagger.GoOpts{Version: goImageTag}).Build(stampedDir(), dagger.GoBuildOpts{
-		Pkg:        ".",
-		Output:     "stamped",
-		Trimpath:   true,
-		Strip:      true,
-		DisableCgo: true,
-		Stamps:     []string{"main.version=v1.2.3", "main.commit=sha=deadbeef"},
+		Pkg:          ".",
+		ArtifactName: "stamped",
+		Trimpath:     true,
+		Strip:        true,
+		DisableCgo:   true,
+		Stamps:       []string{"main.version=v1.2.3", "main.commit=sha=deadbeef"},
 	})
 	got, err := runBuiltBinary(ctx, out.File("stamped"))
 	if err != nil {
@@ -481,10 +519,10 @@ func (t *Tests) BuildStampsReachTheBinary(ctx context.Context, goImageTag string
 // stamped fixture reports flavor=fancy only when the `fancy` tag is set.
 func (t *Tests) BuildTagsSelectTaggedFiles(ctx context.Context, goImageTag string) error {
 	out := dag.Go(dagger.GoOpts{Version: goImageTag}).Build(stampedDir(), dagger.GoBuildOpts{
-		Pkg:        ".",
-		Output:     "stamped",
-		DisableCgo: true,
-		Tags:       []string{"fancy"},
+		Pkg:          ".",
+		ArtifactName: "stamped",
+		DisableCgo:   true,
+		Tags:         []string{"fancy"},
 	})
 	got, err := runBuiltBinary(ctx, out.File("stamped"))
 	if err != nil {
@@ -508,10 +546,10 @@ func (t *Tests) BuildTrimpathRemovesSourcePaths(ctx context.Context, goImageTag 
 		{trimpath: true, want: false},
 	} {
 		out := dag.Go(dagger.GoOpts{Version: goImageTag}).Build(stampedDir(), dagger.GoBuildOpts{
-			Pkg:        ".",
-			Output:     "stamped",
-			DisableCgo: true,
-			Trimpath:   tc.trimpath,
+			Pkg:          ".",
+			ArtifactName: "stamped",
+			DisableCgo:   true,
+			Trimpath:     tc.trimpath,
 		})
 		found, err := binaryContains(ctx, out.File("stamped"), "/src/main.go")
 		if err != nil {
@@ -530,10 +568,10 @@ func (t *Tests) BuildStripShrinksTheBinary(ctx context.Context, goImageTag strin
 	sizes := make(map[bool]int, 2)
 	for _, strip := range []bool{false, true} {
 		out := dag.Go(dagger.GoOpts{Version: goImageTag}).Build(stampedDir(), dagger.GoBuildOpts{
-			Pkg:        ".",
-			Output:     "stamped",
-			DisableCgo: true,
-			Strip:      strip,
+			Pkg:          ".",
+			ArtifactName: "stamped",
+			DisableCgo:   true,
+			Strip:        strip,
 		})
 		size, err := out.File("stamped").Size(ctx)
 		if err != nil {
@@ -547,6 +585,136 @@ func (t *Tests) BuildStripShrinksTheBinary(ctx context.Context, goImageTag strin
 	return nil
 }
 
+// BuildBuildmodeCArchiveProducesArchiveAndHeader asserts C_ARCHIVE reaches
+// `go build -buildmode=c-archive`: the output is the ar archive plus the
+// generated C header, and specifically not an executable — which is what the
+// same fixture and the same -o would produce with the buildmode left off.
+func (t *Tests) BuildBuildmodeCArchiveProducesArchiveAndHeader(ctx context.Context, goImageTag string) error {
+	out := dag.Go(dagger.GoOpts{Version: goImageTag}).Build(carchiveDir(), dagger.GoBuildOpts{
+		Pkg:          ".",
+		ArtifactName: "libgreet.a",
+		Buildmode:    dagger.GoBuildModeCArchive,
+	})
+	entries, err := out.Entries(ctx)
+	if err != nil {
+		return fmt.Errorf("list /out: %w", err)
+	}
+	want := []string{"libgreet.a", "libgreet.h"}
+	if strings.Join(entries, ",") != strings.Join(want, ",") {
+		return fmt.Errorf("expected /out to hold exactly %v, got %v", want, entries)
+	}
+	// An ar archive opens with "!<arch>\n"; an ELF executable opens with
+	// "\x7fELF". Reading the first bytes is what tells the two apart.
+	magic, err := dag.Container().From(alpineImage).
+		WithFile("/x/libgreet.a", out.File("libgreet.a")).
+		WithExec([]string{"head", "-c", "8", "/x/libgreet.a"}).
+		Stdout(ctx)
+	if err != nil {
+		return fmt.Errorf("read archive magic: %w", err)
+	}
+	if magic != "!<arch>\n" {
+		return fmt.Errorf("expected ar magic %q, got %q", "!<arch>\n", magic)
+	}
+	header, err := out.File("libgreet.h").Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("read generated header: %w", err)
+	}
+	if !strings.Contains(header, "Greet") {
+		return fmt.Errorf("expected libgreet.h to declare the exported Greet, got:\n%s", header)
+	}
+	return nil
+}
+
+// BuildBuildmodeMembersAllProduceOutput calls Build once per BuildMode member
+// with a fixture and an output name that mode can actually satisfy, asserting
+// each produces a non-empty artifact. That is what makes every member of the
+// enum reachable rather than merely declared: a member the module failed to
+// map onto a `-buildmode=` value would fail here.
+func (t *Tests) BuildBuildmodeMembersAllProduceOutput(ctx context.Context, goImageTag string) error {
+	for _, tc := range []struct {
+		mode     dagger.GoBuildMode
+		source   *dagger.Directory
+		pkg      string
+		artifact string
+	}{
+		// archive ignores main packages, so it gets the library package out
+		// of the multipkg fixture.
+		{dagger.GoBuildModeArchive, multipkgDir(), "./pkg/foo", "foo.a"},
+		{dagger.GoBuildModeCArchive, carchiveDir(), ".", "libgreet.a"},
+		{dagger.GoBuildModeCShared, carchiveDir(), ".", "libgreet.so"},
+		{dagger.GoBuildModeExe, stampedDir(), ".", "stamped"},
+		{dagger.GoBuildModePie, stampedDir(), ".", "stamped"},
+		{dagger.GoBuildModePlugin, stampedDir(), ".", "stamped.so"},
+	} {
+		size, err := dag.Go(dagger.GoOpts{Version: goImageTag}).
+			Build(tc.source, dagger.GoBuildOpts{
+				Pkg:          tc.pkg,
+				ArtifactName: tc.artifact,
+				Buildmode:    tc.mode,
+			}).
+			File(tc.artifact).
+			Size(ctx)
+		if err != nil {
+			return fmt.Errorf("buildmode %s: %w", tc.mode, err)
+		}
+		if size == 0 {
+			return fmt.Errorf("buildmode %s: expected non-empty %s, got size 0", tc.mode, tc.artifact)
+		}
+	}
+	return nil
+}
+
+// BuildRaceLinksTheDetector asserts race reaches `go build -race`: the racy
+// fixture reports race=on only when the detector is linked in, because
+// -race implies the `race` build tag. The binary is run to prove the
+// detector is present in the artifact and not merely on the command line.
+func (t *Tests) BuildRaceLinksTheDetector(ctx context.Context, goImageTag string) error {
+	for _, tc := range []struct {
+		race bool
+		want string
+	}{
+		{race: false, want: "race=off\n"},
+		{race: true, want: "race=on\n"},
+	} {
+		out := dag.Go(dagger.GoOpts{Version: goImageTag}).Build(racyDir(), dagger.GoBuildOpts{
+			Pkg:          ".",
+			ArtifactName: "racy",
+			Race:         tc.race,
+		})
+		got, err := runBuiltBinaryOnGlibc(ctx, goImageTag, racyDir(), out.File("racy"))
+		if err != nil {
+			return fmt.Errorf("run racy binary (race=%v): %w", tc.race, err)
+		}
+		if got != tc.want {
+			return fmt.Errorf("race=%v: expected %q, got %q", tc.race, tc.want, got)
+		}
+	}
+	return nil
+}
+
+// BuildRejectsRaceWithDisableCgo asserts Build refuses the race+disableCgo
+// pairing up front rather than letting `go build` fail on it, and that the
+// message names both inputs so the caller knows which two are in conflict.
+func (t *Tests) BuildRejectsRaceWithDisableCgo(ctx context.Context, goImageTag string) error {
+	_, err := dag.Go(dagger.GoOpts{Version: goImageTag}).
+		Build(racyDir(), dagger.GoBuildOpts{
+			Pkg:          ".",
+			ArtifactName: "racy",
+			Race:         true,
+			DisableCgo:   true,
+		}).
+		Entries(ctx)
+	if err == nil {
+		return fmt.Errorf("expected Build to reject race with disableCgo, got nil error")
+	}
+	for _, want := range []string{"race", "disableCgo"} {
+		if !strings.Contains(err.Error(), want) {
+			return fmt.Errorf("expected rejection to name %q, got: %s", want, err.Error())
+		}
+	}
+	return nil
+}
+
 // BuildPlatformCrossCompiles asserts platform reaches GOOS/GOARCH: the
 // binary built for linux/arm64 carries the aarch64 machine type in its ELF
 // header (e_machine == 0xb7 at offset 18), which an amd64 build does not.
@@ -556,10 +724,10 @@ func (t *Tests) BuildPlatformCrossCompiles(ctx context.Context, goImageTag strin
 		{"linux/amd64", "3e"},
 	} {
 		out := dag.Go(dagger.GoOpts{Version: goImageTag}).Build(stampedDir(), dagger.GoBuildOpts{
-			Pkg:        ".",
-			Output:     "stamped",
-			DisableCgo: true,
-			Platform:   tc.platform,
+			Pkg:          ".",
+			ArtifactName: "stamped",
+			DisableCgo:   true,
+			Platform:     tc.platform,
 		})
 		got, err := dag.Container().From(alpineImage).
 			WithFile("/bin/app", out.File("stamped")).
@@ -724,8 +892,8 @@ func (t *Tests) RunHelloPrintsHello(ctx context.Context, goImageTag string) erro
 // produced "hello" binary is non-empty.
 func (t *Tests) BuildHelloWritesBinary(ctx context.Context, goImageTag string) error {
 	out := dag.Go(dagger.GoOpts{Version: goImageTag}).Build(helloDir(), dagger.GoBuildOpts{
-		Pkg:    ".",
-		Output: "hello",
+		Pkg:          ".",
+		ArtifactName: "hello",
 	})
 	size, err := out.File("hello").Size(ctx)
 	if err != nil {

--- a/daggerverse/z5labs/goapp.go
+++ b/daggerverse/z5labs/goapp.go
@@ -344,12 +344,12 @@ func (a *GoApp) buildBinaryForPlatform(ctx context.Context, platform, binaryName
 		return nil, err
 	}
 	return dag.Go().Build(a.Source, dagger.GoBuildOpts{
-		Pkg:        a.resolvedPkg(),
-		Output:     binaryName,
-		Trimpath:   true,
-		Strip:      true,
-		DisableCgo: true,
-		Platform:   platform,
+		Pkg:          a.resolvedPkg(),
+		ArtifactName: binaryName,
+		Trimpath:     true,
+		Strip:        true,
+		DisableCgo:   true,
+		Platform:     platform,
 		Stamps: []string{
 			stampVersionVar + "=" + version,
 			stampCommitVar + "=" + commit,

--- a/daggerverse/z5labs/internal/dagger/go.gen.go
+++ b/daggerverse/z5labs/internal/dagger/go.gen.go
@@ -918,30 +918,35 @@ const (
 	GoBuildModeArchive GoBuildMode = "ARCHIVE" // go (../../../../daggerverse/go/buildmode.go:37:2)
 
 	// BuildModeCArchive builds the listed main package into a C archive
-	// (`c-archive`), alongside a generated header. Only the functions
-	// carrying a cgo `//export` comment are callable. Needs cgo, so it
-	// cannot be combined with disableCgo.
-	GoBuildModeCArchive GoBuildMode = "C_ARCHIVE" // go (../../../../daggerverse/go/buildmode.go:42:2)
+	// (`c-archive`). Only the functions carrying a cgo `//export` comment are
+	// callable, and it is those exports rather than the mode that need cgo —
+	// so this is not rejected alongside disableCgo the way race is. With cgo
+	// off, a package whose exports live in cgo files fails to build at all
+	// (`build constraints exclude all Go files`), and a pure-Go main package
+	// still produces an archive, but one exporting nothing and carrying no
+	// generated header. The archive/header pair is a consequence of having
+	// cgo exports, not of asking for this mode.
+	GoBuildModeCArchive GoBuildMode = "C_ARCHIVE" // go (../../../../daggerverse/go/buildmode.go:47:2)
 
 	// BuildModeCShared builds the listed main package into a C shared
-	// library (`c-shared`), alongside a generated header — the same exported
-	// surface as C_ARCHIVE, linked dynamically instead. Needs cgo.
-	GoBuildModeCShared GoBuildMode = "C_SHARED" // go (../../../../daggerverse/go/buildmode.go:46:2)
+	// library (`c-shared`) — the same exported surface as C_ARCHIVE, linked
+	// dynamically instead, and with the same relationship to cgo.
+	GoBuildModeCShared GoBuildMode = "C_SHARED" // go (../../../../daggerverse/go/buildmode.go:51:2)
 
 	// BuildModeExe builds the listed main packages into executables
 	// (`exe`), forcing a position-dependent executable on a toolchain whose
 	// default for the target is PIE.
-	GoBuildModeExe GoBuildMode = "EXE" // go (../../../../daggerverse/go/buildmode.go:50:2)
+	GoBuildModeExe GoBuildMode = "EXE" // go (../../../../daggerverse/go/buildmode.go:55:2)
 
 	// BuildModePie builds the listed main packages into position
 	// independent executables (`pie`), which is what a hardened runtime
 	// wanting ASLR requires.
-	GoBuildModePie GoBuildMode = "PIE" // go (../../../../daggerverse/go/buildmode.go:54:2)
+	GoBuildModePie GoBuildMode = "PIE" // go (../../../../daggerverse/go/buildmode.go:59:2)
 
 	// BuildModePlugin builds the listed main packages into a shared library
 	// loadable at run time with `plugin.Open` (`plugin`). The plugin and
 	// its host have to be built by the same toolchain from the same
 	// dependency versions or the load fails.
-	GoBuildModePlugin GoBuildMode = "PLUGIN" // go (../../../../daggerverse/go/buildmode.go:59:2)
+	GoBuildModePlugin GoBuildMode = "PLUGIN" // go (../../../../daggerverse/go/buildmode.go:64:2)
 
 )

--- a/daggerverse/z5labs/internal/dagger/go.gen.go
+++ b/daggerverse/z5labs/internal/dagger/go.gen.go
@@ -5,6 +5,7 @@ package dagger
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/dagger/querybuilder"
 )
@@ -109,20 +110,27 @@ type GoBuildOpts struct {
 	// Default: "./..."
 	Pkg string // go (../../../../daggerverse/go/main.go:240:2)
 	//
-	// Name of the binary written under /out. Empty means `-o /out/`, which
+	// Name of the artifact written under /out. Empty means `-o /out/`, which
 	// lets go build name each binary after its main package.
 	//
-	Output string // go (../../../../daggerverse/go/main.go:245:2)
+	// Named artifactName rather than output because the Dagger CLI reserves
+	// `--output/-o` for exporting a call's result: a function parameter
+	// called output collides with it, and `dagger call build` then fails to
+	// parse its own flags before it runs anything. Ci.WithBuild's
+	// binaryName dodges the same collision; this one is not always a binary,
+	// because buildmode can make it an archive or a shared library.
+	//
+	ArtifactName string // go (../../../../daggerverse/go/main.go:252:2)
 	//
 	// Pass -trimpath: strip the build's local file system paths out of the
 	// binary, so the output does not depend on where it was compiled.
 	//
-	Trimpath bool // go (../../../../daggerverse/go/main.go:250:2)
+	Trimpath bool // go (../../../../daggerverse/go/main.go:257:2)
 	//
 	// Pass -ldflags "-s -w": drop the symbol table and the DWARF debug
 	// info. Smaller binary, no usable stack symbolization or debugger.
 	//
-	Strip bool // go (../../../../daggerverse/go/main.go:255:2)
+	Strip bool // go (../../../../daggerverse/go/main.go:262:2)
 	//
 	// Link-time variable assignments, each `importpath.Name=value`,
 	// rendered as `-ldflags "-X importpath.Name=value"`. This is how a
@@ -132,25 +140,45 @@ type GoBuildOpts struct {
 	// ignores a stamp naming a variable that does not exist, or one that
 	// is not a package-level string.
 	//
-	Stamps []string // go (../../../../daggerverse/go/main.go:265:2)
+	Stamps []string // go (../../../../daggerverse/go/main.go:272:2)
 	//
 	// Build tags, passed as `-tags a,b,c`. Selects which `//go:build`
 	// files are compiled in.
 	//
-	Tags []string // go (../../../../daggerverse/go/main.go:270:2)
+	Tags []string // go (../../../../daggerverse/go/main.go:277:2)
 	//
 	// Target platform as `GOOS/GOARCH[/variant]`, e.g. "linux/arm64".
 	// Sets GOOS and GOARCH for a cross-compile; empty builds for the
 	// toolchain container's own platform. Any variant segment is ignored —
 	// GOARM/GOAMD64 are left unset.
 	//
-	Platform string // go (../../../../daggerverse/go/main.go:277:2)
+	Platform string // go (../../../../daggerverse/go/main.go:284:2)
 	//
 	// Set CGO_ENABLED=0. Produces a statically linked binary with no libc
 	// dependency, which is what a scratch image needs, at the cost of the
 	// cgo-backed net and os/user implementations.
 	//
-	DisableCgo bool // go (../../../../daggerverse/go/main.go:283:2)
+	DisableCgo bool // go (../../../../daggerverse/go/main.go:290:2)
+	//
+	// Pass -race: link Go's data-race detector into the output. The binary
+	// then reports racing accesses to stderr as it runs, at roughly 2-20x
+	// the CPU and 5-10x the memory of an ordinary build — so this is a
+	// binary for an integration test, not one to ship.
+	//
+	// -race requires cgo, so it cannot be combined with disableCgo (Build
+	// rejects that pairing) and it needs a C toolchain for the target: the
+	// golang image has one for its own platform, but a cross-compile via
+	// platform does not unless the toolchain image provides it.
+	//
+	Race bool // go (../../../../daggerverse/go/main.go:302:2)
+	//
+	// Pass -buildmode=<mode>: what the linker emits, which for most modes is
+	// not an executable. Absent leaves the flag off entirely, so `go build`
+	// picks its own default for the target — an executable for a main
+	// package, an archive for the rest. See BuildMode for what each member
+	// produces.
+	//
+	Buildmode GoBuildMode // go (../../../../daggerverse/go/main.go:310:2)
 }
 
 // Build runs `go build` against the supplied source and returns /out as a
@@ -173,9 +201,9 @@ func (r *Go) Build(source *Directory, opts ...GoBuildOpts) *Directory { // go (.
 		if !querybuilder.IsZeroValue(opts[i].Pkg) {
 			q = q.Arg("pkg", opts[i].Pkg)
 		}
-		// `output` optional argument
-		if !querybuilder.IsZeroValue(opts[i].Output) {
-			q = q.Arg("output", opts[i].Output)
+		// `artifactName` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ArtifactName) {
+			q = q.Arg("artifactName", opts[i].ArtifactName)
 		}
 		// `trimpath` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Trimpath) {
@@ -200,6 +228,14 @@ func (r *Go) Build(source *Directory, opts ...GoBuildOpts) *Directory { // go (.
 		// `disableCgo` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DisableCgo) {
 			q = q.Arg("disableCgo", opts[i].DisableCgo)
+		}
+		// `race` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Race) {
+			q = q.Arg("race", opts[i].Race)
+		}
+		// `buildmode` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Buildmode) {
+			q = q.Arg("buildmode", opts[i].Buildmode)
 		}
 	}
 	q = q.Arg("source", source)
@@ -240,7 +276,7 @@ func (r *Go) Container(source *Directory) *Container { // go (../../../../dagger
 }
 
 // Env runs `go env` in a source-less base container and returns its stdout.
-func (r *Go) Env(ctx context.Context) (string, error) { // go (../../../../daggerverse/go/main.go:448:1)
+func (r *Go) Env(ctx context.Context) (string, error) { // go (../../../../daggerverse/go/main.go:488:1)
 	if r.env != nil {
 		return *r.env, nil
 	}
@@ -255,7 +291,7 @@ func (r *Go) Env(ctx context.Context) (string, error) { // go (../../../../dagge
 // Fmt runs `gofmt -l -d .` against the supplied source. Returns the diff
 // of any unformatted files; non-empty output is also returned as an error so
 // CI fails fast on formatting violations.
-func (r *Go) Fmt(ctx context.Context, source *Directory) (string, error) { // go (../../../../daggerverse/go/main.go:412:1)
+func (r *Go) Fmt(ctx context.Context, source *Directory) (string, error) { // go (../../../../daggerverse/go/main.go:452:1)
 	assertNotNil("source", source)
 	if r.fmt != nil {
 		return *r.fmt, nil
@@ -430,17 +466,17 @@ func (r *Go) Run(ctx context.Context, source *Directory, pkg string, opts ...GoR
 type GoTestOpts struct {
 
 	// Default: "./..."
-	Pkg string // go (../../../../daggerverse/go/main.go:388:2)
+	Pkg string // go (../../../../daggerverse/go/main.go:428:2)
 
-	Race bool // go (../../../../daggerverse/go/main.go:390:2)
+	Race bool // go (../../../../daggerverse/go/main.go:430:2)
 
-	Flags []string // go (../../../../daggerverse/go/main.go:392:2)
+	Flags []string // go (../../../../daggerverse/go/main.go:432:2)
 }
 
 // Test runs `go test -count=1 [-race] [flags] pkg` against the supplied
 // source and returns the combined stdout. -count=1 is always passed to
 // bypass Go's internal test cache.
-func (r *Go) Test(ctx context.Context, source *Directory, opts ...GoTestOpts) (string, error) { // go (../../../../daggerverse/go/main.go:384:1)
+func (r *Go) Test(ctx context.Context, source *Directory, opts ...GoTestOpts) (string, error) { // go (../../../../daggerverse/go/main.go:424:1)
 	assertNotNil("source", source)
 	if r.test != nil {
 		return *r.test, nil
@@ -470,7 +506,7 @@ func (r *Go) Test(ctx context.Context, source *Directory, opts ...GoTestOpts) (s
 
 // ToolVersion runs `go version` in a source-less base container and returns
 // the trimmed output (e.g. "go version go1.23.0 linux/amd64").
-func (r *Go) ToolVersion(ctx context.Context) (string, error) { // go (../../../../daggerverse/go/main.go:456:1)
+func (r *Go) ToolVersion(ctx context.Context) (string, error) { // go (../../../../daggerverse/go/main.go:496:1)
 	if r.toolVersion != nil {
 		return *r.toolVersion, nil
 	}
@@ -501,12 +537,12 @@ func (r *Go) Version(ctx context.Context) (string, error) { // go (../../../../d
 type GoVetOpts struct {
 
 	// Default: "./..."
-	Pkg string // go (../../../../daggerverse/go/main.go:435:2)
+	Pkg string // go (../../../../daggerverse/go/main.go:475:2)
 }
 
 // Vet runs `go vet pkg` against the supplied source. pkg defaults to
 // `./...`. Returns a non-nil error when vet reports any issue.
-func (r *Go) Vet(ctx context.Context, source *Directory, opts ...GoVetOpts) error { // go (../../../../daggerverse/go/main.go:431:1)
+func (r *Go) Vet(ctx context.Context, source *Directory, opts ...GoVetOpts) error { // go (../../../../daggerverse/go/main.go:471:1)
 	assertNotNil("source", source)
 	if r.vet != nil {
 		return nil
@@ -793,3 +829,119 @@ func (r *Query) Go(opts ...GoOpts) *Go { // go (../../../../daggerverse/go/main.
 		query: q,
 	}
 }
+
+// BuildMode is what `go build -buildmode` produces: the kind of artifact the
+// linker emits, which for most of these is not an executable at all. It is an
+// enum rather than a string because the set is closed and each member has a
+// different output shape a caller has to be ready for.
+//
+// Two of `go build`'s modes are deliberately absent. `default` is what
+// omitting this input already means, so a member for it would be a second
+// spelling of the same request. `shared` is only half a feature without a
+// `-linkshared` counterpart on the consuming build, which Build does not have
+// — use Container() if you are building a shared std.
+//
+// Note on rendered names: the Dagger Go SDK derives each GraphQL enum member
+// from the *constant identifier* in SCREAMING_SNAKE_CASE, so these surface as
+// `ARCHIVE`, `C_ARCHIVE`, `C_SHARED`, `EXE`, `PIE` and `PLUGIN`. That is why
+// the `go build` spelling (`c-archive`) lives in buildModeFlags below rather
+// than in the identifier: a hyphen cannot appear in a Go identifier, so the
+// mapping has to be explicit.
+type GoBuildMode string // go (../../../../daggerverse/go/buildmode.go:31:6)
+
+func (GoBuildMode) IsEnum() {}
+
+func (v GoBuildMode) Name() string {
+	switch v {
+	case GoBuildModeArchive:
+		return "ARCHIVE"
+	case GoBuildModeCArchive:
+		return "C_ARCHIVE"
+	case GoBuildModeCShared:
+		return "C_SHARED"
+	case GoBuildModeExe:
+		return "EXE"
+	case GoBuildModePie:
+		return "PIE"
+	case GoBuildModePlugin:
+		return "PLUGIN"
+	default:
+		return ""
+	}
+}
+
+func (v GoBuildMode) Value() string {
+	return string(v)
+}
+
+func (v *GoBuildMode) MarshalJSON() ([]byte, error) {
+	if *v == "" {
+		return []byte(`""`), nil
+	}
+	name := v.Name()
+	if name == "" {
+		return nil, fmt.Errorf("invalid enum value %q", *v)
+	}
+	return json.Marshal(name)
+}
+
+func (v *GoBuildMode) UnmarshalJSON(dt []byte) error {
+	var s string
+	if err := json.Unmarshal(dt, &s); err != nil {
+		return err
+	}
+	switch s {
+	case "":
+		*v = ""
+	case "ARCHIVE":
+		*v = GoBuildModeArchive
+	case "C_ARCHIVE":
+		*v = GoBuildModeCArchive
+	case "C_SHARED":
+		*v = GoBuildModeCShared
+	case "EXE":
+		*v = GoBuildModeExe
+	case "PIE":
+		*v = GoBuildModePie
+	case "PLUGIN":
+		*v = GoBuildModePlugin
+	default:
+		return fmt.Errorf("invalid enum value %q", s)
+	}
+	return nil
+}
+
+const (
+	// BuildModeArchive builds the listed non-main packages into `.a` files
+	// (`archive`). Main packages are ignored, so pointing this at one
+	// produces nothing.
+	GoBuildModeArchive GoBuildMode = "ARCHIVE" // go (../../../../daggerverse/go/buildmode.go:37:2)
+
+	// BuildModeCArchive builds the listed main package into a C archive
+	// (`c-archive`), alongside a generated header. Only the functions
+	// carrying a cgo `//export` comment are callable. Needs cgo, so it
+	// cannot be combined with disableCgo.
+	GoBuildModeCArchive GoBuildMode = "C_ARCHIVE" // go (../../../../daggerverse/go/buildmode.go:42:2)
+
+	// BuildModeCShared builds the listed main package into a C shared
+	// library (`c-shared`), alongside a generated header — the same exported
+	// surface as C_ARCHIVE, linked dynamically instead. Needs cgo.
+	GoBuildModeCShared GoBuildMode = "C_SHARED" // go (../../../../daggerverse/go/buildmode.go:46:2)
+
+	// BuildModeExe builds the listed main packages into executables
+	// (`exe`), forcing a position-dependent executable on a toolchain whose
+	// default for the target is PIE.
+	GoBuildModeExe GoBuildMode = "EXE" // go (../../../../daggerverse/go/buildmode.go:50:2)
+
+	// BuildModePie builds the listed main packages into position
+	// independent executables (`pie`), which is what a hardened runtime
+	// wanting ASLR requires.
+	GoBuildModePie GoBuildMode = "PIE" // go (../../../../daggerverse/go/buildmode.go:54:2)
+
+	// BuildModePlugin builds the listed main packages into a shared library
+	// loadable at run time with `plugin.Open` (`plugin`). The plugin and
+	// its host have to be built by the same toolchain from the same
+	// dependency versions or the load fails.
+	GoBuildModePlugin GoBuildMode = "PLUGIN" // go (../../../../daggerverse/go/buildmode.go:59:2)
+
+)

--- a/daggerverse/z5labs/tests/internal/dagger/go.gen.go
+++ b/daggerverse/z5labs/tests/internal/dagger/go.gen.go
@@ -918,30 +918,35 @@ const (
 	GoBuildModeArchive GoBuildMode = "ARCHIVE" // go (../../../../../daggerverse/go/buildmode.go:37:2)
 
 	// BuildModeCArchive builds the listed main package into a C archive
-	// (`c-archive`), alongside a generated header. Only the functions
-	// carrying a cgo `//export` comment are callable. Needs cgo, so it
-	// cannot be combined with disableCgo.
-	GoBuildModeCArchive GoBuildMode = "C_ARCHIVE" // go (../../../../../daggerverse/go/buildmode.go:42:2)
+	// (`c-archive`). Only the functions carrying a cgo `//export` comment are
+	// callable, and it is those exports rather than the mode that need cgo —
+	// so this is not rejected alongside disableCgo the way race is. With cgo
+	// off, a package whose exports live in cgo files fails to build at all
+	// (`build constraints exclude all Go files`), and a pure-Go main package
+	// still produces an archive, but one exporting nothing and carrying no
+	// generated header. The archive/header pair is a consequence of having
+	// cgo exports, not of asking for this mode.
+	GoBuildModeCArchive GoBuildMode = "C_ARCHIVE" // go (../../../../../daggerverse/go/buildmode.go:47:2)
 
 	// BuildModeCShared builds the listed main package into a C shared
-	// library (`c-shared`), alongside a generated header — the same exported
-	// surface as C_ARCHIVE, linked dynamically instead. Needs cgo.
-	GoBuildModeCShared GoBuildMode = "C_SHARED" // go (../../../../../daggerverse/go/buildmode.go:46:2)
+	// library (`c-shared`) — the same exported surface as C_ARCHIVE, linked
+	// dynamically instead, and with the same relationship to cgo.
+	GoBuildModeCShared GoBuildMode = "C_SHARED" // go (../../../../../daggerverse/go/buildmode.go:51:2)
 
 	// BuildModeExe builds the listed main packages into executables
 	// (`exe`), forcing a position-dependent executable on a toolchain whose
 	// default for the target is PIE.
-	GoBuildModeExe GoBuildMode = "EXE" // go (../../../../../daggerverse/go/buildmode.go:50:2)
+	GoBuildModeExe GoBuildMode = "EXE" // go (../../../../../daggerverse/go/buildmode.go:55:2)
 
 	// BuildModePie builds the listed main packages into position
 	// independent executables (`pie`), which is what a hardened runtime
 	// wanting ASLR requires.
-	GoBuildModePie GoBuildMode = "PIE" // go (../../../../../daggerverse/go/buildmode.go:54:2)
+	GoBuildModePie GoBuildMode = "PIE" // go (../../../../../daggerverse/go/buildmode.go:59:2)
 
 	// BuildModePlugin builds the listed main packages into a shared library
 	// loadable at run time with `plugin.Open` (`plugin`). The plugin and
 	// its host have to be built by the same toolchain from the same
 	// dependency versions or the load fails.
-	GoBuildModePlugin GoBuildMode = "PLUGIN" // go (../../../../../daggerverse/go/buildmode.go:59:2)
+	GoBuildModePlugin GoBuildMode = "PLUGIN" // go (../../../../../daggerverse/go/buildmode.go:64:2)
 
 )

--- a/daggerverse/z5labs/tests/internal/dagger/go.gen.go
+++ b/daggerverse/z5labs/tests/internal/dagger/go.gen.go
@@ -5,6 +5,7 @@ package dagger
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/dagger/querybuilder"
 )
@@ -109,20 +110,27 @@ type GoBuildOpts struct {
 	// Default: "./..."
 	Pkg string // go (../../../../../daggerverse/go/main.go:240:2)
 	//
-	// Name of the binary written under /out. Empty means `-o /out/`, which
+	// Name of the artifact written under /out. Empty means `-o /out/`, which
 	// lets go build name each binary after its main package.
 	//
-	Output string // go (../../../../../daggerverse/go/main.go:245:2)
+	// Named artifactName rather than output because the Dagger CLI reserves
+	// `--output/-o` for exporting a call's result: a function parameter
+	// called output collides with it, and `dagger call build` then fails to
+	// parse its own flags before it runs anything. Ci.WithBuild's
+	// binaryName dodges the same collision; this one is not always a binary,
+	// because buildmode can make it an archive or a shared library.
+	//
+	ArtifactName string // go (../../../../../daggerverse/go/main.go:252:2)
 	//
 	// Pass -trimpath: strip the build's local file system paths out of the
 	// binary, so the output does not depend on where it was compiled.
 	//
-	Trimpath bool // go (../../../../../daggerverse/go/main.go:250:2)
+	Trimpath bool // go (../../../../../daggerverse/go/main.go:257:2)
 	//
 	// Pass -ldflags "-s -w": drop the symbol table and the DWARF debug
 	// info. Smaller binary, no usable stack symbolization or debugger.
 	//
-	Strip bool // go (../../../../../daggerverse/go/main.go:255:2)
+	Strip bool // go (../../../../../daggerverse/go/main.go:262:2)
 	//
 	// Link-time variable assignments, each `importpath.Name=value`,
 	// rendered as `-ldflags "-X importpath.Name=value"`. This is how a
@@ -132,25 +140,45 @@ type GoBuildOpts struct {
 	// ignores a stamp naming a variable that does not exist, or one that
 	// is not a package-level string.
 	//
-	Stamps []string // go (../../../../../daggerverse/go/main.go:265:2)
+	Stamps []string // go (../../../../../daggerverse/go/main.go:272:2)
 	//
 	// Build tags, passed as `-tags a,b,c`. Selects which `//go:build`
 	// files are compiled in.
 	//
-	Tags []string // go (../../../../../daggerverse/go/main.go:270:2)
+	Tags []string // go (../../../../../daggerverse/go/main.go:277:2)
 	//
 	// Target platform as `GOOS/GOARCH[/variant]`, e.g. "linux/arm64".
 	// Sets GOOS and GOARCH for a cross-compile; empty builds for the
 	// toolchain container's own platform. Any variant segment is ignored —
 	// GOARM/GOAMD64 are left unset.
 	//
-	Platform string // go (../../../../../daggerverse/go/main.go:277:2)
+	Platform string // go (../../../../../daggerverse/go/main.go:284:2)
 	//
 	// Set CGO_ENABLED=0. Produces a statically linked binary with no libc
 	// dependency, which is what a scratch image needs, at the cost of the
 	// cgo-backed net and os/user implementations.
 	//
-	DisableCgo bool // go (../../../../../daggerverse/go/main.go:283:2)
+	DisableCgo bool // go (../../../../../daggerverse/go/main.go:290:2)
+	//
+	// Pass -race: link Go's data-race detector into the output. The binary
+	// then reports racing accesses to stderr as it runs, at roughly 2-20x
+	// the CPU and 5-10x the memory of an ordinary build — so this is a
+	// binary for an integration test, not one to ship.
+	//
+	// -race requires cgo, so it cannot be combined with disableCgo (Build
+	// rejects that pairing) and it needs a C toolchain for the target: the
+	// golang image has one for its own platform, but a cross-compile via
+	// platform does not unless the toolchain image provides it.
+	//
+	Race bool // go (../../../../../daggerverse/go/main.go:302:2)
+	//
+	// Pass -buildmode=<mode>: what the linker emits, which for most modes is
+	// not an executable. Absent leaves the flag off entirely, so `go build`
+	// picks its own default for the target — an executable for a main
+	// package, an archive for the rest. See BuildMode for what each member
+	// produces.
+	//
+	Buildmode GoBuildMode // go (../../../../../daggerverse/go/main.go:310:2)
 }
 
 // Build runs `go build` against the supplied source and returns /out as a
@@ -173,9 +201,9 @@ func (r *Go) Build(source *Directory, opts ...GoBuildOpts) *Directory { // go (.
 		if !querybuilder.IsZeroValue(opts[i].Pkg) {
 			q = q.Arg("pkg", opts[i].Pkg)
 		}
-		// `output` optional argument
-		if !querybuilder.IsZeroValue(opts[i].Output) {
-			q = q.Arg("output", opts[i].Output)
+		// `artifactName` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ArtifactName) {
+			q = q.Arg("artifactName", opts[i].ArtifactName)
 		}
 		// `trimpath` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Trimpath) {
@@ -200,6 +228,14 @@ func (r *Go) Build(source *Directory, opts ...GoBuildOpts) *Directory { // go (.
 		// `disableCgo` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DisableCgo) {
 			q = q.Arg("disableCgo", opts[i].DisableCgo)
+		}
+		// `race` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Race) {
+			q = q.Arg("race", opts[i].Race)
+		}
+		// `buildmode` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Buildmode) {
+			q = q.Arg("buildmode", opts[i].Buildmode)
 		}
 	}
 	q = q.Arg("source", source)
@@ -240,7 +276,7 @@ func (r *Go) Container(source *Directory) *Container { // go (../../../../../dag
 }
 
 // Env runs `go env` in a source-less base container and returns its stdout.
-func (r *Go) Env(ctx context.Context) (string, error) { // go (../../../../../daggerverse/go/main.go:448:1)
+func (r *Go) Env(ctx context.Context) (string, error) { // go (../../../../../daggerverse/go/main.go:488:1)
 	if r.env != nil {
 		return *r.env, nil
 	}
@@ -255,7 +291,7 @@ func (r *Go) Env(ctx context.Context) (string, error) { // go (../../../../../da
 // Fmt runs `gofmt -l -d .` against the supplied source. Returns the diff
 // of any unformatted files; non-empty output is also returned as an error so
 // CI fails fast on formatting violations.
-func (r *Go) Fmt(ctx context.Context, source *Directory) (string, error) { // go (../../../../../daggerverse/go/main.go:412:1)
+func (r *Go) Fmt(ctx context.Context, source *Directory) (string, error) { // go (../../../../../daggerverse/go/main.go:452:1)
 	assertNotNil("source", source)
 	if r.fmt != nil {
 		return *r.fmt, nil
@@ -430,17 +466,17 @@ func (r *Go) Run(ctx context.Context, source *Directory, pkg string, opts ...GoR
 type GoTestOpts struct {
 
 	// Default: "./..."
-	Pkg string // go (../../../../../daggerverse/go/main.go:388:2)
+	Pkg string // go (../../../../../daggerverse/go/main.go:428:2)
 
-	Race bool // go (../../../../../daggerverse/go/main.go:390:2)
+	Race bool // go (../../../../../daggerverse/go/main.go:430:2)
 
-	Flags []string // go (../../../../../daggerverse/go/main.go:392:2)
+	Flags []string // go (../../../../../daggerverse/go/main.go:432:2)
 }
 
 // Test runs `go test -count=1 [-race] [flags] pkg` against the supplied
 // source and returns the combined stdout. -count=1 is always passed to
 // bypass Go's internal test cache.
-func (r *Go) Test(ctx context.Context, source *Directory, opts ...GoTestOpts) (string, error) { // go (../../../../../daggerverse/go/main.go:384:1)
+func (r *Go) Test(ctx context.Context, source *Directory, opts ...GoTestOpts) (string, error) { // go (../../../../../daggerverse/go/main.go:424:1)
 	assertNotNil("source", source)
 	if r.test != nil {
 		return *r.test, nil
@@ -470,7 +506,7 @@ func (r *Go) Test(ctx context.Context, source *Directory, opts ...GoTestOpts) (s
 
 // ToolVersion runs `go version` in a source-less base container and returns
 // the trimmed output (e.g. "go version go1.23.0 linux/amd64").
-func (r *Go) ToolVersion(ctx context.Context) (string, error) { // go (../../../../../daggerverse/go/main.go:456:1)
+func (r *Go) ToolVersion(ctx context.Context) (string, error) { // go (../../../../../daggerverse/go/main.go:496:1)
 	if r.toolVersion != nil {
 		return *r.toolVersion, nil
 	}
@@ -501,12 +537,12 @@ func (r *Go) Version(ctx context.Context) (string, error) { // go (../../../../.
 type GoVetOpts struct {
 
 	// Default: "./..."
-	Pkg string // go (../../../../../daggerverse/go/main.go:435:2)
+	Pkg string // go (../../../../../daggerverse/go/main.go:475:2)
 }
 
 // Vet runs `go vet pkg` against the supplied source. pkg defaults to
 // `./...`. Returns a non-nil error when vet reports any issue.
-func (r *Go) Vet(ctx context.Context, source *Directory, opts ...GoVetOpts) error { // go (../../../../../daggerverse/go/main.go:431:1)
+func (r *Go) Vet(ctx context.Context, source *Directory, opts ...GoVetOpts) error { // go (../../../../../daggerverse/go/main.go:471:1)
 	assertNotNil("source", source)
 	if r.vet != nil {
 		return nil
@@ -793,3 +829,119 @@ func (r *Query) Go(opts ...GoOpts) *Go { // go (../../../../../daggerverse/go/ma
 		query: q,
 	}
 }
+
+// BuildMode is what `go build -buildmode` produces: the kind of artifact the
+// linker emits, which for most of these is not an executable at all. It is an
+// enum rather than a string because the set is closed and each member has a
+// different output shape a caller has to be ready for.
+//
+// Two of `go build`'s modes are deliberately absent. `default` is what
+// omitting this input already means, so a member for it would be a second
+// spelling of the same request. `shared` is only half a feature without a
+// `-linkshared` counterpart on the consuming build, which Build does not have
+// — use Container() if you are building a shared std.
+//
+// Note on rendered names: the Dagger Go SDK derives each GraphQL enum member
+// from the *constant identifier* in SCREAMING_SNAKE_CASE, so these surface as
+// `ARCHIVE`, `C_ARCHIVE`, `C_SHARED`, `EXE`, `PIE` and `PLUGIN`. That is why
+// the `go build` spelling (`c-archive`) lives in buildModeFlags below rather
+// than in the identifier: a hyphen cannot appear in a Go identifier, so the
+// mapping has to be explicit.
+type GoBuildMode string // go (../../../../../daggerverse/go/buildmode.go:31:6)
+
+func (GoBuildMode) IsEnum() {}
+
+func (v GoBuildMode) Name() string {
+	switch v {
+	case GoBuildModeArchive:
+		return "ARCHIVE"
+	case GoBuildModeCArchive:
+		return "C_ARCHIVE"
+	case GoBuildModeCShared:
+		return "C_SHARED"
+	case GoBuildModeExe:
+		return "EXE"
+	case GoBuildModePie:
+		return "PIE"
+	case GoBuildModePlugin:
+		return "PLUGIN"
+	default:
+		return ""
+	}
+}
+
+func (v GoBuildMode) Value() string {
+	return string(v)
+}
+
+func (v *GoBuildMode) MarshalJSON() ([]byte, error) {
+	if *v == "" {
+		return []byte(`""`), nil
+	}
+	name := v.Name()
+	if name == "" {
+		return nil, fmt.Errorf("invalid enum value %q", *v)
+	}
+	return json.Marshal(name)
+}
+
+func (v *GoBuildMode) UnmarshalJSON(dt []byte) error {
+	var s string
+	if err := json.Unmarshal(dt, &s); err != nil {
+		return err
+	}
+	switch s {
+	case "":
+		*v = ""
+	case "ARCHIVE":
+		*v = GoBuildModeArchive
+	case "C_ARCHIVE":
+		*v = GoBuildModeCArchive
+	case "C_SHARED":
+		*v = GoBuildModeCShared
+	case "EXE":
+		*v = GoBuildModeExe
+	case "PIE":
+		*v = GoBuildModePie
+	case "PLUGIN":
+		*v = GoBuildModePlugin
+	default:
+		return fmt.Errorf("invalid enum value %q", s)
+	}
+	return nil
+}
+
+const (
+	// BuildModeArchive builds the listed non-main packages into `.a` files
+	// (`archive`). Main packages are ignored, so pointing this at one
+	// produces nothing.
+	GoBuildModeArchive GoBuildMode = "ARCHIVE" // go (../../../../../daggerverse/go/buildmode.go:37:2)
+
+	// BuildModeCArchive builds the listed main package into a C archive
+	// (`c-archive`), alongside a generated header. Only the functions
+	// carrying a cgo `//export` comment are callable. Needs cgo, so it
+	// cannot be combined with disableCgo.
+	GoBuildModeCArchive GoBuildMode = "C_ARCHIVE" // go (../../../../../daggerverse/go/buildmode.go:42:2)
+
+	// BuildModeCShared builds the listed main package into a C shared
+	// library (`c-shared`), alongside a generated header — the same exported
+	// surface as C_ARCHIVE, linked dynamically instead. Needs cgo.
+	GoBuildModeCShared GoBuildMode = "C_SHARED" // go (../../../../../daggerverse/go/buildmode.go:46:2)
+
+	// BuildModeExe builds the listed main packages into executables
+	// (`exe`), forcing a position-dependent executable on a toolchain whose
+	// default for the target is PIE.
+	GoBuildModeExe GoBuildMode = "EXE" // go (../../../../../daggerverse/go/buildmode.go:50:2)
+
+	// BuildModePie builds the listed main packages into position
+	// independent executables (`pie`), which is what a hardened runtime
+	// wanting ASLR requires.
+	GoBuildModePie GoBuildMode = "PIE" // go (../../../../../daggerverse/go/buildmode.go:54:2)
+
+	// BuildModePlugin builds the listed main packages into a shared library
+	// loadable at run time with `plugin.Open` (`plugin`). The plugin and
+	// its host have to be built by the same toolchain from the same
+	// dependency versions or the load fails.
+	GoBuildModePlugin GoBuildMode = "PLUGIN" // go (../../../../../daggerverse/go/buildmode.go:59:2)
+
+)


### PR DESCRIPTION
Closes #343

#328 replaced `Go.Build`'s opaque `flags []string` with named inputs and recorded
that no raw escape hatch survives on `Build`. That left the naming half-done:
`-race` and `-buildmode` were on the list that set the shape and neither was
implemented, so a caller wanting either had to drop out of `Build` into
`Container` and hand-write the whole command line — the outcome the typed
surface exists to prevent.

## Acceptance criteria

- [x] **`Go.Build` exposes `-race` as a named input with a doc comment stating
      what it does to the output and that it requires cgo** — `race bool`, whose
      comment states the 2-20x CPU / 5-10x memory cost, that the result is a
      binary for an integration test rather than one to ship, and that it needs
      cgo and therefore a C toolchain for the target.
- [x] **Passing `race` together with `disableCgo` either fails with a message
      naming both, or is documented as accepted** — decided as **rejected**, up
      front, before any container runs:
      `Build: race and disableCgo cannot be combined: -race links the race
      runtime through cgo, so CGO_ENABLED=0 makes `go build -race` fail — pass one
      or the other`. `BuildRejectsRaceWithDisableCgo` asserts the message names
      both inputs. The related pairing — `race` with `platform` — is documented
      rather than rejected, because it works given a cross toolchain in the image.
- [x] **`Go.Build` exposes `-buildmode` as a Dagger enum rather than a string,
      with every member reachable from the CLI, and each member's effect in its
      doc comment** — `BuildMode` in the new `daggerverse/go/buildmode.go`, with
      a per-member doc comment. Every member was invoked through
      `dagger call build --buildmode=<M>` against a fixture suited to it; all six
      produced their artifact (see *Verification*).
- [x] **The default buildmode remains whatever `go build` picks; the input is
      optional and absent by default** — `+optional`, and an empty mode leaves
      the flag off the command line entirely rather than passing
      `-buildmode=default`.
- [x] **A test per input** — `BuildRaceLinksTheDetector` builds the new `racy`
      fixture twice and **runs** the binary, which reports `race=on` only when
      the detector is linked in (`-race` implies the `race` build tag).
      `BuildBuildmodeCArchiveProducesArchiveAndHeader` asserts `/out` holds
      exactly `libgreet.a` and `libgreet.h`, that the archive opens with the ar
      magic `!<arch>\n` rather than `\x7fELF`, and that the generated header
      declares the exported `Greet` — i.e. an archive/header pair and not an
      executable. `BuildBuildmodeMembersAllProduceOutput` covers all six members.
- [x] **No input is a `+default=true` bool** — `race` is `+optional` (false),
      `buildmode` is `+optional` (empty).
- [x] **`daggerverse/go/README.md`'s build-flag table covers both** — both rows
      added, plus a per-member buildmode table with the `go build` spelling
      beside each rendered name, the two cgo pairings, and the two absent modes.

## The enum, and why the `go build` spellings are a map

Members surface as `ARCHIVE`, `C_ARCHIVE`, `C_SHARED`, `EXE`, `PIE`, `PLUGIN` —
the Dagger Go SDK derives each GraphQL name from the *constant identifier* in
SCREAMING_SNAKE_CASE. `c-archive` cannot be spelled in a Go identifier, so
`buildModeFlags` maps each member onto the value `-buildmode=` takes. Verified
against the generated bindings rather than assumed: `GoBuildModeCArchive`'s
`Name()` returns exactly `C_ARCHIVE`.

Two of `go build`'s modes are deliberately absent. `default` is what omitting
the input already means, so a member would be a second spelling of one request.
`shared` is half a capability without a `-linkshared` counterpart on the
consuming build, and needs `go install -buildmode=shared std` first — filed as
**#346** rather than left as a README paragraph.

## Judgment call: `output` becomes `artifactName`

`Build`'s `output` parameter collides with the Dagger CLI's global `--output/-o`.
The effect is total, not cosmetic — on `main`, **every** `dagger call build`
invocation dies with `flag already exists: output` while parsing its own flags,
before running anything:

```
$ dagger -m daggerverse/go call build --source=... --pkg=. entries   # on main
! flag already exists: output
```

The acceptance criterion above asks that every enum member be reachable from
`dagger call build`, and that could not be met while the old name stood — so the
rename is here by necessity rather than by preference. `Ci.WithBuild`'s
`binaryName` already dodges this exact collision and the README already
explained why, so the module had a precedent; `artifactName` rather than
`binaryName` because `buildmode` makes the output frequently *not* a binary.

Call sites updated: `daggerverse/go/tests`, `daggerverse/go/examples/go`, and
`daggerverse/z5labs`'s `GoApp` (the #328 consumer). Bindings regenerated in all
five modules that depend on `go`.

## Verification

- `dagger check` — green, `ci:generated` included, so the committed generated
  code matches the sources.
- `bash .github/scripts/verify-affected-modules.sh` — green for
  `daggerverse/go` and `daggerverse/z5labs`, both `tests:all`.
- Every buildmode member driven through the CLI against a fixture it suits:
  `ARCHIVE` → `foo.a`, `C_ARCHIVE` → `libgreet.a` + `libgreet.h`, `C_SHARED` →
  `libgreet.so` + `libgreet.h`, `EXE` → `stamped`, `PIE` → `stamped`, `PLUGIN` →
  `stamped.so`.
- `--race=true` from the CLI produces the binary; `--race=true --disable-cgo=true`
  is rejected with the message naming both.

Two fixtures are new: `tests/fixtures/racy` (reports the race detector via the
`race` build tag, since a program cannot query it at run time) and
`tests/fixtures/carchive` (a main package with a cgo `//export`, which is what
`c-archive` and `c-shared` compile). The race binary is run in the toolchain
container rather than the pinned alpine one — `-race` links through cgo, so the
output is glibc-dynamic and will not run under musl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
