### PR TITLE
story(issue-266): render a document's pages in worker-pool execs

### DIFF
--- a/daggerverse/pdf/README.md
+++ b/daggerverse/pdf/README.md
@@ -403,79 +403,169 @@ png  := conv.Png()
 tiff := conv.Tiff()
 ```
 
-### One exec per page, fanned out from Go
+### One invocation per page, one exec per worker
 
 ```go
 doc.Convert().WithDpi(300).WithConcurrency(8).Png()   // default: one page per CPU
 ```
 
-`Png`, `Jpeg`, `Tiff`, `Svg`, `Eps` and `Html` render **one page per exec**, as
-many at a time as `WithConcurrency` allows. The bound, the scheduling, the
-fail-fast and the error message are all Go — nothing about running a conversion
-is interpreted inside a container.
+`Png`, `Jpeg`, `Tiff`, `Svg`, `Eps` and `Html` run **one poppler invocation per
+page**, and split those invocations across **at most `WithConcurrency` execs** —
+one contiguous slice of the document each. The bound, the partition, the
+scheduling, the fail-fast and the error message are all Go; the only thing
+interpreted inside a container is the list of per-page commands that slice was
+handed.
 
-That is a reversal, and it is the same one [#298][i298] made in `tesseract`.
-Until #309 the raster family was a single `pdftoppm` over the whole document,
-and the vector family a page loop *inside* one exec. `pdftoppm` renders a range
-serially in one process, so an N-page document was one core for as long as it
-took, however many the machine had:
+That is two reversals, a release apart, and they answer different questions.
 
-| pages | one exec | one exec per page, Go fan-out |
+**The first** is the same one [#298][i298] made in `tesseract`: until #309 the
+raster family was a single `pdftoppm` over the whole document and the vector
+family a page loop *inside* one exec, and `pdftoppm` renders a range serially in
+one process, so an N-page document was one core for as long as it took, however
+many the machine had.
+
+| pages | one exec | Go fan-out |
 | --- | --- | --- |
 | 12 | 17.0s | **4.0s** |
 | 48 | 60.4s | **6.5s** |
 | 48, one page edited | 60.7s | 6.5s |
-| 48, pages 1–24 already rendered | 61.0s | **4.3s** |
 
-`dagger call document --source=… convert with-dpi --dpi=300 png entries`, median
-of three, a freshly generated document every run so nothing is a cache hit,
-32-CPU host, 300 dpi; ~1.2s of every figure is CLI startup and module load. Both
-columns produce a **byte-identical directory** — the same `sha256` — which is
-the point: concurrency is allowed to change how long a render takes and nothing
-else.
+**The second** is #370, and it is not about parallelism at all — the fan-out
+already admitted only `workers()` pages at a time. It is about how many
+*containers* were created to run them: a 3,000-page conversion on a 16-CPU host
+created 3,000 execs in order to run 16, and then folded 3,000 directories into
+one. That fold is the thing that broke.
 
-The last two rows are the ones worth reading carefully, because **only one of
-them is a win, and it is not the one `tesseract` got.**
+| pages | one exec per page | one exec per slice |
+| --- | --- | --- |
+| 400, 150 dpi | 19.8s, 400 execs | **5.2s**, 32 execs |
+| 3,000, `-scale-to 32` | **fails after 1m7s** | **9.3s**, 32 execs |
 
-- **Editing a page re-renders the whole document, in both columns.** Every
-  page's exec mounts the *same* PDF, so a change to any byte of it invalidates
-  all of them. `tesseract`'s `Batch` gets the opposite result — 50 pages, one
-  edited, 17.5s → 2.5s — because there each exec mounts *its own image file*.
-  A per-item exec only caches per item when the items are separate inputs, and
-  the pages of a PDF are not.
-- **Rendering a page range you have already rendered part of is a win.** Pages
-  1–24 followed by the whole 48 costs 4.3s against 6.4s cold, because the first
-  24 execs are hits. That is the [#300](https://github.com/z5labs/devex/issues/300)
-  sharding case: a document rendered in slices, or a slice widened after the
-  fact, no longer re-renders what it already has.
+Median of three for the 400-page row, a freshly generated document every run so
+nothing is a cache hit, 32-CPU host; ~1.2s of every figure is CLI startup and
+module load. The directory is **byte-identical** across the change and across
+every bound — the same `sha256` for `Png`, `Svg` and `Html` before and after —
+which is the point: concurrency is allowed to change how long a render takes and
+nothing else.
 
-Three properties the serial loop had for free, which the fan-out has to keep:
+#### Why folding per page could not survive a long document
+
+Every `WithDirectory` or `WithFile` that folds an exec's output into the result
+adds an overlayfs lowerdir to the destination snapshot's chain. Mounting that
+snapshot goes through containerd, which compacts the lowerdir list and then
+refuses joined mount data over one page:
+
+```go
+dataInStr := strings.Join(opt.data, ",")
+if len(dataInStr) > pagesize {            // pagesize = 4096
+    return errors.New("mount options is too long")
+}
+```
+
+`containerd/v2@v2.2.3/core/mount/mount_linux.go:153`, the version dagger v0.21.7
+pins. Bisected against a live engine the fold was fine at 430 and failed at 440
+— and **the ceiling shrinks as an engine ages**, because each call burns two
+snapshot IDs and the compacted string is `160 + 9N` bytes at 5-digit IDs, ~393 at
+6 digits, ~357 at 7. The same conversion could work one week and fail the next on
+a busier engine. Reported against a ~3,000 page document in
+[#314](https://github.com/z5labs/devex/discussions/314).
+
+**Chunking the fold only moves that wall** — `sqrt(n)` grouping holds to ~185k
+files and still has a depth that grows with the document. The property worth
+building on instead is that a directory produced by an exec is **one snapshot
+however many files that exec wrote**. The chain is created purely by graph-level
+composition, never by the filesystem, so
+
+    fold depth = number of execs folded
+
+and the page count does not appear in it. Partitioning the pages into
+`workers()` slices makes the depth a property of the machine's core count, which
+does not grow with the document.
+
+> **This matters to a caller assembling a directory of its own.** The ceiling is
+> on the *chain*, not on this module: a consumer that takes this directory and
+> re-folds it a page at a time — `WithFile` per entry into some other tree —
+> rebuilds exactly the depth this removed, and hits the same
+> `mount options is too long` at the same few hundred. Fold the directory once,
+> or fold whatever an exec produced, rather than fold its entries.
+
+#### What that cost, measured rather than assumed
+
+#309 recorded one win that depended on **slice boundaries**, and slicing by
+`workers()` moves those boundaries with the length of the range. Re-run here,
+48 pages at 300 dpi, median of three, a fresh document per run:
+
+| | cold, whole 48 | after pages 1–24 |
+| --- | --- | --- |
+| one exec per page | 4.26s | **3.21s** |
+| one exec per slice | 4.01s | 3.73s |
+
+**The overlapping-page-range win is largely gone**, and that is the trade. Under
+one exec per page, pages 1–24 rendered first left 24 entries the 48-page render
+hit outright. Under slicing, 24 pages on a 32-CPU host is 24 one-page slices
+while 48 pages is sixteen two-page slices plus sixteen one-page ones, so almost
+nothing lines up; what is left (~0.28s) is the `pdfinfo` page count and warm-up.
+The [#300](https://github.com/z5labs/devex/issues/300) sharding case therefore
+re-renders what it has already rendered, unless the *same* range is asked for
+again under the same bound, which is a full hit and free.
+
+It was not worth keeping. Anchoring the slices to the whole document instead of
+to the range would restore the boundaries and cost the thing the sharding case
+exists for: pages 1–24 of a 3,000-page document would fall inside a single
+94-page slice and render in **one** exec, with no parallelism at all.
+
+The other #309 finding is unchanged and was never a win:
+
+- **Editing a page re-renders the whole document.** Every exec mounts the *same*
+  PDF, so a change to any byte of it invalidates all of them. `tesseract`'s
+  `Batch` gets the opposite result — 50 pages, one edited, 17.5s → 2.5s —
+  because there each exec mounts *its own image file*. A per-item exec only
+  caches per item when the items are separate inputs, and the pages of a PDF are
+  not.
+
+#### Properties the serial loop had for free, which the fan-out keeps
 
 - **A page that cannot be rendered fails the whole conversion**, rather than
-  going missing from a directory of a thousand, and the error names the page:
-  `Png page 7 failed (exit 99): …`.
+  going missing from a directory of a thousand, and the error names **the page**
+  and not the slice it shared an exec with: `Png page 7 failed (exit 99): …`.
+  A slice's script reports the page it stopped on and re-raises poppler's own
+  exit status; the module reads that back out of stderr and takes it out of the
+  message it builds.
 - **The first failure cancels the rest.** A conversion that is going to fail has
-  no reason to render the remaining pages first.
+  no reason to render the remaining pages first. Inside the failing slice the
+  pages behind the failure never run; the other slices are cancelled through the
+  fan-out's context.
 - **The pages are assembled in page order**, off execs that finished in whatever
   order they finished in, so the returned directory does not depend on the
   scheduling.
+- **`-singlefile` is retained per page.** The padding width still comes from the
+  Go-side plan and `-forcenum` stays out — see
+  [`Split` and `Merge`](#split-and-merge--page-structure-not-pixels) for the
+  contract both families reach. It is also why a slice's whole output directory
+  can be taken: `-singlefile` writes exactly `<base>.<ext>` and nothing else.
 
-Those three are covered by `Pdf.RenderSchedulingSelfTest` rather than by a
-fixture, and that is not a shortcut — **poppler will not fail a page.** Measured
-against the pinned poppler 25.12, every damaged page shape is a warning on
-stderr and an exit status of 0, with a file still written: a dangling page-tree
-kid, a kid of the wrong type, a loop in the page tree, a null kid, a
-two-million-point `MediaBox`, a `MediaBox` of zero, and a resolution large enough
-to print `Bogus memory allocation size`. The only non-zero exits are for a
-document that cannot be opened at all and for a page range outside it, and both
-are caught before any page is rendered. So no document makes one page of a render
-fail, the scheduling is tested where it lives — `fanout/`, which imports no
-dagger and runs under `go test -race` — and the fail-fast exists for the
-failures poppler *does* report rather than for one this repo can demonstrate.
+Those are covered by `Pdf.RenderSchedulingSelfTest` rather than by a fixture, and
+that is not a shortcut — **poppler will not fail a page.** Measured against the
+pinned poppler 25.12, every damaged page shape is a warning on stderr and an exit
+status of 0, with a file still written: a dangling page-tree kid, a kid of the
+wrong type, a loop in the page tree, a null kid, a two-million-point `MediaBox`,
+a `MediaBox` of zero, and a resolution large enough to print `Bogus memory
+allocation size`. The only non-zero exits are for a document that cannot be
+opened at all and for a page range outside it, and both are caught before any
+page is rendered. So no document makes one page of a render fail, the scheduling
+and the partition are tested where they live — `fanout/`, which imports no dagger
+and runs under `go test -race` — and the fail-fast exists for the failures
+poppler *does* report rather than for one this repo can demonstrate.
 
 > A blank or wrong-looking page is **not** one of the failures this catches, for
 > the same reason: poppler exits 0 for it. [`Fonts`](#fonts--the-blank-page-diagnostic-before-the-blank-page)
 > is the diagnostic for that, before the fact.
+
+`Ps` and `Split` are outside all of this and stayed outside it: each is a single
+invocation writing a single output, so neither has a fold and neither reads
+`WithConcurrency`. `Ps` is asserted byte-identical across the bound rather than
+assumed to be — see [`Svg`, `Eps` and `Ps`](#svg-eps-and-ps--keeping-the-outlines)
+for why a PostScript document cannot be fanned out at all.
 
 [i298]: https://github.com/z5labs/devex/issues/298
 
@@ -494,11 +584,12 @@ one core against ~30s of 14-core recognition — two thirds of the wall clock fo
 a third of the CPU. The same document on a 32-CPU host is ~13s of recognition
 against an unchanged ~60s of render.
 
-**Every existing caller's cache entries churn once**, and that is a property of
-the fan-out and not of the default: one exec per page is N entries at *every*
-bound, including `WithConcurrency(1)`. The first conversion after upgrading
-re-renders; the old single entry is orphaned and expires on Dagger's usual
-7-day TTL.
+The setting now carries a second meaning — how many execs a conversion creates,
+and so how the results cache — because the two were never independent. A slice is
+the unit that hits or misses, so **every existing caller's cache entries churn
+once** whenever the bound changes, and once more on upgrading to this release.
+The first conversion after either re-renders; the orphaned entries expire on
+Dagger's usual 7-day TTL.
 
 #### What the per-page open costs
 
@@ -695,7 +786,8 @@ reachable, and `SvgWritesOneVectorFilePerPage` asserts the absence of a
 
 **EPS refuses multi-page outright.** `pdftocairo -eps` handed a document with a
 second page writes nothing and exits 99 with `EPS files can only contain one
-page.` The per-page fan-out is what turns that refusal into the whole document.
+page.` The per-page invocation is what turns that refusal into the whole
+document.
 Note that an EPS's bounding box is the page's **ink**, not its media box —
 poppler crops to what is drawn, so a US Letter page with one line of text on it
 comes out a few inches wide. That is EPS's own convention (a figure carries its
@@ -708,8 +800,8 @@ per page. A directory of one-page fragments would look tidier beside `Svg` and
 `Eps` and be individually invalid.
 
 That is also why **`Ps` is the one render that stays a single invocation**, and
-why `WithConcurrency` does nothing for it. Every other page-per-file output fans
-out an exec per page and assembles the directory afterwards; a PostScript
+why `WithConcurrency` does nothing for it. Every other page-per-file output runs
+one invocation per page and assembles the directory afterwards; a PostScript
 document cannot be assembled that way, because concatenating the fragments is
 not the same operation as writing the document — the result needs its prologue,
 its page markers and its `%%Pages:` count rewritten, which is a PostScript editor
@@ -757,15 +849,17 @@ at all. `Split` is `pdfseparate`: one PDF per page, named to the same
 `page-0001.pdf` onwards. `Merge` is `pdfunite`: several PDFs concatenated into
 one.
 
-**`Split` stays one exec**, where the renders now fan out a page at a time, and
-that is a measured decision rather than an omission. Splitting is not
+**`Split` stays one exec**, where the renders fan out across `workers()` of them,
+and that is a measured decision rather than an omission. Splitting is not
 rasterizing: `pdfseparate` copies page objects, at **0.8 ms/page** for the whole
 document in one invocation against 5.8 ms/page one invocation per page. A page
 that costs a millisecond does not want its own container — the Dagger exec around
 it costs two orders of magnitude more than the work — so a fan-out here would
 make `Split` slower for every document and buy nothing but cache granularity
 nobody is waiting on. `Convert.WithConcurrency` therefore does not reach it, and
-`Split` needs no bound of its own.
+`Split` needs no bound of its own. It is also the one page-per-file output with
+no fold at all: `pdfseparate` writes every page into one exec's directory, which
+is one snapshot, so the ceiling #370 removed from the renders was never over it.
 
 They are **lossless** in a way no conversion is. Each split page carries the
 original page's own objects across — its text layer, its fonts, its annotations,
@@ -1004,10 +1098,10 @@ range in one invocation, numbered to whatever width the destination pattern
 asked for.
 
 The width comes from `PageCount`, read in **Go**, once per conversion — the
-greater of four and the digits the document's last page needs. That round trip
-is what one exec per page costs and it is the trade the fan-out makes knowingly:
-an exec that renders one page cannot compute a padding width from the files it
-finds, because it finds exactly one. It is the same `pdfinfo` `Info` runs, so a
+greater of four and the digits the document's last page needs. That round trip is
+what the fan-out costs and it is a trade made knowingly: an exec handed a slice
+of the document cannot compute a padding width from the files it finds, because
+no exec sees the whole document. It is the same `pdfinfo` `Info` runs, so a
 conversion of a document already reported on pays nothing for it.
 
 `pdfseparate` is the one that would honour a padded name if it were asked:
@@ -1065,11 +1159,14 @@ transform of its inputs — the document bytes plus the flags — so Dagger's 7-
 default is correct and there is no chained-method propagation problem to worry
 about. Same posture as `tesseract`'s outputs and `kicad`.
 
-What the per-page fan-out changes is the *granularity*: a render is now one cache
-entry per page rather than one per conversion. See [One exec per page](#one-exec-per-page-fanned-out-from-go)
-for what that does and does not buy — it makes an overlapping page range cheap
-and it does **not** make an edited document cheap, because every page's exec
-mounts the same PDF.
+What the fan-out changes is the *granularity*: a render is one cache entry per
+**slice** — `WithConcurrency` of them, or fewer for a document shorter than the
+bound — rather than one per conversion. See
+[One invocation per page](#one-invocation-per-page-one-exec-per-worker) for what
+that does and does not buy. It does **not** make an edited document cheap,
+because every exec mounts the same PDF; and since a slice's boundaries move with
+the length of the range, it no longer makes an overlapping page range cheap
+either — which is measured there rather than assumed.
 
 ## Follow-ups
 
@@ -1078,12 +1175,17 @@ Cropping the render window and selecting odd or even pages (#272); the chained
 does for `tesseract`; linearize, encrypt and repair via qpdf (#274); renderer
 fidelity and colour-profile options (#277).
 
-The per-page fan-out (#309) does **not** address intermediate size: a
-3,000-page 300-dpi directory is still gigabytes crossing a module boundary at
-once, and [#300](https://github.com/z5labs/devex/issues/300)'s `WithPageRange`
-sharding recipe is still the answer to that. What the fan-out changes for it is
-the cost: a shard of a document already partly rendered now reuses the pages it
-has.
+The fan-out (#309, #370) does **not** address intermediate size: a 3,000-page
+300-dpi directory is still gigabytes crossing a module boundary at once, and
+[#300](https://github.com/z5labs/devex/issues/300)'s `WithPageRange` sharding
+recipe is still the answer to that. What #370 changes for it is that a shard no
+longer reuses the pages an overlapping shard already rendered — the slice, not
+the page, is the cache unit now, and its boundaries move with the range. Shard
+for the size, not for the reuse.
+
+The partitioning is written here and will want to move: #321 is where a shared
+fan-out for the workspace belongs, and this and `tesseract`'s `Batch` are two
+copies of the same idea.
 
 `tesseract`'s `FromPdf` was removed in favour of this module (#276): that module
 carries no rasterizer at all now, so `Png()` feeds its `Batch` directly — which

--- a/daggerverse/pdf/README.md
+++ b/daggerverse/pdf/README.md
@@ -448,6 +448,21 @@ every bound — the same `sha256` for `Png`, `Svg` and `Html` before and after �
 which is the point: concurrency is allowed to change how long a render takes and
 nothing else.
 
+> **`Eps` and `Ps` are the exception, and it is cairo's rather than this
+> module's.** Cairo writes the wall clock into every EPS and PS document it
+> produces, as a `%%CreationDate` DSC comment on line three, and honours neither
+> `SOURCE_DATE_EPOCH` nor any `pdftocairo` flag — measured against the pinned
+> cairo 1.18.4. So two `Eps` renders at different bounds are different execs at
+> different instants, that line differs, and the directory digests differ with
+> it. Everything drawn is identical, which is what the suite asserts, file by
+> file, with that one line held aside.
+>
+> This was always true and used to be invisible: at every bound the old fan-out
+> produced *the same* execs, so two bounds were one cache entry and the digests
+> matched without the rendering having to be reproducible at all. Slicing by the
+> bound is what made a pre-existing non-determinism observable. A caller who
+> needs reproducible vector output wants `Svg`, which carries no timestamp.
+
 #### Why folding per page could not survive a long document
 
 Every `WithDirectory` or `WithFile` that folds an exec's output into the result

--- a/daggerverse/pdf/convert.go
+++ b/daggerverse/pdf/convert.go
@@ -128,27 +128,35 @@ func (c *Convert) WithoutAnnotations() *Convert {
 	return out
 }
 
-// WithConcurrency bounds how many pages a render converts at once.
+// WithConcurrency bounds how many pages a render converts at once, and with it
+// how many execs the conversion creates.
 //
 // It defaults to the number of CPUs the module can see, which is what a
-// document wants: every page is its own exec, and poppler renders a page on one
-// core whatever the machine has. A 129-page document at 300 dpi spends about a
-// minute of that one core, and the recognition it is usually rendered for
-// spends its own time across every core — so the render is a third of the CPU
-// and two thirds of the wall clock, and the share grows with core count rather
-// than shrinking.
+// document wants: poppler renders a page on one core whatever the machine has.
+// A 129-page document at 300 dpi spends about a minute of that one core, and the
+// recognition it is usually rendered for spends its own time across every core —
+// so the render is a third of the CPU and two thirds of the wall clock, and the
+// share grows with core count rather than shrinking.
 //
 // Unlike the tesseract module's Batch, this bound needs no companion. poppler's
 // tools are single-threaded, so concurrency here is concurrency and not
 // concurrency multiplied by an OpenMP team; the pages contend for cores the way
 // any other CPU-bound workload does.
 //
-// Pass a number to take less of the machine than the default, or 1 to render one
-// page at a time. Non-positive is rejected at output time.
+// Pass a number to take less of the machine than the default, or 1 to render the
+// whole document in one exec, a page at a time. Non-positive is rejected at
+// output time.
 //
-// It is a scheduling bound and nothing else: the directory a conversion returns
-// is the same whatever it is set to. It is also not what decides how the results
-// cache — one exec per page is what does that, at every bound including 1.
+// The two meanings are one setting because they were never independent. The
+// pages are split into this many contiguous slices and each slice is one exec
+// running its pages' invocations in turn, so the bound is at once how many
+// render at a time and how many containers a conversion creates — a
+// three-thousand-page document is this many, not three thousand. It is what
+// decides how the results cache, too: a slice is the unit that hits or misses.
+//
+// What it is still not is a change to the answer. The directory a conversion
+// returns is byte-identical at every bound; concurrency is allowed to change how
+// long a render takes and nothing else.
 //
 // Ignored by Text, Txt, Bbox, Tsv and Ps, none of which renders a page at a
 // time. See Ps for why that one is a single invocation.
@@ -393,8 +401,8 @@ func (c *Convert) Eps(ctx context.Context) (*dagger.Directory, error) {
 // each individually invalid.
 //
 // That is also why this is the one render that stays a single invocation, and
-// why WithConcurrency does nothing here. Every other page-per-file output fans
-// out one exec per page and assembles the directory afterwards; a PostScript
+// why WithConcurrency does nothing here. Every other page-per-file output runs
+// one invocation per page and assembles the directory afterwards; a PostScript
 // document cannot be assembled that way, because concatenating the fragments is
 // not the same operation as writing the document — the result would need its
 // prologue, its page markers and its `%%Pages:` count rewritten, which is a
@@ -486,8 +494,10 @@ func (c *Convert) textFlags(label string, layout LayoutMode, disablePageBreaks b
 // poppler's. Handed an output base, pdftoppm appends a page number of its own
 // choosing and the format's extension; handed -singlefile it writes exactly
 // `<base>.<ext>` and nothing else, so a render told to produce `page-0007` does.
-// Since each invocation renders one page, that is the whole contract, and the
-// rename pass the raster family used to run afterwards is gone with it.
+// Since each invocation renders one page — several invocations to an exec, but
+// still one page each — that is the whole contract, and the rename pass the
+// raster family used to run afterwards is gone with it. It is also what lets a
+// slice's directory be taken whole: nothing but the pages is in it.
 //
 // -forcenum is gone for the same reason, and could not survive: it overrides
 // -singlefile rather than composing with it, so the two together write
@@ -558,8 +568,8 @@ func (c *Convert) cairoFlags(format pageFormat) ([]string, error) {
 	return args, nil
 }
 
-// pageRender writes one file per page, one exec per page, and returns the
-// directory holding them.
+// pageRender writes one file per page, one exec per slice of pages, and returns
+// the directory holding them.
 //
 // The whole directory of each render is taken rather than the page file alone,
 // because pdftohtml writes more than the page: a page carrying images gets them
@@ -592,26 +602,43 @@ func (c *Convert) pageRender(ctx context.Context, label string, format pageForma
 		}
 		jobs = append(jobs, pageJob{
 			page: page.number,
-			script: strings.Join([]string{
-				"set -e",
-				"mkdir -p " + outputDir,
-				"cd " + outputDir,
-				c.Document.command(format.tool, flags,
-					"-f", strconv.Itoa(page.number), "-l", strconv.Itoa(page.number),
-					sourcePath, name),
-			}, "\n"),
+			command: c.Document.command(format.tool, flags,
+				"-f", strconv.Itoa(page.number), "-l", strconv.Itoa(page.number),
+				sourcePath, name),
 		})
 	}
 
-	execs, err := c.render(ctx, label, jobs)
+	// The `cd` is the prelude's rather than each page's for the same reason the
+	// page commands are unchanged: a slice's script is the per-page commands
+	// concatenated, and everything that is per-conversion rather than per-page
+	// belongs above them.
+	execs, err := c.render(ctx, label,
+		[]string{"mkdir -p " + outputDir, "cd " + outputDir}, jobs)
 	if err != nil {
 		return nil, err
 	}
+	return assemble(execs), nil
+}
+
+// assemble folds the finished execs into the directory a render returns: one
+// WithDirectory per exec, in slice order, which is page order.
+//
+// This is the whole of what #370 changed and the reason it was worth changing.
+// Every fold adds an overlayfs lowerdir to the destination snapshot's chain, and
+// containerd refuses to mount a chain whose compacted mount data exceeds one
+// page — measured at around 440 folds on a fresh engine, and fewer as snapshot
+// IDs grow a digit. A directory produced by an exec is *one* snapshot however
+// many files that exec wrote, so folding per exec rather than per page makes the
+// depth `len(execs)`, which the bound caps and the page count does not enter.
+//
+// It is also why nothing downstream should fold this directory a page at a time
+// to build one of its own: the ceiling is on the chain, not on this module.
+func assemble(execs []*dagger.Container) *dagger.Directory {
 	out := dag.Directory()
 	for _, exec := range execs {
 		out = out.WithDirectory("/", exec.Directory(outputDir))
 	}
-	return out, nil
+	return out
 }
 
 // page is one page of a planned conversion: its number in the source document,
@@ -621,24 +648,28 @@ type page struct {
 	base   string
 }
 
-// pageJob is one page's render — the page it covers and the script that renders
-// it — carried together so a failure can name the page rather than the exec.
+// pageJob is one page's render — the page it covers and the single command that
+// renders it — carried together so a failure can name the page rather than the
+// slice it was rendered in.
+//
+// It is a command and not a script now that several of them run in one exec: the
+// prelude a family needs is written once at the top of a slice's script, and
+// what is per page is exactly the one invocation `plan` sized and named.
 type pageJob struct {
-	page   int
-	script string
-	args   []string
+	page    int
+	command string
 }
 
 // plan resolves which pages a conversion covers and what each one's output is
 // called, and is the one place the naming contract is decided.
 //
 // It costs a PageCount round trip that the in-container page loop was written to
-// avoid, and the trade is deliberate. One exec per page cannot compute the
-// padding width from the files it finds, because each exec finds exactly one; so
-// the width moves to Go, where it needs the page count. That is one pdfinfo per
-// conversion rather than one per page, it is the same exec validateRange already
-// pays for whenever a range is set, and Dagger caches it — a second conversion of
-// the same document does not run it again.
+// avoid, and the trade is deliberate. A fanned-out render cannot compute the
+// padding width from the files it finds, because no exec sees the whole
+// document; so the width moves to Go, where it needs the page count. That is one
+// pdfinfo per conversion rather than one per page, it is the same exec
+// validateRange already pays for whenever a range is set, and Dagger caches it —
+// a second conversion of the same document does not run it again.
 func (c *Convert) plan(ctx context.Context, label string) ([]page, error) {
 	if err := c.validateConcurrency(); err != nil {
 		return nil, err
@@ -697,28 +728,35 @@ func pageNumberWidth(count int) int {
 	return max(minPageNumberWidth, len(strconv.Itoa(count)))
 }
 
-// render runs one exec per page, at most workers() of them at a time, and
-// returns the finished execs positionally.
+// render partitions the pages into at most workers() slices, runs one exec per
+// slice, and returns the finished execs positionally — in slice order, which is
+// page order.
 //
-// The scheduling itself is the fanout package's, which imports no dagger and is
-// tested with `go test -race` — see that package for why the properties it holds
-// cannot be tested against a document instead. What is here is what makes a
-// failure readable: the page each exec covers, in the label its error carries.
-func (c *Convert) render(ctx context.Context, label string, jobs []pageJob) ([]*dagger.Container, error) {
-	execs := make([]*dagger.Container, len(jobs))
+// One exec per *slice* rather than per page is what keeps a conversion's exec
+// count, and so its fold depth, off the length of the document: see assemble for
+// what the fold could not survive, and fanout.Partition for the property that
+// makes it constant. It costs no parallelism, the pages already having been
+// admitted workers() at a time — a three-thousand-page conversion on a 16 CPU
+// host was creating three thousand containers in order to run sixteen.
+//
+// The scheduling and the partitioning are both the fanout package's, which
+// imports no dagger and is tested with `go test -race` — see that package for
+// why the properties they hold cannot be tested against a document instead. What
+// is here is what makes a failure readable: a slice's script names the page each
+// command covers, so the error still carries the page and not the slice.
+func (c *Convert) render(ctx context.Context, label string, prelude []string, jobs []pageJob) ([]*dagger.Container, error) {
+	slices := fanout.Partition(len(jobs), c.workers())
+	execs := make([]*dagger.Container, len(slices))
 
 	// Each unit writes only its own element, and Run does not return until every
 	// unit it started has, so the slice needs no lock of its own.
-	err := fanout.Run(ctx, c.workers(), len(jobs), func(ctx context.Context, i int) error {
-		job := jobs[i]
-		// The label carries the page, so every message this run can produce —
-		// poppler's own failure, and the module's message for an encrypted
-		// document — names the page it came from without the error being
-		// wrapped twice. Returned as it is rather than %w-wrapped: the error
-		// crosses the module boundary, which unwraps a chain back to the inner
-		// error and would drop the page's name along with it.
-		res, err := c.Document.runScript(ctx,
-			fmt.Sprintf("%s page %d", label, job.page), job.script, job.args...)
+	err := fanout.Run(ctx, c.workers(), len(slices), func(ctx context.Context, i int) error {
+		pages := jobs[slices[i].Start:slices[i].End]
+		// Returned as it is rather than %w-wrapped: the error crosses the module
+		// boundary, which unwraps a chain back to the inner error and would drop
+		// the page's name along with it.
+		res, err := c.Document.runPages(ctx, label,
+			pages[0].page, pages[len(pages)-1].page, sliceScript(prelude, pages))
 		if err != nil {
 			return err
 		}
@@ -731,14 +769,39 @@ func (c *Convert) render(ctx context.Context, label string, jobs []pageJob) ([]*
 	return execs, nil
 }
 
-// workers is how many pages render at once: whatever WithConcurrency asked for,
-// or one per CPU the module can see.
+// sliceScript is the script one exec runs: the family's prelude once, then the
+// per-page commands `plan` generated, in page order, each guarded so its failure
+// carries its own page number out of a script that covers several.
 //
-// The default is the core count rather than one because every page is its own
-// exec now, and a single pdftoppm renders a document's pages one after another
-// on one core however many the machine has. What makes the core count safe here
-// — and needs no companion bound, unlike the tesseract module's Batch — is that
-// poppler's tools are single-threaded.
+// The per-page commands are concatenated verbatim, which is what keeps every
+// property of the page-per-exec version that was about the *command* rather than
+// about the exec — `-singlefile` per page, so the padding width still comes from
+// `plan` and `-forcenum` stays out, and one page's `-f`/`-l` bounds.
+//
+// `set -e` is what makes the prelude fail the exec; the page commands do not
+// rely on it, each being an explicitly handled `||`. A failure still stops the
+// pages behind it inside its own slice, and fanout.Run's cancellation is what
+// stops the other slices.
+func sliceScript(prelude []string, jobs []pageJob) string {
+	lines := make([]string, 0, len(prelude)+len(jobs)+2)
+	lines = append(lines, "set -e",
+		pageFailureFn+`() { echo "`+pageFailureMarker+`$1" >&2; exit "$2"; }`)
+	lines = append(lines, prelude...)
+	for _, job := range jobs {
+		lines = append(lines, fmt.Sprintf("%s || %s %d $?", job.command, pageFailureFn, job.page))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// workers is how many pages render at once, and now also how many execs a
+// conversion creates: whatever WithConcurrency asked for, or one per CPU the
+// module can see.
+//
+// The default is the core count rather than one because a single pdftoppm
+// renders a document's pages one after another on one core however many the
+// machine has, so the bound is what turns a document into a parallel render.
+// What makes the core count safe here — and needs no companion bound, unlike the
+// tesseract module's Batch — is that poppler's tools are single-threaded.
 func (c *Convert) workers() int {
 	if c.HasConcurrency {
 		return c.Concurrency
@@ -788,15 +851,17 @@ func (c *Convert) geometry(ctx context.Context, label, flag, output string) (*da
 //
 // One pdftoppm per page, rather than one over the whole document, is what lets
 // the pages render at the same time — poppler renders a range serially in a
-// single process, on one core whatever the machine has — and what makes the
-// results cache per page: an edited page invalidates its own render and nothing
-// else. It is the same reversal #298 made in the tesseract module, for the same
+// single process, on one core whatever the machine has. The invocations are
+// still one per page; what they are not is one per *exec*, several pages'
+// invocations sharing a container so the fold that assembles them stays shallow.
+// It is the same reversal #298 made in the tesseract module, for the same
 // measured reason; see the README.
 //
 // Each page is named outright rather than renamed afterwards, -singlefile making
-// pdftoppm write exactly the file it is given. The files are selected by name
-// off the exec that produced them, in page order, so the returned directory is
-// the same whatever order the renders finished in.
+// pdftoppm write exactly the file it is given. The directory each exec wrote is
+// taken whole, in slice order, so the returned directory is the same whatever
+// order the slices finished in — and it holds exactly the pages, -singlefile
+// being the reason pdftoppm writes nothing else beside them.
 func (c *Convert) raster(ctx context.Context, label string, format rasterFormat) (*dagger.Directory, error) {
 	flags, err := c.rasterFlags(label, format)
 	if err != nil {
@@ -810,30 +875,22 @@ func (c *Convert) raster(ctx context.Context, label string, format rasterFormat)
 	jobs := make([]pageJob, 0, len(pages))
 	for _, page := range pages {
 		bounds := []string{"-f", strconv.Itoa(page.number), "-l", strconv.Itoa(page.number)}
-		// set -e makes a page poppler cannot draw fail here, carrying its own
+		// A page poppler cannot draw fails the conversion carrying its own
 		// message, rather than dropping a file from a directory a caller would
-		// read as a document that was short a page all along.
+		// read as a document that was short a page all along — see sliceScript
+		// for what guards each command.
 		jobs = append(jobs, pageJob{
 			page: page.number,
-			script: strings.Join([]string{
-				"set -e",
-				"mkdir -p " + outputDir,
-				c.Document.command("pdftoppm", concat(flags, bounds),
-					sourcePath, outputDir+"/"+page.base),
-			}, "\n"),
+			command: c.Document.command("pdftoppm", concat(flags, bounds),
+				sourcePath, outputDir+"/"+page.base),
 		})
 	}
 
-	execs, err := c.render(ctx, label, jobs)
+	execs, err := c.render(ctx, label, []string{"mkdir -p " + outputDir}, jobs)
 	if err != nil {
 		return nil, err
 	}
-	out := dag.Directory()
-	for i, page := range pages {
-		name := page.base + "." + format.ext
-		out = out.WithFile(name, execs[i].File(outputDir+"/"+name))
-	}
-	return out, nil
+	return assemble(execs), nil
 }
 
 // concat joins two flag lists into a new slice, which appending to the first

--- a/daggerverse/pdf/convert.go
+++ b/daggerverse/pdf/convert.go
@@ -739,34 +739,27 @@ func pageNumberWidth(count int) int {
 // admitted workers() at a time — a three-thousand-page conversion on a 16 CPU
 // host was creating three thousand containers in order to run sixteen.
 //
-// The scheduling and the partitioning are both the fanout package's, which
-// imports no dagger and is tested with `go test -race` — see that package for
-// why the properties they hold cannot be tested against a document instead. What
-// is here is what makes a failure readable: a slice's script names the page each
-// command covers, so the error still carries the page and not the slice.
+// The scheduling and the partitioning are both fanout.RunSlices', one call
+// taking the bound once — a module that partitioned by one figure and scheduled
+// by another would have two bounds to keep in agreement and no reason for them
+// to differ. That package imports no dagger and is tested with `go test -race`;
+// see it for why the properties it holds cannot be tested against a document
+// instead. What is here is what makes a failure readable: a slice's script names
+// the page each command covers, so the error still carries the page and not the
+// slice.
 func (c *Convert) render(ctx context.Context, label string, prelude []string, jobs []pageJob) ([]*dagger.Container, error) {
-	slices := fanout.Partition(len(jobs), c.workers())
-	execs := make([]*dagger.Container, len(slices))
-
-	// Each unit writes only its own element, and Run does not return until every
-	// unit it started has, so the slice needs no lock of its own.
-	err := fanout.Run(ctx, c.workers(), len(slices), func(ctx context.Context, i int) error {
-		pages := jobs[slices[i].Start:slices[i].End]
-		// Returned as it is rather than %w-wrapped: the error crosses the module
-		// boundary, which unwraps a chain back to the inner error and would drop
-		// the page's name along with it.
-		res, err := c.Document.runPages(ctx, label,
-			pages[0].page, pages[len(pages)-1].page, sliceScript(prelude, pages))
-		if err != nil {
-			return err
-		}
-		execs[i] = res.container
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	return execs, nil
+	return fanout.RunSlices(ctx, c.workers(), jobs,
+		func(ctx context.Context, pages []pageJob) (*dagger.Container, error) {
+			// Returned as it is rather than %w-wrapped: the error crosses the
+			// module boundary, which unwraps a chain back to the inner error and
+			// would drop the page's name along with it.
+			res, err := c.Document.runPages(ctx, label,
+				pages[0].page, pages[len(pages)-1].page, sliceScript(prelude, pages))
+			if err != nil {
+				return nil, err
+			}
+			return res.container, nil
+		})
 }
 
 // sliceScript is the script one exec runs: the family's prelude once, then the

--- a/daggerverse/pdf/convert.go
+++ b/daggerverse/pdf/convert.go
@@ -154,9 +154,17 @@ func (c *Convert) WithoutAnnotations() *Convert {
 // three-thousand-page document is this many, not three thousand. It is what
 // decides how the results cache, too: a slice is the unit that hits or misses.
 //
-// What it is still not is a change to the answer. The directory a conversion
-// returns is byte-identical at every bound; concurrency is allowed to change how
-// long a render takes and nothing else.
+// What it is still not is a change to the answer. The same pages come back under
+// every bound, named the same way and rendered from the same bytes; concurrency
+// is allowed to change how long a render takes and nothing else.
+//
+// One caveat, and it is the renderer's rather than this module's: cairo stamps
+// the wall clock into every EPS and PS document it writes, as a
+// `%%CreationDate` DSC comment, and honours neither SOURCE_DATE_EPOCH nor any
+// pdftocairo flag. Two Eps renders at different bounds are different execs at
+// different instants, so that one line differs and the directory digests differ
+// with it. Everything drawn is identical. Png, Jpeg, Tiff, Svg and Html carry no
+// timestamp and are byte-identical at every bound.
 //
 // Ignored by Text, Txt, Bbox, Tsv and Ps, none of which renders a page at a
 // time. See Ps for why that one is a single invocation.

--- a/daggerverse/pdf/document.go
+++ b/daggerverse/pdf/document.go
@@ -444,6 +444,66 @@ func (d *Document) runScript(ctx context.Context, label string, script string, a
 	return res, nil
 }
 
+// runPages executes one slice of a render — several pages' commands, run in the
+// one exec — and turns a failure into the error the failing page would have
+// carried had it been the only page in the exec.
+//
+// The page comes out of the script rather than out of a label chosen here, which
+// is the whole difference a slice makes: Go knows which pages the exec covers
+// and only the script knows which command was running when it stopped. See
+// sliceScript for how the page is reported and takeFailedPage for how it is read
+// back and removed from what the caller sees.
+//
+// A failure carrying no page is not a page's: the prelude is the only thing in a
+// slice's script that runs outside a guarded command, so it is the output
+// directory that could not be created or entered, and the message names the run
+// of pages rather than inventing one of them.
+func (d *Document) runPages(ctx context.Context, label string, first, last int, script string) (*popplerResult, error) {
+	res, code, err := d.capture(ctx, script)
+	if err != nil {
+		return nil, err
+	}
+	if code == 0 {
+		return res, nil
+	}
+	if page, stderr := takeFailedPage(res.stderr); page > 0 {
+		return nil, d.failure(
+			fmt.Sprintf("%s page %d", label, page), code, res.stdout, stderr)
+	}
+	if first == last {
+		return nil, d.failure(
+			fmt.Sprintf("%s page %d", label, first), code, res.stdout, res.stderr)
+	}
+	return nil, d.failure(
+		fmt.Sprintf("%s pages %d-%d", label, first, last), code, res.stdout, res.stderr)
+}
+
+// takeFailedPage reads back the page a slice's script reported failing on, and
+// returns stderr with that report removed.
+//
+// Removing it is the point of reading it: the page belongs in the message's
+// first line, where a caller looks, and the marker line is this module talking
+// to itself. A stderr carrying no marker yields page 0, which is the caller's
+// signal that the failure was not a page's.
+func takeFailedPage(stderr string) (int, string) {
+	lines := strings.Split(stderr, "\n")
+	kept := make([]string, 0, len(lines))
+	page := 0
+	for _, line := range lines {
+		rest, ok := strings.CutPrefix(line, pageFailureMarker)
+		if !ok {
+			kept = append(kept, line)
+			continue
+		}
+		// A script exits as soon as it reports, so there is at most one marker;
+		// the last one wins if that ever stops being true.
+		if n, err := strconv.Atoi(strings.TrimSpace(rest)); err == nil && n > 0 {
+			page = n
+		}
+	}
+	return page, strings.Join(kept, "\n")
+}
+
 // capture runs a shell script against the bound document and returns its output
 // and its exit code without judging either, which is what Signatures needs: for
 // pdfsig a non-zero exit is as often an answer about the document as it is a

--- a/daggerverse/pdf/fanout/fanout.go
+++ b/daggerverse/pdf/fanout/fanout.go
@@ -1,6 +1,12 @@
 // Package fanout runs a bounded, fail-fast set of concurrent units of work, and
 // partitions a document's pages into the units that run them.
 //
+// RunSlices is the entry point and does both in one call, taking the bound once.
+// Run and Partition are the primitives it is built from and are exported because
+// each is meaningful alone — Run for work that is already a flat count of units,
+// Partition for a caller that needs the boundaries themselves — but a caller
+// passing the same bound to both wants RunSlices.
+//
 // It is a package of its own, importing no dagger, for a reason that is not
 // tidiness: it is the only way these properties are covered at all. poppler will
 // not produce the failure that exercises them. Measured against poppler 25.12 —

--- a/daggerverse/pdf/fanout/fanout.go
+++ b/daggerverse/pdf/fanout/fanout.go
@@ -1,5 +1,5 @@
-// Package fanout runs a bounded, fail-fast set of concurrent units of work,
-// which is what turns a document's pages into one render each.
+// Package fanout runs a bounded, fail-fast set of concurrent units of work, and
+// partitions a document's pages into the units that run them.
 //
 // It is a package of its own, importing no dagger, for a reason that is not
 // tidiness: it is the only way these properties are covered at all. poppler will

--- a/daggerverse/pdf/fanout/partition.go
+++ b/daggerverse/pdf/fanout/partition.go
@@ -1,5 +1,7 @@
 package fanout
 
+import "context"
+
 // Slice is a contiguous run of units, half-open: the units at indices Start
 // through End-1.
 //
@@ -63,4 +65,54 @@ func Partition(count, workers int) []Slice {
 		start += n
 	}
 	return slices
+}
+
+// RunSlices splits items into at most workers contiguous slices, runs one unit
+// of work per slice — at most workers of them at a time — and returns each
+// unit's result positionally, in slice order.
+//
+// It is the whole of the fan-out in one call, and that is deliberate: the bound
+// is one number that means one thing, and a caller cannot partition by one
+// figure and schedule by another. Pairing Partition with Run by hand is what
+// this replaces; the two are still exported because each is meaningful alone —
+// Run for work that is already a flat count of units, Partition for a caller
+// that needs the boundaries themselves — but nothing should be passing the same
+// bound to both.
+//
+// run receives its slice of items and nothing else. It needs no index: the
+// results come back in the order the slices were cut, so position in the
+// returned slice is position in items, and whatever identifies the work is in
+// the items themselves.
+//
+// Everything Run promises holds here. The bound is a ceiling on units in flight,
+// the first failure is the error returned and cancels the rest, and no result is
+// returned at all when one unit fails — a partial fan-out is not a partial
+// answer, it is an answer with a hole in it.
+//
+// Empty items yields no units and no results, which is a fan-out with nothing to
+// do rather than an error; the render family refuses that case by name long
+// before it reaches here.
+func RunSlices[In, Out any](
+	ctx context.Context,
+	workers int,
+	items []In,
+	run func(ctx context.Context, items []In) (Out, error),
+) ([]Out, error) {
+	slices := Partition(len(items), workers)
+	out := make([]Out, len(slices))
+
+	// Each unit writes only its own element, and Run does not return until every
+	// unit it started has, so the slice needs no lock of its own.
+	err := Run(ctx, workers, len(slices), func(ctx context.Context, i int) error {
+		result, err := run(ctx, items[slices[i].Start:slices[i].End])
+		if err != nil {
+			return err
+		}
+		out[i] = result
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }

--- a/daggerverse/pdf/fanout/partition.go
+++ b/daggerverse/pdf/fanout/partition.go
@@ -1,0 +1,66 @@
+package fanout
+
+// Slice is a contiguous run of units, half-open: the units at indices Start
+// through End-1.
+//
+// It is contiguous rather than strided — unit i to worker i%n would balance
+// just as well — because the units are a document's pages in page order, and a
+// slice of consecutive pages is the one shape whose exec both reads and writes
+// a run a human can name.
+type Slice struct {
+	// Start is the index of the slice's first unit.
+	Start int
+	// End is one past the index of its last.
+	End int
+}
+
+// Len is how many units the slice covers.
+func (s Slice) Len() int {
+	return s.End - s.Start
+}
+
+// Partition splits count units into at most workers contiguous slices, each as
+// close to the same size as the division allows.
+//
+// This is the whole of what keeps a conversion's exec count off the page count.
+// A directory produced by an exec is *one* snapshot however many files that
+// exec wrote, so the overlayfs chain a fold builds is as deep as the number of
+// execs folded and no deeper — and containerd refuses to mount a chain whose
+// compacted lowerdir list exceeds one page of joined mount data, which a
+// three-thousand-page document reached at around 440 folds. Handing each exec a
+// slice rather than a page makes the ceiling a property of the machine's core
+// count, which does not grow with the document.
+//
+// Fewer units than workers gives one unit per slice rather than empty slices at
+// the end: an exec with no pages to render is a container created to do nothing.
+// Zero units gives no slices at all, which is a conversion with nothing to do —
+// the render family refuses that by name long before it reaches here.
+//
+// The bigger slices come first, which is arbitrary but fixed: what matters is
+// that one (count, workers) always partitions the same way, so two conversions
+// of the same document under the same bound produce the same execs and hit the
+// same cache entries.
+func Partition(count, workers int) []Slice {
+	if count <= 0 {
+		return nil
+	}
+	if workers < 1 {
+		workers = 1
+	}
+	if workers > count {
+		workers = count
+	}
+
+	size, extra := count/workers, count%workers
+	slices := make([]Slice, 0, workers)
+	start := 0
+	for i := range workers {
+		n := size
+		if i < extra {
+			n++
+		}
+		slices = append(slices, Slice{Start: start, End: start + n})
+		start += n
+	}
+	return slices
+}

--- a/daggerverse/pdf/fanout/selfcheck.go
+++ b/daggerverse/pdf/fanout/selfcheck.go
@@ -16,9 +16,10 @@ const selfCheckTimeout = 30 * time.Second
 // SelfCheck verifies the properties a render depends on and no fixture can
 // exercise: that every page runs, that the bound is honoured in both directions,
 // that a failure in the middle is the error reported, that it stops the pages
-// behind it from starting, and that a document of any length partitions into no
-// more slices than the bound allows. See the package comment for why this is a
-// self-check rather than a test against a document.
+// behind it from starting, that a document of any length partitions into no more
+// slices than the bound allows, and that RunSlices — the one call the module
+// actually makes — holds all of that together. See the package comment for why
+// this is a self-check rather than a test against a document.
 //
 // It is exposed as a Dagger check so a regression fails CI. The same cases run
 // under `go test -race`, which is where the concurrency itself is checked.
@@ -50,6 +51,10 @@ func selfCheckCases() []selfCheckCase {
 		{"a partition's slices differ in size by at most one", checkPartitionIsBalanced},
 		{"a partition holds no empty slice", checkPartitionHasNoEmptySlice},
 		{"a partition is the same every time", checkPartitionIsStable},
+		{"run-slices hands each unit its own contiguous run of items", checkRunSlicesCoversItems},
+		{"run-slices returns one result per slice, in slice order", checkRunSlicesResultsAreOrdered},
+		{"run-slices returns no results when a unit fails", checkRunSlicesFailureReturnsNothing},
+		{"run-slices honours the bound", checkRunSlicesHonoursTheBound},
 	}
 }
 
@@ -342,6 +347,143 @@ func checkPartitionIsStable() error {
 					count, workers, i, first[i], second[i])
 			}
 		}
+	}
+	return nil
+}
+
+// checkRunSlicesCoversItems is the property a rendered directory rests on end to
+// end: every item reaches exactly one unit, units see contiguous runs, and the
+// runs concatenate back into the original in order. A fan-out that dropped or
+// duplicated an item here would produce a directory short a page or holding one
+// twice, which is the silent failure this whole package exists to refuse.
+func checkRunSlicesCoversItems() error {
+	for _, shape := range partitionShapes() {
+		count, workers := shape[0], shape[1]
+
+		items := make([]int, count)
+		for i := range items {
+			items[i] = i + 1
+		}
+		seen, err := RunSlices(context.Background(), workers, items,
+			func(_ context.Context, got []int) ([]int, error) { return got, nil })
+		if err != nil {
+			return fmt.Errorf("RunSlices over %d items at %d workers: %w", count, workers, err)
+		}
+
+		var flat []int
+		for _, run := range seen {
+			if len(run) == 0 {
+				return fmt.Errorf(
+					"RunSlices over %d items at %d workers: a unit was handed no items",
+					count, workers)
+			}
+			flat = append(flat, run...)
+		}
+		if len(flat) != count {
+			return fmt.Errorf(
+				"RunSlices over %d items at %d workers: the units saw %d items",
+				count, workers, len(flat))
+		}
+		for i, v := range flat {
+			if v != i+1 {
+				return fmt.Errorf(
+					"RunSlices over %d items at %d workers: item %d of the concatenated runs is %d",
+					count, workers, i, v)
+			}
+		}
+	}
+	return nil
+}
+
+// checkRunSlicesResultsAreOrdered asserts the results come back in slice order
+// whatever order the units finished in, which is what lets a caller fold them
+// without sorting. The first unit is made to finish last, so a fan-out that
+// appended results as they arrived would fail here and pass on a serial run.
+func checkRunSlicesResultsAreOrdered() error {
+	const (
+		workers = 4
+		count   = 4
+	)
+
+	items := []int{1, 2, 3, 4}
+	got, err := RunSlices(context.Background(), workers, items,
+		func(_ context.Context, run []int) (int, error) {
+			if run[0] == 1 {
+				time.Sleep(20 * time.Millisecond)
+			}
+			return run[0], nil
+		})
+	if err != nil {
+		return err
+	}
+	if len(got) != count {
+		return fmt.Errorf("expected %d results, got %d", count, len(got))
+	}
+	for i, v := range got {
+		if v != items[i] {
+			return fmt.Errorf("result %d is %d, expected %d", i, v, items[i])
+		}
+	}
+	return nil
+}
+
+// checkRunSlicesFailureReturnsNothing asserts a failed fan-out returns the
+// failing unit's own error and no results at all. A partial slice of results is
+// an answer with a hole in it, and a caller folding it would assemble a
+// directory missing whatever the failed unit was carrying.
+func checkRunSlicesFailureReturnsNothing() error {
+	failure := errors.New("this page could not be rendered")
+
+	items := make([]int, 40)
+	got, err := RunSlices(context.Background(), 4, items,
+		func(_ context.Context, _ []int) (string, error) { return "rendered", failure })
+	if !errors.Is(err, failure) {
+		return fmt.Errorf("expected the failing unit's error, got: %v", err)
+	}
+	if got != nil {
+		return fmt.Errorf("expected no results beside the error, got %v", got)
+	}
+	return nil
+}
+
+// checkRunSlicesHonoursTheBound asserts the single bound reaches both halves:
+// never more than workers units in flight, and never more than workers units at
+// all however long the item list is. The second is the one #370 turned on — a
+// three-thousand-page conversion creating three thousand containers to run
+// sixteen is what it exists to refuse.
+func checkRunSlicesHonoursTheBound() error {
+	const (
+		workers = 3
+		count   = 3000
+	)
+
+	var live, peak, units atomic.Int64
+	items := make([]int, count)
+	got, err := RunSlices(context.Background(), workers, items,
+		func(_ context.Context, _ []int) (int, error) {
+			units.Add(1)
+			n := live.Add(1)
+			for {
+				high := peak.Load()
+				if n <= high || peak.CompareAndSwap(high, n) {
+					break
+				}
+			}
+			time.Sleep(time.Millisecond)
+			live.Add(-1)
+			return 0, nil
+		})
+	if err != nil {
+		return err
+	}
+	if p := peak.Load(); p > workers {
+		return fmt.Errorf("expected at most %d units in flight, saw %d", workers, p)
+	}
+	if n := units.Load(); n != workers {
+		return fmt.Errorf("expected %d items to run in %d units, got %d", count, workers, n)
+	}
+	if len(got) != workers {
+		return fmt.Errorf("expected %d results, got %d", workers, len(got))
 	}
 	return nil
 }

--- a/daggerverse/pdf/fanout/selfcheck.go
+++ b/daggerverse/pdf/fanout/selfcheck.go
@@ -15,8 +15,9 @@ const selfCheckTimeout = 30 * time.Second
 
 // SelfCheck verifies the properties a render depends on and no fixture can
 // exercise: that every page runs, that the bound is honoured in both directions,
-// that a failure in the middle is the error reported, and that it stops the
-// pages behind it from starting. See the package comment for why this is a
+// that a failure in the middle is the error reported, that it stops the pages
+// behind it from starting, and that a document of any length partitions into no
+// more slices than the bound allows. See the package comment for why this is a
 // self-check rather than a test against a document.
 //
 // It is exposed as a Dagger check so a regression fails CI. The same cases run
@@ -44,6 +45,11 @@ func selfCheckCases() []selfCheckCase {
 		{"a failure in the middle is the error reported", checkMiddleFailureIsReported},
 		{"the first failure stops the rest from starting", checkFailureStopsTheRest},
 		{"a bound below one still renders", checkBoundBelowOne},
+		{"a partition covers every page once, in order", checkPartitionCoversEveryUnit},
+		{"a partition is never wider than the bound", checkPartitionIsBoundedByWorkers},
+		{"a partition's slices differ in size by at most one", checkPartitionIsBalanced},
+		{"a partition holds no empty slice", checkPartitionHasNoEmptySlice},
+		{"a partition is the same every time", checkPartitionIsStable},
 	}
 }
 
@@ -213,6 +219,129 @@ func checkFailureStopsTheRest() error {
 		return fmt.Errorf(
 			"expected at most the %d units already in flight to run, got %d of %d",
 			workers, n, count)
+	}
+	return nil
+}
+
+// partitionShapes is the (pages, bound) grid every partition property is
+// checked over. It is deliberately lopsided: the document far longer than the
+// bound is the case the exec count has to stay off, the document shorter than
+// the bound is the ordinary one — most documents are shorter than a machine's
+// core count — and the exact multiple is where an off-by-one in the remainder
+// hides.
+func partitionShapes() [][2]int {
+	return [][2]int{
+		{1, 1}, {1, 16}, {2, 16}, {12, 4}, {15, 4}, {16, 16}, {17, 16},
+		{48, 5}, {129, 32}, {437, 16}, {440, 16}, {3000, 16}, {3000, 1}, {200000, 12},
+	}
+}
+
+// checkPartitionCoversEveryUnit pins what the assembled directory rests on: the
+// slices tile the pages exactly, in order, with nothing repeated and nothing
+// dropped. A partition that lost a page would produce a directory short a page,
+// which is the silent failure the whole render family is built to refuse.
+func checkPartitionCoversEveryUnit() error {
+	for _, shape := range partitionShapes() {
+		count, workers := shape[0], shape[1]
+		next := 0
+		for i, s := range Partition(count, workers) {
+			if s.Start != next {
+				return fmt.Errorf(
+					"Partition(%d, %d): slice %d starts at %d, expected %d",
+					count, workers, i, s.Start, next)
+			}
+			next = s.End
+		}
+		if next != count {
+			return fmt.Errorf(
+				"Partition(%d, %d): the slices cover %d units, expected %d",
+				count, workers, next, count)
+		}
+	}
+	if s := Partition(0, 4); s != nil {
+		return fmt.Errorf("Partition(0, 4): expected no slices, got %v", s)
+	}
+	return nil
+}
+
+// checkPartitionIsBoundedByWorkers is the property the fold depth rests on, and
+// the one the containerd mount-data ceiling is a consequence of: however long
+// the document, a conversion folds no more directories than its bound allows.
+func checkPartitionIsBoundedByWorkers() error {
+	for _, shape := range partitionShapes() {
+		count, workers := shape[0], shape[1]
+		if n := len(Partition(count, workers)); n > max(workers, 1) {
+			return fmt.Errorf(
+				"Partition(%d, %d): expected at most %d slices, got %d",
+				count, workers, workers, n)
+		}
+	}
+	// A bound below one is nonsensical and the module rejects it by name; this
+	// is the floor under that, and it must not be an unbounded fan-out.
+	if n := len(Partition(3000, 0)); n != 1 {
+		return fmt.Errorf("Partition(3000, 0): expected 1 slice, got %d", n)
+	}
+	return nil
+}
+
+// checkPartitionIsBalanced asserts no exec is handed materially more of the
+// document than another, which is what keeps the conversion's wall clock at the
+// slowest slice rather than at the longest one.
+func checkPartitionIsBalanced() error {
+	for _, shape := range partitionShapes() {
+		count, workers := shape[0], shape[1]
+		slices := Partition(count, workers)
+		smallest, largest := slices[0].Len(), slices[0].Len()
+		for _, s := range slices {
+			smallest = min(smallest, s.Len())
+			largest = max(largest, s.Len())
+		}
+		if largest-smallest > 1 {
+			return fmt.Errorf(
+				"Partition(%d, %d): slices run from %d to %d units, expected a spread of at most 1",
+				count, workers, smallest, largest)
+		}
+	}
+	return nil
+}
+
+// checkPartitionHasNoEmptySlice asserts a document shorter than the bound gets
+// one slice per page rather than a tail of empty ones. An empty slice is a
+// container created to render nothing, which is exactly the waste this
+// partitioning exists to delete.
+func checkPartitionHasNoEmptySlice() error {
+	for _, shape := range partitionShapes() {
+		count, workers := shape[0], shape[1]
+		for i, s := range Partition(count, workers) {
+			if s.Len() < 1 {
+				return fmt.Errorf(
+					"Partition(%d, %d): slice %d covers %d units",
+					count, workers, i, s.Len())
+			}
+		}
+	}
+	return nil
+}
+
+// checkPartitionIsStable asserts the same arguments always partition the same
+// way. Two conversions of one document under one bound have to produce the same
+// execs, or neither ever hits the other's cache entries.
+func checkPartitionIsStable() error {
+	for _, shape := range partitionShapes() {
+		count, workers := shape[0], shape[1]
+		first, second := Partition(count, workers), Partition(count, workers)
+		if len(first) != len(second) {
+			return fmt.Errorf(
+				"Partition(%d, %d): repeated calls returned %d and %d slices",
+				count, workers, len(first), len(second))
+		}
+		for i := range first {
+			if first[i] != second[i] {
+				return fmt.Errorf(
+					"Partition(%d, %d): slice %d came back as %v and then %v",
+					count, workers, i, first[i], second[i])
+			}
+		}
 	}
 	return nil
 }

--- a/daggerverse/pdf/main.go
+++ b/daggerverse/pdf/main.go
@@ -93,6 +93,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -199,6 +200,23 @@ const (
 	// at once, and so the smallest bound WithConcurrency accepts: zero pages at
 	// a time renders nothing at all.
 	minRenderConcurrency = 1
+
+	// pageFailureFn is the shell function a slice's script routes a failed page
+	// through, and pageFailureMarker the line it prints. Together they are how a
+	// slice of pages rendered in one exec still fails by the page's own name:
+	// the exec carries several pages, so the page cannot come from the label Go
+	// chose for it, and the script is the only thing that knows which command
+	// was running. The marker is stripped back out of stderr before the message
+	// is built — see takeFailedPage — so it names the page without appearing in
+	// what the caller reads.
+	//
+	// The page reaches the function as `$1` and the tool's own exit status as
+	// `$2`, which is re-raised unchanged: a caller reading `exit 99` should be
+	// reading poppler's 99 and not a code this module invented. Inside a shell
+	// function the positional parameters are the function's own, so this does
+	// not collide with any argument a script is run with.
+	pageFailureFn     = "_pdf_page_failed"
+	pageFailureMarker = "pdf-module-page-failed:"
 
 	// defaultDpi is the resolution pages are rendered at when the caller names
 	// none, and is pdftoppm's own default. It is a screen-reading resolution
@@ -425,10 +443,12 @@ func (p *Pdf) Version(ctx context.Context) (string, error) {
 	return strings.TrimSpace(strings.TrimPrefix(first, "pdftotext version")), nil
 }
 
-// RenderSchedulingSelfTest verifies the properties the per-page render fan-out
-// depends on: that every page runs, that WithConcurrency is honoured as both a
-// ceiling and a floor, that a failure partway through is the error reported, and
-// that it stops the pages behind it from starting.
+// RenderSchedulingSelfTest verifies the properties the render fan-out depends
+// on: that every page runs, that WithConcurrency is honoured as both a ceiling
+// and a floor, that a failure partway through is the error reported, that it
+// stops the pages behind it from starting, that a document of any length splits
+// into no more slices than the bound allows, and that a page's failure is still
+// readable back out of the exec that rendered several pages.
 //
 // It sits on the module rather than in the test module because it checks
 // unexported scheduling, and it exists at all because no document can check it.
@@ -438,12 +458,16 @@ func (p *Pdf) Version(ctx context.Context) (string, error) {
 // warning on stderr and an exit status of 0. So the fail-fast has no fixture
 // that would exercise it, and this is what covers it instead.
 //
+// The exec count is here for a different reason: the shape that breaks it is a
+// three-thousand-page document, which is not a fixture any suite should render
+// to learn that a slice count is bounded.
+//
 // It runs in-process and needs no container, so it is cheap enough to be a check
 // of its own.
 //
 // +check
 func (p *Pdf) RenderSchedulingSelfTest(ctx context.Context) error {
-	return fanout.SelfCheck()
+	return errors.Join(fanout.SelfCheck(), renderSelfCheck())
 }
 
 // Document binds one PDF to the toolchain.

--- a/daggerverse/pdf/render_selfcheck.go
+++ b/daggerverse/pdf/render_selfcheck.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// renderSelfCheck verifies the two halves of a slice's script that no document
+// can exercise: that the per-page commands survive being concatenated into one
+// exec, and that a page's failure is still readable back out of what that exec
+// printed.
+//
+// It sits beside the fanout package's self-check and for the same reason.
+// poppler will not fail a page — measured against the pinned poppler 25.12,
+// every damaged page shape is a warning on stderr and an exit status of 0 — so
+// no fixture makes one page of a slice fail, and the reporting has to be checked
+// where it is built instead. The script assembly is checked here rather than
+// through a render because a passing render proves the commands ran, not that
+// each one is still the page's own invocation.
+//
+// Unlike fanout's, these cases cannot also be a `go test`: they read unexported
+// values of package main, and package main imports the generated client, whose
+// package initializer panics outside a Dagger session. The check is the only way
+// to run them, which is why it is one.
+func renderSelfCheck() error {
+	var errs []error
+	for _, c := range renderSelfCheckCases() {
+		if err := c.run(); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", c.name, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+type renderSelfCheckCase struct {
+	name string
+	run  func() error
+}
+
+func renderSelfCheckCases() []renderSelfCheckCase {
+	return []renderSelfCheckCase{
+		{"a slice's script runs the prelude once and every page's command in order", checkSliceScriptShape},
+		{"every page's command is guarded by its own page number", checkSliceScriptNamesEveryPage},
+		{"a reported page is read back and taken out of stderr", checkFailedPageIsReadBack},
+		{"stderr with no report yields no page", checkNoReportYieldsNoPage},
+	}
+}
+
+// sliceScriptFixture is the shape a family hands render: a prelude and three
+// pages' commands. The commands are not poppler's, deliberately — what is being
+// checked is that whatever a family generated survives verbatim.
+func sliceScriptFixture() (prelude []string, jobs []pageJob) {
+	return []string{"mkdir -p /out", "cd /out"}, []pageJob{
+		{page: 7, command: "render-seven"},
+		{page: 8, command: "render-eight"},
+		{page: 9, command: "render-nine"},
+	}
+}
+
+// checkSliceScriptShape pins that the prelude is written once however many pages
+// share the exec, and that the commands follow it in page order. A prelude
+// repeated per page would be harmless; a prelude that moved below a command
+// would render into a directory that does not exist yet.
+func checkSliceScriptShape() error {
+	prelude, jobs := sliceScriptFixture()
+	script := sliceScript(prelude, jobs)
+
+	for _, line := range prelude {
+		if n := strings.Count(script, "\n"+line+"\n"); n != 1 {
+			return fmt.Errorf("expected the prelude line %q exactly once, got %d:\n%s", line, n, script)
+		}
+	}
+	at := make([]int, 0, len(jobs))
+	for _, job := range jobs {
+		i := strings.Index(script, job.command)
+		if i < 0 {
+			return fmt.Errorf("expected page %d's command %q in the script:\n%s", job.page, job.command, script)
+		}
+		at = append(at, i)
+	}
+	for i := 1; i < len(at); i++ {
+		if at[i] <= at[i-1] {
+			return fmt.Errorf(
+				"expected page %d's command after page %d's, got the reverse:\n%s",
+				jobs[i].page, jobs[i-1].page, script)
+		}
+	}
+	if last := strings.Index(script, jobs[0].command); last < strings.Index(script, prelude[len(prelude)-1]) {
+		return fmt.Errorf("expected the whole prelude above the first command:\n%s", script)
+	}
+	return nil
+}
+
+// checkSliceScriptNamesEveryPage is the property a failure's message rests on:
+// every command is followed by the guard that reports *its* page, so a slice of
+// twelve pages that fails on the fourth says four.
+func checkSliceScriptNamesEveryPage() error {
+	prelude, jobs := sliceScriptFixture()
+	script := sliceScript(prelude, jobs)
+
+	for _, job := range jobs {
+		want := fmt.Sprintf("%s || %s %d $?", job.command, pageFailureFn, job.page)
+		if !strings.Contains(script, want) {
+			return fmt.Errorf("expected the script to carry %q:\n%s", want, script)
+		}
+	}
+	if !strings.Contains(script, pageFailureFn+"() {") {
+		return fmt.Errorf("expected the script to define %s:\n%s", pageFailureFn, script)
+	}
+	// The guard re-raises the tool's own status rather than one of this
+	// module's, which is what keeps `exit 99` poppler's 99.
+	if !strings.Contains(script, `exit "$2"`) {
+		return fmt.Errorf("expected the guard to re-raise the command's exit status:\n%s", script)
+	}
+	return nil
+}
+
+// checkFailedPageIsReadBack asserts the round trip the message depends on: the
+// page comes back as a number, and the line carrying it does not come back as
+// part of what the caller reads.
+func checkFailedPageIsReadBack() error {
+	stderr := strings.Join([]string{
+		"Syntax Error: Couldn't find trailer dictionary",
+		pageFailureMarker + "413",
+	}, "\n")
+
+	page, rest := takeFailedPage(stderr)
+	if page != 413 {
+		return fmt.Errorf("expected page 413, got %d", page)
+	}
+	if strings.Contains(rest, pageFailureMarker) {
+		return fmt.Errorf("expected the report to be taken out of stderr, got:\n%s", rest)
+	}
+	if !strings.Contains(rest, "Syntax Error") {
+		return fmt.Errorf("expected poppler's own message to survive, got:\n%s", rest)
+	}
+	return nil
+}
+
+// checkNoReportYieldsNoPage asserts the other half: a failure that never reached
+// a page reports no page, so the message names the run of pages rather than
+// inventing one of them.
+func checkNoReportYieldsNoPage() error {
+	for _, stderr := range []string{
+		"",
+		"mkdir: can't create directory '/out': Read-only file system",
+		pageFailureMarker + "not-a-number",
+	} {
+		if page, _ := takeFailedPage(stderr); page != 0 {
+			return fmt.Errorf("expected no page from %q, got %d", stderr, page)
+		}
+	}
+	return nil
+}

--- a/daggerverse/pdf/tests/internal/dagger/pdf.gen.go
+++ b/daggerverse/pdf/tests/internal/dagger/pdf.gen.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Retrieve the binding value, as type Pdf
-func (r *Binding) AsPdf() *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:254:6)
+func (r *Binding) AsPdf() *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:272:6)
 	q := r.query.Select("asPdf")
 
 	return &Pdf{
@@ -86,7 +86,7 @@ func (r *Env) WithPdfDocumentOutput(name string, description string) *Env { // p
 }
 
 // Create or update a binding of type Pdf in the environment
-func (r *Env) WithPdfInput(name string, value *Pdf, description string) *Env { // pdf (../../../../../daggerverse/pdf/main.go:254:6)
+func (r *Env) WithPdfInput(name string, value *Pdf, description string) *Env { // pdf (../../../../../daggerverse/pdf/main.go:272:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withPdfInput")
 	q = q.Arg("name", name)
@@ -99,7 +99,7 @@ func (r *Env) WithPdfInput(name string, value *Pdf, description string) *Env { /
 }
 
 // Declare a desired Pdf output to be assigned in the environment
-func (r *Env) WithPdfOutput(name string, description string) *Env { // pdf (../../../../../daggerverse/pdf/main.go:254:6)
+func (r *Env) WithPdfOutput(name string, description string) *Env { // pdf (../../../../../daggerverse/pdf/main.go:272:6)
 	q := r.query.Select("withPdfOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -113,7 +113,7 @@ func (r *Env) WithPdfOutput(name string, description string) *Env { // pdf (../.
 // carries the image coordinates and the fonts the image is built with;
 // Document hangs off it so the generated SDK surfaces conversion under
 // `dag.Pdf().Document(...)`.
-type Pdf struct { // pdf (../../../../../daggerverse/pdf/main.go:254:6)
+type Pdf struct { // pdf (../../../../../daggerverse/pdf/main.go:272:6)
 	query *querybuilder.Selection
 
 	id                       *ID
@@ -141,7 +141,7 @@ func (r *Pdf) WithGraphQLQuery(q *querybuilder.Selection) *Pdf {
 // reachable via `container with-exec` — as do the flags of a wrapped tool that
 // this module does not surface, `pdffonts -subst` and `pdfdetach -savefile`
 // among them.
-func (r *Pdf) Container() *Container { // pdf (../../../../../daggerverse/pdf/main.go:400:1)
+func (r *Pdf) Container() *Container { // pdf (../../../../../daggerverse/pdf/main.go:418:1)
 	q := r.query.Select("container")
 
 	return &Container{
@@ -154,7 +154,7 @@ func (r *Pdf) Container() *Container { // pdf (../../../../../daggerverse/pdf/ma
 // The boundary input is a *dagger.File rather than a *dagger.Directory: a PDF
 // resolves nothing relative to its own location, so one file is the whole unit
 // of work however many pages it carries.
-func (r *Pdf) Document(source *File) *PdfDocument { // pdf (../../../../../daggerverse/pdf/main.go:454:1)
+func (r *Pdf) Document(source *File) *PdfDocument { // pdf (../../../../../daggerverse/pdf/main.go:478:1)
 	assertNotNil("source", source)
 	q := r.query.Select("document")
 	q = q.Arg("source", source)
@@ -248,10 +248,12 @@ func (r *Pdf) Merge(sources []*File) *File { // pdf (../../../../../daggerverse/
 	}
 }
 
-// RenderSchedulingSelfTest verifies the properties the per-page render fan-out
-// depends on: that every page runs, that WithConcurrency is honoured as both a
-// ceiling and a floor, that a failure partway through is the error reported, and
-// that it stops the pages behind it from starting.
+// RenderSchedulingSelfTest verifies the properties the render fan-out depends
+// on: that every page runs, that WithConcurrency is honoured as both a ceiling
+// and a floor, that a failure partway through is the error reported, that it
+// stops the pages behind it from starting, that a document of any length splits
+// into no more slices than the bound allows, and that a page's failure is still
+// readable back out of the exec that rendered several pages.
 //
 // It sits on the module rather than in the test module because it checks
 // unexported scheduling, and it exists at all because no document can check it.
@@ -261,9 +263,13 @@ func (r *Pdf) Merge(sources []*File) *File { // pdf (../../../../../daggerverse/
 // warning on stderr and an exit status of 0. So the fail-fast has no fixture
 // that would exercise it, and this is what covers it instead.
 //
+// The exec count is here for a different reason: the shape that breaks it is a
+// three-thousand-page document, which is not a fixture any suite should render
+// to learn that a slice count is bounded.
+//
 // It runs in-process and needs no container, so it is cheap enough to be a check
 // of its own.
-func (r *Pdf) RenderSchedulingSelfTest(ctx context.Context) error { // pdf (../../../../../daggerverse/pdf/main.go:445:1)
+func (r *Pdf) RenderSchedulingSelfTest(ctx context.Context) error { // pdf (../../../../../daggerverse/pdf/main.go:469:1)
 	if r.renderSchedulingSelfTest != nil {
 		return nil
 	}
@@ -274,7 +280,7 @@ func (r *Pdf) RenderSchedulingSelfTest(ctx context.Context) error { // pdf (../.
 
 // Version returns the poppler release the assembled image ships, as the bare
 // version number reported by `pdftotext -v`.
-func (r *Pdf) Version(ctx context.Context) (string, error) { // pdf (../../../../../daggerverse/pdf/main.go:413:1)
+func (r *Pdf) Version(ctx context.Context) (string, error) { // pdf (../../../../../daggerverse/pdf/main.go:431:1)
 	if r.version != nil {
 		return *r.version, nil
 	}
@@ -300,7 +306,7 @@ func (r *Pdf) Version(ctx context.Context) (string, error) { // pdf (../../../..
 // why the credentials are not simply userinfo in the WithApkRepository URL,
 // which would put them in /etc/apk/repositories and in every apk error
 // message that quotes it.
-func (r *Pdf) WithApkAuth(credentials *Secret) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:361:1)
+func (r *Pdf) WithApkAuth(credentials *Secret) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:379:1)
 	assertNotNil("credentials", credentials)
 	q := r.query.Select("withApkAuth")
 	q = q.Arg("credentials", credentials)
@@ -323,7 +329,7 @@ func (r *Pdf) WithApkAuth(credentials *Secret) *Pdf { // pdf (../../../../../dag
 // Repeatable, for a mirror set signed by more than one key. It is a *File
 // rather than a *Secret because a public key is not a credential: it is meant
 // to be in the image, and WithApkAuth is the option for the part that is not.
-func (r *Pdf) WithApkKey(key *File) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:338:1)
+func (r *Pdf) WithApkKey(key *File) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:356:1)
 	assertNotNil("key", key)
 	q := r.query.Select("withApkKey")
 	q = q.Arg("key", key)
@@ -353,7 +359,7 @@ func (r *Pdf) WithApkKey(key *File) *Pdf { // pdf (../../../../../daggerverse/pd
 // call per component. A repository's index is signed, so pair this with
 // WithApkKey unless the mirror is signed by a key the base image already
 // trusts.
-func (r *Pdf) WithApkRepository(url string) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:310:1)
+func (r *Pdf) WithApkRepository(url string) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:328:1)
 	q := r.query.Select("withApkRepository")
 	q = q.Arg("url", url)
 
@@ -377,7 +383,7 @@ func (r *Pdf) WithApkRepository(url string) *Pdf { // pdf (../../../../../dagger
 // /etc/fonts/fonts.conf tells fontconfig to scan, so the faces in it are
 // indistinguishable from packaged ones as far as poppler is concerned. It is
 // mounted rather than copied so a large family does not become an image layer.
-func (r *Pdf) WithFonts(dir *Directory) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:385:1)
+func (r *Pdf) WithFonts(dir *Directory) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:403:1)
 	assertNotNil("dir", dir)
 	q := r.query.Select("withFonts")
 	q = q.Arg("dir", dir)
@@ -434,7 +440,7 @@ type PdfConvertBboxOpts struct {
 	//
 	// Add the block and line boxes poppler groups the words into.
 	//
-	WithLayout bool // pdf (../../../../../daggerverse/pdf/convert.go:268:2)
+	WithLayout bool // pdf (../../../../../daggerverse/pdf/convert.go:276:2)
 }
 
 // Bbox returns the document's text layer as an XHTML report carrying a bounding
@@ -466,7 +472,7 @@ type PdfConvertBboxOpts struct {
 // The render options are ignored, this being an extraction and not a render, and
 // so is LayoutMode: the report's structure is poppler's own and is not the text's
 // reading order. WithPageRange narrows it.
-func (r *PdfConvert) Bbox(opts ...PdfConvertBboxOpts) *File { // pdf (../../../../../daggerverse/pdf/convert.go:264:1)
+func (r *PdfConvert) Bbox(opts ...PdfConvertBboxOpts) *File { // pdf (../../../../../daggerverse/pdf/convert.go:272:1)
 	q := r.query.Select("bbox")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `withLayout` optional argument
@@ -498,7 +504,7 @@ func (r *PdfConvert) Bbox(opts ...PdfConvertBboxOpts) *File { // pdf (../../../.
 //
 // WithDpi governs rasterized regions; WithColorMode, WithScaleTo and
 // WithoutAnnotations are ignored: see the note on Ps.
-func (r *PdfConvert) Eps() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:383:1)
+func (r *PdfConvert) Eps() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:391:1)
 	q := r.query.Select("eps")
 
 	return &Directory{
@@ -525,7 +531,7 @@ func (r *PdfConvert) Eps() *Directory { // pdf (../../../../../daggerverse/pdf/c
 //
 // Every render option is ignored, pdftohtml having no resolution, colour or
 // annotation switch of any kind. WithPageRange narrows it like everything else.
-func (r *PdfConvert) HTML() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:454:1)
+func (r *PdfConvert) HTML() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:462:1)
 	q := r.query.Select("html")
 
 	return &Directory{
@@ -589,7 +595,7 @@ func (r *PdfConvert) UnmarshalJSON(bs []byte) error {
 // Lossy, so it is the format for a preview a human looks at rather than for
 // input another program measures: the artefacts a flat page compresses into sit
 // exactly where thin strokes are, which is where OCR reads.
-func (r *PdfConvert) Jpeg() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:326:1)
+func (r *PdfConvert) Jpeg() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:334:1)
 	q := r.query.Select("jpeg")
 
 	return &Directory{
@@ -603,7 +609,7 @@ func (r *PdfConvert) Jpeg() *Directory { // pdf (../../../../../daggerverse/pdf/
 // PNG is the format to hand another module: it is lossless, so nothing
 // downstream is reading compression artefacts as page content, and it is what
 // every image library reads without a codec question.
-func (r *PdfConvert) Png() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:315:1)
+func (r *PdfConvert) Png() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:323:1)
 	q := r.query.Select("png")
 
 	return &Directory{
@@ -620,8 +626,8 @@ func (r *PdfConvert) Png() *Directory { // pdf (../../../../../daggerverse/pdf/c
 // each individually invalid.
 //
 // That is also why this is the one render that stays a single invocation, and
-// why WithConcurrency does nothing here. Every other page-per-file output fans
-// out one exec per page and assembles the directory afterwards; a PostScript
+// why WithConcurrency does nothing here. Every other page-per-file output runs
+// one invocation per page and assembles the directory afterwards; a PostScript
 // document cannot be assembled that way, because concatenating the fragments is
 // not the same operation as writing the document — the result would need its
 // prologue, its page markers and its `%%Pages:` count rewritten, which is a
@@ -636,7 +642,7 @@ func (r *PdfConvert) Png() *Directory { // pdf (../../../../../daggerverse/pdf/c
 // are dropped rather than forwarded because poppler does not ignore them — it
 // exits non-zero with `-mono may only be used with the -png, -jpeg, or -tiff
 // output options`, and `-hide-annotations` is not a pdftocairo option at all.
-func (r *PdfConvert) Ps() *File { // pdf (../../../../../daggerverse/pdf/convert.go:412:1)
+func (r *PdfConvert) Ps() *File { // pdf (../../../../../daggerverse/pdf/convert.go:420:1)
 	q := r.query.Select("ps")
 
 	return &File{
@@ -664,7 +670,7 @@ func (r *PdfConvert) Ps() *File { // pdf (../../../../../daggerverse/pdf/convert
 // WithDpi governs the rasterized regions a page can still contain — an embedded
 // photograph has no vector form to keep. WithColorMode, WithScaleTo and
 // WithoutAnnotations are ignored: see the note on Ps.
-func (r *PdfConvert) Svg() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:361:1)
+func (r *PdfConvert) Svg() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:369:1)
 	q := r.query.Select("svg")
 
 	return &Directory{
@@ -678,11 +684,11 @@ type PdfConvertTextOpts struct {
 	// How much of the page's physical arrangement survives into the text.
 	// Defaults to reading order.
 	//
-	Layout PdfLayoutMode // pdf (../../../../../daggerverse/pdf/convert.go:182:2)
+	Layout PdfLayoutMode // pdf (../../../../../daggerverse/pdf/convert.go:190:2)
 	//
 	// Emit no form feed between pages.
 	//
-	DisablePageBreaks bool // pdf (../../../../../daggerverse/pdf/convert.go:185:2)
+	DisablePageBreaks bool // pdf (../../../../../daggerverse/pdf/convert.go:193:2)
 }
 
 // Text returns the document's text layer as a string.
@@ -697,7 +703,7 @@ type PdfConvertTextOpts struct {
 // Pages are separated by a form feed (U+000C), including after the last one,
 // which is pdftotext's own convention. Pass disablePageBreaks to drop them, for
 // a consumer that wants one flat stream of text.
-func (r *PdfConvert) Text(ctx context.Context, opts ...PdfConvertTextOpts) (string, error) { // pdf (../../../../../daggerverse/pdf/convert.go:177:1)
+func (r *PdfConvert) Text(ctx context.Context, opts ...PdfConvertTextOpts) (string, error) { // pdf (../../../../../daggerverse/pdf/convert.go:185:1)
 	if r.text != nil {
 		return *r.text, nil
 	}
@@ -726,7 +732,7 @@ func (r *PdfConvert) Text(ctx context.Context, opts ...PdfConvertTextOpts) (stri
 // It is the format the document-imaging world already speaks, and the one to
 // pair with MONO: a bilevel TIFF is what a scanner emits and what an archive
 // expects.
-func (r *PdfConvert) Tiff() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:337:1)
+func (r *PdfConvert) Tiff() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:345:1)
 	q := r.query.Select("tiff")
 
 	return &Directory{
@@ -762,7 +768,7 @@ func (r *PdfConvert) Tiff() *Directory { // pdf (../../../../../daggerverse/pdf/
 // A page with no text layer yields its page row and no word rows rather than a
 // failure, the same boundary Text and Bbox draw. The render options are ignored,
 // as is LayoutMode. WithPageRange narrows it.
-func (r *PdfConvert) Tsv() *File { // pdf (../../../../../daggerverse/pdf/convert.go:305:1)
+func (r *PdfConvert) Tsv() *File { // pdf (../../../../../daggerverse/pdf/convert.go:313:1)
 	q := r.query.Select("tsv")
 
 	return &File{
@@ -776,11 +782,11 @@ type PdfConvertTxtOpts struct {
 	// How much of the page's physical arrangement survives into the text.
 	// Defaults to reading order.
 	//
-	Layout PdfLayoutMode // pdf (../../../../../daggerverse/pdf/convert.go:212:2)
+	Layout PdfLayoutMode // pdf (../../../../../daggerverse/pdf/convert.go:220:2)
 	//
 	// Emit no form feed between pages.
 	//
-	DisablePageBreaks bool // pdf (../../../../../daggerverse/pdf/convert.go:215:2)
+	DisablePageBreaks bool // pdf (../../../../../daggerverse/pdf/convert.go:223:2)
 }
 
 // Txt returns the same text Text returns, as a file rather than a string.
@@ -788,7 +794,7 @@ type PdfConvertTxtOpts struct {
 // Which of the two to reach for is plumbing and nothing more: a file composes
 // with whatever consumes files — another module, an export, a directory being
 // assembled — without the bytes passing through the caller.
-func (r *PdfConvert) Txt(opts ...PdfConvertTxtOpts) *File { // pdf (../../../../../daggerverse/pdf/convert.go:207:1)
+func (r *PdfConvert) Txt(opts ...PdfConvertTxtOpts) *File { // pdf (../../../../../daggerverse/pdf/convert.go:215:1)
 	q := r.query.Select("txt")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `layout` optional argument
@@ -823,31 +829,39 @@ func (r *PdfConvert) WithColorMode(mode PdfColorMode) *PdfConvert { // pdf (../.
 	}
 }
 
-// WithConcurrency bounds how many pages a render converts at once.
+// WithConcurrency bounds how many pages a render converts at once, and with it
+// how many execs the conversion creates.
 //
 // It defaults to the number of CPUs the module can see, which is what a
-// document wants: every page is its own exec, and poppler renders a page on one
-// core whatever the machine has. A 129-page document at 300 dpi spends about a
-// minute of that one core, and the recognition it is usually rendered for
-// spends its own time across every core — so the render is a third of the CPU
-// and two thirds of the wall clock, and the share grows with core count rather
-// than shrinking.
+// document wants: poppler renders a page on one core whatever the machine has.
+// A 129-page document at 300 dpi spends about a minute of that one core, and the
+// recognition it is usually rendered for spends its own time across every core —
+// so the render is a third of the CPU and two thirds of the wall clock, and the
+// share grows with core count rather than shrinking.
 //
 // Unlike the tesseract module's Batch, this bound needs no companion. poppler's
 // tools are single-threaded, so concurrency here is concurrency and not
 // concurrency multiplied by an OpenMP team; the pages contend for cores the way
 // any other CPU-bound workload does.
 //
-// Pass a number to take less of the machine than the default, or 1 to render one
-// page at a time. Non-positive is rejected at output time.
+// Pass a number to take less of the machine than the default, or 1 to render the
+// whole document in one exec, a page at a time. Non-positive is rejected at
+// output time.
 //
-// It is a scheduling bound and nothing else: the directory a conversion returns
-// is the same whatever it is set to. It is also not what decides how the results
-// cache — one exec per page is what does that, at every bound including 1.
+// The two meanings are one setting because they were never independent. The
+// pages are split into this many contiguous slices and each slice is one exec
+// running its pages' invocations in turn, so the bound is at once how many
+// render at a time and how many containers a conversion creates — a
+// three-thousand-page document is this many, not three thousand. It is what
+// decides how the results cache, too: a slice is the unit that hits or misses.
+//
+// What it is still not is a change to the answer. The directory a conversion
+// returns is byte-identical at every bound; concurrency is allowed to change how
+// long a render takes and nothing else.
 //
 // Ignored by Text, Txt, Bbox, Tsv and Ps, none of which renders a page at a
 // time. See Ps for why that one is a single invocation.
-func (r *PdfConvert) WithConcurrency(concurrency int) *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:155:1)
+func (r *PdfConvert) WithConcurrency(concurrency int) *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:163:1)
 	q := r.query.Select("withConcurrency")
 	q = q.Arg("concurrency", concurrency)
 
@@ -1397,18 +1411,18 @@ type PdfOpts struct {
 	//
 	//
 	// Default: "docker.io"
-	Registry string // pdf (../../../../../daggerverse/pdf/main.go:276:2)
+	Registry string // pdf (../../../../../daggerverse/pdf/main.go:294:2)
 	//
 	// Tag of the alpine image the toolchain is assembled on.
 	//
 	//
 	// Default: "3.24"
-	AlpineTag string // pdf (../../../../../daggerverse/pdf/main.go:279:2)
+	AlpineTag string // pdf (../../../../../daggerverse/pdf/main.go:297:2)
 }
 
 // New returns a Pdf module backed by <registry>/library/alpine:<tag> with
 // poppler-utils and a substitute font family installed.
-func (r *Query) Pdf(opts ...PdfOpts) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:271:1)
+func (r *Query) Pdf(opts ...PdfOpts) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:289:1)
 	q := r.query.Select("pdf")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `registry` optional argument

--- a/daggerverse/pdf/tests/internal/dagger/pdf.gen.go
+++ b/daggerverse/pdf/tests/internal/dagger/pdf.gen.go
@@ -440,7 +440,7 @@ type PdfConvertBboxOpts struct {
 	//
 	// Add the block and line boxes poppler groups the words into.
 	//
-	WithLayout bool // pdf (../../../../../daggerverse/pdf/convert.go:276:2)
+	WithLayout bool // pdf (../../../../../daggerverse/pdf/convert.go:284:2)
 }
 
 // Bbox returns the document's text layer as an XHTML report carrying a bounding
@@ -472,7 +472,7 @@ type PdfConvertBboxOpts struct {
 // The render options are ignored, this being an extraction and not a render, and
 // so is LayoutMode: the report's structure is poppler's own and is not the text's
 // reading order. WithPageRange narrows it.
-func (r *PdfConvert) Bbox(opts ...PdfConvertBboxOpts) *File { // pdf (../../../../../daggerverse/pdf/convert.go:272:1)
+func (r *PdfConvert) Bbox(opts ...PdfConvertBboxOpts) *File { // pdf (../../../../../daggerverse/pdf/convert.go:280:1)
 	q := r.query.Select("bbox")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `withLayout` optional argument
@@ -504,7 +504,7 @@ func (r *PdfConvert) Bbox(opts ...PdfConvertBboxOpts) *File { // pdf (../../../.
 //
 // WithDpi governs rasterized regions; WithColorMode, WithScaleTo and
 // WithoutAnnotations are ignored: see the note on Ps.
-func (r *PdfConvert) Eps() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:391:1)
+func (r *PdfConvert) Eps() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:399:1)
 	q := r.query.Select("eps")
 
 	return &Directory{
@@ -531,7 +531,7 @@ func (r *PdfConvert) Eps() *Directory { // pdf (../../../../../daggerverse/pdf/c
 //
 // Every render option is ignored, pdftohtml having no resolution, colour or
 // annotation switch of any kind. WithPageRange narrows it like everything else.
-func (r *PdfConvert) HTML() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:462:1)
+func (r *PdfConvert) HTML() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:470:1)
 	q := r.query.Select("html")
 
 	return &Directory{
@@ -595,7 +595,7 @@ func (r *PdfConvert) UnmarshalJSON(bs []byte) error {
 // Lossy, so it is the format for a preview a human looks at rather than for
 // input another program measures: the artefacts a flat page compresses into sit
 // exactly where thin strokes are, which is where OCR reads.
-func (r *PdfConvert) Jpeg() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:334:1)
+func (r *PdfConvert) Jpeg() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:342:1)
 	q := r.query.Select("jpeg")
 
 	return &Directory{
@@ -609,7 +609,7 @@ func (r *PdfConvert) Jpeg() *Directory { // pdf (../../../../../daggerverse/pdf/
 // PNG is the format to hand another module: it is lossless, so nothing
 // downstream is reading compression artefacts as page content, and it is what
 // every image library reads without a codec question.
-func (r *PdfConvert) Png() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:323:1)
+func (r *PdfConvert) Png() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:331:1)
 	q := r.query.Select("png")
 
 	return &Directory{
@@ -642,7 +642,7 @@ func (r *PdfConvert) Png() *Directory { // pdf (../../../../../daggerverse/pdf/c
 // are dropped rather than forwarded because poppler does not ignore them — it
 // exits non-zero with `-mono may only be used with the -png, -jpeg, or -tiff
 // output options`, and `-hide-annotations` is not a pdftocairo option at all.
-func (r *PdfConvert) Ps() *File { // pdf (../../../../../daggerverse/pdf/convert.go:420:1)
+func (r *PdfConvert) Ps() *File { // pdf (../../../../../daggerverse/pdf/convert.go:428:1)
 	q := r.query.Select("ps")
 
 	return &File{
@@ -670,7 +670,7 @@ func (r *PdfConvert) Ps() *File { // pdf (../../../../../daggerverse/pdf/convert
 // WithDpi governs the rasterized regions a page can still contain — an embedded
 // photograph has no vector form to keep. WithColorMode, WithScaleTo and
 // WithoutAnnotations are ignored: see the note on Ps.
-func (r *PdfConvert) Svg() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:369:1)
+func (r *PdfConvert) Svg() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:377:1)
 	q := r.query.Select("svg")
 
 	return &Directory{
@@ -684,11 +684,11 @@ type PdfConvertTextOpts struct {
 	// How much of the page's physical arrangement survives into the text.
 	// Defaults to reading order.
 	//
-	Layout PdfLayoutMode // pdf (../../../../../daggerverse/pdf/convert.go:190:2)
+	Layout PdfLayoutMode // pdf (../../../../../daggerverse/pdf/convert.go:198:2)
 	//
 	// Emit no form feed between pages.
 	//
-	DisablePageBreaks bool // pdf (../../../../../daggerverse/pdf/convert.go:193:2)
+	DisablePageBreaks bool // pdf (../../../../../daggerverse/pdf/convert.go:201:2)
 }
 
 // Text returns the document's text layer as a string.
@@ -703,7 +703,7 @@ type PdfConvertTextOpts struct {
 // Pages are separated by a form feed (U+000C), including after the last one,
 // which is pdftotext's own convention. Pass disablePageBreaks to drop them, for
 // a consumer that wants one flat stream of text.
-func (r *PdfConvert) Text(ctx context.Context, opts ...PdfConvertTextOpts) (string, error) { // pdf (../../../../../daggerverse/pdf/convert.go:185:1)
+func (r *PdfConvert) Text(ctx context.Context, opts ...PdfConvertTextOpts) (string, error) { // pdf (../../../../../daggerverse/pdf/convert.go:193:1)
 	if r.text != nil {
 		return *r.text, nil
 	}
@@ -732,7 +732,7 @@ func (r *PdfConvert) Text(ctx context.Context, opts ...PdfConvertTextOpts) (stri
 // It is the format the document-imaging world already speaks, and the one to
 // pair with MONO: a bilevel TIFF is what a scanner emits and what an archive
 // expects.
-func (r *PdfConvert) Tiff() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:345:1)
+func (r *PdfConvert) Tiff() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:353:1)
 	q := r.query.Select("tiff")
 
 	return &Directory{
@@ -768,7 +768,7 @@ func (r *PdfConvert) Tiff() *Directory { // pdf (../../../../../daggerverse/pdf/
 // A page with no text layer yields its page row and no word rows rather than a
 // failure, the same boundary Text and Bbox draw. The render options are ignored,
 // as is LayoutMode. WithPageRange narrows it.
-func (r *PdfConvert) Tsv() *File { // pdf (../../../../../daggerverse/pdf/convert.go:313:1)
+func (r *PdfConvert) Tsv() *File { // pdf (../../../../../daggerverse/pdf/convert.go:321:1)
 	q := r.query.Select("tsv")
 
 	return &File{
@@ -782,11 +782,11 @@ type PdfConvertTxtOpts struct {
 	// How much of the page's physical arrangement survives into the text.
 	// Defaults to reading order.
 	//
-	Layout PdfLayoutMode // pdf (../../../../../daggerverse/pdf/convert.go:220:2)
+	Layout PdfLayoutMode // pdf (../../../../../daggerverse/pdf/convert.go:228:2)
 	//
 	// Emit no form feed between pages.
 	//
-	DisablePageBreaks bool // pdf (../../../../../daggerverse/pdf/convert.go:223:2)
+	DisablePageBreaks bool // pdf (../../../../../daggerverse/pdf/convert.go:231:2)
 }
 
 // Txt returns the same text Text returns, as a file rather than a string.
@@ -794,7 +794,7 @@ type PdfConvertTxtOpts struct {
 // Which of the two to reach for is plumbing and nothing more: a file composes
 // with whatever consumes files — another module, an export, a directory being
 // assembled — without the bytes passing through the caller.
-func (r *PdfConvert) Txt(opts ...PdfConvertTxtOpts) *File { // pdf (../../../../../daggerverse/pdf/convert.go:215:1)
+func (r *PdfConvert) Txt(opts ...PdfConvertTxtOpts) *File { // pdf (../../../../../daggerverse/pdf/convert.go:223:1)
 	q := r.query.Select("txt")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `layout` optional argument
@@ -855,13 +855,21 @@ func (r *PdfConvert) WithColorMode(mode PdfColorMode) *PdfConvert { // pdf (../.
 // three-thousand-page document is this many, not three thousand. It is what
 // decides how the results cache, too: a slice is the unit that hits or misses.
 //
-// What it is still not is a change to the answer. The directory a conversion
-// returns is byte-identical at every bound; concurrency is allowed to change how
-// long a render takes and nothing else.
+// What it is still not is a change to the answer. The same pages come back under
+// every bound, named the same way and rendered from the same bytes; concurrency
+// is allowed to change how long a render takes and nothing else.
+//
+// One caveat, and it is the renderer's rather than this module's: cairo stamps
+// the wall clock into every EPS and PS document it writes, as a
+// `%%CreationDate` DSC comment, and honours neither SOURCE_DATE_EPOCH nor any
+// pdftocairo flag. Two Eps renders at different bounds are different execs at
+// different instants, so that one line differs and the directory digests differ
+// with it. Everything drawn is identical. Png, Jpeg, Tiff, Svg and Html carry no
+// timestamp and are byte-identical at every bound.
 //
 // Ignored by Text, Txt, Bbox, Tsv and Ps, none of which renders a page at a
 // time. See Ps for why that one is a single invocation.
-func (r *PdfConvert) WithConcurrency(concurrency int) *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:163:1)
+func (r *PdfConvert) WithConcurrency(concurrency int) *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:171:1)
 	q := r.query.Select("withConcurrency")
 	q = q.Arg("concurrency", concurrency)
 

--- a/daggerverse/pdf/tests/main.go
+++ b/daggerverse/pdf/tests/main.go
@@ -1069,9 +1069,16 @@ func (t *Tests) PsHoldsEveryPageInOneFile(ctx context.Context) error {
 	// Ps is the one render WithConcurrency does not reach, and #370 gave that
 	// setting a second meaning — how many execs a conversion creates — which is
 	// exactly the kind of change that reaches a function documented as being out
-	// of its way. Byte equality across the bound is what says it did not: this
-	// document is written by a single pdftocairo whatever the bound says, and a
-	// Ps that had been fanned out could not produce these bytes at all.
+	// of its way.
+	//
+	// Raw byte equality is the right assertion here precisely because cairo
+	// stamps a wall clock into every PS document it writes (see
+	// RenderConcurrencyAppliesToEveryPerPageFormat). A `Ps` that ignores the
+	// bound is literally the same Dagger query at all three bounds, so it is one
+	// cache entry and one timestamp; a `Ps` that had started reading the bound
+	// would be three different execs at three different instants, and the
+	// `%%CreationDate` alone would fail this even if every drawn byte matched.
+	// The timestamp is the detector, not the noise.
 	for _, n := range []int{1, 4} {
 		got, err := doc.Convert().WithConcurrency(n).Ps().Contents(ctx)
 		if err != nil {
@@ -2999,13 +3006,28 @@ func (t *Tests) RenderConcurrencyMatchesSerialOutput(ctx context.Context) error 
 // markup under pdftohtml's own names — so it is the format whose assembly takes
 // the whole of each render's output rather than one named file, and the format
 // where a fan-out could plausibly lose or collide a file.
+//
+// Eps is compared file by file rather than by digest, and that is not a weaker
+// assertion — it is the only one that has ever meant anything here. **Cairo
+// stamps a wall clock into every EPS and PS it writes**, as a `%%CreationDate`
+// DSC comment on line three, and it honours neither `SOURCE_DATE_EPOCH` nor any
+// pdftocairo flag (measured against the pinned cairo 1.18.4). Until #370 the two
+// bounds produced *literally the same* Dagger query — one exec per page at every
+// bound — so the digests matched because they were one cache entry, and this case
+// asserted nothing about scheduling at all. Now that the bound decides the
+// slicing, the two renders are different execs at different wall-clock instants,
+// and the digests cannot match however deterministic the rendering is. Comparing
+// the bytes with that one line held aside is what actually tests the claim: same
+// names, same rendered content, one field that is a timestamp by construction.
+//
+// Svg and Html keep the digest comparison, cairo's SVG surface and pdftohtml
+// writing no date.
 func (t *Tests) RenderConcurrencyAppliesToEveryPerPageFormat(ctx context.Context) error {
 	for _, tc := range []struct {
 		name   string
 		render func(*dagger.PdfConvert) *dagger.Directory
 	}{
 		{"Svg", func(c *dagger.PdfConvert) *dagger.Directory { return c.Svg() }},
-		{"Eps", func(c *dagger.PdfConvert) *dagger.Directory { return c.Eps() }},
 		// HTML rather than Html: the generated bindings uppercase the acronym.
 		{"Html", func(c *dagger.PdfConvert) *dagger.Directory { return c.HTML() }},
 	} {
@@ -3027,7 +3049,93 @@ func (t *Tests) RenderConcurrencyAppliesToEveryPerPageFormat(ctx context.Context
 				tc.name, concurrent, serial)
 		}
 	}
+
+	conv := pdf().Document(fixture(galleryPdf)).Convert()
+	if err := assertSameRender(ctx, "Eps",
+		conv.WithConcurrency(1).Eps(), conv.WithConcurrency(4).Eps()); err != nil {
+		return err
+	}
 	return nil
+}
+
+// dscCreationDate opens the DSC comment cairo writes its wall clock into. It is
+// the one line of a PS or EPS file that cannot be reproducible.
+const dscCreationDate = "%%CreationDate:"
+
+// assertSameRender compares two renders of one document file by file: identical
+// entry names, and identical bytes once each file's DSC creation date is held
+// aside. It is what a digest comparison would say if cairo did not stamp a
+// timestamp into its own output.
+//
+// The date is required to be present in both rather than merely tolerated when
+// it differs. A render that stopped emitting one — or a comparison quietly
+// passing because both files were empty — would otherwise slip through the
+// normalization, which is the failure mode a "normalize and compare" assertion
+// usually has.
+func assertSameRender(ctx context.Context, label string, serial, concurrent *dagger.Directory) error {
+	serialNames, err := serial.Entries(ctx)
+	if err != nil {
+		return fmt.Errorf("%s one page at a time: %w", label, err)
+	}
+	concurrentNames, err := concurrent.Entries(ctx)
+	if err != nil {
+		return fmt.Errorf("%s four at a time: %w", label, err)
+	}
+	if err := assertPageNames(concurrentNames, serialNames); err != nil {
+		return fmt.Errorf("%s: %s", label, err.Error())
+	}
+
+	serialDir, cleanSerial, err := exportedDir(ctx, serial, "eps-serial")
+	if err != nil {
+		return fmt.Errorf("%s one page at a time: %w", label, err)
+	}
+	defer cleanSerial()
+	concurrentDir, cleanConcurrent, err := exportedDir(ctx, concurrent, "eps-concurrent")
+	if err != nil {
+		return fmt.Errorf("%s four at a time: %w", label, err)
+	}
+	defer cleanConcurrent()
+
+	for _, name := range serialNames {
+		want, err := os.ReadFile(filepath.Join(serialDir, name))
+		if err != nil {
+			return fmt.Errorf("%s: reading %s from the serial render: %w", label, name, err)
+		}
+		got, err := os.ReadFile(filepath.Join(concurrentDir, name))
+		if err != nil {
+			return fmt.Errorf("%s: reading %s from the concurrent render: %w", label, name, err)
+		}
+
+		wantDate, wantRest := takeCreationDate(want)
+		gotDate, gotRest := takeCreationDate(got)
+		if wantDate == "" || gotDate == "" {
+			return fmt.Errorf(
+				"%s: expected %s to carry a %s line in both renders, got %q and %q",
+				label, name, dscCreationDate, wantDate, gotDate)
+		}
+		if !bytes.Equal(wantRest, gotRest) {
+			return fmt.Errorf(
+				"%s: expected %s to be byte-identical whatever the scheduling, apart from its %s; it is not",
+				label, name, dscCreationDate)
+		}
+	}
+	return nil
+}
+
+// takeCreationDate splits a PS or EPS file into the DSC creation-date line and
+// everything else, so the everything-else can be compared exactly.
+func takeCreationDate(file []byte) (date string, rest []byte) {
+	for _, line := range bytes.SplitAfter(file, []byte("\n")) {
+		if bytes.HasPrefix(line, []byte(dscCreationDate)) && date == "" {
+			date = string(bytes.TrimRight(line, "\r\n"))
+			continue
+		}
+		// Only the first is held aside. A second would mean the file is not what
+		// this thinks it is, so it stays in the comparison rather than being
+		// normalized away silently.
+		rest = append(rest, line...)
+	}
+	return date, rest
 }
 
 // SplitWritesOnePdfPerPage asserts Split turns a twelve-page document into

--- a/daggerverse/pdf/tests/main.go
+++ b/daggerverse/pdf/tests/main.go
@@ -1065,6 +1065,24 @@ func (t *Tests) PsHoldsEveryPageInOneFile(ctx context.Context) error {
 		return fmt.Errorf("expected %d page markers for pages %d-%d, got %d",
 			last-first+1, first, last, got)
 	}
+
+	// Ps is the one render WithConcurrency does not reach, and #370 gave that
+	// setting a second meaning — how many execs a conversion creates — which is
+	// exactly the kind of change that reaches a function documented as being out
+	// of its way. Byte equality across the bound is what says it did not: this
+	// document is written by a single pdftocairo whatever the bound says, and a
+	// Ps that had been fanned out could not produce these bytes at all.
+	for _, n := range []int{1, 4} {
+		got, err := doc.Convert().WithConcurrency(n).Ps().Contents(ctx)
+		if err != nil {
+			return fmt.Errorf("Ps at concurrency %d: %w", n, err)
+		}
+		if got != whole {
+			return fmt.Errorf(
+				"expected Ps at concurrency %d to be byte-identical to Ps unbounded, got %d bytes against %d",
+				n, len(got), len(whole))
+		}
+	}
 	return nil
 }
 
@@ -2896,15 +2914,19 @@ func (t *Tests) JpegAndTiffFollowTheSameContract(ctx context.Context) error {
 // and that a bound that would render nothing is refused.
 //
 // Byte equality is the whole promise of the knob: concurrency is allowed to
-// change how long a render takes and nothing else. What it pins now that every
-// page is its own exec is the *assembly* — the pages are collected in page order
-// off execs that finished in whatever order they finished in, so a directory
-// that came out right only because the work happened to be serial would fail
-// here. The digest covers the names and the bytes together.
+// change how long a render takes and nothing else. What it pins now that the
+// bound also decides how the pages are *sliced* into execs is that the slicing
+// is invisible in the answer — the same twelve pages come back whether they were
+// rendered by one exec, four, five or twelve, assembled from directories that
+// finished in whatever order they finished in. The digest covers the names and
+// the bytes together.
 //
-// A bound wider than the document is included because it is the ordinary case
-// for a short document on a large machine: the default is one page per CPU, and
-// most documents are shorter than the core count.
+// Five is in the list because twelve does not divide by it: the slices come out
+// 3, 3, 2, 2, 2, which is the shape an off-by-one in the partition drops a page
+// from. A bound wider than the document is there because it is the ordinary case
+// for a short document on a large machine — the default is one page per CPU, and
+// most documents are shorter than the core count — and it is the shape that must
+// not produce empty execs.
 func (t *Tests) RenderConcurrencyMatchesSerialOutput(ctx context.Context) error {
 	conv := pdf().Document(fixture(ledgerPdf)).Convert()
 
@@ -2925,6 +2947,8 @@ func (t *Tests) RenderConcurrencyMatchesSerialOutput(ctx context.Context) error 
 	}{
 		{"unset, one per CPU", conv.Png()},
 		{"four at a time", conv.WithConcurrency(4).Png()},
+		{"five at a time, which twelve does not divide by", conv.WithConcurrency(5).Png()},
+		{"one exec per page", conv.WithConcurrency(ledgerPages).Png()},
 		{"wider than the document", conv.WithConcurrency(ledgerPages * 4).Png()},
 	} {
 		digest, err := tc.dir.Digest(ctx)

--- a/daggerverse/tesseract/tests/internal/dagger/pdf.gen.go
+++ b/daggerverse/tesseract/tests/internal/dagger/pdf.gen.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Retrieve the binding value, as type Pdf
-func (r *Binding) AsPdf() *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:254:6)
+func (r *Binding) AsPdf() *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:272:6)
 	q := r.query.Select("asPdf")
 
 	return &Pdf{
@@ -86,7 +86,7 @@ func (r *Env) WithPdfDocumentOutput(name string, description string) *Env { // p
 }
 
 // Create or update a binding of type Pdf in the environment
-func (r *Env) WithPdfInput(name string, value *Pdf, description string) *Env { // pdf (../../../../../daggerverse/pdf/main.go:254:6)
+func (r *Env) WithPdfInput(name string, value *Pdf, description string) *Env { // pdf (../../../../../daggerverse/pdf/main.go:272:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withPdfInput")
 	q = q.Arg("name", name)
@@ -99,7 +99,7 @@ func (r *Env) WithPdfInput(name string, value *Pdf, description string) *Env { /
 }
 
 // Declare a desired Pdf output to be assigned in the environment
-func (r *Env) WithPdfOutput(name string, description string) *Env { // pdf (../../../../../daggerverse/pdf/main.go:254:6)
+func (r *Env) WithPdfOutput(name string, description string) *Env { // pdf (../../../../../daggerverse/pdf/main.go:272:6)
 	q := r.query.Select("withPdfOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -113,7 +113,7 @@ func (r *Env) WithPdfOutput(name string, description string) *Env { // pdf (../.
 // carries the image coordinates and the fonts the image is built with;
 // Document hangs off it so the generated SDK surfaces conversion under
 // `dag.Pdf().Document(...)`.
-type Pdf struct { // pdf (../../../../../daggerverse/pdf/main.go:254:6)
+type Pdf struct { // pdf (../../../../../daggerverse/pdf/main.go:272:6)
 	query *querybuilder.Selection
 
 	id                       *ID
@@ -141,7 +141,7 @@ func (r *Pdf) WithGraphQLQuery(q *querybuilder.Selection) *Pdf {
 // reachable via `container with-exec` — as do the flags of a wrapped tool that
 // this module does not surface, `pdffonts -subst` and `pdfdetach -savefile`
 // among them.
-func (r *Pdf) Container() *Container { // pdf (../../../../../daggerverse/pdf/main.go:400:1)
+func (r *Pdf) Container() *Container { // pdf (../../../../../daggerverse/pdf/main.go:418:1)
 	q := r.query.Select("container")
 
 	return &Container{
@@ -154,7 +154,7 @@ func (r *Pdf) Container() *Container { // pdf (../../../../../daggerverse/pdf/ma
 // The boundary input is a *dagger.File rather than a *dagger.Directory: a PDF
 // resolves nothing relative to its own location, so one file is the whole unit
 // of work however many pages it carries.
-func (r *Pdf) Document(source *File) *PdfDocument { // pdf (../../../../../daggerverse/pdf/main.go:454:1)
+func (r *Pdf) Document(source *File) *PdfDocument { // pdf (../../../../../daggerverse/pdf/main.go:478:1)
 	assertNotNil("source", source)
 	q := r.query.Select("document")
 	q = q.Arg("source", source)
@@ -248,10 +248,12 @@ func (r *Pdf) Merge(sources []*File) *File { // pdf (../../../../../daggerverse/
 	}
 }
 
-// RenderSchedulingSelfTest verifies the properties the per-page render fan-out
-// depends on: that every page runs, that WithConcurrency is honoured as both a
-// ceiling and a floor, that a failure partway through is the error reported, and
-// that it stops the pages behind it from starting.
+// RenderSchedulingSelfTest verifies the properties the render fan-out depends
+// on: that every page runs, that WithConcurrency is honoured as both a ceiling
+// and a floor, that a failure partway through is the error reported, that it
+// stops the pages behind it from starting, that a document of any length splits
+// into no more slices than the bound allows, and that a page's failure is still
+// readable back out of the exec that rendered several pages.
 //
 // It sits on the module rather than in the test module because it checks
 // unexported scheduling, and it exists at all because no document can check it.
@@ -261,9 +263,13 @@ func (r *Pdf) Merge(sources []*File) *File { // pdf (../../../../../daggerverse/
 // warning on stderr and an exit status of 0. So the fail-fast has no fixture
 // that would exercise it, and this is what covers it instead.
 //
+// The exec count is here for a different reason: the shape that breaks it is a
+// three-thousand-page document, which is not a fixture any suite should render
+// to learn that a slice count is bounded.
+//
 // It runs in-process and needs no container, so it is cheap enough to be a check
 // of its own.
-func (r *Pdf) RenderSchedulingSelfTest(ctx context.Context) error { // pdf (../../../../../daggerverse/pdf/main.go:445:1)
+func (r *Pdf) RenderSchedulingSelfTest(ctx context.Context) error { // pdf (../../../../../daggerverse/pdf/main.go:469:1)
 	if r.renderSchedulingSelfTest != nil {
 		return nil
 	}
@@ -274,7 +280,7 @@ func (r *Pdf) RenderSchedulingSelfTest(ctx context.Context) error { // pdf (../.
 
 // Version returns the poppler release the assembled image ships, as the bare
 // version number reported by `pdftotext -v`.
-func (r *Pdf) Version(ctx context.Context) (string, error) { // pdf (../../../../../daggerverse/pdf/main.go:413:1)
+func (r *Pdf) Version(ctx context.Context) (string, error) { // pdf (../../../../../daggerverse/pdf/main.go:431:1)
 	if r.version != nil {
 		return *r.version, nil
 	}
@@ -300,7 +306,7 @@ func (r *Pdf) Version(ctx context.Context) (string, error) { // pdf (../../../..
 // why the credentials are not simply userinfo in the WithApkRepository URL,
 // which would put them in /etc/apk/repositories and in every apk error
 // message that quotes it.
-func (r *Pdf) WithApkAuth(credentials *Secret) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:361:1)
+func (r *Pdf) WithApkAuth(credentials *Secret) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:379:1)
 	assertNotNil("credentials", credentials)
 	q := r.query.Select("withApkAuth")
 	q = q.Arg("credentials", credentials)
@@ -323,7 +329,7 @@ func (r *Pdf) WithApkAuth(credentials *Secret) *Pdf { // pdf (../../../../../dag
 // Repeatable, for a mirror set signed by more than one key. It is a *File
 // rather than a *Secret because a public key is not a credential: it is meant
 // to be in the image, and WithApkAuth is the option for the part that is not.
-func (r *Pdf) WithApkKey(key *File) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:338:1)
+func (r *Pdf) WithApkKey(key *File) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:356:1)
 	assertNotNil("key", key)
 	q := r.query.Select("withApkKey")
 	q = q.Arg("key", key)
@@ -353,7 +359,7 @@ func (r *Pdf) WithApkKey(key *File) *Pdf { // pdf (../../../../../daggerverse/pd
 // call per component. A repository's index is signed, so pair this with
 // WithApkKey unless the mirror is signed by a key the base image already
 // trusts.
-func (r *Pdf) WithApkRepository(url string) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:310:1)
+func (r *Pdf) WithApkRepository(url string) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:328:1)
 	q := r.query.Select("withApkRepository")
 	q = q.Arg("url", url)
 
@@ -377,7 +383,7 @@ func (r *Pdf) WithApkRepository(url string) *Pdf { // pdf (../../../../../dagger
 // /etc/fonts/fonts.conf tells fontconfig to scan, so the faces in it are
 // indistinguishable from packaged ones as far as poppler is concerned. It is
 // mounted rather than copied so a large family does not become an image layer.
-func (r *Pdf) WithFonts(dir *Directory) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:385:1)
+func (r *Pdf) WithFonts(dir *Directory) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:403:1)
 	assertNotNil("dir", dir)
 	q := r.query.Select("withFonts")
 	q = q.Arg("dir", dir)
@@ -434,7 +440,7 @@ type PdfConvertBboxOpts struct {
 	//
 	// Add the block and line boxes poppler groups the words into.
 	//
-	WithLayout bool // pdf (../../../../../daggerverse/pdf/convert.go:268:2)
+	WithLayout bool // pdf (../../../../../daggerverse/pdf/convert.go:276:2)
 }
 
 // Bbox returns the document's text layer as an XHTML report carrying a bounding
@@ -466,7 +472,7 @@ type PdfConvertBboxOpts struct {
 // The render options are ignored, this being an extraction and not a render, and
 // so is LayoutMode: the report's structure is poppler's own and is not the text's
 // reading order. WithPageRange narrows it.
-func (r *PdfConvert) Bbox(opts ...PdfConvertBboxOpts) *File { // pdf (../../../../../daggerverse/pdf/convert.go:264:1)
+func (r *PdfConvert) Bbox(opts ...PdfConvertBboxOpts) *File { // pdf (../../../../../daggerverse/pdf/convert.go:272:1)
 	q := r.query.Select("bbox")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `withLayout` optional argument
@@ -498,7 +504,7 @@ func (r *PdfConvert) Bbox(opts ...PdfConvertBboxOpts) *File { // pdf (../../../.
 //
 // WithDpi governs rasterized regions; WithColorMode, WithScaleTo and
 // WithoutAnnotations are ignored: see the note on Ps.
-func (r *PdfConvert) Eps() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:383:1)
+func (r *PdfConvert) Eps() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:391:1)
 	q := r.query.Select("eps")
 
 	return &Directory{
@@ -525,7 +531,7 @@ func (r *PdfConvert) Eps() *Directory { // pdf (../../../../../daggerverse/pdf/c
 //
 // Every render option is ignored, pdftohtml having no resolution, colour or
 // annotation switch of any kind. WithPageRange narrows it like everything else.
-func (r *PdfConvert) HTML() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:454:1)
+func (r *PdfConvert) HTML() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:462:1)
 	q := r.query.Select("html")
 
 	return &Directory{
@@ -589,7 +595,7 @@ func (r *PdfConvert) UnmarshalJSON(bs []byte) error {
 // Lossy, so it is the format for a preview a human looks at rather than for
 // input another program measures: the artefacts a flat page compresses into sit
 // exactly where thin strokes are, which is where OCR reads.
-func (r *PdfConvert) Jpeg() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:326:1)
+func (r *PdfConvert) Jpeg() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:334:1)
 	q := r.query.Select("jpeg")
 
 	return &Directory{
@@ -603,7 +609,7 @@ func (r *PdfConvert) Jpeg() *Directory { // pdf (../../../../../daggerverse/pdf/
 // PNG is the format to hand another module: it is lossless, so nothing
 // downstream is reading compression artefacts as page content, and it is what
 // every image library reads without a codec question.
-func (r *PdfConvert) Png() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:315:1)
+func (r *PdfConvert) Png() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:323:1)
 	q := r.query.Select("png")
 
 	return &Directory{
@@ -620,8 +626,8 @@ func (r *PdfConvert) Png() *Directory { // pdf (../../../../../daggerverse/pdf/c
 // each individually invalid.
 //
 // That is also why this is the one render that stays a single invocation, and
-// why WithConcurrency does nothing here. Every other page-per-file output fans
-// out one exec per page and assembles the directory afterwards; a PostScript
+// why WithConcurrency does nothing here. Every other page-per-file output runs
+// one invocation per page and assembles the directory afterwards; a PostScript
 // document cannot be assembled that way, because concatenating the fragments is
 // not the same operation as writing the document — the result would need its
 // prologue, its page markers and its `%%Pages:` count rewritten, which is a
@@ -636,7 +642,7 @@ func (r *PdfConvert) Png() *Directory { // pdf (../../../../../daggerverse/pdf/c
 // are dropped rather than forwarded because poppler does not ignore them — it
 // exits non-zero with `-mono may only be used with the -png, -jpeg, or -tiff
 // output options`, and `-hide-annotations` is not a pdftocairo option at all.
-func (r *PdfConvert) Ps() *File { // pdf (../../../../../daggerverse/pdf/convert.go:412:1)
+func (r *PdfConvert) Ps() *File { // pdf (../../../../../daggerverse/pdf/convert.go:420:1)
 	q := r.query.Select("ps")
 
 	return &File{
@@ -664,7 +670,7 @@ func (r *PdfConvert) Ps() *File { // pdf (../../../../../daggerverse/pdf/convert
 // WithDpi governs the rasterized regions a page can still contain — an embedded
 // photograph has no vector form to keep. WithColorMode, WithScaleTo and
 // WithoutAnnotations are ignored: see the note on Ps.
-func (r *PdfConvert) Svg() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:361:1)
+func (r *PdfConvert) Svg() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:369:1)
 	q := r.query.Select("svg")
 
 	return &Directory{
@@ -678,11 +684,11 @@ type PdfConvertTextOpts struct {
 	// How much of the page's physical arrangement survives into the text.
 	// Defaults to reading order.
 	//
-	Layout PdfLayoutMode // pdf (../../../../../daggerverse/pdf/convert.go:182:2)
+	Layout PdfLayoutMode // pdf (../../../../../daggerverse/pdf/convert.go:190:2)
 	//
 	// Emit no form feed between pages.
 	//
-	DisablePageBreaks bool // pdf (../../../../../daggerverse/pdf/convert.go:185:2)
+	DisablePageBreaks bool // pdf (../../../../../daggerverse/pdf/convert.go:193:2)
 }
 
 // Text returns the document's text layer as a string.
@@ -697,7 +703,7 @@ type PdfConvertTextOpts struct {
 // Pages are separated by a form feed (U+000C), including after the last one,
 // which is pdftotext's own convention. Pass disablePageBreaks to drop them, for
 // a consumer that wants one flat stream of text.
-func (r *PdfConvert) Text(ctx context.Context, opts ...PdfConvertTextOpts) (string, error) { // pdf (../../../../../daggerverse/pdf/convert.go:177:1)
+func (r *PdfConvert) Text(ctx context.Context, opts ...PdfConvertTextOpts) (string, error) { // pdf (../../../../../daggerverse/pdf/convert.go:185:1)
 	if r.text != nil {
 		return *r.text, nil
 	}
@@ -726,7 +732,7 @@ func (r *PdfConvert) Text(ctx context.Context, opts ...PdfConvertTextOpts) (stri
 // It is the format the document-imaging world already speaks, and the one to
 // pair with MONO: a bilevel TIFF is what a scanner emits and what an archive
 // expects.
-func (r *PdfConvert) Tiff() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:337:1)
+func (r *PdfConvert) Tiff() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:345:1)
 	q := r.query.Select("tiff")
 
 	return &Directory{
@@ -762,7 +768,7 @@ func (r *PdfConvert) Tiff() *Directory { // pdf (../../../../../daggerverse/pdf/
 // A page with no text layer yields its page row and no word rows rather than a
 // failure, the same boundary Text and Bbox draw. The render options are ignored,
 // as is LayoutMode. WithPageRange narrows it.
-func (r *PdfConvert) Tsv() *File { // pdf (../../../../../daggerverse/pdf/convert.go:305:1)
+func (r *PdfConvert) Tsv() *File { // pdf (../../../../../daggerverse/pdf/convert.go:313:1)
 	q := r.query.Select("tsv")
 
 	return &File{
@@ -776,11 +782,11 @@ type PdfConvertTxtOpts struct {
 	// How much of the page's physical arrangement survives into the text.
 	// Defaults to reading order.
 	//
-	Layout PdfLayoutMode // pdf (../../../../../daggerverse/pdf/convert.go:212:2)
+	Layout PdfLayoutMode // pdf (../../../../../daggerverse/pdf/convert.go:220:2)
 	//
 	// Emit no form feed between pages.
 	//
-	DisablePageBreaks bool // pdf (../../../../../daggerverse/pdf/convert.go:215:2)
+	DisablePageBreaks bool // pdf (../../../../../daggerverse/pdf/convert.go:223:2)
 }
 
 // Txt returns the same text Text returns, as a file rather than a string.
@@ -788,7 +794,7 @@ type PdfConvertTxtOpts struct {
 // Which of the two to reach for is plumbing and nothing more: a file composes
 // with whatever consumes files — another module, an export, a directory being
 // assembled — without the bytes passing through the caller.
-func (r *PdfConvert) Txt(opts ...PdfConvertTxtOpts) *File { // pdf (../../../../../daggerverse/pdf/convert.go:207:1)
+func (r *PdfConvert) Txt(opts ...PdfConvertTxtOpts) *File { // pdf (../../../../../daggerverse/pdf/convert.go:215:1)
 	q := r.query.Select("txt")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `layout` optional argument
@@ -823,31 +829,39 @@ func (r *PdfConvert) WithColorMode(mode PdfColorMode) *PdfConvert { // pdf (../.
 	}
 }
 
-// WithConcurrency bounds how many pages a render converts at once.
+// WithConcurrency bounds how many pages a render converts at once, and with it
+// how many execs the conversion creates.
 //
 // It defaults to the number of CPUs the module can see, which is what a
-// document wants: every page is its own exec, and poppler renders a page on one
-// core whatever the machine has. A 129-page document at 300 dpi spends about a
-// minute of that one core, and the recognition it is usually rendered for
-// spends its own time across every core — so the render is a third of the CPU
-// and two thirds of the wall clock, and the share grows with core count rather
-// than shrinking.
+// document wants: poppler renders a page on one core whatever the machine has.
+// A 129-page document at 300 dpi spends about a minute of that one core, and the
+// recognition it is usually rendered for spends its own time across every core —
+// so the render is a third of the CPU and two thirds of the wall clock, and the
+// share grows with core count rather than shrinking.
 //
 // Unlike the tesseract module's Batch, this bound needs no companion. poppler's
 // tools are single-threaded, so concurrency here is concurrency and not
 // concurrency multiplied by an OpenMP team; the pages contend for cores the way
 // any other CPU-bound workload does.
 //
-// Pass a number to take less of the machine than the default, or 1 to render one
-// page at a time. Non-positive is rejected at output time.
+// Pass a number to take less of the machine than the default, or 1 to render the
+// whole document in one exec, a page at a time. Non-positive is rejected at
+// output time.
 //
-// It is a scheduling bound and nothing else: the directory a conversion returns
-// is the same whatever it is set to. It is also not what decides how the results
-// cache — one exec per page is what does that, at every bound including 1.
+// The two meanings are one setting because they were never independent. The
+// pages are split into this many contiguous slices and each slice is one exec
+// running its pages' invocations in turn, so the bound is at once how many
+// render at a time and how many containers a conversion creates — a
+// three-thousand-page document is this many, not three thousand. It is what
+// decides how the results cache, too: a slice is the unit that hits or misses.
+//
+// What it is still not is a change to the answer. The directory a conversion
+// returns is byte-identical at every bound; concurrency is allowed to change how
+// long a render takes and nothing else.
 //
 // Ignored by Text, Txt, Bbox, Tsv and Ps, none of which renders a page at a
 // time. See Ps for why that one is a single invocation.
-func (r *PdfConvert) WithConcurrency(concurrency int) *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:155:1)
+func (r *PdfConvert) WithConcurrency(concurrency int) *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:163:1)
 	q := r.query.Select("withConcurrency")
 	q = q.Arg("concurrency", concurrency)
 
@@ -1397,18 +1411,18 @@ type PdfOpts struct {
 	//
 	//
 	// Default: "docker.io"
-	Registry string // pdf (../../../../../daggerverse/pdf/main.go:276:2)
+	Registry string // pdf (../../../../../daggerverse/pdf/main.go:294:2)
 	//
 	// Tag of the alpine image the toolchain is assembled on.
 	//
 	//
 	// Default: "3.24"
-	AlpineTag string // pdf (../../../../../daggerverse/pdf/main.go:279:2)
+	AlpineTag string // pdf (../../../../../daggerverse/pdf/main.go:297:2)
 }
 
 // New returns a Pdf module backed by <registry>/library/alpine:<tag> with
 // poppler-utils and a substitute font family installed.
-func (r *Query) Pdf(opts ...PdfOpts) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:271:1)
+func (r *Query) Pdf(opts ...PdfOpts) *Pdf { // pdf (../../../../../daggerverse/pdf/main.go:289:1)
 	q := r.query.Select("pdf")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `registry` optional argument

--- a/daggerverse/tesseract/tests/internal/dagger/pdf.gen.go
+++ b/daggerverse/tesseract/tests/internal/dagger/pdf.gen.go
@@ -440,7 +440,7 @@ type PdfConvertBboxOpts struct {
 	//
 	// Add the block and line boxes poppler groups the words into.
 	//
-	WithLayout bool // pdf (../../../../../daggerverse/pdf/convert.go:276:2)
+	WithLayout bool // pdf (../../../../../daggerverse/pdf/convert.go:284:2)
 }
 
 // Bbox returns the document's text layer as an XHTML report carrying a bounding
@@ -472,7 +472,7 @@ type PdfConvertBboxOpts struct {
 // The render options are ignored, this being an extraction and not a render, and
 // so is LayoutMode: the report's structure is poppler's own and is not the text's
 // reading order. WithPageRange narrows it.
-func (r *PdfConvert) Bbox(opts ...PdfConvertBboxOpts) *File { // pdf (../../../../../daggerverse/pdf/convert.go:272:1)
+func (r *PdfConvert) Bbox(opts ...PdfConvertBboxOpts) *File { // pdf (../../../../../daggerverse/pdf/convert.go:280:1)
 	q := r.query.Select("bbox")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `withLayout` optional argument
@@ -504,7 +504,7 @@ func (r *PdfConvert) Bbox(opts ...PdfConvertBboxOpts) *File { // pdf (../../../.
 //
 // WithDpi governs rasterized regions; WithColorMode, WithScaleTo and
 // WithoutAnnotations are ignored: see the note on Ps.
-func (r *PdfConvert) Eps() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:391:1)
+func (r *PdfConvert) Eps() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:399:1)
 	q := r.query.Select("eps")
 
 	return &Directory{
@@ -531,7 +531,7 @@ func (r *PdfConvert) Eps() *Directory { // pdf (../../../../../daggerverse/pdf/c
 //
 // Every render option is ignored, pdftohtml having no resolution, colour or
 // annotation switch of any kind. WithPageRange narrows it like everything else.
-func (r *PdfConvert) HTML() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:462:1)
+func (r *PdfConvert) HTML() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:470:1)
 	q := r.query.Select("html")
 
 	return &Directory{
@@ -595,7 +595,7 @@ func (r *PdfConvert) UnmarshalJSON(bs []byte) error {
 // Lossy, so it is the format for a preview a human looks at rather than for
 // input another program measures: the artefacts a flat page compresses into sit
 // exactly where thin strokes are, which is where OCR reads.
-func (r *PdfConvert) Jpeg() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:334:1)
+func (r *PdfConvert) Jpeg() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:342:1)
 	q := r.query.Select("jpeg")
 
 	return &Directory{
@@ -609,7 +609,7 @@ func (r *PdfConvert) Jpeg() *Directory { // pdf (../../../../../daggerverse/pdf/
 // PNG is the format to hand another module: it is lossless, so nothing
 // downstream is reading compression artefacts as page content, and it is what
 // every image library reads without a codec question.
-func (r *PdfConvert) Png() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:323:1)
+func (r *PdfConvert) Png() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:331:1)
 	q := r.query.Select("png")
 
 	return &Directory{
@@ -642,7 +642,7 @@ func (r *PdfConvert) Png() *Directory { // pdf (../../../../../daggerverse/pdf/c
 // are dropped rather than forwarded because poppler does not ignore them — it
 // exits non-zero with `-mono may only be used with the -png, -jpeg, or -tiff
 // output options`, and `-hide-annotations` is not a pdftocairo option at all.
-func (r *PdfConvert) Ps() *File { // pdf (../../../../../daggerverse/pdf/convert.go:420:1)
+func (r *PdfConvert) Ps() *File { // pdf (../../../../../daggerverse/pdf/convert.go:428:1)
 	q := r.query.Select("ps")
 
 	return &File{
@@ -670,7 +670,7 @@ func (r *PdfConvert) Ps() *File { // pdf (../../../../../daggerverse/pdf/convert
 // WithDpi governs the rasterized regions a page can still contain — an embedded
 // photograph has no vector form to keep. WithColorMode, WithScaleTo and
 // WithoutAnnotations are ignored: see the note on Ps.
-func (r *PdfConvert) Svg() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:369:1)
+func (r *PdfConvert) Svg() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:377:1)
 	q := r.query.Select("svg")
 
 	return &Directory{
@@ -684,11 +684,11 @@ type PdfConvertTextOpts struct {
 	// How much of the page's physical arrangement survives into the text.
 	// Defaults to reading order.
 	//
-	Layout PdfLayoutMode // pdf (../../../../../daggerverse/pdf/convert.go:190:2)
+	Layout PdfLayoutMode // pdf (../../../../../daggerverse/pdf/convert.go:198:2)
 	//
 	// Emit no form feed between pages.
 	//
-	DisablePageBreaks bool // pdf (../../../../../daggerverse/pdf/convert.go:193:2)
+	DisablePageBreaks bool // pdf (../../../../../daggerverse/pdf/convert.go:201:2)
 }
 
 // Text returns the document's text layer as a string.
@@ -703,7 +703,7 @@ type PdfConvertTextOpts struct {
 // Pages are separated by a form feed (U+000C), including after the last one,
 // which is pdftotext's own convention. Pass disablePageBreaks to drop them, for
 // a consumer that wants one flat stream of text.
-func (r *PdfConvert) Text(ctx context.Context, opts ...PdfConvertTextOpts) (string, error) { // pdf (../../../../../daggerverse/pdf/convert.go:185:1)
+func (r *PdfConvert) Text(ctx context.Context, opts ...PdfConvertTextOpts) (string, error) { // pdf (../../../../../daggerverse/pdf/convert.go:193:1)
 	if r.text != nil {
 		return *r.text, nil
 	}
@@ -732,7 +732,7 @@ func (r *PdfConvert) Text(ctx context.Context, opts ...PdfConvertTextOpts) (stri
 // It is the format the document-imaging world already speaks, and the one to
 // pair with MONO: a bilevel TIFF is what a scanner emits and what an archive
 // expects.
-func (r *PdfConvert) Tiff() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:345:1)
+func (r *PdfConvert) Tiff() *Directory { // pdf (../../../../../daggerverse/pdf/convert.go:353:1)
 	q := r.query.Select("tiff")
 
 	return &Directory{
@@ -768,7 +768,7 @@ func (r *PdfConvert) Tiff() *Directory { // pdf (../../../../../daggerverse/pdf/
 // A page with no text layer yields its page row and no word rows rather than a
 // failure, the same boundary Text and Bbox draw. The render options are ignored,
 // as is LayoutMode. WithPageRange narrows it.
-func (r *PdfConvert) Tsv() *File { // pdf (../../../../../daggerverse/pdf/convert.go:313:1)
+func (r *PdfConvert) Tsv() *File { // pdf (../../../../../daggerverse/pdf/convert.go:321:1)
 	q := r.query.Select("tsv")
 
 	return &File{
@@ -782,11 +782,11 @@ type PdfConvertTxtOpts struct {
 	// How much of the page's physical arrangement survives into the text.
 	// Defaults to reading order.
 	//
-	Layout PdfLayoutMode // pdf (../../../../../daggerverse/pdf/convert.go:220:2)
+	Layout PdfLayoutMode // pdf (../../../../../daggerverse/pdf/convert.go:228:2)
 	//
 	// Emit no form feed between pages.
 	//
-	DisablePageBreaks bool // pdf (../../../../../daggerverse/pdf/convert.go:223:2)
+	DisablePageBreaks bool // pdf (../../../../../daggerverse/pdf/convert.go:231:2)
 }
 
 // Txt returns the same text Text returns, as a file rather than a string.
@@ -794,7 +794,7 @@ type PdfConvertTxtOpts struct {
 // Which of the two to reach for is plumbing and nothing more: a file composes
 // with whatever consumes files — another module, an export, a directory being
 // assembled — without the bytes passing through the caller.
-func (r *PdfConvert) Txt(opts ...PdfConvertTxtOpts) *File { // pdf (../../../../../daggerverse/pdf/convert.go:215:1)
+func (r *PdfConvert) Txt(opts ...PdfConvertTxtOpts) *File { // pdf (../../../../../daggerverse/pdf/convert.go:223:1)
 	q := r.query.Select("txt")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `layout` optional argument
@@ -855,13 +855,21 @@ func (r *PdfConvert) WithColorMode(mode PdfColorMode) *PdfConvert { // pdf (../.
 // three-thousand-page document is this many, not three thousand. It is what
 // decides how the results cache, too: a slice is the unit that hits or misses.
 //
-// What it is still not is a change to the answer. The directory a conversion
-// returns is byte-identical at every bound; concurrency is allowed to change how
-// long a render takes and nothing else.
+// What it is still not is a change to the answer. The same pages come back under
+// every bound, named the same way and rendered from the same bytes; concurrency
+// is allowed to change how long a render takes and nothing else.
+//
+// One caveat, and it is the renderer's rather than this module's: cairo stamps
+// the wall clock into every EPS and PS document it writes, as a
+// `%%CreationDate` DSC comment, and honours neither SOURCE_DATE_EPOCH nor any
+// pdftocairo flag. Two Eps renders at different bounds are different execs at
+// different instants, so that one line differs and the directory digests differ
+// with it. Everything drawn is identical. Png, Jpeg, Tiff, Svg and Html carry no
+// timestamp and are byte-identical at every bound.
 //
 // Ignored by Text, Txt, Bbox, Tsv and Ps, none of which renders a page at a
 // time. See Ps for why that one is a single invocation.
-func (r *PdfConvert) WithConcurrency(concurrency int) *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:163:1)
+func (r *PdfConvert) WithConcurrency(concurrency int) *PdfConvert { // pdf (../../../../../daggerverse/pdf/convert.go:171:1)
 	q := r.query.Select("withConcurrency")
 	q = q.Arg("concurrency", concurrency)
 


### PR DESCRIPTION
Closes #370

`Convert` emitted one exec per page and folded the results one graph operation
per page — `WithDirectory` for the vector family, `WithFile` for the raster one.
Every fold adds an overlayfs lowerdir to the destination snapshot's chain, and
containerd refuses joined mount data over one page, so a long document died with
`mount options is too long` — and the ceiling shrank as an engine aged, because
each call burns two snapshot IDs.

The property this builds on instead: **a directory produced by an exec is one
snapshot however many files that exec wrote**. The chain is created purely by
graph-level composition, so `fold depth = number of execs folded` and the page
count need not appear in it. The pages are partitioned into at most `workers()`
contiguous slices, one exec each, whose script is the per-page commands `plan`
already generated, concatenated.

## Acceptance criteria

- [x] **Both families emit at most `workers()` execs for a conversion of any
      length.** `fanout.Partition(count, workers)` is the one place it happens,
      shared by `raster` and `pageRender` through `Convert.render`.
- [x] **Both fold sites become one `WithDirectory` per exec.** `assemble` is now
      the only fold; the raster family's per-page `WithFile` is gone. Taking a
      slice's whole directory is safe because `-singlefile` makes `pdftoppm`
      write exactly `<base>.<ext>` and nothing else.
- [x] **A 3,000 page document converts, and the fold depth is independent of the
      page count.** Measured on a 32-CPU host against a generated 3,000-page
      document: before, `mount options is too long` after 1m7s; after, **9.3s in
      32 execs**. The bound itself is checked cheaply in CI — `Partition(3000,
      16)` is 16 slices — rather than by rendering 3,000 pages in the suite.
- [x] **The page-naming contract is unchanged — byte-identical output.** Same
      `sha256` before and after for `ledger.pdf` Png (`a5acfcce…`) and Svg
      (`bdbeeea4…`) and `gallery.pdf` Html (`65bbcf6a…`).
- [x] **`-singlefile` is retained per page**, a slice's script being the per-page
      commands concatenated, so the padding width still comes from `plan` and
      `-forcenum` stays out.
- [x] **A failure still names the page, and still cancels the rest.** A slice's
      script routes each command through a guard carrying that page's number and
      re-raising poppler's own exit status; `takeFailedPage` reads it back out of
      stderr and removes the marker line from what the caller sees. Inside the
      failing slice the pages behind it never run; the other slices are cancelled
      through `fanout.Run`'s context.
- [x] **`WithConcurrency` keeps its documented meaning and now also sets how many
      execs a conversion creates; the README says so.**
- [x] **`Ps` and `Split` are unchanged.** Neither is touched by the diff; both
      are a single invocation writing a single output. `Ps` is now *asserted*
      byte-identical across the bound rather than assumed to be, and `Split` has
      no `WithConcurrency` to reach it at all.
- [x] **#309's overlapping-page-range measurement re-run and recorded.**
- [x] **The README records that fold depth tracks exec count rather than file
      count**, and what that means for a caller assembling a directory of its own.
- [x] **`dagger develop` re-run wherever bindings are affected.** `daggerverse/pdf`,
      `daggerverse/pdf/tests` and `daggerverse/tesseract/tests`, whose generated
      bindings embed this module's doc comments and line numbers.
- [x] **No `+cache=` directive is added.**

## Measurements

32-CPU host, a freshly generated document every run so nothing is a cache hit.

| | one exec per page | one exec per slice |
| --- | --- | --- |
| 400 pages, 150 dpi | 19.8s, 400 execs | **5.2s**, 32 execs |
| 3,000 pages | **fails after 1m7s** | **9.3s**, 32 execs |

## The judgment call: #309's overlapping-page-range win is gone

Re-run as the issue asked, 48 pages at 300 dpi, median of three:

| | cold, whole 48 | after pages 1–24 |
| --- | --- | --- |
| one exec per page | 4.26s | **3.21s** |
| one exec per slice | 4.01s | 3.73s |

Slice boundaries move with the length of the range — 24 pages on this host is 24
one-page slices, 48 pages is sixteen two-page slices plus sixteen one-page ones —
so almost nothing lines up and the residue is the `pdfinfo` page count.

It was not worth keeping. Anchoring the slices to the whole document rather than
to the range would restore the boundaries and cost the thing the #300 sharding
case exists for: pages 1–24 of a 3,000-page document would fall inside a single
94-page slice and render in **one** exec, with no parallelism at all. The README
records the result and the reasoning; "shard for the size, not for the reuse".

The other public-API judgment call is that `WithConcurrency` gained a second
meaning rather than gaining a sibling setting. The two were never independent —
the bound is the slice count — and a separate knob would let a caller ask for
sixteen at a time out of three thousand execs, which is the configuration this
change exists to delete.

## Verified

- `dagger check` — green.
- `bash .github/scripts/verify-affected-modules.sh` — green: `pdf` checks,
  `pdf/tests:all`, `tesseract/tests:all`.
- `go test -race ./fanout/` in `daggerverse/pdf`.
- `Pdf.RenderSchedulingSelfTest` gained the partition properties (covers every
  page once in order, never wider than the bound, balanced, no empty slice,
  stable) and the slice-script properties (prelude once, every command guarded by
  its own page, the reported page read back and stripped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)