### PR TITLE
story(issue-341): authenticate with credential helpers and token flows

### DIFF
--- a/daggerverse/oci/README.md
+++ b/daggerverse/oci/README.md
@@ -102,8 +102,9 @@ reg := dag.Oci().Registry("ghcr.io", dagger.OciRegistryOpts{
 The config is searched for the host actually dialled. Keys are matched the way
 Docker wrote them rather than literally: `ghcr.io`, `https://ghcr.io` and
 `https://ghcr.io/` are the same host, and Docker Hub is found under any of
-`docker.io`, `index.docker.io`, `registry-1.docker.io` and the legacy
-`https://index.docker.io/v1/`. Within an entry, `auth` (base64
+`docker.io`, `index.docker.io`, `registry-1.docker.io`,
+`registry.hub.docker.com` and the legacy `https://index.docker.io/v1/`. Within
+an entry, `auth` (base64
 `username:password`, padded or not), explicit `username`/`password`,
 `registrytoken` and `identitytoken` are all read.
 
@@ -147,7 +148,10 @@ credentials that lost the precedence contest and, for a Docker config, the
 entries for hosts this connection never dialled — the file arrived as one
 secret, so all of it is the caller's secret. A `auth` blob is scrubbed as well
 as the password inside it: base64 is not encryption, and the blob is the form
-the credential actually travels in.
+the credential actually travels in. Both encodings of that blob are scrubbed,
+padded and unpadded, because the blob that leaks need not be the blob that was
+written — anything rebuilding an `Authorization` header emits the padded form,
+which is a different string carrying the identical credential.
 
 A malformed config fails without quoting itself back, because `encoding/json`
 puts the offending input in its message and the offending input is a file full

--- a/daggerverse/oci/README.md
+++ b/daggerverse/oci/README.md
@@ -58,6 +58,8 @@ reg := dag.Oci().Registry("ghcr.io", dagger.OciRegistryOpts{
 | `host` | registry host, as it appears in an image reference. Ignored when `service` is set |
 | `username` | basic-auth user; omit for an anonymous client |
 | `password` | basic-auth secret |
+| `bearerToken` | a token to send as-is, for a registry that issued one |
+| `dockerConfig` | the contents of a `~/.docker/config.json`, as a secret |
 | `service` | a Dagger-hosted registry, reached over the session network |
 | `insecure` | talk plain HTTP and skip TLS verification. Off by default |
 
@@ -69,8 +71,90 @@ publish path this module replaces made that inference, which meant a test
 affordance decided production TLS behaviour. It is spelled `insecure` rather
 than `tlsVerify` because a `+default=true` bool is unsettable from the CLI.
 
-Password authentication only. Client certificates for mTLS registries, and
-credential-helper and token flows, are follow-ups.
+Client certificates for mTLS registries remain a follow-up.
+
+#### Credentials
+
+There are three ways to authenticate, and exactly one of them is used:
+
+1. **`username` / `password`.** The most specific thing a caller can say, and
+   the only source that names a user.
+2. **`bearerToken`.** Explicit, but it says nothing about which registry it is
+   for, so a caller who supplied a pair as well meant the pair.
+3. **`dockerConfig`.** A file describing many registries at once, so it is the
+   least specific and loses to anything aimed at this one.
+
+Supplying none of them is an anonymous client, which is what a public registry
+wants.
+
+A lower source is **not** consulted once a higher one has been supplied, and a
+401 does not fall through to the next. Retrying with a second credential would
+authenticate as somebody the caller did not choose, and would turn one wrong
+password into two failed attempts against a registry that may be counting
+them.
+
+```go
+reg := dag.Oci().Registry("ghcr.io", dagger.OciRegistryOpts{
+    DockerConfig: dag.SetSecret("docker-config", string(configJSON)),
+})
+```
+
+The config is searched for the host actually dialled. Keys are matched the way
+Docker wrote them rather than literally: `ghcr.io`, `https://ghcr.io` and
+`https://ghcr.io/` are the same host, and Docker Hub is found under any of
+`docker.io`, `index.docker.io`, `registry-1.docker.io` and the legacy
+`https://index.docker.io/v1/`. Within an entry, `auth` (base64
+`username:password`, padded or not), explicit `username`/`password`,
+`registrytoken` and `identitytoken` are all read.
+
+A config that says nothing about the host is not an error — it is a config
+about other registries, and the caller gets anonymous access, which is the
+same answer `docker pull` would give.
+
+#### Credential helpers are not supported
+
+**Credential helpers are not run.** A helper is an external
+`docker-credential-*` binary the Docker CLI executes, and the module runtime
+holds neither `gcloud`, nor `ecr-login`, nor a macOS keychain; reaching one
+would mean shelling out to a helper container, which is the one thing this
+module does not do anywhere.
+
+A config that resolves the bound host through a helper therefore **fails**,
+naming the binary it asked for:
+
+```
+docker config resolves ghcr.io through the credential helper
+docker-credential-gcloud, which this module cannot run: no helper binaries
+exist in the module runtime. Resolve the credential in the caller and pass it
+as username/password or bearerToken
+```
+
+Falling through to anonymous instead would turn "your credential lives
+somewhere I cannot reach" into an unrelated 401 from the registry, with
+nothing in the message pointing at the cause.
+
+This bites only when a helper owns *this* host. A `credsStore` beside an entry
+that already holds a credential loses to that credential, and a `credsStore`
+with no entry for this host is ignored — that is the ordinary shape of a
+config file on any machine where somebody has run `docker login`, and treating
+it as governing every host would break every anonymous pull.
+
+#### Credentials do not reach an error
+
+No credential value appears in an error leaving this module. Every plaintext
+read while resolving one is scrubbed out of the text first, including
+credentials that lost the precedence contest and, for a Docker config, the
+entries for hosts this connection never dialled — the file arrived as one
+secret, so all of it is the caller's secret. A `auth` blob is scrubbed as well
+as the password inside it: base64 is not encryption, and the blob is the form
+the credential actually travels in.
+
+A malformed config fails without quoting itself back, because `encoding/json`
+puts the offending input in its message and the offending input is a file full
+of passwords.
+
+Nothing here reaches a container argument either: the module builds no
+containers at all.
 
 ### PushImage
 
@@ -190,5 +274,18 @@ rather than about GHCR. `registry:2.8` has no such endpoint, and
 `registry:3.0.0` was measured here too and does not register the route either.
 `requireNativeReferrersAPI` keeps that a checked fact rather than a claim in a
 comment.
+
+The bearer-token tests put an nginx gate in front of an anonymous zot, because
+no registry in this repo's test estate issues bearer tokens — zot
+authenticates with htpasswd and nothing else. The gate refuses everything
+without one exact `Authorization: Bearer` header and answers its 401 with a
+`Bearer` challenge, which is what makes both client libraries send the token
+they were given rather than falling back to basic auth.
+
+`CredentialResolutionSelfTest` is a `+check` on the module itself rather than a
+test in `tests/`. It covers how a Docker config is *read* — key matching, entry
+forms, helper refusal, what a malformed file may say — none of which touches
+the network, and all of which would otherwise need a registry per case to
+assert on a string comparison.
 
 [zot]: https://zotregistry.dev/

--- a/daggerverse/oci/auth.go
+++ b/daggerverse/oci/auth.go
@@ -264,6 +264,16 @@ func dockerConfigSecrets(cfg dockerConfigFile) []string {
 		if err != nil {
 			continue
 		}
+		// Both canonical encodings of the same credential, because the blob
+		// that leaks need not be the blob that was written. An unpadded
+		// value in the file is re-encoded padded by anything that rebuilds
+		// the Authorization header, and that padded string is a different
+		// string carrying the identical credential — it would not match
+		// entry.Auth and would survive scrubbing. Whichever of the two the
+		// file already held is a harmless duplicate.
+		secrets = append(secrets,
+			base64.StdEncoding.EncodeToString([]byte(decoded)),
+			base64.RawStdEncoding.EncodeToString([]byte(decoded)))
 		if _, pass, ok := strings.Cut(decoded, ":"); ok {
 			secrets = append(secrets, pass)
 		}

--- a/daggerverse/oci/auth.go
+++ b/daggerverse/oci/auth.go
@@ -1,0 +1,296 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// credential is one registry credential, whichever source it came from.
+//
+// The four fields are the union of what the two client libraries accept:
+// go-containerregistry's authn.AuthConfig and oras' auth.Credential both
+// model basic auth, a bearer access token and a refresh (identity) token,
+// under different names. Holding the union here means precedence is decided
+// once, in one place, rather than once per library.
+type credential struct {
+	username     string
+	password     string
+	accessToken  string
+	refreshToken string
+}
+
+func (cred credential) empty() bool {
+	return cred.username == "" && cred.password == "" &&
+		cred.accessToken == "" && cred.refreshToken == ""
+}
+
+// secrets lists the plaintext values this credential carries, so scrub can
+// keep every one of them out of an error crossing the module boundary. The
+// username is not one: it is not secret, and redacting it would make an
+// authentication failure unreadable.
+func (cred credential) secrets() []string {
+	return []string{cred.password, cred.accessToken, cred.refreshToken}
+}
+
+// credential resolves the credential this connection will authenticate with,
+// along with every plaintext value read on the way — including values that
+// lost, so an error can be scrubbed of them too.
+//
+// Precedence, highest first:
+//
+//  1. username / password. The most specific thing a caller can say, and the
+//     only source that names a user.
+//  2. bearerToken. Explicit, but it says nothing about which registry it is
+//     for, so a caller who supplied a pair as well meant the pair.
+//  3. dockerConfig. A file describing many registries at once, so it is the
+//     least specific and loses to anything aimed at this one.
+//  4. anonymous.
+//
+// A lower source is not consulted once a higher one has been supplied, and in
+// particular a 401 does not fall through to the next. Retrying with a second
+// credential would authenticate as somebody the caller did not choose, and
+// would turn one wrong password into two failed attempts against a registry
+// that may be counting them.
+//
+// addr rather than Host is what the docker config is searched for: it is the
+// address actually dialled, so a Dagger-hosted registry is looked up under
+// the endpoint it was reached at. For every registry on the public network
+// the two are the same string.
+func (reg *Registry) credential(ctx context.Context, addr string) (credential, []string, error) {
+	switch {
+	case reg.Username != "" || reg.Password != nil:
+		cred := credential{username: reg.Username}
+		if reg.Password != nil {
+			pwd, err := reg.Password.Plaintext(ctx)
+			if err != nil {
+				return credential{}, nil, fmt.Errorf("read registry password: %v", err)
+			}
+			cred.password = pwd
+		}
+		return cred, cred.secrets(), nil
+
+	case reg.BearerToken != nil:
+		tok, err := reg.BearerToken.Plaintext(ctx)
+		if err != nil {
+			return credential{}, nil, fmt.Errorf("read registry bearer token: %v", err)
+		}
+		cred := credential{accessToken: tok}
+		return cred, cred.secrets(), nil
+
+	case reg.DockerConfig != nil:
+		raw, err := reg.DockerConfig.Plaintext(ctx)
+		if err != nil {
+			return credential{}, nil, fmt.Errorf("read docker config: %v", err)
+		}
+		return credentialFromDockerConfig(raw, addr)
+
+	default:
+		return credential{}, nil, nil
+	}
+}
+
+// dockerConfigFile is the slice of ~/.docker/config.json this module reads.
+// Everything else in that file — proxies, plugin settings, aliases — belongs
+// to the Docker CLI and means nothing to a registry client.
+type dockerConfigFile struct {
+	Auths       map[string]dockerAuthEntry `json:"auths"`
+	CredsStore  string                     `json:"credsStore"`
+	CredHelpers map[string]string          `json:"credHelpers"`
+}
+
+// dockerAuthEntry is one registry's entry under "auths".
+type dockerAuthEntry struct {
+	// Auth is base64("username:password"), which is what `docker login`
+	// writes when no credential store is configured.
+	Auth string `json:"auth"`
+	// Username and Password are the unencoded form some tools write instead.
+	Username string `json:"username"`
+	Password string `json:"password"`
+	// IdentityToken is an OAuth2 refresh token; RegistryToken is a bearer
+	// token to send as-is.
+	IdentityToken string `json:"identitytoken"`
+	RegistryToken string `json:"registrytoken"`
+}
+
+// credentialFromDockerConfig finds the credential a Docker config holds for
+// addr.
+//
+// A config that says nothing about addr is not an error: it is a config that
+// describes other registries, and the caller gets anonymous access — the same
+// answer `docker pull` would give.
+func credentialFromDockerConfig(raw, addr string) (credential, []string, error) {
+	var cfg dockerConfigFile
+	if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
+		// encoding/json quotes the offending input in its message, and the
+		// offending input here is a file full of passwords. The error says
+		// what is wrong and nothing about what was in it.
+		return credential{}, nil, errors.New("parse docker config: the supplied secret is not valid JSON")
+	}
+
+	// Collected before anything can fail, and returned on every path: a
+	// credential that lost the lookup is still a credential that must not
+	// reach a log.
+	redact := dockerConfigSecrets(cfg)
+	want := normalizeRegistryHost(addr)
+
+	var (
+		entry   dockerAuthEntry
+		matched bool
+	)
+	for key, candidate := range cfg.Auths {
+		if normalizeRegistryHost(key) == want {
+			entry, matched = candidate, true
+			break
+		}
+	}
+
+	cred, err := entry.credential()
+	if err != nil {
+		return credential{}, redact, err
+	}
+	if !cred.empty() {
+		return cred, redact, nil
+	}
+
+	// Nothing usable in the entry. If a helper owns this host, saying so is
+	// far better than silently trying the registry anonymously and reporting
+	// whatever 401 comes back.
+	for key, helper := range cfg.CredHelpers {
+		if normalizeRegistryHost(key) == want {
+			return credential{}, redact, unsupportedHelper(want, helper)
+		}
+	}
+	if matched && cfg.CredsStore != "" {
+		return credential{}, redact, unsupportedHelper(want, cfg.CredsStore)
+	}
+
+	// A credsStore with no entry for this host is the ordinary shape of a
+	// developer's config file. Erroring on it would make every config written
+	// by Docker Desktop unusable for a public registry, so it falls through
+	// to anonymous instead.
+	return credential{}, redact, nil
+}
+
+// unsupportedHelper is the error for a config that resolves a host through a
+// credential helper.
+//
+// Helpers are not honoured and cannot be: a helper is an external binary the
+// Docker CLI executes, and the module runtime is a Go process in a container
+// holding neither gcloud, nor ecr-login, nor a macOS keychain. Reaching them
+// would mean shelling out to a helper container, which is the one thing this
+// module does not do anywhere.
+//
+// So the failure is explicit, names the binary the config asked for, and says
+// what to do instead. The alternative — falling through to anonymous — turns a
+// missing credential into a 401 from somewhere else entirely.
+func unsupportedHelper(host, helper string) error {
+	return fmt.Errorf(
+		"docker config resolves %s through the credential helper docker-credential-%s, "+
+			"which this module cannot run: no helper binaries exist in the module runtime. "+
+			"Resolve the credential in the caller and pass it as username/password or bearerToken",
+		host, helper)
+}
+
+// credential reads one auths entry.
+//
+// The explicit username and password fields win over the packed auth blob
+// when both are present: a tool that wrote both wrote the unencoded pair
+// last, and they are the ones a human editing the file would have changed.
+func (entry dockerAuthEntry) credential() (credential, error) {
+	cred := credential{
+		username:     entry.Username,
+		password:     entry.Password,
+		accessToken:  entry.RegistryToken,
+		refreshToken: entry.IdentityToken,
+	}
+	if entry.Auth == "" {
+		return cred, nil
+	}
+
+	decoded, err := decodeDockerAuth(entry.Auth)
+	if err != nil {
+		return credential{}, err
+	}
+	user, pass, ok := strings.Cut(decoded, ":")
+	if !ok {
+		return credential{}, errors.New(`docker config: an "auth" value does not decode to "username:password"`)
+	}
+	if cred.username == "" {
+		cred.username = user
+	}
+	if cred.password == "" {
+		cred.password = pass
+	}
+	return cred, nil
+}
+
+// decodeDockerAuth decodes an "auth" value. Padded standard base64 is what
+// `docker login` writes; the unpadded form is accepted because other tools
+// write it and rejecting it would fail for a reason the user cannot see.
+//
+// The error carries no part of the value: a partially decoded credential is
+// still a credential.
+func decodeDockerAuth(auth string) (string, error) {
+	if decoded, err := base64.StdEncoding.DecodeString(auth); err == nil {
+		return string(decoded), nil
+	}
+	decoded, err := base64.RawStdEncoding.DecodeString(auth)
+	if err != nil {
+		return "", errors.New(`docker config: an "auth" value is not valid base64`)
+	}
+	return string(decoded), nil
+}
+
+// dockerConfigSecrets lists every plaintext credential anywhere in the
+// config, not only the one that matched.
+//
+// The whole file was handed over as one secret, so every value in it is the
+// caller's secret. Scrubbing only the entry that won would let a stray error
+// mentioning some other host's password through.
+func dockerConfigSecrets(cfg dockerConfigFile) []string {
+	secrets := make([]string, 0, len(cfg.Auths)*4)
+	for _, entry := range cfg.Auths {
+		secrets = append(secrets, entry.Password, entry.IdentityToken, entry.RegistryToken)
+		if entry.Auth == "" {
+			continue
+		}
+		// The blob itself is a credential in transport encoding.
+		secrets = append(secrets, entry.Auth)
+		decoded, err := decodeDockerAuth(entry.Auth)
+		if err != nil {
+			continue
+		}
+		if _, pass, ok := strings.Cut(decoded, ":"); ok {
+			secrets = append(secrets, pass)
+		}
+	}
+	return secrets
+}
+
+// normalizeRegistryHost reduces a Docker config key or a registry address to
+// the bare host[:port] both sides can be compared on.
+//
+// Config keys are written every way a decade of Docker CLI versions allowed:
+// "ghcr.io", "https://ghcr.io", and for Docker Hub the legacy
+// "https://index.docker.io/v1/". Comparing them literally would miss the
+// entry a user can plainly see in their file.
+func normalizeRegistryHost(host string) string {
+	normalized := strings.TrimSpace(host)
+	if scheme := strings.Index(normalized, "://"); scheme >= 0 {
+		normalized = normalized[scheme+3:]
+	}
+	normalized, _, _ = strings.Cut(normalized, "/")
+	normalized = strings.ToLower(normalized)
+
+	// Docker Hub answers to four names and `docker login` may have written
+	// any of them.
+	switch normalized {
+	case "index.docker.io", "registry-1.docker.io", "registry.hub.docker.com":
+		return "docker.io"
+	}
+	return normalized
+}

--- a/daggerverse/oci/authselftest.go
+++ b/daggerverse/oci/authselftest.go
@@ -46,13 +46,15 @@ func checkHostNormalization() error {
 		{"http://localhost:5000", "localhost:5000"},
 		{"  GHCR.IO  ", "ghcr.io"},
 		{"registry.example.com:5000/v2/", "registry.example.com:5000"},
-		// The four names Docker Hub answers to. `docker login` has written
-		// each of them at some point in its history, and a user looking at
-		// their own config file cannot tell which they got.
+		// Every name Docker Hub answers to. `docker login` has written each
+		// of them at some point in its history, and a user looking at their
+		// own config file cannot tell which they got. The list here and the
+		// one in the README are the same list.
 		{"docker.io", "docker.io"},
 		{"index.docker.io", "docker.io"},
 		{"https://index.docker.io/v1/", "docker.io"},
 		{"registry-1.docker.io", "docker.io"},
+		{"registry.hub.docker.com", "docker.io"},
 	}
 	var failures []error
 	for _, tc := range cases {
@@ -305,7 +307,8 @@ func checkEveryCredentialIsRedacted() error {
 	  "auths": {
 	    "ghcr.io": {"auth":"Z2g6Z2hw"},
 	    "quay.io": {"username":"q","password":"quay-password"},
-	    "gcr.io": {"identitytoken":"gcr-refresh","registrytoken":"gcr-bearer"}
+	    "gcr.io": {"identitytoken":"gcr-refresh","registrytoken":"gcr-bearer"},
+	    "unpadded.example.com": {"auth":"dXNlcjpwYXM"}
 	  }
 	}`
 
@@ -320,8 +323,17 @@ func checkEveryCredentialIsRedacted() error {
 
 	var failures []error
 	// "ghp" is the matched host's password, "Z2g6Z2hw" the blob it travelled
-	// in, and the rest belong to hosts that lost the lookup.
-	for _, want := range []string{"ghp", "Z2g6Z2hw", "quay-password", "gcr-refresh", "gcr-bearer"} {
+	// in, and the next three belong to hosts that lost the lookup.
+	//
+	// The last two are the same credential in both encodings. The file holds
+	// it unpadded; anything that rebuilds an Authorization header from it
+	// emits the padded form, which is a different string carrying the
+	// identical credential, so scrubbing only what the file happened to
+	// contain would let it through.
+	for _, want := range []string{
+		"ghp", "Z2g6Z2hw", "quay-password", "gcr-refresh", "gcr-bearer",
+		"dXNlcjpwYXM", "dXNlcjpwYXM=",
+	} {
 		if !indexed[want] {
 			failures = append(failures, fmt.Errorf("%q is not in the redaction list %q", want, redact))
 		}

--- a/daggerverse/oci/authselftest.go
+++ b/daggerverse/oci/authselftest.go
@@ -1,0 +1,336 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// credentialSelfCheck exercises docker-config credential resolution in
+// process.
+//
+// It sits here rather than in tests/ because what it covers cannot be reached
+// from there at a sensible price. Every case below is a shape of
+// ~/.docker/config.json — a key written with a scheme, Docker Hub under its
+// legacy name, an unpadded auth blob, a credsStore beside an empty entry —
+// and reaching each one through the test module would mean standing up a
+// registry per shape to assert on a string comparison that never touches the
+// network. The live tests in tests/ prove the resolved credential actually
+// authenticates; this proves the right one is resolved.
+//
+// Every case is run and every failure is reported: a run that stopped at the
+// first would hide the rest behind whichever happened to be listed first.
+func credentialSelfCheck() error {
+	var failures []error
+	for _, check := range []func() error{
+		checkHostNormalization,
+		checkAuthEntryShapes,
+		checkHostMatching,
+		checkCredentialHelpers,
+		checkMalformedConfigsSayNothing,
+		checkEveryCredentialIsRedacted,
+	} {
+		if err := check(); err != nil {
+			failures = append(failures, err)
+		}
+	}
+	return errors.Join(failures...)
+}
+
+// checkHostNormalization covers the ways a config key and a dialled address
+// can spell the same registry.
+func checkHostNormalization() error {
+	cases := []struct{ in, want string }{
+		{"ghcr.io", "ghcr.io"},
+		{"https://ghcr.io", "ghcr.io"},
+		{"http://localhost:5000", "localhost:5000"},
+		{"  GHCR.IO  ", "ghcr.io"},
+		{"registry.example.com:5000/v2/", "registry.example.com:5000"},
+		// The four names Docker Hub answers to. `docker login` has written
+		// each of them at some point in its history, and a user looking at
+		// their own config file cannot tell which they got.
+		{"docker.io", "docker.io"},
+		{"index.docker.io", "docker.io"},
+		{"https://index.docker.io/v1/", "docker.io"},
+		{"registry-1.docker.io", "docker.io"},
+	}
+	var failures []error
+	for _, tc := range cases {
+		if got := normalizeRegistryHost(tc.in); got != tc.want {
+			failures = append(failures, fmt.Errorf("normalizeRegistryHost(%q) = %q, want %q", tc.in, got, tc.want))
+		}
+	}
+	return errors.Join(failures...)
+}
+
+// checkAuthEntryShapes covers the forms one auths entry is written in.
+func checkAuthEntryShapes() error {
+	cases := []struct {
+		name string
+		json string
+		want credential
+	}{
+		{
+			name: "packed auth blob",
+			json: `{"auths":{"ghcr.io":{"auth":"dXNlcjpwYXNz"}}}`,
+			want: credential{username: "user", password: "pass"},
+		},
+		{
+			// Some tools omit the padding. Rejecting it would fail for a
+			// reason invisible to whoever wrote the file: the padded and
+			// unpadded forms of the same credential look alike.
+			name: "unpadded auth blob",
+			json: `{"auths":{"ghcr.io":{"auth":"dXNlcjpwYXM"}}}`,
+			want: credential{username: "user", password: "pas"},
+		},
+		{
+			name: "explicit username and password",
+			json: `{"auths":{"ghcr.io":{"username":"user","password":"pass"}}}`,
+			want: credential{username: "user", password: "pass"},
+		},
+		{
+			// A password containing a colon still round-trips: only the
+			// first colon separates the two halves.
+			name: "password containing a colon",
+			json: `{"auths":{"ghcr.io":{"auth":"dXNlcjpwYTpzcw=="}}}`,
+			want: credential{username: "user", password: "pa:ss"},
+		},
+		{
+			// What `docker login` writes for a registry that issued an
+			// OAuth2 refresh token: an auth blob with an empty password
+			// beside the token.
+			name: "identity token",
+			json: `{"auths":{"ghcr.io":{"auth":"dXNlcjo=","identitytoken":"refresh-me"}}}`,
+			want: credential{username: "user", refreshToken: "refresh-me"},
+		},
+		{
+			name: "registry token",
+			json: `{"auths":{"ghcr.io":{"registrytoken":"bearer-me"}}}`,
+			want: credential{accessToken: "bearer-me"},
+		},
+	}
+
+	var failures []error
+	for _, tc := range cases {
+		got, _, err := credentialFromDockerConfig(tc.json, "ghcr.io")
+		if err != nil {
+			failures = append(failures, fmt.Errorf("%s: unexpected error: %v", tc.name, err))
+			continue
+		}
+		if got != tc.want {
+			failures = append(failures, fmt.Errorf("%s: got %+v, want %+v", tc.name, got, tc.want))
+		}
+	}
+	return errors.Join(failures...)
+}
+
+// checkHostMatching covers which entry a lookup lands on, and what happens
+// when it lands on none.
+func checkHostMatching() error {
+	const config = `{
+	  "auths": {
+	    "https://index.docker.io/v1/": {"auth":"aHViOmh1Yg=="},
+	    "https://ghcr.io": {"auth":"Z2g6Z2hw"},
+	    "registry.example.com:5000": {"auth":"cmVnOnJlZw=="}
+	  }
+	}`
+
+	cases := []struct {
+		addr string
+		want credential
+	}{
+		{"docker.io", credential{username: "hub", password: "hub"}},
+		{"index.docker.io", credential{username: "hub", password: "hub"}},
+		{"ghcr.io", credential{username: "gh", password: "ghp"}},
+		{"registry.example.com:5000", credential{username: "reg", password: "reg"}},
+		// A port is part of the identity: a config for the registry on 5000
+		// says nothing about the one on 5001.
+		{"registry.example.com:5001", credential{}},
+		// A config that names other registries is a request for anonymous
+		// access here, not an error.
+		{"quay.io", credential{}},
+	}
+
+	var failures []error
+	for _, tc := range cases {
+		got, _, err := credentialFromDockerConfig(config, tc.addr)
+		if err != nil {
+			failures = append(failures, fmt.Errorf("lookup %s: unexpected error: %v", tc.addr, err))
+			continue
+		}
+		if got != tc.want {
+			failures = append(failures, fmt.Errorf("lookup %s: got %+v, want %+v", tc.addr, got, tc.want))
+		}
+	}
+	return errors.Join(failures...)
+}
+
+// checkCredentialHelpers covers the boundary between "this host's credential
+// is somewhere I cannot reach" and "this file says nothing about this host".
+//
+// Getting that boundary wrong in the strict direction is the expensive
+// mistake: a credsStore is present in essentially every config Docker Desktop
+// writes, and treating it as governing every host would make a public,
+// anonymous pull fail for anyone who has ever run `docker login`.
+func checkCredentialHelpers() error {
+	var failures []error
+
+	wantsHelper := []struct {
+		name   string
+		json   string
+		addr   string
+		binary string
+	}{
+		{
+			name:   "per-host helper",
+			json:   `{"credHelpers":{"1234.dkr.ecr.us-east-1.amazonaws.com":"ecr-login"}}`,
+			addr:   "1234.dkr.ecr.us-east-1.amazonaws.com",
+			binary: "docker-credential-ecr-login",
+		},
+		{
+			name:   "credsStore with an entry for this host",
+			json:   `{"credsStore":"desktop","auths":{"ghcr.io":{}}}`,
+			addr:   "ghcr.io",
+			binary: "docker-credential-desktop",
+		},
+	}
+	for _, tc := range wantsHelper {
+		_, _, err := credentialFromDockerConfig(tc.json, tc.addr)
+		if err == nil {
+			failures = append(failures, fmt.Errorf("%s: want an error naming %s, got none", tc.name, tc.binary))
+			continue
+		}
+		if !strings.Contains(err.Error(), tc.binary) {
+			failures = append(failures, fmt.Errorf("%s: error does not name %s: %v", tc.name, tc.binary, err))
+		}
+	}
+
+	wantsCredential := []struct {
+		name string
+		json string
+		addr string
+		want credential
+	}{
+		{
+			// A credential written in the file wins over the store: it is
+			// there, and the store is not reachable.
+			name: "credsStore beside a usable entry",
+			json: `{"credsStore":"desktop","auths":{"ghcr.io":{"auth":"Z2g6Z2hw"}}}`,
+			addr: "ghcr.io",
+			want: credential{username: "gh", password: "ghp"},
+		},
+		{
+			name: "per-host helper beside a usable entry",
+			json: `{"credHelpers":{"ghcr.io":"gcloud"},"auths":{"ghcr.io":{"auth":"Z2g6Z2hw"}}}`,
+			addr: "ghcr.io",
+			want: credential{username: "gh", password: "ghp"},
+		},
+		{
+			// The ordinary developer config, seen from a public registry.
+			name: "credsStore with no entry for this host",
+			json: `{"credsStore":"desktop","auths":{"ghcr.io":{}}}`,
+			addr: "quay.io",
+			want: credential{},
+		},
+		{
+			name: "helpers for other hosts only",
+			json: `{"credHelpers":{"gcr.io":"gcloud"}}`,
+			addr: "quay.io",
+			want: credential{},
+		},
+	}
+	for _, tc := range wantsCredential {
+		got, _, err := credentialFromDockerConfig(tc.json, tc.addr)
+		if err != nil {
+			failures = append(failures, fmt.Errorf("%s: unexpected error: %v", tc.name, err))
+			continue
+		}
+		if got != tc.want {
+			failures = append(failures, fmt.Errorf("%s: got %+v, want %+v", tc.name, got, tc.want))
+		}
+	}
+	return errors.Join(failures...)
+}
+
+// checkMalformedConfigsSayNothing asserts a config this module cannot read
+// fails without quoting itself back.
+//
+// encoding/json puts the offending input in its error message, and the
+// offending input here is a file full of passwords. A parse failure must
+// therefore be replaced, not wrapped.
+func checkMalformedConfigsSayNothing() error {
+	cases := []struct {
+		name    string
+		json    string
+		mustNot string
+	}{
+		{
+			name:    "not json at all",
+			json:    `not json, and here is a password: hunter2`,
+			mustNot: "hunter2",
+		},
+		{
+			name:    "auth is not base64",
+			json:    `{"auths":{"ghcr.io":{"auth":"not base64 hunter2"}}}`,
+			mustNot: "hunter2",
+		},
+		{
+			name:    "auth has no separator",
+			json:    `{"auths":{"ghcr.io":{"auth":"aHVudGVyMg=="}}}`,
+			mustNot: "hunter2",
+		},
+	}
+
+	var failures []error
+	for _, tc := range cases {
+		_, _, err := credentialFromDockerConfig(tc.json, "ghcr.io")
+		if err == nil {
+			failures = append(failures, fmt.Errorf("%s: want an error, got none", tc.name))
+			continue
+		}
+		if strings.Contains(err.Error(), tc.mustNot) {
+			failures = append(failures, fmt.Errorf("%s: the error quotes the config back: %v", tc.name, err))
+		}
+	}
+	return errors.Join(failures...)
+}
+
+// checkEveryCredentialIsRedacted asserts the redaction list covers the whole
+// file, not just the entry that matched.
+//
+// The file arrived as one secret, so every credential in it is the caller's
+// secret — including the ones for hosts this connection never dialled.
+func checkEveryCredentialIsRedacted() error {
+	const config = `{
+	  "auths": {
+	    "ghcr.io": {"auth":"Z2g6Z2hw"},
+	    "quay.io": {"username":"q","password":"quay-password"},
+	    "gcr.io": {"identitytoken":"gcr-refresh","registrytoken":"gcr-bearer"}
+	  }
+	}`
+
+	_, redact, err := credentialFromDockerConfig(config, "ghcr.io")
+	if err != nil {
+		return fmt.Errorf("unexpected error: %v", err)
+	}
+	indexed := make(map[string]bool, len(redact))
+	for _, secret := range redact {
+		indexed[secret] = true
+	}
+
+	var failures []error
+	// "ghp" is the matched host's password, "Z2g6Z2hw" the blob it travelled
+	// in, and the rest belong to hosts that lost the lookup.
+	for _, want := range []string{"ghp", "Z2g6Z2hw", "quay-password", "gcr-refresh", "gcr-bearer"} {
+		if !indexed[want] {
+			failures = append(failures, fmt.Errorf("%q is not in the redaction list %q", want, redact))
+		}
+	}
+
+	// And the list has to be applied, not merely collected.
+	scrubbed := (&conn{redact: redact}).scrub(errors.New("401 from ghcr.io: tried ghp and quay-password"))
+	if strings.Contains(scrubbed.Error(), "ghp") || strings.Contains(scrubbed.Error(), "quay-password") {
+		failures = append(failures, fmt.Errorf("scrub left a credential behind: %v", scrubbed))
+	}
+	return errors.Join(failures...)
+}

--- a/daggerverse/oci/dagger.gen.go
+++ b/daggerverse/oci/dagger.gen.go
@@ -75,27 +75,33 @@ func (r *Oci) UnmarshalJSON(bs []byte) error {
 
 func (r Registry) MarshalJSON() ([]byte, error) {
 	var concrete struct {
-		Host     string
-		Username string
-		Insecure bool
-		Password *dagger.Secret
-		Service  *dagger.Service
+		Host         string
+		Username     string
+		Insecure     bool
+		Password     *dagger.Secret
+		BearerToken  *dagger.Secret
+		DockerConfig *dagger.Secret
+		Service      *dagger.Service
 	}
 	concrete.Host = r.Host
 	concrete.Username = r.Username
 	concrete.Insecure = r.Insecure
 	concrete.Password = r.Password
+	concrete.BearerToken = r.BearerToken
+	concrete.DockerConfig = r.DockerConfig
 	concrete.Service = r.Service
 	return json.Marshal(&concrete)
 }
 
 func (r *Registry) UnmarshalJSON(bs []byte) error {
 	var concrete struct {
-		Host     string
-		Username string
-		Insecure bool
-		Password *dagger.Secret
-		Service  *dagger.Service
+		Host         string
+		Username     string
+		Insecure     bool
+		Password     *dagger.Secret
+		BearerToken  *dagger.Secret
+		DockerConfig *dagger.Secret
+		Service      *dagger.Service
 	}
 	err := json.Unmarshal(bs, &concrete)
 	if err != nil {
@@ -105,6 +111,8 @@ func (r *Registry) UnmarshalJSON(bs []byte) error {
 	r.Username = concrete.Username
 	r.Insecure = concrete.Insecure
 	r.Password = concrete.Password
+	r.BearerToken = concrete.BearerToken
+	r.DockerConfig = concrete.DockerConfig
 	r.Service = concrete.Service
 	return nil
 }
@@ -228,6 +236,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 	switch parentName {
 	case "Oci":
 		switch fnName {
+		case "CredentialResolutionSelfTest":
+			var parent Oci
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Oci).CredentialResolutionSelfTest(&parent, ctx)
 		case "Registry":
 			var parent Oci
 			err = json.Unmarshal(parentJSON, &parent)
@@ -255,6 +270,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg password", err))
 				}
 			}
+			var bearerToken *dagger.Secret
+			if inputArgs["bearerToken"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["bearerToken"]), &bearerToken)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg bearerToken", err))
+				}
+			}
+			var dockerConfig *dagger.Secret
+			if inputArgs["dockerConfig"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["dockerConfig"]), &dockerConfig)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg dockerConfig", err))
+				}
+			}
 			var service *dagger.Service
 			if inputArgs["service"] != nil {
 				err = json.Unmarshal([]byte(inputArgs["service"]), &service)
@@ -269,7 +298,7 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg insecure", err))
 				}
 			}
-			return (*Oci).Registry(&parent, host, username, password, service, insecure), nil
+			return (*Oci).Registry(&parent, host, username, password, bearerToken, dockerConfig, service, insecure), nil
 		default:
 			return nil, fmt.Errorf("unknown function %s", fnName)
 		}

--- a/daggerverse/oci/image.go
+++ b/daggerverse/oci/image.go
@@ -248,12 +248,19 @@ func (c *conn) nameOptions() []name.Option {
 }
 
 // remoteOptions builds the go-containerregistry options for this connection.
+//
+// RegistryToken is go-containerregistry's name for a bearer token sent as-is,
+// and IdentityToken its name for an OAuth2 refresh token — the same two
+// things oras calls AccessToken and RefreshToken. The mapping lives here so
+// that credential resolution never has to know which library will be used.
 func (c *conn) remoteOptions(ctx context.Context) []remote.Option {
 	opts := []remote.Option{remote.WithContext(ctx)}
-	if c.username != "" || c.password != "" {
+	if !c.cred.empty() {
 		opts = append(opts, remote.WithAuth(authn.FromConfig(authn.AuthConfig{
-			Username: c.username,
-			Password: c.password,
+			Username:      c.cred.username,
+			Password:      c.cred.password,
+			RegistryToken: c.cred.accessToken,
+			IdentityToken: c.cred.refreshToken,
 		})))
 	} else {
 		opts = append(opts, remote.WithAuth(authn.Anonymous))

--- a/daggerverse/oci/main.go
+++ b/daggerverse/oci/main.go
@@ -30,11 +30,36 @@ import (
 // reached through Registry.
 type Oci struct{}
 
+// CredentialResolutionSelfTest checks how a Docker config is read: which
+// entry a host matches, which of an entry's forms wins, when a credential
+// helper is refused, and what a malformed config is allowed to say.
+//
+// It sits on the module rather than in tests/ because it checks unexported
+// resolution that never reaches the network, and because each case is one
+// shape of a config file — reaching them all through tests/ would mean a
+// registry per shape to assert on a string comparison. The live tests still
+// prove a resolved credential authenticates; this proves the right one was
+// resolved.
+//
+// It runs in process and needs no container, so it is cheap enough to be a
+// check of its own.
+//
+// +check
+func (m *Oci) CredentialResolutionSelfTest(ctx context.Context) error {
+	return credentialSelfCheck()
+}
+
 // Registry binds one registry host and its credentials. service, when
 // non-nil, is a Dagger-hosted registry reached by hostname rather than over
 // the public network — its endpoint replaces host as the address dialled,
 // because a session service's hostname is assigned by the engine and cannot
 // be predicted by the caller.
+//
+// There are three ways to authenticate and they have a fixed precedence:
+// username/password beats bearerToken, which beats dockerConfig, and
+// supplying none of them is an anonymous client. See Registry.credential for
+// why the order is that one and why a 401 never falls through to the next
+// source.
 //
 // insecure is explicit and defaults to off: it means plain HTTP and no TLS
 // verification. It is deliberately not inferred from service being set —
@@ -55,6 +80,18 @@ func (m *Oci) Registry(
 	//
 	// +optional
 	password *dagger.Secret,
+	// A bearer token to send as-is, for a registry that issued one. Used
+	// only when no username or password was given.
+	//
+	// +optional
+	bearerToken *dagger.Secret,
+	// A Docker config file — the contents of ~/.docker/config.json — to read
+	// this host's credentials out of. Used only when nothing more specific
+	// was given. Credential helpers named by the file are not run; a host
+	// that resolves through one fails naming it.
+	//
+	// +optional
+	dockerConfig *dagger.Secret,
 	// A Dagger-hosted registry to reach over the session network instead of
 	// over the public network.
 	//
@@ -66,11 +103,13 @@ func (m *Oci) Registry(
 	insecure bool,
 ) *Registry {
 	return &Registry{
-		Host:     host,
-		Username: username,
-		Password: password,
-		Service:  service,
-		Insecure: insecure,
+		Host:         host,
+		Username:     username,
+		Password:     password,
+		BearerToken:  bearerToken,
+		DockerConfig: dockerConfig,
+		Service:      service,
+		Insecure:     insecure,
 	}
 }
 
@@ -91,20 +130,33 @@ type Registry struct {
 	//
 	// +private
 	Password *dagger.Secret
+	// BearerToken is a token to send as-is in an Authorization header.
+	//
+	// +private
+	BearerToken *dagger.Secret
+	// DockerConfig is a ~/.docker/config.json to read credentials from.
+	//
+	// +private
+	DockerConfig *dagger.Secret
 	// Service is the Dagger-hosted registry, when there is one.
 	//
 	// +private
 	Service *dagger.Service
 }
 
-// conn is a resolved connection: the address actually dialled plus the
-// plaintext credentials. Built once per method call, because resolving a
-// service endpoint and a secret both need a context.
+// conn is a resolved connection: the address actually dialled, the
+// credential to present there, and every plaintext value read while working
+// that out. Built once per method call, because resolving a service endpoint
+// and a secret both need a context.
 type conn struct {
 	addr     string
-	username string
-	password string
 	insecure bool
+	cred     credential
+	// redact holds the plaintext values that must never appear in an error
+	// leaving this module — including credentials that lost the precedence
+	// contest, because a value the caller handed over is secret whether or
+	// not it was used.
+	redact []string
 }
 
 // connect resolves the registry address and credentials.
@@ -113,7 +165,7 @@ type conn struct {
 // Registry() takes no context: it is a pure constructor, and starting a
 // service is not.
 func (reg *Registry) connect(ctx context.Context) (*conn, error) {
-	c := &conn{username: reg.Username, insecure: reg.Insecure}
+	c := &conn{insecure: reg.Insecure}
 
 	switch {
 	case reg.Service != nil:
@@ -132,13 +184,12 @@ func (reg *Registry) connect(ctx context.Context) (*conn, error) {
 		return nil, errors.New("registry: host is required when no service is given")
 	}
 
-	if reg.Password != nil {
-		pwd, err := reg.Password.Plaintext(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("read registry password: %v", err)
-		}
-		c.password = pwd
+	cred, redact, err := reg.credential(ctx, c.addr)
+	c.redact = redact
+	if err != nil {
+		return nil, c.scrub(err)
 	}
+	c.cred = cred
 	return c, nil
 }
 
@@ -155,20 +206,32 @@ func (c *conn) ref(repository, reference string) string {
 	return c.addr + "/" + repository + sep + reference
 }
 
-// scrub removes the password from an error's text before it crosses the
-// module boundary. Registries carry credentials in an Authorization header,
-// so a leak is not expected — but a 401 body, a redirect URL, or a client
-// library that echoes its request would each be a way for one to happen, and
-// the cost of being wrong is a password in a CI log forever.
+// scrub removes every credential value from an error's text before it
+// crosses the module boundary. Registries carry credentials in an
+// Authorization header, so a leak is not expected — but a 401 body, a
+// redirect URL, or a client library that echoes its request would each be a
+// way for one to happen, and the cost of being wrong is a password in a CI
+// log forever.
+//
+// It covers all of them, not just the one that authenticated: a bearer token
+// and a Docker config are as secret as a password, and a config file holds
+// credentials for hosts this connection never dialled.
 func (c *conn) scrub(err error) error {
 	if err == nil {
 		return nil
 	}
 	msg := err.Error()
-	if c.password == "" || !strings.Contains(msg, c.password) {
+	scrubbed := msg
+	for _, secret := range c.redact {
+		if secret == "" {
+			continue
+		}
+		scrubbed = strings.ReplaceAll(scrubbed, secret, "***")
+	}
+	if scrubbed == msg {
 		return err
 	}
-	return errors.New(strings.ReplaceAll(msg, c.password, "***"))
+	return errors.New(scrubbed)
 }
 
 // httpClient builds the HTTP client used for every oras request on this
@@ -185,10 +248,12 @@ func (c *conn) httpClient() *orasauth.Client {
 	}
 	base.Cache = orasauth.NewCache()
 	base.SetUserAgent("dagger-oci-module")
-	if c.username != "" || c.password != "" {
+	if !c.cred.empty() {
 		base.Credential = orasauth.StaticCredential(c.addr, orasauth.Credential{
-			Username: c.username,
-			Password: c.password,
+			Username:     c.cred.username,
+			Password:     c.cred.password,
+			AccessToken:  c.cred.accessToken,
+			RefreshToken: c.cred.refreshToken,
 		})
 	}
 	return &base

--- a/daggerverse/oci/tests/auth.go
+++ b/daggerverse/oci/tests/auth.go
@@ -1,0 +1,474 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"dagger/tests/internal/dagger"
+)
+
+// AuthenticatesFromDockerConfig asserts a caller can hand over a
+// ~/.docker/config.json and have this module find the host's credentials in
+// it — no username, no password, just the file a `docker login` already
+// wrote.
+//
+// Both client libraries are exercised: PushImage goes through
+// go-containerregistry and Resolve through oras, and the credential
+// resolution feeding them is shared. A test using only one would leave the
+// other silently anonymous.
+func (t *Tests) AuthenticatesFromDockerConfig(ctx context.Context) error {
+	reg, err := newRegistry(ctx)
+	if err != nil {
+		return err
+	}
+	repo, err := uniqueName(ctx, "docker-config")
+	if err != nil {
+		return err
+	}
+	endpoint, err := reg.endpoint(ctx)
+	if err != nil {
+		return err
+	}
+	config, err := dockerConfigSecret(ctx, dockerConfig{
+		auths: map[string]dockerAuth{endpoint: {username: registryUser, password: reg.Password}},
+	})
+	if err != nil {
+		return err
+	}
+
+	client := dag.Oci().Registry("test-registry.invalid", dagger.OciRegistryOpts{
+		DockerConfig: config,
+		Service:      reg.Service,
+		Insecure:     true,
+	})
+
+	pushed, err := client.PushImage(ctx, repo, "v1", []*dagger.Container{baseImage("linux/amd64")})
+	if err != nil {
+		return fmt.Errorf("PushImage authenticated from a docker config: %v", err)
+	}
+	got, err := client.Resolve(ctx, repo, "v1")
+	if err != nil {
+		return fmt.Errorf("Resolve authenticated from a docker config: %v", err)
+	}
+	if got != pushed {
+		return fmt.Errorf("Resolve returned %s, want the pushed digest %s", got, pushed)
+	}
+	return nil
+}
+
+// DockerConfigCredentialsDoNotLeak asserts that a docker config carrying the
+// wrong password fails with a 401 whose text holds neither that password nor
+// the base64 blob it was packed into.
+//
+// The blob matters as much as the password. It is base64, not encryption, so
+// a `auth` value in a CI log is a password in a CI log — and it is the form
+// the credential actually travels in, which makes it the one a client library
+// echoing its own request would print.
+func (t *Tests) DockerConfigCredentialsDoNotLeak(ctx context.Context) error {
+	reg, err := newRegistry(ctx)
+	if err != nil {
+		return err
+	}
+	repo, err := uniqueName(ctx, "docker-config-unauthorized")
+	if err != nil {
+		return err
+	}
+	wrong, err := uniqueName(ctx, "wrong")
+	if err != nil {
+		return err
+	}
+	endpoint, err := reg.endpoint(ctx)
+	if err != nil {
+		return err
+	}
+
+	auth := dockerAuth{username: registryUser, password: wrong}
+	config, err := dockerConfigSecret(ctx, dockerConfig{
+		auths: map[string]dockerAuth{endpoint: auth},
+	})
+	if err != nil {
+		return err
+	}
+
+	client := dag.Oci().Registry("test-registry.invalid", dagger.OciRegistryOpts{
+		DockerConfig: config,
+		Service:      reg.Service,
+		Insecure:     true,
+	})
+
+	_, err = client.PushImage(ctx, repo, "v1", []*dagger.Container{baseImage("linux/amd64")})
+	if err == nil {
+		return errors.New("PushImage with a docker config holding the wrong password succeeded")
+	}
+	text := err.Error()
+	if strings.Contains(text, wrong) {
+		return fmt.Errorf("the error text leaks the password from the docker config: %s", text)
+	}
+	if strings.Contains(text, auth.blob()) {
+		return fmt.Errorf("the error text leaks the docker config's base64 auth value: %s", text)
+	}
+	if strings.Contains(text, reg.Password) {
+		return fmt.Errorf("the error text leaks the registry's real password: %s", text)
+	}
+	lower := strings.ToLower(text)
+	if !strings.Contains(lower, "401") && !strings.Contains(lower, "unauthorized") {
+		return fmt.Errorf("the error does not look like a 401: %s", text)
+	}
+	return nil
+}
+
+// DockerConfigCredentialHelperIsNotSupported asserts that a config resolving
+// this host through a credential helper fails, and that the failure names the
+// helper binary it asked for.
+//
+// Helpers are not honoured and cannot be: one is an external
+// docker-credential-* binary the Docker CLI executes, and the module runtime
+// holds no gcloud, no ecr-login and no keychain. The alternative to failing
+// is falling through to anonymous, which turns "your credential lives
+// somewhere I cannot reach" into an unrelated 401 from the registry — a
+// failure whose cause is invisible in the message.
+func (t *Tests) DockerConfigCredentialHelperIsNotSupported(ctx context.Context) error {
+	reg, err := newRegistry(ctx)
+	if err != nil {
+		return err
+	}
+	repo, err := uniqueName(ctx, "cred-helper")
+	if err != nil {
+		return err
+	}
+	endpoint, err := reg.endpoint(ctx)
+	if err != nil {
+		return err
+	}
+	config, err := dockerConfigSecret(ctx, dockerConfig{
+		credHelpers: map[string]string{endpoint: "gcloud"},
+	})
+	if err != nil {
+		return err
+	}
+
+	client := dag.Oci().Registry("test-registry.invalid", dagger.OciRegistryOpts{
+		DockerConfig: config,
+		Service:      reg.Service,
+		Insecure:     true,
+	})
+
+	_, err = client.PushImage(ctx, repo, "v1", []*dagger.Container{baseImage("linux/amd64")})
+	if err == nil {
+		return errors.New("PushImage with a credential-helper-only docker config succeeded")
+	}
+	if !strings.Contains(err.Error(), "docker-credential-gcloud") {
+		return fmt.Errorf("the error does not name the credential helper it could not run: %v", err)
+	}
+	return nil
+}
+
+// AuthenticatesWithBearerToken asserts a token supplied on its own reaches
+// the registry as an Authorization: Bearer header, and that a wrong one is
+// refused without either token appearing in the error.
+//
+// The registry behind the gate is anonymous, so nothing here can pass by
+// accident on some other credential: the only thing separating the two halves
+// of this test is the token.
+func (t *Tests) AuthenticatesWithBearerToken(ctx context.Context) error {
+	upstream, err := newAnonymousRegistry(ctx)
+	if err != nil {
+		return err
+	}
+	proxy, err := newBearerProxy(ctx, upstream)
+	if err != nil {
+		return err
+	}
+	repo, err := uniqueName(ctx, "bearer")
+	if err != nil {
+		return err
+	}
+
+	client := proxy.client(nil)
+	pushed, err := client.PushImage(ctx, repo, "v1", []*dagger.Container{baseImage("linux/amd64")})
+	if err != nil {
+		return fmt.Errorf("PushImage through a bearer-gated proxy: %v", err)
+	}
+	got, err := client.Resolve(ctx, repo, "v1")
+	if err != nil {
+		return fmt.Errorf("Resolve through a bearer-gated proxy: %v", err)
+	}
+	if got != pushed {
+		return fmt.Errorf("Resolve returned %s, want the pushed digest %s", got, pushed)
+	}
+
+	wrong, err := uniqueName(ctx, "wrong-token")
+	if err != nil {
+		return err
+	}
+	wrongName, err := uniqueName(ctx, "oci-bad-bearer")
+	if err != nil {
+		return err
+	}
+	refused := proxy.client(dag.SetSecret(wrongName, wrong))
+	if _, err := refused.Resolve(ctx, repo, "v1"); err == nil {
+		return errors.New("Resolve with the wrong bearer token succeeded")
+	} else if strings.Contains(err.Error(), wrong) {
+		return fmt.Errorf("the error text leaks the bearer token that was used: %v", err)
+	} else if strings.Contains(err.Error(), proxy.Token) {
+		return fmt.Errorf("the error text leaks the proxy's real bearer token: %v", err)
+	}
+	return nil
+}
+
+// PasswordBeatsTokenAndDockerConfig pins the top of the precedence order: a
+// username and password win over a bearer token and over a docker config,
+// both of which are wrong here and would fail the push if either were used.
+//
+// Precedence has to be tested from the winning side. A test that supplied
+// only correct credentials would pass whichever source the module happened to
+// read, and the bug this guards against — a later source quietly overwriting
+// an earlier one — would be invisible.
+func (t *Tests) PasswordBeatsTokenAndDockerConfig(ctx context.Context) error {
+	reg, err := newRegistry(ctx)
+	if err != nil {
+		return err
+	}
+	repo, err := uniqueName(ctx, "password-wins")
+	if err != nil {
+		return err
+	}
+	endpoint, err := reg.endpoint(ctx)
+	if err != nil {
+		return err
+	}
+	decoys, err := decoyCredentials(ctx, endpoint)
+	if err != nil {
+		return err
+	}
+
+	client := dag.Oci().Registry("test-registry.invalid", dagger.OciRegistryOpts{
+		Username:     registryUser,
+		Password:     reg.Secret,
+		BearerToken:  decoys.token,
+		DockerConfig: decoys.config,
+		Service:      reg.Service,
+		Insecure:     true,
+	})
+
+	pushed, err := client.PushImage(ctx, repo, "v1", []*dagger.Container{baseImage("linux/amd64")})
+	if err != nil {
+		return fmt.Errorf("PushImage with a correct password beside a wrong token and config: %v", err)
+	}
+	got, err := client.Resolve(ctx, repo, "v1")
+	if err != nil {
+		return fmt.Errorf("Resolve with a correct password beside a wrong token and config: %v", err)
+	}
+	if got != pushed {
+		return fmt.Errorf("Resolve returned %s, want the pushed digest %s", got, pushed)
+	}
+	return nil
+}
+
+// TokenBeatsDockerConfig pins the middle rung: with no username or password,
+// a bearer token is used and the docker config beside it is not.
+//
+// The config names the same host and holds credentials the gate would refuse,
+// so a module that preferred the file — or that fell back to it after the
+// token — would fail here rather than pass quietly.
+func (t *Tests) TokenBeatsDockerConfig(ctx context.Context) error {
+	upstream, err := newAnonymousRegistry(ctx)
+	if err != nil {
+		return err
+	}
+	proxy, err := newBearerProxy(ctx, upstream)
+	if err != nil {
+		return err
+	}
+	repo, err := uniqueName(ctx, "token-wins")
+	if err != nil {
+		return err
+	}
+	endpoint, err := endpointOf(ctx, proxy.Service)
+	if err != nil {
+		return err
+	}
+	decoys, err := decoyCredentials(ctx, endpoint)
+	if err != nil {
+		return err
+	}
+
+	client := dag.Oci().Registry("bearer-proxy.invalid", dagger.OciRegistryOpts{
+		BearerToken:  proxy.Secret,
+		DockerConfig: decoys.config,
+		Service:      proxy.Service,
+		Insecure:     true,
+	})
+
+	pushed, err := client.PushImage(ctx, repo, "v1", []*dagger.Container{baseImage("linux/amd64")})
+	if err != nil {
+		return fmt.Errorf("PushImage with a correct token beside a wrong docker config: %v", err)
+	}
+	got, err := client.Resolve(ctx, repo, "v1")
+	if err != nil {
+		return fmt.Errorf("Resolve with a correct token beside a wrong docker config: %v", err)
+	}
+	if got != pushed {
+		return fmt.Errorf("Resolve returned %s, want the pushed digest %s", got, pushed)
+	}
+	return nil
+}
+
+// AnonymousAccessNeedsNoCredentials asserts the bottom of the order still
+// works, in the two shapes it comes in: no credentials at all, and a docker
+// config that simply says nothing about this host.
+//
+// The second shape is the one that breaks by accident. A developer's config
+// carries a credsStore for Docker Desktop and entries for two or three
+// registries; reading it as "this file governs every host" would make every
+// public pull fail with an unrunnable-helper error. It has to mean "nothing
+// here is about that registry", and fall through to anonymous.
+func (t *Tests) AnonymousAccessNeedsNoCredentials(ctx context.Context) error {
+	upstream, err := newAnonymousRegistry(ctx)
+	if err != nil {
+		return err
+	}
+	bare, err := uniqueName(ctx, "anonymous")
+	if err != nil {
+		return err
+	}
+
+	client := dag.Oci().Registry("anonymous-registry.invalid", dagger.OciRegistryOpts{
+		Service:  upstream,
+		Insecure: true,
+	})
+	pushed, err := client.PushImage(ctx, bare, "v1", []*dagger.Container{baseImage("linux/amd64")})
+	if err != nil {
+		return fmt.Errorf("PushImage with no credentials at all: %v", err)
+	}
+	got, err := client.Resolve(ctx, bare, "v1")
+	if err != nil {
+		return fmt.Errorf("Resolve with no credentials at all: %v", err)
+	}
+	if got != pushed {
+		return fmt.Errorf("Resolve returned %s, want the pushed digest %s", got, pushed)
+	}
+
+	// A config about other registries entirely, including the credsStore a
+	// Docker Desktop install writes.
+	config, err := dockerConfigSecret(ctx, dockerConfig{
+		credsStore: "desktop",
+		auths: map[string]dockerAuth{
+			"ghcr.io": {username: "someone", password: "not-for-this-host"},
+		},
+	})
+	if err != nil {
+		return err
+	}
+	elsewhere, err := uniqueName(ctx, "anonymous-with-config")
+	if err != nil {
+		return err
+	}
+
+	withConfig := dag.Oci().Registry("anonymous-registry.invalid", dagger.OciRegistryOpts{
+		DockerConfig: config,
+		Service:      upstream,
+		Insecure:     true,
+	})
+	pushed, err = withConfig.PushImage(ctx, elsewhere, "v1", []*dagger.Container{baseImage("linux/amd64")})
+	if err != nil {
+		return fmt.Errorf("PushImage with a docker config naming other registries: %v", err)
+	}
+	got, err = withConfig.Resolve(ctx, elsewhere, "v1")
+	if err != nil {
+		return fmt.Errorf("Resolve with a docker config naming other registries: %v", err)
+	}
+	if got != pushed {
+		return fmt.Errorf("Resolve returned %s, want the pushed digest %s", got, pushed)
+	}
+	return nil
+}
+
+// dockerAuth is one entry of a rendered docker config.
+type dockerAuth struct {
+	username string
+	password string
+}
+
+// blob is the base64 "auth" value docker login would have written.
+func (auth dockerAuth) blob() string {
+	return base64.StdEncoding.EncodeToString([]byte(auth.username + ":" + auth.password))
+}
+
+// dockerConfig is the config file a test hands to the module.
+type dockerConfig struct {
+	auths       map[string]dockerAuth
+	credsStore  string
+	credHelpers map[string]string
+}
+
+// dockerConfigSecret renders a ~/.docker/config.json and wraps it in a Dagger
+// secret.
+//
+// It is rendered through encoding/json rather than a format string: the
+// values in it are random per run, and a hand-built JSON document is one
+// unescaped character away from a parse failure that would look like a module
+// bug.
+func dockerConfigSecret(ctx context.Context, config dockerConfig) (*dagger.Secret, error) {
+	file := map[string]any{}
+	if len(config.auths) > 0 {
+		auths := map[string]any{}
+		for host, auth := range config.auths {
+			auths[host] = map[string]any{"auth": auth.blob()}
+		}
+		file["auths"] = auths
+	}
+	if config.credsStore != "" {
+		file["credsStore"] = config.credsStore
+	}
+	if len(config.credHelpers) > 0 {
+		file["credHelpers"] = config.credHelpers
+	}
+
+	raw, err := json.Marshal(file)
+	if err != nil {
+		return nil, fmt.Errorf("render docker config: %v", err)
+	}
+	// The secret's name is derived from an independent random rather than
+	// from anything in the file: names surface in trace UIs.
+	nameHex, err := dag.Random().Sha256(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("random sha256 (docker config secret name): %v", err)
+	}
+	return dag.SetSecret("oci-docker-config-"+nameHex[:16], string(raw)), nil
+}
+
+// decoys is a bearer token and a docker config that are both wrong for the
+// registry they name.
+type decoys struct {
+	token  *dagger.Secret
+	config *dagger.Secret
+}
+
+// decoyCredentials builds credentials that would fail if they were used, so a
+// precedence test can tell "the right source won" from "any source worked".
+func decoyCredentials(ctx context.Context, host string) (*decoys, error) {
+	wrongToken, err := uniqueName(ctx, "decoy-token")
+	if err != nil {
+		return nil, err
+	}
+	tokenName, err := uniqueName(ctx, "oci-decoy-token")
+	if err != nil {
+		return nil, err
+	}
+	wrongPassword, err := uniqueName(ctx, "decoy-password")
+	if err != nil {
+		return nil, err
+	}
+	config, err := dockerConfigSecret(ctx, dockerConfig{
+		auths: map[string]dockerAuth{host: {username: "decoy", password: wrongPassword}},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &decoys{token: dag.SetSecret(tokenName, wrongToken), config: config}, nil
+}

--- a/daggerverse/oci/tests/dagger.gen.go
+++ b/daggerverse/oci/tests/dagger.gen.go
@@ -213,6 +213,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).AnnotationsSurvivePush(&parent, ctx)
+		case "AnonymousAccessNeedsNoCredentials":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).AnonymousAccessNeedsNoCredentials(&parent, ctx)
 		case "AttachFailsForUnknownSubject":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -227,6 +234,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).AttachThenFetchRoundTripsContent(&parent, ctx)
+		case "AuthenticatesFromDockerConfig":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).AuthenticatesFromDockerConfig(&parent, ctx)
+		case "AuthenticatesWithBearerToken":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).AuthenticatesWithBearerToken(&parent, ctx)
 		case "CopyPreservesAllManifests":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -234,6 +255,27 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).CopyPreservesAllManifests(&parent, ctx)
+		case "DockerConfigCredentialHelperIsNotSupported":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).DockerConfigCredentialHelperIsNotSupported(&parent, ctx)
+		case "DockerConfigCredentialsDoNotLeak":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).DockerConfigCredentialsDoNotLeak(&parent, ctx)
+		case "PasswordBeatsTokenAndDockerConfig":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).PasswordBeatsTokenAndDockerConfig(&parent, ctx)
 		case "PushArtifactThenFetchRoundTripsContent":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -304,6 +346,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).ResolveIsNotCached(&parent, ctx)
+		case "TokenBeatsDockerConfig":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).TokenBeatsDockerConfig(&parent, ctx)
 		default:
 			return nil, fmt.Errorf("unknown function %s", fnName)
 		}

--- a/daggerverse/oci/tests/internal/dagger/oci.gen.go
+++ b/daggerverse/oci/tests/internal/dagger/oci.gen.go
@@ -19,7 +19,7 @@ func (r *Binding) AsOci() *Oci { // oci (../../../../../daggerverse/oci/main.go:
 }
 
 // Retrieve the binding value, as type OciRegistry
-func (r *Binding) AsOciRegistry() *OciRegistry { // oci (../../../../../daggerverse/oci/main.go:82:6)
+func (r *Binding) AsOciRegistry() *OciRegistry { // oci (../../../../../daggerverse/oci/main.go:121:6)
 	q := r.query.Select("asOciRegistry")
 
 	return &OciRegistry{
@@ -52,7 +52,7 @@ func (r *Env) WithOciOutput(name string, description string) *Env { // oci (../.
 }
 
 // Create or update a binding of type OciRegistry in the environment
-func (r *Env) WithOciRegistryInput(name string, value *OciRegistry, description string) *Env { // oci (../../../../../daggerverse/oci/main.go:82:6)
+func (r *Env) WithOciRegistryInput(name string, value *OciRegistry, description string) *Env { // oci (../../../../../daggerverse/oci/main.go:121:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withOciRegistryInput")
 	q = q.Arg("name", name)
@@ -65,7 +65,7 @@ func (r *Env) WithOciRegistryInput(name string, value *OciRegistry, description 
 }
 
 // Declare a desired OciRegistry output to be assigned in the environment
-func (r *Env) WithOciRegistryOutput(name string, description string) *Env { // oci (../../../../../daggerverse/oci/main.go:82:6)
+func (r *Env) WithOciRegistryOutput(name string, description string) *Env { // oci (../../../../../daggerverse/oci/main.go:121:6)
 	q := r.query.Select("withOciRegistryOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -80,13 +80,36 @@ func (r *Env) WithOciRegistryOutput(name string, description string) *Env { // o
 type Oci struct { // oci (../../../../../daggerverse/oci/main.go:31:6)
 	query *querybuilder.Selection
 
-	id *ID
+	credentialResolutionSelfTest *Void
+	id                           *ID
 }
 
 func (r *Oci) WithGraphQLQuery(q *querybuilder.Selection) *Oci {
 	return &Oci{
 		query: q,
 	}
+}
+
+// CredentialResolutionSelfTest checks how a Docker config is read: which
+// entry a host matches, which of an entry's forms wins, when a credential
+// helper is refused, and what a malformed config is allowed to say.
+//
+// It sits on the module rather than in tests/ because it checks unexported
+// resolution that never reaches the network, and because each case is one
+// shape of a config file — reaching them all through tests/ would mean a
+// registry per shape to assert on a string comparison. The live tests still
+// prove a resolved credential authenticates; this proves the right one was
+// resolved.
+//
+// It runs in process and needs no container, so it is cheap enough to be a
+// check of its own.
+func (r *Oci) CredentialResolutionSelfTest(ctx context.Context) error { // oci (../../../../../daggerverse/oci/main.go:48:1)
+	if r.credentialResolutionSelfTest != nil {
+		return nil
+	}
+	q := r.query.Select("credentialResolutionSelfTest")
+
+	return q.Execute(ctx)
 }
 
 // A unique identifier for this Oci.
@@ -143,20 +166,32 @@ type OciRegistryOpts struct {
 	//
 	// Username for basic authentication. Omit for an anonymous client.
 	//
-	Username string // oci (../../../../../daggerverse/oci/main.go:53:2)
+	Username string // oci (../../../../../daggerverse/oci/main.go:78:2)
 	//
 	// Password or token for basic authentication.
 	//
-	Password *Secret // oci (../../../../../daggerverse/oci/main.go:57:2)
+	Password *Secret // oci (../../../../../daggerverse/oci/main.go:82:2)
+	//
+	// A bearer token to send as-is, for a registry that issued one. Used
+	// only when no username or password was given.
+	//
+	BearerToken *Secret // oci (../../../../../daggerverse/oci/main.go:87:2)
+	//
+	// A Docker config file — the contents of ~/.docker/config.json — to read
+	// this host's credentials out of. Used only when nothing more specific
+	// was given. Credential helpers named by the file are not run; a host
+	// that resolves through one fails naming it.
+	//
+	DockerConfig *Secret // oci (../../../../../daggerverse/oci/main.go:94:2)
 	//
 	// A Dagger-hosted registry to reach over the session network instead of
 	// over the public network.
 	//
-	Service *Service // oci (../../../../../daggerverse/oci/main.go:62:2)
+	Service *Service // oci (../../../../../daggerverse/oci/main.go:99:2)
 	//
 	// Talk plain HTTP and skip TLS verification. Off by default.
 	//
-	Insecure bool // oci (../../../../../daggerverse/oci/main.go:66:2)
+	Insecure bool // oci (../../../../../daggerverse/oci/main.go:103:2)
 }
 
 // Registry binds one registry host and its credentials. service, when
@@ -165,12 +200,18 @@ type OciRegistryOpts struct {
 // because a session service's hostname is assigned by the engine and cannot
 // be predicted by the caller.
 //
+// There are three ways to authenticate and they have a fixed precedence:
+// username/password beats bearerToken, which beats dockerConfig, and
+// supplying none of them is an anonymous client. See Registry.credential for
+// why the order is that one and why a 401 never falls through to the next
+// source.
+//
 // insecure is explicit and defaults to off: it means plain HTTP and no TLS
 // verification. It is deliberately not inferred from service being set —
 // that inference is a test affordance leaking into production behaviour. It
 // is spelled insecure rather than tlsVerify because a bool defaulting to
 // true is unsettable from the CLI.
-func (r *Oci) Registry(host string, opts ...OciRegistryOpts) *OciRegistry { // oci (../../../../../daggerverse/oci/main.go:46:1)
+func (r *Oci) Registry(host string, opts ...OciRegistryOpts) *OciRegistry { // oci (../../../../../daggerverse/oci/main.go:71:1)
 	q := r.query.Select("registry")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `username` optional argument
@@ -180,6 +221,14 @@ func (r *Oci) Registry(host string, opts ...OciRegistryOpts) *OciRegistry { // o
 		// `password` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Password) {
 			q = q.Arg("password", opts[i].Password)
+		}
+		// `bearerToken` optional argument
+		if !querybuilder.IsZeroValue(opts[i].BearerToken) {
+			q = q.Arg("bearerToken", opts[i].BearerToken)
+		}
+		// `dockerConfig` optional argument
+		if !querybuilder.IsZeroValue(opts[i].DockerConfig) {
+			q = q.Arg("dockerConfig", opts[i].DockerConfig)
 		}
 		// `service` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Service) {
@@ -210,7 +259,7 @@ func (r *Oci) AsNode() Node {
 // Every method carries a never-cache directive on its own doc-comment line:
 // registry state is mutable and pushes are side-effecting, so the directive
 // repeats on each chained method rather than living only on the factory.
-type OciRegistry struct { // oci (../../../../../daggerverse/oci/main.go:82:6)
+type OciRegistry struct { // oci (../../../../../daggerverse/oci/main.go:121:6)
 	query *querybuilder.Selection
 
 	attach       *string
@@ -294,7 +343,7 @@ func (r *OciRegistry) Fetch(repository string, digest string) *File { // oci (..
 }
 
 // Host is the registry host this handle was built for.
-func (r *OciRegistry) Host(ctx context.Context) (string, error) { // oci (../../../../../daggerverse/oci/main.go:84:2)
+func (r *OciRegistry) Host(ctx context.Context) (string, error) { // oci (../../../../../daggerverse/oci/main.go:123:2)
 	if r.host != nil {
 		return *r.host, nil
 	}
@@ -356,7 +405,7 @@ func (r *OciRegistry) UnmarshalJSON(bs []byte) error {
 }
 
 // Insecure reports whether this handle talks plain HTTP.
-func (r *OciRegistry) Insecure(ctx context.Context) (bool, error) { // oci (../../../../../daggerverse/oci/main.go:88:2)
+func (r *OciRegistry) Insecure(ctx context.Context) (bool, error) { // oci (../../../../../daggerverse/oci/main.go:127:2)
 	if r.insecure != nil {
 		return *r.insecure, nil
 	}
@@ -488,7 +537,7 @@ func (r *OciRegistry) Resolve(ctx context.Context, repository string, tag string
 }
 
 // Username is the basic-auth user, empty for an anonymous client.
-func (r *OciRegistry) Username(ctx context.Context) (string, error) { // oci (../../../../../daggerverse/oci/main.go:86:2)
+func (r *OciRegistry) Username(ctx context.Context) (string, error) { // oci (../../../../../daggerverse/oci/main.go:125:2)
 	if r.username != nil {
 		return *r.username, nil
 	}

--- a/daggerverse/oci/tests/main.go
+++ b/daggerverse/oci/tests/main.go
@@ -75,6 +75,13 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("PushFailsAgainstPlaintextRegistryByDefault", t.PushFailsAgainstPlaintextRegistryByDefault)
 	jobs = jobs.WithJob("PushSucceedsAgainstPlaintextRegistryWhenInsecure", t.PushSucceedsAgainstPlaintextRegistryWhenInsecure)
 	jobs = jobs.WithJob("PushFailsWithBadCredentials", t.PushFailsWithBadCredentials)
+	jobs = jobs.WithJob("AuthenticatesFromDockerConfig", t.AuthenticatesFromDockerConfig)
+	jobs = jobs.WithJob("DockerConfigCredentialsDoNotLeak", t.DockerConfigCredentialsDoNotLeak)
+	jobs = jobs.WithJob("DockerConfigCredentialHelperIsNotSupported", t.DockerConfigCredentialHelperIsNotSupported)
+	jobs = jobs.WithJob("AuthenticatesWithBearerToken", t.AuthenticatesWithBearerToken)
+	jobs = jobs.WithJob("PasswordBeatsTokenAndDockerConfig", t.PasswordBeatsTokenAndDockerConfig)
+	jobs = jobs.WithJob("TokenBeatsDockerConfig", t.TokenBeatsDockerConfig)
+	jobs = jobs.WithJob("AnonymousAccessNeedsNoCredentials", t.AnonymousAccessNeedsNoCredentials)
 
 	return jobs.Run(ctx)
 }

--- a/daggerverse/oci/tests/registry.go
+++ b/daggerverse/oci/tests/registry.go
@@ -129,15 +129,152 @@ func (tr *testRegistry) strict() *dagger.OciRegistry {
 // assertions that have to talk to it directly rather than through the
 // module under test.
 func (tr *testRegistry) endpoint(ctx context.Context) (string, error) {
-	svc, err := tr.Service.Start(ctx)
+	return endpointOf(ctx, tr.Service)
+}
+
+// endpointOf starts a service and returns the host:port it answers on.
+//
+// The credential tests need this for a second reason beyond talking to the
+// registry directly: a docker config is keyed by host, and the host a
+// Dagger-hosted registry is reached at is assigned by the engine, so the
+// config can only be written once the service has an endpoint.
+func endpointOf(ctx context.Context, service *dagger.Service) (string, error) {
+	svc, err := service.Start(ctx)
 	if err != nil {
-		return "", fmt.Errorf("start registry: %v", err)
+		return "", fmt.Errorf("start service: %v", err)
 	}
 	ep, err := svc.Endpoint(ctx)
 	if err != nil {
-		return "", fmt.Errorf("registry endpoint: %v", err)
+		return "", fmt.Errorf("service endpoint: %v", err)
 	}
 	return ep, nil
+}
+
+// anonymousZotConfig is the same registry with the auth block removed
+// entirely: zot then allows every operation without credentials.
+const anonymousZotConfig = `{
+  "storage": { "rootDirectory": "/var/lib/registry", "dedupe": false },
+  "http": { "address": "0.0.0.0", "port": "5000" },
+  "log": { "level": "warn" }
+}`
+
+// newAnonymousRegistry stands up a registry that asks for no credentials.
+//
+// It stands in for a public registry. The alternative — pointing an anonymous
+// test at docker.io — would make a green suite depend on an unauthenticated
+// pull rate limit, and would say nothing this does not: what is under test is
+// that the module sends no Authorization header and does not fail for the
+// want of one.
+//
+// NONCE is why each caller gets its own instance. Dagger content-addresses
+// services, so two identical container definitions are one running service
+// shared across tests and across sessions; a random makes the definitions
+// differ, which keeps one test's pushes out of another's registry.
+func newAnonymousRegistry(ctx context.Context) (*dagger.Service, error) {
+	nonce, err := dag.Random().Sha256(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("random sha256 (registry nonce): %v", err)
+	}
+	return dag.Container().From(registryImage()).
+		WithEnvVariable("NONCE", nonce).
+		WithNewFile("/etc/zot/config.json", anonymousZotConfig).
+		WithExposedPort(5000).
+		AsService(dagger.ContainerAsServiceOpts{
+			UseEntrypoint: true,
+			Args:          []string{"serve", "/etc/zot/config.json"},
+		}), nil
+}
+
+// proxyImage is the reverse proxy the bearer tests put in front of a
+// registry. Pinned for the same reason zot is.
+const proxyImage = "nginx:1.29-alpine"
+
+// bearerProxyTemplate gates every request on one exact bearer token and
+// forwards what survives to the registry bound as "registry".
+//
+// The 401 carries a Bearer challenge because both client libraries decide how
+// to authenticate from the WWW-Authenticate header on the first refusal. A
+// bare 401 makes them give up, and a Basic challenge makes them send basic
+// auth — so a gate without this header would test nothing about bearer
+// tokens. Neither library then calls the realm: an access token supplied by
+// the caller is sent as-is, which is exactly the flow under test.
+//
+// ${BEARER_TOKEN} is substituted by the nginx image's own entrypoint at
+// container start, from a secret environment variable. The token therefore
+// never appears in a container argument or in an image layer.
+const bearerProxyTemplate = `server {
+    listen 80;
+    server_name _;
+    client_max_body_size 0;
+
+    location / {
+        add_header WWW-Authenticate 'Bearer realm="http://bearer-proxy.invalid/token",service="registry"' always;
+        if ($http_authorization != "Bearer ${BEARER_TOKEN}") {
+            return 401;
+        }
+        proxy_pass http://registry:5000;
+        proxy_set_header Host $http_host;
+        proxy_request_buffering off;
+        proxy_read_timeout 300s;
+    }
+}
+`
+
+// bearerProxy is a registry reachable only with one bearer token.
+type bearerProxy struct {
+	Service *dagger.Service
+	Secret  *dagger.Secret
+	Token   string
+}
+
+// newBearerProxy puts a bearer-token gate in front of upstream.
+//
+// No registry in this repo's test estate issues bearer tokens — zot
+// authenticates with htpasswd and nothing else — so the only way to exercise
+// the flow a real token-issuing registry uses is to build the gate. What it
+// proves is narrow and exactly the acceptance criterion: a token handed to
+// Registry() arrives at the far end as `Authorization: Bearer <token>`.
+//
+// NGINX_ENVSUBST_FILTER restricts the entrypoint's substitution to
+// BEARER_TOKEN. Without it envsubst also replaces nginx's own
+// $http_authorization and $http_host with empty strings, and the gate then
+// refuses everything.
+func newBearerProxy(ctx context.Context, upstream *dagger.Service) (*bearerProxy, error) {
+	token, err := dag.Random().Sha256(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("random sha256 (bearer token): %v", err)
+	}
+	nameHex, err := dag.Random().Sha256(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("random sha256 (bearer secret name): %v", err)
+	}
+	secret := dag.SetSecret("oci-bearer-token-"+nameHex[:16], token)
+
+	svc := dag.Container().From(proxyImage).
+		WithServiceBinding("registry", upstream).
+		WithEnvVariable("NGINX_ENVSUBST_FILTER", "BEARER_TOKEN").
+		WithSecretVariable("BEARER_TOKEN", secret).
+		WithNewFile("/etc/nginx/templates/default.conf.template", bearerProxyTemplate).
+		WithExposedPort(80).
+		AsService(dagger.ContainerAsServiceOpts{
+			UseEntrypoint: true,
+			Args:          []string{"nginx", "-g", "daemon off;"},
+		})
+
+	return &bearerProxy{Service: svc, Secret: secret, Token: token}, nil
+}
+
+// client is a handle on the gated registry. A nil token means the proxy's
+// own, which is the one that gets through.
+func (proxy *bearerProxy) client(token *dagger.Secret) *dagger.OciRegistry {
+	if token == nil {
+		token = proxy.Secret
+	}
+	return dag.Oci().Registry("bearer-proxy.invalid", dagger.OciRegistryOpts{
+		BearerToken: token,
+		Service:     proxy.Service,
+		Insecure:    true,
+	})
 }
 
 // requireNativeReferrersAPI asserts the test registry answers


### PR DESCRIPTION
Closes #341

`Registry()` gains two credential sources beside `username`/`password`: a
bearer token to send as-is, and a `~/.docker/config.json` handed over as a
`*dagger.Secret`.

## Acceptance criteria

- [x] **A caller can authenticate from a supplied Docker config file passed as
  a `*dagger.Secret`** — new `dockerConfig` argument.
  `AuthenticatesFromDockerConfig` pushes and resolves with nothing but the
  file, which exercises both client libraries: `PushImage` goes through
  go-containerregistry and `Resolve` through oras, and a test using only one
  would leave the other silently anonymous.
- [x] **Credential helpers referenced by that config are honoured, or their
  non-support is documented explicitly** — non-support, documented in the
  README under its own heading and enforced at runtime. A config resolving the
  bound host through a helper fails naming the binary it asked for;
  `DockerConfigCredentialHelperIsNotSupported` holds it to that.
- [x] **A bearer token can be supplied directly for registries that issue
  them** — new `bearerToken` argument, mapped to oras' `AccessToken` and
  go-containerregistry's `RegistryToken`. `AuthenticatesWithBearerToken` pushes
  and resolves through a gate that refuses everything without one exact
  `Authorization: Bearer` header.
- [x] **Precedence between the credential sources is defined and tested** —
  `username`/`password` > `bearerToken` > `dockerConfig` > anonymous, and a 401
  never falls through to the next source.
  `PasswordBeatsTokenAndDockerConfig` and `TokenBeatsDockerConfig` supply
  credentials that are *wrong* at every rung below the one under test, so
  neither can pass on whichever source the module happened to read.
- [x] **No credential value appears in an error message, a trace span name, or
  a container argument** — `scrub` now covers every plaintext the connection
  read, not just the password. The module builds no containers, so there is no
  container argument to leak into; secrets cross the boundary as
  `*dagger.Secret` and never as span names.
  `DockerConfigCredentialsDoNotLeak` and the wrong-token half of
  `AuthenticatesWithBearerToken` assert on the error text.
- [x] **Anonymous access to a public registry still works with no credentials
  supplied** — `AnonymousAccessNeedsNoCredentials`, in both shapes: no
  credentials at all, and a Docker config that says nothing about this host.

## Judgment calls that shaped the public API

**Precedence is strict, not a fallback chain.** A lower source is not consulted
once a higher one has been supplied, and a 401 does not escalate to the next.
Falling through would authenticate as somebody the caller did not choose, and
would turn one wrong password into two failed attempts against a registry that
may be counting them.

**Credential helpers fail loudly rather than falling through to anonymous.** A
helper is an external `docker-credential-*` binary the Docker CLI executes, and
the module runtime holds no `gcloud`, no `ecr-login` and no keychain; reaching
one would mean shelling out to a helper container, which is the one thing this
module does not do anywhere. Falling through would turn "your credential lives
somewhere I cannot reach" into an unrelated 401 with nothing in the message
pointing at the cause.

**But a `credsStore` with no entry for the host is ignored.** That is the
ordinary shape of a config file on any machine where somebody has run
`docker login`, and reading it as governing every host would make every
anonymous pull fail with an unrunnable-helper error. A credential written in
the file also beats a store, because it is there and the store is not.

**A config that says nothing about the host is not an error** — it is a config
about other registries, and the caller gets anonymous access, the same answer
`docker pull` would give.

**The config is searched for the address actually dialled**, not `host`, so a
Dagger-hosted registry is looked up under the endpoint it was reached at. For
every registry on the public network the two are the same string.

**Redaction covers the whole file, not the entry that matched.** The config
arrived as one secret, so every credential in it is the caller's — including
hosts this connection never dialled. The base64 `auth` blob is scrubbed as well
as the password inside it: base64 is not encryption, and the blob is the form
the credential actually travels in. A malformed config fails without quoting
itself back, because `encoding/json` puts the offending input in its message
and the offending input is a file full of passwords.

**`bearerToken`, not `token`.** `password` is already routinely a token; a name
that did not say *which* kind would be the ambiguous one of the two.

## Testing notes

The bearer tests put an **nginx gate in front of an anonymous zot**. No registry
in this repo's test estate issues bearer tokens — zot authenticates with
htpasswd and nothing else. The gate answers its 401 with a `Bearer` challenge,
which is what makes both client libraries send the supplied token rather than
falling back to basic auth; the token reaches nginx through a secret
environment variable substituted at container start, so it never appears in a
container argument or an image layer.

`CredentialResolutionSelfTest` is a `+check` on the module rather than a test in
`tests/`, following `Pdf.RenderSchedulingSelfTest`. It covers how a config is
*read* — scheme-prefixed keys, Docker Hub's four names, unpadded base64,
`identitytoken`/`registrytoken`, helper refusal, what a malformed file may say —
none of which touches the network, and all of which would otherwise need a
registry per case to assert on a string comparison. It was falsified against two
deliberate mutations before being kept.

## Verification

- `dagger check` — green (`ci:generated`, `ci:generated-self-test`,
  `ci:selection-self-test`).
- `bash .github/scripts/verify-affected-modules.sh` — green:
  `oci:credential-resolution-self-test` and `tests:all`, 21 tests including the
  7 new ones.
- `dagger develop` re-run in both `daggerverse/oci` and `daggerverse/oci/tests`
  after the last source edit; the regenerated bindings are committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
