### PR TITLE
story(daggerverse): run golangci-lint v2 in the standard pipeline's lint stage

### DIFF
--- a/daggerverse/go/README.md
+++ b/daggerverse/go/README.md
@@ -287,3 +287,47 @@ if _, err := dag.Container().
 The `WithBuild` second parameter is named `binaryName` (CLI flag
 `--binary-name`) to avoid colliding with Dagger CLI's top-level
 `--output/-o` flag.
+
+### Lint stage: golangci-lint v2
+
+`WithLint` installs **golangci-lint v2**. Write your `.golangci.yml` in the
+v2 dialect — the file has to open with `version: "2"`:
+
+```yaml
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+```
+
+The majors are not interchangeable, and the mismatch is not tolerated in
+either direction. A v1 binary handed a v2 file answers `you are using a
+configuration file for golangci-lint v2 with golangci-lint v1`; a v2 binary
+handed a v1 file answers `unsupported version of the configuration: ""`.
+Either way nothing is linted. So this is worth knowing before the pipeline
+rejects the file rather than after —
+[upstream's migration guide](https://golangci-lint.run/docs/product/migration-guide)
+covers translating an existing v1 config, and `golangci-lint migrate` does
+most of it.
+
+The exact release is pinned by `defaultGolangciLintVersion` in
+[`ci.go`](ci.go), and that constant is the only place it is written down: no
+config file, bundled or adopted, repeats it. `WithLint(version, config)`
+overrides it per pipeline, and the module path installed follows the pinned
+major — `github.com/golangci/golangci-lint/cmd/golangci-lint` below v2, and
+`.../golangci-lint/v2/cmd/golangci-lint` at v2 and above — so pinning a
+`v1.x` release rolls the stage back, config dialect included, without
+forking anything.
+
+The linter is built with an unpinned Go toolchain rather than with the one
+`Go` was constructed for. golangci-lint's own `go.mod` tracks the newest Go
+release (v2 needs 1.25) and the official `golang` images set
+`GOTOOLCHAIN=local`, so building it inside a project's toolchain fails for
+any project a release or two behind. It is a tool, not part of the
+project's build; it still *runs* against the project's toolchain.

--- a/daggerverse/go/ci.go
+++ b/daggerverse/go/ci.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"dagger/go/internal/dagger"
@@ -12,8 +13,24 @@ import (
 )
 
 const (
-	defaultGolangciLintVersion = "v1.64.8"
+	// defaultGolangciLintVersion is the golangci-lint release the lint
+	// stage installs when the caller pins nothing. This is the single
+	// place the pin is stated: bumping it is one edit, and nothing —
+	// not a bundled config, not an adopter's `.golangci.yml` — repeats
+	// the number.
+	//
+	// Its major version is load-bearing beyond the pin, because it is
+	// also the configuration dialect. golangci-lint v1 does not ignore
+	// a v2 config file, it refuses it outright ("you are using a
+	// configuration file for golangci-lint v2 with golangci-lint v1"),
+	// and v2 refuses a v1 file the same way. A v2 pin therefore means
+	// every `.golangci.yml` reaching this stage must open with
+	// `version: "2"`.
+	defaultGolangciLintVersion = "v2.12.2"
+
 	golangciLintConfigMountPath = "/tmp/.golangci.yml"
+
+	golangciLintModulePath = "github.com/golangci/golangci-lint"
 )
 
 // Ci is a chained builder for a standardized Go CI pipeline. Construct via
@@ -72,6 +89,13 @@ func (c *Ci) WithVet() *Ci {
 // installed golangci-lint version (defaults to defaultGolangciLintVersion
 // when empty). config, if non-nil, is mounted at golangciLintConfigMountPath
 // and passed to golangci-lint via --config.
+//
+// The default is a golangci-lint **v2** release, so a config passed here
+// must be written in the v2 dialect — a file opening with `version: "2"`.
+// A v1 file is not tolerated by a v2 binary; it is rejected before any
+// linter runs. Pass a `v1.x` version to roll the whole stage back, config
+// dialect included; the module path installed follows the version's major,
+// so both majors are reachable without forking this pipeline.
 func (c *Ci) WithLint(
 	// +optional
 	version string,
@@ -172,11 +196,25 @@ func (c *Ci) runLint(ctx context.Context) error {
 	if version == "" {
 		version = defaultGolangciLintVersion
 	}
+	pkg, err := golangciLintPkg(version)
+	if err != nil {
+		return err
+	}
 	// Build golangci-lint in a source-less container so the install
 	// dedupes across fixtures. Mounting it into the lint container as
 	// a file keeps the source mount (and per-fixture cache key) off
 	// the install span — see plan for the trace that motivated this.
-	lintBin, err := c.Go.Install("github.com/golangci/golangci-lint/cmd/golangci-lint@" + version)
+	//
+	// The toolchain used is deliberately not c.Go's. golangci-lint's own
+	// go.mod tracks the newest Go release (v2 needs 1.25), the official
+	// golang images set GOTOOLCHAIN=local so there is no automatic
+	// upgrade, and a project pinned to an older Go therefore could not
+	// build the linter at all. The linter is a tool, not part of the
+	// project's build: analysing a `go 1.23` module with a binary built
+	// by a newer toolchain is exactly what upstream's prebuilt releases
+	// do. Keeping the install off c.Go's pin also means every caller
+	// shares one install regardless of what they pinned.
+	lintBin, err := new(Go).Install(pkg)
 	if err != nil {
 		return err
 	}
@@ -193,6 +231,51 @@ func (c *Ci) runLint(ctx context.Context) error {
 	args = append(args, "./...")
 	_, err = ctr.WithExec(args).Sync(ctx)
 	return err
+}
+
+// golangciLintPkg returns the `go install` argument that builds the
+// requested golangci-lint release.
+//
+// The import path is a function of the version, not a constant: Go's
+// semantic import versioning means golangci-lint's module path gained a
+// `/v2` element at v2.0.0, so `.../cmd/golangci-lint@v2.12.2` on the v1
+// path resolves to nothing. Deriving the element from the version is what
+// lets a caller pin either major — roll forward, or roll back to a v1
+// release along with a v1 config — without forking this pipeline.
+func golangciLintPkg(version string) (string, error) {
+	major, err := majorFromVersion(version)
+	if err != nil {
+		return "", fmt.Errorf("golangci-lint version %q: %w", version, err)
+	}
+	path := golangciLintModulePath
+	if major >= 2 {
+		path += "/v" + strconv.Itoa(major)
+	}
+	return path + "/cmd/golangci-lint@" + version, nil
+}
+
+// majorFromVersion returns the major version number of a `vN...` string,
+// tolerating anything after the major (`v2`, `v2.12.2`, `v2.0.0-rc1`,
+// `v2.0.1-0.20240101120000-abcdef123456`). It errors rather than guessing
+// on a version it cannot read a major out of — a bare commit hash, say —
+// because guessing means silently choosing the wrong module path and
+// surfacing as an unresolvable package rather than as a bad pin.
+func majorFromVersion(version string) (int, error) {
+	if !strings.HasPrefix(version, "v") {
+		return 0, fmt.Errorf(`must be a semver tag beginning with "v"`)
+	}
+	digits := version[1:]
+	if i := strings.IndexFunc(digits, func(r rune) bool { return r < '0' || r > '9' }); i >= 0 {
+		digits = digits[:i]
+	}
+	if digits == "" {
+		return 0, fmt.Errorf(`must be a semver tag beginning with "v" followed by a major version number`)
+	}
+	major, err := strconv.Atoi(digits)
+	if err != nil {
+		return 0, fmt.Errorf("unreadable major version: %w", err)
+	}
+	return major, nil
 }
 
 // runBuild compiles c.Source. pkg defaults to "."; binaryName defaults to

--- a/daggerverse/go/examples/go/internal/dagger/go.gen.go
+++ b/daggerverse/go/examples/go/internal/dagger/go.gen.go
@@ -20,7 +20,7 @@ func (r *Binding) AsGo() *Go { // go (../../../../../../daggerverse/go/main.go:2
 }
 
 // Retrieve the binding value, as type GoCi
-func (r *Binding) AsGoCi() *GoCi { // go (../../../../../../daggerverse/go/ci.go:27:6)
+func (r *Binding) AsGoCi() *GoCi { // go (../../../../../../daggerverse/go/ci.go:44:6)
 	q := r.query.Select("asGoCi")
 
 	return &GoCi{
@@ -29,7 +29,7 @@ func (r *Binding) AsGoCi() *GoCi { // go (../../../../../../daggerverse/go/ci.go
 }
 
 // Create or update a binding of type GoCi in the environment
-func (r *Env) WithGoCiInput(name string, value *GoCi, description string) *Env { // go (../../../../../../daggerverse/go/ci.go:27:6)
+func (r *Env) WithGoCiInput(name string, value *GoCi, description string) *Env { // go (../../../../../../daggerverse/go/ci.go:44:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withGoCiInput")
 	q = q.Arg("name", name)
@@ -42,7 +42,7 @@ func (r *Env) WithGoCiInput(name string, value *GoCi, description string) *Env {
 }
 
 // Declare a desired GoCi output to be assigned in the environment
-func (r *Env) WithGoCiOutput(name string, description string) *Env { // go (../../../../../../daggerverse/go/ci.go:27:6)
+func (r *Env) WithGoCiOutput(name string, description string) *Env { // go (../../../../../../daggerverse/go/ci.go:44:6)
 	q := r.query.Select("withGoCiOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -246,7 +246,7 @@ func (r *Go) Build(source *Directory, opts ...GoBuildOpts) *Directory { // go (.
 }
 
 // Ci returns a new pipeline builder bound to the supplied source.
-func (r *Go) Ci(source *Directory) *GoCi { // go (../../../../../../daggerverse/go/ci.go:55:1)
+func (r *Go) Ci(source *Directory) *GoCi { // go (../../../../../../daggerverse/go/ci.go:72:1)
 	assertNotNil("source", source)
 	q := r.query.Select("ci")
 	q = q.Arg("source", source)
@@ -666,7 +666,7 @@ func (r *Go) AsNode() Node {
 // errors are aggregated. Stage 2 builds the source and Run returns the
 // produced binary as a *dagger.File. Downstream consumers compose that file
 // into their own pipelines (package, sign, publish, ...).
-type GoCi struct { // go (../../../../../../daggerverse/go/ci.go:27:6)
+type GoCi struct { // go (../../../../../../daggerverse/go/ci.go:44:6)
 	query *querybuilder.Selection
 
 	check *Void
@@ -692,7 +692,7 @@ func (r *GoCi) WithGraphQLQuery(q *querybuilder.Selection) *GoCi {
 // aggregated error. Use when callers want to run the checks
 // independently of the build (for example multi-platform pipelines
 // that share one check run across N platform builds).
-func (r *GoCi) Check(ctx context.Context) error { // go (../../../../../../daggerverse/go/ci.go:124:1)
+func (r *GoCi) Check(ctx context.Context) error { // go (../../../../../../daggerverse/go/ci.go:148:1)
 	if r.check != nil {
 		return nil
 	}
@@ -753,7 +753,7 @@ func (r *GoCi) UnmarshalJSON(bs []byte) error {
 // Run executes the pipeline: stage 1 (Check) → stage 2 (build). Returns
 // the built binary as a *dagger.File. On stage-1 failure, returns the
 // aggregated error from Check and a nil file (stage 2 is skipped).
-func (r *GoCi) Run() *File { // go (../../../../../../daggerverse/go/ci.go:149:1)
+func (r *GoCi) Run() *File { // go (../../../../../../daggerverse/go/ci.go:173:1)
 	q := r.query.Select("run")
 
 	return &File{
@@ -763,9 +763,9 @@ func (r *GoCi) Run() *File { // go (../../../../../../daggerverse/go/ci.go:149:1
 
 // GoCiWithBuildOpts contains options for GoCi.WithBuild
 type GoCiWithBuildOpts struct {
-	Pkg string // go (../../../../../../daggerverse/go/ci.go:107:2)
+	Pkg string // go (../../../../../../daggerverse/go/ci.go:131:2)
 
-	BinaryName string // go (../../../../../../daggerverse/go/ci.go:109:2)
+	BinaryName string // go (../../../../../../daggerverse/go/ci.go:133:2)
 }
 
 // WithBuild configures the build stage parameters. pkg defaults to "."
@@ -775,7 +775,7 @@ type GoCiWithBuildOpts struct {
 //
 // Note: the binary-name flag is called binaryName (CLI: --binary-name) to
 // avoid colliding with Dagger CLI's top-level --output/-o flag.
-func (r *GoCi) WithBuild(opts ...GoCiWithBuildOpts) *GoCi { // go (../../../../../../daggerverse/go/ci.go:105:1)
+func (r *GoCi) WithBuild(opts ...GoCiWithBuildOpts) *GoCi { // go (../../../../../../daggerverse/go/ci.go:129:1)
 	q := r.query.Select("withBuild")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `pkg` optional argument
@@ -794,7 +794,7 @@ func (r *GoCi) WithBuild(opts ...GoCiWithBuildOpts) *GoCi { // go (../../../../.
 }
 
 // WithFmt enables the gofmt check stage.
-func (r *GoCi) WithFmt() *GoCi { // go (../../../../../../daggerverse/go/ci.go:60:1)
+func (r *GoCi) WithFmt() *GoCi { // go (../../../../../../daggerverse/go/ci.go:77:1)
 	q := r.query.Select("withFmt")
 
 	return &GoCi{
@@ -804,16 +804,23 @@ func (r *GoCi) WithFmt() *GoCi { // go (../../../../../../daggerverse/go/ci.go:6
 
 // GoCiWithLintOpts contains options for GoCi.WithLint
 type GoCiWithLintOpts struct {
-	Version string // go (../../../../../../daggerverse/go/ci.go:77:2)
+	Version string // go (../../../../../../daggerverse/go/ci.go:101:2)
 
-	Config *File // go (../../../../../../daggerverse/go/ci.go:79:2)
+	Config *File // go (../../../../../../daggerverse/go/ci.go:103:2)
 }
 
 // WithLint enables the golangci-lint check stage. version pins the
 // installed golangci-lint version (defaults to defaultGolangciLintVersion
 // when empty). config, if non-nil, is mounted at golangciLintConfigMountPath
 // and passed to golangci-lint via --config.
-func (r *GoCi) WithLint(opts ...GoCiWithLintOpts) *GoCi { // go (../../../../../../daggerverse/go/ci.go:75:1)
+//
+// The default is a golangci-lint **v2** release, so a config passed here
+// must be written in the v2 dialect — a file opening with `version: "2"`.
+// A v1 file is not tolerated by a v2 binary; it is rejected before any
+// linter runs. Pass a `v1.x` version to roll the whole stage back, config
+// dialect included; the module path installed follows the version's major,
+// so both majors are reachable without forking this pipeline.
+func (r *GoCi) WithLint(opts ...GoCiWithLintOpts) *GoCi { // go (../../../../../../daggerverse/go/ci.go:99:1)
 	q := r.query.Select("withLint")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `version` optional argument
@@ -833,12 +840,12 @@ func (r *GoCi) WithLint(opts ...GoCiWithLintOpts) *GoCi { // go (../../../../../
 
 // GoCiWithTestOpts contains options for GoCi.WithTest
 type GoCiWithTestOpts struct {
-	Race bool // go (../../../../../../daggerverse/go/ci.go:91:2)
+	Race bool // go (../../../../../../daggerverse/go/ci.go:115:2)
 }
 
 // WithTest enables the `go test ./...` check stage. Pass race=true to
 // enable the data-race detector.
-func (r *GoCi) WithTest(opts ...GoCiWithTestOpts) *GoCi { // go (../../../../../../daggerverse/go/ci.go:89:1)
+func (r *GoCi) WithTest(opts ...GoCiWithTestOpts) *GoCi { // go (../../../../../../daggerverse/go/ci.go:113:1)
 	q := r.query.Select("withTest")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `race` optional argument
@@ -853,7 +860,7 @@ func (r *GoCi) WithTest(opts ...GoCiWithTestOpts) *GoCi { // go (../../../../../
 }
 
 // WithVet enables the `go vet ./...` check stage.
-func (r *GoCi) WithVet() *GoCi { // go (../../../../../../daggerverse/go/ci.go:66:1)
+func (r *GoCi) WithVet() *GoCi { // go (../../../../../../daggerverse/go/ci.go:83:1)
 	q := r.query.Select("withVet")
 
 	return &GoCi{

--- a/daggerverse/go/tests/dagger.gen.go
+++ b/daggerverse/go/tests/dagger.gen.go
@@ -465,6 +465,27 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Tests).CiWithFmtPasses(&parent, ctx, goImageTag)
+		case "CiWithLintAcceptsV2Config":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var goImageTag string
+			if inputArgs["goImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["goImageTag"]), &goImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg goImageTag", err))
+				}
+			}
+			return nil, (*Tests).CiWithLintAcceptsV2Config(&parent, ctx, goImageTag)
+		case "CiWithLintBuildsUnderOlderGoToolchain":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).CiWithLintBuildsUnderOlderGoToolchain(&parent, ctx)
 		case "CiWithLintPasses":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -479,6 +500,48 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Tests).CiWithLintPasses(&parent, ctx, goImageTag)
+		case "CiWithLintRejectsUnreadableVersion":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var goImageTag string
+			if inputArgs["goImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["goImageTag"]), &goImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg goImageTag", err))
+				}
+			}
+			return nil, (*Tests).CiWithLintRejectsUnreadableVersion(&parent, ctx, goImageTag)
+		case "CiWithLintRejectsV1Config":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var goImageTag string
+			if inputArgs["goImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["goImageTag"]), &goImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg goImageTag", err))
+				}
+			}
+			return nil, (*Tests).CiWithLintRejectsV1Config(&parent, ctx, goImageTag)
+		case "CiWithLintRollsBackToV1":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var goImageTag string
+			if inputArgs["goImageTag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["goImageTag"]), &goImageTag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg goImageTag", err))
+				}
+			}
+			return nil, (*Tests).CiWithLintRollsBackToV1(&parent, ctx, goImageTag)
 		case "CiWithTestPasses":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/go/tests/fixtures/golangci/v1.yml
+++ b/daggerverse/go/tests/fixtures/golangci/v1.yml
@@ -1,0 +1,8 @@
+# A minimal golangci-lint v1 configuration — no `version` field, and the v1
+# spelling of "only these linters". Kept as the negative fixture: a v2 binary
+# refuses this file, which is what pins the stage to v2 rather than to
+# "whatever config happens to parse".
+linters:
+  disable-all: true
+  enable:
+    - govet

--- a/daggerverse/go/tests/fixtures/golangci/v2.yml
+++ b/daggerverse/go/tests/fixtures/golangci/v2.yml
@@ -1,0 +1,9 @@
+# A minimal golangci-lint v2 configuration. `version: "2"` is what makes it
+# v2: the field is required by a v2 binary and rejected by a v1 one, so this
+# file is the proof that the lint stage really does run v2.
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - govet

--- a/daggerverse/go/tests/internal/dagger/go.gen.go
+++ b/daggerverse/go/tests/internal/dagger/go.gen.go
@@ -20,7 +20,7 @@ func (r *Binding) AsGo() *Go { // go (../../../../../daggerverse/go/main.go:24:6
 }
 
 // Retrieve the binding value, as type GoCi
-func (r *Binding) AsGoCi() *GoCi { // go (../../../../../daggerverse/go/ci.go:27:6)
+func (r *Binding) AsGoCi() *GoCi { // go (../../../../../daggerverse/go/ci.go:44:6)
 	q := r.query.Select("asGoCi")
 
 	return &GoCi{
@@ -29,7 +29,7 @@ func (r *Binding) AsGoCi() *GoCi { // go (../../../../../daggerverse/go/ci.go:27
 }
 
 // Create or update a binding of type GoCi in the environment
-func (r *Env) WithGoCiInput(name string, value *GoCi, description string) *Env { // go (../../../../../daggerverse/go/ci.go:27:6)
+func (r *Env) WithGoCiInput(name string, value *GoCi, description string) *Env { // go (../../../../../daggerverse/go/ci.go:44:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withGoCiInput")
 	q = q.Arg("name", name)
@@ -42,7 +42,7 @@ func (r *Env) WithGoCiInput(name string, value *GoCi, description string) *Env {
 }
 
 // Declare a desired GoCi output to be assigned in the environment
-func (r *Env) WithGoCiOutput(name string, description string) *Env { // go (../../../../../daggerverse/go/ci.go:27:6)
+func (r *Env) WithGoCiOutput(name string, description string) *Env { // go (../../../../../daggerverse/go/ci.go:44:6)
 	q := r.query.Select("withGoCiOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -246,7 +246,7 @@ func (r *Go) Build(source *Directory, opts ...GoBuildOpts) *Directory { // go (.
 }
 
 // Ci returns a new pipeline builder bound to the supplied source.
-func (r *Go) Ci(source *Directory) *GoCi { // go (../../../../../daggerverse/go/ci.go:55:1)
+func (r *Go) Ci(source *Directory) *GoCi { // go (../../../../../daggerverse/go/ci.go:72:1)
 	assertNotNil("source", source)
 	q := r.query.Select("ci")
 	q = q.Arg("source", source)
@@ -666,7 +666,7 @@ func (r *Go) AsNode() Node {
 // errors are aggregated. Stage 2 builds the source and Run returns the
 // produced binary as a *dagger.File. Downstream consumers compose that file
 // into their own pipelines (package, sign, publish, ...).
-type GoCi struct { // go (../../../../../daggerverse/go/ci.go:27:6)
+type GoCi struct { // go (../../../../../daggerverse/go/ci.go:44:6)
 	query *querybuilder.Selection
 
 	check *Void
@@ -692,7 +692,7 @@ func (r *GoCi) WithGraphQLQuery(q *querybuilder.Selection) *GoCi {
 // aggregated error. Use when callers want to run the checks
 // independently of the build (for example multi-platform pipelines
 // that share one check run across N platform builds).
-func (r *GoCi) Check(ctx context.Context) error { // go (../../../../../daggerverse/go/ci.go:124:1)
+func (r *GoCi) Check(ctx context.Context) error { // go (../../../../../daggerverse/go/ci.go:148:1)
 	if r.check != nil {
 		return nil
 	}
@@ -753,7 +753,7 @@ func (r *GoCi) UnmarshalJSON(bs []byte) error {
 // Run executes the pipeline: stage 1 (Check) → stage 2 (build). Returns
 // the built binary as a *dagger.File. On stage-1 failure, returns the
 // aggregated error from Check and a nil file (stage 2 is skipped).
-func (r *GoCi) Run() *File { // go (../../../../../daggerverse/go/ci.go:149:1)
+func (r *GoCi) Run() *File { // go (../../../../../daggerverse/go/ci.go:173:1)
 	q := r.query.Select("run")
 
 	return &File{
@@ -763,9 +763,9 @@ func (r *GoCi) Run() *File { // go (../../../../../daggerverse/go/ci.go:149:1)
 
 // GoCiWithBuildOpts contains options for GoCi.WithBuild
 type GoCiWithBuildOpts struct {
-	Pkg string // go (../../../../../daggerverse/go/ci.go:107:2)
+	Pkg string // go (../../../../../daggerverse/go/ci.go:131:2)
 
-	BinaryName string // go (../../../../../daggerverse/go/ci.go:109:2)
+	BinaryName string // go (../../../../../daggerverse/go/ci.go:133:2)
 }
 
 // WithBuild configures the build stage parameters. pkg defaults to "."
@@ -775,7 +775,7 @@ type GoCiWithBuildOpts struct {
 //
 // Note: the binary-name flag is called binaryName (CLI: --binary-name) to
 // avoid colliding with Dagger CLI's top-level --output/-o flag.
-func (r *GoCi) WithBuild(opts ...GoCiWithBuildOpts) *GoCi { // go (../../../../../daggerverse/go/ci.go:105:1)
+func (r *GoCi) WithBuild(opts ...GoCiWithBuildOpts) *GoCi { // go (../../../../../daggerverse/go/ci.go:129:1)
 	q := r.query.Select("withBuild")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `pkg` optional argument
@@ -794,7 +794,7 @@ func (r *GoCi) WithBuild(opts ...GoCiWithBuildOpts) *GoCi { // go (../../../../.
 }
 
 // WithFmt enables the gofmt check stage.
-func (r *GoCi) WithFmt() *GoCi { // go (../../../../../daggerverse/go/ci.go:60:1)
+func (r *GoCi) WithFmt() *GoCi { // go (../../../../../daggerverse/go/ci.go:77:1)
 	q := r.query.Select("withFmt")
 
 	return &GoCi{
@@ -804,16 +804,23 @@ func (r *GoCi) WithFmt() *GoCi { // go (../../../../../daggerverse/go/ci.go:60:1
 
 // GoCiWithLintOpts contains options for GoCi.WithLint
 type GoCiWithLintOpts struct {
-	Version string // go (../../../../../daggerverse/go/ci.go:77:2)
+	Version string // go (../../../../../daggerverse/go/ci.go:101:2)
 
-	Config *File // go (../../../../../daggerverse/go/ci.go:79:2)
+	Config *File // go (../../../../../daggerverse/go/ci.go:103:2)
 }
 
 // WithLint enables the golangci-lint check stage. version pins the
 // installed golangci-lint version (defaults to defaultGolangciLintVersion
 // when empty). config, if non-nil, is mounted at golangciLintConfigMountPath
 // and passed to golangci-lint via --config.
-func (r *GoCi) WithLint(opts ...GoCiWithLintOpts) *GoCi { // go (../../../../../daggerverse/go/ci.go:75:1)
+//
+// The default is a golangci-lint **v2** release, so a config passed here
+// must be written in the v2 dialect — a file opening with `version: "2"`.
+// A v1 file is not tolerated by a v2 binary; it is rejected before any
+// linter runs. Pass a `v1.x` version to roll the whole stage back, config
+// dialect included; the module path installed follows the version's major,
+// so both majors are reachable without forking this pipeline.
+func (r *GoCi) WithLint(opts ...GoCiWithLintOpts) *GoCi { // go (../../../../../daggerverse/go/ci.go:99:1)
 	q := r.query.Select("withLint")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `version` optional argument
@@ -833,12 +840,12 @@ func (r *GoCi) WithLint(opts ...GoCiWithLintOpts) *GoCi { // go (../../../../../
 
 // GoCiWithTestOpts contains options for GoCi.WithTest
 type GoCiWithTestOpts struct {
-	Race bool // go (../../../../../daggerverse/go/ci.go:91:2)
+	Race bool // go (../../../../../daggerverse/go/ci.go:115:2)
 }
 
 // WithTest enables the `go test ./...` check stage. Pass race=true to
 // enable the data-race detector.
-func (r *GoCi) WithTest(opts ...GoCiWithTestOpts) *GoCi { // go (../../../../../daggerverse/go/ci.go:89:1)
+func (r *GoCi) WithTest(opts ...GoCiWithTestOpts) *GoCi { // go (../../../../../daggerverse/go/ci.go:113:1)
 	q := r.query.Select("withTest")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `race` optional argument
@@ -853,7 +860,7 @@ func (r *GoCi) WithTest(opts ...GoCiWithTestOpts) *GoCi { // go (../../../../../
 }
 
 // WithVet enables the `go vet ./...` check stage.
-func (r *GoCi) WithVet() *GoCi { // go (../../../../../daggerverse/go/ci.go:66:1)
+func (r *GoCi) WithVet() *GoCi { // go (../../../../../daggerverse/go/ci.go:83:1)
 	q := r.query.Select("withVet")
 
 	return &GoCi{

--- a/daggerverse/go/tests/main.go
+++ b/daggerverse/go/tests/main.go
@@ -23,6 +23,8 @@ type Tests struct{}
 // Note: ContainerInfersVersionFromGoMod intentionally ignores goImageTag —
 // it asserts the empty-version inference path against a 1.23 fixture, so a
 // caller-supplied override would defeat what the test is verifying.
+// CiWithLintBuildsUnderOlderGoToolchain takes no goImageTag at all for the
+// same reason: the toolchain it pins is the subject of the assertion.
 //
 // parallel caps how many tests run concurrently inside this suite. Defaults
 // to 0 (unbounded fan-out) — each `dagger check` job runs on its own GH
@@ -148,6 +150,19 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("CiWithLintPasses", func(ctx context.Context) error {
 		return t.CiWithLintPasses(ctx, goImageTag)
 	})
+	jobs = jobs.WithJob("CiWithLintAcceptsV2Config", func(ctx context.Context) error {
+		return t.CiWithLintAcceptsV2Config(ctx, goImageTag)
+	})
+	jobs = jobs.WithJob("CiWithLintRejectsV1Config", func(ctx context.Context) error {
+		return t.CiWithLintRejectsV1Config(ctx, goImageTag)
+	})
+	jobs = jobs.WithJob("CiWithLintRollsBackToV1", func(ctx context.Context) error {
+		return t.CiWithLintRollsBackToV1(ctx, goImageTag)
+	})
+	jobs = jobs.WithJob("CiWithLintRejectsUnreadableVersion", func(ctx context.Context) error {
+		return t.CiWithLintRejectsUnreadableVersion(ctx, goImageTag)
+	})
+	jobs = jobs.WithJob("CiWithLintBuildsUnderOlderGoToolchain", t.CiWithLintBuildsUnderOlderGoToolchain)
 	jobs = jobs.WithJob("CiRunHelloAllStages", func(ctx context.Context) error {
 		return t.CiRunHelloAllStages(ctx, goImageTag)
 	})
@@ -332,6 +347,114 @@ func (t *Tests) CiWithLintPasses(ctx context.Context, goImageTag string) error {
 	}
 	if size == 0 {
 		return fmt.Errorf("expected non-empty binary, got size 0")
+	}
+	return nil
+}
+
+// golangciConfig returns one of the lint-dialect config fixtures by file
+// name (v1.yml / v2.yml).
+func golangciConfig(name string) *dagger.File {
+	return dag.CurrentModule().Source().File("fixtures/golangci/" + name)
+}
+
+// CiWithLintAcceptsV2Config runs the lint stage with a golangci-lint **v2**
+// configuration and asserts it passes.
+//
+// This is the assertion that the default pin is a v2 release. A v1 binary
+// does not ignore a v2 config file, it refuses it before running any
+// linter — "you are using a configuration file for golangci-lint v2 with
+// golangci-lint v1" — so this test fails outright the moment the pin slips
+// back across the major boundary, which is the failure adopters hit.
+func (t *Tests) CiWithLintAcceptsV2Config(ctx context.Context, goImageTag string) error {
+	err := dag.Go(dagger.GoOpts{Version: goImageTag}).Ci(helloDir()).
+		WithLint(dagger.GoCiWithLintOpts{Config: golangciConfig("v2.yml")}).
+		Check(ctx)
+	if err != nil {
+		return fmt.Errorf("Ci.WithLint with a v2 config: %w", err)
+	}
+	return nil
+}
+
+// CiWithLintRejectsV1Config is the other half of CiWithLintAcceptsV2Config:
+// a v1-dialect config must now fail. Without it, "accepts a v2 config" is
+// also satisfied by a binary that accepts everything, and the dialect the
+// stage actually requires would stay unpinned.
+//
+// The assertion is on *how* it fails, not merely that it does. The
+// module boundary drops golangci-lint's stderr from the Go error — what
+// survives is the exec's exit code — and golangci-lint distinguishes the
+// two outcomes there: 3 is "could not load the config", 1 is "the config
+// loaded and linters reported issues". Accepting any failure would let a
+// v2 binary that merely dislikes the fixture pass for a v1 binary that
+// happily loaded a v1 file.
+func (t *Tests) CiWithLintRejectsV1Config(ctx context.Context, goImageTag string) error {
+	err := dag.Go(dagger.GoOpts{Version: goImageTag}).Ci(helloDir()).
+		WithLint(dagger.GoCiWithLintOpts{Config: golangciConfig("v1.yml")}).
+		Check(ctx)
+	if err == nil {
+		return fmt.Errorf("expected Ci.WithLint with a v1 config to fail under a v2 golangci-lint, got nil")
+	}
+	if msg := err.Error(); !strings.Contains(msg, "exit code: 3") {
+		return fmt.Errorf("expected the v1 config to be refused as unloadable (golangci-lint exit code 3), got: %s", msg)
+	}
+	return nil
+}
+
+// CiWithLintRollsBackToV1 pins a golangci-lint v1 release together with a
+// v1-dialect config and asserts the stage passes.
+//
+// Rolling back is not merely a different `@version`: Go's semantic import
+// versioning put v2 on a `/v2` module path, so the package installed has
+// to follow the pinned major. This is the test that the derivation works
+// on the other side of that boundary — without it, everything below v2 is
+// a path nothing exercises.
+func (t *Tests) CiWithLintRollsBackToV1(ctx context.Context, goImageTag string) error {
+	err := dag.Go(dagger.GoOpts{Version: goImageTag}).Ci(helloDir()).
+		WithLint(dagger.GoCiWithLintOpts{
+			Version: "v1.64.8",
+			Config:  golangciConfig("v1.yml"),
+		}).
+		Check(ctx)
+	if err != nil {
+		return fmt.Errorf("Ci.WithLint pinned to v1.64.8: %w", err)
+	}
+	return nil
+}
+
+// CiWithLintRejectsUnreadableVersion asserts a version the module cannot
+// read a major out of is refused with a message naming it, rather than
+// being guessed at and surfacing later as an unresolvable package.
+func (t *Tests) CiWithLintRejectsUnreadableVersion(ctx context.Context, goImageTag string) error {
+	err := dag.Go(dagger.GoOpts{Version: goImageTag}).Ci(helloDir()).
+		WithLint(dagger.GoCiWithLintOpts{Version: "1.64.8"}).
+		Check(ctx)
+	if err == nil {
+		return fmt.Errorf(`expected Ci.WithLint pinned to "1.64.8" to fail, got nil`)
+	}
+	if msg := err.Error(); !strings.Contains(msg, `golangci-lint version "1.64.8"`) {
+		return fmt.Errorf("expected the error to name the rejected version, got: %s", msg)
+	}
+	return nil
+}
+
+// CiWithLintBuildsUnderOlderGoToolchain pins the Go toolchain below what
+// golangci-lint v2's own go.mod requires and asserts the lint stage still
+// runs.
+//
+// golangci-lint tracks the newest Go release, and the official golang
+// images set GOTOOLCHAIN=local, so building the linter inside a project's
+// pinned toolchain fails for any project a release or two behind — exactly
+// the repository most likely to be adopting the standard pipeline. The
+// stage therefore builds the linter with an unpinned toolchain and only
+// *runs* it under the project's. Pinning 1.23 here rather than honouring
+// goImageTag is the point of the test; a caller-supplied override would
+// defeat it.
+func (t *Tests) CiWithLintBuildsUnderOlderGoToolchain(ctx context.Context) error {
+	err := dag.Go(dagger.GoOpts{Version: "1.23"}).Ci(helloDir()).
+		WithLint().
+		Check(ctx)
+	if err != nil {
+		return fmt.Errorf("Ci.WithLint under a pinned go1.23 toolchain: %w", err)
 	}
 	return nil
 }

--- a/daggerverse/z5labs/configs/golangci.yml
+++ b/daggerverse/z5labs/configs/golangci.yml
@@ -1,8 +1,23 @@
+# The lint policy the standard pipeline applies when an adopter supplies no
+# `.golangci.yml` of their own, and the file to copy as a starting point when
+# they do.
+#
+# The pipeline runs golangci-lint **v2**, and the majors are not
+# interchangeable: a v2 binary refuses a v1 configuration file outright,
+# before any linter runs, and v1 refuses a v2 one. So an override must be
+# written in this dialect. `version: "2"` below is the config schema's own
+# version — required by v2, absent from v1 — and not the tool pin. The pin
+# is a single constant in the `go` module (defaultGolangciLintVersion), which
+# is where a bump belongs; nothing here restates it, and neither should an
+# adopter's file. Pass lintVersion to GoApp / GoLib to pin or roll back
+# without forking the pipeline.
+version: "2"
+
 run:
   timeout: 5m
 
 linters:
-  disable-all: true
+  default: none
   enable:
     - errcheck
     - govet

--- a/daggerverse/z5labs/dagger.gen.go
+++ b/daggerverse/z5labs/dagger.gen.go
@@ -83,6 +83,7 @@ func (r GoApp) MarshalJSON() ([]byte, error) {
 		AuthUsername        string
 		Auth                *dagger.Secret
 		LintConfig          *dagger.File
+		LintVersion         string
 		Platforms           []string
 		RegistryService     *dagger.Service
 		Insecure            bool
@@ -99,6 +100,7 @@ func (r GoApp) MarshalJSON() ([]byte, error) {
 	concrete.AuthUsername = r.AuthUsername
 	concrete.Auth = r.Auth
 	concrete.LintConfig = r.LintConfig
+	concrete.LintVersion = r.LintVersion
 	concrete.Platforms = r.Platforms
 	concrete.RegistryService = r.RegistryService
 	concrete.Insecure = r.Insecure
@@ -119,6 +121,7 @@ func (r *GoApp) UnmarshalJSON(bs []byte) error {
 		AuthUsername        string
 		Auth                *dagger.Secret
 		LintConfig          *dagger.File
+		LintVersion         string
 		Platforms           []string
 		RegistryService     *dagger.Service
 		Insecure            bool
@@ -139,6 +142,7 @@ func (r *GoApp) UnmarshalJSON(bs []byte) error {
 	r.AuthUsername = concrete.AuthUsername
 	r.Auth = concrete.Auth
 	r.LintConfig = concrete.LintConfig
+	r.LintVersion = concrete.LintVersion
 	r.Platforms = concrete.Platforms
 	r.RegistryService = concrete.RegistryService
 	r.Insecure = concrete.Insecure
@@ -151,18 +155,21 @@ func (r *GoApp) UnmarshalJSON(bs []byte) error {
 
 func (r GoLib) MarshalJSON() ([]byte, error) {
 	var concrete struct {
-		Source     *dagger.Directory
-		LintConfig *dagger.File
+		Source      *dagger.Directory
+		LintConfig  *dagger.File
+		LintVersion string
 	}
 	concrete.Source = r.Source
 	concrete.LintConfig = r.LintConfig
+	concrete.LintVersion = r.LintVersion
 	return json.Marshal(&concrete)
 }
 
 func (r *GoLib) UnmarshalJSON(bs []byte) error {
 	var concrete struct {
-		Source     *dagger.Directory
-		LintConfig *dagger.File
+		Source      *dagger.Directory
+		LintConfig  *dagger.File
+		LintVersion string
 	}
 	err := json.Unmarshal(bs, &concrete)
 	if err != nil {
@@ -170,6 +177,7 @@ func (r *GoLib) UnmarshalJSON(bs []byte) error {
 	}
 	r.Source = concrete.Source
 	r.LintConfig = concrete.LintConfig
+	r.LintVersion = concrete.LintVersion
 	return nil
 }
 
@@ -424,6 +432,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg lintConfig", err))
 				}
 			}
+			var lintVersion string
+			if inputArgs["lintVersion"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["lintVersion"]), &lintVersion)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg lintVersion", err))
+				}
+			}
 			var platforms []string
 			if inputArgs["platforms"] != nil {
 				err = json.Unmarshal([]byte(inputArgs["platforms"]), &platforms)
@@ -473,7 +488,7 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg signingKey", err))
 				}
 			}
-			return (*Z5labs).GoApp(&parent, source, pkg, binaryName, publishOn, registry, authUsername, auth, lintConfig, platforms, registryService, insecure, idTokenRequestUrl, idTokenRequestToken, idTokenService, signingKey), nil
+			return (*Z5labs).GoApp(&parent, source, pkg, binaryName, publishOn, registry, authUsername, auth, lintConfig, lintVersion, platforms, registryService, insecure, idTokenRequestUrl, idTokenRequestToken, idTokenService, signingKey), nil
 		case "GoLib":
 			var parent Z5labs
 			err = json.Unmarshal(parentJSON, &parent)
@@ -494,7 +509,14 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg lintConfig", err))
 				}
 			}
-			return (*Z5labs).GoLib(&parent, source, lintConfig), nil
+			var lintVersion string
+			if inputArgs["lintVersion"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["lintVersion"]), &lintVersion)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg lintVersion", err))
+				}
+			}
+			return (*Z5labs).GoLib(&parent, source, lintConfig, lintVersion), nil
 		default:
 			return nil, fmt.Errorf("unknown function %s", fnName)
 		}

--- a/daggerverse/z5labs/goapp.go
+++ b/daggerverse/z5labs/goapp.go
@@ -29,6 +29,8 @@ type GoApp struct {
 	// +private
 	LintConfig *dagger.File
 	// +private
+	LintVersion string
+	// +private
 	Platforms []string
 	// +private
 	RegistryService *dagger.Service
@@ -83,7 +85,7 @@ func (a *GoApp) Ci(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if err := sharedCheck(ctx, a.Source, a.LintConfig); err != nil {
+	if err := sharedCheck(ctx, a.Source, a.LintConfig, a.LintVersion); err != nil {
 		return "", err
 	}
 	annotations, err := a.ociAnnotations(ctx)

--- a/daggerverse/z5labs/golib.go
+++ b/daggerverse/z5labs/golib.go
@@ -12,6 +12,8 @@ type GoLib struct {
 	Source *dagger.Directory
 	// +private
 	LintConfig *dagger.File
+	// +private
+	LintVersion string
 }
 
 // Ci runs the standardized check stages (fmt, vet, lint, test -race)
@@ -20,5 +22,5 @@ type GoLib struct {
 // +check
 // +cache="session"
 func (l *GoLib) Ci(ctx context.Context) error {
-	return sharedCheck(ctx, l.Source, l.LintConfig)
+	return sharedCheck(ctx, l.Source, l.LintConfig, l.LintVersion)
 }

--- a/daggerverse/z5labs/helpers.go
+++ b/daggerverse/z5labs/helpers.go
@@ -69,7 +69,11 @@ func writeWorkdirFile(name string, content []byte) (*dagger.File, error) {
 
 // sharedCheck runs the standard z5labs check stages (fmt, vet, lint with
 // the resolved config, test -race) against source via the go module dep.
-func sharedCheck(ctx context.Context, source *dagger.Directory, lintOverride *dagger.File) error {
+//
+// lintVersion is passed straight through: empty means the `go` module's
+// pinned default, which is what keeps the pin a single edit in one place
+// rather than a number restated here as well.
+func sharedCheck(ctx context.Context, source *dagger.Directory, lintOverride *dagger.File, lintVersion string) error {
 	cfg, err := resolvedLintConfig(ctx, lintOverride)
 	if err != nil {
 		return err
@@ -78,7 +82,7 @@ func sharedCheck(ctx context.Context, source *dagger.Directory, lintOverride *da
 		Ci(source).
 		WithFmt().
 		WithVet().
-		WithLint(dagger.GoCiWithLintOpts{Config: cfg}).
+		WithLint(dagger.GoCiWithLintOpts{Config: cfg, Version: lintVersion}).
 		WithTest(dagger.GoCiWithTestOpts{Race: true}).
 		Check(ctx)
 }

--- a/daggerverse/z5labs/internal/dagger/go.gen.go
+++ b/daggerverse/z5labs/internal/dagger/go.gen.go
@@ -20,7 +20,7 @@ func (r *Binding) AsGo() *Go { // go (../../../../daggerverse/go/main.go:24:6)
 }
 
 // Retrieve the binding value, as type GoCi
-func (r *Binding) AsGoCi() *GoCi { // go (../../../../daggerverse/go/ci.go:27:6)
+func (r *Binding) AsGoCi() *GoCi { // go (../../../../daggerverse/go/ci.go:44:6)
 	q := r.query.Select("asGoCi")
 
 	return &GoCi{
@@ -29,7 +29,7 @@ func (r *Binding) AsGoCi() *GoCi { // go (../../../../daggerverse/go/ci.go:27:6)
 }
 
 // Create or update a binding of type GoCi in the environment
-func (r *Env) WithGoCiInput(name string, value *GoCi, description string) *Env { // go (../../../../daggerverse/go/ci.go:27:6)
+func (r *Env) WithGoCiInput(name string, value *GoCi, description string) *Env { // go (../../../../daggerverse/go/ci.go:44:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withGoCiInput")
 	q = q.Arg("name", name)
@@ -42,7 +42,7 @@ func (r *Env) WithGoCiInput(name string, value *GoCi, description string) *Env {
 }
 
 // Declare a desired GoCi output to be assigned in the environment
-func (r *Env) WithGoCiOutput(name string, description string) *Env { // go (../../../../daggerverse/go/ci.go:27:6)
+func (r *Env) WithGoCiOutput(name string, description string) *Env { // go (../../../../daggerverse/go/ci.go:44:6)
 	q := r.query.Select("withGoCiOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -246,7 +246,7 @@ func (r *Go) Build(source *Directory, opts ...GoBuildOpts) *Directory { // go (.
 }
 
 // Ci returns a new pipeline builder bound to the supplied source.
-func (r *Go) Ci(source *Directory) *GoCi { // go (../../../../daggerverse/go/ci.go:55:1)
+func (r *Go) Ci(source *Directory) *GoCi { // go (../../../../daggerverse/go/ci.go:72:1)
 	assertNotNil("source", source)
 	q := r.query.Select("ci")
 	q = q.Arg("source", source)
@@ -666,7 +666,7 @@ func (r *Go) AsNode() Node {
 // errors are aggregated. Stage 2 builds the source and Run returns the
 // produced binary as a *dagger.File. Downstream consumers compose that file
 // into their own pipelines (package, sign, publish, ...).
-type GoCi struct { // go (../../../../daggerverse/go/ci.go:27:6)
+type GoCi struct { // go (../../../../daggerverse/go/ci.go:44:6)
 	query *querybuilder.Selection
 
 	check *Void
@@ -692,7 +692,7 @@ func (r *GoCi) WithGraphQLQuery(q *querybuilder.Selection) *GoCi {
 // aggregated error. Use when callers want to run the checks
 // independently of the build (for example multi-platform pipelines
 // that share one check run across N platform builds).
-func (r *GoCi) Check(ctx context.Context) error { // go (../../../../daggerverse/go/ci.go:124:1)
+func (r *GoCi) Check(ctx context.Context) error { // go (../../../../daggerverse/go/ci.go:148:1)
 	if r.check != nil {
 		return nil
 	}
@@ -753,7 +753,7 @@ func (r *GoCi) UnmarshalJSON(bs []byte) error {
 // Run executes the pipeline: stage 1 (Check) → stage 2 (build). Returns
 // the built binary as a *dagger.File. On stage-1 failure, returns the
 // aggregated error from Check and a nil file (stage 2 is skipped).
-func (r *GoCi) Run() *File { // go (../../../../daggerverse/go/ci.go:149:1)
+func (r *GoCi) Run() *File { // go (../../../../daggerverse/go/ci.go:173:1)
 	q := r.query.Select("run")
 
 	return &File{
@@ -763,9 +763,9 @@ func (r *GoCi) Run() *File { // go (../../../../daggerverse/go/ci.go:149:1)
 
 // GoCiWithBuildOpts contains options for GoCi.WithBuild
 type GoCiWithBuildOpts struct {
-	Pkg string // go (../../../../daggerverse/go/ci.go:107:2)
+	Pkg string // go (../../../../daggerverse/go/ci.go:131:2)
 
-	BinaryName string // go (../../../../daggerverse/go/ci.go:109:2)
+	BinaryName string // go (../../../../daggerverse/go/ci.go:133:2)
 }
 
 // WithBuild configures the build stage parameters. pkg defaults to "."
@@ -775,7 +775,7 @@ type GoCiWithBuildOpts struct {
 //
 // Note: the binary-name flag is called binaryName (CLI: --binary-name) to
 // avoid colliding with Dagger CLI's top-level --output/-o flag.
-func (r *GoCi) WithBuild(opts ...GoCiWithBuildOpts) *GoCi { // go (../../../../daggerverse/go/ci.go:105:1)
+func (r *GoCi) WithBuild(opts ...GoCiWithBuildOpts) *GoCi { // go (../../../../daggerverse/go/ci.go:129:1)
 	q := r.query.Select("withBuild")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `pkg` optional argument
@@ -794,7 +794,7 @@ func (r *GoCi) WithBuild(opts ...GoCiWithBuildOpts) *GoCi { // go (../../../../d
 }
 
 // WithFmt enables the gofmt check stage.
-func (r *GoCi) WithFmt() *GoCi { // go (../../../../daggerverse/go/ci.go:60:1)
+func (r *GoCi) WithFmt() *GoCi { // go (../../../../daggerverse/go/ci.go:77:1)
 	q := r.query.Select("withFmt")
 
 	return &GoCi{
@@ -804,16 +804,23 @@ func (r *GoCi) WithFmt() *GoCi { // go (../../../../daggerverse/go/ci.go:60:1)
 
 // GoCiWithLintOpts contains options for GoCi.WithLint
 type GoCiWithLintOpts struct {
-	Version string // go (../../../../daggerverse/go/ci.go:77:2)
+	Version string // go (../../../../daggerverse/go/ci.go:101:2)
 
-	Config *File // go (../../../../daggerverse/go/ci.go:79:2)
+	Config *File // go (../../../../daggerverse/go/ci.go:103:2)
 }
 
 // WithLint enables the golangci-lint check stage. version pins the
 // installed golangci-lint version (defaults to defaultGolangciLintVersion
 // when empty). config, if non-nil, is mounted at golangciLintConfigMountPath
 // and passed to golangci-lint via --config.
-func (r *GoCi) WithLint(opts ...GoCiWithLintOpts) *GoCi { // go (../../../../daggerverse/go/ci.go:75:1)
+//
+// The default is a golangci-lint **v2** release, so a config passed here
+// must be written in the v2 dialect — a file opening with `version: "2"`.
+// A v1 file is not tolerated by a v2 binary; it is rejected before any
+// linter runs. Pass a `v1.x` version to roll the whole stage back, config
+// dialect included; the module path installed follows the version's major,
+// so both majors are reachable without forking this pipeline.
+func (r *GoCi) WithLint(opts ...GoCiWithLintOpts) *GoCi { // go (../../../../daggerverse/go/ci.go:99:1)
 	q := r.query.Select("withLint")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `version` optional argument
@@ -833,12 +840,12 @@ func (r *GoCi) WithLint(opts ...GoCiWithLintOpts) *GoCi { // go (../../../../dag
 
 // GoCiWithTestOpts contains options for GoCi.WithTest
 type GoCiWithTestOpts struct {
-	Race bool // go (../../../../daggerverse/go/ci.go:91:2)
+	Race bool // go (../../../../daggerverse/go/ci.go:115:2)
 }
 
 // WithTest enables the `go test ./...` check stage. Pass race=true to
 // enable the data-race detector.
-func (r *GoCi) WithTest(opts ...GoCiWithTestOpts) *GoCi { // go (../../../../daggerverse/go/ci.go:89:1)
+func (r *GoCi) WithTest(opts ...GoCiWithTestOpts) *GoCi { // go (../../../../daggerverse/go/ci.go:113:1)
 	q := r.query.Select("withTest")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `race` optional argument
@@ -853,7 +860,7 @@ func (r *GoCi) WithTest(opts ...GoCiWithTestOpts) *GoCi { // go (../../../../dag
 }
 
 // WithVet enables the `go vet ./...` check stage.
-func (r *GoCi) WithVet() *GoCi { // go (../../../../daggerverse/go/ci.go:66:1)
+func (r *GoCi) WithVet() *GoCi { // go (../../../../daggerverse/go/ci.go:83:1)
 	q := r.query.Select("withVet")
 
 	return &GoCi{

--- a/daggerverse/z5labs/main.go
+++ b/daggerverse/z5labs/main.go
@@ -1,6 +1,13 @@
 // Package main implements the z5labs daggerverse module: opinionated CI
 // and release pipelines for Go projects. Construct via the GoApp or GoLib
 // factories on Z5labs; call the terminal Ci method to run the pipeline.
+//
+// The lint stage runs golangci-lint v2. A repository adopting this pipeline
+// keeps its `.golangci.yml` in the v2 dialect — the file opens with
+// `version: "2"` — because a v2 binary refuses a v1 file outright rather
+// than ignoring it. Supplying no file at all takes the bundled policy in
+// configs/golangci.yml, which is the v2 file to copy from. The release is
+// pinned once, in the `go` module; lintVersion moves it, either major.
 package main
 
 import (
@@ -75,8 +82,23 @@ func (m *Z5labs) GoApp(
 	authUsername string,
 	// +optional
 	auth *dagger.Secret,
+	// A `.golangci.yml` replacing the bundled default policy.
+	//
+	// The lint stage runs golangci-lint v2, so this file must be written
+	// in the v2 dialect — it has to open with `version: "2"`. The majors
+	// are not interchangeable: a v2 binary refuses a v1 file outright,
+	// before running any linter. Pass lintVersion to move the whole stage,
+	// dialect included, to another release.
+	//
 	// +optional
 	lintConfig *dagger.File,
+	// The golangci-lint release the lint stage installs, e.g. "v2.12.2".
+	// Empty takes the version pinned by the `go` module, which is a v2
+	// release; pinning a "v1.x" release here rolls the stage — and the
+	// config dialect it requires — back to v1.
+	//
+	// +optional
+	lintVersion string,
 	// +optional
 	platforms []string,
 	// +optional
@@ -134,6 +156,7 @@ func (m *Z5labs) GoApp(
 		AuthUsername:    authUsername,
 		Auth:            auth,
 		LintConfig:      lintConfig,
+		LintVersion:     lintVersion,
 		Platforms:       platforms,
 		RegistryService: registryService,
 		Insecure:        insecure,
@@ -149,8 +172,23 @@ func (m *Z5labs) GoApp(
 // publish equivalent for libraries.
 func (m *Z5labs) GoLib(
 	source *dagger.Directory,
+	// A `.golangci.yml` replacing the bundled default policy.
+	//
+	// The lint stage runs golangci-lint v2, so this file must be written
+	// in the v2 dialect — it has to open with `version: "2"`. The majors
+	// are not interchangeable: a v2 binary refuses a v1 file outright,
+	// before running any linter. Pass lintVersion to move the whole stage,
+	// dialect included, to another release.
+	//
 	// +optional
 	lintConfig *dagger.File,
+	// The golangci-lint release the lint stage installs, e.g. "v2.12.2".
+	// Empty takes the version pinned by the `go` module, which is a v2
+	// release; pinning a "v1.x" release here rolls the stage — and the
+	// config dialect it requires — back to v1.
+	//
+	// +optional
+	lintVersion string,
 ) *GoLib {
-	return &GoLib{Source: source, LintConfig: lintConfig}
+	return &GoLib{Source: source, LintConfig: lintConfig, LintVersion: lintVersion}
 }

--- a/daggerverse/z5labs/tests/dagger.gen.go
+++ b/daggerverse/z5labs/tests/dagger.gen.go
@@ -381,6 +381,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).GoLibCiPassesForValidSource(&parent, ctx)
+		case "GoLibCiRoutesLintVersion":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).GoLibCiRoutesLintVersion(&parent, ctx)
 		default:
 			return nil, fmt.Errorf("unknown function %s", fnName)
 		}

--- a/daggerverse/z5labs/tests/internal/dagger/go.gen.go
+++ b/daggerverse/z5labs/tests/internal/dagger/go.gen.go
@@ -20,7 +20,7 @@ func (r *Binding) AsGo() *Go { // go (../../../../../daggerverse/go/main.go:24:6
 }
 
 // Retrieve the binding value, as type GoCi
-func (r *Binding) AsGoCi() *GoCi { // go (../../../../../daggerverse/go/ci.go:27:6)
+func (r *Binding) AsGoCi() *GoCi { // go (../../../../../daggerverse/go/ci.go:44:6)
 	q := r.query.Select("asGoCi")
 
 	return &GoCi{
@@ -29,7 +29,7 @@ func (r *Binding) AsGoCi() *GoCi { // go (../../../../../daggerverse/go/ci.go:27
 }
 
 // Create or update a binding of type GoCi in the environment
-func (r *Env) WithGoCiInput(name string, value *GoCi, description string) *Env { // go (../../../../../daggerverse/go/ci.go:27:6)
+func (r *Env) WithGoCiInput(name string, value *GoCi, description string) *Env { // go (../../../../../daggerverse/go/ci.go:44:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withGoCiInput")
 	q = q.Arg("name", name)
@@ -42,7 +42,7 @@ func (r *Env) WithGoCiInput(name string, value *GoCi, description string) *Env {
 }
 
 // Declare a desired GoCi output to be assigned in the environment
-func (r *Env) WithGoCiOutput(name string, description string) *Env { // go (../../../../../daggerverse/go/ci.go:27:6)
+func (r *Env) WithGoCiOutput(name string, description string) *Env { // go (../../../../../daggerverse/go/ci.go:44:6)
 	q := r.query.Select("withGoCiOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -246,7 +246,7 @@ func (r *Go) Build(source *Directory, opts ...GoBuildOpts) *Directory { // go (.
 }
 
 // Ci returns a new pipeline builder bound to the supplied source.
-func (r *Go) Ci(source *Directory) *GoCi { // go (../../../../../daggerverse/go/ci.go:55:1)
+func (r *Go) Ci(source *Directory) *GoCi { // go (../../../../../daggerverse/go/ci.go:72:1)
 	assertNotNil("source", source)
 	q := r.query.Select("ci")
 	q = q.Arg("source", source)
@@ -666,7 +666,7 @@ func (r *Go) AsNode() Node {
 // errors are aggregated. Stage 2 builds the source and Run returns the
 // produced binary as a *dagger.File. Downstream consumers compose that file
 // into their own pipelines (package, sign, publish, ...).
-type GoCi struct { // go (../../../../../daggerverse/go/ci.go:27:6)
+type GoCi struct { // go (../../../../../daggerverse/go/ci.go:44:6)
 	query *querybuilder.Selection
 
 	check *Void
@@ -692,7 +692,7 @@ func (r *GoCi) WithGraphQLQuery(q *querybuilder.Selection) *GoCi {
 // aggregated error. Use when callers want to run the checks
 // independently of the build (for example multi-platform pipelines
 // that share one check run across N platform builds).
-func (r *GoCi) Check(ctx context.Context) error { // go (../../../../../daggerverse/go/ci.go:124:1)
+func (r *GoCi) Check(ctx context.Context) error { // go (../../../../../daggerverse/go/ci.go:148:1)
 	if r.check != nil {
 		return nil
 	}
@@ -753,7 +753,7 @@ func (r *GoCi) UnmarshalJSON(bs []byte) error {
 // Run executes the pipeline: stage 1 (Check) → stage 2 (build). Returns
 // the built binary as a *dagger.File. On stage-1 failure, returns the
 // aggregated error from Check and a nil file (stage 2 is skipped).
-func (r *GoCi) Run() *File { // go (../../../../../daggerverse/go/ci.go:149:1)
+func (r *GoCi) Run() *File { // go (../../../../../daggerverse/go/ci.go:173:1)
 	q := r.query.Select("run")
 
 	return &File{
@@ -763,9 +763,9 @@ func (r *GoCi) Run() *File { // go (../../../../../daggerverse/go/ci.go:149:1)
 
 // GoCiWithBuildOpts contains options for GoCi.WithBuild
 type GoCiWithBuildOpts struct {
-	Pkg string // go (../../../../../daggerverse/go/ci.go:107:2)
+	Pkg string // go (../../../../../daggerverse/go/ci.go:131:2)
 
-	BinaryName string // go (../../../../../daggerverse/go/ci.go:109:2)
+	BinaryName string // go (../../../../../daggerverse/go/ci.go:133:2)
 }
 
 // WithBuild configures the build stage parameters. pkg defaults to "."
@@ -775,7 +775,7 @@ type GoCiWithBuildOpts struct {
 //
 // Note: the binary-name flag is called binaryName (CLI: --binary-name) to
 // avoid colliding with Dagger CLI's top-level --output/-o flag.
-func (r *GoCi) WithBuild(opts ...GoCiWithBuildOpts) *GoCi { // go (../../../../../daggerverse/go/ci.go:105:1)
+func (r *GoCi) WithBuild(opts ...GoCiWithBuildOpts) *GoCi { // go (../../../../../daggerverse/go/ci.go:129:1)
 	q := r.query.Select("withBuild")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `pkg` optional argument
@@ -794,7 +794,7 @@ func (r *GoCi) WithBuild(opts ...GoCiWithBuildOpts) *GoCi { // go (../../../../.
 }
 
 // WithFmt enables the gofmt check stage.
-func (r *GoCi) WithFmt() *GoCi { // go (../../../../../daggerverse/go/ci.go:60:1)
+func (r *GoCi) WithFmt() *GoCi { // go (../../../../../daggerverse/go/ci.go:77:1)
 	q := r.query.Select("withFmt")
 
 	return &GoCi{
@@ -804,16 +804,23 @@ func (r *GoCi) WithFmt() *GoCi { // go (../../../../../daggerverse/go/ci.go:60:1
 
 // GoCiWithLintOpts contains options for GoCi.WithLint
 type GoCiWithLintOpts struct {
-	Version string // go (../../../../../daggerverse/go/ci.go:77:2)
+	Version string // go (../../../../../daggerverse/go/ci.go:101:2)
 
-	Config *File // go (../../../../../daggerverse/go/ci.go:79:2)
+	Config *File // go (../../../../../daggerverse/go/ci.go:103:2)
 }
 
 // WithLint enables the golangci-lint check stage. version pins the
 // installed golangci-lint version (defaults to defaultGolangciLintVersion
 // when empty). config, if non-nil, is mounted at golangciLintConfigMountPath
 // and passed to golangci-lint via --config.
-func (r *GoCi) WithLint(opts ...GoCiWithLintOpts) *GoCi { // go (../../../../../daggerverse/go/ci.go:75:1)
+//
+// The default is a golangci-lint **v2** release, so a config passed here
+// must be written in the v2 dialect — a file opening with `version: "2"`.
+// A v1 file is not tolerated by a v2 binary; it is rejected before any
+// linter runs. Pass a `v1.x` version to roll the whole stage back, config
+// dialect included; the module path installed follows the version's major,
+// so both majors are reachable without forking this pipeline.
+func (r *GoCi) WithLint(opts ...GoCiWithLintOpts) *GoCi { // go (../../../../../daggerverse/go/ci.go:99:1)
 	q := r.query.Select("withLint")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `version` optional argument
@@ -833,12 +840,12 @@ func (r *GoCi) WithLint(opts ...GoCiWithLintOpts) *GoCi { // go (../../../../../
 
 // GoCiWithTestOpts contains options for GoCi.WithTest
 type GoCiWithTestOpts struct {
-	Race bool // go (../../../../../daggerverse/go/ci.go:91:2)
+	Race bool // go (../../../../../daggerverse/go/ci.go:115:2)
 }
 
 // WithTest enables the `go test ./...` check stage. Pass race=true to
 // enable the data-race detector.
-func (r *GoCi) WithTest(opts ...GoCiWithTestOpts) *GoCi { // go (../../../../../daggerverse/go/ci.go:89:1)
+func (r *GoCi) WithTest(opts ...GoCiWithTestOpts) *GoCi { // go (../../../../../daggerverse/go/ci.go:113:1)
 	q := r.query.Select("withTest")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `race` optional argument
@@ -853,7 +860,7 @@ func (r *GoCi) WithTest(opts ...GoCiWithTestOpts) *GoCi { // go (../../../../../
 }
 
 // WithVet enables the `go vet ./...` check stage.
-func (r *GoCi) WithVet() *GoCi { // go (../../../../../daggerverse/go/ci.go:66:1)
+func (r *GoCi) WithVet() *GoCi { // go (../../../../../daggerverse/go/ci.go:83:1)
 	q := r.query.Select("withVet")
 
 	return &GoCi{

--- a/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
+++ b/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type Z5Labs
-func (r *Binding) AsZ5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:17:6)
+func (r *Binding) AsZ5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:24:6)
 	q := r.query.Select("asZ5Labs")
 
 	return &Z5Labs{
@@ -118,7 +118,7 @@ func (r *Env) WithZ5LabsGoLibOutput(name string, description string) *Env { // z
 }
 
 // Create or update a binding of type Z5Labs in the environment
-func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:17:6)
+func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:24:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withZ5LabsInput")
 	q = q.Arg("name", name)
@@ -131,7 +131,7 @@ func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *E
 }
 
 // Declare a desired Z5Labs output to be assigned in the environment
-func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:17:6)
+func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:24:6)
 	q := r.query.Select("withZ5LabsOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -143,7 +143,7 @@ func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs
 
 // Z5labs is the root module type. Construct project archetypes via
 // GoApp / GoLib.
-func (r *Query) Z5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:17:6)
+func (r *Query) Z5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:24:6)
 	q := r.query.Select("z5Labs")
 
 	return &Z5Labs{
@@ -153,7 +153,7 @@ func (r *Query) Z5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/
 
 // Z5labs is the root module type. Construct project archetypes via
 // GoApp / GoLib.
-type Z5Labs struct { // z5labs (../../../../../daggerverse/z5labs/main.go:17:6)
+type Z5Labs struct { // z5labs (../../../../../daggerverse/z5labs/main.go:24:6)
 	query *querybuilder.Selection
 
 	id *ID
@@ -169,40 +169,55 @@ func (r *Z5Labs) WithGraphQLQuery(q *querybuilder.Selection) *Z5Labs {
 type Z5LabsGoAppOpts struct {
 
 	// Default: "."
-	Pkg string // z5labs (../../../../../daggerverse/z5labs/main.go:65:2)
+	Pkg string // z5labs (../../../../../daggerverse/z5labs/main.go:72:2)
 
-	BinaryName string // z5labs (../../../../../daggerverse/z5labs/main.go:67:2)
+	BinaryName string // z5labs (../../../../../daggerverse/z5labs/main.go:74:2)
 
 	// Default: "^refs/heads/main$"
-	PublishOn string // z5labs (../../../../../daggerverse/z5labs/main.go:70:2)
+	PublishOn string // z5labs (../../../../../daggerverse/z5labs/main.go:77:2)
 
-	Registry string // z5labs (../../../../../daggerverse/z5labs/main.go:72:2)
+	Registry string // z5labs (../../../../../daggerverse/z5labs/main.go:79:2)
 
 	// Default: "ci"
-	AuthUsername string // z5labs (../../../../../daggerverse/z5labs/main.go:75:2)
+	AuthUsername string // z5labs (../../../../../daggerverse/z5labs/main.go:82:2)
 
-	Auth *Secret // z5labs (../../../../../daggerverse/z5labs/main.go:77:2)
+	Auth *Secret // z5labs (../../../../../daggerverse/z5labs/main.go:84:2)
+	//
+	// A `.golangci.yml` replacing the bundled default policy.
+	//
+	// The lint stage runs golangci-lint v2, so this file must be written
+	// in the v2 dialect — it has to open with `version: "2"`. The majors
+	// are not interchangeable: a v2 binary refuses a v1 file outright,
+	// before running any linter. Pass lintVersion to move the whole stage,
+	// dialect included, to another release.
+	//
+	LintConfig *File // z5labs (../../../../../daggerverse/z5labs/main.go:94:2)
+	//
+	// The golangci-lint release the lint stage installs, e.g. "v2.12.2".
+	// Empty takes the version pinned by the `go` module, which is a v2
+	// release; pinning a "v1.x" release here rolls the stage — and the
+	// config dialect it requires — back to v1.
+	//
+	LintVersion string // z5labs (../../../../../daggerverse/z5labs/main.go:101:2)
 
-	LintConfig *File // z5labs (../../../../../daggerverse/z5labs/main.go:79:2)
+	Platforms []string // z5labs (../../../../../daggerverse/z5labs/main.go:103:2)
 
-	Platforms []string // z5labs (../../../../../daggerverse/z5labs/main.go:81:2)
+	RegistryService *Service // z5labs (../../../../../daggerverse/z5labs/main.go:105:2)
 
-	RegistryService *Service // z5labs (../../../../../daggerverse/z5labs/main.go:83:2)
-
-	Insecure bool // z5labs (../../../../../daggerverse/z5labs/main.go:85:2)
+	Insecure bool // z5labs (../../../../../daggerverse/z5labs/main.go:107:2)
 	//
 	// The CI provider's OIDC token request endpoint —
 	// `ACTIONS_ID_TOKEN_REQUEST_URL` on GitHub Actions, and whatever the
 	// equivalent is elsewhere. Required for any run that publishes.
 	//
-	IDTokenRequestURL string // z5labs (../../../../../daggerverse/z5labs/main.go:91:2)
+	IDTokenRequestURL string // z5labs (../../../../../daggerverse/z5labs/main.go:113:2)
 	//
 	// The bearer token for that endpoint —
 	// `ACTIONS_ID_TOKEN_REQUEST_TOKEN` on GitHub Actions. A secret,
 	// because it is a credential for minting identity tokens. Required
 	// for any run that publishes.
 	//
-	IDTokenRequestToken *Secret // z5labs (../../../../../daggerverse/z5labs/main.go:98:2)
+	IDTokenRequestToken *Secret // z5labs (../../../../../daggerverse/z5labs/main.go:120:2)
 	//
 	// A Dagger-hosted OIDC token endpoint, reached over the session
 	// network instead of the public one. When set, its engine-assigned
@@ -216,7 +231,7 @@ type Z5LabsGoAppOpts struct {
 	// which runs a real token endpoint, and by anyone whose issuer is
 	// itself a Dagger service.
 	//
-	IDTokenService *Service // z5labs (../../../../../daggerverse/z5labs/main.go:112:2)
+	IDTokenService *Service // z5labs (../../../../../daggerverse/z5labs/main.go:134:2)
 	//
 	// A PEM-encoded EC private key to sign the provenance with, instead
 	// of an ephemeral key certified by the public sigstore CA.
@@ -227,7 +242,7 @@ type Z5LabsGoAppOpts struct {
 	// reach a public CA. Leaving it unset is keyless signing and is what
 	// a normal CI publish should do.
 	//
-	SigningKey *Secret // z5labs (../../../../../daggerverse/z5labs/main.go:123:2)
+	SigningKey *Secret // z5labs (../../../../../daggerverse/z5labs/main.go:145:2)
 }
 
 // GoApp wires up an opinionated CI/release pipeline for a `package main`
@@ -271,7 +286,7 @@ type Z5LabsGoAppOpts struct {
 // service for their own reasons silently publish over an unverified
 // connection. It is spelled insecure rather than tlsVerify because a bool
 // defaulting to true cannot be turned off from the CLI.
-func (r *Z5Labs) GoApp(source *Directory, opts ...Z5LabsGoAppOpts) *Z5LabsGoApp { // z5labs (../../../../../daggerverse/z5labs/main.go:61:1)
+func (r *Z5Labs) GoApp(source *Directory, opts ...Z5LabsGoAppOpts) *Z5LabsGoApp { // z5labs (../../../../../daggerverse/z5labs/main.go:68:1)
 	assertNotNil("source", source)
 	q := r.query.Select("goApp")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -302,6 +317,10 @@ func (r *Z5Labs) GoApp(source *Directory, opts ...Z5LabsGoAppOpts) *Z5LabsGoApp 
 		// `lintConfig` optional argument
 		if !querybuilder.IsZeroValue(opts[i].LintConfig) {
 			q = q.Arg("lintConfig", opts[i].LintConfig)
+		}
+		// `lintVersion` optional argument
+		if !querybuilder.IsZeroValue(opts[i].LintVersion) {
+			q = q.Arg("lintVersion", opts[i].LintVersion)
 		}
 		// `platforms` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Platforms) {
@@ -341,18 +360,38 @@ func (r *Z5Labs) GoApp(source *Directory, opts ...Z5LabsGoAppOpts) *Z5LabsGoApp 
 
 // Z5LabsGoLibOpts contains options for Z5Labs.GoLib
 type Z5LabsGoLibOpts struct {
-	LintConfig *File // z5labs (../../../../../daggerverse/z5labs/main.go:153:2)
+	//
+	// A `.golangci.yml` replacing the bundled default policy.
+	//
+	// The lint stage runs golangci-lint v2, so this file must be written
+	// in the v2 dialect — it has to open with `version: "2"`. The majors
+	// are not interchangeable: a v2 binary refuses a v1 file outright,
+	// before running any linter. Pass lintVersion to move the whole stage,
+	// dialect included, to another release.
+	//
+	LintConfig *File // z5labs (../../../../../daggerverse/z5labs/main.go:184:2)
+	//
+	// The golangci-lint release the lint stage installs, e.g. "v2.12.2".
+	// Empty takes the version pinned by the `go` module, which is a v2
+	// release; pinning a "v1.x" release here rolls the stage — and the
+	// config dialect it requires — back to v1.
+	//
+	LintVersion string // z5labs (../../../../../daggerverse/z5labs/main.go:191:2)
 }
 
 // GoLib wires up the checks-only pipeline for a Go library. v1 has no
 // publish equivalent for libraries.
-func (r *Z5Labs) GoLib(source *Directory, opts ...Z5LabsGoLibOpts) *Z5LabsGoLib { // z5labs (../../../../../daggerverse/z5labs/main.go:150:1)
+func (r *Z5Labs) GoLib(source *Directory, opts ...Z5LabsGoLibOpts) *Z5LabsGoLib { // z5labs (../../../../../daggerverse/z5labs/main.go:173:1)
 	assertNotNil("source", source)
 	q := r.query.Select("goLib")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `lintConfig` optional argument
 		if !querybuilder.IsZeroValue(opts[i].LintConfig) {
 			q = q.Arg("lintConfig", opts[i].LintConfig)
+		}
+		// `lintVersion` optional argument
+		if !querybuilder.IsZeroValue(opts[i].LintVersion) {
+			q = q.Arg("lintVersion", opts[i].LintVersion)
 		}
 	}
 	q = q.Arg("source", source)
@@ -528,7 +567,7 @@ func (r *Z5LabsGoApp) WithGraphQLQuery(q *querybuilder.Selection) *Z5LabsGoApp {
 
 // Builder returns the local-dev sibling that produces the same image CI
 // would publish, single-arch (host platform).
-func (r *Z5LabsGoApp) Builder() *Z5LabsBuilder { // z5labs (../../../../../daggerverse/z5labs/goapp.go:378:1)
+func (r *Z5LabsGoApp) Builder() *Z5LabsBuilder { // z5labs (../../../../../daggerverse/z5labs/goapp.go:380:1)
 	q := r.query.Select("builder")
 
 	return &Z5LabsBuilder{
@@ -564,7 +603,7 @@ func (r *Z5LabsGoApp) Builder() *Z5LabsBuilder { // z5labs (../../../../../dagge
 // Publish is a side-effecting operation against an external registry, so
 // the whole pipeline is uncached — re-runs (e.g. after a retry, or after
 // a new ref appears within the same engine session) must actually push.
-func (r *Z5LabsGoApp) Ci(ctx context.Context) (string, error) { // z5labs (../../../../../daggerverse/z5labs/goapp.go:78:1)
+func (r *Z5LabsGoApp) Ci(ctx context.Context) (string, error) { // z5labs (../../../../../daggerverse/z5labs/goapp.go:80:1)
 	if r.ci != nil {
 		return *r.ci, nil
 	}
@@ -649,7 +688,7 @@ func (r *Z5LabsGoLib) WithGraphQLQuery(q *querybuilder.Selection) *Z5LabsGoLib {
 
 // Ci runs the standardized check stages (fmt, vet, lint, test -race)
 // against the supplied library source.
-func (r *Z5LabsGoLib) Ci(ctx context.Context) error { // z5labs (../../../../../daggerverse/z5labs/golib.go:22:1)
+func (r *Z5LabsGoLib) Ci(ctx context.Context) error { // z5labs (../../../../../daggerverse/z5labs/golib.go:24:1)
 	if r.ci != nil {
 		return nil
 	}

--- a/daggerverse/z5labs/tests/main.go
+++ b/daggerverse/z5labs/tests/main.go
@@ -104,6 +104,7 @@ func (t *Tests) All(
 	}
 	jobs = jobs.WithJob("GoLibCiPassesForValidSource", t.GoLibCiPassesForValidSource)
 	jobs = jobs.WithJob("GoLibCiFailsForFailingTest", t.GoLibCiFailsForFailingTest)
+	jobs = jobs.WithJob("GoLibCiRoutesLintVersion", t.GoLibCiRoutesLintVersion)
 	jobs = jobs.WithJob("BuilderBinaryProducesCompiledBinary", t.BuilderBinaryProducesCompiledBinary)
 	jobs = jobs.WithJob("BuilderContainerProducesScratchImageWithBinary", t.BuilderContainerProducesScratchImageWithBinary)
 	jobs = jobs.WithJob("GoAppCiRejectsMissingGitDir", t.GoAppCiRejectsMissingGitDir)
@@ -225,9 +226,35 @@ func curlManifestDigest(ctx context.Context, svc *dagger.Service, host, user, pw
 
 // GoLibCiPassesForValidSource asserts that GoLib.Ci against a clean,
 // vet-clean, gofmt-clean library fixture returns no error.
+//
+// This is also what proves the bundled configs/golangci.yml and the
+// pinned golangci-lint speak the same dialect. The two majors reject each
+// other's config files outright, so a v1 config reaching a v2 binary — or
+// the reverse — fails this test before any linter runs.
 func (t *Tests) GoLibCiPassesForValidSource(ctx context.Context) error {
 	if err := dag.Z5Labs().GoLib(helloLibDir()).Ci(ctx); err != nil {
 		return fmt.Errorf("GoLib.Ci on hello-lib: %w", err)
+	}
+	return nil
+}
+
+// GoLibCiRoutesLintVersion asserts the archetype's lintVersion reaches the
+// lint stage rather than being accepted and dropped.
+//
+// It pins a version the `go` module refuses to read a major out of, so the
+// assertion is a message naming that version — which can only have come
+// from the lint stage. Proving routing this way costs no container work,
+// and a pin that *is* valid is exercised where the behaviour lives, in the
+// `go` module's own suite.
+func (t *Tests) GoLibCiRoutesLintVersion(ctx context.Context) error {
+	err := dag.Z5Labs().GoLib(helloLibDir(), dagger.Z5LabsGoLibOpts{
+		LintVersion: "1.64.8",
+	}).Ci(ctx)
+	if err == nil {
+		return fmt.Errorf(`expected GoLib.Ci with lintVersion "1.64.8" to fail, got nil`)
+	}
+	if msg := err.Error(); !strings.Contains(msg, `golangci-lint version "1.64.8"`) {
+		return fmt.Errorf("expected the error to name the rejected lint version, got: %s", msg)
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #374

The standard pipeline's lint stage pinned golangci-lint `v1.64.8`, and v1 does
not ignore a v2 configuration file — it refuses it, before any linter runs. So a
repository adopting the standard could not commit the dialect the ecosystem
defaults to, and only discovered the requirement when the pipeline rejected the
file. `Zaba505/cpybkc#60` hit exactly that and has a v1 config committed as a
temporary measure.

## What changed

- `daggerverse/go`: `defaultGolangciLintVersion` → `v2.12.2`.
- `daggerverse/go`: the installed package path now follows the pinned **major**.
  Go's semantic import versioning put golangci-lint on a `/v2` module path at
  v2.0.0, so a version alone is not enough to install either major; a bad version
  is refused by name rather than guessed at and surfacing later as an
  unresolvable package.
- `daggerverse/z5labs`: `configs/golangci.yml` rewritten in the v2 dialect,
  selecting the same five linters (errcheck, govet, ineffassign, staticcheck,
  unused). Verified with `golangci-lint config verify` (exit 0) and
  `golangci-lint linters`, which lists those five and nothing else.
- `daggerverse/z5labs`: `GoApp` and `GoLib` take `lintVersion`, threaded through
  `sharedCheck` to `Ci.WithLint`.

## Acceptance criteria

- [x] **The standard pipeline's lint stage runs golangci-lint v2** — the pin is a
  v2 release, and `CiWithLintAcceptsV2Config` / `CiWithLintRejectsV1Config` assert
  the dialect from both sides. The negative asserts golangci-lint's exit code 3
  ("config would not load") rather than any failure, so a binary that merely
  disliked the fixture could not pass for one that accepted a v1 file.
- [x] **The bundled `configs/golangci.yml` is v2 syntax and selects the same
  linters** — see above. `GoLibCiPassesForValidSource` runs it end to end, which
  is only possible if config and binary agree on the major.
- [x] **`GoLib` and `GoApp` accept a lint version** — `lintVersion` on both.
  `GoLibCiRoutesLintVersion` proves the value reaches the lint stage;
  `CiWithLintRollsBackToV1` proves a `v1.x` pin plus a v1 config actually runs,
  which is the rollback claim rather than a restatement of it.
- [x] **The pinned version is documented where an adopter writing a
  `.golangci.yml` will see it** — a "Lint stage: golangci-lint v2" section in
  `daggerverse/go/README.md` with a copyable v2 config and both mismatch error
  messages; the `lintConfig` and `lintVersion` doc comments on `GoApp`/`GoLib`,
  which is what `dagger call go-lib --help` prints; the z5labs package doc; and a
  header on the bundled config itself, the file an adopter copies.
- [x] **Bumping the pin is a single edit** — `defaultGolangciLintVersion` is the
  only place the release is written down. No config file repeats it, and the
  install path is derived from it rather than stated beside it.

## Judgment calls

- **`version: "2"` in the bundled config is not the pin restated.** It is the
  config schema's own version field, required by every v2 config and absent from
  every v1 one; it does not move when the patch pin moves. Documentation names
  the *dialect* (v2) for the same reason — that is what an adopter needs before
  writing a file, and it changes only on a major bump.
- **The linter is built with an unpinned Go toolchain, not the project's.**
  golangci-lint's `go.mod` tracks the newest Go release (v2 needs 1.25) and the
  official `golang` images set `GOTOOLCHAIN=local`, so building the linter inside
  a project's pin fails outright for any project a release or two behind — the
  repository most likely to be adopting this pipeline. It is a tool, not part of
  the project's build, and it still *runs* against the project's toolchain.
  `CiWithLintBuildsUnderOlderGoToolchain` pins Go 1.23 and asserts the stage
  works. A side effect is that every caller now shares one linter install
  regardless of what they pinned, which is what the existing comment about
  deduping the install was already reaching for. Confirmed that a v1 rollback
  still builds under a current toolchain, so this does not cost the rollback path.
- **An unreadable version errors rather than defaulting.** `WithLint(version:
  "1.64.8")` — no leading `v` — cannot yield a major, and guessing one means
  silently choosing the wrong module path. It is refused with the version named.

## Verification

- `dagger check` — green.
- `bash .github/scripts/verify-affected-modules.sh` — `daggerverse/go` and
  `daggerverse/z5labs` suites green.
- `dagger -m ci call generated` — green. Generated code was regenerated with the
  pinned `v0.21.7` CLI, so no `engineVersion` moved.
- Each new test also run individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)