### PR TITLE
fix(z5labs): write the provenance envelope when the binary name carries a slash

### DIFF
--- a/daggerverse/z5labs/helpers.go
+++ b/daggerverse/z5labs/helpers.go
@@ -23,14 +23,25 @@ func resolvedLintConfig(_ context.Context, override *dagger.File) (*dagger.File,
 
 // writeWorkdirFile writes content to a content-addressed subdir of the
 // module's scratch workdir and returns it as a *dagger.File.
+//
+// name may carry path separators. The provenance envelope is named after
+// the binary, and a binary name is "<owner>/<repo>" for any registry
+// without single-segment repositories — GHCR, which is the shape this
+// module's own guidance leads to. So the directory created is the
+// parent of the final path rather than the content-addressed dir alone,
+// and the temp pattern is name's last element: os.CreateTemp rejects any
+// pattern containing a separator, by documented design.
 func writeWorkdirFile(name string, content []byte) (*dagger.File, error) {
 	sum := sha256.Sum256(content)
 	dir := "out-" + hex.EncodeToString(sum[:])
-	if err := os.MkdirAll(dir, 0o700); err != nil {
+	path := filepath.Join(dir, name)
+	parent := filepath.Dir(path)
+	if err := os.MkdirAll(parent, 0o700); err != nil {
 		return nil, err
 	}
-	path := filepath.Join(dir, name)
-	tmp, err := os.CreateTemp(dir, "."+name+"-*")
+	// The temp file is created in the same directory it is renamed into,
+	// so the rename stays within one filesystem and lands atomically.
+	tmp, err := os.CreateTemp(parent, "."+filepath.Base(path)+"-*")
 	if err != nil {
 		return nil, err
 	}

--- a/daggerverse/z5labs/tests/attest.go
+++ b/daggerverse/z5labs/tests/attest.go
@@ -266,6 +266,83 @@ func (t *Tests) GoAppCiAttachesSbomsAndProvenance(ctx context.Context) error {
 	return checkStatement(statement, digest, prov.Claims)
 }
 
+// GoAppCiAttestsTwoSegmentBinaryNames asserts a publish whose binary name
+// carries a "/" still lands all three attestations.
+//
+// A two-segment binary name is not an edge case, it is the only working
+// GHCR configuration: GHCR has no single-segment repositories, so
+// `ghcr.io/<name>` cannot exist and the owner has to be folded into the
+// binary name — folding it into the registry instead breaks the attach,
+// because the oci module keys its credential on the registry address.
+//
+// It is checked end to end because the break was not in the push: the
+// provenance envelope is written to the module's own filesystem before it
+// is attached, and the helper that wrote it treated the name as a single
+// path element. That failed only after the image and both SBOMs had
+// already been pushed, leaving a published image with no provenance and a
+// red build (devex#363). The SBOMs go through Dagger's Directory.withFile
+// and were never affected, so they are asserted here too — the point is
+// that the whole publish survives the name, not one document of it.
+func (t *Tests) GoAppCiAttestsTwoSegmentBinaryNames(ctx context.Context) error {
+	const (
+		tag        = "v8.0.0"
+		repository = "z5labs/hello"
+	)
+	src, err := gitFixture(ctx, helloDir(), "main", []string{tag})
+	if err != nil {
+		return fmt.Errorf("gitFixture: %v", err)
+	}
+	headSha, err := headFullSha(ctx, src)
+	if err != nil {
+		return err
+	}
+	svc, _, secret, err := localRegistry(ctx)
+	if err != nil {
+		return err
+	}
+	prov, err := newProvenanceHarness(ctx, headSha)
+	if err != nil {
+		return err
+	}
+	digest, err := dag.Z5Labs().GoApp(src, prov.opts(dagger.Z5LabsGoAppOpts{
+		BinaryName:      repository,
+		PublishOn:       "^refs/tags/v.+",
+		Registry:        registryAlias + ":5000",
+		AuthUsername:    "ci",
+		Auth:            secret,
+		RegistryService: svc,
+		Insecure:        true,
+		Platforms:       []string{hostPlatform()},
+	})).Ci(ctx)
+	if err != nil {
+		return fmt.Errorf("Ci: %v", err)
+	}
+
+	registry := testRegistry(svc, secret)
+	for _, artifactType := range []string{spdxArtifactType, cycloneDxArtifactType, provenanceArtifactType} {
+		found, err := referrersOf(ctx, registry, repository, digest, artifactType)
+		if err != nil {
+			return err
+		}
+		if len(found) != 1 {
+			return fmt.Errorf("expected exactly 1 referrer of type %s on %s/%s, got %d", artifactType, repository, digest, len(found))
+		}
+	}
+
+	// The envelope is verified rather than counted: the bug replaced the
+	// bytes with an error, so a referrer that is present but unreadable
+	// would be the same failure wearing a different shape.
+	envelope, err := attachedDocument(ctx, registry, repository, digest, provenanceArtifactType)
+	if err != nil {
+		return err
+	}
+	statement, err := verifyEnvelope(envelope, prov.Public)
+	if err != nil {
+		return err
+	}
+	return checkStatement(statement, digest, prov.Claims)
+}
+
 // GoAppCiRefusesToPublishWithoutProvenanceMachinery asserts a publish
 // that cannot produce provenance fails, and fails before pushing.
 //

--- a/daggerverse/z5labs/tests/dagger.gen.go
+++ b/daggerverse/z5labs/tests/dagger.gen.go
@@ -241,6 +241,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).GoAppCiAttachesSbomsAndProvenance(&parent, ctx)
+		case "GoAppCiAttestsTwoSegmentBinaryNames":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).GoAppCiAttestsTwoSegmentBinaryNames(&parent, ctx)
 		case "GoAppCiErrorsWhenPublishOnMatchesButCredsMissing":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/z5labs/tests/main.go
+++ b/daggerverse/z5labs/tests/main.go
@@ -124,6 +124,7 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("GoAppCiRebuildIsByteIdenticalPerPlatform", t.GoAppCiRebuildIsByteIdenticalPerPlatform)
 	jobs = jobs.WithJob("GoAppCiAnnotatesEveryPlatformVariant", t.GoAppCiAnnotatesEveryPlatformVariant)
 	jobs = jobs.WithJob("GoAppCiAttachesSbomsAndProvenance", t.GoAppCiAttachesSbomsAndProvenance)
+	jobs = jobs.WithJob("GoAppCiAttestsTwoSegmentBinaryNames", t.GoAppCiAttestsTwoSegmentBinaryNames)
 	jobs = jobs.WithJob("GoAppCiRefusesToPublishWithoutProvenanceMachinery", t.GoAppCiRefusesToPublishWithoutProvenanceMachinery)
 	jobs = jobs.WithJob("GoAppCiRedactsCredentialsFromTheSourceAnnotation", t.GoAppCiRedactsCredentialsFromTheSourceAnnotation)
 


### PR DESCRIPTION
Closes #363

## What broke

`GoApp.Ci` could not write the provenance envelope when `--binary-name` carried a `/` —
the only working GHCR configuration, since GHCR has no single-segment repositories and
folding the owner into `--registry` instead breaks the attach. The run failed *after* the
image and both SBOMs had been pushed, so the image shipped unattested and the build went red:

```
Error: write provenance envelope: createtemp .z5labs/dfcad.intoto.jsonl-*: pattern contains path separator
```

`writeWorkdirFile` treated `name` as a single path element, which broke it twice over:

- `os.CreateTemp` rejects any pattern containing a separator, by documented design.
- Only the content-addressed `dir` was created, so `out-<sum>/z5labs/` never existed and the
  final `os.Rename` would have failed on the missing directory even once `CreateTemp` was fixed.

## The fix

`daggerverse/z5labs/helpers.go` now creates the parent of the *final* path rather than the
content-addressed directory alone, and derives the temp pattern from the path's last element.
The temp file still lands in the directory it is renamed into, so the rename stays atomic.

Taken over flattening the name at the call site because it also keeps the attached filename
matching the binary name, and it is the helper — not its one caller — that held the wrong
assumption.

## Test

`GoAppCiAttestsTwoSegmentBinaryNames` publishes to a two-segment repository and reads all
three attestations back off the digest, verifying the DSSE envelope against the key the
publish signed with. End to end rather than a unit test on the helper because the envelope is
counted *and* decoded: a referrer that is present but unreadable is the same failure wearing a
different shape. The SBOMs are asserted alongside it — they go through `Directory.withFile`
and were never affected, but the claim is that the whole publish survives the name.

Confirmed to reproduce: run against the unfixed helper it fails with the exact reported error
(`createtemp .z5labs/hello.intoto.jsonl-*: pattern contains path separator`), and passes with
the fix.

## Verified locally

- `dagger -m daggerverse/z5labs/tests call go-app-ci-attests-two-segment-binary-names` — red before, green after
- `dagger check` — all three root checks OK
- `bash .github/scripts/verify-affected-modules.sh` — exit 0, `tests:all` OK

## Relationship to #360

Same trigger, different module and different root cause; #360 is already fixed on `main` by
#362. Both had to land before a GHCR publish could go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
