### PR TITLE
story(issue-286): budget a run-everything leg separately from its module's per-check legs

### DIFF
--- a/.github/workflows/change-aware-ci.yml
+++ b/.github/workflows/change-aware-ci.yml
@@ -102,7 +102,9 @@ on:
       timeouts:
         description: >-
           Per-leg check-step budgets in minutes, as a JSON object keyed by a leg's
-          display name or by a module directory (which covers every leg of that module).
+          display name, by a module directory (which covers every leg of that module),
+          or by "<module-dir>:*" (which covers that module's coarse run-everything leg
+          alone, since a coarse leg's display name is its module directory).
         type: string
         default: "{}"
       default-timeout:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,23 +60,35 @@ jobs:
       # module's checks run concurrently and share their container builds — most
       # coarse legs too.
       #
+      # Three key shapes: `<dir>` covers every leg of a module, `<dir>:*` covers only
+      # that module's coarse run-everything leg, and `<dir>:<check>` covers one
+      # per-check leg. The middle shape exists because a coarse leg's name *is* the
+      # module directory (#306), so a bare module key cannot mean "the coarse leg
+      # only" and a whole-suite budget would otherwise be inherited by legs that each
+      # run a single check.
+      #
+      # What the entries below are for:
+      #
       #   .                        the root module's `generated` runs codegen for
       #                            every module in the workspace, paying in one leg
       #                            the module-build cost the others spread across
-      #                            themselves (#184) — ~5m on a cold engine. Its two
-      #                            per-check keys tighten the checks that do no such
-      #                            sweep.
+      #                            themselves (#184) — ~5m on a cold engine. This
+      #                            stays a bare module key: the only per-check leg
+      #                            that inherits it is `.:generated`, which does that
+      #                            same sweep, and the two that do not are tightened
+      #                            below it.
       #   daggerverse/workspace-ci declares that same whole-workspace `generated` as
       #                            its own check, so its coarse leg repeats the
       #                            sweep; measured at 5m12s against the 6m default.
-      #
-      # A module key covers that module's coarse leg AND its per-check legs, since a
-      # coarse leg's name *is* the module directory (#306). Neither key above names a
-      # module that also produces per-check legs worth tightening, so nothing here is
-      # bound more loosely than it needs to be.
+      #                            Here the coarse budget is bound to `:*` and to
+      #                            `:generated`, the two legs that actually sweep, so
+      #                            `:selection-self-test` and `:memo-store-self-test`
+      #                            — both in-process, no engine work — fall back to
+      #                            the default instead of carrying 15.
       timeouts: >-
         {".": 15, ".:generated-self-test": 8, ".:selection-self-test": 2,
-        "daggerverse/workspace-ci": 15}
+        "daggerverse/workspace-ci:*": 15, "daggerverse/workspace-ci:generated": 15,
+        "daggerverse/workspace-ci:generated-self-test": 8}
 
     # Only DAGGER_CLOUD_TOKEN is actually consumed; MEMO_TOKEN is left unset so the
     # called workflow falls back to this run's own GITHUB_TOKEN, scoped by the

--- a/ci/internal/dagger/workspace-ci.gen.go
+++ b/ci/internal/dagger/workspace-ci.gen.go
@@ -63,18 +63,21 @@ type WorkspaceCiOpts struct {
 	SplitModules []string // workspace-ci (../../../daggerverse/workspace-ci/main.go:94:2)
 	//
 	// Per-leg check-step budgets in minutes, as a JSON object keyed by a leg's
-	// display name or by a module directory (which covers every leg of that
-	// module). It is JSON because Dagger function parameters cannot be Go maps.
+	// display name, by a module directory (which covers every leg of that module),
+	// or by "<module-dir>:*" (which covers that module's coarse run-everything leg
+	// and none of its per-check legs, since a coarse leg's display name *is* its
+	// module directory). It is JSON because Dagger function parameters cannot be Go
+	// maps.
 	//
 	//
 	// Default: "{}"
-	Timeouts string // workspace-ci (../../../daggerverse/workspace-ci/main.go:101:2)
+	Timeouts string // workspace-ci (../../../daggerverse/workspace-ci/main.go:104:2)
 	//
 	// The check-step budget in minutes for a leg with no override.
 	//
 	//
 	// Default: 6
-	DefaultTimeout int // workspace-ci (../../../daggerverse/workspace-ci/main.go:106:2)
+	DefaultTimeout int // workspace-ci (../../../daggerverse/workspace-ci/main.go:109:2)
 	//
 	// Where recorded passes live. ACTIONS_CACHE is read-only from this module and
 	// leaves recording to an actions/cache/save step; GIT_REFS is a store the
@@ -83,23 +86,23 @@ type WorkspaceCiOpts struct {
 	//
 	//
 	// Default: ACTIONS_CACHE
-	MemoStore WorkspaceCiMemoStore // workspace-ci (../../../daggerverse/workspace-ci/main.go:114:2)
+	MemoStore WorkspaceCiMemoStore // workspace-ci (../../../daggerverse/workspace-ci/main.go:117:2)
 	//
 	// A credential for the memoization store: a GitHub token on memoRepo with
 	// actions:read for ACTIONS_CACHE, or contents:read for GIT_REFS — plus
 	// contents:write if this run is to record anything.
 	//
-	MemoToken *Secret // workspace-ci (../../../daggerverse/workspace-ci/main.go:120:2)
+	MemoToken *Secret // workspace-ci (../../../daggerverse/workspace-ci/main.go:123:2)
 	//
 	// The owner/name whose Actions cache, or whose git refs, hold the memoization
 	// store.
 	//
-	MemoRepo string // workspace-ci (../../../daggerverse/workspace-ci/main.go:125:2)
+	MemoRepo string // workspace-ci (../../../daggerverse/workspace-ci/main.go:128:2)
 	//
 	// The GitHub API root the store is reached through. Defaults to
 	// https://api.github.com; set it for GitHub Enterprise Server.
 	//
-	MemoAPI string // workspace-ci (../../../daggerverse/workspace-ci/main.go:130:2)
+	MemoAPI string // workspace-ci (../../../daggerverse/workspace-ci/main.go:133:2)
 	//
 	// The git refs whose scopes may be trusted to hold recorded passes, spelled in
 	// full (refs/heads/main, refs/pull/12/merge). They are the refs a plan reads,
@@ -107,14 +110,14 @@ type WorkspaceCiOpts struct {
 	// nothing and records nothing: a scope a run can write is a scope that must be
 	// chosen deliberately.
 	//
-	MemoRefs []string // workspace-ci (../../../daggerverse/workspace-ci/main.go:138:2)
+	MemoRefs []string // workspace-ci (../../../daggerverse/workspace-ci/main.go:141:2)
 	//
 	// How long, in seconds, a recorded pass may be honoured. This is the answer to
 	// base-image drift, which a source-derived hash cannot see.
 	//
 	//
 	// Default: 86400
-	MemoTTL int // workspace-ci (../../../daggerverse/workspace-ci/main.go:144:2)
+	MemoTTL int // workspace-ci (../../../daggerverse/workspace-ci/main.go:147:2)
 }
 
 // New configures a planner.
@@ -193,12 +196,12 @@ type WorkspaceCiAffectedModulesOpts struct {
 	//
 	// The repository to plan for. Defaults to the calling workspace.
 	//
-	Repo *Directory // workspace-ci (../../../daggerverse/workspace-ci/main.go:294:2)
+	Repo *Directory // workspace-ci (../../../daggerverse/workspace-ci/main.go:297:2)
 	//
 	// The workspace to read repo from when repo is omitted. Defaults to the
 	// caller's.
 	//
-	Workspace *Workspace // workspace-ci (../../../daggerverse/workspace-ci/main.go:299:2)
+	Workspace *Workspace // workspace-ci (../../../daggerverse/workspace-ci/main.go:302:2)
 }
 
 // AffectedModules returns, as a JSON array of repo-relative directories, the
@@ -207,7 +210,7 @@ type WorkspaceCiAffectedModulesOpts struct {
 // reach" without paying for check enumeration.
 //
 // The arguments mean what they mean on Plan.
-func (r *WorkspaceCi) AffectedModules(ctx context.Context, base string, head string, opts ...WorkspaceCiAffectedModulesOpts) (string, error) { // workspace-ci (../../../daggerverse/workspace-ci/main.go:284:1)
+func (r *WorkspaceCi) AffectedModules(ctx context.Context, base string, head string, opts ...WorkspaceCiAffectedModulesOpts) (string, error) { // workspace-ci (../../../daggerverse/workspace-ci/main.go:287:1)
 	if r.affectedModules != nil {
 		return *r.affectedModules, nil
 	}
@@ -348,7 +351,7 @@ func (r *WorkspaceCi) UnmarshalJSON(bs []byte) error {
 // later run its full time and looks exactly like a workspace nobody has recorded
 // against yet, and a scope that leaks costs correctness. Like SelectionSelfTest it
 // runs in-process and needs no network, no credential and no services.
-func (r *WorkspaceCi) MemoStoreSelfTest(ctx context.Context) error { // workspace-ci (../../../daggerverse/workspace-ci/main.go:492:1)
+func (r *WorkspaceCi) MemoStoreSelfTest(ctx context.Context) error { // workspace-ci (../../../daggerverse/workspace-ci/main.go:495:1)
 	if r.memoStoreSelfTest != nil {
 		return nil
 	}
@@ -361,16 +364,16 @@ func (r *WorkspaceCi) MemoStoreSelfTest(ctx context.Context) error { // workspac
 type WorkspaceCiPlanOpts struct {
 
 	// Default: JSON
-	Format WorkspaceCiFormat // workspace-ci (../../../daggerverse/workspace-ci/main.go:235:2)
+	Format WorkspaceCiFormat // workspace-ci (../../../daggerverse/workspace-ci/main.go:238:2)
 	//
 	// The repository to plan for. Defaults to the calling workspace.
 	//
-	Repo *Directory // workspace-ci (../../../daggerverse/workspace-ci/main.go:239:2)
+	Repo *Directory // workspace-ci (../../../daggerverse/workspace-ci/main.go:242:2)
 	//
 	// The workspace to read repo from when repo is omitted. Defaults to the
 	// caller's.
 	//
-	Workspace *Workspace // workspace-ci (../../../daggerverse/workspace-ci/main.go:244:2)
+	Workspace *Workspace // workspace-ci (../../../daggerverse/workspace-ci/main.go:247:2)
 	//
 	// Input hashes a previous run already proved good, as a JSON array. They are
 	// honoured on the same terms as the ones read from the memoization store, and
@@ -380,14 +383,14 @@ type WorkspaceCiPlanOpts struct {
 	//
 	//
 	// Default: "[]"
-	KnownGood string // workspace-ci (../../../daggerverse/workspace-ci/main.go:253:2)
+	KnownGood string // workspace-ci (../../../daggerverse/workspace-ci/main.go:256:2)
 	//
 	// Emit a diagnostics object — the plan plus which modules had to be loaded to
 	// produce it, whether everything was selected, which legs a recorded pass
 	// retired, and whether recorded passes were honoured at all — instead of the
 	// bare plan. Intended for tests and for explaining a plan, not for CI.
 	//
-	Diagnostics bool // workspace-ci (../../../daggerverse/workspace-ci/main.go:260:2)
+	Diagnostics bool // workspace-ci (../../../daggerverse/workspace-ci/main.go:263:2)
 }
 
 // Plan returns the legs of CI to run for a change, each already routed to the
@@ -418,7 +421,7 @@ type WorkspaceCiPlanOpts struct {
 // explicitly is also the escape hatch for a caller whose .git is a file rather
 // than a directory (a git worktree), which would otherwise degrade to running
 // everything.
-func (r *WorkspaceCi) Plan(ctx context.Context, base string, head string, opts ...WorkspaceCiPlanOpts) (string, error) { // workspace-ci (../../../daggerverse/workspace-ci/main.go:226:1)
+func (r *WorkspaceCi) Plan(ctx context.Context, base string, head string, opts ...WorkspaceCiPlanOpts) (string, error) { // workspace-ci (../../../daggerverse/workspace-ci/main.go:229:1)
 	if r.plan != nil {
 		return *r.plan, nil
 	}
@@ -474,7 +477,7 @@ func (r *WorkspaceCi) Plan(ctx context.Context, base string, head string, opts .
 // thing: a call that named no ref, because with no ref there is no scope to judge
 // and refusing silently would be indistinguishable from a scope that was judged
 // and rejected.
-func (r *WorkspaceCi) RecordPass(ctx context.Context, hash string, ref string, commit string) (string, error) { // workspace-ci (../../../daggerverse/workspace-ci/main.go:337:1)
+func (r *WorkspaceCi) RecordPass(ctx context.Context, hash string, ref string, commit string) (string, error) { // workspace-ci (../../../daggerverse/workspace-ci/main.go:340:1)
 	if r.recordPass != nil {
 		return *r.recordPass, nil
 	}
@@ -495,7 +498,7 @@ func (r *WorkspaceCi) RecordPass(ctx context.Context, hash string, ref string, c
 // under-running a consumer's checks or handing their CI system something it cannot
 // parse. It runs in-process and needs no services, so it is cheap enough to run on
 // every leg set.
-func (r *WorkspaceCi) SelectionSelfTest(ctx context.Context) error { // workspace-ci (../../../daggerverse/workspace-ci/main.go:469:1)
+func (r *WorkspaceCi) SelectionSelfTest(ctx context.Context) error { // workspace-ci (../../../daggerverse/workspace-ci/main.go:472:1)
 	if r.selectionSelfTest != nil {
 		return nil
 	}
@@ -518,7 +521,7 @@ func (r *WorkspaceCi) AsNode() Node {
 // the *constant identifier* in SCREAMING_SNAKE_CASE, and the CLI takes that member
 // name rather than the value — hence `--format=GITHUB_ACTIONS`. The values here are
 // spelled to match, so there is only ever one spelling to remember.
-type WorkspaceCiFormat string // workspace-ci (../../../daggerverse/workspace-ci/main.go:182:6)
+type WorkspaceCiFormat string // workspace-ci (../../../daggerverse/workspace-ci/main.go:185:6)
 
 func (WorkspaceCiFormat) IsEnum() {}
 
@@ -573,15 +576,15 @@ func (v *WorkspaceCiFormat) UnmarshalJSON(dt []byte) error {
 const (
 	// FormatGithubActions is a single-line JSON array, ready to write to
 	// GITHUB_OUTPUT and expand with fromJSON as a matrix.
-	WorkspaceCiFormatGithubActions WorkspaceCiFormat = "GITHUB_ACTIONS" // workspace-ci (../../../daggerverse/workspace-ci/main.go:189:2)
+	WorkspaceCiFormatGithubActions WorkspaceCiFormat = "GITHUB_ACTIONS" // workspace-ci (../../../daggerverse/workspace-ci/main.go:192:2)
 
 	// FormatJSON is the canonical form: an indented JSON array of legs.
-	WorkspaceCiFormatJson WorkspaceCiFormat = "JSON" // workspace-ci (../../../daggerverse/workspace-ci/main.go:186:2)
+	WorkspaceCiFormatJson WorkspaceCiFormat = "JSON" // workspace-ci (../../../daggerverse/workspace-ci/main.go:189:2)
 
 	// FormatJenkins is Groovy: a map of leg name to closure, which is what a
 	// declarative pipeline's parallel step takes. Write it to a file, `load` it,
 	// and hand the result straight to `parallel`.
-	WorkspaceCiFormatJenkins WorkspaceCiFormat = "JENKINS" // workspace-ci (../../../daggerverse/workspace-ci/main.go:193:2)
+	WorkspaceCiFormatJenkins WorkspaceCiFormat = "JENKINS" // workspace-ci (../../../daggerverse/workspace-ci/main.go:196:2)
 
 )
 

--- a/daggerverse/workspace-ci/README.md
+++ b/daggerverse/workspace-ci/README.md
@@ -236,6 +236,37 @@ Each named module costs one load, which is the thing this path exists to avoid �
 so name the ones that need it, not every module with more than one check. A name
 that matches no module in the plan is reported on stderr rather than ignored.
 
+### Budgeting a coarse leg
+
+`--timeouts` is a JSON object of check-step budgets in minutes. Three key shapes
+match a leg, and the most specific one that does wins:
+
+| key | reaches |
+| --- | --- |
+| `<module-dir>` | every leg of that module, coarse and per-check alike |
+| `<module-dir>:*` | that module's coarse run-everything leg alone |
+| `<module-dir>:<check>` | that one per-check leg alone |
+
+The middle shape exists because a coarse leg's `name` **is** its module directory
+— there is no check to name it after — so a bare module key cannot mean "the
+coarse leg only". Without it, raising a module's budget to fit its whole suite
+also raises every per-check leg that module contributes on the narrow path, and
+those are bounded by one check rather than by the sum of them. That is the
+difference between fast-failing a stuck check in six minutes and in fifteen.
+
+```jsonc
+{
+  "daggerverse/kafka/tests:*": 15,  // the whole suite in one engine
+  "daggerverse/kafka/tests:tls": 8  // one check that is slow on its own
+}                                   // every other check: the default
+```
+
+`*` is matched literally, not as a wildcard — a check name comes from a Go method
+identifier, so no real leg can be spelled `<module-dir>:*`. A table with no `:*`
+key resolves exactly as it did before the shape existed. A key that matches no leg
+is silently unused, as before: the loud failure is reserved for a table that could
+not be read at all, or one carrying a non-positive budget.
+
 **It will not return an empty plan.** A workspace it cannot read is an error: an
 empty matrix skips the run job and passes the gate having run nothing. Everything
 else fails safe towards running too much.

--- a/daggerverse/workspace-ci/main.go
+++ b/daggerverse/workspace-ci/main.go
@@ -93,8 +93,11 @@ func New(
 	// +optional
 	splitModules []string,
 	// Per-leg check-step budgets in minutes, as a JSON object keyed by a leg's
-	// display name or by a module directory (which covers every leg of that
-	// module). It is JSON because Dagger function parameters cannot be Go maps.
+	// display name, by a module directory (which covers every leg of that module),
+	// or by "<module-dir>:*" (which covers that module's coarse run-everything leg
+	// and none of its per-check legs, since a coarse leg's display name *is* its
+	// module directory). It is JSON because Dagger function parameters cannot be Go
+	// maps.
 	//
 	// +optional
 	// +default="{}"

--- a/daggerverse/workspace-ci/planner/plan.go
+++ b/daggerverse/workspace-ci/planner/plan.go
@@ -65,8 +65,9 @@ func ModuleEntry(moduleDir string) Entry {
 // a leg <module-dir>:<check>, so no per-check leg can answer true here.
 func (e Entry) IsCoarse() bool { return e.Name == e.Module }
 
-// Timeouts are per-leg step budgets in minutes. Three key shapes match a leg, and
-// Apply resolves them weakest first:
+// Timeouts are per-leg step budgets in minutes. Three key shapes reach a leg —
+// listed here by what each one covers, widest first, which is not the order Apply
+// resolves them in; Apply documents that:
 //
 //	<module-dir>          every leg of that module, coarse and per-check alike
 //	<module-dir>:*        that module's coarse run-everything leg alone

--- a/daggerverse/workspace-ci/planner/plan.go
+++ b/daggerverse/workspace-ci/planner/plan.go
@@ -49,13 +49,45 @@ func CheckEntry(moduleDir, moduleName, checkName string) Entry {
 // ModuleEntry is a leg that runs every check a module has, without the plan ever
 // having loaded it. It is what the run-everything path emits, and what a module
 // whose checks could not be enumerated falls back to.
+//
+// Its display name is the module directory, because there is no check to name it
+// after. That makes Name and Module the same string, which is the collision
+// Timeouts has a key shape of its own for; see IsCoarse and CoarseKey.
 func ModuleEntry(moduleDir string) Entry {
 	return Entry{Name: moduleDir, Module: moduleDir}
 }
 
-// Timeouts are per-leg step budgets in minutes, keyed by either a leg's display
-// name or a module directory (which covers every leg of that module).
+// IsCoarse reports whether this leg runs a module's whole suite rather than one of
+// its checks — a ModuleEntry, which is what the run-everything path emits and what
+// a module whose checks could not be enumerated falls back to.
+//
+// A coarse leg is exactly a leg whose Name is its Module: CheckEntry always names
+// a leg <module-dir>:<check>, so no per-check leg can answer true here.
+func (e Entry) IsCoarse() bool { return e.Name == e.Module }
+
+// Timeouts are per-leg step budgets in minutes. Three key shapes match a leg, and
+// Apply resolves them weakest first:
+//
+//	<module-dir>          every leg of that module, coarse and per-check alike
+//	<module-dir>:*        that module's coarse run-everything leg alone
+//	<module-dir>:<check>  that one per-check leg alone
+//
+// The middle shape is there because a coarse leg's display name *is* its module
+// directory (see ModuleEntry), so without it the only key that reaches a coarse leg
+// also reaches every per-check leg that module contributes on the narrow path. That
+// coupling is not free: a coarse leg is bounded by the sum of a module's checks,
+// less whatever concurrency and shared containers buy back, while a per-check leg is
+// bounded by one check. Binding the latter to the former is the difference between
+// fast-failing a stuck check in six minutes and in fifteen.
+//
+// A key is matched literally and `*` is not a wildcard — a check name comes from a
+// Go method identifier, so no real leg can be spelled <module-dir>:* and the coarse
+// shape cannot collide with one.
 type Timeouts map[string]int
+
+// CoarseKey is the Timeouts key that reaches a module's coarse run-everything leg
+// and none of its per-check legs.
+func CoarseKey(moduleDir string) string { return moduleDir + ":*" }
 
 // ParseTimeouts reads the JSON object form of Timeouts. Function parameters
 // cannot be Go maps, so this is how the override table crosses the module
@@ -80,8 +112,23 @@ func ParseTimeouts(raw string) (Timeouts, error) {
 	return t, nil
 }
 
-// Apply fills in each entry's Timeout and JobTimeout: the override for its name,
-// else the override for its module, else def.
+// Apply fills in each entry's Timeout and JobTimeout, taking the last of these that
+// the table carries a key for:
+//
+//	def                nothing matched
+//	t[<module-dir>]    every leg of that module
+//	t[<leg-name>]      that leg alone
+//	t[<module-dir>:*]  a coarse leg only, and only where one exists
+//
+// The coarse shape resolves last, and only for a leg where IsCoarse holds. That
+// order is what the collision needs: on a coarse leg Name and Module are the same
+// string, so the middle two lines are one key and reading the coarse shape earlier
+// would let the module-wide budget take it straight back. On a per-check leg the
+// coarse shape never matches, which is what keeps a module's whole-suite budget off
+// the legs that each run one check.
+//
+// So a caller who sets no <module-dir>:* key gets exactly the older two-shape
+// behaviour, a module budget included.
 func (t Timeouts) Apply(entries []Entry, def int) []Entry {
 	out := make([]Entry, 0, len(entries))
 	for _, e := range entries {
@@ -90,6 +137,9 @@ func (t Timeouts) Apply(entries []Entry, def int) []Entry {
 			e.Timeout = v
 		}
 		if v, ok := t[e.Name]; ok {
+			e.Timeout = v
+		}
+		if v, ok := t[CoarseKey(e.Module)]; ok && e.IsCoarse() {
 			e.Timeout = v
 		}
 		e.JobTimeout = e.Timeout + JobTimeoutHeadroom

--- a/daggerverse/workspace-ci/planner/planner_test.go
+++ b/daggerverse/workspace-ci/planner/planner_test.go
@@ -97,6 +97,96 @@ func TestTimeoutsApply(t *testing.T) {
 	}
 }
 
+// TestIsCoarse pins the property the coarse key shape rests on: a run-everything leg
+// is exactly a leg whose name is its module, and no per-check leg can be one.
+func TestIsCoarse(t *testing.T) {
+	if !ModuleEntry("mods/a").IsCoarse() {
+		t.Error("a run-everything leg did not report as coarse")
+	}
+	if CheckEntry("mods/a", "a", "ok").IsCoarse() {
+		t.Error("a per-check leg reported as coarse")
+	}
+	// The one leg name that could be mistaken for a module directory is a check
+	// whose module is the workspace root, and even that keeps the colon.
+	if CheckEntry(".", "ci", "generated").IsCoarse() {
+		t.Error("a root-module per-check leg reported as coarse")
+	}
+}
+
+// TestTimeoutsApplyCoarseKey pins the whole point of the <module-dir>:* shape (#306):
+// a module whose whole suite needs a long budget can say so without dragging the
+// per-check legs it contributes on the narrow path up with it.
+func TestTimeoutsApplyCoarseKey(t *testing.T) {
+	// A module that produces both leg shapes at once is not what a single plan
+	// emits, but it is what makes the two resolutions comparable in one table.
+	entries := []Entry{
+		ModuleEntry("mods/a"),
+		CheckEntry("mods/a", "a", "ok"),
+		CheckEntry("mods/a", "a", "slow"),
+		ModuleEntry("mods/b"),
+	}
+
+	for _, tc := range []struct {
+		name string
+		t    Timeouts
+		want map[string]int
+	}{
+		{
+			name: "the coarse key alone leaves the per-check legs on the default",
+			t:    Timeouts{CoarseKey("mods/a"): 15},
+			want: map[string]int{"mods/a": 15, "mods/a:ok": 6, "mods/a:slow": 6, "mods/b": 6},
+		},
+		{
+			name: "the coarse key beats the module key on the coarse leg only",
+			t:    Timeouts{"mods/a": 9, CoarseKey("mods/a"): 15},
+			want: map[string]int{"mods/a": 15, "mods/a:ok": 9, "mods/a:slow": 9, "mods/b": 6},
+		},
+		{
+			name: "a per-check key still wins on its own leg",
+			t:    Timeouts{"mods/a": 9, CoarseKey("mods/a"): 15, "mods/a:slow": 20},
+			want: map[string]int{"mods/a": 15, "mods/a:ok": 9, "mods/a:slow": 20, "mods/b": 6},
+		},
+		{
+			name: "a coarse key for a module with no coarse leg reaches nothing",
+			t:    Timeouts{CoarseKey("mods/a"): 15, CoarseKey("mods/c"): 30},
+			want: map[string]int{"mods/a": 15, "mods/a:ok": 6, "mods/a:slow": 6, "mods/b": 6},
+		},
+		{
+			// AC: a table with no coarse key resolves exactly as it did before the
+			// shape existed — the module key still covers the coarse leg.
+			name: "a table with no coarse key is unchanged",
+			t:    Timeouts{"mods/a": 9},
+			want: map[string]int{"mods/a": 9, "mods/a:ok": 9, "mods/a:slow": 9, "mods/b": 6},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, e := range tc.t.Apply(entries, 6) {
+				if e.Timeout != tc.want[e.Name] {
+					t.Errorf("%q got a step budget of %d, want %d", e.Name, e.Timeout, tc.want[e.Name])
+				}
+				if e.JobTimeout != e.Timeout+JobTimeoutHeadroom {
+					t.Errorf("%q got a job budget of %d, want %d", e.Name, e.JobTimeout, e.Timeout+JobTimeoutHeadroom)
+				}
+			}
+		})
+	}
+}
+
+// TestParseTimeoutsCoarseKey pins that the coarse shape survives the JSON round trip
+// the table crosses the module boundary as, including its validation.
+func TestParseTimeoutsCoarseKey(t *testing.T) {
+	got, err := ParseTimeouts(`{"daggerverse/kafka/tests:*": 15}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got[CoarseKey("daggerverse/kafka/tests")] != 15 {
+		t.Errorf("parsed %v", got)
+	}
+	if _, err := ParseTimeouts(`{"daggerverse/kafka/tests:*": 0}`); err == nil {
+		t.Error("a non-positive coarse budget was accepted")
+	}
+}
+
 // TestRender pins the two formats and, above all, that an empty plan renders as an
 // empty array: `null` survives a workflow's non-empty test and then breaks
 // fromJSON.

--- a/daggerverse/workspace-ci/tests/internal/dagger/workspace-ci.gen.go
+++ b/daggerverse/workspace-ci/tests/internal/dagger/workspace-ci.gen.go
@@ -63,18 +63,21 @@ type WorkspaceCiOpts struct {
 	SplitModules []string // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:94:2)
 	//
 	// Per-leg check-step budgets in minutes, as a JSON object keyed by a leg's
-	// display name or by a module directory (which covers every leg of that
-	// module). It is JSON because Dagger function parameters cannot be Go maps.
+	// display name, by a module directory (which covers every leg of that module),
+	// or by "<module-dir>:*" (which covers that module's coarse run-everything leg
+	// and none of its per-check legs, since a coarse leg's display name *is* its
+	// module directory). It is JSON because Dagger function parameters cannot be Go
+	// maps.
 	//
 	//
 	// Default: "{}"
-	Timeouts string // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:101:2)
+	Timeouts string // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:104:2)
 	//
 	// The check-step budget in minutes for a leg with no override.
 	//
 	//
 	// Default: 6
-	DefaultTimeout int // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:106:2)
+	DefaultTimeout int // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:109:2)
 	//
 	// Where recorded passes live. ACTIONS_CACHE is read-only from this module and
 	// leaves recording to an actions/cache/save step; GIT_REFS is a store the
@@ -83,23 +86,23 @@ type WorkspaceCiOpts struct {
 	//
 	//
 	// Default: ACTIONS_CACHE
-	MemoStore WorkspaceCiMemoStore // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:114:2)
+	MemoStore WorkspaceCiMemoStore // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:117:2)
 	//
 	// A credential for the memoization store: a GitHub token on memoRepo with
 	// actions:read for ACTIONS_CACHE, or contents:read for GIT_REFS — plus
 	// contents:write if this run is to record anything.
 	//
-	MemoToken *Secret // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:120:2)
+	MemoToken *Secret // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:123:2)
 	//
 	// The owner/name whose Actions cache, or whose git refs, hold the memoization
 	// store.
 	//
-	MemoRepo string // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:125:2)
+	MemoRepo string // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:128:2)
 	//
 	// The GitHub API root the store is reached through. Defaults to
 	// https://api.github.com; set it for GitHub Enterprise Server.
 	//
-	MemoAPI string // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:130:2)
+	MemoAPI string // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:133:2)
 	//
 	// The git refs whose scopes may be trusted to hold recorded passes, spelled in
 	// full (refs/heads/main, refs/pull/12/merge). They are the refs a plan reads,
@@ -107,14 +110,14 @@ type WorkspaceCiOpts struct {
 	// nothing and records nothing: a scope a run can write is a scope that must be
 	// chosen deliberately.
 	//
-	MemoRefs []string // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:138:2)
+	MemoRefs []string // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:141:2)
 	//
 	// How long, in seconds, a recorded pass may be honoured. This is the answer to
 	// base-image drift, which a source-derived hash cannot see.
 	//
 	//
 	// Default: 86400
-	MemoTTL int // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:144:2)
+	MemoTTL int // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:147:2)
 }
 
 // New configures a planner.
@@ -193,12 +196,12 @@ type WorkspaceCiAffectedModulesOpts struct {
 	//
 	// The repository to plan for. Defaults to the calling workspace.
 	//
-	Repo *Directory // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:294:2)
+	Repo *Directory // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:297:2)
 	//
 	// The workspace to read repo from when repo is omitted. Defaults to the
 	// caller's.
 	//
-	Workspace *Workspace // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:299:2)
+	Workspace *Workspace // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:302:2)
 }
 
 // AffectedModules returns, as a JSON array of repo-relative directories, the
@@ -207,7 +210,7 @@ type WorkspaceCiAffectedModulesOpts struct {
 // reach" without paying for check enumeration.
 //
 // The arguments mean what they mean on Plan.
-func (r *WorkspaceCi) AffectedModules(ctx context.Context, base string, head string, opts ...WorkspaceCiAffectedModulesOpts) (string, error) { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:284:1)
+func (r *WorkspaceCi) AffectedModules(ctx context.Context, base string, head string, opts ...WorkspaceCiAffectedModulesOpts) (string, error) { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:287:1)
 	if r.affectedModules != nil {
 		return *r.affectedModules, nil
 	}
@@ -348,7 +351,7 @@ func (r *WorkspaceCi) UnmarshalJSON(bs []byte) error {
 // later run its full time and looks exactly like a workspace nobody has recorded
 // against yet, and a scope that leaks costs correctness. Like SelectionSelfTest it
 // runs in-process and needs no network, no credential and no services.
-func (r *WorkspaceCi) MemoStoreSelfTest(ctx context.Context) error { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:492:1)
+func (r *WorkspaceCi) MemoStoreSelfTest(ctx context.Context) error { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:495:1)
 	if r.memoStoreSelfTest != nil {
 		return nil
 	}
@@ -361,16 +364,16 @@ func (r *WorkspaceCi) MemoStoreSelfTest(ctx context.Context) error { // workspac
 type WorkspaceCiPlanOpts struct {
 
 	// Default: JSON
-	Format WorkspaceCiFormat // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:235:2)
+	Format WorkspaceCiFormat // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:238:2)
 	//
 	// The repository to plan for. Defaults to the calling workspace.
 	//
-	Repo *Directory // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:239:2)
+	Repo *Directory // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:242:2)
 	//
 	// The workspace to read repo from when repo is omitted. Defaults to the
 	// caller's.
 	//
-	Workspace *Workspace // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:244:2)
+	Workspace *Workspace // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:247:2)
 	//
 	// Input hashes a previous run already proved good, as a JSON array. They are
 	// honoured on the same terms as the ones read from the memoization store, and
@@ -380,14 +383,14 @@ type WorkspaceCiPlanOpts struct {
 	//
 	//
 	// Default: "[]"
-	KnownGood string // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:253:2)
+	KnownGood string // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:256:2)
 	//
 	// Emit a diagnostics object — the plan plus which modules had to be loaded to
 	// produce it, whether everything was selected, which legs a recorded pass
 	// retired, and whether recorded passes were honoured at all — instead of the
 	// bare plan. Intended for tests and for explaining a plan, not for CI.
 	//
-	Diagnostics bool // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:260:2)
+	Diagnostics bool // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:263:2)
 }
 
 // Plan returns the legs of CI to run for a change, each already routed to the
@@ -418,7 +421,7 @@ type WorkspaceCiPlanOpts struct {
 // explicitly is also the escape hatch for a caller whose .git is a file rather
 // than a directory (a git worktree), which would otherwise degrade to running
 // everything.
-func (r *WorkspaceCi) Plan(ctx context.Context, base string, head string, opts ...WorkspaceCiPlanOpts) (string, error) { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:226:1)
+func (r *WorkspaceCi) Plan(ctx context.Context, base string, head string, opts ...WorkspaceCiPlanOpts) (string, error) { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:229:1)
 	if r.plan != nil {
 		return *r.plan, nil
 	}
@@ -474,7 +477,7 @@ func (r *WorkspaceCi) Plan(ctx context.Context, base string, head string, opts .
 // thing: a call that named no ref, because with no ref there is no scope to judge
 // and refusing silently would be indistinguishable from a scope that was judged
 // and rejected.
-func (r *WorkspaceCi) RecordPass(ctx context.Context, hash string, ref string, commit string) (string, error) { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:337:1)
+func (r *WorkspaceCi) RecordPass(ctx context.Context, hash string, ref string, commit string) (string, error) { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:340:1)
 	if r.recordPass != nil {
 		return *r.recordPass, nil
 	}
@@ -495,7 +498,7 @@ func (r *WorkspaceCi) RecordPass(ctx context.Context, hash string, ref string, c
 // under-running a consumer's checks or handing their CI system something it cannot
 // parse. It runs in-process and needs no services, so it is cheap enough to run on
 // every leg set.
-func (r *WorkspaceCi) SelectionSelfTest(ctx context.Context) error { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:469:1)
+func (r *WorkspaceCi) SelectionSelfTest(ctx context.Context) error { // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:472:1)
 	if r.selectionSelfTest != nil {
 		return nil
 	}
@@ -518,7 +521,7 @@ func (r *WorkspaceCi) AsNode() Node {
 // the *constant identifier* in SCREAMING_SNAKE_CASE, and the CLI takes that member
 // name rather than the value — hence `--format=GITHUB_ACTIONS`. The values here are
 // spelled to match, so there is only ever one spelling to remember.
-type WorkspaceCiFormat string // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:182:6)
+type WorkspaceCiFormat string // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:185:6)
 
 func (WorkspaceCiFormat) IsEnum() {}
 
@@ -573,15 +576,15 @@ func (v *WorkspaceCiFormat) UnmarshalJSON(dt []byte) error {
 const (
 	// FormatGithubActions is a single-line JSON array, ready to write to
 	// GITHUB_OUTPUT and expand with fromJSON as a matrix.
-	WorkspaceCiFormatGithubActions WorkspaceCiFormat = "GITHUB_ACTIONS" // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:189:2)
+	WorkspaceCiFormatGithubActions WorkspaceCiFormat = "GITHUB_ACTIONS" // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:192:2)
 
 	// FormatJSON is the canonical form: an indented JSON array of legs.
-	WorkspaceCiFormatJson WorkspaceCiFormat = "JSON" // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:186:2)
+	WorkspaceCiFormatJson WorkspaceCiFormat = "JSON" // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:189:2)
 
 	// FormatJenkins is Groovy: a map of leg name to closure, which is what a
 	// declarative pipeline's parallel step takes. Write it to a file, `load` it,
 	// and hand the result straight to `parallel`.
-	WorkspaceCiFormatJenkins WorkspaceCiFormat = "JENKINS" // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:193:2)
+	WorkspaceCiFormatJenkins WorkspaceCiFormat = "JENKINS" // workspace-ci (../../../../../daggerverse/workspace-ci/main.go:196:2)
 
 )
 


### PR DESCRIPTION
Closes #306

## What changed

`planner.Timeouts` gains a third key shape, `<module-dir>:*`, which reaches a
module's coarse run-everything leg and none of its per-check legs.

`Timeouts.Apply` now resolves a budget from the weakest matching key to the
strongest:

| key | reaches |
| --- | --- |
| `def` | nothing matched |
| `t[<module-dir>]` | every leg of that module |
| `t[<leg-name>]` | that leg alone |
| `t[<module-dir>:*]` | a coarse leg only, and only where one exists |

## The judgment calls

**Key shape rather than a second table.** Of the three options the issue
sketched, `--full-timeouts` is a second parameter to keep in sync — a second
workflow input on `change-aware-ci.yml`, a second env var in every consumer, and
a second thing to forget. A multiplier cannot express "15 minutes for the suite,
6 for each check" without arithmetic the caller has to do backwards. One table
with a distinguishing shape keeps the whole budget readable in one place, and is
the option that costs a consumer nothing until they use it.

**The coarse key resolves *last*, not most-specific-first.** On a coarse leg
`Name == Module`, so `t[<leg-name>]` and `t[<module-dir>]` are literally the same
lookup. Reading the coarse shape any earlier would let the module-wide key take
it straight back. On a per-check leg the coarse shape never matches at all, which
is what keeps a whole-suite budget off legs bounded by one check.

**`*` is matched literally, not as a glob.** A check name comes from a Go method
identifier, so no real leg can be spelled `<module-dir>:*` and the shape cannot
collide with one. `CoarseKey(dir)` builds it, and `Entry.IsCoarse()` names the
`Name == Module` property the whole thing rests on, so the collision is stated in
code rather than only discoverable by reading `ModuleEntry`.

## devex's own table, narrowed

`daggerverse/workspace-ci` had a bare module key of 15 minutes because its coarse
leg repeats the whole-workspace codegen sweep (measured 5m12s). That 15 was
inherited by all four of its per-check legs. It is now bound to `:*` and to
`:generated` — the two legs that actually sweep — plus `:generated-self-test` at
the 8 minutes the identical root-module check already uses. `:selection-self-test`
and `:memo-store-self-test`, both in-process with no engine work, fall back to the
6 minute default.

The root module's `.` stays a bare module key deliberately: the only per-check leg
that inherits it is `.:generated`, which does that same sweep and needs it, and
the two that do not are already tightened alongside it. That reasoning is now
written into the workflow comment rather than left to be re-derived.

Note the issue's example — `daggerverse/kafka/tests` — is no longer in the table
at all: it is in `split-modules`, so it emits no coarse leg and its per-check legs
were already on the default. The over-binding the issue describes had moved to
`daggerverse/workspace-ci`, and that is what is narrowed here.

## Acceptance criteria

- [x] **A caller can give a module's coarse run-everything leg a different budget
      from that module's per-check legs, without naming every check.** —
      `{"<dir>:*": 15}` budgets the coarse leg; the per-check legs are untouched.
- [x] **The existing single-table behaviour still resolves as documented for
      callers who set no coarse budget.** — the new lookup is guarded on both the
      key being present and `IsCoarse()`; pinned by the
      `a table with no coarse key is unchanged` case.
- [x] **`Timeouts.Apply`'s precedence, including `Name == Module` on a coarse leg,
      is documented where the table is defined.** — the precedence table and the
      reason for the ordering are on `Apply`; the key shapes and the collision are
      on the `Timeouts` type; `ModuleEntry` now points at both.
- [x] **Covered by `planner` unit tests, which need no engine.** — `TestIsCoarse`,
      `TestTimeoutsApplyCoarseKey` (five resolutions) and
      `TestParseTimeoutsCoarseKey`. All pure; no engine, no services.
- [x] **devex's `CHECK_TIMEOUTS` in `.github/workflows/ci.yml` is narrowed to use
      it.** — as above.

Also documented in `daggerverse/workspace-ci/README.md` (a new
*Budgeting a coarse leg* section) and in the `timeouts` input description on
`change-aware-ci.yml`, so a consumer reading either finds the shape.

## Verified

- `go test ./planner/` — 16 tests pass
- `gofmt -l .` — clean
- `dagger check` (root) — `ci:generated`, `ci:generated-self-test`,
  `ci:selection-self-test` all OK
- `bash .github/scripts/verify-affected-modules.sh` — `workspace-ci:generated`,
  `:generated-self-test`, `:memo-store-self-test`, `:selection-self-test` and
  `tests:all` all OK
- Bindings regenerated with `dagger develop` in `daggerverse/workspace-ci`,
  `daggerverse/workspace-ci/tests` and the root, after the last source edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)