### PR TITLE
story(issue-218): recognise a batch in worker-pool execs

### DIFF
--- a/daggerverse/tesseract/README.md
+++ b/daggerverse/tesseract/README.md
@@ -220,7 +220,7 @@ The last row is the whole reason concurrency implies the bound: same four
 passes as the second row, threads unbounded, 174x apart. A caller who reaches
 for concurrency without having read anything about libgomp would otherwise land
 there. (What `Batch` costs on top of these numbers is a separate question, and a
-separate measurement, in [One exec per image](#one-exec-per-image-fanned-out-from-go).)
+separate measurement, in [One invocation per image](#one-invocation-per-image-one-exec-per-worker).)
 
 An `ompThreadLimit` named on `New` is left alone, because it was named.
 Otherwise the bound rides on a copy of the module the batch makes for itself, so
@@ -389,69 +389,181 @@ of one PDF want. It is just not what a folder of independent scans wants, and it
 is not what the fast path wants either: one serial pass over N pages forfeits
 exactly the concurrency the next section is about.)
 
-So a batch is its images recognised as **`Document`s** — one exec each, each
-mounting its own image, each rendering its own artifact set — and what runs
-several of them at a time is Go.
+So a batch is its images recognised **one invocation each**, each mounting its
+own image, each rendering its own artifact set — and what schedules them is Go.
 
-### One exec per image, fanned out from Go
+### One invocation per image, one exec per worker
 
 ```go
 tess.Batch(scans).WithConcurrency(8).Export(ctx, formats)   // default: one per CPU
 ```
 
-`Batch.Export` resolves the glob, builds a `Document` per match, and runs them
-through a slot channel bounded by `WithConcurrency`. The bound, the scheduling,
-the fail-fast and the error message are all `batch.go` — nothing about running a
-batch is interpreted inside a container, so all of it is typed, reviewable and
-debuggable the same way the rest of the module is.
+`Batch.Export` resolves the glob, splits the matches into **at most
+`WithConcurrency` contiguous slices**, and runs one exec per slice — each of
+which mounts its slice's images and recognises them in turn. The bound, the
+partition, the scheduling, the fail-fast and the error message are all
+`batch.go`; the only thing interpreted inside a container is the list of
+per-image commands that slice was handed.
 
-That is a reversal. Until #298 the batch was **one** exec looping a
+That is two reversals, and they answer different questions.
+
+**The first** is #298. Until then the batch was **one** exec looping a
 tab-separated manifest in `sh`, on the argument that the exec — its mounts, its
 cache lookup — was the expensive part and should be paid once per directory
-rather than once per page. Measured end-to-end, it is not:
+rather than once per page. Measured end to end, it is not:
 
-| pages | one exec, `sh` loop | one exec per image, Go fan-out |
+| pages | one exec, `sh` loop | Go fan-out |
 | --- | --- | --- |
 | 11 | 5.5s | **2.8s** |
 | 50 | 17.5s | **5.0s** |
 | 50, one page edited | 17.5s | **2.5s** |
 
-`dagger call batch --source=… export --formats=TXT entries`, median of three,
-cold inputs each run, 32-CPU host; ~1.7s of every figure is CLI startup and
-module load. The one-exec column is the manifest loop recognising one image at a
-time, which is what it did, threads unbounded; the Go column is the default —
-one recognition per CPU, one OpenMP thread each.
+**The second** is #371, and it is not about parallelism at all — the fan-out
+already admitted only `workers()` images at a time. It is about how many
+*containers* were created to run them: a 3,000-image batch on a 32-CPU host
+created 3,000 execs in order to run 32, and then folded 3,000 directories into
+one, **twice over if two formats were asked for**. That fold is the thing that
+broke.
 
-The last row is the one that does not close with more cores. The old exec
-mounted the whole source directory, so editing any page invalidated the mount
-and re-recognised **all fifty**; a per-image exec keys on that image, so the
-other forty-nine are cache hits. For a corpus that grows or gets corrected a
-page at a time, that is the difference between a re-run and a re-do.
+| images, formats | one exec per image | one exec per slice |
+| --- | --- | --- |
+| 50, TXT, cold | 5.35s, 50 execs | **4.35s**, 32 execs |
+| 50, TXT, one page edited | **2.75s** | 2.94s |
+| 300, TXT | 28.2s, 300 execs | **13.7s**, 32 execs |
+| 300, TXT+TSV | **fails after 26.4s** | **12.6s**, 32 execs |
+| 3,000, TXT | — | **123.6s**, 32 execs |
+| 3,000, TXT+TSV | — | **96.6s**, 32 execs |
 
-Three properties the serial loop had for free, which the fan-out has to keep:
+`dagger call batch --source=… export --formats=… entries`, 32-CPU host, dagger
+v0.21.7, both columns measured in the same session; the 50-image rows are the
+median of three with a fresh source directory every run so nothing is a cache
+hit. ~1.2s of every figure is CLI startup and module load. The 3,000-image rows
+are single runs, and the TXT one carries the 90MB upload of the source directory
+that the TXT+TSV run then found warm — which is why the two-format run is the
+faster of them. The 3,000-image case was never run against the left-hand column:
+300 images with two formats already fails there, so 3,000 has nothing to measure.
+
+The failure is literal, and it is containerd's:
+
+```
+failed to mount /tmp/dagger-mount…: [{Type:overlay … lowerdir=…:…:…}]:
+mount options is too long
+```
+
+#### Why folding per artifact could not survive a large batch
+
+Every `WithFile` or `WithDirectory` that folds an exec's output into the result
+adds an overlayfs lowerdir to the destination snapshot's chain. Mounting that
+snapshot goes through containerd, which compacts the lowerdir list and then
+refuses joined mount data over one page:
+
+```go
+dataInStr := strings.Join(opt.data, ",")
+if len(dataInStr) > pagesize {            // pagesize = 4096
+    return errors.New("mount options is too long")
+}
+```
+
+`containerd/v2@v2.2.3/core/mount/mount_linux.go:153`, the version dagger v0.21.7
+pins. Bisected against a live engine the fold was fine at 430 and failed at 440
+— and **the ceiling shrinks as an engine ages**, because each call burns two
+snapshot IDs, so it is ~437 at 5-digit snapshot IDs, ~393 at 6 digits and ~357 at
+7. The same batch could work one week and fail the next on a busier engine.
+Reported in [#314](https://github.com/z5labs/devex/discussions/314).
+
+The old fold sat **inside the format loop**, so the ceiling was images × formats:
+one format bought ~437 images and asking for two halved it to ~215. That is the
+300-image row above — 300 images pass at one format and fail at two, on the same
+engine, in the same minute.
+
+**Chunking the fold only moves that wall** — `sqrt(n)` grouping still has a depth
+that grows with the batch. The property worth building on instead is that a
+directory produced by an exec is **one snapshot however many files that exec
+wrote**. The chain is created purely by graph-level composition, never by the
+filesystem, so
+
+    fold depth = number of execs folded
+
+and neither the image count nor the format count appears in it. Partitioning the
+images into `workers()` slices makes the depth a property of the machine's core
+count, which does not grow with the batch; each slice's exec writes every
+requested format for every one of its images, and the whole of what it wrote is
+taken at once.
+
+> **This matters to a caller assembling a directory of its own.** The ceiling is
+> on the *chain*, not on this module: a consumer that takes this directory and
+> re-folds it a file at a time — `WithFile` per entry into some other tree —
+> rebuilds exactly the depth this removed, and hits the same
+> `mount options is too long` at the same few hundred. Fold the directory once,
+> rather than fold its entries.
+
+#### What that cost, measured rather than assumed
+
+**The unit that caches is now the slice, not the image.** #298's win — 50 pages
+with one edited re-recognising one page — was a property of one exec per image,
+and slicing coarsens it: at 50 images on a 32-CPU host the slices are one and two
+images, so an edited page re-recognises up to one neighbour with it. Re-run here,
+that is **2.75s → 2.94s**, and it grows with the ratio of images to cores: 3,000
+images on 32 cores is ~94 to a slice, so a corrected page re-runs ~94.
+
+`WithConcurrency` is the control for it. A caller who corrects one page of a
+large corpus at a time and wants the old granularity back asks for a bound at or
+above the image count — `WithConcurrency(len(files))` is one exec per image
+again, at the cost of the fold ceiling coming back with it.
+
+**The images are mounted, not copied, and that is load-bearing.** #371 was
+written expecting a single filtered `WithDirectory` — include patterns naming the
+slice's files — to stage a slice in one graph operation. Measured on dagger
+v0.21.7 it re-recognises the **whole batch** when one image changes: 4.84s
+against 2.66s, which is a cold run. The mechanism is buildkit's. An exec mount
+carrying a path *selector* gets a content-based cache key computed from the bytes
+at that path; a copy into the container's rootfs is keyed on the source
+directory's digest as a whole, include patterns or not. So one mount per image is
+what keeps an edit local — and it adds no chain either, a mount being an
+independent mount point rather than a layer on a snapshot.
+
+#### Properties the serial loop had for free, which the fan-out keeps
 
 - **A page that cannot be read still fails the batch**, rather than going
-  missing from a thousand results, and the error names the page — tesseract's
-  own message often cannot, because handed a file leptonica will not decode it
-  falls back to reading the file as a list of image paths and reports the
-  *contents* of the first line as the file it could not open.
+  missing from a thousand results, and the error names **the page** and not the
+  slice it shared an exec with: `Batch: "scans/torn.png": tesseract failed (exit
+  1): …`. A slice's script reports the position it stopped on and re-raises
+  tesseract's own exit status; the module reads that back out of stderr and takes
+  it out of the message it builds. tesseract's own message often cannot name the
+  page, because handed a file leptonica will not decode it falls back to reading
+  the file as a list of image paths and reports the *contents* of the first line
+  as the file it could not open.
 - **The first failure cancels the rest.** A batch that is going to fail has no
-  reason to recognise the remaining pages first.
+  reason to recognise the remaining pages first. Inside the failing slice the
+  images behind the failure never run; the other slices are cancelled through the
+  fan-out's context.
 - **The artifacts are assembled in sorted order**, off execs that finished in
   whatever order they finished in, so the returned directory does not depend on
   the scheduling.
 
-What it no longer has to do is protect a record format: file names with tabs or
-newlines in them were rejected when a manifest had to carry them, and are
-ordinary inputs now.
+Those are covered by `Tesseract.BatchSchedulingSelfTest` as well as by fixtures,
+and that is not a shortcut. The bound as a *floor* needs recognitions that block
+until every one of them has arrived, which no image does; the exec count needs
+three thousand images, which is not a fixture any suite should recognise to learn
+that a slice count is bounded; and the shell quoting needs file names this
+repository will not commit. The scheduling and the partition live in `fanout/`,
+which imports no dagger and runs under `go test -race`.
+
+What the batch no longer has to do is protect a record format: file names with
+tabs or newlines in them were rejected when a manifest had to carry them, and are
+ordinary inputs now — they are shell-quoted, along with every other word of every
+invocation, rather than being refused.
 
 Recognising more than one image at a time also caps OpenMP at one thread per
 process, unless an `ompThreadLimit` was named on `New` — see [OpenMP
 fan-out](#openmp-fan-out--ompthreadlimit) for the measured reason, which is that
 concurrency multiplied by threads is the one shape slower than doing nothing.
-The bound rides on a copy of the module rather than the caller's, so nothing
-else built from the same `Tesseract` sees it, and the two images still share the
-package fetch.
+The processes are the slices' execs rather than the images': a slice runs its
+images one after another, so there are `workers()` tesseract processes alive at a
+time whether the batch holds sixteen images or three thousand, which is exactly
+the count the bound names. The bound rides on a copy of the module rather than
+the caller's, so nothing else built from the same `Tesseract` sees it, and the
+two images still share the package fetch.
 
 ### Which files take part
 
@@ -602,7 +714,7 @@ directory of PNGs states them:
   render always names it.
 - **The thread bound.** `OmpThreadLimit: 1` alongside `WithConcurrency`, or the
   two multiply — see [OpenMP fan-out](#openmp-fan-out--ompthreadlimit). `Batch`
-  applies it to its own exec when the caller named no bound, so this is
+  applies it to its own execs when the caller named no bound, so this is
   belt-and-braces rather than required.
 
 **Page order is name order.** The `pdf` module pads its page numbers to a fixed
@@ -784,11 +896,21 @@ and there is no chained-method propagation problem to worry about. `Container`,
 a floating Alpine tag can resolve differently across sessions.
 
 What *is* worth knowing is the granularity underneath those functions. A `Batch`
-recognises each image in its own exec mounting only that image, so the engine
-caches per page: the second export of a fifty-page folder with one page edited
-re-recognises one page. `Training` is the opposite by nature — one exec for the
-whole run, one cache entry, see [One exec, one cache entry](#one-exec-one-cache-entry)
-— because a fine-tune is not separable into per-sample work.
+recognises a **slice** of images per exec, each image mounted on its own, so the
+engine caches per slice: the second export of a fifty-page folder with one page
+edited re-recognises that page's slice — one or two pages at the default bound on
+a 32-CPU host, and `ceil(images / WithConcurrency)` in general. It was one page
+before #371; see [What that cost](#what-that-cost-measured-rather-than-assumed)
+for the number and for the bound that buys the old granularity back.
+
+The count that does *not* grow is the exec count, and with it the fold depth:
+**fold depth tracks the number of execs, not the number of files**, because a
+directory produced by an exec is one snapshot however many files it holds. That
+is what keeps a three-thousand-image batch off containerd's mount-data ceiling.
+
+`Training` is the opposite by nature — one exec for the whole run, one cache
+entry, see [One exec, one cache entry](#one-exec-one-cache-entry) — because a
+fine-tune is not separable into per-sample work.
 
 ## Follow-ups
 
@@ -796,6 +918,12 @@ An `examples/go` cookbook (#224); evaluation against a held-out set (#231);
 authenticating to a private *container* registry for the mirrored Alpine image
 (#235), which the apk options above deliberately do not cover — they configure
 the package fetch, not the image pull.
+
+`fanout/` is a **copy** of `pdf/fanout`, deliberately and temporarily. Each
+daggerverse module is its own Go module whose Dagger context is its own
+directory, so neither can import the other's packages; #321 is the issue that
+lifts one shared fan-out out of both. Keeping the two identical until then is
+what makes that a move rather than a merge, so a change to one belongs in both.
 
 The chained `Ci` builder (#223) and the training toolchain (#222) both landed —
 see above. `Ci` deliberately exposes only `WithLanguage` of the seven recognition

--- a/daggerverse/tesseract/batch.go
+++ b/daggerverse/tesseract/batch.go
@@ -6,9 +6,10 @@ import (
 	"path"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
-	"sync"
 
+	"dagger/tesseract/fanout"
 	"dagger/tesseract/internal/dagger"
 )
 
@@ -29,12 +30,13 @@ var imageExtensions = []string{
 // all of them. It carries the same options type Document does, so the two
 // cannot drift: every With* here forwards to the shared builder.
 //
-// It is also built out of Document rather than merely resembling one. Each
-// matched image is recognised as its own Document — its own exec, its own
-// mounts, its own cache entry — and what runs several of them at a time is Go,
-// not a runner inside a container. That is what keeps the scheduling, the
-// bound and the failure reporting in a language with types and a debugger,
-// instead of in a shell script mounted into an image.
+// Each matched image is recognised by its own tesseract invocation, and the
+// invocations are split across at most WithConcurrency execs — one contiguous
+// slice of the batch each. What decides the bound, the partition, the
+// scheduling, the fail-fast and the failure message is Go; the only thing
+// interpreted inside a container is the list of per-image commands that slice
+// was handed. That keeps all of it in a language with types and a debugger,
+// instead of in a runner mounted into an image.
 type Batch struct {
 	// +private
 	Tesseract *Tesseract
@@ -66,15 +68,14 @@ func (b *Batch) WithGlob(pattern string) *Batch {
 	return &out
 }
 
-// WithConcurrency bounds how many images the batch recognises at once.
+// WithConcurrency bounds how many images the batch recognises at once, and with
+// it how many execs the export creates.
 //
 // It defaults to the number of CPUs the module can see, which is what a batch
-// wants: every image is its own exec, and recognising them one at a time would
-// pay that overhead N times for none of the parallelism it buys. Processes are
-// how tesseract parallelises well — eleven pages on four CPUs take 3.37s one at
-// a time and 1.05s eleven at a time, ~90% efficiency where its own OpenMP
-// manages 33%, because those regions sit inside the LSTM inner loops and do not
-// amortize.
+// wants: processes are how tesseract parallelises well — eleven pages on four
+// CPUs take 3.37s one at a time and 1.05s eleven at a time, ~90% efficiency
+// where its own OpenMP manages 33%, because those regions sit inside the LSTM
+// inner loops and do not amortize.
 //
 // Recognising more than one at a time therefore also caps OpenMP at one thread
 // per process, unless the caller named an explicit ompThreadLimit on New, which
@@ -84,7 +85,20 @@ func (b *Batch) WithGlob(pattern string) *Batch {
 // 174x.
 //
 // Pass a number to take less of the machine than the default, or 1 to recognise
-// one image at a time. Non-positive is rejected at output time.
+// the whole batch in one exec, an image at a time. Non-positive is rejected at
+// output time.
+//
+// The two meanings are one setting because they were never independent. The
+// images are split into this many contiguous slices and each slice is one exec
+// running its images' invocations in turn, so the bound is at once how many
+// recognise at a time and how many containers an export creates — a
+// three-thousand-image batch is this many, not three thousand. It is what
+// decides how the results cache, too: a slice is the unit that hits or misses,
+// so an edited image re-recognises its slice rather than only itself.
+//
+// What it is still not is a change to the answer. The same artifacts come back
+// under every bound, named the same way and recognised from the same bytes;
+// concurrency is allowed to change how long an export takes and nothing else.
 func (b *Batch) WithConcurrency(
 	// Maximum number of images to recognise at the same time.
 	concurrency int,
@@ -154,18 +168,19 @@ func (b *Batch) Files(ctx context.Context) ([]string, error) {
 // input layout, with one artifact per requested format per image: `scans/a.png`
 // becomes `scans/a.txt` alongside `scans/a.pdf`.
 //
-// Each image is recognised on its own, as its own exec, WithConcurrency of them
-// at a time. tesseract's own list-file mode — a text file of image paths as the
-// FILE argument — is not what a batch wants, because it treats the list as one
+// Each image is recognised by its own invocation, WithConcurrency of them at a
+// time, and each invocation writes its artifacts straight onto the mirrored
+// path. tesseract's own list-file mode — a text file of image paths as the FILE
+// argument — is not what a batch wants, because it treats the list as one
 // multi-page *document*: it renders a single concatenated artifact set (one .txt
 // with form-feed page breaks, one multi-page PDF) and offers no way to get the
 // per-image files this returns.
 //
-// One exec per image is what makes the results cache per image too: an edited
-// page invalidates its own recognition and nothing else, which is the whole
-// difference for a corpus that grows a page at a time. It costs one exec's
-// overhead per page instead of per batch — see the README for what that is
-// worth measured — and it is the shape that lets the fan-out live in Go.
+// One invocation per image is what makes the results cache per slice of images
+// rather than per batch: an edited page invalidates the slice it falls in and
+// nothing else, which is most of the difference for a corpus that grows a page
+// at a time. See the README for what that is worth measured, and for why the
+// slice — rather than the image — is the granularity now.
 func (b *Batch) Export(
 	ctx context.Context,
 	// Output formats to render for each image in the batch.
@@ -193,89 +208,252 @@ func (b *Batch) Export(
 	if err != nil {
 		return nil, err
 	}
-
-	// Assembling the mirrored directory is pure graph-building — every
-	// recognition has already run — so it is one WithFile per artifact, in a
-	// fixed order, off the exec that produced it.
-	out := dag.Directory()
-	for i, source := range sources {
-		base := outputBaseFor(source)
-		for _, format := range selected {
-			ext := formatTable[format].ext
-			out = out.WithFile(base+ext, execs[i].File(outputBase+ext))
-		}
-	}
-	return out, nil
+	return assemble(execs), nil
 }
 
-// recognise runs one exec per image, at most workers() of them at a time, and
-// returns the finished execs positionally.
+// assemble folds the finished execs into the directory an export returns: one
+// WithDirectory per exec, in slice order, which is sorted-path order.
 //
-// The bound is a slot channel rather than an unbounded fan-out because a
-// thousand pages is a thousand containers otherwise, and because recognition
-// that is already using every core gains nothing from being asked for more of
-// them at once.
+// This is the whole of what #371 changed and the reason it was worth changing.
+// Every fold adds an overlayfs lowerdir to the destination snapshot's chain, and
+// containerd refuses to mount a chain whose compacted mount data exceeds one
+// page — measured at around 440 folds on a fresh engine, and fewer as snapshot
+// IDs grow a digit. A directory produced by an exec is *one* snapshot however
+// many files that exec wrote, so folding per exec rather than per artifact makes
+// the depth len(execs), which the bound caps and neither the image count nor the
+// format count enters.
+//
+// The format loop leaving this fold is half of that: it used to multiply the
+// depth, so asking for two formats halved the number of images a batch could
+// carry. Each slice's exec now writes every requested format for every one of
+// its images, and the whole of what it wrote is taken at once.
+//
+// It is also why nothing downstream should fold this directory an artifact at a
+// time to build one of its own: the ceiling is on the chain, not on this module.
+func assemble(execs []*dagger.Container) *dagger.Directory {
+	out := dag.Directory()
+	for _, exec := range execs {
+		out = out.WithDirectory("/", exec.Directory(outputDir))
+	}
+	return out
+}
+
+// recognise partitions the images into at most workers() slices, runs one exec
+// per slice, and returns the finished execs positionally — in slice order, which
+// is sorted-path order.
+//
+// One exec per *slice* rather than per image is what keeps a batch's exec count,
+// and so its fold depth, off the number of images: see assemble for what the
+// fold could not survive, and fanout.Partition for the property that makes it
+// constant. It costs no parallelism, the images already having been admitted
+// workers() at a time — a three-thousand-image batch on a 16 CPU host was
+// creating three thousand containers in order to run sixteen.
+//
+// The scheduling and the partitioning are both fanout.RunSlices', one call
+// taking the bound once — a module that partitioned by one figure and scheduled
+// by another would have two bounds to keep in agreement and no reason for them
+// to differ. That package imports no dagger and is tested with `go test -race`.
 //
 // The first failure cancels the rest: a batch that is going to fail has no
 // reason to recognise the remaining pages first, and the error it reports names
-// the image. tesseract's own message usually cannot — handed a file leptonica
-// will not decode, it falls back to reading the file as a list of image paths
-// and reports the *contents* of its first line as the file it could not open.
+// the image rather than the slice it shared an exec with. tesseract's own
+// message usually cannot — handed a file leptonica will not decode, it falls
+// back to reading the file as a list of image paths and reports the *contents*
+// of its first line as the file it could not open.
+//
+// The flags are rendered once here rather than per slice. They are the same for
+// every recognition in the batch, and a bad one should be reported as itself
+// instead of as a failure of whichever slice happened to run first.
 func (b *Batch) recognise(ctx context.Context, sources []string, configs []string) ([]*dagger.Container, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	toolchain := b.toolchain()
+	flags, err := b.Options.flags(toolchain)
+	if err != nil {
+		return nil, err
+	}
+	args := append(flags, configs...)
 
-	var (
-		wg    sync.WaitGroup
-		mu    sync.Mutex
-		first error
-	)
-	execs := make([]*dagger.Container, len(sources))
-	slots := make(chan struct{}, b.workers())
-
-	for i, source := range sources {
-		wg.Go(func() {
-			select {
-			case slots <- struct{}{}:
-				defer func() { <-slots }()
-			case <-ctx.Done():
-				return
-			}
-
-			exec, err := b.document(source).run(ctx, outputBase, configs...)
-
-			mu.Lock()
-			defer mu.Unlock()
-			if err != nil {
-				// Formatted rather than %w-wrapped: the error crosses the
-				// module boundary, which unwraps a chain back to the inner
-				// error and would drop the image's name along with it.
-				if first == nil {
-					first = fmt.Errorf("Batch: %q: %v", source, err)
-					cancel()
-				}
-				return
-			}
-			execs[i] = exec
+	return fanout.RunSlices(ctx, b.workers(), sources,
+		func(ctx context.Context, slice []string) (*dagger.Container, error) {
+			return b.recogniseSlice(ctx, toolchain, slice, args)
 		})
-	}
-	wg.Wait()
-
-	if first != nil {
-		return nil, first
-	}
-	return execs, nil
 }
 
-// document binds one matched image to the toolchain as the Document it is, so
-// the two units of work share their execution as well as their option set: a
-// batch is its images recognised as Documents, several at a time.
-func (b *Batch) document(source string) *Document {
-	return &Document{
-		Tesseract: b.toolchain(),
-		Source:    b.Source.File(source),
-		Options:   b.Options,
+// recogniseSlice runs one slice of the batch: its images mounted at their own
+// paths, its recognitions run in turn inside one exec, and its artifacts written
+// straight onto the mirrored paths.
+//
+// The images are *mounted* rather than copied in, one mount each, and that is
+// the half of this change that is easy to get wrong in either direction.
+//
+// Copying them in a file at a time is what the fold on the output side had to
+// stop doing: every copy adds an overlayfs lowerdir to the container's own
+// rootfs chain, so the input side would rebuild exactly the depth assemble just
+// shed. A mount adds none — it is an independent mount point on the exec, not a
+// layer on a snapshot — so nothing here grows the chain, whatever the slice
+// holds.
+//
+// Copying the slice in with **one** filtered operation would be shallower still,
+// and #371 was written expecting that to be the answer. Measured on dagger
+// v0.21.7, it is not: a `WithDirectory(…, Include: slice)` re-recognises the
+// *whole batch* when one image changes — 50 images with one edited took 4.84s
+// against 2.66s for the per-image mount it replaced, which is a cold run. The
+// mechanism is buildkit's, and it is the same one #298 was relying on without
+// naming: an exec mount carrying a path *selector* gets a content-based cache
+// key computed from the bytes at that path, and nothing else does. A copy into
+// the rootfs is keyed on the source directory's digest as a whole, include
+// patterns or not, so every slice's exec is invalidated by an edit to any image
+// in the directory.
+//
+// So the mount is not a stylistic preference over the copy; it is the only shape
+// measured to keep an edited page from re-recognising the other forty-nine.
+// Mounting the whole source directory in one go loses it for the same reason —
+// a mount with no selector is not content-hashed either — which is what #298
+// found and what this must not undo.
+func (b *Batch) recogniseSlice(
+	ctx context.Context,
+	toolchain *Tesseract,
+	slice []string,
+	args []string,
+) (*dagger.Container, error) {
+	ctr := toolchain.Container().WithDirectory(outputDir, dag.Directory())
+	for _, source := range slice {
+		ctr = ctr.WithMountedFile(batchSourceDir+"/"+source, b.Source.File(source))
 	}
+
+	exec := b.Options.mount(ctr).WithExec(
+		[]string{"sh", "-c", sliceScript(slice, args)},
+		dagger.ContainerWithExecOpts{Expect: dagger.ReturnTypeAny})
+	code, err := exec.ExitCode(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if code == 0 {
+		return exec, nil
+	}
+	return nil, sliceFailure(ctx, exec, slice, code)
+}
+
+// sliceScript is the script one exec runs: the guard, the output directories the
+// slice's images mirror, and then one guarded tesseract invocation per image in
+// slice order.
+//
+// Every word of every invocation is shell-quoted, which the argv the recognition
+// used to be built as did not have to be. Two of those words are the caller's
+// outright — the image's path, and any `-c name=value` WithParameter set — so a
+// join without quoting would be the caller writing shell.
+//
+// `set -e` is what makes the mkdir fail the exec; the recognitions do not rely
+// on it, each being an explicitly handled `||`. A failure still stops the images
+// behind it inside its own slice, and fanout.Run's cancellation is what stops
+// the other slices.
+func sliceScript(slice []string, args []string) string {
+	lines := make([]string, 0, len(slice)+3)
+	lines = append(lines, "set -e",
+		imageFailureFn+`() { echo "`+imageFailureMarker+`$1" >&2; exit "$2"; }`,
+		shellCommand(append([]string{"mkdir", "-p"}, outputDirsFor(slice)...)))
+
+	for i, source := range slice {
+		command := shellCommand(append([]string{
+			"tesseract",
+			batchSourceDir + "/" + source,
+			outputDir + "/" + outputBaseFor(source),
+		}, args...))
+		lines = append(lines, fmt.Sprintf("%s || %s %d $?", command, imageFailureFn, i))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// outputDirsFor is the set of directories a slice's artifacts land in, sorted
+// and de-duplicated, which one `mkdir -p` then creates. tesseract will not
+// create an output base's directory and fails with a bare `Error, cannot create
+// output file` if it is missing.
+func outputDirsFor(slice []string) []string {
+	seen := make(map[string]struct{}, len(slice))
+	dirs := make([]string, 0, len(slice))
+	for _, source := range slice {
+		dir := path.Join(outputDir, path.Dir(source))
+		if _, dup := seen[dir]; dup {
+			continue
+		}
+		seen[dir] = struct{}{}
+		dirs = append(dirs, dir)
+	}
+	sort.Strings(dirs)
+	return dirs
+}
+
+// sliceFailure turns a failed slice into the error the failing image would have
+// carried had it been the only image in the exec.
+//
+// The image comes out of the script rather than out of a label chosen here,
+// which is the whole difference a slice makes: Go knows which images the exec
+// covers and only the script knows which invocation was running when it stopped.
+// See sliceScript for how the position is reported and takeFailedImage for how
+// it is read back and removed from what the caller sees.
+//
+// A failure carrying no position is not an image's: the mkdir is the only thing
+// in a slice's script that runs outside a guarded command, so the message names
+// the run of images rather than inventing one of them.
+func sliceFailure(ctx context.Context, exec *dagger.Container, slice []string, code int) error {
+	stdout, _ := exec.Stdout(ctx)
+	stderr, _ := exec.Stderr(ctx)
+	at, stderr := takeFailedImage(stderr)
+	// Formatted rather than %w-wrapped: the error crosses the module boundary,
+	// which unwraps a chain back to the inner error and would drop the image's
+	// name along with it.
+	if at >= 0 && at < len(slice) {
+		return fmt.Errorf("Batch: %q: tesseract failed (exit %d):\n%s",
+			slice[at], code, joinOutput(stdout, stderr))
+	}
+	return fmt.Errorf("Batch: %q..%q: tesseract failed (exit %d):\n%s",
+		slice[0], slice[len(slice)-1], code, joinOutput(stdout, stderr))
+}
+
+// takeFailedImage reads back the position a slice's script reported failing on,
+// and returns stderr with that report removed.
+//
+// Removing it is the point of reading it: the image belongs in the message's
+// first line, where a caller looks, and the marker line is this module talking
+// to itself. A stderr carrying no marker yields -1, which is the caller's signal
+// that the failure was not an image's.
+func takeFailedImage(stderr string) (int, string) {
+	lines := strings.Split(stderr, "\n")
+	kept := make([]string, 0, len(lines))
+	at := -1
+	for _, line := range lines {
+		rest, ok := strings.CutPrefix(line, imageFailureMarker)
+		if !ok {
+			kept = append(kept, line)
+			continue
+		}
+		// A script exits as soon as it reports, so there is at most one marker;
+		// the last one wins if that ever stops being true.
+		if n, err := strconv.Atoi(strings.TrimSpace(rest)); err == nil && n >= 0 {
+			at = n
+		}
+	}
+	return at, strings.Join(kept, "\n")
+}
+
+// shellCommand joins words into one shell command, quoting every one of them.
+//
+// Quoting all of them rather than the ones that need it is deliberate: which
+// words are the caller's changes as options are added, and a rule that has to be
+// re-derived per word is a rule that eventually is not applied to a new one.
+func shellCommand(words []string) string {
+	quoted := make([]string, 0, len(words))
+	for _, word := range words {
+		quoted = append(quoted, shellQuote(word))
+	}
+	return strings.Join(quoted, " ")
+}
+
+// shellQuote renders one word as a single-quoted shell literal. Inside single
+// quotes the shell interprets nothing at all, so the only thing that has to be
+// handled is a single quote itself: the literal is closed, an escaped quote is
+// emitted, and the literal is reopened.
+func shellQuote(word string) string {
+	return "'" + strings.ReplaceAll(word, "'", `'\''`) + "'"
 }
 
 // toolchain is the module the batch's recognitions run on: the caller's, or a
@@ -283,11 +461,17 @@ func (b *Batch) document(source string) *Document {
 //
 // Concurrency multiplied by per-process threads rather than bounded by cores is
 // the one shape slower than doing nothing (see WithConcurrency), and one thread
-// per process is the fast shape outright. The bound rides on a copy of the
-// module rather than on the caller's, so nothing else built from the same
-// Tesseract sees it; it is applied after `apk add`, so the two images still
-// share the package fetch. An ompThreadLimit the caller named on New is theirs
-// and is left alone.
+// per process is the fast shape outright. The processes are the slices' execs
+// rather than the images' — a slice runs its images one after another, so there
+// are workers() tesseract processes alive at a time whether the batch holds
+// sixteen images or three thousand, which is exactly the count the bound names.
+// That is why the bound needs no adjusting for the partitioning: it was always
+// counting concurrent recognitions, and it still is.
+//
+// The bound rides on a copy of the module rather than on the caller's, so
+// nothing else built from the same Tesseract sees it; it is applied after `apk
+// add`, so the two images still share the package fetch. An ompThreadLimit the
+// caller named on New is theirs and is left alone.
 func (b *Batch) toolchain() *Tesseract {
 	if b.workers() <= minBatchConcurrency || b.Tesseract.OmpThreadLimit != hostCpuOmpThreadLimit {
 		return b.Tesseract
@@ -305,13 +489,15 @@ func (b *Batch) with(opts options) *Batch {
 	return &out
 }
 
-// workers is how many recognitions run at once: whatever WithConcurrency asked
-// for, or one per CPU the module can see.
+// workers is how many recognitions run at once, and now also how many execs an
+// export creates: whatever WithConcurrency asked for, or one per CPU the module
+// can see.
 //
-// The default is the core count rather than one because every image is its own
-// exec now: recognising them one at a time would pay that exec's overhead N
-// times over and spend none of the parallelism it bought. What makes the core
-// count safe is toolchain's OpenMP bound — see WithConcurrency.
+// The default is the core count rather than one because a single tesseract
+// recognises its image on close to one core whatever the machine has — its own
+// OpenMP regions sit inside the LSTM inner loops and run at ~33% efficiency — so
+// the bound is what turns a folder of scans into a parallel recognition. What
+// makes the core count safe is toolchain's OpenMP bound — see WithConcurrency.
 func (b *Batch) workers() int {
 	if b.HasConcurrency {
 		return b.Concurrency

--- a/daggerverse/tesseract/batch_selfcheck.go
+++ b/daggerverse/tesseract/batch_selfcheck.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// batchSelfCheck verifies the two halves of a slice's script that no directory
+// of images can exercise: that the per-image invocations survive being
+// concatenated into one exec, and that an image's failure is still readable back
+// out of what that exec printed.
+//
+// It sits beside the fanout package's self-check and for a related reason. A
+// fixture can show that *an* unreadable image fails the batch by name —
+// BatchConcurrencyReportsFailingImage does — but not that every image in a slice
+// carries its own position, which is what a twelve-image slice failing on its
+// fourth depends on. Nor can a fixture show what quoting does to a path a caller
+// could write and this suite will not commit: a file name holding a quote, a
+// space or a `$`.
+//
+// Unlike fanout's, these cases cannot also be a `go test`: they read unexported
+// values of package main, and package main imports the generated client, whose
+// package initializer panics outside a Dagger session. The check is the only way
+// to run them, which is why it is one.
+func batchSelfCheck() error {
+	var errs []error
+	for _, c := range batchSelfCheckCases() {
+		if err := c.run(); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", c.name, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+type batchSelfCheckCase struct {
+	name string
+	run  func() error
+}
+
+func batchSelfCheckCases() []batchSelfCheckCase {
+	return []batchSelfCheckCase{
+		{"a slice's script creates every output directory once, above the recognitions", checkSliceScriptShape},
+		{"every image's invocation is guarded by its own position", checkSliceScriptNamesEveryImage},
+		{"every word of an invocation is quoted", checkSliceScriptQuotesEveryWord},
+		{"a reported image is read back and taken out of stderr", checkFailedImageIsReadBack},
+		{"stderr with no report yields no image", checkNoReportYieldsNoImage},
+	}
+}
+
+// sliceScriptFixture is the shape recognise hands the script builder: a slice of
+// images at two depths, and the flags every recognition in the batch shares.
+func sliceScriptFixture() (slice []string, args []string) {
+	return []string{"scans/page-1.png", "scans/page-2.png", "scans/deep/page-3.tif"},
+		[]string{"-l", "eng", "txt"}
+}
+
+// checkSliceScriptShape pins that the output directories are created once
+// however many images share the exec, and that they are created before any
+// recognition writes into them. tesseract will not create an output base's
+// directory, so a mkdir that moved below a recognition would fail that
+// recognition rather than being harmless.
+func checkSliceScriptShape() error {
+	slice, args := sliceScriptFixture()
+	script := sliceScript(slice, args)
+
+	mkdir := shellCommand(append([]string{"mkdir", "-p"}, outputDirsFor(slice)...))
+	if n := strings.Count(script, "\n"+mkdir+"\n"); n != 1 {
+		return fmt.Errorf("expected the mkdir %q exactly once, got %d:\n%s", mkdir, n, script)
+	}
+	for _, want := range []string{"'/out/scans'", "'/out/scans/deep'"} {
+		if !strings.Contains(mkdir, want) {
+			return fmt.Errorf("expected the mkdir to create %s, got %q", want, mkdir)
+		}
+	}
+
+	at := make([]int, 0, len(slice))
+	for _, source := range slice {
+		i := strings.Index(script, shellQuote(batchSourceDir+"/"+source))
+		if i < 0 {
+			return fmt.Errorf("expected %q to be recognised in the script:\n%s", source, script)
+		}
+		at = append(at, i)
+	}
+	if at[0] < strings.Index(script, mkdir) {
+		return fmt.Errorf("expected the mkdir above the first recognition:\n%s", script)
+	}
+	for i := 1; i < len(at); i++ {
+		if at[i] <= at[i-1] {
+			return fmt.Errorf(
+				"expected %q to be recognised after %q, got the reverse:\n%s",
+				slice[i], slice[i-1], script)
+		}
+	}
+	return nil
+}
+
+// checkSliceScriptNamesEveryImage is the property a failure's message rests on:
+// every invocation is followed by the guard that reports *its* position in the
+// slice, so a slice of twelve images that fails on the fourth says the fourth.
+func checkSliceScriptNamesEveryImage() error {
+	slice, args := sliceScriptFixture()
+	script := sliceScript(slice, args)
+
+	for i, source := range slice {
+		want := fmt.Sprintf("%s || %s %d $?", shellCommand(append([]string{
+			"tesseract",
+			batchSourceDir + "/" + source,
+			outputDir + "/" + outputBaseFor(source),
+		}, args...)), imageFailureFn, i)
+		if !strings.Contains(script, want) {
+			return fmt.Errorf("expected the script to carry %q:\n%s", want, script)
+		}
+	}
+	if !strings.Contains(script, imageFailureFn+"() {") {
+		return fmt.Errorf("expected the script to define %s:\n%s", imageFailureFn, script)
+	}
+	// The guard re-raises tesseract's own status rather than one of this
+	// module's, which is what keeps `exit 1` tesseract's 1.
+	if !strings.Contains(script, `exit "$2"`) {
+		return fmt.Errorf("expected the guard to re-raise the invocation's exit status:\n%s", script)
+	}
+	return nil
+}
+
+// checkSliceScriptQuotesEveryWord is what stands between a caller's file name or
+// parameter value and the shell. Both reach the script as words of a command
+// this module joins, and neither is anything this module generated.
+func checkSliceScriptQuotesEveryWord() error {
+	slice := []string{`scans/o'brien; rm -rf $HOME.png`}
+	args := []string{"-c", "tessedit_char_whitelist=$(id)"}
+	script := sliceScript(slice, args)
+
+	for _, word := range []string{
+		batchSourceDir + "/" + slice[0],
+		outputDir + "/" + outputBaseFor(slice[0]),
+		args[1],
+	} {
+		if !strings.Contains(script, shellQuote(word)) {
+			return fmt.Errorf("expected %q to be quoted in the script:\n%s", word, script)
+		}
+	}
+	if !strings.Contains(script, `'\''brien`) {
+		return fmt.Errorf("expected the embedded quote to be escaped:\n%s", script)
+	}
+
+	// The assertion that actually covers a word this check did not think of:
+	// scan the assembled command and require that everything *outside* a quoted
+	// literal is a word separator. A `;`, a `$` or an unbalanced quote reaching
+	// the shell would show up here whatever it was spelled as. The guard suffix
+	// is deliberately not scanned — its `||` and `$?` are this module's own and
+	// are meant to reach the shell.
+	command := shellCommand(append([]string{
+		"tesseract",
+		batchSourceDir + "/" + slice[0],
+		outputDir + "/" + outputBaseFor(slice[0]),
+	}, args...))
+	if loose, err := unquoted(command); err != nil {
+		return fmt.Errorf("%w:\n%s", err, command)
+	} else if strings.Trim(loose, " ") != "" {
+		return fmt.Errorf("expected only separators outside the quoted literals, got %q:\n%s",
+			loose, command)
+	}
+	return nil
+}
+
+// unquoted returns everything in a shell command that sits outside a
+// single-quoted literal, and reports a literal that is never closed.
+//
+// Inside single quotes the shell interprets nothing, so what is left over is the
+// whole of what it can act on. The one escape shellQuote emits — `'\''`, which
+// closes the literal, emits a backslash-escaped quote and reopens it — is
+// recognised and contributes nothing.
+func unquoted(command string) (string, error) {
+	var (
+		loose  strings.Builder
+		inside bool
+	)
+	for i := 0; i < len(command); i++ {
+		switch c := command[i]; {
+		case c == '\'':
+			inside = !inside
+		case inside:
+			// Literal text; the shell never sees it as anything else.
+		case c == '\\' && i+1 < len(command) && command[i+1] == '\'':
+			i++
+		default:
+			loose.WriteByte(c)
+		}
+	}
+	if inside {
+		return loose.String(), errors.New("expected every quoted literal to be closed")
+	}
+	return loose.String(), nil
+}
+
+// checkFailedImageIsReadBack asserts the round trip the message depends on: the
+// image comes back as a position, and the line carrying it does not come back as
+// part of what the caller reads.
+func checkFailedImageIsReadBack() error {
+	stderr := strings.Join([]string{
+		"Error in pixReadStream: Pdf reading is not supported",
+		imageFailureMarker + "0",
+		"",
+	}, "\n")
+
+	at, rest := takeFailedImage(stderr)
+	if at != 0 {
+		return fmt.Errorf("expected position 0, got %d", at)
+	}
+	if strings.Contains(rest, imageFailureMarker) {
+		return fmt.Errorf("expected the report to be taken out of stderr, got:\n%s", rest)
+	}
+	if !strings.Contains(rest, "pixReadStream") {
+		return fmt.Errorf("expected tesseract's own message to survive, got:\n%s", rest)
+	}
+	return nil
+}
+
+// checkNoReportYieldsNoImage asserts the other half: a failure that never
+// reached an image reports no position, so the message names the run of images
+// rather than inventing one of them.
+func checkNoReportYieldsNoImage() error {
+	for _, stderr := range []string{
+		"",
+		"mkdir: can't create directory '/out': Read-only file system",
+		imageFailureMarker + "not-a-number",
+		imageFailureMarker + "-1",
+	} {
+		if at, _ := takeFailedImage(stderr); at != -1 {
+			return fmt.Errorf("expected no image from %q, got %d", stderr, at)
+		}
+	}
+	return nil
+}

--- a/daggerverse/tesseract/dagger.gen.go
+++ b/daggerverse/tesseract/dagger.gen.go
@@ -1006,6 +1006,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Tesseract).Batch(&parent, source), nil
+		case "BatchSchedulingSelfTest":
+			var parent Tesseract
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tesseract).BatchSchedulingSelfTest(&parent, ctx)
 		case "Ci":
 			var parent Tesseract
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/tesseract/fanout/fanout.go
+++ b/daggerverse/tesseract/fanout/fanout.go
@@ -1,0 +1,100 @@
+// Package fanout runs a bounded, fail-fast set of concurrent units of work, and
+// partitions a batch's images into the units that recognise them.
+//
+// RunSlices is the entry point and does both in one call, taking the bound once.
+// Run and Partition are the primitives it is built from and are exported because
+// each is meaningful alone — Run for work that is already a flat count of units,
+// Partition for a caller that needs the boundaries themselves — but a caller
+// passing the same bound to both wants RunSlices.
+//
+// It is a package of its own, importing no dagger, so the scheduling can be
+// checked with `go test -race` and with no engine at all. That matters most for
+// the two properties a fixture cannot reach. The bound as a *floor* needs units
+// that block until every one of them has arrived, which no recognition does; and
+// the exec count staying off the image count is a claim about three thousand
+// images, which is not a suite's fixture — the containerd fold ceiling this
+// partitioning exists for was hit at around four hundred and forty, so the
+// smallest fixture that would demonstrate it is already far past what any check
+// should recognise.
+//
+// This is a copy of daggerverse/pdf/fanout, deliberately and temporarily. Each
+// daggerverse module is its own Go module whose Dagger context is its own
+// directory, so neither can import the other's packages; devex#321 is the issue
+// that lifts one shared fan-out out of both. Keeping the two identical until then
+// is what makes that lift a move rather than a merge, so a change here belongs in
+// both copies.
+package fanout
+
+import (
+	"context"
+	"sync"
+)
+
+// Run performs count units of work, at most workers of them at a time, and
+// returns the first error any of them reported.
+//
+// The bound is a slot channel rather than an unbounded fan-out because a
+// three-thousand-image batch is three thousand containers otherwise, and because
+// a machine whose cores are already busy gains nothing from being asked for more
+// of them at once.
+//
+// The first failure cancels the rest: the context handed to run is cancelled as
+// soon as any unit fails, and a unit that has not yet taken a slot never starts.
+// Work already in flight is not interrupted beyond that cancellation — a
+// recognition that ignores its context runs to completion — so this bounds what
+// is *started* rather than what is finished.
+//
+// run is called with the index of its unit and may write to distinct elements of
+// a caller-owned slice without further synchronisation: no two calls share an
+// index, and Run does not return until every call it started has returned.
+func Run(ctx context.Context, workers, count int, run func(ctx context.Context, i int) error) error {
+	if workers < 1 {
+		workers = 1
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var (
+		wg    sync.WaitGroup
+		mu    sync.Mutex
+		first error
+	)
+	slots := make(chan struct{}, workers)
+
+	for i := range count {
+		wg.Go(func() {
+			select {
+			case slots <- struct{}{}:
+				defer func() { <-slots }()
+			case <-ctx.Done():
+				// Cancelled before this unit ever started. The failure that
+				// cancelled it is the one worth reporting, and it is already
+				// recorded, so this contributes nothing.
+				return
+			}
+
+			// Taking a slot is not enough to have won the race. A select whose
+			// cases are both ready picks between them at random, so a unit
+			// offered a free slot — which the failing unit has just released —
+			// takes it as readily as it observes the cancellation. Without this
+			// second look a failure stops the *queue* but still lets the units
+			// behind it start, which is the whole property this exists for.
+			if ctx.Err() != nil {
+				return
+			}
+
+			if err := run(ctx, i); err != nil {
+				mu.Lock()
+				defer mu.Unlock()
+				if first == nil {
+					first = err
+					cancel()
+				}
+			}
+		})
+	}
+	wg.Wait()
+
+	return first
+}

--- a/daggerverse/tesseract/fanout/fanout_test.go
+++ b/daggerverse/tesseract/fanout/fanout_test.go
@@ -1,0 +1,25 @@
+package fanout
+
+import "testing"
+
+// TestSelfCheck runs the cases the tesseract module exposes as a Dagger check,
+// so the same assertions are covered here under `go test -race` — which is where
+// the scheduling itself is checked, the race detector being the only thing that
+// sees a concurrent write to a shared slot.
+func TestSelfCheck(t *testing.T) {
+	if err := SelfCheck(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestCases runs each case on its own so a failure names itself, which
+// SelfCheck's joined error cannot do as clearly from a CI log.
+func TestCases(t *testing.T) {
+	for _, c := range selfCheckCases() {
+		t.Run(c.name, func(t *testing.T) {
+			if err := c.run(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/daggerverse/tesseract/fanout/partition.go
+++ b/daggerverse/tesseract/fanout/partition.go
@@ -1,0 +1,118 @@
+package fanout
+
+import "context"
+
+// Slice is a contiguous run of units, half-open: the units at indices Start
+// through End-1.
+//
+// It is contiguous rather than strided — unit i to worker i%n would balance
+// just as well — because the units are a batch's images in sorted path order,
+// and a slice of consecutive paths is the one shape whose exec both reads and
+// writes a run a human can name.
+type Slice struct {
+	// Start is the index of the slice's first unit.
+	Start int
+	// End is one past the index of its last.
+	End int
+}
+
+// Len is how many units the slice covers.
+func (s Slice) Len() int {
+	return s.End - s.Start
+}
+
+// Partition splits count units into at most workers contiguous slices, each as
+// close to the same size as the division allows.
+//
+// This is the whole of what keeps a batch's exec count off the image count. A
+// directory produced by an exec is *one* snapshot however many files that exec
+// wrote, so the overlayfs chain a fold builds is as deep as the number of execs
+// folded and no deeper — and containerd refuses to mount a chain whose compacted
+// lowerdir list exceeds one page of joined mount data, which a three-thousand
+// image batch reached at around 440 folds. Handing each exec a slice rather than
+// an image makes the ceiling a property of the machine's core count, which does
+// not grow with the batch.
+//
+// Fewer units than workers gives one unit per slice rather than empty slices at
+// the end: an exec with no images to recognise is a container created to do
+// nothing. Zero units gives no slices at all, which is a batch with nothing to
+// do — Export refuses that by name long before it reaches here.
+//
+// The bigger slices come first, which is arbitrary but fixed: what matters is
+// that one (count, workers) always partitions the same way, so two exports of
+// the same directory under the same bound produce the same execs and hit the
+// same cache entries.
+func Partition(count, workers int) []Slice {
+	if count <= 0 {
+		return nil
+	}
+	if workers < 1 {
+		workers = 1
+	}
+	if workers > count {
+		workers = count
+	}
+
+	size, extra := count/workers, count%workers
+	slices := make([]Slice, 0, workers)
+	start := 0
+	for i := range workers {
+		n := size
+		if i < extra {
+			n++
+		}
+		slices = append(slices, Slice{Start: start, End: start + n})
+		start += n
+	}
+	return slices
+}
+
+// RunSlices splits items into at most workers contiguous slices, runs one unit
+// of work per slice — at most workers of them at a time — and returns each
+// unit's result positionally, in slice order.
+//
+// It is the whole of the fan-out in one call, and that is deliberate: the bound
+// is one number that means one thing, and a caller cannot partition by one
+// figure and schedule by another. Pairing Partition with Run by hand is what
+// this replaces; the two are still exported because each is meaningful alone —
+// Run for work that is already a flat count of units, Partition for a caller
+// that needs the boundaries themselves — but nothing should be passing the same
+// bound to both.
+//
+// run receives its slice of items and nothing else. It needs no index: the
+// results come back in the order the slices were cut, so position in the
+// returned slice is position in items, and whatever identifies the work is in
+// the items themselves.
+//
+// Everything Run promises holds here. The bound is a ceiling on units in flight,
+// the first failure is the error returned and cancels the rest, and no result is
+// returned at all when one unit fails — a partial fan-out is not a partial
+// answer, it is an answer with a hole in it.
+//
+// Empty items yields no units and no results, which is a fan-out with nothing to
+// do rather than an error; Export refuses that case by name long before it
+// reaches here.
+func RunSlices[In, Out any](
+	ctx context.Context,
+	workers int,
+	items []In,
+	run func(ctx context.Context, items []In) (Out, error),
+) ([]Out, error) {
+	slices := Partition(len(items), workers)
+	out := make([]Out, len(slices))
+
+	// Each unit writes only its own element, and Run does not return until every
+	// unit it started has, so the slice needs no lock of its own.
+	err := Run(ctx, workers, len(slices), func(ctx context.Context, i int) error {
+		result, err := run(ctx, items[slices[i].Start:slices[i].End])
+		if err != nil {
+			return err
+		}
+		out[i] = result
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/daggerverse/tesseract/fanout/selfcheck.go
+++ b/daggerverse/tesseract/fanout/selfcheck.go
@@ -1,0 +1,509 @@
+package fanout
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// selfCheckTimeout bounds the cases that wait for concurrency to happen, so a
+// bound that is too narrow fails as a timeout rather than hanging CI.
+const selfCheckTimeout = 30 * time.Second
+
+// SelfCheck verifies the properties a batch depends on and no fixture can
+// exercise: that every unit runs, that the bound is honoured in both directions,
+// that a failure in the middle is the error reported, that it stops the units
+// behind it from starting, that a batch of any size partitions into no more
+// slices than the bound allows, and that RunSlices — the one call the module
+// actually makes — holds all of that together. See the package comment for why
+// this is a self-check rather than a test against a directory of images.
+//
+// It is exposed as a Dagger check so a regression fails CI. The same cases run
+// under `go test -race`, which is where the concurrency itself is checked.
+func SelfCheck() error {
+	var errs []error
+	for _, c := range selfCheckCases() {
+		if err := c.run(); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", c.name, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+type selfCheckCase struct {
+	name string
+	run  func() error
+}
+
+func selfCheckCases() []selfCheckCase {
+	return []selfCheckCase{
+		{"every unit runs exactly once, positionally", checkEveryUnitRuns},
+		{"no more than the bound run at once", checkBoundIsACeiling},
+		{"the bound is reached", checkBoundIsReached},
+		{"a failure in the middle is the error reported", checkMiddleFailureIsReported},
+		{"the first failure stops the rest from starting", checkFailureStopsTheRest},
+		{"a bound below one still recognises", checkBoundBelowOne},
+		{"a partition covers every image once, in order", checkPartitionCoversEveryUnit},
+		{"a partition is never wider than the bound", checkPartitionIsBoundedByWorkers},
+		{"a partition's slices differ in size by at most one", checkPartitionIsBalanced},
+		{"a partition holds no empty slice", checkPartitionHasNoEmptySlice},
+		{"a partition is the same every time", checkPartitionIsStable},
+		{"run-slices hands each unit its own contiguous run of items", checkRunSlicesCoversItems},
+		{"run-slices returns one result per slice, in slice order", checkRunSlicesResultsAreOrdered},
+		{"run-slices returns no results when a unit fails", checkRunSlicesFailureReturnsNothing},
+		{"run-slices honours the bound", checkRunSlicesHonoursTheBound},
+	}
+}
+
+// checkEveryUnitRuns pins the property the assembled directory rests on: each
+// unit runs once, and writes to its own index.
+func checkEveryUnitRuns() error {
+	const count = 64
+
+	got := make([]int, count)
+	var runs atomic.Int64
+	err := Run(context.Background(), 8, count, func(_ context.Context, i int) error {
+		runs.Add(1)
+		got[i] = i + 1
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if n := runs.Load(); n != count {
+		return fmt.Errorf("expected %d units to run, got %d", count, n)
+	}
+	for i, v := range got {
+		if v != i+1 {
+			return fmt.Errorf("unit %d wrote %d to its slot, expected %d", i, v, i+1)
+		}
+	}
+	return nil
+}
+
+// checkBoundIsACeiling asserts the slot channel is a ceiling: never more than
+// workers units in flight at once.
+func checkBoundIsACeiling() error {
+	const (
+		workers = 3
+		count   = 40
+	)
+
+	var live, peak atomic.Int64
+	err := Run(context.Background(), workers, count, func(_ context.Context, _ int) error {
+		n := live.Add(1)
+		for {
+			max := peak.Load()
+			if n <= max || peak.CompareAndSwap(max, n) {
+				break
+			}
+		}
+		time.Sleep(time.Millisecond)
+		live.Add(-1)
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if p := peak.Load(); p > workers {
+		return fmt.Errorf("expected at most %d units in flight, saw %d", workers, p)
+	}
+	return nil
+}
+
+// checkBoundIsReached asserts the bound is also a floor — that the units really
+// do run at the same time rather than one after another, which a ceiling alone
+// would not distinguish.
+//
+// Every unit waits until all of them have arrived, so a fan-out narrower than
+// the bound cannot finish: it fails as a timeout rather than as a wrong answer.
+func checkBoundIsReached() error {
+	const workers = 4
+
+	var (
+		mu      sync.Mutex
+		arrived int
+		all     = make(chan struct{})
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), selfCheckTimeout)
+	defer cancel()
+
+	err := Run(ctx, workers, workers, func(ctx context.Context, _ int) error {
+		mu.Lock()
+		arrived++
+		if arrived == workers {
+			close(all)
+		}
+		mu.Unlock()
+
+		select {
+		case <-all:
+			return nil
+		case <-ctx.Done():
+			return fmt.Errorf("only %d of %d units ran at once", arrived, workers)
+		}
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// checkMiddleFailureIsReported is the case the image name rests on: the error the
+// caller sees is the failing unit's own, naming the image that failed rather than
+// summarising that something did.
+//
+// The unit that fails is the fourth to *run* rather than the fourth by index,
+// because which index reaches the pool first is the Go scheduler's business and
+// not this package's — goroutines contend for a slot, they do not queue in
+// order. With a bound of one that makes the case exactly deterministic: four
+// units run, the fourth fails, and none of the remaining six starts.
+func checkMiddleFailureIsReported() error {
+	const (
+		count  = 10
+		breaks = 4
+	)
+
+	var (
+		mu      sync.Mutex
+		ran     []int
+		failure error
+	)
+	err := Run(context.Background(), 1, count, func(_ context.Context, i int) error {
+		mu.Lock()
+		defer mu.Unlock()
+		ran = append(ran, i)
+		if len(ran) == breaks {
+			failure = fmt.Errorf("image %d could not be read", i+1)
+			return failure
+		}
+		return nil
+	})
+
+	mu.Lock()
+	defer mu.Unlock()
+	if failure == nil {
+		return fmt.Errorf("expected %d units to run, got %d", breaks, len(ran))
+	}
+	if !errors.Is(err, failure) {
+		return fmt.Errorf("expected the failing unit's own error %q, got: %v", failure, err)
+	}
+	if len(ran) != breaks {
+		return fmt.Errorf(
+			"expected the failure to stop the fan-out after %d units, got %d", breaks, len(ran))
+	}
+	return nil
+}
+
+// checkFailureStopsTheRest asserts a batch that is going to fail does not
+// recognise the rest of the directory first.
+//
+// Every unit fails, so which one lands first does not matter — what is asserted
+// is how many got to start at all. Nothing beyond a full pool can: a failing
+// unit records its error and cancels while it still holds its slot, so the unit
+// that inherits that slot finds the fan-out already cancelled.
+func checkFailureStopsTheRest() error {
+	const (
+		workers = 4
+		count   = 200
+	)
+
+	failure := errors.New("this image could not be read")
+	var entered atomic.Int64
+	err := Run(context.Background(), workers, count, func(_ context.Context, _ int) error {
+		entered.Add(1)
+		return failure
+	})
+	if !errors.Is(err, failure) {
+		return fmt.Errorf("expected a failing unit's error, got: %v", err)
+	}
+	if n := entered.Load(); n > workers {
+		return fmt.Errorf(
+			"expected at most the %d units already in flight to run, got %d of %d",
+			workers, n, count)
+	}
+	return nil
+}
+
+// partitionShapes is the (images, bound) grid every partition property is
+// checked over. It is deliberately lopsided: the batch far larger than the bound
+// is the case the exec count has to stay off, the batch smaller than the bound is
+// the ordinary one — most scan folders are smaller than a machine's core count —
+// and the exact multiple is where an off-by-one in the remainder hides.
+func partitionShapes() [][2]int {
+	return [][2]int{
+		{1, 1}, {1, 16}, {2, 16}, {12, 4}, {15, 4}, {16, 16}, {17, 16},
+		{48, 5}, {129, 32}, {437, 16}, {440, 16}, {3000, 16}, {3000, 1}, {200000, 12},
+	}
+}
+
+// checkPartitionCoversEveryUnit pins what the assembled directory rests on: the
+// slices tile the images exactly, in order, with nothing repeated and nothing
+// dropped. A partition that lost an image would produce a directory short an
+// artifact, which is the silent failure the whole batch is built to refuse.
+func checkPartitionCoversEveryUnit() error {
+	for _, shape := range partitionShapes() {
+		count, workers := shape[0], shape[1]
+		next := 0
+		for i, s := range Partition(count, workers) {
+			if s.Start != next {
+				return fmt.Errorf(
+					"Partition(%d, %d): slice %d starts at %d, expected %d",
+					count, workers, i, s.Start, next)
+			}
+			next = s.End
+		}
+		if next != count {
+			return fmt.Errorf(
+				"Partition(%d, %d): the slices cover %d units, expected %d",
+				count, workers, next, count)
+		}
+	}
+	if s := Partition(0, 4); s != nil {
+		return fmt.Errorf("Partition(0, 4): expected no slices, got %v", s)
+	}
+	return nil
+}
+
+// checkPartitionIsBoundedByWorkers is the property the fold depth rests on, and
+// the one the containerd mount-data ceiling is a consequence of: however many
+// images, a batch folds no more directories than its bound allows.
+func checkPartitionIsBoundedByWorkers() error {
+	for _, shape := range partitionShapes() {
+		count, workers := shape[0], shape[1]
+		if n := len(Partition(count, workers)); n > max(workers, 1) {
+			return fmt.Errorf(
+				"Partition(%d, %d): expected at most %d slices, got %d",
+				count, workers, workers, n)
+		}
+	}
+	// A bound below one is nonsensical and the module rejects it by name; this
+	// is the floor under that, and it must not be an unbounded fan-out.
+	if n := len(Partition(3000, 0)); n != 1 {
+		return fmt.Errorf("Partition(3000, 0): expected 1 slice, got %d", n)
+	}
+	return nil
+}
+
+// checkPartitionIsBalanced asserts no exec is handed materially more of the
+// batch than another, which is what keeps the export's wall clock at the slowest
+// slice rather than at the largest one.
+func checkPartitionIsBalanced() error {
+	for _, shape := range partitionShapes() {
+		count, workers := shape[0], shape[1]
+		slices := Partition(count, workers)
+		smallest, largest := slices[0].Len(), slices[0].Len()
+		for _, s := range slices {
+			smallest = min(smallest, s.Len())
+			largest = max(largest, s.Len())
+		}
+		if largest-smallest > 1 {
+			return fmt.Errorf(
+				"Partition(%d, %d): slices run from %d to %d units, expected a spread of at most 1",
+				count, workers, smallest, largest)
+		}
+	}
+	return nil
+}
+
+// checkPartitionHasNoEmptySlice asserts a batch smaller than the bound gets one
+// slice per image rather than a tail of empty ones. An empty slice is a container
+// created to recognise nothing, which is exactly the waste this partitioning
+// exists to delete.
+func checkPartitionHasNoEmptySlice() error {
+	for _, shape := range partitionShapes() {
+		count, workers := shape[0], shape[1]
+		for i, s := range Partition(count, workers) {
+			if s.Len() < 1 {
+				return fmt.Errorf(
+					"Partition(%d, %d): slice %d covers %d units",
+					count, workers, i, s.Len())
+			}
+		}
+	}
+	return nil
+}
+
+// checkPartitionIsStable asserts the same arguments always partition the same
+// way. Two exports of one directory under one bound have to produce the same
+// execs, or neither ever hits the other's cache entries.
+func checkPartitionIsStable() error {
+	for _, shape := range partitionShapes() {
+		count, workers := shape[0], shape[1]
+		first, second := Partition(count, workers), Partition(count, workers)
+		if len(first) != len(second) {
+			return fmt.Errorf(
+				"Partition(%d, %d): repeated calls returned %d and %d slices",
+				count, workers, len(first), len(second))
+		}
+		for i := range first {
+			if first[i] != second[i] {
+				return fmt.Errorf(
+					"Partition(%d, %d): slice %d came back as %v and then %v",
+					count, workers, i, first[i], second[i])
+			}
+		}
+	}
+	return nil
+}
+
+// checkRunSlicesCoversItems is the property an exported directory rests on end to
+// end: every item reaches exactly one unit, units see contiguous runs, and the
+// runs concatenate back into the original in order. A fan-out that dropped or
+// duplicated an item here would produce a directory short an image's artifacts or
+// holding one twice, which is the silent failure this whole package exists to
+// refuse.
+func checkRunSlicesCoversItems() error {
+	for _, shape := range partitionShapes() {
+		count, workers := shape[0], shape[1]
+
+		items := make([]int, count)
+		for i := range items {
+			items[i] = i + 1
+		}
+		seen, err := RunSlices(context.Background(), workers, items,
+			func(_ context.Context, got []int) ([]int, error) { return got, nil })
+		if err != nil {
+			return fmt.Errorf("RunSlices over %d items at %d workers: %w", count, workers, err)
+		}
+
+		var flat []int
+		for _, run := range seen {
+			if len(run) == 0 {
+				return fmt.Errorf(
+					"RunSlices over %d items at %d workers: a unit was handed no items",
+					count, workers)
+			}
+			flat = append(flat, run...)
+		}
+		if len(flat) != count {
+			return fmt.Errorf(
+				"RunSlices over %d items at %d workers: the units saw %d items",
+				count, workers, len(flat))
+		}
+		for i, v := range flat {
+			if v != i+1 {
+				return fmt.Errorf(
+					"RunSlices over %d items at %d workers: item %d of the concatenated runs is %d",
+					count, workers, i, v)
+			}
+		}
+	}
+	return nil
+}
+
+// checkRunSlicesResultsAreOrdered asserts the results come back in slice order
+// whatever order the units finished in, which is what lets a caller fold them
+// without sorting. The first unit is made to finish last, so a fan-out that
+// appended results as they arrived would fail here and pass on a serial run.
+func checkRunSlicesResultsAreOrdered() error {
+	const (
+		workers = 4
+		count   = 4
+	)
+
+	items := []int{1, 2, 3, 4}
+	got, err := RunSlices(context.Background(), workers, items,
+		func(_ context.Context, run []int) (int, error) {
+			if run[0] == 1 {
+				time.Sleep(20 * time.Millisecond)
+			}
+			return run[0], nil
+		})
+	if err != nil {
+		return err
+	}
+	if len(got) != count {
+		return fmt.Errorf("expected %d results, got %d", count, len(got))
+	}
+	for i, v := range got {
+		if v != items[i] {
+			return fmt.Errorf("result %d is %d, expected %d", i, v, items[i])
+		}
+	}
+	return nil
+}
+
+// checkRunSlicesFailureReturnsNothing asserts a failed fan-out returns the
+// failing unit's own error and no results at all. A partial slice of results is
+// an answer with a hole in it, and a caller folding it would assemble a
+// directory missing whatever the failed unit was carrying.
+func checkRunSlicesFailureReturnsNothing() error {
+	failure := errors.New("this image could not be read")
+
+	items := make([]int, 40)
+	got, err := RunSlices(context.Background(), 4, items,
+		func(_ context.Context, _ []int) (string, error) { return "recognised", failure })
+	if !errors.Is(err, failure) {
+		return fmt.Errorf("expected the failing unit's error, got: %v", err)
+	}
+	if got != nil {
+		return fmt.Errorf("expected no results beside the error, got %v", got)
+	}
+	return nil
+}
+
+// checkRunSlicesHonoursTheBound asserts the single bound reaches both halves:
+// never more than workers units in flight, and never more than workers units at
+// all however long the item list is. The second is the one #371 turned on — a
+// three-thousand-image batch creating three thousand containers to run sixteen is
+// what it exists to refuse.
+func checkRunSlicesHonoursTheBound() error {
+	const (
+		workers = 3
+		count   = 3000
+	)
+
+	var live, peak, units atomic.Int64
+	items := make([]int, count)
+	got, err := RunSlices(context.Background(), workers, items,
+		func(_ context.Context, _ []int) (int, error) {
+			units.Add(1)
+			n := live.Add(1)
+			for {
+				high := peak.Load()
+				if n <= high || peak.CompareAndSwap(high, n) {
+					break
+				}
+			}
+			time.Sleep(time.Millisecond)
+			live.Add(-1)
+			return 0, nil
+		})
+	if err != nil {
+		return err
+	}
+	if p := peak.Load(); p > workers {
+		return fmt.Errorf("expected at most %d units in flight, saw %d", workers, p)
+	}
+	if n := units.Load(); n != workers {
+		return fmt.Errorf("expected %d items to run in %d units, got %d", count, workers, n)
+	}
+	if len(got) != workers {
+		return fmt.Errorf("expected %d results, got %d", workers, len(got))
+	}
+	return nil
+}
+
+// checkBoundBelowOne asserts a nonsensical bound recognises the batch rather than
+// deadlocking on a channel of no capacity. The module rejects such a bound long
+// before this, by name; this is the floor under that.
+func checkBoundBelowOne() error {
+	const count = 5
+
+	var runs atomic.Int64
+	err := Run(context.Background(), 0, count, func(_ context.Context, _ int) error {
+		runs.Add(1)
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if n := runs.Load(); n != count {
+		return fmt.Errorf("expected %d units to run, got %d", count, n)
+	}
+	return nil
+}

--- a/daggerverse/tesseract/main.go
+++ b/daggerverse/tesseract/main.go
@@ -49,11 +49,13 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
 	"strings"
 
+	"dagger/tesseract/fanout"
 	"dagger/tesseract/internal/dagger"
 )
 
@@ -121,6 +123,37 @@ const (
 	// extension filter isImagePath applies on top of it, because Dagger's glob
 	// has no brace expansion to spell the alternation with.
 	defaultBatchGlob = "**/*"
+
+	// batchSourceDir is where one worker's slice of the batch is mounted, under
+	// the caller's own paths: `scans/deep/page-3.png` is mounted at
+	// `/work/batch/scans/deep/page-3.png` and recognised onto
+	// `/out/scans/deep/page-3`. Keeping the input layout is what lets the
+	// mirrored output layout be written outright rather than renamed afterwards,
+	// what lets a slice's whole output directory be taken as one snapshot, and
+	// what keeps tesseract's own messages naming something the caller wrote.
+	batchSourceDir = workDir + "/batch"
+
+	// imageFailureFn is the shell function a slice's script routes a failed
+	// image through, and imageFailureMarker the line it prints. Together they
+	// are how a slice of images recognised in one exec still fails by the
+	// image's own name: the exec carries several images, so the image cannot
+	// come from a label Go chose for it, and the script is the only thing that
+	// knows which command was running. The marker is stripped back out of stderr
+	// before the message is built — see takeFailedImage — so it names the image
+	// without appearing in what the caller reads.
+	//
+	// What the function is handed is the image's *position in the slice* rather
+	// than its path. Go already holds the slice, so the position is enough to
+	// name the image, and a position cannot be a path carrying a newline, a
+	// quote or the marker's own text.
+	//
+	// The position reaches the function as `$1` and tesseract's own exit status
+	// as `$2`, which is re-raised unchanged: a caller reading `exit 1` should be
+	// reading tesseract's 1 and not a code this module invented. Inside a shell
+	// function the positional parameters are the function's own, so this does
+	// not collide with any argument the script is run with.
+	imageFailureFn     = "_tesseract_image_failed"
+	imageFailureMarker = "tesseract-module-image-failed:"
 
 	// trainingSourceDir is where Training mounts the caller's pairs together
 	// with the box files generated for them, and trainingManifestPath the
@@ -419,6 +452,29 @@ func (t *Tesseract) Container() *dagger.Container {
 	return ctr
 }
 
+// BatchSchedulingSelfTest verifies the properties the batch fan-out depends on:
+// that every image runs, that WithConcurrency is honoured as both a ceiling and
+// a floor, that a failure partway through is the error reported, that it stops
+// the images behind it from starting, that a batch of any size splits into no
+// more slices than the bound allows, and that an image's failure is still
+// readable back out of the exec that recognised several images.
+//
+// It sits on the module rather than in the test module because it checks
+// unexported scheduling and unexported script assembly, and it exists at all
+// because no directory of images can check most of it. The bound as a floor
+// needs recognitions that block until every one of them has arrived; the exec
+// count needs three thousand images, which is not a fixture any suite should
+// recognise to learn that a slice count is bounded; and the quoting needs file
+// names this repository will not commit.
+//
+// It runs in-process and needs no container, so it is cheap enough to be a check
+// of its own.
+//
+// +check
+func (t *Tesseract) BatchSchedulingSelfTest(ctx context.Context) error {
+	return errors.Join(fanout.SelfCheck(), batchSelfCheck())
+}
+
 // Version returns the tesseract release the assembled image ships, as the
 // bare version number reported by `tesseract --version`.
 //
@@ -648,5 +704,12 @@ func parseLangs(out string) []string {
 func combinedOutput(ctx context.Context, exec *dagger.Container) string {
 	stdout, _ := exec.Stdout(ctx)
 	stderr, _ := exec.Stderr(ctx)
+	return joinOutput(stdout, stderr)
+}
+
+// joinOutput is combinedOutput over streams already read, which is what a batch
+// slice needs: its stderr has this module's own failure marker taken out of it
+// before the message is built, so it cannot be re-read off the exec here.
+func joinOutput(stdout, stderr string) string {
 	return strings.TrimSpace(strings.TrimSpace(stdout) + "\n" + strings.TrimSpace(stderr))
 }

--- a/daggerverse/tesseract/tests/internal/dagger/tesseract.gen.go
+++ b/daggerverse/tesseract/tests/internal/dagger/tesseract.gen.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Retrieve the binding value, as type Tesseract
-func (r *Binding) AsTesseract() *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:222:6)
+func (r *Binding) AsTesseract() *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:255:6)
 	q := r.query.Select("asTesseract")
 
 	return &Tesseract{
@@ -20,7 +20,7 @@ func (r *Binding) AsTesseract() *Tesseract { // tesseract (../../../../../dagger
 }
 
 // Retrieve the binding value, as type TesseractBatch
-func (r *Binding) AsTesseractBatch() *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:38:6)
+func (r *Binding) AsTesseractBatch() *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:40:6)
 	q := r.query.Select("asTesseractBatch")
 
 	return &TesseractBatch{
@@ -56,7 +56,7 @@ func (r *Binding) AsTesseractTraining() *TesseractTraining { // tesseract (../..
 }
 
 // Create or update a binding of type TesseractBatch in the environment
-func (r *Env) WithTesseractBatchInput(name string, value *TesseractBatch, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/batch.go:38:6)
+func (r *Env) WithTesseractBatchInput(name string, value *TesseractBatch, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/batch.go:40:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withTesseractBatchInput")
 	q = q.Arg("name", name)
@@ -69,7 +69,7 @@ func (r *Env) WithTesseractBatchInput(name string, value *TesseractBatch, descri
 }
 
 // Declare a desired TesseractBatch output to be assigned in the environment
-func (r *Env) WithTesseractBatchOutput(name string, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/batch.go:38:6)
+func (r *Env) WithTesseractBatchOutput(name string, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/batch.go:40:6)
 	q := r.query.Select("withTesseractBatchOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -128,7 +128,7 @@ func (r *Env) WithTesseractDocumentOutput(name string, description string) *Env 
 }
 
 // Create or update a binding of type Tesseract in the environment
-func (r *Env) WithTesseractInput(name string, value *Tesseract, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/main.go:222:6)
+func (r *Env) WithTesseractInput(name string, value *Tesseract, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/main.go:255:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withTesseractInput")
 	q = q.Arg("name", name)
@@ -141,7 +141,7 @@ func (r *Env) WithTesseractInput(name string, value *Tesseract, description stri
 }
 
 // Declare a desired Tesseract output to be assigned in the environment
-func (r *Env) WithTesseractOutput(name string, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/main.go:222:6)
+func (r *Env) WithTesseractOutput(name string, description string) *Env { // tesseract (../../../../../daggerverse/tesseract/main.go:255:6)
 	q := r.query.Select("withTesseractOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -184,18 +184,18 @@ type TesseractOpts struct {
 	//
 	//
 	// Default: "docker.io"
-	Registry string // tesseract (../../../../../daggerverse/tesseract/main.go:248:2)
+	Registry string // tesseract (../../../../../daggerverse/tesseract/main.go:281:2)
 	//
 	// Tag of the alpine image the toolchain is assembled on.
 	//
 	//
 	// Default: "3.24"
-	AlpineTag string // tesseract (../../../../../daggerverse/tesseract/main.go:251:2)
+	AlpineTag string // tesseract (../../../../../daggerverse/tesseract/main.go:284:2)
 	//
 	// Language codes to install, one apk package each. Empty installs "eng".
 	// "osd" is not a recognition language but is required by Document.Osd.
 	//
-	Languages []string // tesseract (../../../../../daggerverse/tesseract/main.go:255:2)
+	Languages []string // tesseract (../../../../../daggerverse/tesseract/main.go:288:2)
 	//
 	// Upper bound on the OpenMP threads tesseract may use, set on the
 	// assembled image as OMP_THREAD_LIMIT. Unset, tesseract uses one thread
@@ -206,12 +206,12 @@ type TesseractOpts struct {
 	// slowdown reports (tesseract-ocr/tesseract#2611, #1171, #263). One
 	// thread per pass is the usual setting there.
 	//
-	OmpThreadLimit int // tesseract (../../../../../daggerverse/tesseract/main.go:265:2)
+	OmpThreadLimit int // tesseract (../../../../../daggerverse/tesseract/main.go:298:2)
 }
 
 // New returns a Tesseract module backed by <registry>/library/alpine:<tag>
 // with tesseract-ocr and one language package per requested language.
-func (r *Query) Tesseract(opts ...TesseractOpts) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:243:1)
+func (r *Query) Tesseract(opts ...TesseractOpts) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:276:1)
 	q := r.query.Select("tesseract")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `registry` optional argument
@@ -241,12 +241,13 @@ func (r *Query) Tesseract(opts ...TesseractOpts) *Tesseract { // tesseract (../.
 // It carries the image coordinates and the language set the image is built
 // with; Document hangs off it so the generated SDK surfaces recognition under
 // `dag.Tesseract().Document(...)`.
-type Tesseract struct { // tesseract (../../../../../daggerverse/tesseract/main.go:222:6)
+type Tesseract struct { // tesseract (../../../../../daggerverse/tesseract/main.go:255:6)
 	query *querybuilder.Selection
 
-	id         *ID
-	parameters *string
-	version    *string
+	batchSchedulingSelfTest *Void
+	id                      *ID
+	parameters              *string
+	version                 *string
 }
 type WithTesseractFunc func(r *Tesseract) *Tesseract
 
@@ -271,7 +272,7 @@ func (r *Tesseract) WithGraphQLQuery(q *querybuilder.Selection) *Tesseract {
 // with whatever reads the results the same way the input directory was
 // composed. Which files take part is a glob, defaulting to the image
 // extensions leptonica can read.
-func (r *Tesseract) Batch(source *Directory) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/main.go:487:1)
+func (r *Tesseract) Batch(source *Directory) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/main.go:543:1)
 	assertNotNil("source", source)
 	q := r.query.Select("batch")
 	q = q.Arg("source", source)
@@ -279,6 +280,32 @@ func (r *Tesseract) Batch(source *Directory) *TesseractBatch { // tesseract (../
 	return &TesseractBatch{
 		query: q,
 	}
+}
+
+// BatchSchedulingSelfTest verifies the properties the batch fan-out depends on:
+// that every image runs, that WithConcurrency is honoured as both a ceiling and
+// a floor, that a failure partway through is the error reported, that it stops
+// the images behind it from starting, that a batch of any size splits into no
+// more slices than the bound allows, and that an image's failure is still
+// readable back out of the exec that recognised several images.
+//
+// It sits on the module rather than in the test module because it checks
+// unexported scheduling and unexported script assembly, and it exists at all
+// because no directory of images can check most of it. The bound as a floor
+// needs recognitions that block until every one of them has arrived; the exec
+// count needs three thousand images, which is not a fixture any suite should
+// recognise to learn that a slice count is bounded; and the quoting needs file
+// names this repository will not commit.
+//
+// It runs in-process and needs no container, so it is cheap enough to be a check
+// of its own.
+func (r *Tesseract) BatchSchedulingSelfTest(ctx context.Context) error { // tesseract (../../../../../daggerverse/tesseract/main.go:474:1)
+	if r.batchSchedulingSelfTest != nil {
+		return nil
+	}
+	q := r.query.Select("batchSchedulingSelfTest")
+
+	return q.Execute(ctx)
 }
 
 // Ci returns a new pipeline builder over a directory of scans. Which files take
@@ -301,7 +328,7 @@ func (r *Tesseract) Ci(source *Directory) *TesseractCi { // tesseract (../../../
 //
 // A requested OpenMP bound lives here rather than on the recognition
 // invocation so everything reached through this escape hatch inherits it too.
-func (r *Tesseract) Container() *Container { // tesseract (../../../../../daggerverse/tesseract/main.go:399:1)
+func (r *Tesseract) Container() *Container { // tesseract (../../../../../daggerverse/tesseract/main.go:432:1)
 	q := r.query.Select("container")
 
 	return &Container{
@@ -314,7 +341,7 @@ func (r *Tesseract) Container() *Container { // tesseract (../../../../../dagger
 // The boundary input is a *dagger.File rather than a *dagger.Directory, unlike
 // the kicad module's Project: tesseract resolves nothing relative to its input,
 // so one image — including a multi-page TIFF — is the whole unit of work.
-func (r *Tesseract) Document(source *File) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/main.go:475:1)
+func (r *Tesseract) Document(source *File) *TesseractDocument { // tesseract (../../../../../daggerverse/tesseract/main.go:531:1)
 	assertNotNil("source", source)
 	q := r.query.Select("document")
 	q = q.Arg("source", source)
@@ -377,7 +404,7 @@ func (r *Tesseract) UnmarshalJSON(bs []byte) error {
 // `tesseract --list-langs`: the packaged languages and any model WithTessdata
 // added, as one set. This is what Document.WithLanguage validates against, and
 // it includes "osd" when that model was installed or supplied.
-func (r *Tesseract) Langs(ctx context.Context) ([]string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:445:1)
+func (r *Tesseract) Langs(ctx context.Context) ([]string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:501:1)
 	q := r.query.Select("langs")
 
 	var response []string
@@ -389,7 +416,7 @@ func (r *Tesseract) Langs(ctx context.Context) ([]string, error) { // tesseract 
 // Parameters returns tesseract's control-variable table — every name, its
 // default value and a one-line description — as `tesseract --print-parameters`
 // prints it. These are the names Document.WithParameter accepts.
-func (r *Tesseract) Parameters(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:460:1)
+func (r *Tesseract) Parameters(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:516:1)
 	if r.parameters != nil {
 		return *r.parameters, nil
 	}
@@ -413,7 +440,7 @@ func (r *Tesseract) Parameters(ctx context.Context) (string, error) { // tessera
 //
 // The model it produces pairs directly with WithTessdata, so a fine-tune and
 // the recognition that uses it are two calls on the same module.
-func (r *Tesseract) Training(source *Directory) *TesseractTraining { // tesseract (../../../../../daggerverse/tesseract/main.go:503:1)
+func (r *Tesseract) Training(source *Directory) *TesseractTraining { // tesseract (../../../../../daggerverse/tesseract/main.go:559:1)
 	assertNotNil("source", source)
 	q := r.query.Select("training")
 	q = q.Arg("source", source)
@@ -425,7 +452,7 @@ func (r *Tesseract) Training(source *Directory) *TesseractTraining { // tesserac
 
 // Version returns the tesseract release the assembled image ships, as the
 // bare version number reported by `tesseract --version`.
-func (r *Tesseract) Version(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:426:1)
+func (r *Tesseract) Version(ctx context.Context) (string, error) { // tesseract (../../../../../daggerverse/tesseract/main.go:482:1)
 	if r.version != nil {
 		return *r.version, nil
 	}
@@ -451,7 +478,7 @@ func (r *Tesseract) Version(ctx context.Context) (string, error) { // tesseract 
 // why the credentials are not simply userinfo in the WithApkRepository URL,
 // which would put them in /etc/apk/repositories and in every apk error message
 // that quotes it.
-func (r *Tesseract) WithApkAuth(credentials *Secret) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:381:1)
+func (r *Tesseract) WithApkAuth(credentials *Secret) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:414:1)
 	assertNotNil("credentials", credentials)
 	q := r.query.Select("withApkAuth")
 	q = q.Arg("credentials", credentials)
@@ -474,7 +501,7 @@ func (r *Tesseract) WithApkAuth(credentials *Secret) *Tesseract { // tesseract (
 // Repeatable, for a mirror set signed by more than one key. It is a *File
 // rather than a *Secret because a public key is not a credential: it is meant
 // to be in the image, and WithApkAuth is the option for the part that is not.
-func (r *Tesseract) WithApkKey(key *File) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:358:1)
+func (r *Tesseract) WithApkKey(key *File) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:391:1)
 	assertNotNil("key", key)
 	q := r.query.Select("withApkKey")
 	q = q.Arg("key", key)
@@ -504,7 +531,7 @@ func (r *Tesseract) WithApkKey(key *File) *Tesseract { // tesseract (../../../..
 // call per component. A repository's index is signed, so pair this with
 // WithApkKey unless the mirror is signed by a key the base image already
 // trusts.
-func (r *Tesseract) WithApkRepository(url string) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:330:1)
+func (r *Tesseract) WithApkRepository(url string) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:363:1)
 	q := r.query.Select("withApkRepository")
 	q = q.Arg("url", url)
 
@@ -528,7 +555,7 @@ func (r *Tesseract) WithApkRepository(url string) *Tesseract { // tesseract (../
 // renderer configfiles and the font the PDF renderer needs. A caller-supplied
 // model wins over a packaged one of the same name, which is what makes
 // replacing the stock `eng` with a fine-tuned one work.
-func (r *Tesseract) WithTessdata(dir *Directory) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:301:1)
+func (r *Tesseract) WithTessdata(dir *Directory) *Tesseract { // tesseract (../../../../../daggerverse/tesseract/main.go:334:1)
 	assertNotNil("dir", dir)
 	q := r.query.Select("withTessdata")
 	q = q.Arg("dir", dir)
@@ -550,13 +577,14 @@ func (r *Tesseract) AsNode() Node {
 // all of them. It carries the same options type Document does, so the two
 // cannot drift: every With* here forwards to the shared builder.
 //
-// It is also built out of Document rather than merely resembling one. Each
-// matched image is recognised as its own Document — its own exec, its own
-// mounts, its own cache entry — and what runs several of them at a time is Go,
-// not a runner inside a container. That is what keeps the scheduling, the
-// bound and the failure reporting in a language with types and a debugger,
-// instead of in a shell script mounted into an image.
-type TesseractBatch struct { // tesseract (../../../../../daggerverse/tesseract/batch.go:38:6)
+// Each matched image is recognised by its own tesseract invocation, and the
+// invocations are split across at most WithConcurrency execs — one contiguous
+// slice of the batch each. What decides the bound, the partition, the
+// scheduling, the fail-fast and the failure message is Go; the only thing
+// interpreted inside a container is the list of per-image commands that slice
+// was handed. That keeps all of it in a language with types and a debugger,
+// instead of in a runner mounted into an image.
+type TesseractBatch struct { // tesseract (../../../../../daggerverse/tesseract/batch.go:40:6)
 	query *querybuilder.Selection
 
 	id *ID
@@ -580,19 +608,20 @@ func (r *TesseractBatch) WithGraphQLQuery(q *querybuilder.Selection) *TesseractB
 // input layout, with one artifact per requested format per image: `scans/a.png`
 // becomes `scans/a.txt` alongside `scans/a.pdf`.
 //
-// Each image is recognised on its own, as its own exec, WithConcurrency of them
-// at a time. tesseract's own list-file mode — a text file of image paths as the
-// FILE argument — is not what a batch wants, because it treats the list as one
+// Each image is recognised by its own invocation, WithConcurrency of them at a
+// time, and each invocation writes its artifacts straight onto the mirrored
+// path. tesseract's own list-file mode — a text file of image paths as the FILE
+// argument — is not what a batch wants, because it treats the list as one
 // multi-page *document*: it renders a single concatenated artifact set (one .txt
 // with form-feed page breaks, one multi-page PDF) and offers no way to get the
 // per-image files this returns.
 //
-// One exec per image is what makes the results cache per image too: an edited
-// page invalidates its own recognition and nothing else, which is the whole
-// difference for a corpus that grows a page at a time. It costs one exec's
-// overhead per page instead of per batch — see the README for what that is
-// worth measured — and it is the shape that lets the fan-out live in Go.
-func (r *TesseractBatch) Export(formats []TesseractFormat) *Directory { // tesseract (../../../../../daggerverse/tesseract/batch.go:169:1)
+// One invocation per image is what makes the results cache per slice of images
+// rather than per batch: an edited page invalidates the slice it falls in and
+// nothing else, which is most of the difference for a corpus that grows a page
+// at a time. See the README for what that is worth measured, and for why the
+// slice — rather than the image — is the granularity now.
+func (r *TesseractBatch) Export(formats []TesseractFormat) *Directory { // tesseract (../../../../../daggerverse/tesseract/batch.go:184:1)
 	q := r.query.Select("export")
 	q = q.Arg("formats", formats)
 
@@ -610,7 +639,7 @@ func (r *TesseractBatch) Export(formats []TesseractFormat) *Directory { // tesse
 // It answers the question a glob always raises — did that pattern pick up what
 // I meant? — without paying for the recognition, and it fails on an empty match
 // exactly as Export does.
-func (r *TesseractBatch) Files(ctx context.Context) ([]string, error) { // tesseract (../../../../../daggerverse/tesseract/batch.go:149:1)
+func (r *TesseractBatch) Files(ctx context.Context) ([]string, error) { // tesseract (../../../../../daggerverse/tesseract/batch.go:163:1)
 	q := r.query.Select("files")
 
 	var response []string
@@ -668,15 +697,14 @@ func (r *TesseractBatch) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
-// WithConcurrency bounds how many images the batch recognises at once.
+// WithConcurrency bounds how many images the batch recognises at once, and with
+// it how many execs the export creates.
 //
 // It defaults to the number of CPUs the module can see, which is what a batch
-// wants: every image is its own exec, and recognising them one at a time would
-// pay that overhead N times for none of the parallelism it buys. Processes are
-// how tesseract parallelises well — eleven pages on four CPUs take 3.37s one at
-// a time and 1.05s eleven at a time, ~90% efficiency where its own OpenMP
-// manages 33%, because those regions sit inside the LSTM inner loops and do not
-// amortize.
+// wants: processes are how tesseract parallelises well — eleven pages on four
+// CPUs take 3.37s one at a time and 1.05s eleven at a time, ~90% efficiency
+// where its own OpenMP manages 33%, because those regions sit inside the LSTM
+// inner loops and do not amortize.
 //
 // Recognising more than one at a time therefore also caps OpenMP at one thread
 // per process, unless the caller named an explicit ompThreadLimit on New, which
@@ -686,8 +714,21 @@ func (r *TesseractBatch) UnmarshalJSON(bs []byte) error {
 // 174x.
 //
 // Pass a number to take less of the machine than the default, or 1 to recognise
-// one image at a time. Non-positive is rejected at output time.
-func (r *TesseractBatch) WithConcurrency(concurrency int) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:88:1)
+// the whole batch in one exec, an image at a time. Non-positive is rejected at
+// output time.
+//
+// The two meanings are one setting because they were never independent. The
+// images are split into this many contiguous slices and each slice is one exec
+// running its images' invocations in turn, so the bound is at once how many
+// recognise at a time and how many containers an export creates — a
+// three-thousand-image batch is this many, not three thousand. It is what
+// decides how the results cache, too: a slice is the unit that hits or misses,
+// so an edited image re-recognises its slice rather than only itself.
+//
+// What it is still not is a change to the answer. The same artifacts come back
+// under every bound, named the same way and recognised from the same bytes;
+// concurrency is allowed to change how long an export takes and nothing else.
+func (r *TesseractBatch) WithConcurrency(concurrency int) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:102:1)
 	q := r.query.Select("withConcurrency")
 	q = q.Arg("concurrency", concurrency)
 
@@ -698,7 +739,7 @@ func (r *TesseractBatch) WithConcurrency(concurrency int) *TesseractBatch { // t
 
 // WithDpi declares the source resolution (`--dpi`) for every image in the
 // batch. See Document.WithDpi.
-func (r *TesseractBatch) WithDpi(dpi int) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:118:1)
+func (r *TesseractBatch) WithDpi(dpi int) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:132:1)
 	q := r.query.Select("withDpi")
 	q = q.Arg("dpi", dpi)
 
@@ -709,7 +750,7 @@ func (r *TesseractBatch) WithDpi(dpi int) *TesseractBatch { // tesseract (../../
 
 // WithEngine selects the OCR engine (`--oem`) for every image in the batch.
 // See Document.WithEngine.
-func (r *TesseractBatch) WithEngine(mode TesseractEngineMode) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:112:1)
+func (r *TesseractBatch) WithEngine(mode TesseractEngineMode) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:126:1)
 	q := r.query.Select("withEngine")
 	q = q.Arg("mode", mode)
 
@@ -728,7 +769,7 @@ func (r *TesseractBatch) WithEngine(mode TesseractEngineMode) *TesseractBatch { 
 // directory, and leptonica sniffs content rather than trusting extensions, so
 // `**/*.scan` is a reasonable thing to ask for. PDFs stay rejected either way,
 // because leptonica genuinely cannot read them.
-func (r *TesseractBatch) WithGlob(pattern string) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:63:1)
+func (r *TesseractBatch) WithGlob(pattern string) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:65:1)
 	q := r.query.Select("withGlob")
 	q = q.Arg("pattern", pattern)
 
@@ -739,7 +780,7 @@ func (r *TesseractBatch) WithGlob(pattern string) *TesseractBatch { // tesseract
 
 // WithLanguage selects the recognition language (`-l`) for every image in the
 // batch. See Document.WithLanguage.
-func (r *TesseractBatch) WithLanguage(lang string) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:100:1)
+func (r *TesseractBatch) WithLanguage(lang string) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:114:1)
 	q := r.query.Select("withLanguage")
 	q = q.Arg("lang", lang)
 
@@ -750,7 +791,7 @@ func (r *TesseractBatch) WithLanguage(lang string) *TesseractBatch { // tesserac
 
 // WithPageSegmentation sets how much layout analysis precedes recognition
 // (`--psm`) for every image in the batch. See Document.WithPageSegmentation.
-func (r *TesseractBatch) WithPageSegmentation(mode TesseractPageSegMode) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:106:1)
+func (r *TesseractBatch) WithPageSegmentation(mode TesseractPageSegMode) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:120:1)
 	q := r.query.Select("withPageSegmentation")
 	q = q.Arg("mode", mode)
 
@@ -761,7 +802,7 @@ func (r *TesseractBatch) WithPageSegmentation(mode TesseractPageSegMode) *Tesser
 
 // WithParameter sets one of tesseract's control variables (`-c name=value`)
 // for every image in the batch. See Document.WithParameter.
-func (r *TesseractBatch) WithParameter(name string, value string) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:124:1)
+func (r *TesseractBatch) WithParameter(name string, value string) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:138:1)
 	q := r.query.Select("withParameter")
 	q = q.Arg("name", name)
 	q = q.Arg("value", value)
@@ -773,7 +814,7 @@ func (r *TesseractBatch) WithParameter(name string, value string) *TesseractBatc
 
 // WithUserPatterns supplies a pattern list (`--user-patterns`) for every image
 // in the batch. See Document.WithUserPatterns.
-func (r *TesseractBatch) WithUserPatterns(patterns *File) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:136:1)
+func (r *TesseractBatch) WithUserPatterns(patterns *File) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:150:1)
 	assertNotNil("patterns", patterns)
 	q := r.query.Select("withUserPatterns")
 	q = q.Arg("patterns", patterns)
@@ -785,7 +826,7 @@ func (r *TesseractBatch) WithUserPatterns(patterns *File) *TesseractBatch { // t
 
 // WithUserWords supplies a word list (`--user-words`) for every image in the
 // batch. See Document.WithUserWords.
-func (r *TesseractBatch) WithUserWords(words *File) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:130:1)
+func (r *TesseractBatch) WithUserWords(words *File) *TesseractBatch { // tesseract (../../../../../daggerverse/tesseract/batch.go:144:1)
 	assertNotNil("words", words)
 	q := r.query.Select("withUserWords")
 	q = q.Arg("words", words)

--- a/daggerverse/tesseract/tests/main.go
+++ b/daggerverse/tesseract/tests/main.go
@@ -1201,11 +1201,19 @@ func (t *Tests) BatchRejectsAmbiguousInput(ctx context.Context) error {
 //
 // Byte equality is the whole promise of the knob: concurrency is allowed to
 // change how long a batch takes and nothing else. What it pins now that the
-// fan-out is Go and each image is its own exec is the *assembly* — the artifacts
-// are collected in sorted order off execs that finished in whatever order they
-// finished in, so a directory that came out right only because the work
-// happened to be serial would fail here. The digest covers the mirrored layout
-// too, nested directories and all.
+// bound also decides how the images are *sliced* into execs is that the slicing
+// is invisible in the answer — the same four images come back whether they were
+// recognised by one exec, two, three, four or sixteen, assembled from
+// directories that finished in whatever order they finished in. The digest
+// covers the mirrored layout too, nested directories and all.
+//
+// Three is in the list because four does not divide by it: the slices come out
+// 2, 1, 1, which is the shape an off-by-one in the partition drops an image
+// from. A bound wider than the batch is there because it is the ordinary case
+// for a small scan folder on a large machine — the default is one recognition
+// per CPU, and most folders are smaller than the core count — and it is the
+// shape that must not produce empty execs. One is the whole batch in a single
+// exec, which before #371 was still four containers.
 func (t *Tests) BatchConcurrencyMatchesSerialOutput(ctx context.Context) error {
 	source := dag.Directory().
 		WithFile("scans/page-1.png", fixture(sentencePng)).
@@ -1215,7 +1223,7 @@ func (t *Tests) BatchConcurrencyMatchesSerialOutput(ctx context.Context) error {
 	batch := ocr().Batch(source)
 	formats := []dagger.TesseractFormat{dagger.TesseractFormatTxt, dagger.TesseractFormatTsv}
 
-	serial := batch.Export(formats)
+	serial := batch.WithConcurrency(1).Export(formats)
 	concurrent := batch.WithConcurrency(4).Export(formats)
 
 	entries, err := concurrent.Glob(ctx, "**/*")
@@ -1236,16 +1244,27 @@ func (t *Tests) BatchConcurrencyMatchesSerialOutput(ctx context.Context) error {
 
 	serialDigest, err := serial.Digest(ctx)
 	if err != nil {
-		return fmt.Errorf("Export without concurrency: %w", err)
+		return fmt.Errorf("Export one image at a time: %w", err)
 	}
-	concurrentDigest, err := concurrent.Digest(ctx)
-	if err != nil {
-		return fmt.Errorf("Export with concurrency: %w", err)
-	}
-	if serialDigest != concurrentDigest {
-		return fmt.Errorf(
-			"expected a concurrent batch to produce byte-identical artifacts, got digest %s against the serial run's %s",
-			concurrentDigest, serialDigest)
+	for _, tc := range []struct {
+		name string
+		dir  *dagger.Directory
+	}{
+		{"unset, one per CPU", batch.Export(formats)},
+		{"two at a time", batch.WithConcurrency(2).Export(formats)},
+		{"three at a time, which four does not divide by", batch.WithConcurrency(3).Export(formats)},
+		{"one exec per image", concurrent},
+		{"wider than the batch", batch.WithConcurrency(16).Export(formats)},
+	} {
+		digest, err := tc.dir.Digest(ctx)
+		if err != nil {
+			return fmt.Errorf("Export %s: %w", tc.name, err)
+		}
+		if digest != serialDigest {
+			return fmt.Errorf(
+				"expected a batch recognised %s to produce byte-identical artifacts, got digest %s against the one-exec run's %s",
+				tc.name, digest, serialDigest)
+		}
 	}
 
 	// Zero workers would recognise nothing at all, which is a directory of
@@ -1265,24 +1284,33 @@ func (t *Tests) BatchConcurrencyMatchesSerialOutput(ctx context.Context) error {
 }
 
 // BatchConcurrencyReportsFailingImage asserts a page tesseract cannot read
-// fails the whole batch — recognised one at a time or four at a time — with a
+// fails the whole batch — however the images were sliced into execs — with a
 // message that names the page and carries tesseract's own complaint about it.
 //
 // Failing loudly is the half of a parallel rewrite that is easy to lose: a
 // runner that reports only its own exit status turns an unreadable page into a
 // batch that "succeeded" with one artifact quietly missing from a thousand.
 //
-// Naming the page has to be the batch's own doing. tesseract handed a file
+// Naming the page has to be the batch's own doing, and since #371 that means
+// naming it out of an exec that recognised several. tesseract handed a file
 // leptonica will not decode falls back to reading it as a list of image paths,
 // so its message names the file's first *line* rather than the file — here,
-// the words in the fake PNG. Two of the good pages recognise fine either side
-// of it, so what is asserted is a failure that survives its siblings
-// succeeding.
+// the words in the fake PNG. Good pages recognise fine either side of it, so
+// what is asserted is a failure that survives its siblings succeeding.
+//
+// The bounds are chosen to put the torn page at three different positions in
+// its slice. Sorted, the five images are page-3, page-1, page-2, torn, zz-page-5;
+// at a bound of one that is a single exec failing on its *fourth* invocation
+// with a fifth still to come, at two it is the first invocation of the second
+// slice, and at five it is an exec of its own. A slice that reported its own
+// name, or the first image in it, would pass the last of those and fail the
+// other two.
 func (t *Tests) BatchConcurrencyReportsFailingImage(ctx context.Context) error {
 	source := dag.Directory().
 		WithFile("scans/page-1.png", fixture(sentencePng)).
 		WithFile("scans/page-2.png", fixture(sentencePng)).
 		WithFile("scans/deep/page-3.png", fixture(sentencePng)).
+		WithFile("scans/zz-page-5.png", fixture(sentencePng)).
 		WithNewFile("scans/torn.png", "not an image at all\n")
 	batch := ocr().Batch(source)
 
@@ -1290,8 +1318,10 @@ func (t *Tests) BatchConcurrencyReportsFailingImage(ctx context.Context) error {
 		name  string
 		batch *dagger.TesseractBatch
 	}{
-		{"one at a time", batch},
-		{"four at a time", batch.WithConcurrency(4)},
+		{"in one exec, fourth of five", batch.WithConcurrency(1)},
+		{"first of its slice", batch.WithConcurrency(2)},
+		{"in an exec of its own", batch.WithConcurrency(5)},
+		{"at the default bound", batch},
 	} {
 		_, err := tc.batch.
 			Export([]dagger.TesseractFormat{dagger.TesseractFormatTxt}).
@@ -1302,6 +1332,14 @@ func (t *Tests) BatchConcurrencyReportsFailingImage(ctx context.Context) error {
 		for _, want := range []string{"scans/torn.png", "cannot be read", "Error during processing"} {
 			if !strings.Contains(err.Error(), want) {
 				return fmt.Errorf("expected the failure %s to mention %q, got: %v", tc.name, want, err)
+			}
+		}
+		// The slice's other images must not be mistaken for the failing one,
+		// which is what a message built from the slice rather than from the
+		// script would do.
+		for _, unwanted := range []string{"scans/deep/page-3.png", "scans/zz-page-5.png"} {
+			if strings.Contains(err.Error(), "Batch: "+strconv.Quote(unwanted)+":") {
+				return fmt.Errorf("expected the failure %s to name only the torn page, got: %v", tc.name, err)
 			}
 		}
 	}


### PR DESCRIPTION
Closes #371.

`Batch.Export` ran one exec per image and folded one `WithFile` per image **per
format**. A 3,000-image batch therefore created 3,000 containers in order to run
32, and then built a 3,000-deep overlayfs chain — which containerd refuses once
the compacted lowerdir list exceeds one page. Because the fold sat inside the
format loop, the ceiling was images × formats.

Measured on this branch's engine, `main` at 300 images:

```
300 images, TXT      → 28.2s, 300 execs
300 images, TXT+TSV  → mount options is too long, after 26.4s
```

The images are now partitioned into at most `workers()` contiguous slices, one
exec per slice, and `assemble` folds one `WithDirectory` per exec. Fold depth is
`len(execs)`, which the bound caps and neither the image count nor the format
count enters.

## Measured

32-CPU host, dagger v0.21.7, both columns in the same session. The 50-image rows
are the median of three with a fresh source directory each run.

| images, formats | one exec per image | one exec per slice |
| --- | --- | --- |
| 50, TXT, cold | 5.35s, 50 execs | **4.35s**, 32 execs |
| 50, TXT, one page edited | **2.75s** | 2.94s |
| 300, TXT | 28.2s, 300 execs | **13.7s**, 32 execs |
| 300, TXT+TSV | **fails after 26.4s** | **12.6s**, 32 execs |
| 3,000, TXT | — | **123.6s**, 32 execs |
| 3,000, TXT+TSV | — | **96.6s**, 32 execs |

3,000 was never run against the left column: 300 with two formats already fails
there.

## Judgment calls

**The input side is one mount per image, not one filtered `WithDirectory`.** The
issue prescribed a single filtered copy — include patterns naming the slice's
files — as "one graph operation whose result is content-addressed on the files it
actually contains", and asked for the caching to be measured either way rather
than assumed. Measured, it is not content-addressed: a
`WithDirectory(…, Include: slice)` re-recognises the **whole batch** when one
image changes — 4.84s against 2.66s, which is a cold run — at every bound,
including one image per slice. The mechanism is buildkit's: an exec mount
carrying a path *selector* gets a content-based cache key computed from the bytes
at that path, and a copy into the container's rootfs is keyed on the source
directory's digest as a whole, include patterns or not.

So the slice's images are mounted, one `WithMountedFile` each. That is not a
single graph operation, so **criterion 2's letter is not met**; its stated reason
is — a mount is an independent mount point rather than a layer on a snapshot, so
nothing on the input side adds to any overlayfs chain, whatever the slice holds.
Both the finding and the shape are written down at `recogniseSlice`.

**The unit that caches is now the slice, not the image**, which is criterion 7's
measurement coming out the less convenient way. At 50 images on 32 cores the
slices are one and two images, so #298's one-page-edited re-export goes 2.75s →
2.94s; at 3,000 images on 32 cores a corrected page re-runs ~94. The README says
so, and names `WithConcurrency(len(files))` as the way to buy the old granularity
back at the cost of the ceiling. Criterion 8's cold number improved (5.35s →
4.35s); its edited number is 0.19s worse, and that difference is the slicing
itself rather than an implementation cost.

**`fanout/` is a copy of `pdf/fanout`**, deliberately and temporarily. Each
daggerverse module is its own Go module whose Dagger context is its own
directory, so neither can import the other's packages; #321 is the issue that
lifts one shared fan-out out of both. The two are kept identical — same `Run`,
`Partition`, `Slice`, `RunSlices` — so that lift is a move rather than a merge.
Noted in the package comment and in the README's follow-ups.

**A new `+check`, `Tesseract.BatchSchedulingSelfTest`.** It joins `fanout`'s
self-check with a new one over the slice script. Neither half can be a fixture:
the bound as a floor needs recognitions that block until all of them arrive, the
exec count needs three thousand images, and the shell quoting needs file names
this repository will not commit.

**Every word of every invocation is shell-quoted.** A slice runs several
recognitions, so the invocations are a script rather than an argv, and two of
their words are the caller's outright — the image path, and any
`WithParameter` value. `unquoted()` in the self-check scans the assembled command
and requires everything outside a quoted literal to be a separator, so a word
this change did not think of is still covered.

## Acceptance criteria

- [x] `recognise` emits at most `workers()` execs for a batch of any size — one
      per slice — rather than one per image
- [~] Each worker's input is built with a single graph operation — **changed
      after measurement**: one mount per image, which adds no chain either. See
      the judgment call above
- [x] `Export`'s fold is one `WithDirectory` per exec; the per-format inner loop
      left the fold, so the ceiling no longer halves for a second format
- [x] 3,000 images complete for one format (123.6s) and for two (96.6s), without
      `mount options is too long`
- [x] A failure names the image it came from rather than the slice, and cancels
      the rest. `BatchConcurrencyReportsFailingImage` now runs the torn page at
      three positions in its slice — fourth of five in one exec, first of its
      slice, and alone — which a message built from the slice would fail
- [x] The OpenMP bound still reaches every recognition and is still one thread
      per process, now `workers()` processes rather than one per image
- [x] Measured: an edit re-runs its **slice**, not only its image — 2.75s →
      2.94s at 50 images on 32 cores. Recorded in the README, which says the
      granularity is now the slice
- [x] #298's numbers re-run: 50 pages 5.35s → **4.35s**, one-page-edited
      re-export 2.75s → 2.94s. Both in the README table
- [x] `Training`'s manifest, and its rejection of file names carrying tabs or
      newlines, are untouched
- [x] The README records that fold depth tracks exec count rather than file count
- [x] `dagger develop` re-run in `daggerverse/tesseract` and
      `daggerverse/tesseract/tests`, regenerated code committed
- [x] No `+cache=` directive added

## Verified

- `dagger check` — `ci:generated`, `ci:generated-self-test`,
  `ci:selection-self-test` all OK
- `bash .github/scripts/verify-affected-modules.sh` —
  `tesseract:batch-scheduling-self-test` OK, `tests:all` OK
- `go test -race ./fanout/` in `daggerverse/tesseract`
- The benchmarks above, against a live engine, including a baseline worktree at
  `origin/main` for the left-hand column

🤖 Generated with [Claude Code](https://claude.com/claude-code)
