### PR TITLE
story(issue-286): accept symbolic revisions for base and head

### DIFF
--- a/ci/internal/dagger/workspace-ci.gen.go
+++ b/ci/internal/dagger/workspace-ci.gen.go
@@ -193,12 +193,12 @@ type WorkspaceCiAffectedModulesOpts struct {
 	//
 	// The repository to plan for. Defaults to the calling workspace.
 	//
-	Repo *Directory // workspace-ci (../../../daggerverse/workspace-ci/main.go:288:2)
+	Repo *Directory // workspace-ci (../../../daggerverse/workspace-ci/main.go:294:2)
 	//
 	// The workspace to read repo from when repo is omitted. Defaults to the
 	// caller's.
 	//
-	Workspace *Workspace // workspace-ci (../../../daggerverse/workspace-ci/main.go:293:2)
+	Workspace *Workspace // workspace-ci (../../../daggerverse/workspace-ci/main.go:299:2)
 }
 
 // AffectedModules returns, as a JSON array of repo-relative directories, the
@@ -207,7 +207,7 @@ type WorkspaceCiAffectedModulesOpts struct {
 // reach" without paying for check enumeration.
 //
 // The arguments mean what they mean on Plan.
-func (r *WorkspaceCi) AffectedModules(ctx context.Context, base string, head string, opts ...WorkspaceCiAffectedModulesOpts) (string, error) { // workspace-ci (../../../daggerverse/workspace-ci/main.go:279:1)
+func (r *WorkspaceCi) AffectedModules(ctx context.Context, base string, head string, opts ...WorkspaceCiAffectedModulesOpts) (string, error) { // workspace-ci (../../../daggerverse/workspace-ci/main.go:284:1)
 	if r.affectedModules != nil {
 		return *r.affectedModules, nil
 	}
@@ -348,7 +348,7 @@ func (r *WorkspaceCi) UnmarshalJSON(bs []byte) error {
 // later run its full time and looks exactly like a workspace nobody has recorded
 // against yet, and a scope that leaks costs correctness. Like SelectionSelfTest it
 // runs in-process and needs no network, no credential and no services.
-func (r *WorkspaceCi) MemoStoreSelfTest(ctx context.Context) error { // workspace-ci (../../../daggerverse/workspace-ci/main.go:486:1)
+func (r *WorkspaceCi) MemoStoreSelfTest(ctx context.Context) error { // workspace-ci (../../../daggerverse/workspace-ci/main.go:492:1)
 	if r.memoStoreSelfTest != nil {
 		return nil
 	}
@@ -361,16 +361,16 @@ func (r *WorkspaceCi) MemoStoreSelfTest(ctx context.Context) error { // workspac
 type WorkspaceCiPlanOpts struct {
 
 	// Default: JSON
-	Format WorkspaceCiFormat // workspace-ci (../../../daggerverse/workspace-ci/main.go:230:2)
+	Format WorkspaceCiFormat // workspace-ci (../../../daggerverse/workspace-ci/main.go:235:2)
 	//
 	// The repository to plan for. Defaults to the calling workspace.
 	//
-	Repo *Directory // workspace-ci (../../../daggerverse/workspace-ci/main.go:234:2)
+	Repo *Directory // workspace-ci (../../../daggerverse/workspace-ci/main.go:239:2)
 	//
 	// The workspace to read repo from when repo is omitted. Defaults to the
 	// caller's.
 	//
-	Workspace *Workspace // workspace-ci (../../../daggerverse/workspace-ci/main.go:239:2)
+	Workspace *Workspace // workspace-ci (../../../daggerverse/workspace-ci/main.go:244:2)
 	//
 	// Input hashes a previous run already proved good, as a JSON array. They are
 	// honoured on the same terms as the ones read from the memoization store, and
@@ -380,14 +380,14 @@ type WorkspaceCiPlanOpts struct {
 	//
 	//
 	// Default: "[]"
-	KnownGood string // workspace-ci (../../../daggerverse/workspace-ci/main.go:248:2)
+	KnownGood string // workspace-ci (../../../daggerverse/workspace-ci/main.go:253:2)
 	//
 	// Emit a diagnostics object — the plan plus which modules had to be loaded to
 	// produce it, whether everything was selected, which legs a recorded pass
 	// retired, and whether recorded passes were honoured at all — instead of the
 	// bare plan. Intended for tests and for explaining a plan, not for CI.
 	//
-	Diagnostics bool // workspace-ci (../../../daggerverse/workspace-ci/main.go:255:2)
+	Diagnostics bool // workspace-ci (../../../daggerverse/workspace-ci/main.go:260:2)
 }
 
 // Plan returns the legs of CI to run for a change, each already routed to the
@@ -399,9 +399,13 @@ type WorkspaceCiPlanOpts struct {
 // a pass may be recorded under (empty means never memoize), and the step and job
 // budgets in minutes.
 //
-// base and head are the commit SHAs to diff, three-dot (merge-base) like a PR's
-// change set. An empty or all-zeros base — a new branch, a missing base — means
-// "run everything".
+// base and head are the revisions to diff, three-dot (merge-base) like a PR's
+// change set. Either may be written in any form git's rev-parse takes — a full or
+// abbreviated commit SHA, a branch or tag name, HEAD, or those with ~ and ^
+// suffixes — so CI can pass the SHAs its event payload carries and a person can
+// pass `--base=main --head=HEAD`. An empty or all-zeros base — a new branch, a
+// missing base — means "run everything", and so does a revision this repository
+// cannot resolve.
 //
 // A plan that cannot read the workspace is an error, never an empty plan: an empty
 // matrix skips the run job and passes the gate having run nothing. Everything else
@@ -414,7 +418,7 @@ type WorkspaceCiPlanOpts struct {
 // explicitly is also the escape hatch for a caller whose .git is a file rather
 // than a directory (a git worktree), which would otherwise degrade to running
 // everything.
-func (r *WorkspaceCi) Plan(ctx context.Context, base string, head string, opts ...WorkspaceCiPlanOpts) (string, error) { // workspace-ci (../../../daggerverse/workspace-ci/main.go:222:1)
+func (r *WorkspaceCi) Plan(ctx context.Context, base string, head string, opts ...WorkspaceCiPlanOpts) (string, error) { // workspace-ci (../../../daggerverse/workspace-ci/main.go:226:1)
 	if r.plan != nil {
 		return *r.plan, nil
 	}
@@ -470,7 +474,7 @@ func (r *WorkspaceCi) Plan(ctx context.Context, base string, head string, opts .
 // thing: a call that named no ref, because with no ref there is no scope to judge
 // and refusing silently would be indistinguishable from a scope that was judged
 // and rejected.
-func (r *WorkspaceCi) RecordPass(ctx context.Context, hash string, ref string, commit string) (string, error) { // workspace-ci (../../../daggerverse/workspace-ci/main.go:331:1)
+func (r *WorkspaceCi) RecordPass(ctx context.Context, hash string, ref string, commit string) (string, error) { // workspace-ci (../../../daggerverse/workspace-ci/main.go:337:1)
 	if r.recordPass != nil {
 		return *r.recordPass, nil
 	}
@@ -491,7 +495,7 @@ func (r *WorkspaceCi) RecordPass(ctx context.Context, hash string, ref string, c
 // under-running a consumer's checks or handing their CI system something it cannot
 // parse. It runs in-process and needs no services, so it is cheap enough to run on
 // every leg set.
-func (r *WorkspaceCi) SelectionSelfTest(ctx context.Context) error { // workspace-ci (../../../daggerverse/workspace-ci/main.go:463:1)
+func (r *WorkspaceCi) SelectionSelfTest(ctx context.Context) error { // workspace-ci (../../../daggerverse/workspace-ci/main.go:469:1)
 	if r.selectionSelfTest != nil {
 		return nil
 	}

--- a/ci/internal/dagger/workspace-ci.gen.go
+++ b/ci/internal/dagger/workspace-ci.gen.go
@@ -403,8 +403,8 @@ type WorkspaceCiPlanOpts struct {
 // change set. Either may be written in any form git's rev-parse takes — a full or
 // abbreviated commit SHA, a branch or tag name, HEAD, or those with ~ and ^
 // suffixes — so CI can pass the SHAs its event payload carries and a person can
-// pass `--base=main --head=HEAD`. An empty or all-zeros base — a new branch, a
-// missing base — means "run everything", and so does a revision this repository
+// pass `--base=main --head=HEAD`. Either side empty or all-zeros — a new branch,
+// a missing base — means "run everything", and so does a revision this repository
 // cannot resolve.
 //
 // A plan that cannot read the workspace is an error, never an empty plan: an empty

--- a/daggerverse/workspace-ci/README.md
+++ b/daggerverse/workspace-ci/README.md
@@ -10,7 +10,18 @@ a CI system needs one call and at most a format shim.
 # from anywhere in your workspace
 dagger -m github.com/z5labs/devex/daggerverse/workspace-ci call plan \
   --base="$BASE_SHA" --head="$HEAD_SHA"
+
+# or by hand, where you have names rather than SHAs
+dagger -m github.com/z5labs/devex/daggerverse/workspace-ci call plan \
+  --base=main --head=HEAD
 ```
+
+`base` and `head` take any revision `git rev-parse` does: a full or abbreviated
+commit SHA, a branch or tag name, `HEAD`, and any of those with `~` and `^`
+suffixes. CI passes the SHAs its event payload carries; a person passes the names
+they already have. A revision the repository cannot resolve runs everything — see
+[What the planner will not do](#what-the-planner-will-not-do) — so a typo costs a
+run its time, not its coverage.
 
 ```json
 [
@@ -233,6 +244,7 @@ else fails safe towards running too much.
 | --- | --- |
 | no `dagger.json` anywhere | **error** |
 | the diff range is unusable (new branch, all-zeros base) | everything runs |
+| a revision names no commit here (typo, deleted branch, shallow clone) | everything runs |
 | `.git` cannot be read | everything runs, nothing is memoized |
 | a module's dependencies cannot be read | that module always runs |
 | a module's source context cannot be read | everything under it counts as an input |

--- a/daggerverse/workspace-ci/gitdiff/gitdiff.go
+++ b/daggerverse/workspace-ci/gitdiff/gitdiff.go
@@ -81,17 +81,18 @@ type Change struct {
 // repoDir is a working-tree root containing a .git directory. Renamed paths
 // contribute both their old and new names (conservative — the change could affect
 // the module on either side), with the old name marked Deleted. base and head are
-// full commit SHAs. The result is sorted by path.
+// revisions in every form git's rev-parse takes — see resolveCommit. The result is
+// sorted by path.
 func Changes(repoDir, base, head string) ([]Change, error) {
 	repo, err := git.PlainOpen(repoDir)
 	if err != nil {
 		return nil, fmt.Errorf("open repo %q: %w", repoDir, err)
 	}
-	baseCommit, err := repo.CommitObject(plumbing.NewHash(base))
+	baseCommit, err := resolveCommit(repo, base)
 	if err != nil {
 		return nil, fmt.Errorf("resolve base %q: %w", base, err)
 	}
-	headCommit, err := repo.CommitObject(plumbing.NewHash(head))
+	headCommit, err := resolveCommit(repo, head)
 	if err != nil {
 		return nil, fmt.Errorf("resolve head %q: %w", head, err)
 	}
@@ -143,4 +144,28 @@ func Changes(repoDir, base, head string) ([]Change, error) {
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
 	return out, nil
+}
+
+// resolveCommit turns a revision into the commit it names, accepting everything
+// git's rev-parse does: a full or abbreviated commit SHA, a branch or tag name,
+// HEAD, and any of those carrying git's ~ and ^ suffixes. An annotated tag is
+// dereferenced to the commit it points at.
+//
+// It goes through go-git's rev-parse rather than hashing the string directly
+// because plumbing.NewHash zero-fills anything that is not forty hex digits: a
+// branch name used to arrive as the all-zeros object id and fail as though its
+// commit were missing. A commit SHA is still the form CI supplies — it is what
+// the event payload carries — but anyone running the planner by hand has `main`
+// and `HEAD`, not the SHAs those name.
+//
+// An unresolvable revision is an error, which Changes' caller turns into "no
+// usable diff, run everything" rather than a failure. That is the same fail-safe
+// an unusable diff range takes, and it is what keeps a typo costing time instead
+// of correctness.
+func resolveCommit(repo *git.Repository, rev string) (*object.Commit, error) {
+	hash, err := repo.ResolveRevision(plumbing.Revision(rev))
+	if err != nil {
+		return nil, err
+	}
+	return repo.CommitObject(*hash)
 }

--- a/daggerverse/workspace-ci/gitdiff/gitdiff_test.go
+++ b/daggerverse/workspace-ci/gitdiff/gitdiff_test.go
@@ -65,6 +65,17 @@ func newTestRepo(t *testing.T) testRepo {
 			t.Fatalf("set %s: %v", ref, err)
 		}
 	}
+
+	// An annotated tag on the same commit. It is a tag *object* rather than a
+	// reference straight to the commit, so resolving it has to peel one level —
+	// which is a separate path through rev-parse from the lightweight tag above
+	// and would otherwise go untested.
+	if _, err := repo.CreateTag("v0.2.0", plumbing.NewHash(tr.commits[0]), &git.CreateTagOptions{
+		Tagger:  &signature,
+		Message: "annotated v0.2.0",
+	}); err != nil {
+		t.Fatalf("annotated tag: %v", err)
+	}
 	return tr
 }
 
@@ -88,7 +99,8 @@ func TestChangesAcceptsSymbolicRevisions(t *testing.T) {
 	for _, tc := range []struct{ name, base, head string }{
 		{"full shas", tr.commits[0], tr.commits[2]},
 		{"branch and head", "base-branch", "HEAD"},
-		{"tag and head", "v0.1.0", "HEAD"},
+		{"lightweight tag and head", "v0.1.0", "HEAD"},
+		{"annotated tag and head", "v0.2.0", "HEAD"},
 		{"head relative", "HEAD~2", "HEAD"},
 		{"branch and sha", "base-branch", tr.commits[2]},
 		{"sha and branch tip", tr.commits[0], "HEAD~0"},

--- a/daggerverse/workspace-ci/gitdiff/gitdiff_test.go
+++ b/daggerverse/workspace-ci/gitdiff/gitdiff_test.go
@@ -1,0 +1,170 @@
+package gitdiff
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+// signature is fixed so a repository built twice is built identically.
+var signature = object.Signature{
+	Name:  "gitdiff test",
+	Email: "test@example.invalid",
+	When:  time.Unix(1700000000, 0).UTC(),
+}
+
+// testRepo is a three-commit repository with a branch and a tag naming its first
+// commit, which is the shape every revision form below is asked about.
+type testRepo struct {
+	dir     string
+	commits []string // in the order they were made
+}
+
+// newTestRepo builds it. first.txt lands in the initial commit, second.txt in the
+// next, third.txt in the last, so a range picks out exactly the files it covers.
+func newTestRepo(t *testing.T) testRepo {
+	t.Helper()
+	dir := t.TempDir()
+	repo, err := git.PlainInit(dir, false)
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("worktree: %v", err)
+	}
+	tr := testRepo{dir: dir}
+	for _, name := range []string{"first.txt", "second.txt", "third.txt"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(name+"\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		if _, err := wt.Add("."); err != nil {
+			t.Fatalf("stage %s: %v", name, err)
+		}
+		hash, err := wt.Commit("add "+name, &git.CommitOptions{Author: &signature, Committer: &signature})
+		if err != nil {
+			t.Fatalf("commit %s: %v", name, err)
+		}
+		tr.commits = append(tr.commits, hash.String())
+	}
+
+	// A branch and a lightweight tag on the first commit, so a range can be asked
+	// for the way a person asks for one.
+	for _, ref := range []plumbing.ReferenceName{
+		plumbing.NewBranchReferenceName("base-branch"),
+		plumbing.NewTagReferenceName("v0.1.0"),
+	} {
+		hashRef := plumbing.NewHashReference(ref, plumbing.NewHash(tr.commits[0]))
+		if err := repo.Storer.SetReference(hashRef); err != nil {
+			t.Fatalf("set %s: %v", ref, err)
+		}
+	}
+	return tr
+}
+
+// paths flattens a change set to the paths it names.
+func paths(changes []Change) []string {
+	out := make([]string, 0, len(changes))
+	for _, c := range changes {
+		out = append(out, c.Path)
+	}
+	return out
+}
+
+// TestChangesAcceptsSymbolicRevisions proves a range named symbolically — a
+// branch, a tag, HEAD, HEAD-relative — yields exactly what the equivalent SHAs
+// yield. The GitHub event payload carries SHAs; a person at a terminal has `main`
+// and `HEAD`, and both have to reach the same plan.
+func TestChangesAcceptsSymbolicRevisions(t *testing.T) {
+	tr := newTestRepo(t)
+	want := []string{"second.txt", "third.txt"}
+
+	for _, tc := range []struct{ name, base, head string }{
+		{"full shas", tr.commits[0], tr.commits[2]},
+		{"branch and head", "base-branch", "HEAD"},
+		{"tag and head", "v0.1.0", "HEAD"},
+		{"head relative", "HEAD~2", "HEAD"},
+		{"branch and sha", "base-branch", tr.commits[2]},
+		{"sha and branch tip", tr.commits[0], "HEAD~0"},
+		{"abbreviated shas", tr.commits[0][:8], tr.commits[2][:8]},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			changes, err := Changes(tr.dir, tc.base, tc.head)
+			if err != nil {
+				t.Fatalf("Changes(%q, %q): %v", tc.base, tc.head, err)
+			}
+			if got := paths(changes); !slices.Equal(got, want) {
+				t.Errorf("Changes(%q, %q) = %v, want %v", tc.base, tc.head, got, want)
+			}
+		})
+	}
+}
+
+// TestChangesRejectsAnUnresolvableRevision proves an unresolvable revision is an
+// error rather than an empty change set. The distinction is load-bearing: the
+// caller turns an error into "run everything" and an empty change set means the
+// diff really was empty, so a typo that returned no changes would silently skip
+// every check.
+func TestChangesRejectsAnUnresolvableRevision(t *testing.T) {
+	tr := newTestRepo(t)
+	for _, tc := range []struct{ name, base, head string }{
+		{"unknown base branch", "no-such-branch", "HEAD"},
+		{"unknown head branch", "HEAD~2", "no-such-branch"},
+		{"absent sha", "0123456789abcdef0123456789abcdef01234567", "HEAD"},
+		{"empty base", "", "HEAD"},
+		{"zero sha", "0000000000000000000000000000000000000000", "HEAD"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			changes, err := Changes(tr.dir, tc.base, tc.head)
+			if err == nil {
+				t.Fatalf("Changes(%q, %q) = %v, want an error", tc.base, tc.head, paths(changes))
+			}
+		})
+	}
+}
+
+// TestChangesUsesMergeBaseSemantics proves the three-dot rule survives symbolic
+// revisions: a commit made on the base branch after the two diverged is not
+// attributed to head. Resolving a branch name to its tip is what makes this
+// reachable at all — with SHAs the caller would have had to find the tip first.
+func TestChangesUsesMergeBaseSemantics(t *testing.T) {
+	tr := newTestRepo(t)
+	repo, err := git.PlainOpen(tr.dir)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("worktree: %v", err)
+	}
+
+	// Move onto the branch that names the first commit and commit there, so the
+	// two lines of history have diverged.
+	if err := wt.Checkout(&git.CheckoutOptions{Branch: plumbing.NewBranchReferenceName("base-branch")}); err != nil {
+		t.Fatalf("checkout: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tr.dir, "on-base.txt"), []byte("on-base\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := wt.Add("."); err != nil {
+		t.Fatalf("stage: %v", err)
+	}
+	if _, err := wt.Commit("add on-base.txt", &git.CommitOptions{Author: &signature, Committer: &signature}); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	changes, err := Changes(tr.dir, "base-branch", tr.commits[2])
+	if err != nil {
+		t.Fatalf("Changes: %v", err)
+	}
+	want := []string{"second.txt", "third.txt"}
+	if got := paths(changes); !slices.Equal(got, want) {
+		t.Errorf("Changes(base-branch, head) = %v, want %v; on-base.txt was made on the base after the two diverged", got, want)
+	}
+}

--- a/daggerverse/workspace-ci/main.go
+++ b/daggerverse/workspace-ci/main.go
@@ -206,8 +206,8 @@ const (
 // change set. Either may be written in any form git's rev-parse takes — a full or
 // abbreviated commit SHA, a branch or tag name, HEAD, or those with ~ and ^
 // suffixes — so CI can pass the SHAs its event payload carries and a person can
-// pass `--base=main --head=HEAD`. An empty or all-zeros base — a new branch, a
-// missing base — means "run everything", and so does a revision this repository
+// pass `--base=main --head=HEAD`. Either side empty or all-zeros — a new branch,
+// a missing base — means "run everything", and so does a revision this repository
 // cannot resolve.
 //
 // A plan that cannot read the workspace is an error, never an empty plan: an empty

--- a/daggerverse/workspace-ci/main.go
+++ b/daggerverse/workspace-ci/main.go
@@ -202,9 +202,13 @@ const (
 // a pass may be recorded under (empty means never memoize), and the step and job
 // budgets in minutes.
 //
-// base and head are the commit SHAs to diff, three-dot (merge-base) like a PR's
-// change set. An empty or all-zeros base — a new branch, a missing base — means
-// "run everything".
+// base and head are the revisions to diff, three-dot (merge-base) like a PR's
+// change set. Either may be written in any form git's rev-parse takes — a full or
+// abbreviated commit SHA, a branch or tag name, HEAD, or those with ~ and ^
+// suffixes — so CI can pass the SHAs its event payload carries and a person can
+// pass `--base=main --head=HEAD`. An empty or all-zeros base — a new branch, a
+// missing base — means "run everything", and so does a revision this repository
+// cannot resolve.
 //
 // A plan that cannot read the workspace is an error, never an empty plan: an empty
 // matrix skips the run job and passes the gate having run nothing. Everything else
@@ -221,9 +225,10 @@ const (
 // +cache="never"
 func (m *WorkspaceCi) Plan(
 	ctx context.Context,
-	// The commit the change is measured from.
+	// The revision the change is measured from: a commit SHA, a branch or tag
+	// name, HEAD, or any of those with git's ~ and ^ suffixes.
 	base string,
-	// The commit the change is measured to.
+	// The revision the change is measured to, in the same forms as base.
 	head string,
 	// +optional
 	// +default="JSON"
@@ -278,9 +283,10 @@ func (m *WorkspaceCi) Plan(
 // +cache="never"
 func (m *WorkspaceCi) AffectedModules(
 	ctx context.Context,
-	// The commit the change is measured from.
+	// The revision the change is measured from: a commit SHA, a branch or tag
+	// name, HEAD, or any of those with git's ~ and ^ suffixes.
 	base string,
-	// The commit the change is measured to.
+	// The revision the change is measured to, in the same forms as base.
 	head string,
 	// The repository to plan for. Defaults to the calling workspace.
 	//

--- a/daggerverse/workspace-ci/planner/attribute.go
+++ b/daggerverse/workspace-ci/planner/attribute.go
@@ -24,10 +24,17 @@ const RootModule = "."
 // github.event.before for the first push to a new branch.
 const zeroSHA = "0000000000000000000000000000000000000000"
 
-// DiffRange validates a (base, head) commit pair for change detection. It
+// DiffRange validates a (base, head) revision pair for change detection. It
 // returns ok=false — meaning "no usable diff, run everything" — when either side
 // is empty or is the all-zeros SHA (new branch / no base). Callers diff
 // base...head (three-dot, merge-base) to obtain a change set.
+//
+// Anything else is passed through for the caller to resolve against the
+// repository, so a branch, a tag or HEAD reaches git untouched. The all-zeros SHA
+// is rejected here rather than left to that resolution on purpose: it is a
+// sentinel GitHub sends and not a revision anybody means, so "no usable base"
+// stays a decision this package makes and not an accident of what git happens to
+// do with forty zeros.
 func DiffRange(base, head string) (b, h string, ok bool) {
 	if base == "" || head == "" || base == zeroSHA || head == zeroSHA {
 		return "", "", false

--- a/daggerverse/workspace-ci/tests/dagger.gen.go
+++ b/daggerverse/workspace-ci/tests/dagger.gen.go
@@ -234,6 +234,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).NewRejectsMemoTokenWithoutRepo(&parent, ctx)
+		case "PlanAcceptsSymbolicRevisions":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).PlanAcceptsSymbolicRevisions(&parent, ctx)
 		case "PlanAlwaysRunsUnhashableLeg":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -311,6 +318,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).PlanRefusesRecordedPassesWhenGlobalInputChanged(&parent, ctx)
+		case "PlanRunsEverythingOnAnUnresolvableRevision":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).PlanRunsEverythingOnAnUnresolvableRevision(&parent, ctx)
 		case "PlanRunsEverythingOnAnUnusableDiffRange":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/workspace-ci/tests/fixture.go
+++ b/daggerverse/workspace-ci/tests/fixture.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 
 	"dagger/tests/internal/dagger"
@@ -41,6 +42,17 @@ const (
 	cTouchGlobal = "touch global"
 	cTouchFlow   = "touch workflow"
 	cTouchRoot   = "touch root"
+)
+
+// Symbolic names in the fixture's history. They exist so a test can ask for a
+// range the way a person does — `--base=main --head=feature` — and not only by
+// SHA. They name a range whose plan is a strict subset of the workspace, because
+// a revision that fails to resolve falls back to running everything and a
+// full-plan assertion could not tell that apart from success.
+const (
+	fxBaseBranch = "main"
+	fxHeadBranch = "feature"
+	fxBaseTag    = "v0.1.0"
 )
 
 // Module directories in the fixture.
@@ -161,6 +173,23 @@ func newFixture(ctx context.Context, variant string) (fixture, error) {
 		}
 	}
 
+	// Symbolic names for two of those commits. HEAD stays where the last commit
+	// left it — these are extra refs, not a checkout — so every test that reads
+	// HEAD sees exactly what it saw before.
+	for _, ref := range []struct {
+		name plumbing.ReferenceName
+		at   string
+	}{
+		{plumbing.NewBranchReferenceName(fxBaseBranch), cInitial},
+		{plumbing.NewBranchReferenceName(fxHeadBranch), cTouchA},
+		{plumbing.NewTagReferenceName(fxBaseTag), cInitial},
+	} {
+		hashRef := plumbing.NewHashReference(ref.name, plumbing.NewHash(fx.at(ref.at)))
+		if err := repo.Storer.SetReference(hashRef); err != nil {
+			return fixture{}, fmt.Errorf("name %s: %w", ref.name, err)
+		}
+	}
+
 	// An input no commit contains: a module with one of these can never be hashed
 	// from git objects, and so can never be memoized.
 	if err := write(fxDirty+"/untracked.go", "package main\n\nconst untracked = 1\n"); err != nil {
@@ -196,6 +225,23 @@ func (fx fixture) before(name string) string {
 		if n == name && i > 0 {
 			return fx.commits[fx.order[i-1]]
 		}
+	}
+	return ""
+}
+
+// rev returns the HEAD-relative revision naming the given commit — `HEAD` for the
+// tip, `HEAD~n` for anything behind it — so a test can name a commit
+// symbolically without hard-coding how long the fixture's history happens to be.
+func (fx fixture) rev(name string) string {
+	for i, n := range fx.order {
+		back := len(fx.order) - 1 - i
+		if n != name {
+			continue
+		}
+		if back == 0 {
+			return "HEAD"
+		}
+		return fmt.Sprintf("HEAD~%d", back)
 	}
 	return ""
 }

--- a/daggerverse/workspace-ci/tests/internal/dagger/workspace-ci.gen.go
+++ b/daggerverse/workspace-ci/tests/internal/dagger/workspace-ci.gen.go
@@ -193,12 +193,12 @@ type WorkspaceCiAffectedModulesOpts struct {
 	//
 	// The repository to plan for. Defaults to the calling workspace.
 	//
-	Repo *Directory // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:288:2)
+	Repo *Directory // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:294:2)
 	//
 	// The workspace to read repo from when repo is omitted. Defaults to the
 	// caller's.
 	//
-	Workspace *Workspace // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:293:2)
+	Workspace *Workspace // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:299:2)
 }
 
 // AffectedModules returns, as a JSON array of repo-relative directories, the
@@ -207,7 +207,7 @@ type WorkspaceCiAffectedModulesOpts struct {
 // reach" without paying for check enumeration.
 //
 // The arguments mean what they mean on Plan.
-func (r *WorkspaceCi) AffectedModules(ctx context.Context, base string, head string, opts ...WorkspaceCiAffectedModulesOpts) (string, error) { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:279:1)
+func (r *WorkspaceCi) AffectedModules(ctx context.Context, base string, head string, opts ...WorkspaceCiAffectedModulesOpts) (string, error) { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:284:1)
 	if r.affectedModules != nil {
 		return *r.affectedModules, nil
 	}
@@ -348,7 +348,7 @@ func (r *WorkspaceCi) UnmarshalJSON(bs []byte) error {
 // later run its full time and looks exactly like a workspace nobody has recorded
 // against yet, and a scope that leaks costs correctness. Like SelectionSelfTest it
 // runs in-process and needs no network, no credential and no services.
-func (r *WorkspaceCi) MemoStoreSelfTest(ctx context.Context) error { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:486:1)
+func (r *WorkspaceCi) MemoStoreSelfTest(ctx context.Context) error { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:492:1)
 	if r.memoStoreSelfTest != nil {
 		return nil
 	}
@@ -361,16 +361,16 @@ func (r *WorkspaceCi) MemoStoreSelfTest(ctx context.Context) error { // workspac
 type WorkspaceCiPlanOpts struct {
 
 	// Default: JSON
-	Format WorkspaceCiFormat // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:230:2)
+	Format WorkspaceCiFormat // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:235:2)
 	//
 	// The repository to plan for. Defaults to the calling workspace.
 	//
-	Repo *Directory // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:234:2)
+	Repo *Directory // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:239:2)
 	//
 	// The workspace to read repo from when repo is omitted. Defaults to the
 	// caller's.
 	//
-	Workspace *Workspace // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:239:2)
+	Workspace *Workspace // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:244:2)
 	//
 	// Input hashes a previous run already proved good, as a JSON array. They are
 	// honoured on the same terms as the ones read from the memoization store, and
@@ -380,14 +380,14 @@ type WorkspaceCiPlanOpts struct {
 	//
 	//
 	// Default: "[]"
-	KnownGood string // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:248:2)
+	KnownGood string // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:253:2)
 	//
 	// Emit a diagnostics object — the plan plus which modules had to be loaded to
 	// produce it, whether everything was selected, which legs a recorded pass
 	// retired, and whether recorded passes were honoured at all — instead of the
 	// bare plan. Intended for tests and for explaining a plan, not for CI.
 	//
-	Diagnostics bool // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:255:2)
+	Diagnostics bool // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:260:2)
 }
 
 // Plan returns the legs of CI to run for a change, each already routed to the
@@ -399,9 +399,13 @@ type WorkspaceCiPlanOpts struct {
 // a pass may be recorded under (empty means never memoize), and the step and job
 // budgets in minutes.
 //
-// base and head are the commit SHAs to diff, three-dot (merge-base) like a PR's
-// change set. An empty or all-zeros base — a new branch, a missing base — means
-// "run everything".
+// base and head are the revisions to diff, three-dot (merge-base) like a PR's
+// change set. Either may be written in any form git's rev-parse takes — a full or
+// abbreviated commit SHA, a branch or tag name, HEAD, or those with ~ and ^
+// suffixes — so CI can pass the SHAs its event payload carries and a person can
+// pass `--base=main --head=HEAD`. An empty or all-zeros base — a new branch, a
+// missing base — means "run everything", and so does a revision this repository
+// cannot resolve.
 //
 // A plan that cannot read the workspace is an error, never an empty plan: an empty
 // matrix skips the run job and passes the gate having run nothing. Everything else
@@ -414,7 +418,7 @@ type WorkspaceCiPlanOpts struct {
 // explicitly is also the escape hatch for a caller whose .git is a file rather
 // than a directory (a git worktree), which would otherwise degrade to running
 // everything.
-func (r *WorkspaceCi) Plan(ctx context.Context, base string, head string, opts ...WorkspaceCiPlanOpts) (string, error) { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:222:1)
+func (r *WorkspaceCi) Plan(ctx context.Context, base string, head string, opts ...WorkspaceCiPlanOpts) (string, error) { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:226:1)
 	if r.plan != nil {
 		return *r.plan, nil
 	}
@@ -470,7 +474,7 @@ func (r *WorkspaceCi) Plan(ctx context.Context, base string, head string, opts .
 // thing: a call that named no ref, because with no ref there is no scope to judge
 // and refusing silently would be indistinguishable from a scope that was judged
 // and rejected.
-func (r *WorkspaceCi) RecordPass(ctx context.Context, hash string, ref string, commit string) (string, error) { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:331:1)
+func (r *WorkspaceCi) RecordPass(ctx context.Context, hash string, ref string, commit string) (string, error) { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:337:1)
 	if r.recordPass != nil {
 		return *r.recordPass, nil
 	}
@@ -491,7 +495,7 @@ func (r *WorkspaceCi) RecordPass(ctx context.Context, hash string, ref string, c
 // under-running a consumer's checks or handing their CI system something it cannot
 // parse. It runs in-process and needs no services, so it is cheap enough to run on
 // every leg set.
-func (r *WorkspaceCi) SelectionSelfTest(ctx context.Context) error { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:463:1)
+func (r *WorkspaceCi) SelectionSelfTest(ctx context.Context) error { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:469:1)
 	if r.selectionSelfTest != nil {
 		return nil
 	}

--- a/daggerverse/workspace-ci/tests/internal/dagger/workspace-ci.gen.go
+++ b/daggerverse/workspace-ci/tests/internal/dagger/workspace-ci.gen.go
@@ -403,8 +403,8 @@ type WorkspaceCiPlanOpts struct {
 // change set. Either may be written in any form git's rev-parse takes — a full or
 // abbreviated commit SHA, a branch or tag name, HEAD, or those with ~ and ^
 // suffixes — so CI can pass the SHAs its event payload carries and a person can
-// pass `--base=main --head=HEAD`. An empty or all-zeros base — a new branch, a
-// missing base — means "run everything", and so does a revision this repository
+// pass `--base=main --head=HEAD`. Either side empty or all-zeros — a new branch,
+// a missing base — means "run everything", and so does a revision this repository
 // cannot resolve.
 //
 // A plan that cannot read the workspace is an error, never an empty plan: an empty

--- a/daggerverse/workspace-ci/tests/main.go
+++ b/daggerverse/workspace-ci/tests/main.go
@@ -188,20 +188,125 @@ func (t *Tests) PlanRunsEverythingOnGlobalPathChange(ctx context.Context) error 
 // PlanRunsEverythingOnAnUnusableDiffRange proves the fail-safe: a base that cannot
 // be diffed — a new branch, whose before-SHA GitHub sends as all zeros — runs
 // everything rather than nothing.
+//
+// The all-zeros SHA is a sentinel and not a revision, so it keeps that meaning
+// however the other side is spelled: it is rejected before the repository is
+// consulted, and a symbolic head cannot turn it into a range worth diffing.
 func (t *Tests) PlanRunsEverythingOnAnUnusableDiffRange(ctx context.Context) error {
 	fx, err := newFixture(ctx, "")
 	if err != nil {
 		return err
 	}
 	zero := strings.Repeat("0", 40)
-	got, err := explainRange(ctx, dag.WorkspaceCi(), fx, zero, fx.at(cTouchRoot), "")
+	for _, form := range []struct{ base, head string }{
+		{zero, fx.at(cTouchRoot)},
+		{zero, fxHeadBranch},
+		{zero, "HEAD"},
+		{fxBaseBranch, zero},
+		{"", fxHeadBranch},
+	} {
+		got, err := explainRange(ctx, dag.WorkspaceCi(), fx, form.base, form.head, "")
+		if err != nil {
+			return fmt.Errorf("--base=%q --head=%q: %w", form.base, form.head, err)
+		}
+		if !got.Full {
+			return fmt.Errorf("--base=%q --head=%q did not run everything: %v", form.base, form.head, names(got.Plan))
+		}
+		if err := wantLegs(got, fxRoot, fxGlobal, fxA, fxB, fxC, fxDirty); err != nil {
+			return fmt.Errorf("--base=%q --head=%q: %w", form.base, form.head, err)
+		}
+	}
+	return nil
+}
+
+// PlanAcceptsSymbolicRevisions proves a range named the way a person names one —
+// a branch, a tag, HEAD-relative, or a mixture of those and a SHA — plans exactly
+// what the equivalent pair of SHAs plans. CI passes SHAs because that is what the
+// event payload carries; anyone running Plan by hand has `main` and `HEAD`.
+//
+// The range is the single commit that touches mods/a, so the expected plan is a
+// strict subset of the workspace. That matters: a revision that does not resolve
+// falls back to running everything, which an assertion against a full plan could
+// not tell from success.
+func (t *Tests) PlanAcceptsSymbolicRevisions(ctx context.Context) error {
+	fx, err := newFixture(ctx, "")
 	if err != nil {
 		return err
 	}
-	if !got.Full {
-		return fmt.Errorf("an unusable diff range did not run everything: %v", names(got.Plan))
+	ci := dag.WorkspaceCi()
+	bySHA, err := explain(ctx, ci, fx, cTouchA, "")
+	if err != nil {
+		return err
 	}
-	return wantLegs(got, fxRoot, fxGlobal, fxA, fxB, fxC, fxDirty)
+	if err := wantLegs(bySHA, ".:root-ok", "mods/a:ok", "mods/b:ok"); err != nil {
+		return fmt.Errorf("by SHA: %w", err)
+	}
+
+	for _, form := range []struct{ base, head string }{
+		{fxBaseBranch, fxHeadBranch},
+		{fxBaseTag, fxHeadBranch},
+		{fx.rev(cInitial), fx.rev(cTouchA)},
+		{fxBaseBranch, fx.at(cTouchA)},
+		{fx.at(cInitial), fxHeadBranch},
+	} {
+		got, err := explainRange(ctx, ci, fx, form.base, form.head, "")
+		if err != nil {
+			return fmt.Errorf("--base=%s --head=%s: %w", form.base, form.head, err)
+		}
+		if got.Full {
+			return fmt.Errorf("--base=%s --head=%s ran everything, so the revisions did not resolve", form.base, form.head)
+		}
+		if have, want := names(got.Plan), names(bySHA.Plan); !slices.Equal(have, want) {
+			return fmt.Errorf("--base=%s --head=%s planned %v, want the SHA range's %v", form.base, form.head, have, want)
+		}
+	}
+
+	// The literal `HEAD` the issue's example uses. Its range is the commit that
+	// touches the root module, which legitimately runs everything, so this asserts
+	// agreement with the SHA form rather than a subset — the cases above are what
+	// prove resolution happened at all.
+	head, err := explainRange(ctx, ci, fx, fx.rev(cTouchFlow), fx.rev(cTouchRoot), "")
+	if err != nil {
+		return fmt.Errorf("--base=HEAD~1 --head=HEAD: %w", err)
+	}
+	byTipSHA, err := explain(ctx, ci, fx, cTouchRoot, "")
+	if err != nil {
+		return err
+	}
+	if have, want := names(head.Plan), names(byTipSHA.Plan); !slices.Equal(have, want) {
+		return fmt.Errorf("--base=HEAD~1 --head=HEAD planned %v, want the SHA range's %v", have, want)
+	}
+	return nil
+}
+
+// PlanRunsEverythingOnAnUnresolvableRevision proves a revision that names no
+// commit — a typo, a branch that was deleted, a shallow clone that never fetched
+// the base — runs everything rather than erroring or, worse, planning nothing.
+//
+// It is the same fail-safe an all-zeros base takes, and it is why resolution
+// failure is deliberately not promoted to an error: a name the repository cannot
+// resolve must cost a run its time, never its coverage.
+func (t *Tests) PlanRunsEverythingOnAnUnresolvableRevision(ctx context.Context) error {
+	fx, err := newFixture(ctx, "")
+	if err != nil {
+		return err
+	}
+	for _, form := range []struct{ base, head string }{
+		{"no-such-branch", fxHeadBranch},
+		{fxBaseBranch, "no-such-branch"},
+	} {
+		got, err := explainRange(ctx, dag.WorkspaceCi(), fx, form.base, form.head, "")
+		if err != nil {
+			return fmt.Errorf("--base=%s --head=%s errored instead of running everything: %w", form.base, form.head, err)
+		}
+		if !got.Full {
+			return fmt.Errorf("--base=%s --head=%s did not run everything: %v", form.base, form.head, names(got.Plan))
+		}
+		if err := wantLegs(got, fxRoot, fxGlobal, fxA, fxB, fxC, fxDirty); err != nil {
+			return fmt.Errorf("--base=%s --head=%s: %w", form.base, form.head, err)
+		}
+	}
+	return nil
 }
 
 // PlanErrorsOnWorkspaceWithNoModules proves a workspace it cannot read is an
@@ -234,6 +339,8 @@ func (t *Tests) All(ctx context.Context) error {
 		"plan-attributes-deleted-paths-to-their-module":          t.PlanAttributesDeletedPathsToTheirModule,
 		"plan-runs-everything-on-global-path-change":             t.PlanRunsEverythingOnGlobalPathChange,
 		"plan-runs-everything-on-an-unusable-diff-range":         t.PlanRunsEverythingOnAnUnusableDiffRange,
+		"plan-accepts-symbolic-revisions":                        t.PlanAcceptsSymbolicRevisions,
+		"plan-runs-everything-on-an-unresolvable-revision":       t.PlanRunsEverythingOnAnUnresolvableRevision,
 		"plan-errors-on-workspace-with-no-modules":               t.PlanErrorsOnWorkspaceWithNoModules,
 		"plan-drops-known-good-leg":                              t.PlanDropsKnownGoodLeg,
 		"plan-refuses-recorded-passes-when-global-input-changed": t.PlanRefusesRecordedPassesWhenGlobalInputChanged,


### PR DESCRIPTION
Closes #291

`Plan` and `AffectedModules` took commit SHAs because that is what the GitHub
event payload carries. Anyone running them by hand has `main`, `HEAD~1` or a
tag — and those went to `plumbing.NewHash`, which zero-fills anything that is
not forty hex digits, so a branch name failed as though its commit were missing
and the run silently fell back to running everything. `gitdiff` now resolves
both ends through go-git's rev-parse.

## Acceptance criteria

- [x] **`--base=main --head=HEAD` plans the same set as the equivalent SHAs.**
  `resolveCommit` goes through `Repository.ResolveRevision`, which takes every
  form `git rev-parse` does: full and abbreviated SHAs, branch and tag names,
  `HEAD`, and the `~`/`^` suffixes, dereferencing an annotated tag to its
  commit. `PlanAcceptsSymbolicRevisions` asserts five spellings of one range —
  branch/branch, tag/branch, `HEAD~n`/`HEAD~n`, and both mixtures of a name and
  a SHA — plan exactly what the SHA pair plans.
- [x] **An unresolvable revision runs the full suite rather than erroring.**
  Resolution failure stays an error inside `gitdiff`, which `changeSet` already
  turns into "no usable diff, run everything" — the same fail-safe an unusable
  diff range takes. `PlanRunsEverythingOnAnUnresolvableRevision` covers an
  unknown name on either side.
- [x] **The all-zeros SHA keeps its "no usable base" meaning.**
  `planner.DiffRange` still rejects it before the repository is consulted, so it
  stays a decision this module makes rather than whatever git happens to do with
  forty zeros. `PlanRunsEverythingOnAnUnusableDiffRange` now also covers zeros
  paired with a *symbolic* head, which is the combination this change newly
  makes reachable.

## Judgment calls

- **Resolution lives in `gitdiff`, not in `planner`.** `planner` is deliberately
  free of git, filesystem and Dagger dependencies — that is what makes its rules
  unit-testable and what `SelectionSelfTest` exercises. `DiffRange` keeps
  rejecting empty and all-zeros and now passes everything else through
  untouched, so the sentinel is handled without teaching the pure package to
  open a repository.
- **An unresolvable revision is not promoted to an error.** Failing loudly on a
  typo is defensible, but it would make `Plan` fail where every other unreadable
  input runs too much instead. A name the repository cannot resolve — a deleted
  branch, a shallow clone that never fetched the base — costs a run its time,
  never its coverage.
- **The fixture gained refs, not commits.** `newFixture` now sets `main`,
  `feature` and `v0.1.0` on existing commits. HEAD is untouched, so every test
  that hashes the HEAD tree sees exactly what it saw before. The symbolic range
  they name is the single `mods/a` commit, whose plan is a strict subset of the
  workspace — an assertion against a *full* plan could not tell resolution
  working from resolution failing, since both run everything.
- **Literal `HEAD` is pinned in both places.** The Dagger test's subset cases
  are `HEAD~n`-relative, since the fixture's tip is a root-module change that
  legitimately runs everything; the bare `HEAD` spelling is asserted there
  against its SHA equivalent, and directly in `gitdiff`'s unit tests where the
  diff is checkable.

## Verified

- `dagger check` — green (root module's three checks).
- `bash .github/scripts/verify-affected-modules.sh` — green:
  `workspace-ci` generated/generated-self-test/memo-store-self-test/selection-self-test
  and `tests:all`.
- `go test ./...` in `daggerverse/workspace-ci` — green, including the new
  `gitdiff` package tests.
- The new `gitdiff` tests were run against the pre-fix `plumbing.NewHash` path
  and fail there with `resolve base "base-branch": object not found`, while the
  full-SHA case passes under both — so they pin the new behaviour without
  re-asserting the old.
- Bindings regenerated with `dagger develop` in `daggerverse/workspace-ci`,
  `daggerverse/workspace-ci/tests` and the repository root (the root's
  `ci/internal/dagger` bindings embed `main.go` line numbers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)