### PR TITLE
story(issue-286): record passes to the memo store from the module

### DIFF
--- a/ci/internal/dagger/workspace-ci.gen.go
+++ b/ci/internal/dagger/workspace-ci.gen.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Retrieve the binding value, as type WorkspaceCi
-func (r *Binding) AsWorkspaceCi() *WorkspaceCi { // workspace-ci (../../../daggerverse/workspace-ci/main.go:31:6)
+func (r *Binding) AsWorkspaceCi() *WorkspaceCi { // workspace-ci (../../../daggerverse/workspace-ci/main.go:32:6)
 	q := r.query.Select("asWorkspaceCi")
 
 	return &WorkspaceCi{
@@ -20,7 +20,7 @@ func (r *Binding) AsWorkspaceCi() *WorkspaceCi { // workspace-ci (../../../dagge
 }
 
 // Create or update a binding of type WorkspaceCi in the environment
-func (r *Env) WithWorkspaceCiInput(name string, value *WorkspaceCi, description string) *Env { // workspace-ci (../../../daggerverse/workspace-ci/main.go:31:6)
+func (r *Env) WithWorkspaceCiInput(name string, value *WorkspaceCi, description string) *Env { // workspace-ci (../../../daggerverse/workspace-ci/main.go:32:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withWorkspaceCiInput")
 	q = q.Arg("name", name)
@@ -33,7 +33,7 @@ func (r *Env) WithWorkspaceCiInput(name string, value *WorkspaceCi, description 
 }
 
 // Declare a desired WorkspaceCi output to be assigned in the environment
-func (r *Env) WithWorkspaceCiOutput(name string, description string) *Env { // workspace-ci (../../../daggerverse/workspace-ci/main.go:31:6)
+func (r *Env) WithWorkspaceCiOutput(name string, description string) *Env { // workspace-ci (../../../daggerverse/workspace-ci/main.go:32:6)
 	q := r.query.Select("withWorkspaceCiOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -51,7 +51,7 @@ type WorkspaceCiOpts struct {
 	// source context, so nothing else would attribute them. Defaults to
 	// .github/workflows/, which costs nothing in a workspace that has none.
 	//
-	GlobalPaths []string // workspace-ci (../../../daggerverse/workspace-ci/main.go:58:2)
+	GlobalPaths []string // workspace-ci (../../../daggerverse/workspace-ci/main.go:85:2)
 	//
 	// Repo-relative directories of modules whose checks must each get their own leg
 	// even when everything runs. The run-everything path otherwise emits one leg per
@@ -60,7 +60,7 @@ type WorkspaceCiOpts struct {
 	// single runner. Splitting a module costs loading it — the one thing that path
 	// exists to avoid — so name only the modules that need it.
 	//
-	SplitModules []string // workspace-ci (../../../daggerverse/workspace-ci/main.go:67:2)
+	SplitModules []string // workspace-ci (../../../daggerverse/workspace-ci/main.go:94:2)
 	//
 	// Per-leg check-step budgets in minutes, as a JSON object keyed by a leg's
 	// display name or by a module directory (which covers every leg of that
@@ -68,39 +68,57 @@ type WorkspaceCiOpts struct {
 	//
 	//
 	// Default: "{}"
-	Timeouts string // workspace-ci (../../../daggerverse/workspace-ci/main.go:74:2)
+	Timeouts string // workspace-ci (../../../daggerverse/workspace-ci/main.go:101:2)
 	//
 	// The check-step budget in minutes for a leg with no override.
 	//
 	//
 	// Default: 6
-	DefaultTimeout int // workspace-ci (../../../daggerverse/workspace-ci/main.go:79:2)
+	DefaultTimeout int // workspace-ci (../../../daggerverse/workspace-ci/main.go:106:2)
 	//
-	// A credential for reading the memoization store: a GitHub token with
-	// actions:read on memoRepo. Nothing is ever written from here — see README.md.
+	// Where recorded passes live. ACTIONS_CACHE is read-only from this module and
+	// leaves recording to an actions/cache/save step; GIT_REFS is a store the
+	// module owns both sides of, so RecordPass can write it from anywhere a token
+	// reaches. See README.md — the two have different trust arguments.
 	//
-	MemoToken *Secret // workspace-ci (../../../daggerverse/workspace-ci/main.go:84:2)
 	//
-	// The owner/name whose Actions cache holds the memoization store.
+	// Default: ACTIONS_CACHE
+	MemoStore WorkspaceCiMemoStore // workspace-ci (../../../daggerverse/workspace-ci/main.go:114:2)
 	//
-	MemoRepo string // workspace-ci (../../../daggerverse/workspace-ci/main.go:88:2)
+	// A credential for the memoization store: a GitHub token on memoRepo with
+	// actions:read for ACTIONS_CACHE, or contents:read for GIT_REFS — plus
+	// contents:write if this run is to record anything.
 	//
-	// The git refs whose cache scopes may be trusted to hold recorded passes.
-	// Defaults to none, which reads nothing: a scope a run can write is a scope
-	// that must be chosen deliberately.
+	MemoToken *Secret // workspace-ci (../../../daggerverse/workspace-ci/main.go:120:2)
 	//
-	MemoRefs []string // workspace-ci (../../../daggerverse/workspace-ci/main.go:94:2)
+	// The owner/name whose Actions cache, or whose git refs, hold the memoization
+	// store.
+	//
+	MemoRepo string // workspace-ci (../../../daggerverse/workspace-ci/main.go:125:2)
+	//
+	// The GitHub API root the store is reached through. Defaults to
+	// https://api.github.com; set it for GitHub Enterprise Server.
+	//
+	MemoAPI string // workspace-ci (../../../daggerverse/workspace-ci/main.go:130:2)
+	//
+	// The git refs whose scopes may be trusted to hold recorded passes, spelled in
+	// full (refs/heads/main, refs/pull/12/merge). They are the refs a plan reads,
+	// and the only refs RecordPass will write from. Defaults to none, which reads
+	// nothing and records nothing: a scope a run can write is a scope that must be
+	// chosen deliberately.
+	//
+	MemoRefs []string // workspace-ci (../../../daggerverse/workspace-ci/main.go:138:2)
 	//
 	// How long, in seconds, a recorded pass may be honoured. This is the answer to
 	// base-image drift, which a source-derived hash cannot see.
 	//
 	//
 	// Default: 86400
-	MemoTTL int // workspace-ci (../../../daggerverse/workspace-ci/main.go:100:2)
+	MemoTTL int // workspace-ci (../../../daggerverse/workspace-ci/main.go:144:2)
 }
 
 // New configures a planner.
-func (r *Query) WorkspaceCi(opts ...WorkspaceCiOpts) *WorkspaceCi { // workspace-ci (../../../daggerverse/workspace-ci/main.go:51:1)
+func (r *Query) WorkspaceCi(opts ...WorkspaceCiOpts) *WorkspaceCi { // workspace-ci (../../../daggerverse/workspace-ci/main.go:78:1)
 	q := r.query.Select("workspaceCi")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `globalPaths` optional argument
@@ -119,6 +137,10 @@ func (r *Query) WorkspaceCi(opts ...WorkspaceCiOpts) *WorkspaceCi { // workspace
 		if !querybuilder.IsZeroValue(opts[i].DefaultTimeout) {
 			q = q.Arg("defaultTimeout", opts[i].DefaultTimeout)
 		}
+		// `memoStore` optional argument
+		if !querybuilder.IsZeroValue(opts[i].MemoStore) {
+			q = q.Arg("memoStore", opts[i].MemoStore)
+		}
 		// `memoToken` optional argument
 		if !querybuilder.IsZeroValue(opts[i].MemoToken) {
 			q = q.Arg("memoToken", opts[i].MemoToken)
@@ -126,6 +148,10 @@ func (r *Query) WorkspaceCi(opts ...WorkspaceCiOpts) *WorkspaceCi { // workspace
 		// `memoRepo` optional argument
 		if !querybuilder.IsZeroValue(opts[i].MemoRepo) {
 			q = q.Arg("memoRepo", opts[i].MemoRepo)
+		}
+		// `memoApi` optional argument
+		if !querybuilder.IsZeroValue(opts[i].MemoAPI) {
+			q = q.Arg("memoApi", opts[i].MemoAPI)
 		}
 		// `memoRefs` optional argument
 		if !querybuilder.IsZeroValue(opts[i].MemoRefs) {
@@ -143,14 +169,16 @@ func (r *Query) WorkspaceCi(opts ...WorkspaceCiOpts) *WorkspaceCi { // workspace
 }
 
 // WorkspaceCi plans CI for the workspace it is invoked from.
-type WorkspaceCi struct { // workspace-ci (../../../daggerverse/workspace-ci/main.go:31:6)
+type WorkspaceCi struct { // workspace-ci (../../../daggerverse/workspace-ci/main.go:32:6)
 	query *querybuilder.Selection
 
 	affectedModules   *string
 	generated         *Void
 	generatedSelfTest *Void
 	id                *ID
+	memoStoreSelfTest *Void
 	plan              *string
+	recordPass        *string
 	selectionSelfTest *Void
 }
 
@@ -165,12 +193,12 @@ type WorkspaceCiAffectedModulesOpts struct {
 	//
 	// The repository to plan for. Defaults to the calling workspace.
 	//
-	Repo *Directory // workspace-ci (../../../daggerverse/workspace-ci/main.go:235:2)
+	Repo *Directory // workspace-ci (../../../daggerverse/workspace-ci/main.go:288:2)
 	//
 	// The workspace to read repo from when repo is omitted. Defaults to the
 	// caller's.
 	//
-	Workspace *Workspace // workspace-ci (../../../daggerverse/workspace-ci/main.go:240:2)
+	Workspace *Workspace // workspace-ci (../../../daggerverse/workspace-ci/main.go:293:2)
 }
 
 // AffectedModules returns, as a JSON array of repo-relative directories, the
@@ -179,7 +207,7 @@ type WorkspaceCiAffectedModulesOpts struct {
 // reach" without paying for check enumeration.
 //
 // The arguments mean what they mean on Plan.
-func (r *WorkspaceCi) AffectedModules(ctx context.Context, base string, head string, opts ...WorkspaceCiAffectedModulesOpts) (string, error) { // workspace-ci (../../../daggerverse/workspace-ci/main.go:226:1)
+func (r *WorkspaceCi) AffectedModules(ctx context.Context, base string, head string, opts ...WorkspaceCiAffectedModulesOpts) (string, error) { // workspace-ci (../../../daggerverse/workspace-ci/main.go:279:1)
 	if r.affectedModules != nil {
 		return *r.affectedModules, nil
 	}
@@ -309,20 +337,40 @@ func (r *WorkspaceCi) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
+// MemoStoreSelfTest verifies the store this module owns both sides of — that a
+// pass is recorded under its own ref's scope, that recording the same hash twice
+// writes nothing and refreshes no TTL, that entries read back, that one older
+// than the TTL does not, and that one ref's scope stays out of another's — against
+// an in-process stub of GitHub's API.
+//
+// It is a check rather than only a Go test because this is the half of
+// memoization that fails silently: a store that quietly takes nothing costs every
+// later run its full time and looks exactly like a workspace nobody has recorded
+// against yet, and a scope that leaks costs correctness. Like SelectionSelfTest it
+// runs in-process and needs no network, no credential and no services.
+func (r *WorkspaceCi) MemoStoreSelfTest(ctx context.Context) error { // workspace-ci (../../../daggerverse/workspace-ci/main.go:486:1)
+	if r.memoStoreSelfTest != nil {
+		return nil
+	}
+	q := r.query.Select("memoStoreSelfTest")
+
+	return q.Execute(ctx)
+}
+
 // WorkspaceCiPlanOpts contains options for WorkspaceCi.Plan
 type WorkspaceCiPlanOpts struct {
 
 	// Default: JSON
-	Format WorkspaceCiFormat // workspace-ci (../../../daggerverse/workspace-ci/main.go:177:2)
+	Format WorkspaceCiFormat // workspace-ci (../../../daggerverse/workspace-ci/main.go:230:2)
 	//
 	// The repository to plan for. Defaults to the calling workspace.
 	//
-	Repo *Directory // workspace-ci (../../../daggerverse/workspace-ci/main.go:181:2)
+	Repo *Directory // workspace-ci (../../../daggerverse/workspace-ci/main.go:234:2)
 	//
 	// The workspace to read repo from when repo is omitted. Defaults to the
 	// caller's.
 	//
-	Workspace *Workspace // workspace-ci (../../../daggerverse/workspace-ci/main.go:186:2)
+	Workspace *Workspace // workspace-ci (../../../daggerverse/workspace-ci/main.go:239:2)
 	//
 	// Input hashes a previous run already proved good, as a JSON array. They are
 	// honoured on the same terms as the ones read from the memoization store, and
@@ -332,14 +380,14 @@ type WorkspaceCiPlanOpts struct {
 	//
 	//
 	// Default: "[]"
-	KnownGood string // workspace-ci (../../../daggerverse/workspace-ci/main.go:195:2)
+	KnownGood string // workspace-ci (../../../daggerverse/workspace-ci/main.go:248:2)
 	//
 	// Emit a diagnostics object — the plan plus which modules had to be loaded to
 	// produce it, whether everything was selected, which legs a recorded pass
 	// retired, and whether recorded passes were honoured at all — instead of the
 	// bare plan. Intended for tests and for explaining a plan, not for CI.
 	//
-	Diagnostics bool // workspace-ci (../../../daggerverse/workspace-ci/main.go:202:2)
+	Diagnostics bool // workspace-ci (../../../daggerverse/workspace-ci/main.go:255:2)
 }
 
 // Plan returns the legs of CI to run for a change, each already routed to the
@@ -366,7 +414,7 @@ type WorkspaceCiPlanOpts struct {
 // explicitly is also the escape hatch for a caller whose .git is a file rather
 // than a directory (a git worktree), which would otherwise degrade to running
 // everything.
-func (r *WorkspaceCi) Plan(ctx context.Context, base string, head string, opts ...WorkspaceCiPlanOpts) (string, error) { // workspace-ci (../../../daggerverse/workspace-ci/main.go:169:1)
+func (r *WorkspaceCi) Plan(ctx context.Context, base string, head string, opts ...WorkspaceCiPlanOpts) (string, error) { // workspace-ci (../../../daggerverse/workspace-ci/main.go:222:1)
 	if r.plan != nil {
 		return *r.plan, nil
 	}
@@ -402,13 +450,48 @@ func (r *WorkspaceCi) Plan(ctx context.Context, base string, head string, opts .
 	return response, q.Execute(ctx)
 }
 
+// RecordPass records that the leg whose inputs hashed to hash passed, so a later
+// run that computes the same hash can skip it. It is the write half of what Plan
+// reads, for the stores this module owns both sides of.
+//
+// It reports what it did, as one word, and **never fails a check that passed**.
+// Recording happens after the work is already green, so a store that will not
+// take the entry has to cost a later run its time and nothing else. A caller who
+// wants a store problem to be loud should compare the returned word:
+//
+//	RECORDED         a new entry now names this hash
+//	ALREADY_RECORDED an earlier run got there; nothing was written or refreshed
+//	REFUSED          ref is not one of memoRefs, so this scope is not writable
+//	SKIPPED          nothing to record: an empty hash, or no store configured
+//	UNSUPPORTED      the configured store cannot be written from this module
+//	FAILED           the store would not take the entry; stderr says why
+//
+// The error return is not how a store problem is reported. It carries exactly one
+// thing: a call that named no ref, because with no ref there is no scope to judge
+// and refusing silently would be indistinguishable from a scope that was judged
+// and rejected.
+func (r *WorkspaceCi) RecordPass(ctx context.Context, hash string, ref string, commit string) (string, error) { // workspace-ci (../../../daggerverse/workspace-ci/main.go:331:1)
+	if r.recordPass != nil {
+		return *r.recordPass, nil
+	}
+	q := r.query.Select("recordPass")
+	q = q.Arg("hash", hash)
+	q = q.Arg("ref", ref)
+	q = q.Arg("commit", commit)
+
+	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
 // SelectionSelfTest verifies the change -> modules -> legs mapping, the properties
 // a recorded pass depends on, and the shape each format renders a plan in, against
 // fixed fixtures — so a regression in any of them fails CI rather than silently
 // under-running a consumer's checks or handing their CI system something it cannot
 // parse. It runs in-process and needs no services, so it is cheap enough to run on
 // every leg set.
-func (r *WorkspaceCi) SelectionSelfTest(ctx context.Context) error { // workspace-ci (../../../daggerverse/workspace-ci/main.go:372:1)
+func (r *WorkspaceCi) SelectionSelfTest(ctx context.Context) error { // workspace-ci (../../../daggerverse/workspace-ci/main.go:463:1)
 	if r.selectionSelfTest != nil {
 		return nil
 	}
@@ -431,7 +514,7 @@ func (r *WorkspaceCi) AsNode() Node {
 // the *constant identifier* in SCREAMING_SNAKE_CASE, and the CLI takes that member
 // name rather than the value — hence `--format=GITHUB_ACTIONS`. The values here are
 // spelled to match, so there is only ever one spelling to remember.
-type WorkspaceCiFormat string // workspace-ci (../../../daggerverse/workspace-ci/main.go:129:6)
+type WorkspaceCiFormat string // workspace-ci (../../../daggerverse/workspace-ci/main.go:182:6)
 
 func (WorkspaceCiFormat) IsEnum() {}
 
@@ -486,14 +569,84 @@ func (v *WorkspaceCiFormat) UnmarshalJSON(dt []byte) error {
 const (
 	// FormatGithubActions is a single-line JSON array, ready to write to
 	// GITHUB_OUTPUT and expand with fromJSON as a matrix.
-	WorkspaceCiFormatGithubActions WorkspaceCiFormat = "GITHUB_ACTIONS" // workspace-ci (../../../daggerverse/workspace-ci/main.go:136:2)
+	WorkspaceCiFormatGithubActions WorkspaceCiFormat = "GITHUB_ACTIONS" // workspace-ci (../../../daggerverse/workspace-ci/main.go:189:2)
 
 	// FormatJSON is the canonical form: an indented JSON array of legs.
-	WorkspaceCiFormatJson WorkspaceCiFormat = "JSON" // workspace-ci (../../../daggerverse/workspace-ci/main.go:133:2)
+	WorkspaceCiFormatJson WorkspaceCiFormat = "JSON" // workspace-ci (../../../daggerverse/workspace-ci/main.go:186:2)
 
 	// FormatJenkins is Groovy: a map of leg name to closure, which is what a
 	// declarative pipeline's parallel step takes. Write it to a file, `load` it,
 	// and hand the result straight to `parallel`.
-	WorkspaceCiFormatJenkins WorkspaceCiFormat = "JENKINS" // workspace-ci (../../../daggerverse/workspace-ci/main.go:140:2)
+	WorkspaceCiFormatJenkins WorkspaceCiFormat = "JENKINS" // workspace-ci (../../../daggerverse/workspace-ci/main.go:193:2)
+
+)
+
+// MemoStore is where recorded passes live, and decides whether this module can
+// record one at all.
+//
+// Note on rendered names: as with Format, the CLI takes the enum member the SDK
+// derives from the constant identifier, so the values are spelled to match.
+type WorkspaceCiMemoStore string // workspace-ci (../../../daggerverse/workspace-ci/main.go:60:6)
+
+func (WorkspaceCiMemoStore) IsEnum() {}
+
+func (v WorkspaceCiMemoStore) Name() string {
+	switch v {
+	case WorkspaceCiMemoStoreActionsCache:
+		return "ACTIONS_CACHE"
+	case WorkspaceCiMemoStoreGitRefs:
+		return "GIT_REFS"
+	default:
+		return ""
+	}
+}
+
+func (v WorkspaceCiMemoStore) Value() string {
+	return string(v)
+}
+
+func (v *WorkspaceCiMemoStore) MarshalJSON() ([]byte, error) {
+	if *v == "" {
+		return []byte(`""`), nil
+	}
+	name := v.Name()
+	if name == "" {
+		return nil, fmt.Errorf("invalid enum value %q", *v)
+	}
+	return json.Marshal(name)
+}
+
+func (v *WorkspaceCiMemoStore) UnmarshalJSON(dt []byte) error {
+	var s string
+	if err := json.Unmarshal(dt, &s); err != nil {
+		return err
+	}
+	switch s {
+	case "":
+		*v = ""
+	case "ACTIONS_CACHE":
+		*v = WorkspaceCiMemoStoreActionsCache
+	case "GIT_REFS":
+		*v = WorkspaceCiMemoStoreGitRefs
+	default:
+		return fmt.Errorf("invalid enum value %q", s)
+	}
+	return nil
+}
+
+const (
+	// MemoStoreActionsCache is GitHub's Actions cache, an entry being the key
+	// workspace-ci-memo-v1-<hash> and nothing else. This module reads it and can
+	// never write it: a cache write needs ACTIONS_RUNTIME_TOKEN, which only a
+	// running workflow holds, so recording stays an actions/cache/save step and
+	// RecordPass reports UNSUPPORTED.
+	WorkspaceCiMemoStoreActionsCache WorkspaceCiMemoStore = "ACTIONS_CACHE" // workspace-ci (../../../daggerverse/workspace-ci/main.go:68:2)
+
+	// MemoStoreGitRefs is a namespace of git refs in memoRepo, which an ordinary
+	// repository token both reads and writes — so RecordPass works, and a CI
+	// system with no equivalent of actions/cache/save can memoize. Its trust
+	// argument is not the Actions cache's and is spelled out in README.md: GitHub
+	// isolates cache scopes for you, and it does not isolate refs.
+	WorkspaceCiMemoStoreGitRefs WorkspaceCiMemoStore = "GIT_REFS" // workspace-ci (../../../daggerverse/workspace-ci/main.go:74:2)
 
 )

--- a/daggerverse/workspace-ci/README.md
+++ b/daggerverse/workspace-ci/README.md
@@ -35,7 +35,9 @@ dagger -m github.com/z5labs/devex/daggerverse/workspace-ci call plan \
 | `jobTimeout` | the surrounding job's budget: `timeout` plus setup headroom, computed here because most CI expression languages have no arithmetic |
 
 `affected-modules` answers the attribution half on its own — which modules a
-change reached — without loading any of them.
+change reached — without loading any of them. `record-pass` is the other end of
+`hash`: it writes the entry a later run's plan reads back, for the store this
+module owns both sides of. See [The store](#the-store).
 
 ## Formats
 
@@ -92,6 +94,11 @@ run's own `GITHUB_TOKEN`. Without `actions: read` the store simply cannot be
 read, which costs speed and never correctness. `memoize: false` turns off both
 the read and the recording.
 
+The workflow uses the `ACTIONS_CACHE` store, so its recording step is
+`actions/cache/save` as above. `GIT_REFS` is for consumers whose CI system has no
+equivalent — and for GitHub consumers who would rather have one call do both
+halves; moving the workflow onto it is tracked separately.
+
 Three things a caller owns rather than the workflow:
 
 - **Permissions.** The workflow declares none, so it inherits the calling job's
@@ -138,9 +145,11 @@ Three properties worth knowing before you wire it up:
   does not remove.
 - **`jobTimeout` is not rendered**, because a branch has no surrounding job to
   bound. Each branch carries its leg's step budget as a `timeout`.
-- **`hash` is not rendered either.** Recording a pass needs a cache the module
-  cannot write to, so memoization here means reading `--format=JSON` alongside
-  and doing the recording yourself.
+- **`hash` is not rendered either**, so memoization here means reading
+  `--format=JSON` alongside and re-associating the hashes with the branches by
+  leg name. `record-pass` now removes the harder half of that — a Jenkins
+  pipeline with a `GIT_REFS` store can do the recording with one call and no
+  cache action — but the branches still do not carry the hash to record.
 
 An empty plan emits `[:]`, an empty `Map`, which `parallel` accepts as a no-op —
 `[]` is an empty `List` and `parallel` would reject it.
@@ -161,9 +170,9 @@ consumer pinning `change-aware-ci.yml@v1.2.3` should pass
 `module: github.com/z5labs/devex/daggerverse/workspace-ci@v1.2.3` alongside it,
 or the workflow it pinned will plan with whatever the planner has since become.
 
-To also adopt `generated`, `generated-self-test` and `selection-self-test` as
-checks of your own, install this module as a **dependency of your root module**
-and declare them there:
+To also adopt `generated`, `generated-self-test`, `selection-self-test` and
+`memo-store-self-test` as checks of your own, install this module as a
+**dependency of your root module** and declare them there:
 
 ```go
 // +check
@@ -308,8 +317,23 @@ its own trust boundary.
 
 ### The store
 
-Reading is all this module does. A write needs `ACTIONS_RUNTIME_TOKEN`, which
-only a running workflow has, so recording a pass stays a CI-native step:
+There are two, chosen with `--memo-store`. They differ in exactly one way that
+matters — whether this module can write them — and that difference propagates
+into two different trust arguments, so they are spelled out separately below.
+
+Either one is pointed at with `--memo-token`, `--memo-repo` and `--memo-refs`
+(and `--memo-api` for GitHub Enterprise Server). `--memo-refs` is the list of git
+refs whose scopes may hold a pass, spelled in full, and it defaults to none: a
+scope a run can write is one that has to be chosen deliberately. You can also
+skip the store entirely and pass hashes you read yourself as
+`--known-good='["…"]'`.
+
+#### `ACTIONS_CACHE` — read here, written by the workflow
+
+The default, and what `change-aware-ci.yml` uses. An entry is a GitHub Actions
+cache key, `workspace-ci-memo-v1-<hash>`, and nothing else; nothing ever reads
+the payload back. Writing one needs `ACTIONS_RUNTIME_TOKEN`, which only a running
+workflow has, so recording stays a CI-native step:
 
 ```yaml
 - uses: actions/cache/save@v4
@@ -319,14 +343,70 @@ only a running workflow has, so recording a pass stays a CI-native step:
     key: workspace-ci-memo-v1-${{ matrix.job.hash }}
 ```
 
-The entry's whole meaning is its key; nothing ever reads the payload back. Point
-the planner at the store with `--memo-token`, `--memo-repo` and `--memo-refs`, or
-pass hashes you read yourself as `--known-good='["…"]'`.
+`record-pass` reports `UNSUPPORTED` against this store rather than pretending.
 
-That read/write asymmetry is also what bounds the trust. A run can only write
-cache entries under its own `GITHUB_REF`, so nominating the default branch and a
-PR's own scope admits no other branch and no fork — stricter than GitHub's own
-restore rules, which would also expose a stacked PR's base branch.
+That read/write asymmetry is also what bounds the trust, and **GitHub enforces
+it**: a run can only write cache entries under its own `GITHUB_REF`, so
+nominating the default branch and a PR's own scope admits no other branch and no
+fork — stricter than GitHub's own restore rules, which would also expose a
+stacked PR's base branch.
+
+#### `GIT_REFS` — read and written here
+
+A store this module owns both sides of, so `record-pass` works and a CI system
+with no equivalent of `actions/cache/save` can memoize at all. An entry is a git
+ref in `--memo-repo` and, again, nothing else:
+
+```
+refs/workspace-ci-memo/v1/<scope>/<input-hash>/<unix-seconds>
+```
+
+`<scope>` is the hex encoding of the recording run's ref — hex because a raw ref
+name contains slashes, which would make `refs/heads/main` a path prefix of
+`refs/heads/main/feature` and let a branch anyone can create read and poison the
+default branch's scope. Decode one with `printf %s <scope> | xxd -r -p`. The
+timestamp is in the name because GitHub's ref listing carries no date, and a TTL
+read on every plan must not cost an API call per entry. The ref points at the
+commit that passed, so `git log` on it shows what proved the hash.
+
+Recording is one call per green leg:
+
+```
+dagger -m <planner> call \
+  --memo-store=GIT_REFS --memo-token=env:GH_TOKEN \
+  --memo-repo="$REPO" --memo-refs="$REF" \
+  record-pass --hash="$HASH" --ref="$REF" --commit="$SHA"
+```
+
+It prints one word — `RECORDED`, `ALREADY_RECORDED`, `REFUSED`, `SKIPPED`,
+`UNSUPPORTED` or `FAILED` — and **never fails**. Recording happens after the work
+is already green, so a store outage has to cost a later run its time and nothing
+else; a caller who wants it loud compares the word. Recording a hash the store
+already holds writes nothing and does not refresh its timestamp, because doing so
+would extend a TTL whose whole job is to bound how long a pass may be honoured.
+An empty hash — a leg the planner could not hash — records nothing. The one hard
+error is a call that names no ref, because with no ref there is no scope to judge
+and a silent refusal would be indistinguishable from one that was judged.
+
+#### The trust argument for module-side writes
+
+This is the part that is **not** inherited from the Actions cache, and it is
+stated here rather than left implicit because the difference is easy to miss:
+
+- **GitHub isolates cache scopes. It does not isolate refs.** A token that can
+  create a ref can create any ref, including one under another branch's scope. So
+  the module refusing to write from a ref outside `--memo-refs` is a guard
+  against *accident*, not against a malicious writer, and it is the reason
+  `record-pass` returns `REFUSED` rather than writing quietly.
+- **The enforcement is the credential.** On GitHub Actions a fork pull request's
+  `GITHUB_TOKEN` is read-only, so a fork cannot record at all — the same boundary
+  the Actions cache gives, arrived at differently. Grant `contents: write` only
+  to the runs whose scopes you nominated, and protect
+  `refs/workspace-ci-memo/*` with a repository ruleset if you want the boundary
+  enforced server-side rather than by which jobs hold which token.
+- **Everything downstream is unchanged.** A ref-store entry is honoured on
+  exactly the same terms as a cache entry: the same TTL, the same per-scope
+  reads, and the same wholesale refusal below.
 
 Within a PR's own scope the writer is that PR, so the planner refuses to honour
 *any* recorded pass once a **global input** changed. Those are the only paths
@@ -383,7 +463,8 @@ hash.**
 A source-derived hash cannot see upstream drift: checks that boot real services
 from floating tags mean an identical tree does not imply an identical container.
 The answer is an explicit bound on how long a recorded pass may be honoured —
-`--memo-ttl`, 24h by default, applied against each cache entry's `created_at`.
+`--memo-ttl`, 24h by default, applied against each entry's write time — an
+Actions cache entry's `created_at`, or the timestamp in a ref entry's own name.
 
 Folding resolved image digests into the hash was rejected: it means resolving
 every module's images, which is most of the cost memoization is meant to avoid,
@@ -435,6 +516,16 @@ dependency-free module in the workspace, or whichever one `--probe-module` names
 a recorded pass depends on, against fixed in-process fixtures. It needs no engine
 and no services, so it is cheap enough to run on every leg set.
 
+`memo-store-self-test` does the same for the store this module writes: that a
+pass lands under its own ref's scope, that recording it twice writes nothing and
+refreshes no TTL, that entries read back, that one past the TTL does not, and
+that one ref's scope stays out of another's. It drives the real HTTP client
+against an in-process stub of GitHub's API, so it too needs no network, no
+credential and no services. It is a check and not only a Go test because this is
+the half of memoization that fails silently — a store that quietly takes nothing
+looks exactly like one nobody has recorded into, and a scope that leaks costs
+correctness rather than time.
+
 ## Two deliberate omissions
 
 **No `PlanShouldNotBeCached` test**, though `plan` carries `+cache="never"` and
@@ -447,10 +538,15 @@ tree the planner never read — but it is unprovable, and a test that proves
 nothing is worse than none. `generated-self-test` remains the real proof for the
 codegen half.
 
-**No end-to-end test of the memo store read.** The rules that matter — a
-known-good hash drops its leg, a global input retires every recorded pass, an
-unhashable leg is never dropped — are tested through `--known-good`, which is the
-same code path. What the store itself contributes is prefix matching, TTL
-filtering and ref scoping, which are unit-tested against a stub in `memostore`,
-because reaching the real Actions cache API from a test would mean a live GitHub
-token and a live cache.
+**No end-to-end test against a real store.** The rules that matter on the read
+side — a known-good hash drops its leg, a global input retires every recorded
+pass, an unhashable leg is never dropped — are tested through `--known-good`,
+which is the same code path. What each store itself contributes is prefix
+matching, TTL filtering, ref scoping and, for `GIT_REFS`, recording: those are
+covered against an in-process stub, in `memostore`'s Go test and in
+`memo-store-self-test`, because reaching the real APIs from a test would mean a
+live GitHub token, a live cache and refs written into a real repository. The
+`record-pass` tests in `tests/` therefore assert the decisions the module makes
+before the store is reached — which store, which ref, which hash — and prove a
+trusted ref really does go on to the store by watching it fail against one that
+cannot answer.

--- a/daggerverse/workspace-ci/dagger.gen.go
+++ b/daggerverse/workspace-ci/dagger.gen.go
@@ -65,8 +65,10 @@ func (r WorkspaceCi) MarshalJSON() ([]byte, error) {
 		SplitModules   []string
 		Timeouts       string
 		DefaultTimeout int
+		MemoStore      MemoStore
 		MemoToken      *dagger.Secret
 		MemoRepo       string
+		MemoAPI        string
 		MemoRefs       []string
 		MemoTTL        int
 	}
@@ -74,8 +76,10 @@ func (r WorkspaceCi) MarshalJSON() ([]byte, error) {
 	concrete.SplitModules = r.SplitModules
 	concrete.Timeouts = r.Timeouts
 	concrete.DefaultTimeout = r.DefaultTimeout
+	concrete.MemoStore = r.MemoStore
 	concrete.MemoToken = r.MemoToken
 	concrete.MemoRepo = r.MemoRepo
+	concrete.MemoAPI = r.MemoAPI
 	concrete.MemoRefs = r.MemoRefs
 	concrete.MemoTTL = r.MemoTTL
 	return json.Marshal(&concrete)
@@ -87,8 +91,10 @@ func (r *WorkspaceCi) UnmarshalJSON(bs []byte) error {
 		SplitModules   []string
 		Timeouts       string
 		DefaultTimeout int
+		MemoStore      MemoStore
 		MemoToken      *dagger.Secret
 		MemoRepo       string
+		MemoAPI        string
 		MemoRefs       []string
 		MemoTTL        int
 	}
@@ -100,8 +106,10 @@ func (r *WorkspaceCi) UnmarshalJSON(bs []byte) error {
 	r.SplitModules = concrete.SplitModules
 	r.Timeouts = concrete.Timeouts
 	r.DefaultTimeout = concrete.DefaultTimeout
+	r.MemoStore = concrete.MemoStore
 	r.MemoToken = concrete.MemoToken
 	r.MemoRepo = concrete.MemoRepo
+	r.MemoAPI = concrete.MemoAPI
 	r.MemoRefs = concrete.MemoRefs
 	r.MemoTTL = concrete.MemoTTL
 	return nil
@@ -151,6 +159,52 @@ func (r *Format) UnmarshalJSON(bs []byte) error {
 		*r = FormatJSON
 	case "Jenkins":
 		*r = FormatJenkins
+	default:
+		return fmt.Errorf("invalid enum value %q", s)
+	}
+	return nil
+}
+
+func (r MemoStore) IsEnum() {}
+
+func (r MemoStore) Name() string {
+	switch r {
+	case MemoStoreActionsCache:
+		return "ActionsCache"
+	case MemoStoreGitRefs:
+		return "GitRefs"
+	}
+	return ""
+}
+
+func (r MemoStore) Value() string {
+	return string(r)
+}
+
+func (r MemoStore) MarshalJSON() ([]byte, error) {
+	if r == "" {
+		return []byte("\"\""), nil
+	}
+	name := r.Name()
+	if name == "" {
+		return nil, fmt.Errorf("invalid enum value %q", r)
+	}
+	return json.Marshal(name)
+}
+
+func (r *MemoStore) UnmarshalJSON(bs []byte) error {
+	var s string
+	err := json.Unmarshal(bs, &s)
+	if err != nil {
+		return err
+	}
+	switch s {
+	case "":
+		*r = ""
+	case "ActionsCache":
+		*r = MemoStoreActionsCache
+	case "GitRefs":
+		*r = MemoStoreGitRefs
 	default:
 		return fmt.Errorf("invalid enum value %q", s)
 	}
@@ -332,6 +386,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*WorkspaceCi).GeneratedSelfTest(&parent, ctx, probeModule)
+		case "MemoStoreSelfTest":
+			var parent WorkspaceCi
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*WorkspaceCi).MemoStoreSelfTest(&parent, ctx)
 		case "Plan":
 			var parent WorkspaceCi
 			err = json.Unmarshal(parentJSON, &parent)
@@ -388,6 +449,34 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*WorkspaceCi).Plan(&parent, ctx, base, head, format, repo, workspace, knownGood, diagnostics)
+		case "RecordPass":
+			var parent WorkspaceCi
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var hash string
+			if inputArgs["hash"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["hash"]), &hash)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg hash", err))
+				}
+			}
+			var ref string
+			if inputArgs["ref"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["ref"]), &ref)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg ref", err))
+				}
+			}
+			var commit string
+			if inputArgs["commit"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["commit"]), &commit)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg commit", err))
+				}
+			}
+			return (*WorkspaceCi).RecordPass(&parent, ctx, hash, ref, commit)
 		case "SelectionSelfTest":
 			var parent WorkspaceCi
 			err = json.Unmarshal(parentJSON, &parent)
@@ -429,6 +518,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg defaultTimeout", err))
 				}
 			}
+			var memoStore MemoStore
+			if inputArgs["memoStore"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["memoStore"]), &memoStore)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg memoStore", err))
+				}
+			}
 			var memoToken *dagger.Secret
 			if inputArgs["memoToken"] != nil {
 				err = json.Unmarshal([]byte(inputArgs["memoToken"]), &memoToken)
@@ -441,6 +537,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				err = json.Unmarshal([]byte(inputArgs["memoRepo"]), &memoRepo)
 				if err != nil {
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg memoRepo", err))
+				}
+			}
+			var memoApi string
+			if inputArgs["memoAPI"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["memoAPI"]), &memoApi)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg memoAPI", err))
 				}
 			}
 			var memoRefs []string
@@ -457,7 +560,7 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg memoTTL", err))
 				}
 			}
-			return New(globalPaths, splitModules, timeouts, defaultTimeout, memoToken, memoRepo, memoRefs, memoTtl)
+			return New(globalPaths, splitModules, timeouts, defaultTimeout, memoStore, memoToken, memoRepo, memoApi, memoRefs, memoTtl)
 		default:
 			return nil, fmt.Errorf("unknown function %s", fnName)
 		}

--- a/daggerverse/workspace-ci/main.go
+++ b/daggerverse/workspace-ci/main.go
@@ -25,6 +25,7 @@ import (
 	"dagger/workspace-ci/gitdiff"
 	"dagger/workspace-ci/internal/dagger"
 	"dagger/workspace-ci/planner"
+	"dagger/workspace-ci/refstore"
 )
 
 // WorkspaceCi plans CI for the workspace it is invoked from.
@@ -38,14 +39,40 @@ type WorkspaceCi struct {
 	// +private
 	DefaultTimeout int
 	// +private
+	MemoStore MemoStore
+	// +private
 	MemoToken *dagger.Secret
 	// +private
 	MemoRepo string
+	// +private
+	MemoAPI string
 	// +private
 	MemoRefs []string
 	// +private
 	MemoTTL int
 }
+
+// MemoStore is where recorded passes live, and decides whether this module can
+// record one at all.
+//
+// Note on rendered names: as with Format, the CLI takes the enum member the SDK
+// derives from the constant identifier, so the values are spelled to match.
+type MemoStore string
+
+const (
+	// MemoStoreActionsCache is GitHub's Actions cache, an entry being the key
+	// workspace-ci-memo-v1-<hash> and nothing else. This module reads it and can
+	// never write it: a cache write needs ACTIONS_RUNTIME_TOKEN, which only a
+	// running workflow holds, so recording stays an actions/cache/save step and
+	// RecordPass reports UNSUPPORTED.
+	MemoStoreActionsCache MemoStore = "ACTIONS_CACHE"
+	// MemoStoreGitRefs is a namespace of git refs in memoRepo, which an ordinary
+	// repository token both reads and writes — so RecordPass works, and a CI
+	// system with no equivalent of actions/cache/save can memoize. Its trust
+	// argument is not the Actions cache's and is spelled out in README.md: GitHub
+	// isolates cache scopes for you, and it does not isolate refs.
+	MemoStoreGitRefs MemoStore = "GIT_REFS"
+)
 
 // New configures a planner.
 func New(
@@ -77,18 +104,35 @@ func New(
 	// +optional
 	// +default=6
 	defaultTimeout int,
-	// A credential for reading the memoization store: a GitHub token with
-	// actions:read on memoRepo. Nothing is ever written from here — see README.md.
+	// Where recorded passes live. ACTIONS_CACHE is read-only from this module and
+	// leaves recording to an actions/cache/save step; GIT_REFS is a store the
+	// module owns both sides of, so RecordPass can write it from anywhere a token
+	// reaches. See README.md — the two have different trust arguments.
+	//
+	// +optional
+	// +default="ACTIONS_CACHE"
+	memoStore MemoStore,
+	// A credential for the memoization store: a GitHub token on memoRepo with
+	// actions:read for ACTIONS_CACHE, or contents:read for GIT_REFS — plus
+	// contents:write if this run is to record anything.
 	//
 	// +optional
 	memoToken *dagger.Secret,
-	// The owner/name whose Actions cache holds the memoization store.
+	// The owner/name whose Actions cache, or whose git refs, hold the memoization
+	// store.
 	//
 	// +optional
 	memoRepo string,
-	// The git refs whose cache scopes may be trusted to hold recorded passes.
-	// Defaults to none, which reads nothing: a scope a run can write is a scope
-	// that must be chosen deliberately.
+	// The GitHub API root the store is reached through. Defaults to
+	// https://api.github.com; set it for GitHub Enterprise Server.
+	//
+	// +optional
+	memoAPI string,
+	// The git refs whose scopes may be trusted to hold recorded passes, spelled in
+	// full (refs/heads/main, refs/pull/12/merge). They are the refs a plan reads,
+	// and the only refs RecordPass will write from. Defaults to none, which reads
+	// nothing and records nothing: a scope a run can write is a scope that must be
+	// chosen deliberately.
 	//
 	// +optional
 	memoRefs []string,
@@ -105,6 +149,13 @@ func New(
 	if memoToken != nil && memoRepo == "" {
 		return nil, fmt.Errorf("memoToken needs memoRepo: a token with no repository to read cannot be scoped, and silently reading nothing would look like a workspace with no recorded passes")
 	}
+	switch memoStore {
+	case "", MemoStoreActionsCache:
+		memoStore = MemoStoreActionsCache
+	case MemoStoreGitRefs:
+	default:
+		return nil, fmt.Errorf("memoStore %q is not a store this module knows: use %s or %s", memoStore, MemoStoreActionsCache, MemoStoreGitRefs)
+	}
 	if len(globalPaths) == 0 {
 		globalPaths = planner.GlobalPathsDefault()
 	}
@@ -113,8 +164,10 @@ func New(
 		SplitModules:   splitModules,
 		Timeouts:       timeouts,
 		DefaultTimeout: defaultTimeout,
+		MemoStore:      memoStore,
 		MemoToken:      memoToken,
 		MemoRepo:       memoRepo,
+		MemoAPI:        memoAPI,
 		MemoRefs:       memoRefs,
 		MemoTTL:        memoTTL,
 	}, nil
@@ -253,6 +306,44 @@ func (m *WorkspaceCi) AffectedModules(
 	return string(out), nil
 }
 
+// RecordPass records that the leg whose inputs hashed to hash passed, so a later
+// run that computes the same hash can skip it. It is the write half of what Plan
+// reads, for the stores this module owns both sides of.
+//
+// It reports what it did, as one word, and **never fails a check that passed**.
+// Recording happens after the work is already green, so a store that will not
+// take the entry has to cost a later run its time and nothing else. A caller who
+// wants a store problem to be loud should compare the returned word:
+//
+//	RECORDED         a new entry now names this hash
+//	ALREADY_RECORDED an earlier run got there; nothing was written or refreshed
+//	REFUSED          ref is not one of memoRefs, so this scope is not writable
+//	SKIPPED          nothing to record: an empty hash, or no store configured
+//	UNSUPPORTED      the configured store cannot be written from this module
+//	FAILED           the store would not take the entry; stderr says why
+//
+// The error return is not how a store problem is reported. It carries exactly one
+// thing: a call that named no ref, because with no ref there is no scope to judge
+// and refusing silently would be indistinguishable from a scope that was judged
+// and rejected.
+//
+// +cache="never"
+func (m *WorkspaceCi) RecordPass(
+	ctx context.Context,
+	// The leg's input hash, exactly as Plan emitted it. An empty hash is a leg
+	// that may never be memoized, and recording one is a no-op.
+	hash string,
+	// The git ref the run that passed is on, spelled the way memoRefs spells it —
+	// refs/heads/main, refs/pull/12/merge. Nothing is written unless it is one of
+	// them.
+	ref string,
+	// The commit whose checks passed. The entry points at it, so `git log` on a
+	// recorded ref shows what proved the hash.
+	commit string,
+) (string, error) {
+	return m.recordPass(ctx, hash, ref, commit)
+}
+
 // planReport is what Plan reports when asked to explain itself.
 //
 // It is unexported on purpose: an exported struct in package main is a Dagger
@@ -377,6 +468,23 @@ func (m *WorkspaceCi) SelectionSelfTest(ctx context.Context) error {
 		return err
 	}
 	return planner.RenderSelfCheck()
+}
+
+// MemoStoreSelfTest verifies the store this module owns both sides of — that a
+// pass is recorded under its own ref's scope, that recording the same hash twice
+// writes nothing and refreshes no TTL, that entries read back, that one older
+// than the TTL does not, and that one ref's scope stays out of another's — against
+// an in-process stub of GitHub's API.
+//
+// It is a check rather than only a Go test because this is the half of
+// memoization that fails silently: a store that quietly takes nothing costs every
+// later run its full time and looks exactly like a workspace nobody has recorded
+// against yet, and a scope that leaks costs correctness. Like SelectionSelfTest it
+// runs in-process and needs no network, no credential and no services.
+//
+// +check
+func (m *WorkspaceCi) MemoStoreSelfTest(ctx context.Context) error {
+	return refstore.SelfCheck()
 }
 
 // parseKnownGood turns a JSON array of recorded input hashes into a set. An

--- a/daggerverse/workspace-ci/memo.go
+++ b/daggerverse/workspace-ci/memo.go
@@ -4,21 +4,41 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
+	"strings"
 	"time"
 
 	"dagger/workspace-ci/memostore"
+	"dagger/workspace-ci/refstore"
+)
+
+// What RecordPass reports. See its doc comment for what each one means. They are
+// plain words rather than an enum so a CI system can compare them in shell
+// without knowing anything about Dagger.
+const (
+	outcomeRecorded    = "RECORDED"
+	outcomeDuplicate   = "ALREADY_RECORDED"
+	outcomeRefused     = "REFUSED"
+	outcomeSkipped     = "SKIPPED"
+	outcomeUnsupported = "UNSUPPORTED"
+	outcomeFailed      = "FAILED"
 )
 
 // storedPasses returns the input hashes some earlier run already passed on,
 // according to the memoization store.
 //
-// Only the refs the caller nominated are read, and reading is all this module ever
-// does — a write needs ACTIONS_RUNTIME_TOKEN, which is a CI-native concern, so
-// recording a pass stays a step in the calling workflow. That asymmetry is also
-// what bounds the trust: a run can only write cache entries under its own ref, so
-// nominating the default branch and a PR's own scope admits no other branch and no
-// fork. Within a PR's own scope the writer is that PR, which is why MemoTrusted
-// refuses every recorded pass once a global input changed.
+// Only the refs the caller nominated are read. Which store that is decides
+// whether this module can also write it: GitHub's Actions cache cannot be written
+// without ACTIONS_RUNTIME_TOKEN, which is a CI-native concern, so recording there
+// stays a step in the calling workflow — while the git-ref store takes the same
+// credential for both halves and RecordPass writes it from here.
+//
+// Either way the trust is bounded by the scopes the caller nominated. With the
+// Actions cache a run can only write entries under its own ref; with git refs this
+// module only writes from a ref in MemoRefs. So nominating the default branch and
+// a PR's own scope admits no other branch and no fork. Within a PR's own scope the
+// writer is that PR, which is why MemoTrusted refuses every recorded pass once a
+// global input changed.
 //
 // Every failure is soft. An unreadable store, an unparseable response, a listing
 // that ran long: each shrinks the known-good set, which costs CI time and never
@@ -36,7 +56,7 @@ func (m *WorkspaceCi) storedPasses(ctx context.Context) (map[string]bool, error)
 	cutoff := time.Now().Add(-time.Duration(m.MemoTTL) * time.Second)
 	out := map[string]bool{}
 	for _, ref := range m.MemoRefs {
-		hashes, err := memostore.Hashes(ctx, memostore.GithubAPI, token, m.MemoRepo, ref, cutoff)
+		hashes, err := m.readScope(ctx, token, ref, cutoff)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "workspace-ci: cannot read the memo store for %q (%v); those legs will just run\n", ref, err)
 		}
@@ -45,4 +65,68 @@ func (m *WorkspaceCi) storedPasses(ctx context.Context) (map[string]bool, error)
 		}
 	}
 	return out, nil
+}
+
+// readScope reads one ref's scope out of whichever store is configured.
+func (m *WorkspaceCi) readScope(ctx context.Context, token, ref string, cutoff time.Time) ([]string, error) {
+	if m.MemoStore == MemoStoreGitRefs {
+		return refstore.Hashes(ctx, m.api(), token, m.MemoRepo, ref, cutoff)
+	}
+	return memostore.Hashes(ctx, m.api(), token, m.MemoRepo, ref, cutoff)
+}
+
+// recordPass writes one entry, and swallows every reason it could not.
+//
+// The order of the guards is the argument for why a module-side write is safe to
+// enable: the store has to be one this module can write at all, and then the ref
+// the run is on has to be one the caller nominated. Neither guard is enforcement
+// — a token that can create refs can create any ref — so the enforcement is the
+// credential's own permissions plus whatever ruleset protects refstore.Namespace,
+// which is what README.md says out loud rather than leaving implicit. What the
+// refusal buys is that a run on an untrusted ref cannot record *by accident*,
+// which is the failure that would otherwise arrive quietly and in bulk.
+func (m *WorkspaceCi) recordPass(ctx context.Context, hash, ref, commit string) (string, error) {
+	if strings.TrimSpace(ref) == "" {
+		return "", fmt.Errorf("recordPass needs the git ref the run is on: with no ref there is no scope to judge, and refusing silently would be indistinguishable from a scope that was judged and rejected")
+	}
+	if hash == "" {
+		// The plan says this leg may never be memoized. Recording nothing is the
+		// whole point of an empty hash, so it is not worth a warning.
+		return outcomeSkipped, nil
+	}
+	if m.MemoToken == nil || m.MemoRepo == "" {
+		fmt.Fprintf(os.Stderr, "workspace-ci: no memoization store is configured; recorded nothing for %s\n", hash)
+		return outcomeSkipped, nil
+	}
+	if m.MemoStore != MemoStoreGitRefs {
+		fmt.Fprintf(os.Stderr, "workspace-ci: the %s store cannot be written from this module — a cache write needs ACTIONS_RUNTIME_TOKEN, which only a running workflow holds. Record with actions/cache/save, or configure --memo-store=%s.\n", m.MemoStore, MemoStoreGitRefs)
+		return outcomeUnsupported, nil
+	}
+	if !slices.Contains(m.MemoRefs, ref) {
+		fmt.Fprintf(os.Stderr, "workspace-ci: %q is not one of the trusted refs %v; recorded nothing for %s\n", ref, m.MemoRefs, hash)
+		return outcomeRefused, nil
+	}
+
+	token, err := m.MemoToken.Plaintext(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "workspace-ci: cannot read the memo token (%v); recorded nothing for %s\n", err, hash)
+		return outcomeFailed, nil
+	}
+	created, err := refstore.Record(ctx, m.api(), token, m.MemoRepo, ref, hash, commit, time.Now())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "workspace-ci: cannot record a pass for %s (%v); that leg will just run again\n", hash, err)
+		return outcomeFailed, nil
+	}
+	if !created {
+		return outcomeDuplicate, nil
+	}
+	return outcomeRecorded, nil
+}
+
+// api is the GitHub API root the store is reached through.
+func (m *WorkspaceCi) api() string {
+	if m.MemoAPI != "" {
+		return m.MemoAPI
+	}
+	return memostore.GithubAPI
 }

--- a/daggerverse/workspace-ci/refstore/refstore.go
+++ b/daggerverse/workspace-ci/refstore/refstore.go
@@ -1,0 +1,277 @@
+// Package refstore records and reads which checks already passed on which
+// inputs, as git refs in a GitHub repository.
+//
+// It exists because the module cannot write the other store. A GitHub Actions
+// cache entry is written with ACTIONS_RUNTIME_TOKEN, which only a running
+// workflow holds, so recording a pass there has to be a step in the calling
+// workflow: one concept split across two places, and no way to record at all
+// from a CI system with no equivalent of actions/cache/save. A git ref is
+// created with an ordinary repository token, which is the same credential the
+// read already takes — so this is a store the module owns both sides of.
+//
+// An entry is a ref and nothing else; there is no payload to fetch and none is
+// ever read:
+//
+//	refs/workspace-ci-memo/v1/<scope>/<input-hash>/<unix-seconds>
+//
+// <scope> is the hex encoding of the git ref the recording run was on. Hex
+// rather than the ref itself for two reasons, both of which are correctness and
+// not taste. A ref name contains slashes, so nesting it raw would make
+// refs/heads/main a path prefix of refs/heads/main/feature and a listing of the
+// first would return the second's entries — a branch anyone can create could
+// then poison the default branch's scope. And a ref name may contain characters
+// that are legal in a branch but not in the ref this store would build from it.
+// Hex has neither problem, needs no URL escaping, and decodes with
+// `printf %s <scope> | xxd -r -p`.
+//
+// <unix-seconds> is in the name because the TTL is read far more often than it
+// is written: GitHub's ref listing carries no timestamp, so a date held anywhere
+// else would cost one API call per entry on every plan.
+//
+// Nothing here imports Dagger, so it is testable against a stub; SelfCheck is
+// that test in a form CI runs.
+package refstore
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Namespace is the ref prefix this store owns, and is what a repository ruleset
+// should protect if writes are to be restricted to trusted runs. The version in
+// it is the escape hatch for a change that must retire every existing entry at
+// once, independently of how the input hash itself is composed.
+const Namespace = "refs/workspace-ci-memo/v1/"
+
+// pageSize is GitHub's maximum page size, and maxPages bounds the walk: a scope
+// larger than that is one where the TTL is doing nothing, and reading it forever
+// would cost more time than the skips it buys.
+const (
+	pageSize = 100
+	maxPages = 20
+)
+
+// requestTimeout bounds one request. The store is an optimisation, so a slow one
+// must not hold up a plan — or a recording — for long.
+const requestTimeout = 30 * time.Second
+
+// Scope renders a git ref as the single, opaque path component this store keys
+// entries under. See the package doc for why it is hex.
+func Scope(ref string) string {
+	return hex.EncodeToString([]byte(ref))
+}
+
+// prefix is where every entry recorded from ref lives. The trailing slash is
+// load-bearing: it is what stops one scope's listing reaching into another whose
+// encoded name merely extends it.
+func prefix(ref string) string {
+	return Namespace + Scope(ref) + "/"
+}
+
+// Record writes an entry saying that the leg whose inputs hashed to hash passed
+// at commit, under ref's scope.
+//
+// It reports whether it created anything. An entry for this hash already in this
+// scope is left exactly as it is: the entry's whole meaning is its name, so a
+// second recording would carry no new information, and refreshing its timestamp
+// would extend a TTL whose entire job is to bound how long a pass may be
+// honoured.
+//
+// Errors are the caller's to soften. Recording happens after a check has already
+// passed, so a store that will not take the entry must cost a later run some
+// time and never fail the run that is holding it.
+func Record(ctx context.Context, api, token, repo, ref, hash, commit string, now time.Time) (bool, error) {
+	if err := validHash(hash); err != nil {
+		return false, err
+	}
+	if commit == "" {
+		return false, fmt.Errorf("recording %s needs the commit that passed: a ref has to point at an object", hash)
+	}
+	client := &http.Client{Timeout: requestTimeout}
+
+	entry := prefix(ref) + hash + "/"
+	existing, err := matching(ctx, client, api, token, repo, strings.TrimSuffix(entry, "/"))
+	if err != nil {
+		return false, err
+	}
+	for _, r := range existing {
+		if strings.HasPrefix(r, entry) {
+			return false, nil
+		}
+	}
+
+	body, err := json.Marshal(map[string]string{
+		"ref": entry + strconv.FormatInt(now.Unix(), 10),
+		"sha": commit,
+	})
+	if err != nil {
+		return false, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		fmt.Sprintf("%s/repos/%s/git/refs", api, repo), bytes.NewReader(body))
+	if err != nil {
+		return false, err
+	}
+	authorize(req, token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+	switch resp.StatusCode {
+	case http.StatusCreated:
+		return true, nil
+	case http.StatusUnprocessableEntity:
+		// The ref already exists, which here means a concurrent run recorded the
+		// same hash in the same second. Both runs proved the same thing, so the
+		// loser has nothing to report.
+		return false, nil
+	default:
+		return false, fmt.Errorf("POST %s/git/refs: %s", repo, resp.Status)
+	}
+}
+
+// Hashes returns the input hashes recorded under ref and written since cutoff.
+//
+// Entries older than the cutoff are ignored. That TTL is the answer to
+// base-image drift, which a source-derived hash cannot see: checks that boot real
+// services from floating tags mean an identical tree does not imply an identical
+// container. It is applied to the timestamp in the entry's own name, so an entry
+// cannot outlive its window by being rewritten.
+//
+// An error here is soft by contract, exactly as it is for the Actions cache
+// store: the caller shrinks its known-good set, which costs CI time and never
+// correctness.
+func Hashes(ctx context.Context, api, token, repo, ref string, cutoff time.Time) ([]string, error) {
+	client := &http.Client{Timeout: requestTimeout}
+	p := prefix(ref)
+	refs, err := matching(ctx, client, api, token, repo, strings.TrimSuffix(p, "/"))
+	if err != nil {
+		return nil, err
+	}
+
+	seen := map[string]bool{}
+	var out []string
+	for _, r := range refs {
+		rest, ok := strings.CutPrefix(r, p)
+		if !ok {
+			continue // a neighbouring scope whose encoded name extends this one
+		}
+		hash, stamp, ok := strings.Cut(rest, "/")
+		if !ok || hash == "" || strings.Contains(stamp, "/") {
+			continue // not an entry this version of the store wrote
+		}
+		if validHash(hash) != nil {
+			continue
+		}
+		secs, err := strconv.ParseInt(stamp, 10, 64)
+		if err != nil {
+			continue
+		}
+		if time.Unix(secs, 0).Before(cutoff) {
+			continue
+		}
+		if seen[hash] {
+			continue
+		}
+		seen[hash] = true
+		out = append(out, hash)
+	}
+	return out, nil
+}
+
+// matching lists every ref beginning with the given prefix. GitHub's endpoint
+// takes the prefix with "refs/" stripped and matches on whole path components
+// only in the sense that it does no matching of its own — it is a plain string
+// prefix — which is why every caller here re-filters on a prefix ending in "/".
+func matching(ctx context.Context, client *http.Client, api, token, repo, refPrefix string) ([]string, error) {
+	var out []string
+	for page := 1; page <= maxPages; page++ {
+		found, more, err := matchingPage(ctx, client, api, token, repo, refPrefix, page)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, found...)
+		if !more {
+			return out, nil
+		}
+	}
+	return out, fmt.Errorf("stopped reading the store at %q after %d pages", refPrefix, maxPages)
+}
+
+func matchingPage(
+	ctx context.Context,
+	client *http.Client,
+	api, token, repo, refPrefix string,
+	page int,
+) (refs []string, more bool, err error) {
+	q := url.Values{
+		"per_page": {fmt.Sprint(pageSize)},
+		"page":     {fmt.Sprint(page)},
+	}
+	endpoint := fmt.Sprintf("%s/repos/%s/git/matching-refs/%s?%s",
+		api, repo, strings.TrimPrefix(refPrefix, "refs/"), q.Encode())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, false, err
+	}
+	authorize(req, token)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, false, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		// GitHub answers a prefix that matches nothing either way depending on how
+		// much of it exists. Neither means the store is broken.
+		return nil, false, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, false, fmt.Errorf("GET %s/git/matching-refs: %s", repo, resp.Status)
+	}
+	var listing []struct {
+		Ref string `json:"ref"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&listing); err != nil {
+		return nil, false, fmt.Errorf("decode the ref listing: %w", err)
+	}
+	for _, e := range listing {
+		refs = append(refs, e.Ref)
+	}
+	return refs, len(listing) >= pageSize, nil
+}
+
+func authorize(req *http.Request, token string) {
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+}
+
+// validHash rejects anything that is not an input hash as this planner spells
+// them. A hash is folded straight into a ref name, so a value carrying a slash or
+// a character git will not accept would either land somewhere it was not meant to
+// or fail obscurely at the API.
+func validHash(hash string) error {
+	if hash == "" {
+		return fmt.Errorf("an empty input hash is a leg that must never be memoized")
+	}
+	for i := 0; i < len(hash); i++ {
+		c := hash[i]
+		if (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') {
+			continue
+		}
+		return fmt.Errorf("%q is not an input hash: they are lowercase hex", hash)
+	}
+	return nil
+}

--- a/daggerverse/workspace-ci/refstore/refstore_test.go
+++ b/daggerverse/workspace-ci/refstore/refstore_test.go
@@ -1,0 +1,48 @@
+package refstore
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+// TestSelfCheck runs the same cases a consumer's CI runs through the module's
+// memo-store-self-test check, so `go test ./...` and the check cannot disagree
+// about whether this store works.
+func TestSelfCheck(t *testing.T) {
+	if err := SelfCheck(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestScopeIsReversible pins the one property the hex encoding is chosen for
+// besides safety: an operator looking at a ref in the store can work out which
+// branch recorded it.
+func TestScopeIsReversible(t *testing.T) {
+	for _, ref := range []string{
+		"refs/heads/main",
+		"refs/pull/12/merge",
+		"refs/heads/feature/a b?c*",
+	} {
+		got := Scope(ref)
+		if strings.ContainsAny(got, "/%.") {
+			t.Errorf("Scope(%q) = %q, which is not a single safe path component", ref, got)
+		}
+		back, err := hex.DecodeString(got)
+		if err != nil || string(back) != ref {
+			t.Errorf("Scope(%q) = %q, which decodes to %q (%v)", ref, got, back, err)
+		}
+	}
+}
+
+// TestScopesDoNotNest is the encoding's whole point: one ref's entries must be
+// unreachable from another ref's listing, including when one branch name extends
+// another.
+func TestScopesDoNotNest(t *testing.T) {
+	if a, b := prefix("refs/heads/main"), prefix("refs/heads/main-2"); strings.HasPrefix(b, a) {
+		t.Fatalf("%q is a prefix of %q, so listing one scope would read the other", a, b)
+	}
+	if a, b := prefix("refs/heads/main"), prefix("refs/heads/main/feature"); strings.HasPrefix(b, a) {
+		t.Fatalf("%q is a prefix of %q, so listing one scope would read the other", a, b)
+	}
+}

--- a/daggerverse/workspace-ci/refstore/selfcheck.go
+++ b/daggerverse/workspace-ci/refstore/selfcheck.go
@@ -1,0 +1,293 @@
+package refstore
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+)
+
+// SelfCheck exercises the whole module-owned store — recording an entry,
+// declining to record one that is already there, reading entries back, dropping
+// ones older than the TTL, and keeping one ref's scope out of another's — against
+// an in-process stub of GitHub's git-refs API.
+//
+// It is here rather than only in refstore_test.go because a consumer's CI runs
+// checks, not `go test`, and this is the half of memoization whose failure mode
+// is silent: a store that will not take an entry costs nothing today and every
+// later run its full time, while a scope that leaks costs correctness. The stub
+// binds loopback inside the calling process, so this needs no network, no
+// credential and no service.
+func SelfCheck() error {
+	var errs []error
+	for _, c := range []struct {
+		name string
+		run  func(*stub) error
+	}{
+		{"records an entry under its ref's scope", checkRecords},
+		{"does not record the same hash twice", checkIsIdempotent},
+		{"reads recorded hashes back", checkReadsBack},
+		{"ignores an entry older than the TTL", checkHonoursTTL},
+		{"keeps one scope out of another that extends it", checkScopesAreIsolated},
+		{"reports a store it cannot read", checkReportsAnUnreadableStore},
+		{"reports a store that refuses a write", checkReportsARefusedWrite},
+		{"refuses to key an entry on something that is not a hash", checkRejectsABadHash},
+	} {
+		s := newStub()
+		err := c.run(s)
+		s.Close()
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", c.name, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+const (
+	selfRepo   = "z5labs/devex"
+	selfToken  = "self-check"
+	selfCommit = "0123456789abcdef0123456789abcdef01234567"
+	selfHash   = "a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90"
+	selfOther  = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+	selfRef    = "refs/heads/main"
+	// selfNeighbour is chosen so that Scope(selfRef) is a strict prefix of
+	// Scope(selfNeighbour) — which is exactly the leak the trailing slash exists
+	// to close, and would be invisible against an unrelated branch name.
+	selfNeighbour = "refs/heads/main-2"
+)
+
+func checkRecords(s *stub) error {
+	now := time.Unix(1_700_000_000, 0)
+	created, err := Record(context.Background(), s.URL, selfToken, selfRepo, selfRef, selfHash, selfCommit, now)
+	if err != nil {
+		return err
+	}
+	if !created {
+		return fmt.Errorf("recording into an empty store created nothing")
+	}
+	want := Namespace + Scope(selfRef) + "/" + selfHash + "/1700000000"
+	if got := s.refs(); !slices.Equal(got, []string{want}) {
+		return fmt.Errorf("the store holds %v, want [%s]", got, want)
+	}
+	if got := s.sha(want); got != selfCommit {
+		return fmt.Errorf("the entry points at %q, want the commit that passed (%q)", got, selfCommit)
+	}
+	return nil
+}
+
+func checkIsIdempotent(s *stub) error {
+	ctx := context.Background()
+	if _, err := Record(ctx, s.URL, selfToken, selfRepo, selfRef, selfHash, selfCommit, time.Unix(1_700_000_000, 0)); err != nil {
+		return err
+	}
+	before := s.writes()
+	// A day later, which is what makes this worth asserting: a re-record that
+	// refreshed the timestamp would extend a TTL whose job is to bound how long a
+	// pass may be honoured.
+	created, err := Record(ctx, s.URL, selfToken, selfRepo, selfRef, selfHash, selfCommit, time.Unix(1_700_086_400, 0))
+	if err != nil {
+		return err
+	}
+	if created {
+		return fmt.Errorf("recording a hash the store already held reported a new entry")
+	}
+	if got := s.writes(); got != before {
+		return fmt.Errorf("recording a hash the store already held issued %d write(s)", got-before)
+	}
+	if got := len(s.refs()); got != 1 {
+		return fmt.Errorf("the store holds %d entries for one hash", got)
+	}
+	return nil
+}
+
+func checkReadsBack(s *stub) error {
+	ctx := context.Background()
+	now := time.Unix(1_700_000_000, 0)
+	for _, h := range []string{selfHash, selfOther} {
+		if _, err := Record(ctx, s.URL, selfToken, selfRepo, selfRef, h, selfCommit, now); err != nil {
+			return err
+		}
+	}
+	got, err := Hashes(ctx, s.URL, selfToken, selfRepo, selfRef, now.Add(-time.Hour))
+	if err != nil {
+		return err
+	}
+	slices.Sort(got)
+	want := []string{selfHash, selfOther}
+	slices.Sort(want)
+	if !slices.Equal(got, want) {
+		return fmt.Errorf("read %v back, want %v", got, want)
+	}
+	return nil
+}
+
+func checkHonoursTTL(s *stub) error {
+	ctx := context.Background()
+	now := time.Unix(1_700_000_000, 0)
+	if _, err := Record(ctx, s.URL, selfToken, selfRepo, selfRef, selfHash, selfCommit, now.Add(-48*time.Hour)); err != nil {
+		return err
+	}
+	if _, err := Record(ctx, s.URL, selfToken, selfRepo, selfRef, selfOther, selfCommit, now.Add(-time.Minute)); err != nil {
+		return err
+	}
+	got, err := Hashes(ctx, s.URL, selfToken, selfRepo, selfRef, now.Add(-24*time.Hour))
+	if err != nil {
+		return err
+	}
+	if !slices.Equal(got, []string{selfOther}) {
+		return fmt.Errorf("read %v back, want only the entry inside the TTL (%s)", got, selfOther)
+	}
+	return nil
+}
+
+func checkScopesAreIsolated(s *stub) error {
+	ctx := context.Background()
+	now := time.Unix(1_700_000_000, 0)
+	if !strings.HasPrefix(Scope(selfNeighbour), Scope(selfRef)) {
+		return fmt.Errorf("the fixture no longer proves anything: %q does not extend %q", selfNeighbour, selfRef)
+	}
+	if _, err := Record(ctx, s.URL, selfToken, selfRepo, selfNeighbour, selfHash, selfCommit, now); err != nil {
+		return err
+	}
+	got, err := Hashes(ctx, s.URL, selfToken, selfRepo, selfRef, now.Add(-time.Hour))
+	if err != nil {
+		return err
+	}
+	if len(got) != 0 {
+		return fmt.Errorf("%q read %v out of %q's scope", selfRef, got, selfNeighbour)
+	}
+	// And the neighbour must still be able to read its own.
+	got, err = Hashes(ctx, s.URL, selfToken, selfRepo, selfNeighbour, now.Add(-time.Hour))
+	if err != nil {
+		return err
+	}
+	if !slices.Equal(got, []string{selfHash}) {
+		return fmt.Errorf("%q read %v of its own entries", selfNeighbour, got)
+	}
+	return nil
+}
+
+func checkReportsAnUnreadableStore(s *stub) error {
+	s.deny(http.StatusForbidden)
+	if _, err := Hashes(context.Background(), s.URL, selfToken, selfRepo, selfRef, time.Unix(0, 0)); err == nil {
+		return fmt.Errorf("a 403 on the listing was read as an empty store")
+	}
+	return nil
+}
+
+func checkReportsARefusedWrite(s *stub) error {
+	s.deny(http.StatusForbidden)
+	_, err := Record(context.Background(), s.URL, selfToken, selfRepo, selfRef, selfHash, selfCommit, time.Unix(1_700_000_000, 0))
+	if err == nil {
+		return fmt.Errorf("a store that refused the write reported success")
+	}
+	return nil
+}
+
+func checkRejectsABadHash(s *stub) error {
+	for _, bad := range []string{"", "not-a-hash", selfHash + "/../" + selfOther, strings.ToUpper(selfHash)} {
+		if _, err := Record(context.Background(), s.URL, selfToken, selfRepo, selfRef, bad, selfCommit, time.Now()); err == nil {
+			return fmt.Errorf("%q was accepted as an input hash", bad)
+		}
+	}
+	if got := s.writes(); got != 0 {
+		return fmt.Errorf("a rejected hash still issued %d write(s)", got)
+	}
+	return nil
+}
+
+// stub is enough of GitHub's git-refs API to record against: a map from ref name
+// to the object it points at, listed by prefix and created once.
+type stub struct {
+	*httptest.Server
+
+	mu      sync.Mutex
+	objects map[string]string
+	written int
+	denied  int
+}
+
+func newStub() *stub {
+	s := &stub{objects: map[string]string{}}
+	s.Server = httptest.NewServer(http.HandlerFunc(s.serve))
+	return s
+}
+
+// deny makes every subsequent request fail with status, which is how a token
+// without the scope, or a ruleset protecting the namespace, actually presents.
+func (s *stub) deny(status int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.denied = status
+}
+
+func (s *stub) refs() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, 0, len(s.objects))
+	for r := range s.objects {
+		out = append(out, r)
+	}
+	slices.Sort(out)
+	return out
+}
+
+func (s *stub) sha(ref string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.objects[ref]
+}
+
+func (s *stub) writes() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.written
+}
+
+func (s *stub) serve(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.denied != 0 {
+		w.WriteHeader(s.denied)
+		return
+	}
+	if got := r.Header.Get("Authorization"); got != "Bearer "+selfToken {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	base := "/repos/" + selfRepo + "/git/"
+	switch {
+	case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, base+"matching-refs/"):
+		want := "refs/" + strings.TrimPrefix(r.URL.Path, base+"matching-refs/")
+		var out []map[string]string
+		for _, ref := range slices.Sorted(maps.Keys(s.objects)) {
+			if strings.HasPrefix(ref, want) {
+				out = append(out, map[string]string{"ref": ref})
+			}
+		}
+		_ = json.NewEncoder(w).Encode(out)
+	case r.Method == http.MethodPost && r.URL.Path == base+"refs":
+		s.written++
+		var body struct{ Ref, Sha string }
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if _, ok := s.objects[body.Ref]; ok {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			return
+		}
+		s.objects[body.Ref] = body.Sha
+		w.WriteHeader(http.StatusCreated)
+	default:
+		w.WriteHeader(http.StatusNotFound)
+	}
+}

--- a/daggerverse/workspace-ci/tests/dagger.gen.go
+++ b/daggerverse/workspace-ci/tests/dagger.gen.go
@@ -206,6 +206,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).All(&parent, ctx)
+		case "MemoStoreSelfTestPasses":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).MemoStoreSelfTestPasses(&parent, ctx)
+		case "NewRejectsAnUnknownMemoStore":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).NewRejectsAnUnknownMemoStore(&parent, ctx)
 		case "NewRejectsMalformedTimeouts":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -325,6 +339,55 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).PlanSplitsNamedModulesOnTheRunEverythingPath(&parent, ctx)
+		case "RecordPassNeedsTheRunsRef":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).RecordPassNeedsTheRunsRef(&parent, ctx)
+		case "RecordPassNeverFailsThePassingCheck":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).RecordPassNeverFailsThePassingCheck(&parent, ctx)
+		case "RecordPassReachesTheStoreFromTrustedRef":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).RecordPassReachesTheStoreFromTrustedRef(&parent, ctx)
+		case "RecordPassRefusesAnUntrustedRef":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).RecordPassRefusesAnUntrustedRef(&parent, ctx)
+		case "RecordPassSaysTheActionsCacheIsUnwritable":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).RecordPassSaysTheActionsCacheIsUnwritable(&parent, ctx)
+		case "RecordPassSkipsAnUnhashableLeg":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).RecordPassSkipsAnUnhashableLeg(&parent, ctx)
+		case "RecordPassSkipsWithNoStoreConfigured":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).RecordPassSkipsWithNoStoreConfigured(&parent, ctx)
 		case "SelectionSelfTestPasses":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/workspace-ci/tests/internal/dagger/workspace-ci.gen.go
+++ b/daggerverse/workspace-ci/tests/internal/dagger/workspace-ci.gen.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Retrieve the binding value, as type WorkspaceCi
-func (r *Binding) AsWorkspaceCi() *WorkspaceCi { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:31:6)
+func (r *Binding) AsWorkspaceCi() *WorkspaceCi { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:32:6)
 	q := r.query.Select("asWorkspaceCi")
 
 	return &WorkspaceCi{
@@ -20,7 +20,7 @@ func (r *Binding) AsWorkspaceCi() *WorkspaceCi { // workspace-ci (../../../../..
 }
 
 // Create or update a binding of type WorkspaceCi in the environment
-func (r *Env) WithWorkspaceCiInput(name string, value *WorkspaceCi, description string) *Env { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:31:6)
+func (r *Env) WithWorkspaceCiInput(name string, value *WorkspaceCi, description string) *Env { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:32:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withWorkspaceCiInput")
 	q = q.Arg("name", name)
@@ -33,7 +33,7 @@ func (r *Env) WithWorkspaceCiInput(name string, value *WorkspaceCi, description 
 }
 
 // Declare a desired WorkspaceCi output to be assigned in the environment
-func (r *Env) WithWorkspaceCiOutput(name string, description string) *Env { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:31:6)
+func (r *Env) WithWorkspaceCiOutput(name string, description string) *Env { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:32:6)
 	q := r.query.Select("withWorkspaceCiOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -51,7 +51,7 @@ type WorkspaceCiOpts struct {
 	// source context, so nothing else would attribute them. Defaults to
 	// .github/workflows/, which costs nothing in a workspace that has none.
 	//
-	GlobalPaths []string // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:58:2)
+	GlobalPaths []string // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:85:2)
 	//
 	// Repo-relative directories of modules whose checks must each get their own leg
 	// even when everything runs. The run-everything path otherwise emits one leg per
@@ -60,7 +60,7 @@ type WorkspaceCiOpts struct {
 	// single runner. Splitting a module costs loading it — the one thing that path
 	// exists to avoid — so name only the modules that need it.
 	//
-	SplitModules []string // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:67:2)
+	SplitModules []string // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:94:2)
 	//
 	// Per-leg check-step budgets in minutes, as a JSON object keyed by a leg's
 	// display name or by a module directory (which covers every leg of that
@@ -68,39 +68,57 @@ type WorkspaceCiOpts struct {
 	//
 	//
 	// Default: "{}"
-	Timeouts string // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:74:2)
+	Timeouts string // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:101:2)
 	//
 	// The check-step budget in minutes for a leg with no override.
 	//
 	//
 	// Default: 6
-	DefaultTimeout int // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:79:2)
+	DefaultTimeout int // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:106:2)
 	//
-	// A credential for reading the memoization store: a GitHub token with
-	// actions:read on memoRepo. Nothing is ever written from here — see README.md.
+	// Where recorded passes live. ACTIONS_CACHE is read-only from this module and
+	// leaves recording to an actions/cache/save step; GIT_REFS is a store the
+	// module owns both sides of, so RecordPass can write it from anywhere a token
+	// reaches. See README.md — the two have different trust arguments.
 	//
-	MemoToken *Secret // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:84:2)
 	//
-	// The owner/name whose Actions cache holds the memoization store.
+	// Default: ACTIONS_CACHE
+	MemoStore WorkspaceCiMemoStore // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:114:2)
 	//
-	MemoRepo string // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:88:2)
+	// A credential for the memoization store: a GitHub token on memoRepo with
+	// actions:read for ACTIONS_CACHE, or contents:read for GIT_REFS — plus
+	// contents:write if this run is to record anything.
 	//
-	// The git refs whose cache scopes may be trusted to hold recorded passes.
-	// Defaults to none, which reads nothing: a scope a run can write is a scope
-	// that must be chosen deliberately.
+	MemoToken *Secret // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:120:2)
 	//
-	MemoRefs []string // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:94:2)
+	// The owner/name whose Actions cache, or whose git refs, hold the memoization
+	// store.
+	//
+	MemoRepo string // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:125:2)
+	//
+	// The GitHub API root the store is reached through. Defaults to
+	// https://api.github.com; set it for GitHub Enterprise Server.
+	//
+	MemoAPI string // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:130:2)
+	//
+	// The git refs whose scopes may be trusted to hold recorded passes, spelled in
+	// full (refs/heads/main, refs/pull/12/merge). They are the refs a plan reads,
+	// and the only refs RecordPass will write from. Defaults to none, which reads
+	// nothing and records nothing: a scope a run can write is a scope that must be
+	// chosen deliberately.
+	//
+	MemoRefs []string // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:138:2)
 	//
 	// How long, in seconds, a recorded pass may be honoured. This is the answer to
 	// base-image drift, which a source-derived hash cannot see.
 	//
 	//
 	// Default: 86400
-	MemoTTL int // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:100:2)
+	MemoTTL int // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:144:2)
 }
 
 // New configures a planner.
-func (r *Query) WorkspaceCi(opts ...WorkspaceCiOpts) *WorkspaceCi { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:51:1)
+func (r *Query) WorkspaceCi(opts ...WorkspaceCiOpts) *WorkspaceCi { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:78:1)
 	q := r.query.Select("workspaceCi")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `globalPaths` optional argument
@@ -119,6 +137,10 @@ func (r *Query) WorkspaceCi(opts ...WorkspaceCiOpts) *WorkspaceCi { // workspace
 		if !querybuilder.IsZeroValue(opts[i].DefaultTimeout) {
 			q = q.Arg("defaultTimeout", opts[i].DefaultTimeout)
 		}
+		// `memoStore` optional argument
+		if !querybuilder.IsZeroValue(opts[i].MemoStore) {
+			q = q.Arg("memoStore", opts[i].MemoStore)
+		}
 		// `memoToken` optional argument
 		if !querybuilder.IsZeroValue(opts[i].MemoToken) {
 			q = q.Arg("memoToken", opts[i].MemoToken)
@@ -126,6 +148,10 @@ func (r *Query) WorkspaceCi(opts ...WorkspaceCiOpts) *WorkspaceCi { // workspace
 		// `memoRepo` optional argument
 		if !querybuilder.IsZeroValue(opts[i].MemoRepo) {
 			q = q.Arg("memoRepo", opts[i].MemoRepo)
+		}
+		// `memoApi` optional argument
+		if !querybuilder.IsZeroValue(opts[i].MemoAPI) {
+			q = q.Arg("memoApi", opts[i].MemoAPI)
 		}
 		// `memoRefs` optional argument
 		if !querybuilder.IsZeroValue(opts[i].MemoRefs) {
@@ -143,14 +169,16 @@ func (r *Query) WorkspaceCi(opts ...WorkspaceCiOpts) *WorkspaceCi { // workspace
 }
 
 // WorkspaceCi plans CI for the workspace it is invoked from.
-type WorkspaceCi struct { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:31:6)
+type WorkspaceCi struct { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:32:6)
 	query *querybuilder.Selection
 
 	affectedModules   *string
 	generated         *Void
 	generatedSelfTest *Void
 	id                *ID
+	memoStoreSelfTest *Void
 	plan              *string
+	recordPass        *string
 	selectionSelfTest *Void
 }
 
@@ -165,12 +193,12 @@ type WorkspaceCiAffectedModulesOpts struct {
 	//
 	// The repository to plan for. Defaults to the calling workspace.
 	//
-	Repo *Directory // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:235:2)
+	Repo *Directory // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:288:2)
 	//
 	// The workspace to read repo from when repo is omitted. Defaults to the
 	// caller's.
 	//
-	Workspace *Workspace // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:240:2)
+	Workspace *Workspace // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:293:2)
 }
 
 // AffectedModules returns, as a JSON array of repo-relative directories, the
@@ -179,7 +207,7 @@ type WorkspaceCiAffectedModulesOpts struct {
 // reach" without paying for check enumeration.
 //
 // The arguments mean what they mean on Plan.
-func (r *WorkspaceCi) AffectedModules(ctx context.Context, base string, head string, opts ...WorkspaceCiAffectedModulesOpts) (string, error) { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:226:1)
+func (r *WorkspaceCi) AffectedModules(ctx context.Context, base string, head string, opts ...WorkspaceCiAffectedModulesOpts) (string, error) { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:279:1)
 	if r.affectedModules != nil {
 		return *r.affectedModules, nil
 	}
@@ -309,20 +337,40 @@ func (r *WorkspaceCi) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
+// MemoStoreSelfTest verifies the store this module owns both sides of — that a
+// pass is recorded under its own ref's scope, that recording the same hash twice
+// writes nothing and refreshes no TTL, that entries read back, that one older
+// than the TTL does not, and that one ref's scope stays out of another's — against
+// an in-process stub of GitHub's API.
+//
+// It is a check rather than only a Go test because this is the half of
+// memoization that fails silently: a store that quietly takes nothing costs every
+// later run its full time and looks exactly like a workspace nobody has recorded
+// against yet, and a scope that leaks costs correctness. Like SelectionSelfTest it
+// runs in-process and needs no network, no credential and no services.
+func (r *WorkspaceCi) MemoStoreSelfTest(ctx context.Context) error { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:486:1)
+	if r.memoStoreSelfTest != nil {
+		return nil
+	}
+	q := r.query.Select("memoStoreSelfTest")
+
+	return q.Execute(ctx)
+}
+
 // WorkspaceCiPlanOpts contains options for WorkspaceCi.Plan
 type WorkspaceCiPlanOpts struct {
 
 	// Default: JSON
-	Format WorkspaceCiFormat // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:177:2)
+	Format WorkspaceCiFormat // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:230:2)
 	//
 	// The repository to plan for. Defaults to the calling workspace.
 	//
-	Repo *Directory // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:181:2)
+	Repo *Directory // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:234:2)
 	//
 	// The workspace to read repo from when repo is omitted. Defaults to the
 	// caller's.
 	//
-	Workspace *Workspace // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:186:2)
+	Workspace *Workspace // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:239:2)
 	//
 	// Input hashes a previous run already proved good, as a JSON array. They are
 	// honoured on the same terms as the ones read from the memoization store, and
@@ -332,14 +380,14 @@ type WorkspaceCiPlanOpts struct {
 	//
 	//
 	// Default: "[]"
-	KnownGood string // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:195:2)
+	KnownGood string // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:248:2)
 	//
 	// Emit a diagnostics object — the plan plus which modules had to be loaded to
 	// produce it, whether everything was selected, which legs a recorded pass
 	// retired, and whether recorded passes were honoured at all — instead of the
 	// bare plan. Intended for tests and for explaining a plan, not for CI.
 	//
-	Diagnostics bool // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:202:2)
+	Diagnostics bool // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:255:2)
 }
 
 // Plan returns the legs of CI to run for a change, each already routed to the
@@ -366,7 +414,7 @@ type WorkspaceCiPlanOpts struct {
 // explicitly is also the escape hatch for a caller whose .git is a file rather
 // than a directory (a git worktree), which would otherwise degrade to running
 // everything.
-func (r *WorkspaceCi) Plan(ctx context.Context, base string, head string, opts ...WorkspaceCiPlanOpts) (string, error) { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:169:1)
+func (r *WorkspaceCi) Plan(ctx context.Context, base string, head string, opts ...WorkspaceCiPlanOpts) (string, error) { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:222:1)
 	if r.plan != nil {
 		return *r.plan, nil
 	}
@@ -402,13 +450,48 @@ func (r *WorkspaceCi) Plan(ctx context.Context, base string, head string, opts .
 	return response, q.Execute(ctx)
 }
 
+// RecordPass records that the leg whose inputs hashed to hash passed, so a later
+// run that computes the same hash can skip it. It is the write half of what Plan
+// reads, for the stores this module owns both sides of.
+//
+// It reports what it did, as one word, and **never fails a check that passed**.
+// Recording happens after the work is already green, so a store that will not
+// take the entry has to cost a later run its time and nothing else. A caller who
+// wants a store problem to be loud should compare the returned word:
+//
+//	RECORDED         a new entry now names this hash
+//	ALREADY_RECORDED an earlier run got there; nothing was written or refreshed
+//	REFUSED          ref is not one of memoRefs, so this scope is not writable
+//	SKIPPED          nothing to record: an empty hash, or no store configured
+//	UNSUPPORTED      the configured store cannot be written from this module
+//	FAILED           the store would not take the entry; stderr says why
+//
+// The error return is not how a store problem is reported. It carries exactly one
+// thing: a call that named no ref, because with no ref there is no scope to judge
+// and refusing silently would be indistinguishable from a scope that was judged
+// and rejected.
+func (r *WorkspaceCi) RecordPass(ctx context.Context, hash string, ref string, commit string) (string, error) { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:331:1)
+	if r.recordPass != nil {
+		return *r.recordPass, nil
+	}
+	q := r.query.Select("recordPass")
+	q = q.Arg("hash", hash)
+	q = q.Arg("ref", ref)
+	q = q.Arg("commit", commit)
+
+	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
 // SelectionSelfTest verifies the change -> modules -> legs mapping, the properties
 // a recorded pass depends on, and the shape each format renders a plan in, against
 // fixed fixtures — so a regression in any of them fails CI rather than silently
 // under-running a consumer's checks or handing their CI system something it cannot
 // parse. It runs in-process and needs no services, so it is cheap enough to run on
 // every leg set.
-func (r *WorkspaceCi) SelectionSelfTest(ctx context.Context) error { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:372:1)
+func (r *WorkspaceCi) SelectionSelfTest(ctx context.Context) error { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:463:1)
 	if r.selectionSelfTest != nil {
 		return nil
 	}
@@ -431,7 +514,7 @@ func (r *WorkspaceCi) AsNode() Node {
 // the *constant identifier* in SCREAMING_SNAKE_CASE, and the CLI takes that member
 // name rather than the value — hence `--format=GITHUB_ACTIONS`. The values here are
 // spelled to match, so there is only ever one spelling to remember.
-type WorkspaceCiFormat string // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:129:6)
+type WorkspaceCiFormat string // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:182:6)
 
 func (WorkspaceCiFormat) IsEnum() {}
 
@@ -486,14 +569,84 @@ func (v *WorkspaceCiFormat) UnmarshalJSON(dt []byte) error {
 const (
 	// FormatGithubActions is a single-line JSON array, ready to write to
 	// GITHUB_OUTPUT and expand with fromJSON as a matrix.
-	WorkspaceCiFormatGithubActions WorkspaceCiFormat = "GITHUB_ACTIONS" // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:136:2)
+	WorkspaceCiFormatGithubActions WorkspaceCiFormat = "GITHUB_ACTIONS" // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:189:2)
 
 	// FormatJSON is the canonical form: an indented JSON array of legs.
-	WorkspaceCiFormatJson WorkspaceCiFormat = "JSON" // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:133:2)
+	WorkspaceCiFormatJson WorkspaceCiFormat = "JSON" // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:186:2)
 
 	// FormatJenkins is Groovy: a map of leg name to closure, which is what a
 	// declarative pipeline's parallel step takes. Write it to a file, `load` it,
 	// and hand the result straight to `parallel`.
-	WorkspaceCiFormatJenkins WorkspaceCiFormat = "JENKINS" // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:140:2)
+	WorkspaceCiFormatJenkins WorkspaceCiFormat = "JENKINS" // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:193:2)
+
+)
+
+// MemoStore is where recorded passes live, and decides whether this module can
+// record one at all.
+//
+// Note on rendered names: as with Format, the CLI takes the enum member the SDK
+// derives from the constant identifier, so the values are spelled to match.
+type WorkspaceCiMemoStore string // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:60:6)
+
+func (WorkspaceCiMemoStore) IsEnum() {}
+
+func (v WorkspaceCiMemoStore) Name() string {
+	switch v {
+	case WorkspaceCiMemoStoreActionsCache:
+		return "ACTIONS_CACHE"
+	case WorkspaceCiMemoStoreGitRefs:
+		return "GIT_REFS"
+	default:
+		return ""
+	}
+}
+
+func (v WorkspaceCiMemoStore) Value() string {
+	return string(v)
+}
+
+func (v *WorkspaceCiMemoStore) MarshalJSON() ([]byte, error) {
+	if *v == "" {
+		return []byte(`""`), nil
+	}
+	name := v.Name()
+	if name == "" {
+		return nil, fmt.Errorf("invalid enum value %q", *v)
+	}
+	return json.Marshal(name)
+}
+
+func (v *WorkspaceCiMemoStore) UnmarshalJSON(dt []byte) error {
+	var s string
+	if err := json.Unmarshal(dt, &s); err != nil {
+		return err
+	}
+	switch s {
+	case "":
+		*v = ""
+	case "ACTIONS_CACHE":
+		*v = WorkspaceCiMemoStoreActionsCache
+	case "GIT_REFS":
+		*v = WorkspaceCiMemoStoreGitRefs
+	default:
+		return fmt.Errorf("invalid enum value %q", s)
+	}
+	return nil
+}
+
+const (
+	// MemoStoreActionsCache is GitHub's Actions cache, an entry being the key
+	// workspace-ci-memo-v1-<hash> and nothing else. This module reads it and can
+	// never write it: a cache write needs ACTIONS_RUNTIME_TOKEN, which only a
+	// running workflow holds, so recording stays an actions/cache/save step and
+	// RecordPass reports UNSUPPORTED.
+	WorkspaceCiMemoStoreActionsCache WorkspaceCiMemoStore = "ACTIONS_CACHE" // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:68:2)
+
+	// MemoStoreGitRefs is a namespace of git refs in memoRepo, which an ordinary
+	// repository token both reads and writes — so RecordPass works, and a CI
+	// system with no equivalent of actions/cache/save can memoize. Its trust
+	// argument is not the Actions cache's and is spelled out in README.md: GitHub
+	// isolates cache scopes for you, and it does not isolate refs.
+	WorkspaceCiMemoStoreGitRefs WorkspaceCiMemoStore = "GIT_REFS" // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:74:2)
 
 )

--- a/daggerverse/workspace-ci/tests/main.go
+++ b/daggerverse/workspace-ci/tests/main.go
@@ -247,6 +247,15 @@ func (t *Tests) All(ctx context.Context) error {
 		"plan-splits-named-modules-on-the-run-everything-path":   t.PlanSplitsNamedModulesOnTheRunEverythingPath,
 		"new-rejects-malformed-timeouts":                         t.NewRejectsMalformedTimeouts,
 		"new-rejects-memo-token-without-repo":                    t.NewRejectsMemoTokenWithoutRepo,
+		"new-rejects-an-unknown-memo-store":                      t.NewRejectsAnUnknownMemoStore,
+		"record-pass-refuses-an-untrusted-ref":                   t.RecordPassRefusesAnUntrustedRef,
+		"record-pass-reaches-the-store-from-trusted-ref":         t.RecordPassReachesTheStoreFromTrustedRef,
+		"record-pass-never-fails-the-passing-check":              t.RecordPassNeverFailsThePassingCheck,
+		"record-pass-skips-an-unhashable-leg":                    t.RecordPassSkipsAnUnhashableLeg,
+		"record-pass-says-the-actions-cache-is-unwritable":       t.RecordPassSaysTheActionsCacheIsUnwritable,
+		"record-pass-skips-with-no-store-configured":             t.RecordPassSkipsWithNoStoreConfigured,
+		"record-pass-needs-the-runs-ref":                         t.RecordPassNeedsTheRunsRef,
+		"memo-store-self-test-passes":                            t.MemoStoreSelfTestPasses,
 		"selection-self-test-passes":                             t.SelectionSelfTestPasses,
 	} {
 		g.Go(func() error {

--- a/daggerverse/workspace-ci/tests/record.go
+++ b/daggerverse/workspace-ci/tests/record.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"dagger/tests/internal/dagger"
+)
+
+// trustedRef is the ref these tests nominate as writable, and untrustedRef one
+// they never do. The second is deliberately an extension of the first: a store
+// that keyed entries on a raw ref name would let it reach into the first's scope,
+// so nothing about the trust boundary should be prefix-shaped either.
+const (
+	trustedRef   = "refs/heads/main"
+	untrustedRef = "refs/heads/main-2"
+	// someHash is shaped like a real input hash. Nothing here reaches a store that
+	// could hold it.
+	someHash = "a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90"
+	// someCommit is a well-formed object id, for the same reason.
+	someCommit = "0123456789abcdef0123456789abcdef01234567"
+	// unreachableAPI is a port nothing listens on, so a call that gets as far as
+	// the store fails immediately and provably without leaving the engine.
+	unreachableAPI = "http://127.0.0.1:1"
+)
+
+// recorder builds a planner configured against a module-owned store, with a
+// throwaway credential and one trusted ref.
+func recorder(store dagger.WorkspaceCiMemoStore, api string) (*dagger.WorkspaceCi, error) {
+	token, err := randomSecret()
+	if err != nil {
+		return nil, err
+	}
+	return dag.WorkspaceCi(dagger.WorkspaceCiOpts{
+		MemoStore: store,
+		MemoToken: token,
+		MemoRepo:  "z5labs/devex",
+		MemoAPI:   api,
+		MemoRefs:  []string{trustedRef},
+	}), nil
+}
+
+// RecordPassRefusesAnUntrustedRef is the trust boundary for module-side writes.
+// A run whose ref the caller never nominated must record nothing, and it must
+// refuse before it reaches the store rather than relying on the store to say no —
+// so this points it at an API that cannot answer, and still expects REFUSED.
+func (t *Tests) RecordPassRefusesAnUntrustedRef(ctx context.Context) error {
+	ci, err := recorder(dagger.WorkspaceCiMemoStoreGitRefs, unreachableAPI)
+	if err != nil {
+		return err
+	}
+	got, err := ci.RecordPass(ctx, someHash, untrustedRef, someCommit)
+	if err != nil {
+		return err
+	}
+	if got != "REFUSED" {
+		return fmt.Errorf("recording from %q reported %q, want REFUSED", untrustedRef, got)
+	}
+	return nil
+}
+
+// RecordPassReachesTheStoreFromTrustedRef is the other half of the same
+// boundary, and the reason the test above proves anything: from a nominated ref
+// the module really does go on to write, so REFUSED is a judgement about the ref
+// and not a planner that never writes at all. The store here cannot answer, so
+// the outcome is FAILED — which is also the point of the next test.
+func (t *Tests) RecordPassReachesTheStoreFromTrustedRef(ctx context.Context) error {
+	ci, err := recorder(dagger.WorkspaceCiMemoStoreGitRefs, unreachableAPI)
+	if err != nil {
+		return err
+	}
+	got, err := ci.RecordPass(ctx, someHash, trustedRef, someCommit)
+	if err != nil {
+		return err
+	}
+	if got != "FAILED" {
+		return fmt.Errorf("recording from %q reported %q, want FAILED against an unreachable store", trustedRef, got)
+	}
+	return nil
+}
+
+// RecordPassNeverFailsThePassingCheck pins the contract the whole function
+// hangs on: recording runs after the work is already green, so a store that
+// cannot be reached at all reports itself in the return value and never as an
+// error. A store outage that turned a passing suite red would be strictly worse
+// than no memoization.
+func (t *Tests) RecordPassNeverFailsThePassingCheck(ctx context.Context) error {
+	ci, err := recorder(dagger.WorkspaceCiMemoStoreGitRefs, unreachableAPI)
+	if err != nil {
+		return err
+	}
+	if _, err := ci.RecordPass(ctx, someHash, trustedRef, someCommit); err != nil {
+		return fmt.Errorf("an unreachable store failed the call: %w", err)
+	}
+	return nil
+}
+
+// RecordPassSkipsAnUnhashableLeg proves the empty hash means the same thing on
+// the write side as on the read side. A leg the planner could not hash must never
+// have anything recorded for it — a hash of "" would otherwise become an entry
+// every later unhashable leg matched.
+func (t *Tests) RecordPassSkipsAnUnhashableLeg(ctx context.Context) error {
+	ci, err := recorder(dagger.WorkspaceCiMemoStoreGitRefs, unreachableAPI)
+	if err != nil {
+		return err
+	}
+	got, err := ci.RecordPass(ctx, "", trustedRef, someCommit)
+	if err != nil {
+		return err
+	}
+	if got != "SKIPPED" {
+		return fmt.Errorf("recording an unhashable leg reported %q, want SKIPPED", got)
+	}
+	return nil
+}
+
+// RecordPassSaysTheActionsCacheIsUnwritable keeps the old constraint honest. The
+// Actions cache still needs ACTIONS_RUNTIME_TOKEN, so a consumer who configures it
+// and then calls RecordPass has to be told, in the return value, rather than
+// getting a silent no-op that looks exactly like a store nobody has recorded into.
+func (t *Tests) RecordPassSaysTheActionsCacheIsUnwritable(ctx context.Context) error {
+	ci, err := recorder(dagger.WorkspaceCiMemoStoreActionsCache, unreachableAPI)
+	if err != nil {
+		return err
+	}
+	got, err := ci.RecordPass(ctx, someHash, trustedRef, someCommit)
+	if err != nil {
+		return err
+	}
+	if got != "UNSUPPORTED" {
+		return fmt.Errorf("recording into the Actions cache reported %q, want UNSUPPORTED", got)
+	}
+	return nil
+}
+
+// RecordPassSkipsWithNoStoreConfigured covers the default posture: memoization
+// off is a planner that records nothing, not one that errors.
+func (t *Tests) RecordPassSkipsWithNoStoreConfigured(ctx context.Context) error {
+	got, err := dag.WorkspaceCi().RecordPass(ctx, someHash, trustedRef, someCommit)
+	if err != nil {
+		return err
+	}
+	if got != "SKIPPED" {
+		return fmt.Errorf("recording with no store configured reported %q, want SKIPPED", got)
+	}
+	return nil
+}
+
+// RecordPassNeedsTheRunsRef is the one hard error. With no ref there is no scope
+// to judge, so a silent refusal would be indistinguishable from a scope that was
+// judged and rejected — and a CI system that never passes its ref would record
+// nothing forever while reading as if it were.
+func (t *Tests) RecordPassNeedsTheRunsRef(ctx context.Context) error {
+	ci, err := recorder(dagger.WorkspaceCiMemoStoreGitRefs, unreachableAPI)
+	if err != nil {
+		return err
+	}
+	if _, err := ci.RecordPass(ctx, someHash, "", someCommit); err == nil {
+		return fmt.Errorf("recording without the run's ref was accepted")
+	}
+	return nil
+}
+
+// NewRejectsAnUnknownMemoStore proves a misspelled store is a configuration
+// error rather than a silent fall back to the read-only one, which would record
+// nothing and look like a store nobody has written to.
+func (t *Tests) NewRejectsAnUnknownMemoStore(ctx context.Context) error {
+	_, err := dag.WorkspaceCi(dagger.WorkspaceCiOpts{MemoStore: "S3"}).
+		RecordPass(ctx, someHash, trustedRef, someCommit)
+	if err == nil {
+		return fmt.Errorf("an unknown memo store was accepted")
+	}
+	return nil
+}
+
+// MemoStoreSelfTestPasses runs the module's own store check the way a consumer's
+// CI would, so a regression in recording, idempotence, TTL filtering or scope
+// isolation fails here too rather than only where it is installed.
+func (t *Tests) MemoStoreSelfTestPasses(ctx context.Context) error {
+	return dag.WorkspaceCi().MemoStoreSelfTest(ctx)
+}


### PR DESCRIPTION
Closes #289

The module could read the known-good set but never write it: a GitHub Actions
cache entry needs `ACTIONS_RUNTIME_TOKEN`, which only a running workflow holds,
so recording stayed an `actions/cache/save` step. That split one concept across
two places and left any CI system without an equivalent action unable to
memoize at all.

This adds a second store, chosen with `--memo-store`, that the module owns both
sides of.

## Acceptance criteria

- [x] **A `RecordPass`-style function writes an entry keyed by input hash.**
      `record-pass --hash --ref --commit` writes
      `refs/workspace-ci-memo/v1/<scope>/<hash>/<unix>` in `--memo-repo`, under
      the new `--memo-store=GIT_REFS`. `plan` reads the same namespace back, so
      one credential now covers both halves.
- [x] **It is a no-op on an existing key and never fails a check that passed.**
      A hash already in the scope is left alone — not even its timestamp is
      refreshed, since that would extend the TTL that bounds how long a pass may
      be honoured. Every store problem is reported in the return value
      (`FAILED`) and never as an error; the only hard error is a call that names
      no ref.
- [x] **It refuses to write from an untrusted ref scope.** A ref outside
      `--memo-refs` returns `REFUSED` before the store is reached.
- [x] **The trust argument for module-side writes is documented, not implicit.**
      A dedicated README section says out loud that GitHub isolates cache scopes
      and does **not** isolate refs, so the refusal guards against accident and
      the real enforcement is the credential's permissions plus a ruleset over
      `refs/workspace-ci-memo/*`.

## Judgment calls that shaped the public API

- **A second store rather than a second write path for the same one.** The
  Actions cache genuinely cannot be written with a repository token, so
  `record-pass` reports `UNSUPPORTED` there rather than pretending. `--memo-store`
  defaults to `ACTIONS_CACHE`, so nothing existing changes behaviour.
- **`record-pass` returns a word, not an enum or an error.** Recording runs
  after the work is green, so a store outage must cost a later run its time and
  nothing else; a caller who wants it loud compares the word in shell.
  `RECORDED` / `ALREADY_RECORDED` / `REFUSED` / `SKIPPED` / `UNSUPPORTED` /
  `FAILED`.
- **The scope component is hex.** A raw ref name contains slashes, which would
  make `refs/heads/main` a path prefix of `refs/heads/main/feature` and let a
  branch anyone can create read and poison the default branch's scope. There is
  a test asserting the two scopes do not nest.
- **The timestamp is in the ref name.** GitHub's ref listing carries no date, so
  holding it anywhere else would cost one API call per entry on every plan.
- **`--memo-api` is new and optional.** It exists for GitHub Enterprise Server,
  and it is what lets the tests drive the real HTTP client at a store that
  cannot answer.
- **The reusable workflow is unchanged** and still records with
  `actions/cache/save`; moving it needs `contents: write` and a per-store
  permission story, which is #364.

## Verified

- `dagger check` — green (`ci:generated`, `ci:generated-self-test`,
  `ci:selection-self-test`).
- `bash .github/scripts/verify-affected-modules.sh` — green:
  `workspace-ci:generated`, `generated-self-test`, the new
  `workspace-ci:memo-store-self-test`, `selection-self-test`, and `tests:all`.
- Each of the eight new tests run individually before `tests:all`, plus
  `go test ./...` in `refstore`.

The new `memo-store-self-test` check drives the real HTTP client against an
in-process stub of GitHub's API — recording, idempotence, TTL filtering, scope
isolation, an unreadable store and a refused write. It is a check and not only a
Go test because this is the half of memoization that fails silently: a store
that quietly takes nothing looks exactly like one nobody has recorded into.

🤖 Generated with [Claude Code](https://claude.com/claude-code)