### PR TITLE
fix(oci): keep a registry that cannot delete manifests from failing an attach

### DIFF
--- a/daggerverse/CLAUDE.md
+++ b/daggerverse/CLAUDE.md
@@ -107,14 +107,21 @@ nothing in this repo has to choose.
 
 Two consequences worth knowing before debugging one of them:
 
-- **The fallback needs manifest deletion.** Attaching a *second* referrer to
-  one subject means replacing the tag's index, which means deleting the one
-  it replaces. `registry:2` has deletion off by default, so the first
-  attachment succeeds and the second fails with `405 unsupported` from a
-  `DELETE`. Test registries need `REGISTRY_STORAGE_DELETE_ENABLED=true`;
-  GHCR allows the delete.
+- **The fallback tries to delete a manifest, and GHCR refuses.** Attaching a
+  *second* referrer to one subject means replacing the tag's index, after
+  which `oras-go` deletes the index it replaced. GHCR does not support
+  manifest `DELETE` and answers `405 unsupported`, which fails the whole
+  push — *after* the referrer and the updated index have both landed. Set
+  [`remote.Repository.SkipReferrersGC`][skipgc] to keep the housekeeping
+  from failing a publish; `daggerverse/oci` does, and the cost is one
+  unreferenced index per replacement. Do not paper over it in a test
+  registry with `REGISTRY_STORAGE_DELETE_ENABLED=true`: that makes the
+  suite green against a registry no publish target resembles, which is how
+  devex#360 reached a real release.
 - **A referrer is addressed by digest, not by a tag of its own.** Push it
   with `oras.CopyGraph`, not `oras.Copy` — see `daggerverse/oci/artifact.go`.
+
+[skipgc]: https://pkg.go.dev/oras.land/oras-go/v2/registry/remote#Repository
 
 ## Provenance: the identity comes from the token, never from a parameter
 

--- a/daggerverse/oci/README.md
+++ b/daggerverse/oci/README.md
@@ -266,6 +266,15 @@ referrer, err := reg.Attach(ctx, "z5labs/myapp", imageDigest, sbom, "application
 repository fails naming the digest instead of leaving a dangling referrer
 behind.
 
+On a registry that does not serve the OCI 1.1 referrers API — GHCR does not —
+`oras` stores the referrers index under the tag `sha256-<subject digest>`
+instead. Each further attachment replaces that index, and `oras` would then
+delete the index it replaced. This module does not let it: GHCR refuses a
+manifest `DELETE` with `405 unsupported`, and a publish that has already
+pushed the referrer and updated the index should not fail over housekeeping.
+The cost is one unreferenced index per replacement, which nothing lists and
+nothing resolves to.
+
 ### Referrers
 
 Lists the artifacts attached to `subject` as a JSON array of OCI descriptors.
@@ -312,14 +321,21 @@ raw, err := reg.Manifest(ctx, "z5labs/myapp", "v1.2.3")
 
 ## Tests
 
-`tests/` runs against [zot][zot] rather than `registry:2`, because the
-referrer tests need a registry serving the native OCI 1.1 referrers API.
+`tests/` runs against [zot][zot] rather than `registry:2`, because most of the
+referrer tests need a registry serving the native OCI 1.1 referrers API and
 `oras` silently falls back to the OCI 1.1 tag schema against one that does
-not, so a suite green over the fallback would be evidence about the fallback
-rather than about GHCR. `registry:2.8` has no such endpoint, and
-`registry:3.0.0` was measured here too and does not register the route either.
-`requireNativeReferrersAPI` keeps that a checked fact rather than a claim in a
-comment.
+not. `registry:2.8` has no such endpoint, and `registry:3.0.0` was measured
+here too and does not register the route either.
+`requireNativeReferrersAPI` keeps which path a test took a checked fact rather
+than a claim in a comment.
+
+The fallback is not a lesser path, though — it is the one GHCR takes, so
+`AttachSucceedsWhereManifestDeleteIsUnsupported` deliberately runs against a
+plain `registry:2.8.3` with deletion left off, which is GHCR's shape in the
+two respects that matter. It asserts both of those with
+`requireNoNativeReferrersAPI` and `requireManifestDeleteUnsupported` before
+attaching anything, then attaches twice to one subject — the second
+attachment being the one that replaces the referrers index and used to fail.
 
 The bearer-token tests put an nginx gate in front of an anonymous zot, because
 no registry in this repo's test estate issues bearer tokens — zot

--- a/daggerverse/oci/artifact.go
+++ b/daggerverse/oci/artifact.go
@@ -266,6 +266,20 @@ func (c *conn) repository(repository string) (*orasremote.Repository, error) {
 	}
 	repo.PlainHTTP = c.insecure
 	repo.Client = c.httpClient()
+	// A registry without the referrers API — GHCR — sends oras down the
+	// referrers tag schema, where the index lives under sha256-<subject>.
+	// Attaching a second referrer replaces that index, and oras then deletes
+	// the one it replaced. GHCR does not support manifest deletion and
+	// answers 405, which fails the push after the referrer and the updated
+	// index have both landed: a red build over housekeeping, and an error
+	// saying the attachment failed when it did not.
+	//
+	// Skipping the collection leaves one unreferenced index per replacement
+	// behind. That is the right trade unconditionally rather than per
+	// registry: whether a registry can delete is not discoverable without
+	// attempting the delete, which is the thing that fails, and a dangling
+	// manifest costs a consumer nothing — it is unreferenced and unlisted.
+	repo.SkipReferrersGC = true
 	return repo, nil
 }
 

--- a/daggerverse/oci/tests/dagger.gen.go
+++ b/daggerverse/oci/tests/dagger.gen.go
@@ -227,6 +227,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).AttachFailsForUnknownSubject(&parent, ctx)
+		case "AttachSucceedsWhereManifestDeleteIsUnsupported":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).AttachSucceedsWhereManifestDeleteIsUnsupported(&parent, ctx)
 		case "AttachThenFetchRoundTripsContent":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/oci/tests/main.go
+++ b/daggerverse/oci/tests/main.go
@@ -70,6 +70,7 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("ReferrersListsAttachedArtifacts", t.ReferrersListsAttachedArtifacts)
 	jobs = jobs.WithJob("ReferrersFiltersByArtifactType", t.ReferrersFiltersByArtifactType)
 	jobs = jobs.WithJob("AttachFailsForUnknownSubject", t.AttachFailsForUnknownSubject)
+	jobs = jobs.WithJob("AttachSucceedsWhereManifestDeleteIsUnsupported", t.AttachSucceedsWhereManifestDeleteIsUnsupported)
 	jobs = jobs.WithJob("ResolveIsNotCached", t.ResolveIsNotCached)
 	jobs = jobs.WithJob("PushImageIsNotCached", t.PushImageIsNotCached)
 	jobs = jobs.WithJob("PushFailsAgainstPlaintextRegistryByDefault", t.PushFailsAgainstPlaintextRegistryByDefault)
@@ -302,9 +303,10 @@ func (t *Tests) PushFailsWithBadCredentials(ctx context.Context) error {
 // is serving the native OCI 1.1 referrers API.
 //
 // That second assertion is the point of the test. oras falls back to the tag
-// schema against a registry without /v2/<name>/referrers/<digest>, and a
-// green suite over the fallback would be evidence about the fallback and
-// nothing about GHCR, which serves the real endpoint.
+// schema against a registry without /v2/<name>/referrers/<digest>, so without
+// it a green run would not say which of the two paths it exercised. The
+// fallback is GHCR's path and has a test of its own,
+// AttachSucceedsWhereManifestDeleteIsUnsupported.
 func (t *Tests) ReferrersListsAttachedArtifacts(ctx context.Context) error {
 	reg, err := newRegistry(ctx)
 	if err != nil {
@@ -420,14 +422,82 @@ func (t *Tests) AttachFailsForUnknownSubject(ctx context.Context) error {
 	return nil
 }
 
+// AttachSucceedsWhereManifestDeleteIsUnsupported asserts that attaching a
+// second referrer to one subject works on a registry that serves no
+// referrers API and refuses to delete a manifest — which is GHCR.
+//
+// Both halves are needed to reproduce it, and the test checks it is really
+// getting both before it attaches anything. Without the referrers API oras
+// falls back to the referrers tag schema, where the second attachment
+// replaces the index the first one wrote; oras then deletes the index it
+// replaced, the registry answers 405, and the whole push fails after the
+// referrer and the updated index have already landed. The module skips that
+// collection, so this is one dangling index and no error.
+//
+// The rest of the referrer tests run against zot and are evidence about the
+// native path. This is the only one that exercises the path GHCR takes.
+func (t *Tests) AttachSucceedsWhereManifestDeleteIsUnsupported(ctx context.Context) error {
+	svc, err := newGhcrShapedRegistry(ctx)
+	if err != nil {
+		return err
+	}
+	client := dag.Oci().Registry("ghcr-shaped.invalid", dagger.OciRegistryOpts{
+		Service:  svc,
+		Insecure: true,
+	})
+	repo, err := uniqueName(ctx, "no-delete")
+	if err != nil {
+		return err
+	}
+
+	subject, err := client.PushImage(ctx, repo, "v1", []*dagger.Container{baseImage("linux/amd64")})
+	if err != nil {
+		return fmt.Errorf("PushImage: %v", err)
+	}
+	if err := requireNoNativeReferrersAPI(ctx, svc, repo, subject); err != nil {
+		return err
+	}
+	if err := requireManifestDeleteUnsupported(ctx, svc, repo); err != nil {
+		return err
+	}
+
+	sbom, err := attachTo(ctx, client, repo, subject, "sbom.json", sbomArtifactType)
+	if err != nil {
+		return err
+	}
+	// The first attachment creates the referrers index and the second
+	// replaces it, so only this one triggers the collection that GHCR
+	// refuses. A test attaching once would pass with or without the fix.
+	attestation, err := attachTo(ctx, client, repo, subject, "attestation.json", attestationArtifactType)
+	if err != nil {
+		return err
+	}
+
+	raw, err := client.Referrers(ctx, repo, subject)
+	if err != nil {
+		return fmt.Errorf("Referrers: %v", err)
+	}
+	got, err := decodeDescriptors(raw)
+	if err != nil {
+		return err
+	}
+	return wantDigests(got, raw, sbom, attestation)
+}
+
 // attach uploads a one-file artifact against subject and returns its digest.
 func (tr *testRegistry) attach(ctx context.Context, repo, subject, name, artifactType string) (string, error) {
+	return attachTo(ctx, tr.client(), repo, subject, name, artifactType)
+}
+
+// attachTo is attach against any registry handle, for the tests that stand
+// up a registry other than the suite's default zot.
+func attachTo(ctx context.Context, client *dagger.OciRegistry, repo, subject, name, artifactType string) (string, error) {
 	body, err := uniqueName(ctx, "body")
 	if err != nil {
 		return "", err
 	}
 	content := dag.Directory().WithNewFile(name, body).File(name)
-	digest, err := tr.client().Attach(ctx, repo, subject, content, artifactType)
+	digest, err := client.Attach(ctx, repo, subject, content, artifactType)
 	if err != nil {
 		return "", fmt.Errorf("Attach %s (%s): %v", name, artifactType, err)
 	}

--- a/daggerverse/oci/tests/registry.go
+++ b/daggerverse/oci/tests/registry.go
@@ -22,15 +22,17 @@ const registryUser = "ci"
 // registryImage is zot, not the registry:2 the other test modules in this
 // repo use and not distribution 3 either.
 //
-// The referrers tests need a registry that serves the native OCI 1.1
+// Most of the referrers tests need a registry that serves the native OCI 1.1
 // referrers API, because oras silently falls back to the OCI 1.1 tag schema
-// against one that does not — and a suite green over the fallback is
-// evidence about the fallback, not about GHCR. registry:2.8 has no such
+// against one that does not, and a suite that only ever ran one of those two
+// paths would say nothing about the other. registry:2.8 has no such
 // endpoint. registry:3.0.0 was measured here too and does not register the
 // route either: GET /v2/<name>/referrers/<digest> comes back as a bare
 // "404 page not found" from the router, not a registry error. zot serves it.
 // requireNativeReferrersAPI keeps that a checked fact rather than a claim in
 // this comment.
+//
+// The fallback path is GHCR's, and newGhcrShapedRegistry covers it.
 //
 // zot publishes one image per architecture rather than a manifest list, so
 // the tag has to name the arch. Test module code runs in a linux container
@@ -299,14 +301,110 @@ func (proxy *bearerProxy) client(token *dagger.Secret) *dagger.OciRegistry {
 	})
 }
 
+// distributionImage is a registry shaped like GHCR: it serves no referrers
+// API, and it refuses manifest deletion. Pinned for the same reason zot is —
+// both of those are the properties under test, and a moving tag could take
+// either of them away.
+const distributionImage = "registry:2.8.3"
+
+// newGhcrShapedRegistry stands up a registry that cannot delete a manifest
+// and does not serve the referrers API.
+//
+// Those are GHCR's two relevant properties, and together they are what
+// AttachSucceedsWhereManifestDeleteIsUnsupported needs: no referrers API
+// sends oras down the referrers *tag* schema, and on that path it replaces
+// the index under sha256-<subject> and then deletes the index it replaced.
+// zot cannot stand in here — it serves the referrers API, so the fallback
+// never runs and no delete is ever attempted.
+//
+// Deletion is off by default in distribution, so nothing turns it off. It
+// is anonymous because credentials are exercised everywhere else in this
+// suite and are not what this test is about. NONCE is why each caller gets
+// its own instance: Dagger content-addresses services, so two identical
+// definitions are one shared registry across tests and across sessions.
+func newGhcrShapedRegistry(ctx context.Context) (*dagger.Service, error) {
+	nonce, err := dag.Random().Sha256(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("random sha256 (registry nonce): %v", err)
+	}
+	return dag.Container().From(distributionImage).
+		WithEnvVariable("NONCE", nonce).
+		WithExposedPort(5000).
+		AsService(dagger.ContainerAsServiceOpts{UseEntrypoint: true}), nil
+}
+
+// requireNoNativeReferrersAPI is requireNativeReferrersAPI's opposite, and
+// exists for the same reason: it keeps which code path a test exercised a
+// checked fact. A registry that grew the endpoint would answer every
+// referrer assertion off the native API, and the fallback this test is
+// about would go unexercised while the test stayed green.
+func requireNoNativeReferrersAPI(ctx context.Context, svc *dagger.Service, repo, subject string) error {
+	status, body, err := probe(ctx, svc, http.MethodGet, fmt.Sprintf("/v2/%s/referrers/%s", repo, subject))
+	if err != nil {
+		return err
+	}
+	if status == http.StatusOK {
+		return fmt.Errorf("%s serves the native referrers API: GET /v2/<repo>/referrers/<digest> returned 200, "+
+			"so oras will not take the tag-schema fallback this test is about (body %s)", distributionImage, body)
+	}
+	return nil
+}
+
+// requireManifestDeleteUnsupported asserts the registry refuses to delete a
+// manifest, which is the half of GHCR's behaviour that turned a successful
+// attach into a failed one.
+//
+// The digest it tries to delete is of content the registry has never seen,
+// so a registry that did support deletion has nothing to lose by it. That
+// works because distribution checks whether deletion is enabled before it
+// checks whether the manifest exists.
+func requireManifestDeleteUnsupported(ctx context.Context, svc *dagger.Service, repo string) error {
+	absent, err := dag.Random().Sha256(ctx)
+	if err != nil {
+		return fmt.Errorf("random sha256 (absent digest): %v", err)
+	}
+	status, body, err := probe(ctx, svc, http.MethodDelete, fmt.Sprintf("/v2/%s/manifests/sha256:%s", repo, absent))
+	if err != nil {
+		return err
+	}
+	if status != http.StatusMethodNotAllowed {
+		return fmt.Errorf("%s answered DELETE /v2/<repo>/manifests/<digest> with %d, want 405: "+
+			"this registry can delete manifests, so it is not the shape of GHCR (body %s)",
+			distributionImage, status, body)
+	}
+	return nil
+}
+
+// probe issues one unauthenticated request straight at a registry and
+// returns its status and body, for the assertions that are about what the
+// registry itself does rather than about the module.
+func probe(ctx context.Context, svc *dagger.Service, method, path string) (int, string, error) {
+	endpoint, err := endpointOf(ctx, svc)
+	if err != nil {
+		return 0, "", err
+	}
+	url := "http://" + endpoint + path
+	req, err := http.NewRequestWithContext(ctx, method, url, nil)
+	if err != nil {
+		return 0, "", fmt.Errorf("build %s request: %v", method, err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, "", fmt.Errorf("%s %s: %v", method, url, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	return resp.StatusCode, string(body), nil
+}
+
 // requireNativeReferrersAPI asserts the test registry answers
 // GET /v2/<repo>/referrers/<digest> itself.
 //
-// It is the assertion that makes the referrer tests evidence about GHCR. A
-// registry without the endpoint returns 404, oras silently falls back to the
-// OCI 1.1 tag schema, and every referrer assertion still passes — against a
-// code path GHCR does not use. Checking the status code directly is the only
-// way to tell those two green suites apart.
+// It is the assertion that pins which code path the referrer tests ran over.
+// A registry without the endpoint returns 404, oras silently falls back to
+// the OCI 1.1 tag schema, and every referrer assertion still passes — over
+// the other path entirely. Checking the status code directly is the only way
+// to tell those two green suites apart.
 func requireNativeReferrersAPI(ctx context.Context, tr *testRegistry, repo, subject string) error {
 	endpoint, err := tr.endpoint(ctx)
 	if err != nil {

--- a/daggerverse/z5labs/tests/main.go
+++ b/daggerverse/z5labs/tests/main.go
@@ -158,15 +158,15 @@ func localRegistry(ctx context.Context) (*dagger.Service, string, *dagger.Secret
 		File("/tmp/htpasswd")
 	svc := dag.Container().From("registry:2").
 		WithMountedFile("/auth/htpasswd", htpasswdFile).
-		// registry:2 does not implement the OCI 1.1 referrers API, so a
-		// client attaching a second referrer to the same subject falls
-		// back to the referrers *tag* scheme — and updating that tag
-		// means deleting the index it replaces. Deletion is off by
-		// default, which surfaces as a 405 on the second attachment and
-		// on nothing else. Enabling it here is what lets these tests
-		// exercise the fallback path a registry without the referrers
-		// API actually takes.
-		WithEnvVariable("REGISTRY_STORAGE_DELETE_ENABLED", "true").
+		// Manifest deletion is left off, which is distribution's default
+		// and GHCR's behaviour. registry:2 implements no referrers API
+		// either, so a client attaching a second referrer to one subject
+		// falls back to the referrers *tag* scheme, replaces the index
+		// under that tag, and would delete the index it replaced. This
+		// suite used to turn deletion on so that delete would succeed —
+		// which made it green over a registry no publish target
+		// resembles, and hid devex#360 until GHCR failed a real release.
+		// The oci module skips the collection instead.
 		WithEnvVariable("REGISTRY_AUTH", "htpasswd").
 		WithEnvVariable("REGISTRY_AUTH_HTPASSWD_REALM", "Registry").
 		WithEnvVariable("REGISTRY_AUTH_HTPASSWD_PATH", "/auth/htpasswd").


### PR DESCRIPTION
Closes #360.

## What was wrong

GHCR serves no referrers API, so `oras-go` stores the referrers index under the tag
`sha256-<subject>`. Attaching a *second* referrer replaces that index and then deletes the index
it replaced — GHCR answers that `DELETE` with `405 unsupported`, which fails `CopyGraph` after
the referrer and the updated index have both landed. `GoApp.Ci` attaches SPDX then CycloneDX to
each digest, so every publish tripped it on the second one: image out, attestations in place,
build red, and an error saying the attachment failed when it had not.

## The fix

`repo.SkipReferrersGC = true` in `daggerverse/oci/artifact.go`'s `repository` helper, so the
housekeeping delete is never attempted. Unconditional rather than per-registry: whether a
registry can delete is not discoverable without attempting the delete, which is the thing that
fails. The cost is one unreferenced index per replacement — nothing lists it and nothing
resolves to it.

## Why it was not caught

`daggerverse/z5labs/tests` set `REGISTRY_STORAGE_DELETE_ENABLED=true` on its `registry:2` so
the delete would succeed. That made the end-to-end publish green against a registry no publish
target resembles. It is gone, and the suite now runs against a registry with GHCR's shape.

## Test

`AttachSucceedsWhereManifestDeleteIsUnsupported` runs against a plain `registry:2.8.3` — no
referrers API, deletion off — and asserts both of those properties (`requireNoNativeReferrersAPI`,
`requireManifestDeleteUnsupported`) before attaching anything, so a future image bump cannot make
it vacuous. It then attaches twice to one subject and lists both. On `main` it fails with the
reported error verbatim:

```
push referrer to ...: failed to delete dangling referrers index sha256:a8ab1a8c... for
referrers tag sha256-c897dbfe...: DELETE ".../manifests/sha256:a8ab1a8c...": response status
code 405: unsupported: The operation is unsupported.
```

The zot-based referrer tests are unchanged and remain the coverage of the native path; the
comments claiming the native path was the GHCR one were corrected in `daggerverse/CLAUDE.md`,
`daggerverse/oci/README.md` and the test comments.

## Left open

Issue #360's second question — a failed attach leaves a published-but-unattested image and a red
build — is a change to `GoApp.Ci`'s publish ordering, not to this bug. Filed as #361.

## Verified locally

- `dagger check` — green
- `bash .github/scripts/verify-affected-modules.sh` — green (`oci` and `z5labs`, both suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
