### PR TITLE
fix(issue-345): make the cycle's waits finish inside the call that starts them

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -17,7 +17,10 @@ worktree, implement, verify, PR, wait for checks, get a Copilot review and
 answer it, label for auto merge, close the issue, clean up — then stops.
 `run-backlog` repeats that with a fresh `issue-worker` subagent per iteration,
 so each issue starts from clean context, and halts on `BACKLOG EMPTY`, on
-`BLOCKED`, or at a bounded iteration count.
+`BLOCKED`, or at a bounded iteration count. A worker that hands back control
+with its issue unfinished says `IN FLIGHT` and is *resumed* rather than
+replaced — a fresh worker would take a different issue and leave the first one's
+pull request open for good.
 
 Nothing repository-specific lives in the skills. The knobs live in
 `.claude/backlog.json` — which label, milestone and optional project field value
@@ -34,7 +37,7 @@ The cycle never runs `gh pr merge`. It labels the pull request and
 GitHub, gated by the default branch's protection rules — which is what puts the
 merge policy somewhere readable and what lets the loop run unattended at all.
 
-Three parts of the cycle are scripts rather than numbered steps, for the same
+Four parts of the cycle are scripts rather than numbered steps, for the same
 reason: they carry no judgment, and a procedure an agent retypes cannot be
 tested.
 
@@ -73,6 +76,25 @@ response — a repository that writes its ordering in prose would come back
 arrived at from the other direction. So a body parse that finds nothing never
 escalates to it, and `setup-backlog` reports that typed dependencies exist
 rather than inferring the style from their absence.
+
+Waiting for CI is
+[`scripts/await-checks.sh`](backlog/scripts/await-checks.sh) — `0 settled / 1
+failed / 2 still running / 3 no checks reported`. It replaced `gh pr checks
+--watch` handed to a background monitor, which was the cycle's one real
+deadlock. A monitor reports *after* the turn that armed it, and a worker
+subagent ends its turn by **returning** to its caller — so the wait died with
+the agent, and the resumed worker held for an event that could never arrive
+while the rule against busy-waiting stopped it checking by hand. One measured
+iteration cost about 2.4M tokens across thirteen resume nudges, against a
+300–375k band, and one of those resumes made no tool calls at all. All three
+waits are now bounded, blocking calls sharing one contract: exit 2 means "not
+finished, call me again", in the same turn.
+
+Its judgment is one function — fail-fast over pending siblings, `skipping` as
+settled, an unreadable or empty response as *not reported yet* rather than as an
+answer — exposed as `--classify` on stdin and pinned offline by
+[`scripts/await-checks_test.sh`](backlog/scripts/await-checks_test.sh). A red
+check read as pending is a wait that times out; read as settled, it is a merge.
 
 The review gate is
 [`scripts/await-review.sh`](backlog/scripts/await-review.sh) — request, wait,

--- a/plugins/backlog/.claude-plugin/plugin.json
+++ b/plugins/backlog/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "backlog",
   "description": "Run a repository's story backlog unattended — one issue at a time, from selection through worktree, verification, pull request, Copilot review and label-driven auto merge",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": { "name": "z5labs" }
 }

--- a/plugins/backlog/agents/issue-worker.md
+++ b/plugins/backlog/agents/issue-worker.md
@@ -1,7 +1,7 @@
 ---
 name: issue-worker
 description: Runs one iteration of the backlog cycle — invokes the `backlog:next-issue` skill, takes a single story issue from selection to a merged pull request, and returns that run's report verbatim. Spawned once per iteration by `backlog:run-backlog`; not usually invoked directly.
-tools: Skill, Bash, Read, Write, Edit, Glob, Grep, Monitor, TaskCreate, TaskUpdate
+tools: Skill, Bash, Read, Write, Edit, Glob, Grep, TaskCreate, TaskUpdate
 ---
 
 You run **one** iteration of a repository's backlog cycle and then return.
@@ -36,15 +36,23 @@ report will read like an ordinary successful iteration.
   one iteration later, where nothing points back at the cause.
 - **Never delete a remote branch.** The merge workflow owns remote cleanup. Clean up only
   the worktree and local branch you created.
-- **Never busy-wait on a `Monitor` call.** The cycle's three long waits — CI checks, the
-  Copilot review, the merge — are each one `Monitor` call, and its result comes back to you
-  on its own. Once a wait is armed your turn is over: no no-op `sleep` Bash calls to pass the
-  time, and no reading, `cat`-ing or `tail`-ing a wait's output file, log or task record to
-  see how a monitor that has not reported yet is getting on. Neither makes the wait finish
-  sooner and both cost a full turn each; one measured iteration burned a quarter of its
-  tokens that way. Where a wait needs a precondition, put it inside the monitored command as
-  `until <precondition>; do sleep 5; done; <blocking command>`, which the skill spells out at
-  step 6.
+- **A wait finishes inside the call that starts it.** The cycle's three long waits — CI
+  checks, the Copilot review, the merge — are each one bounded, blocking `Bash` call on a
+  script the plugin ships, and the answer comes back in that call. Exit 2 means "not finished,
+  ask again": run the same command again, in the same turn. Do **not** reach for `Monitor` or
+  `run_in_background`; both report *after* the turn ends, and your turn ending **is** your
+  return to your caller, so the wait dies with you and you come back holding for an event that
+  can never arrive. That deadlock cost one measured iteration thirteen resume nudges and about
+  2.4M tokens. `Monitor` is not among your tools for exactly that reason.
+- **Never busy-wait either.** No no-op `sleep` Bash calls to pass the time, and no reading,
+  `cat`-ing or `tail`-ing a log, output file or task record to see how a wait is getting on.
+  One measured iteration burned a quarter of its tokens that way. After an exit 2 the correct
+  move is the wait again — not a hand-rolled poll of your own.
+- **Never end a turn with a gate unresolved.** If you are handed back control mid-cycle
+  anyway, nothing is running on your behalf: make one direct status query for the gate you
+  had reached, act on it, and re-run the wait if it is still pending. A resumed turn that
+  makes no tool call at all is the single worst outcome available to you — it costs your
+  caller your entire context and moves the cycle nowhere.
 - **Do not weaken a test to make it pass**, and do not label a pull request whose review
   never completed.
 - **Do not retry selection unscoped, or on another scope.** If selection fails on the project
@@ -58,10 +66,16 @@ not a conversation.
 
 - Return the cycle's report as `backlog:next-issue` defines it, and make its **first line**
   the sentinel where there is one: `BACKLOG EMPTY` when the backlog holds no matching open
-  issues, `BLOCKED` when you stopped early, for any reason.
-- Do not soften, paraphrase or bury those two words. A blocked run reported as "I ran into
-  a small problem" reads to the caller as a successful iteration, and the loop then spends
-  its remaining iterations re-hitting the same wall.
+  issues, `BLOCKED` when you stopped early, for any reason, and `IN FLIGHT` when you are
+  handing control back with the cycle unfinished — a pull request open, the issue not closed.
+- Do not soften, paraphrase or bury those words. A blocked run reported as "I ran into a
+  small problem" reads to the caller as a successful iteration, and the loop then spends its
+  remaining iterations re-hitting the same wall. An unfinished run described without
+  `IN FLIGHT` reads the same way, and your caller then starts a fresh iteration over your
+  open pull request, leaving it and its worktree behind for good.
+- `IN FLIGHT` is not a softer `BLOCKED`. Use it when the cycle can be picked up exactly where
+  it stands, and name the issue, the pull request and the gate you had reached; use `BLOCKED`
+  when it needs a person.
 - On a completed iteration, name the issue number and title, the pull request number and
   URL, the check result, whether the pull request reached `MERGED`, and whether Copilot
   reviewed — or, when `review.required` is `false`, say plainly that the pull request merged

--- a/plugins/backlog/scripts/await-checks.sh
+++ b/plugins/backlog/scripts/await-checks.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# await-checks.sh — wait for a pull request's checks to settle, bounded.
+#
+# Usage: await-checks.sh <pr-number>
+#        await-checks.sh --classify        # classify a checks JSON array on stdin
+#
+# Why this is a script and not `gh pr checks --watch`.
+#
+# `--watch` blocks for as long as CI takes and has no bound of its own, which
+# left the cycle two bad options. Run it in the foreground and the call can die
+# mid-wait — and a wait that never finished looks exactly like a pull request
+# whose checks failed. Hand it to a background wait instead and the result
+# arrives after the turn that armed it, which is the failure that deadlocked the
+# loop: the worker of `backlog:run-backlog` ends its turn by RETURNING to its
+# caller, so a wait reporting after the turn reports to nobody, and the resumed
+# worker holds for an event that can never arrive.
+#
+# So the wait is bounded here instead, and "not finished yet" is an exit code
+# rather than a killed process. Re-running resumes it — the state lives on
+# GitHub and this only reads it — so a caller loops on exit 2 within one turn
+# instead of waiting across turns.
+#
+# The classification is fail-fast for the same reason `--fail-fast` was: a red
+# check does not turn green, and a red one sitting beside a pending one must not
+# read as "still waiting". `--classify` exposes exactly that decision on stdin,
+# with no network, which is what `await-checks_test.sh` exercises.
+#
+# Exit codes:
+#   0  every check has settled and none failed; stdout lists them
+#   1  a check failed or was cancelled; stdout names it, with its link
+#   2  checks are still running after the bound — re-run to keep waiting
+#   3  no checks were ever reported: nothing gates this pull request
+#   4  usage or precondition failure
+
+set -uo pipefail
+
+POLL_COUNT=${BACKLOG_CHECKS_POLL_COUNT:-20}
+POLL_SECONDS=${BACKLOG_CHECKS_POLL_SECONDS:-15}
+
+fail() { local code=$1; shift; printf 'await-checks: %s\n' "$*" >&2; exit "$code"; }
+
+command -v jq >/dev/null 2>&1 || fail 4 "jq is not on PATH"
+
+# ------------------------------------------------------------ classifying -----
+# One array of checks in, one verdict out. Prints the checks it is reporting on.
+#
+#   0  settled, none failed
+#   1  at least one failed or was cancelled — printed, and nothing else is
+#   2  at least one still pending, none failed
+#   3  nothing to classify: no checks in the input, or it is not an array
+classify() { # <checks json>
+  local json=$1 bad
+
+  printf '%s' "$json" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1 || return 3
+
+  bad=$(printf '%s' "$json" \
+    | jq -r '.[] | select(.bucket == "fail" or .bucket == "cancel") | "\(.bucket)  \(.name)  \(.link // "")"')
+  if [ -n "$bad" ]; then
+    printf '%s\n' "$bad"
+    return 1
+  fi
+
+  printf '%s' "$json" | jq -e 'all(.[]; .bucket != "pending")' >/dev/null 2>&1 || return 2
+
+  printf '%s' "$json" | jq -r '.[] | "\(.bucket)  \(.name)  \(.link // "")"'
+  return 0
+}
+
+if [ "${1:-}" = --classify ]; then
+  [ $# -eq 1 ] || fail 4 "usage: await-checks.sh --classify  (JSON on stdin)"
+  classify "$(cat)"
+  exit $?
+fi
+
+# ---------------------------------------------------------------- waiting -----
+[ $# -eq 1 ] || fail 4 "usage: await-checks.sh <pr-number>"
+PR=$1
+case "$PR" in ''|*[!0-9]*) fail 4 "pull request number must be an integer (got '$PR')" ;; esac
+
+command -v gh >/dev/null 2>&1 || fail 4 "gh is not on PATH"
+
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null) \
+  || fail 4 "cannot resolve the repository slug from gh"
+[ -n "$REPO" ] || fail 4 "cannot resolve the repository slug from gh"
+
+# Read the pull request once before polling. Without this a mistyped number
+# polls for the whole bound and then reports exit 3 — "nothing gates this pull
+# request" — which is a very wrong answer to give about a pull request that does
+# not exist.
+gh pr view "$PR" --repo "$REPO" --json number >/dev/null 2>&1 \
+  || fail 4 "cannot read PR #$PR in $REPO"
+
+# `gh pr checks` exits 8 while checks are pending and 1 when one has failed, so
+# its exit code says nothing about whether the READ succeeded. The JSON is the
+# thing to test, and classify() treats an empty or unparseable body as "not
+# reported yet" rather than as an answer.
+checks() {
+  gh pr checks "$PR" --repo "$REPO" --json name,bucket,state,link 2>/dev/null
+}
+
+seen=0
+for i in $(seq 1 "$POLL_COUNT"); do
+  report=$(classify "$(checks)")
+  case $? in
+    0) printf '%s\n' "$report"; exit 0 ;;
+    1) printf '%s\n' "$report"; fail 1 "a check on PR #$PR did not pass" ;;
+    2) seen=1 ;;
+  esac
+
+  [ "$i" -lt "$POLL_COUNT" ] && sleep "$POLL_SECONDS"
+done
+
+[ "$seen" -eq 1 ] \
+  || fail 3 "no checks reported on PR #$PR after $((POLL_COUNT * POLL_SECONDS))s; nothing gates this pull request"
+
+fail 2 "checks on PR #$PR are still running after $((POLL_COUNT * POLL_SECONDS))s; re-run to keep waiting"

--- a/plugins/backlog/scripts/await-checks_test.sh
+++ b/plugins/backlog/scripts/await-checks_test.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# await-checks_test.sh — the fixture corpus for await-checks.sh's classification.
+#
+# Every case is a `gh pr checks --json name,bucket,state,link` response, fed to
+# `--classify`, which is the whole of the script's judgment: everything else is
+# polling and a bound. Offline, no network.
+#
+# The cases that matter are the ones where a wrong verdict is invisible. A red
+# check sitting beside a pending one must classify as FAILED, not as "still
+# waiting" — the cycle labels a pull request for auto merge on the strength of
+# this exit code, so a failure read as pending is a wait that eventually times
+# out and gets re-run, and a failure read as settled is a merge.
+#
+# Run: plugins/backlog/scripts/await-checks_test.sh
+# Exit 0 when every case matches, 1 otherwise.
+
+set -uo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+SUT="$HERE/await-checks.sh"
+[ -x "$SUT" ] || { printf 'await-checks.sh is not executable at %s\n' "$SUT" >&2; exit 1; }
+
+pass=0
+fail=0
+
+# check <name> <expected exit> <expected stdout lines, or ''> <json>
+check() {
+  local name=$1 want=$2 want_out=$3 json=$4 got got_out
+  got_out=$(printf '%s' "$json" | "$SUT" --classify)
+  got=$?
+  local lines
+  lines=$(printf '%s\n' "$got_out" | grep -c .)
+  if [ "$got" = "$want" ] && { [ -z "$want_out" ] || [ "$lines" = "$want_out" ]; }; then
+    pass=$((pass + 1))
+    printf '  ok   %-58s [exit %s]\n' "$name" "$got"
+  else
+    fail=$((fail + 1))
+    printf '  FAIL %-58s want exit %s got %s\n' "$name" "$want" "$got"
+    printf '%s\n' "$got_out" | sed 's/^/         /'
+  fi
+}
+
+printf '\nsettled\n'
+
+check 'every check passed' 0 1 \
+'[{"name":"CI Gate","bucket":"pass","state":"SUCCESS","link":"l1"}]'
+
+# `skipping` is settled, not pending. The auto-merge workflow's own jobs are
+# routinely skipped, and a run where one of them is skipped is a green run.
+check 'a skipped check is settled' 0 2 \
+'[{"name":"CI Gate","bucket":"pass","state":"SUCCESS","link":"l1"},
+  {"name":"enable auto merge","bucket":"skipping","state":"","link":"l2"}]'
+
+printf '\nfailed — these must not read as pending or as settled\n'
+
+check 'a failed check' 1 1 \
+'[{"name":"CI Gate","bucket":"fail","state":"FAILURE","link":"l1"}]'
+
+# The one that would be invisible: `--fail-fast` existed because a red check
+# does not turn green, and waiting out its pending siblings buys nothing.
+check 'a failed check beside a pending one' 1 1 \
+'[{"name":"CI Gate","bucket":"fail","state":"FAILURE","link":"l1"},
+  {"name":"tests","bucket":"pending","state":"","link":"l2"}]'
+
+check 'a cancelled check counts as failed' 1 1 \
+'[{"name":"CI Gate","bucket":"cancel","state":"CANCELLED","link":"l1"},
+  {"name":"tests","bucket":"pass","state":"SUCCESS","link":"l2"}]'
+
+check 'only the failures are printed' 1 1 \
+'[{"name":"a","bucket":"pass","state":"SUCCESS","link":"l1"},
+  {"name":"b","bucket":"fail","state":"FAILURE","link":"l2"},
+  {"name":"c","bucket":"pass","state":"SUCCESS","link":"l3"}]'
+
+printf '\npending\n'
+
+check 'everything still running' 2 '' \
+'[{"name":"CI Gate","bucket":"pending","state":"","link":"l1"}]'
+
+check 'one still running among green ones' 2 '' \
+'[{"name":"a","bucket":"pass","state":"SUCCESS","link":"l1"},
+  {"name":"b","bucket":"pending","state":"","link":"l2"}]'
+
+printf '\nnothing to classify — the caller keeps polling, it does not conclude\n'
+
+# `gh pr checks` prints nothing at all on a branch with no workflows, and the
+# runs queue for a few seconds after a push, so "no checks" is a state the poll
+# loop passes through on the way to a perfectly ordinary green run. It becomes
+# exit 3 only when the bound is up.
+check 'no checks reported' 3 '' '[]'
+check 'gh printed nothing' 3 '' ''
+check 'gh printed an error rather than JSON' 3 '' 'no checks reported on the branch'
+check 'an object rather than an array' 3 '' '{"message":"Not Found"}'
+
+printf '\nusage\n'
+
+usage_check() { # <name> <expected exit> <args...>
+  local name=$1 want=$2; shift 2
+  "$SUT" "$@" >/dev/null 2>&1
+  local got=$?
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1)); printf '  ok   %-58s [exit %s]\n' "$name" "$got"
+  else
+    fail=$((fail + 1)); printf '  FAIL %-58s want exit %s got %s\n' "$name" "$want" "$got"
+  fi
+}
+
+usage_check 'no arguments' 4
+usage_check 'a pull request number that is not a number' 4 not-a-number
+usage_check '--classify takes no other argument' 4 --classify 12 </dev/null
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/plugins/backlog/scripts/await-review.sh
+++ b/plugins/backlog/scripts/await-review.sh
@@ -49,7 +49,11 @@
 
 set -uo pipefail
 
-POLL_COUNT=${BACKLOG_REVIEW_POLL_COUNT:-40}
+# Five minutes per call, deliberately: the caller waits by BLOCKING on this
+# script, so the bound has to fit inside a single foreground call rather than
+# span turns. Copilot routinely takes longer than that; exit 2 is the answer,
+# and the caller runs it again in the same turn.
+POLL_COUNT=${BACKLOG_REVIEW_POLL_COUNT:-20}
 POLL_SECONDS=${BACKLOG_REVIEW_POLL_SECONDS:-15}
 BOT_LOGIN='copilot-pull-request-reviewer[bot]'
 

--- a/plugins/backlog/scripts/finish-issue.sh
+++ b/plugins/backlog/scripts/finish-issue.sh
@@ -39,7 +39,11 @@
 
 set -uo pipefail
 
-POLL_COUNT=${BACKLOG_MERGE_POLL_COUNT:-40}
+# Five minutes per call, deliberately: the caller waits by BLOCKING on this
+# script, so the bound has to fit inside a single foreground call rather than
+# span turns. A merge queued behind a slow check takes longer; exit 2 is the
+# answer, and the caller runs it again in the same turn.
+POLL_COUNT=${BACKLOG_MERGE_POLL_COUNT:-20}
 POLL_SECONDS=${BACKLOG_MERGE_POLL_SECONDS:-15}
 
 fail() { local code=$1; shift; printf 'finish-issue: %s\n' "$*" >&2; exit "$code"; }

--- a/plugins/backlog/skills/next-issue/SKILL.md
+++ b/plugins/backlog/skills/next-issue/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: next-issue
 description: Take exactly one eligible story issue from the backlog through the full development cycle — select it, branch a worktree, implement the acceptance criteria, run the repository's verify commands, open a pull request, wait for checks, get a Copilot review and answer it, then label the pull request for GitHub to auto merge, close the issue and clean up. Use this whenever the user asks to "work the backlog", "take the next issue", "do the next story", "pick up the next ticket", or runs the backlog loop; it is also what the `issue-worker` agent invokes on every iteration of `backlog:run-backlog`. Everything repository-specific comes from `.claude/backlog.json`. Skip this when the user names a specific issue to explore rather than to land, or when they want the backlog bootstrapped rather than worked — that is `backlog:setup-backlog`.
-allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Monitor, TaskCreate, TaskUpdate, EnterWorktree, ExitWorktree
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, TaskCreate, TaskUpdate, EnterWorktree, ExitWorktree
 ---
 
 # next-issue
@@ -308,77 +308,92 @@ closes the issue explicitly. Running it here is what separates those two failure
 that never formed from a link nothing honoured — instead of leaving them to look identical
 ten minutes later.
 
-## 6. Wait for checks
+## 6. Wait for checks — one call, and then another if it is not finished
 
-Pass this as the `command` of a `Monitor` call:
+The wait is an ordinary **blocking `Bash` call**. Its result comes back in that same call:
 
 ```
-gh pr checks <pr> --repo <repo> --watch --fail-fast
+"${CLAUDE_PLUGIN_ROOT}/scripts/await-checks.sh" <pr>
 ```
 
-**Not to Bash.** `--watch` blocks until every check finishes, which on a repository with real
-CI outlasts the Bash tool — the call is killed mid-wait, and a wait that never finished looks
-exactly like a pull request whose checks failed. Every wait in this cycle goes through
-`Monitor` for that reason; step 7 and step 10 are the same.
+Give the Bash tool a `timeout` of `330000`. The script bounds itself at five minutes, so that
+number only has to outlive it.
 
-Set `timeout_ms` to cover the monitored command's own wait. It defaults to five minutes,
-while the scripts steps 7 and 10 monitor wait up to ten, so `660000` covers every wait in
-this cycle with room to spare. A monitor killed halfway through a wait that would have
-succeeded reads as a failed wait.
+| exit | meaning | what you do |
+| --- | --- | --- |
+| 0 | every check has settled and none failed | continue to step 7 |
+| 1 | a check failed or was cancelled; stdout names it with its link | read the logs (`gh run view <id> --log-failed`), fix, push, and wait again. After **three** failed attempts on the same root cause, stop and report instead of looping |
+| 2 | still running when the five minutes were up | **run the same command again.** Nothing failed and nothing was lost — the script only reads GitHub. Each re-run is one more tool call in the turn you are already in. After six consecutive 2s — half an hour of checks that will not settle — stop and report `BLOCKED` naming the pull request |
+| 3 | no checks were ever reported | nothing gates this pull request. Record `no checks reported` in the report and continue — do not silently treat it as a pass. This is the same gap `backlog:setup-backlog` reports when the default branch has no required status check, seen from the other side: with no required check, the label in step 9 merges the pull request the instant it lands |
+| 4 | usage or precondition failure | `BLOCKED`; the plugin or the environment is wrong, not the pull request |
 
-### Waiting is not something you do
+Exit 2 is the normal case on a repository with real CI, and it is **not** a failure to be
+reported, retried differently, or worked around. It is the wait saying "ask again".
 
-This is the first of the cycle's three waits, and the rule is the same for all of them.
+The verdict the script gives is not one you should second-guess by reading the checks
+yourself: a failed check beside a still-pending one is exit 1, not exit 2, and a `skipping`
+check is settled rather than outstanding. `scripts/await-checks_test.sh` is the offline
+fixture corpus for those rules; a change to them belongs there, not here.
 
-A `Monitor` call is the wait. Its result comes back to you on its own — the command's output
-arrives as notifications and its exit is reported when it ends — so there is nothing to
-collect, nothing to check, and nothing you can do that makes it arrive sooner. Once the wait
-is armed, **your turn is over.** The next thing you do is read what came back.
+### How to wait — and the three ways not to
 
-Two improvisations have been measured on real runs, and both are forbidden by name:
+This is the first of the cycle's three long waits; step 7 and step 10 have the same shape and
+the same exit-2 contract. One rule covers all three: **the wait's result must come back inside
+the call that started it.** Everything below follows from that.
 
-- **No no-op `sleep` Bash calls to pass the time.** `sleep 0.5; echo ok` and its variants
-  advance nothing — the monitored command is a separate process and it is not waiting on you
-  — while each one costs a full assistant turn. One measured iteration spent 106 turns, about
-  a quarter of its entire token cost, on that loop to buy under a minute of real waiting; the
-  two iterations either side of it spent 0 and 2.
-- **No peeking.** Do not `Read`, `cat` or `tail` a wait's output file, log or task record to
-  see how a `Monitor` that has not reported yet is getting on, and do not re-run the
-  underlying command by hand to check on it. Its output reaches you in full when it ends.
+- **Not `Monitor`.** A `Monitor` call reports through notifications that arrive *after* the
+  turn that armed it. Run interactively, that works. Run the way this cycle almost always runs
+  — as `backlog:run-backlog`'s `issue-worker` subagent — and it deadlocks: your next message
+  is your **return value**, so ending the turn with a wait armed ends the agent, and the wait
+  dies with it. You are then resumed believing a wait is live, hold for an event that can never
+  arrive, and do nothing. Measured on a real run: one iteration needed thirteen resume nudges
+  at 178–192k tokens each — about 2.4M tokens against a 300–375k band — and one of those
+  resumes made zero tool calls in 6.5 seconds while CI had been green for some time. `Monitor`
+  is not in this skill's `allowed-tools`, and that is the fix rather than a restriction to
+  route around.
+- **Not `run_in_background`.** Same defect — the result lands after the turn — plus one of its
+  own: it has been observed exiting immediately without ever polling, reporting whatever the
+  first sample happened to be as though the wait had completed.
+- **Not turns of your own.** No no-op `sleep` Bash calls to pass the time, and no peeking:
+  do not `Read`, `cat` or `tail` a log, output file or task record to see how a wait is
+  getting on, and do not re-run the underlying `gh` command by hand alongside one. A blocking
+  call leaves nothing to peek at while it runs, so what this forbids is the temptation *after*
+  an exit 2 — polling by hand instead of simply calling the wait again. One measured iteration
+  spent 106 turns, about a quarter of its entire token cost, on that loop to buy under a
+  minute of real waiting; the two iterations either side of it spent 0 and 2.
 
-The `Bash` tool's own description states the same rule from the other side: *foreground
-`sleep` is blocked; use `Monitor` with an until-loop to wait on a condition.*
+Where a wait needs a precondition, the precondition goes **inside** the waiting command, never
+into a turn of yours — `until <precondition>; do sleep 5; done; <blocking command>` is the
+sanctioned shape, and the three scripts already do it for you. That is also why the `Bash`
+tool's ban on foreground `sleep` is not violated here: the sleeps are inside a bounded command
+that is doing the waiting, not calls of yours that pass the time.
 
-And do **not** reach for Bash `run_in_background` when a wait feels unreliable. It is not a
-more observable `Monitor`; it is a wait that has been observed exiting immediately without
-ever polling, reporting whatever the first sample happened to be as though the wait had
-completed. `Monitor` is the tool that actually waits. Where a wait needs a precondition, the
-precondition goes inside the monitored command — see `no checks reported` below — never into
-a turn of your own.
+### If you are resumed mid-cycle
 
-- Exit 0 → green, continue.
-- Failure → read the logs (`gh run view <id> --log-failed`), fix, push, and re-watch. After
-  **three** failed attempts on the same root cause, stop and report instead of looping.
-- `no checks reported` → most often the workflows have not been created yet; runs queue for a
-  few seconds after a push. Do not re-check by hand and do not sleep between checks. Put the
-  precondition inside the `Monitor` command, so one call waits for the checks to appear and
-  then watches them:
+You should never hand control back with a gate unresolved — the blocking calls above are what
+make that avoidable. If it happens anyway and you find yourself resumed partway through the
+cycle, then **nothing is running on your behalf.** Any wait from an earlier turn has already
+returned or died with that turn; there is no event still coming, and no amount of holding will
+produce one.
 
-  ```
-  until gh pr checks <pr> --repo <repo> >/dev/null 2>&1; do sleep 5; done; gh pr checks <pr> --repo <repo> --watch --fail-fast
-  ```
+So do not hold, and do not report that you are waiting. Make **one** direct status query for
+the gate you had reached —
 
-  `until <precondition>; do sleep 5; done; <blocking command>` is the sanctioned shape for
-  every "wait for X to exist, then wait for X to finish" in this cycle. The `sleep` is inside
-  the monitored command rather than in a turn of yours, and the whole wait costs one call.
-  `timeout_ms` bounds it, so a precondition that never becomes true ends the monitor instead
-  of hanging the cycle.
+```
+"${CLAUDE_PLUGIN_ROOT}/scripts/await-checks.sh" <pr>          # step 6
+"${CLAUDE_PLUGIN_ROOT}/scripts/await-review.sh" <pr>          # step 7 — idempotent
+gh pr view <pr> --repo <repo> --json state,autoMergeRequest   # step 9
+"${CLAUDE_PLUGIN_ROOT}/scripts/finish-issue.sh" <n> <pr> issue-<n>   # step 10 — guarded
+```
 
-  If that call ends with the checks still unreported, nothing gates this pull request. Do not
-  silently treat it as a pass: record `no checks reported` in the report and continue. This is
-  the same gap `backlog:setup-backlog` reports when the default branch has no required status
-  check, seen from the other side — with no required check, the label in step 9 merges the
-  pull request the instant it lands.
+The three scripts are the query as well as the wait: each reads the current state first and
+returns immediately when the gate has already settled, so re-entering one costs a moment, not
+five minutes.
+
+— act on what it says, and if the gate is genuinely still pending, start the wait again with
+the blocking call. The no-polling rule above is about not polling *alongside* a live wait;
+with no wait running, that single query is exactly the right move, and doing nothing is the
+one response that cannot be right.
 
 ## 7. The Copilot review — one call
 
@@ -386,21 +401,21 @@ a turn of your own.
 Nothing here is optional when it is `true`.
 
 Requesting the review, waiting for it, and deciding whether what landed *is* a review are one
-call. Pass it as the `command` of a `Monitor` call with `timeout_ms` of `660000` — the wait
-runs up to ten minutes, past both the Bash tool's ceiling and `Monitor`'s default — and not to
-Bash with `run_in_background`. This is the longest wait in the cycle and the one that has
-attracted busy-waiting; step 6's rule holds unchanged here. Arm it, end your turn, and read
-the exit code when it arrives:
+call — a blocking `Bash` call, the same shape as step 6's, with the Bash tool's `timeout` set
+to `330000` and the script bounding itself at five minutes:
 
 ```
 "${CLAUDE_PLUGIN_ROOT}/scripts/await-review.sh" <pr>
 ```
 
+This is the longest wait in the cycle and the one that has attracted busy-waiting. Step 6's
+rules hold here unchanged: not `Monitor`, not `run_in_background`, and not turns of your own.
+
 | exit | meaning | what you do |
 | --- | --- | --- |
 | 0 | a review **completed** — it left comments, or reported it generated none. stdout is its body | continue to step 8 |
 | 1 | the most recent review **declined** the work; stdout is why | `BLOCKED`, and do **not** label. If it is the 300-file limit, say so and suggest how the work could be split |
-| 2 | timed out waiting | re-run it; it resumes. If it times out again, `BLOCKED` |
+| 2 | the five minutes were up with no review yet | **run it again**, in the same turn. It resumes: a review already requested is not requested twice, and one already posted is classified immediately. Copilot routinely takes longer than one call, so this is the expected outcome, not a fault. After four re-runs — about twenty minutes with nothing posted — `BLOCKED` |
 | 3 | the review could not be requested — Copilot code review is probably not enabled for this organisation | `BLOCKED`, naming that |
 | 4 | usage or precondition failure | `BLOCKED`; the plugin or the environment is wrong, not the pull request |
 
@@ -446,7 +461,8 @@ newer completed review is not misread.
 Every finding above is a reason the wait is *inside* a script rather than in your hands. None
 of them is a reason to look in on the script while it runs — a review that has not landed yet
 reads exactly like one that never will, from your side, and the script is the thing that can
-tell those apart. Re-run it after an exit 2; do not check on it before one.
+tell those apart. Re-run it after an exit 2; do not go looking at the review endpoints in
+between.
 
 ## 8. Address the review
 
@@ -552,29 +568,28 @@ gh run list --repo <repo> --workflow <merge.workflow> --branch issue-<n> --limit
 that workflow in the whole repository — anyone labelling another pull request while yours is
 queued hands you their result, and it reads as a verdict on yours.
 
-If it has not completed, waiting for it is a `Monitor` call in the form step 6 gives, not a
-sequence of Bash calls of your own:
+If it has not completed, **do not build a wait of your own for it** — no sleeps, no polling
+loop in turns of yours. Step 10 is a bounded wait for the merge itself, which is the outcome
+this run is only a proxy for: go there and read its exit code. Come back here if it exits 2
+more than twice — then read the run list once more, and its conclusion is the answer:
 
 ```
-until [ "$(gh run list --repo <repo> --workflow <merge.workflow> --branch issue-<n> --limit 1 --json status --jq '.[0].status // ""')" = completed ]; do sleep 5; done
-gh run list --repo <repo> --workflow <merge.workflow> --branch issue-<n> --limit 1 --json conclusion --jq '.[0].conclusion'
+gh run list --repo <repo> --workflow <merge.workflow> --branch issue-<n> --limit 1 --json status,conclusion
 ```
 
-A `success` conclusion with the pull
-request still open means auto merge is armed and waiting on a check. A `failure` conclusion
-means the workflow itself is broken — report it, with the output of
-`gh run view <id> --log-failed`, rather than falling back to a manual merge, which is what
-this whole step exists to avoid.
+A `success` conclusion with the pull request still open means auto merge is armed and waiting
+on a check. A `failure` conclusion means the workflow itself is broken — report it, with the
+output of `gh run view <id> --log-failed`, rather than falling back to a manual merge, which
+is what this whole step exists to avoid.
 
 ## 10. Finish — one call
 
 Everything after the label is mechanism, not judgment: wait for the merge, close the issue,
-verify it closed, drop the worktree, delete the local branch. Run it as one script rather
-than as five steps. Pass it as the `command` of a `Monitor` call with `timeout_ms` of
-`660000` — the wait runs up to ten minutes, past both the Bash tool's ceiling and `Monitor`'s
-default — and not to Bash with `run_in_background`. Step 6's rule holds here too: arm it, end
-your turn, and read the exit code when it arrives. Do not sleep, and do not read the pull
-request or the worktree to see how far it has got.
+verify it closed, drop the worktree, delete the local branch. Run it as one script rather than
+as five steps — a blocking `Bash` call with the tool's `timeout` set to `330000`, the script
+bounding itself at five minutes. Step 6's rules hold here too: not `Monitor`, not
+`run_in_background`, no sleeps of your own, and no reading the pull request or the worktree to
+see how far it has got.
 
 ```
 "${CLAUDE_PLUGIN_ROOT}/scripts/finish-issue.sh" <n> <pr> issue-<n>
@@ -586,7 +601,7 @@ Read its exit code. It is the assertion, and each value means one thing:
 | --- | --- | --- |
 | 0 | merged, issue confirmed `CLOSED`, local cleanup done | continue to the report |
 | 1 | the pull request closed without merging | `BLOCKED`, naming the pull request |
-| 2 | timed out waiting for the merge | re-run it; it resumes. If it times out again with nothing running, `BLOCKED` |
+| 2 | the five minutes were up and the merge had not landed | **run it again**, in the same turn; every step is guarded, so it resumes. After three re-runs — a quarter of an hour with the pull request still open — go back to step 9's run list to find out why, and `BLOCKED` if nothing is running |
 | 3 | the issue would not close | `BLOCKED` — this is the one that makes the next iteration redo merged work |
 | 4 | usage or precondition failure | `BLOCKED`; the plugin or the environment is wrong, not the pull request |
 
@@ -645,7 +660,8 @@ Running interactively without the plugin root set, do the same five things by ha
 order, and check the state after the close rather than assuming it:
 
 ```
-# 1. wait for MERGED (Monitor); CLOSED without merging and a timeout are both failures
+# 1. wait for MERGED, bounded and in the foreground; CLOSED without merging is a failure,
+#    and a bound reached is "call it again", not "it failed"
 # 2. gh issue view <n> --repo <repo> --json state -q .state
 # 3. if OPEN: gh issue close <n> --repo <repo> --comment "Implemented in #<pr>, merged as <sha>."
 # 4. re-read the state and confirm CLOSED
@@ -682,6 +698,24 @@ scoped backlog says nothing about the rest of it.
 
 If you stopped early, say exactly where and why, beginning the report with `BLOCKED`.
 
+### If you have to hand back control unfinished
+
+Sometimes control goes back to your caller with the cycle still running — you ran out of room,
+or something outside the cycle interrupted you. That is neither a block nor a finished
+iteration, and it has its own first line:
+
+> `IN FLIGHT` — issue #<n>, PR #<pr>, stopped at step <k> waiting for <the gate>.
+
+Then say what state you left behind: the branch, the worktree, whether the pull request is
+labelled. `backlog:run-backlog` reads that word and **resumes you** instead of starting a new
+iteration over your open pull request.
+
+Never leave a mid-cycle return unlabelled. A report that merely describes how far you got
+reads to the driver as a completed iteration, and the next iteration is then spawned over an
+unmerged pull request, with your worktree still on disk and the issue still open. And do not
+use `IN FLIGHT` where `BLOCKED` belongs: `IN FLIGHT` says the cycle can be picked up exactly
+where it stands, `BLOCKED` says it needs a person.
+
 ## Stop conditions
 
 Stop and report — do not push through — if any of these happen:
@@ -696,8 +730,12 @@ Stop and report — do not push through — if any of these happen:
 - Landing the pull request would require a force-push, a branch-protection override, or
   discarding someone else's commits.
 - `git status` in the main checkout is dirty with changes you did not make.
-- `review.required` is `true` and `await-review.sh` exited non-zero — the review declined,
-  timed out, or could not be requested.
+- `review.required` is `true` and `await-review.sh` exited 1 or 3 — the review declined, or
+  could not be requested at all.
+- A wait's exit 2 outlasts its re-run budget: six for `await-checks.sh`, four for
+  `await-review.sh`, three for `finish-issue.sh`. An exit 2 on its own is not a stop
+  condition — it is the wait asking to be called again, in the same turn — but a gate that
+  will not settle inside those budgets is a pull request that needs a person.
 
 When you stop for one of these, begin the report with `BLOCKED` so the caller can tell a
 halted cycle from a finished one at a glance. `backlog:run-backlog` halts the loop on that

--- a/plugins/backlog/skills/run-backlog/SKILL.md
+++ b/plugins/backlog/skills/run-backlog/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: run-backlog
 description: Drive a repository's story backlog unattended, one issue at a time, by spawning a fresh `issue-worker` subagent per iteration and halting on `BACKLOG EMPTY`, on `BLOCKED`, or at a bounded iteration count. Use this whenever the user wants the backlog worked continuously rather than a single issue — "run the backlog", "work through the issues", "keep taking stories until you run out", "drain the milestone", "work through the workspace-ci stories", "work the In Progress stories", or a `/loop` that repeats the cycle. Takes an optional integer argument setting the maximum number of iterations, and optional `--project-value <value>`, `--project-field <name>`, `--project-owner <login>` and `--project-number <n>` arguments restricting the whole run to one value of one single-select field on a GitHub project. Skip this when the user wants exactly one issue (`backlog:next-issue`) or wants the repository bootstrapped first (`backlog:setup-backlog`).
-allowed-tools: Agent, Bash, Read, Glob, Grep, TaskCreate, TaskUpdate, ScheduleWakeup
+allowed-tools: Agent, SendMessage, Bash, Read, Glob, Grep, TaskCreate, TaskUpdate, ScheduleWakeup
 ---
 
 # run-backlog
@@ -129,7 +129,8 @@ Read the worker's final message and act on its first line:
 | --- | --- |
 | `BACKLOG EMPTY` | **Halt.** The backlog holds no matching open issues. This is success, not failure. Under a scope it means *that scope* is drained, and the rest of the backlog is untouched — say which. |
 | `BLOCKED …` | **Halt.** Report the worker's reason verbatim. |
-| anything else | Record a one-line outcome and continue to the next iteration. |
+| `IN FLIGHT …` | **Resume that same worker.** Its issue is unfinished and its pull request is open; do not start the next iteration. See below. |
+| anything else | The iteration finished. Record a one-line outcome and continue to the next one. |
 
 Also halt if:
 
@@ -141,9 +142,40 @@ Also halt if:
 - The bound is reached. Say so plainly: a loop that stopped at its bound with work left is a
   different outcome from a drained backlog, and the user's next move differs.
 
-Record per iteration: issue number and title, pull request number, merged / blocked, and the
-token cost the agent result reports for that worker. Nothing else. Keep the running list
-short enough that you can still see all of it at the end.
+Record per iteration: issue number and title, pull request number, merged / blocked, how many
+times the worker had to be resumed, and the token cost the agent result reports for that
+worker. Nothing else. Keep the running list short enough that you can still see all of it at
+the end.
+
+### A worker that comes back mid-cycle
+
+`IN FLIGHT` is the worker saying it handed control back with its issue unfinished: a pull
+request open, a worktree on disk, the issue not closed. It is not an empty backlog, it is not
+a block, and it is not a finished iteration. The three-branch table above used to have no row
+for it, so the driver recorded an outcome and spawned the next iteration — **abandoning an
+open pull request**, with nothing in the run pointing at what happened.
+
+Resume the **same** worker. A fresh one would select a different issue and leave the first
+one's pull request open for good:
+
+```
+SendMessage(
+  <the worker's agent id or name>,
+  "Continue the cycle from where you stopped. Nothing is running on your behalf — any wait
+   from your last turn is over. Query the gate you had reached once, act on what it says,
+   and finish the iteration."
+)
+```
+
+A resume does **not** consume an iteration of the bound; no new issue was taken. It is not
+free either — it re-costs the worker's whole context, 178–192k tokens on the runs this was
+measured on — so allow **two** resumes for one worker. If it comes back `IN FLIGHT` a third
+time, halt and report `BLOCKED` naming the issue, the pull request and the gate it could not
+get past: something is wrong that a fourth nudge will not fix.
+
+A worker that returns mid-cycle *without* the sentinel is the same situation with the label
+missing. If a report names a pull request that never reached `MERGED` and does not begin
+`BLOCKED`, treat it as `IN FLIGHT` — resume it — rather than as a completed iteration.
 
 ### What an iteration should cost
 
@@ -151,19 +183,28 @@ A worker that takes one story from selection to a merged pull request costs roug
 **300–375k tokens** and 300–390 assistant turns, at about a thousand tokens a turn. Three
 consecutive iterations measured against a real repository came in at 370k / 346k / 405k.
 
-The third one did not do more work. It **busy-waited**: filled the time while a `Monitor`
-wait was outstanding with no-op `sleep` Bash calls and with reads of the wait's output file,
-106 turns of them out of 419 — about 100k tokens, a quarter of the iteration, spent to buy
-under a minute of real waiting. The two either side of it spent 0 and 2 turns that way on
-comparable work, and nothing in the three reports distinguished them.
+An iteration far outside that band is almost always about *how it waited*, and there are two
+**opposite** failures that land in the same place. Their remedies contradict each other, so it
+is worth saying which one you saw rather than just that the iteration was expensive.
 
-So an iteration well past the band is a wait that was watched rather than an issue that was
-large.
+- **It watched the wait.** The worker filled the time while a wait was outstanding with no-op
+  `sleep` calls and re-reads of the wait's output file — 106 turns out of 419 on one measured
+  iteration, about 100k tokens, a quarter of it, to buy under a minute of real waiting. The
+  iterations either side spent 0 and 2 turns that way on comparable work. Signature: a very
+  high turn count for the work done, inside a single worker. Remedy: **fewer** turns.
+- **It stopped dead at the wait.** The worker armed a wait that did not survive the turn
+  boundary, handed control back, and on resume held for an event that could never arrive. One
+  measured resume made **zero tool calls in 6.5 seconds** while CI had been green for some
+  time; that iteration needed thirteen resume nudges at 178–192k tokens each — about 2.4M
+  tokens — and it did eventually merge, which is what makes it easy to miss. Signature: many
+  resumes, each costing a full context, several of them doing almost nothing. Remedy: the
+  opposite one — **act**, with a single direct status query, exactly where the first failure
+  says to do nothing.
 
-`backlog:next-issue` forbids both improvisations by name at step 6 and `issue-worker` repeats
-the rule, so a worker doing it is a worker that departed from the cycle. Name it in the
-report when the table shows it: the iteration count and the outcomes look identical either
-way, and the cost column is the only place a run that regressed is visible.
+Both are departures from the cycle. `backlog:next-issue` step 6 addresses each by name, and
+the second is why `Monitor` is not in the worker's tools at all. Name whichever the table
+shows: the iteration count and the outcomes look identical either way, and the cost and resume
+columns are the only place a run that regressed is visible.
 
 ## 2. What you never do yourself
 
@@ -175,6 +216,10 @@ way, and the cost column is the only place a run that regressed is visible.
   by hand, halt and say so — the next spawn is likely to fail regardless.
 - **Never implement the issue in your own context** when the worker reports `BLOCKED`. The
   block is a request for a human, which is the one thing a loop cannot supply.
+- **Never spawn the next iteration over an open pull request.** A worker that came back with
+  its issue unfinished gets resumed, not replaced. The new worker would take a different
+  issue, and the first one's pull request, worktree and open issue would be left behind with
+  no one holding them.
 - **Never widen the bound mid-run** because the backlog turned out to be longer. Finish,
   report, and let the user re-run.
 - **Never drop, widen or edit any part of the scope mid-run**, and never respond to a worker
@@ -191,7 +236,8 @@ way, and the cost column is the only place a run that regressed is visible.
 ## 3. Report
 
 Close with the iteration table, the scope the run was under if it had one, the reason the
-loop stopped in its own words (`BACKLOG EMPTY`, `BLOCKED`, bound reached, worker failure),
+loop stopped in its own words (`BACKLOG EMPTY`, `BLOCKED`, bound reached, worker failure,
+a worker that could not be got past `IN FLIGHT`),
 and — if anything merged without a review because `review.required` is `false` — that fact,
 once, for the whole run.
 

--- a/plugins/backlog/skills/setup-backlog/SKILL.md
+++ b/plugins/backlog/skills/setup-backlog/SKILL.md
@@ -369,8 +369,8 @@ Core list, language-agnostic:
 {
   "permissions": {
     "allow": [
-      "Read", "Glob", "Grep", "Agent", "Skill",
-      "Monitor", "TaskCreate", "TaskUpdate", "ScheduleWakeup",
+      "Read", "Glob", "Grep", "Agent", "Skill", "SendMessage",
+      "TaskCreate", "TaskUpdate", "ScheduleWakeup",
       "EnterWorktree", "ExitWorktree",
       "Edit(**)",
       "Bash(git status*)", "Bash(git diff*)", "Bash(git log*)", "Bash(git show*)",


### PR DESCRIPTION
Closes #345

## What was wrong

A worker that armed a `Monitor` and ended its turn deadlocked. A monitor reports *after* the turn that armed it; an `issue-worker` subagent ends its turn by **returning** to its caller, so the wait died with the agent and the resumed worker held for an event that could never arrive. Step 6's no-polling rule — correct while a wait is live, but stated unconditionally — then stopped it recovering by hand. One measured iteration cost ~2.4M tokens across thirteen resume nudges against a 300–375k band, and one resume did zero tool calls in 6.5s while CI had been green for some time.

The driver had no rule for a worker returning mid-cycle either: following its three-branch table literally, it would record an outcome and spawn the next iteration over an open, unmerged pull request.

## What changed

**1. Waits finish inside the call that starts them** (the root cause). All three long waits are now bounded, blocking `Bash` calls sharing one contract: **exit 2 means "not finished, call me again"**, in the same turn.

- New `scripts/await-checks.sh` replaces `gh pr checks --watch` — `0 settled / 1 failed / 2 still running / 3 no checks reported / 4 usage`, self-bounded at five minutes.
- `await-review.sh` and `finish-issue.sh` drop from a ten-minute to a five-minute bound, so each fits one foreground call. Both were already resumable; that is what makes exit 2 cheap.
- Step 9's merge-workflow wait is gone: step 10 is already a bounded wait for the merge itself.

**2. `Monitor` is structurally unavailable** — removed from `next-issue`'s `allowed-tools` and from `issue-worker`'s `tools`, rather than forbidden in prose. Note this does not undo #336: busy-waiting is still forbidden, and the two rules are now stated as the pair they are.

**3. The step-6 rule is scoped to a live wait.** "Do not poll *alongside* a wait" — and a new "If you are resumed mid-cycle" section says plainly that any wait from an earlier turn is over, that a single direct status query is then the correct move, and that doing nothing is the one response that cannot be right.

**4. The driver gets its fourth branch.** A worker returning mid-cycle reports `IN FLIGHT` and is **resumed** via `SendMessage`, capped at two resumes before `BLOCKED` — never replaced by a new iteration over its open pull request. A mid-cycle return without the sentinel is treated the same way.

**5. The two over-band causes are separated** in `run-backlog`'s cost section — a wait that was *watched* (too many turns) and a wait that was *abandoned* (too many resumes doing nothing) — because the remedies contradict each other.

`plugins/backlog` version 0.3.0 → 0.4.0, without which none of this reaches an installed copy.

## Verified

- `plugins/backlog/scripts/await-checks_test.sh` — 15 offline fixture cases, all passing. The ones that matter: a failed check beside a pending one classifies as **failed**, `skipping` counts as settled, and an empty or unparseable read is "not reported yet" rather than an answer.
- `plugins/backlog/scripts/select-issue_test.sh` — 62 passed, 0 failed (unchanged, checked for collateral).
- `await-checks.sh` run live against merged PR #344: exit 0, ten checks listed. Bogus PR number → exit 4 rather than a five-minute wait ending in "nothing gates this pull request".

## Judgment calls

- **Blocking `Bash` over `Monitor`, for both callers.** Two paths (monitor interactively, blocking under the worker) would have doubled the prose the model has to disambiguate at exactly the point it has already been shown to get it wrong. A blocking call is correct in both contexts; interactively it costs a foreground wait of at most five minutes.
- **Five-minute bounds, not ten.** A wait has to fit inside one foreground call with headroom, and exit 2 is cheap — one more tool call in a turn already in progress.
- **`IN FLIGHT` as a third sentinel** rather than having the driver infer an unfinished iteration from the prose of a report. The driver's branch is mechanical; the fallback for an unlabelled mid-cycle return is documented too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)