### PR TITLE
story(backlog): make every selector a runtime decision, and stop a stale milestone reading as an empty backlog

### DIFF
--- a/plugins/backlog/.claude-plugin/plugin.json
+++ b/plugins/backlog/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "backlog",
   "description": "Run a repository's story backlog unattended — one issue at a time, from selection through worktree, verification, pull request, Copilot review and label-driven auto merge",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "author": { "name": "z5labs" }
 }

--- a/plugins/backlog/agents/issue-worker.md
+++ b/plugins/backlog/agents/issue-worker.md
@@ -18,12 +18,13 @@ Skill tool is not granted to this agent; backlog:next-issue cannot be invoked`. 
 fallback: reconstructing the cycle from memory is how the footnotes that make it work get
 dropped.
 
-If your prompt names a project scope — any of `--project-value`, `--project-field`,
-`--project-owner`, `--project-number` — carry **all** of them through to the skill's selection
-step unchanged. They are not advisory and they are not yours to widen, narrow or swap: an
-unscoped selection picks up an issue from somewhere else in the backlog and merges it, and a
-selection scoped on the wrong field does the same while still looking scoped. Either way your
-report will read like an ordinary successful iteration.
+If your prompt names selection arguments — any of `--project-value`, `--project-field`,
+`--project-owner`, `--project-number`, `--no-project-filter`, `--label`, `--milestone`,
+`--no-milestone-filter`, `--all`, `--issue` — carry **all** of them through to the skill's
+selection step unchanged. They are not advisory and they are not yours to widen, narrow or
+swap: an unscoped selection picks up an issue from somewhere else in the backlog and merges
+it, and a selection made on the wrong field, milestone or label does the same while still
+looking scoped. Either way your report will read like an ordinary successful iteration.
 
 ## Rules that outrank anything else you conclude mid-run
 
@@ -55,9 +56,10 @@ report will read like an ordinary successful iteration.
   caller your entire context and moves the cycle nowhere.
 - **Do not weaken a test to make it pass**, and do not label a pull request whose review
   never completed.
-- **Do not retry selection unscoped, or on another scope.** If selection fails on the project
-  scope you were given, that is a `BLOCKED` report — not a reason to drop a flag, try a
-  different field or value, or edit `.claude/backlog.json` until it resolves.
+- **Do not retry selection unscoped, or on other arguments.** If selection fails on the
+  arguments you were given — an unresolvable project scope, a milestone that does not exist —
+  that is a `BLOCKED` report. It is not a reason to drop an argument, try a different field,
+  value, milestone or label, or edit `.claude/backlog.json` until it resolves.
 
 ## Your final message is the return value
 

--- a/plugins/backlog/assets/backlog.schema.json
+++ b/plugins/backlog/assets/backlog.schema.json
@@ -9,7 +9,7 @@
   "properties": {
     "select": {
       "type": "object",
-      "description": "Which open issues make up the backlog.",
+      "description": "Which open issues make up the backlog. Every key here is a *default* that one run can override on the `scripts/select-issue.sh` command line — `--label`, `--milestone`/`--no-milestone-filter`, the four `--project-*` flags and `--no-project-filter`, `--all` to drop every optional narrowing at once, and `--issue <n>` to bypass selection entirely and name one issue. What belongs in this file is what stays true between runs; \"just the v0.3.0 stories today\" is a property of one run and needs no edit to a tracked file.",
       "additionalProperties": false,
       "required": ["label", "milestone", "limit"],
       "properties": {
@@ -17,12 +17,12 @@
           "type": "string",
           "minLength": 1,
           "default": "story",
-          "description": "The issue label that marks an issue as backlog work. Issues without it are never selected."
+          "description": "The issue label that marks an issue as backlog work. Issues without it are never selected. A default rather than a floor: `select-issue.sh --label <name>` replaces it for one run, which is how a repository whose backlog is normally `story` can be run once over `bug` without an edit here. It is the one selector `--all` does not clear, because the label defines what the backlog *is* rather than narrowing it — an issue without it was never backlog work."
         },
         "milestone": {
           "type": ["string", "null"],
           "default": null,
-          "description": "Restrict the backlog to a single milestone by title. `null` means every open issue carrying the label, whatever milestone it is in — and the `--milestone` flag is then omitted from `gh issue list` entirely rather than passed empty."
+          "description": "Restrict the backlog to a single milestone by title. `null` means every open issue carrying the label, whatever milestone it is in — and the `--milestone` flag is then omitted from `gh issue list` entirely rather than passed empty. Overridable per run: `select-issue.sh --milestone <title>` names another and `--no-milestone-filter` (or `--all`) drops it, so \"drain the v0.3.0 stories today\" needs no edit here. Whichever source it comes from, the title is checked against the repository's own milestones (`state=all`) before any issue is listed, and one that does not exist is a hard failure naming the titles that do. That check exists because a value here *decays*: a milestone shipped and deleted leaves `gh issue list --milestone` answering `[]` with exit 0, which reads as a drained backlog and stops the loop looking like success. Measured — it halted a repository holding an open, eligible, unmilestoned story."
         },
         "limit": {
           "type": "integer",

--- a/plugins/backlog/scripts/select-issue.sh
+++ b/plugins/backlog/scripts/select-issue.sh
@@ -6,7 +6,7 @@
 #                        [--project-owner <login>] [--project-number <n>]
 #                        [--project-field <name>] [--project-value <value>]
 #        select-issue.sh [--no-milestone-filter] [--no-project-filter]
-#        select-issue.sh --all
+#        select-issue.sh [--label <name>] --all
 #        select-issue.sh --issue <n>
 #        select-issue.sh --extract <blocked-by|depends-on|none> [file]
 #        select-issue.sh --native-deps <repo> [file]
@@ -577,11 +577,29 @@ GIVEN=""       # the project flags this run named, for the messages below
 NARROWING=""   # every flag that sets or clears an *optional* narrowing
 LABELLED=""    # `--label`, which defines the backlog rather than narrowing it
 
-USAGE='usage: select-issue.sh [--label <name>] [--milestone <title> | --no-milestone-filter] [--project-owner <login>] [--project-number <n>] [--project-field <name>] [--project-value <value> | --no-project-filter] | --all | --issue <n>'
+# Three forms, because `--all` and `--issue` are not alternatives to the same
+# things. `--all` drops the optional narrowings and keeps the label, so it
+# composes with `--label` and with nothing else; `--issue` replaces selection
+# outright and composes with nothing at all. One flat line with `| --all |
+# --issue` at the end would say both are exclusive modes, which is wrong for the
+# first and is the text every argument error prints.
+USAGE='usage: select-issue.sh [--label <name>] [--milestone <title> | --no-milestone-filter] [--project-owner <login>] [--project-number <n>] [--project-field <name>] [--project-value <value> | --no-project-filter]
+       select-issue.sh [--label <name>] --all
+       select-issue.sh --issue <n>'
 
 set_opt() { # <flag> <value>
-  [ -n "$2" ] \
-    || fail 4 "$1 needs a non-empty value; to drop every optional narrowing, pass --all"
+  # The remedy for an empty value differs by flag, and naming the wrong one is
+  # worse than naming none: a milestone and a project scope are cleared by their
+  # own flags (or `--all`), while a label cannot be cleared at all because it is
+  # what the backlog is.
+  if [ -z "$2" ]; then
+    case "$1" in
+      --label)     fail 4 "--label needs a non-empty value; the backlog is always defined by a label, so there is nothing to clear" ;;
+      --milestone) fail 4 "--milestone needs a non-empty value; to run with no milestone, pass --no-milestone-filter or --all" ;;
+      --issue)     fail 4 "--issue needs a non-empty value; to search the backlog instead, pass no --issue at all" ;;
+      *)           fail 4 "$1 needs a non-empty value; to run unscoped, pass --no-project-filter or --all" ;;
+    esac
+  fi
   case "$1" in
     --project-owner)  OPT_PROJECT_OWNER=$2;  OPT_PROJECT_OWNER_SET=1;  GIVEN="$GIVEN $1" ;;
     --project-number) OPT_PROJECT_NUMBER=$2; OPT_PROJECT_NUMBER_SET=1; GIVEN="$GIVEN $1" ;;

--- a/plugins/backlog/scripts/select-issue.sh
+++ b/plugins/backlog/scripts/select-issue.sh
@@ -2,9 +2,12 @@
 #
 # select-issue.sh — pick the next eligible backlog issue, as one call.
 #
-# Usage: select-issue.sh [--project-owner <login>] [--project-number <n>]
+# Usage: select-issue.sh [--label <name>] [--milestone <title>]
+#                        [--project-owner <login>] [--project-number <n>]
 #                        [--project-field <name>] [--project-value <value>]
-#        select-issue.sh --no-project-filter
+#        select-issue.sh [--no-milestone-filter] [--no-project-filter]
+#        select-issue.sh --all
+#        select-issue.sh --issue <n>
 #        select-issue.sh --extract <blocked-by|depends-on|none> [file]
 #        select-issue.sh --native-deps <repo> [file]
 #        select-issue.sh --project-items <repo> <field> <value> [file]
@@ -47,10 +50,28 @@
 # every rule about what counts as in scope is exercised by the test without a
 # network call.
 #
+# Every selector is a *runtime* decision. `.claude/backlog.json` supplies the
+# default for each one and every one of them can be overridden for a single run:
+# `--label`, `--milestone`/`--no-milestone-filter`, the four `--project-*` flags
+# and `--no-project-filter`, `--all` to drop every optional narrowing at once,
+# and `--issue <n>` to name one issue outright.
+#
+# Config is a default, never a floor. The failure that established this: avroc's
+# config pinned `select.milestone: "v0.2.0"`, the milestone was later deleted,
+# and `gh issue list --milestone v0.2.0` answered `[]` with exit 0 over a backlog
+# holding an eligible unmilestoned story. That reported BACKLOG EMPTY — "success,
+# not failure" by the loop's own table — and halted a workable backlog with
+# nothing in the run pointing at the milestone. So a milestone is now checked
+# against the repository's milestones before the issue query, exactly as a
+# project value is checked against its field's options, and a run that wants a
+# different milestone (or none) says so on the command line instead of editing a
+# tracked file.
+#
 # Exit codes:
 #   0   an issue was selected; stdout is {"number":N,"title":"..."}
-#   4   usage or precondition failure (no gh/jq/git, the config is unusable, or
-#       a requested project scope could not be resolved)
+#   4   usage or precondition failure (no gh/jq/git, the config is unusable, a
+#       requested project scope could not be resolved, or a requested milestone
+#       does not exist)
 #   10  BACKLOG EMPTY — no open issue carries the label (and milestone, and
 #       project field value)
 #   11  BLOCKED — open issues remain and none is eligible
@@ -516,7 +537,25 @@ project_fetch() { # <owner> <number> <field> ; needs ERRFILE
 #
 # Separate flags rather than one with an empty-string sentinel. `--project-value ''`
 # would have to mean "no scope", which is the same conflation `--milestone ''`
-# is avoided for below.
+# is avoided for.
+#
+# The label and the milestone get the same treatment, and for the same reason.
+# "Just the v0.3.0 stories today" is exactly as much a property of one run as
+# "just the workspace-ci stories today", and until these flags existed only the
+# second was expressible — while `run-backlog`'s own description advertised
+# "drain the milestone" as a trigger phrase for a request the vocabulary could
+# not accept.
+#
+# `--all` is the one input that means "no optional narrowing at all": it clears
+# the milestone and the project scope together, so a caller does not have to know
+# which axes a given repository happens to have configured. It deliberately does
+# *not* clear the label, which is not an optional narrowing but the definition of
+# what the backlog is — an issue without it was never backlog work.
+#
+# `--issue <n>` names one issue instead of searching for one. The dependency walk
+# still runs against it, because "work this issue next" is a statement about
+# order and not a licence to start something whose blockers are open; an issue
+# with unmet dependencies is BLOCKED naming them, never a silent selection.
 OPT_PROJECT_OWNER=""
 OPT_PROJECT_OWNER_SET=0
 OPT_PROJECT_NUMBER=""
@@ -526,45 +565,96 @@ OPT_PROJECT_FIELD_SET=0
 OPT_PROJECT_VALUE=""
 OPT_PROJECT_VALUE_SET=0
 OPT_NO_PROJECT=0
-GIVEN=""   # the project flags this run named, for the messages below
+OPT_LABEL=""
+OPT_LABEL_SET=0
+OPT_MILESTONE=""
+OPT_MILESTONE_SET=0
+OPT_NO_MILESTONE=0
+OPT_ALL=0
+OPT_ISSUE=""
+OPT_ISSUE_SET=0
+GIVEN=""       # the project flags this run named, for the messages below
+NARROWING=""   # every flag that sets or clears an *optional* narrowing
+LABELLED=""    # `--label`, which defines the backlog rather than narrowing it
 
-USAGE='usage: select-issue.sh [--project-owner <login>] [--project-number <n>] [--project-field <name>] [--project-value <value>] | --no-project-filter'
+USAGE='usage: select-issue.sh [--label <name>] [--milestone <title> | --no-milestone-filter] [--project-owner <login>] [--project-number <n>] [--project-field <name>] [--project-value <value> | --no-project-filter] | --all | --issue <n>'
 
-set_project_opt() { # <flag> <value>
+set_opt() { # <flag> <value>
   [ -n "$2" ] \
-    || fail 4 "$1 needs a non-empty value; to run unscoped, pass --no-project-filter or nothing at all"
+    || fail 4 "$1 needs a non-empty value; to drop every optional narrowing, pass --all"
   case "$1" in
-    --project-owner)  OPT_PROJECT_OWNER=$2;  OPT_PROJECT_OWNER_SET=1 ;;
-    --project-number) OPT_PROJECT_NUMBER=$2; OPT_PROJECT_NUMBER_SET=1 ;;
-    --project-field)  OPT_PROJECT_FIELD=$2;  OPT_PROJECT_FIELD_SET=1 ;;
-    --project-value)  OPT_PROJECT_VALUE=$2;  OPT_PROJECT_VALUE_SET=1 ;;
+    --project-owner)  OPT_PROJECT_OWNER=$2;  OPT_PROJECT_OWNER_SET=1;  GIVEN="$GIVEN $1" ;;
+    --project-number) OPT_PROJECT_NUMBER=$2; OPT_PROJECT_NUMBER_SET=1; GIVEN="$GIVEN $1" ;;
+    --project-field)  OPT_PROJECT_FIELD=$2;  OPT_PROJECT_FIELD_SET=1;  GIVEN="$GIVEN $1" ;;
+    --project-value)  OPT_PROJECT_VALUE=$2;  OPT_PROJECT_VALUE_SET=1;  GIVEN="$GIVEN $1" ;;
+    --label)          OPT_LABEL=$2;          OPT_LABEL_SET=1;          LABELLED=" $1"; return 0 ;;
+    --milestone)      OPT_MILESTONE=$2;      OPT_MILESTONE_SET=1 ;;
+    --issue)
+      case "$2" in
+        *[!0-9]*|0) fail 4 "--issue must be a positive integer (found '$2')" ;;
+      esac
+      OPT_ISSUE=$2; OPT_ISSUE_SET=1
+      # Not a narrowing of the backlog but a replacement for searching one, so
+      # it is checked against the others below rather than counted among them.
+      return 0 ;;
   esac
-  GIVEN="$GIVEN $1"
+  NARROWING="$NARROWING $1"
 }
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    --project-owner|--project-number|--project-field|--project-value)
+    --project-owner|--project-number|--project-field|--project-value|--label|--milestone|--issue)
       [ $# -ge 2 ] || fail 4 "$1 needs a value"
-      set_project_opt "$1" "$2"
+      set_opt "$1" "$2"
       shift 2 ;;
-    --project-owner=*|--project-number=*|--project-field=*|--project-value=*)
-      set_project_opt "${1%%=*}" "${1#*=}"
+    --project-owner=*|--project-number=*|--project-field=*|--project-value=*|--label=*|--milestone=*|--issue=*)
+      set_opt "${1%%=*}" "${1#*=}"
       shift ;;
     --no-project-filter)
       OPT_NO_PROJECT=1
+      NARROWING="$NARROWING $1"
+      shift ;;
+    --no-milestone-filter)
+      OPT_NO_MILESTONE=1
+      NARROWING="$NARROWING $1"
+      shift ;;
+    --all)
+      OPT_ALL=1
       shift ;;
     *)
       fail 4 "unknown argument '$1'; $USAGE" ;;
   esac
 done
 
-# `--no-project-filter` is "run unscoped", so it contradicts every flag that
-# describes a scope — not just the value. Accepting `--project-field X
-# --no-project-filter` would have to silently discard one of the two, and
-# discarding either is a run that is not the run that was asked for.
+# A clearing flag and a narrowing one on the same axis is not a request this can
+# answer: it would have to silently discard one of the two, and discarding either
+# is a run that is not the run that was asked for. `--no-project-filter` is "run
+# unscoped", so it contradicts every flag that describes a scope and not just the
+# value.
 [ "$OPT_NO_PROJECT" -eq 1 ] && [ -n "$GIVEN" ] \
   && fail 4 "--no-project-filter cannot be combined with$GIVEN"
+[ "$OPT_NO_MILESTONE" -eq 1 ] && [ "$OPT_MILESTONE_SET" -eq 1 ] \
+  && fail 4 "--no-milestone-filter cannot be combined with --milestone"
+
+# `--all` says "no optional narrowing at all", which contradicts every flag that
+# narrows one — and every flag that clears one, which it already does. Accepting
+# the pair would leave "unnarrowed except for this" as a meaning nobody asked
+# for. `--label` is deliberately not on that list: the label defines the backlog
+# rather than narrowing it, so `--all --label task` is "the whole `task` backlog".
+[ "$OPT_ALL" -eq 1 ] && [ -n "$NARROWING" ] \
+  && fail 4 "--all cannot be combined with$NARROWING; it already drops every optional narrowing"
+
+# `--issue` bypasses the search entirely, so every flag that describes *which*
+# search to run is contradictory beside it — including `--label`, which under
+# every other invocation says what the backlog is. Saying so is the difference
+# between a run that knows it selected an out-of-backlog issue and one that
+# thinks it narrowed a backlog it never read.
+if [ "$OPT_ISSUE_SET" -eq 1 ]; then
+  ISSUE_CONFLICTS="$NARROWING$LABELLED"
+  [ "$OPT_ALL" -eq 1 ] && ISSUE_CONFLICTS="$ISSUE_CONFLICTS --all"
+  [ -n "$ISSUE_CONFLICTS" ] \
+    && fail 4 "--issue cannot be combined with$ISSUE_CONFLICTS; it selects one issue instead of searching the backlog"
+fi
 
 # ----------------------------------------------------------------- config -----
 command -v gh >/dev/null 2>&1 || fail 4 "gh is not on PATH"
@@ -584,7 +674,16 @@ PROJECT_KIND=$(jq -r 'if (.select.project // null) == null then "absent" else (.
 STYLE=$(jq -r '.dependencies.style // ""' "$CFG")
 VERIFY_N=$(jq -r 'if (.verify | type) == "array" then (.verify | length) else -1 end' "$CFG")
 
-[ -n "$LABEL" ] || fail 4 "$CFG: select.label is missing or empty"
+# Flag over config, for the same reason the project keys work that way: the
+# config describes the repository's backlog, and a run is not entitled to rewrite
+# a tracked file to describe itself. The config value is still validated when the
+# flag did not replace it, so a broken file is caught on the runs that use it.
+[ "$OPT_LABEL_SET" -eq 1 ] && LABEL=$OPT_LABEL
+[ -n "$LABEL" ] || fail 4 "$CFG: select.label is missing or empty; set it, or pass --label <name>"
+
+[ "$OPT_MILESTONE_SET" -eq 1 ] && MILESTONE=$OPT_MILESTONE
+{ [ "$OPT_NO_MILESTONE" -eq 1 ] || [ "$OPT_ALL" -eq 1 ]; } && MILESTONE=""
+
 case "$LIMIT" in
   ''|*[!0-9]*) fail 4 "$CFG: select.limit must be a positive integer (found '${LIMIT:-null}')" ;;
   0)           fail 4 "$CFG: select.limit must be at least 1" ;;
@@ -624,7 +723,7 @@ esac
 [ "$OPT_PROJECT_NUMBER_SET" -eq 1 ] && PROJECT_NUMBER=$OPT_PROJECT_NUMBER
 [ "$OPT_PROJECT_FIELD_SET" -eq 1 ]  && PROJECT_FIELD=$OPT_PROJECT_FIELD
 [ "$OPT_PROJECT_VALUE_SET" -eq 1 ]  && PROJECT_VALUE=$OPT_PROJECT_VALUE
-[ "$OPT_NO_PROJECT" -eq 1 ] && PROJECT_VALUE=""
+{ [ "$OPT_NO_PROJECT" -eq 1 ] || [ "$OPT_ALL" -eq 1 ]; } && PROJECT_VALUE=""
 
 # Validated up front rather than at the point of use: a scope that cannot be
 # resolved has to stop selection, not degrade it to the unscoped backlog.
@@ -660,56 +759,129 @@ REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null) \
   || fail 4 "cannot resolve the repository slug from gh"
 [ -n "$REPO" ] || fail 4 "cannot resolve the repository slug from gh"
 
-# ------------------------------------------------------------------- list -----
-# --limit is always passed. gh's default page size is 30, and on a longer
-# backlog the issues past the first page do not error — they are simply absent,
-# so the cycle reports an empty or blocked backlog that is neither.
-#
-# --milestone is passed only when one is configured. An empty --milestone is not
-# the same as no milestone filter, which is why this is an argument array rather
-# than a string the caller interpolates.
-LIST_ARGS=(--repo "$REPO" --state open --label "$LABEL" --limit "$LIMIT")
-[ -n "$MILESTONE" ] && LIST_ARGS+=(--milestone "$MILESTONE")
-
-CANDIDATES=$(gh issue list "${LIST_ARGS[@]}" \
-  --json number,title --jq 'sort_by(.number)[] | "\(.number)\t\(.title)"') \
-  || fail 4 "gh issue list failed for $REPO"
-
 SCOPE_NOTE=""
 [ -n "$PROJECT_VALUE" ] && SCOPE_NOTE=" with $PROJECT_FIELD = '$PROJECT_VALUE' in project $PROJECT_OWNER/$PROJECT_NUMBER"
+BLOCKED_SUBJECT="every open issue carrying the label '$LABEL'$SCOPE_NOTE"
 
-if [ -z "$CANDIDATES" ]; then
-  printf 'BACKLOG EMPTY\n'
-  note "no open issue in $REPO carries the label '$LABEL'${MILESTONE:+ in milestone '$MILESTONE'}"
-  exit 10
+# -------------------------------------------------------------- milestone -----
+# The milestone is checked against the repository's own milestones before any
+# issue is listed, exactly as a project value is checked against its field's
+# declared options — and for the identical reason. `gh issue list --milestone` on
+# a title that does not exist does not object:
+#
+#   $ gh issue list --repo z5labs/avroc --state open --label story --milestone v0.2.0 --json number
+#   []
+#   $ echo $?
+#   0
+#
+# So a milestone that was closed, renamed or deleted resolves to an empty
+# candidate set, which prints BACKLOG EMPTY and halts the loop on a backlog that
+# is fully workable. That is not hypothetical: it is what `select.milestone:
+# "v0.2.0"` did to avroc after the milestone was deleted, over an open, eligible,
+# unmilestoned story.
+#
+# `state=all`, because a closed milestone can still hold open issues and naming
+# one is a legitimate request. Both sources are checked, config included — a
+# stale config value is the case that fired, and it is the one a flag-only check
+# would still miss.
+if [ -n "$MILESTONE" ] && [ "$OPT_ISSUE_SET" -eq 0 ]; then
+  MILESTONE_SRC="$CFG: select.milestone"
+  [ "$OPT_MILESTONE_SET" -eq 1 ] && MILESTONE_SRC="--milestone"
+
+  MILESTONES=$(gh api --paginate "repos/$REPO/milestones?state=all&per_page=100" --jq '.[].title') \
+    || fail 4 "cannot read the milestones of $REPO to check the one named by $MILESTONE_SRC"
+
+  if ! printf '%s\n' "$MILESTONES" | grep -qxF -- "$MILESTONE"; then
+    if [ -z "$MILESTONES" ]; then
+      fail 4 "$MILESTONE_SRC names milestone '$MILESTONE', which $REPO does not have; it has no milestones at all"
+    fi
+    HAVE=$(printf '%s' "$MILESTONES" | tr '\n' ',')
+    fail 4 "$MILESTONE_SRC names milestone '$MILESTONE', which $REPO does not have; its milestones are: ${HAVE%,}"
+  fi
 fi
 
-# ---------------------------------------------------------------- scoping -----
-# Applied before the dependency walk, so the walk sees only in-scope issues and
-# cannot be held up by a blocker outside the scope it was asked for.
-#
-# The limit above still bounds the *label* query, not this one: on a backlog
-# longer than select.limit, an in-scope issue can fall off the end before the
-# scope is ever applied. That is why the limit defaults to 200 rather than to
-# gh's page size of 30.
-if [ -n "$PROJECT_VALUE" ]; then
-  # `|| exit $?` on both: a `fail` inside a command substitution exits only the
-  # subshell, and without this the script would carry on with an empty scope —
-  # which is the unscoped-selection failure this whole section exists to make
-  # impossible.
-  need_errfile
-  PROJECT_PAGES=$(project_fetch "$PROJECT_OWNER" "$PROJECT_NUMBER" "$PROJECT_FIELD") || exit $?
-  IN_SCOPE=$(project_items "$REPO" "$PROJECT_FIELD" "$PROJECT_VALUE" <<<"$PROJECT_PAGES") || exit $?
+if [ "$OPT_ISSUE_SET" -eq 1 ]; then
+  # ------------------------------------------------------------- one issue -----
+  # Named rather than searched for. The dependency walk below still runs against
+  # it, so this changes *which* issues are considered and nothing about whether
+  # the one considered is workable.
+  #
+  # Every narrowing it stepped over is named, one line each, whether or not that
+  # narrowing was configured. A run that selected an issue outside the backlog it
+  # would otherwise have searched has to say so — otherwise its diagnostics read
+  # exactly like a run that searched and found this issue at the top.
+  MILESTONE_NOTE="no milestone is configured"
+  [ -n "$MILESTONE" ] && MILESTONE_NOTE="milestone '$MILESTONE'"
+  PROJECT_NOTE="no project scope is configured"
+  [ -n "$PROJECT_VALUE" ] && PROJECT_NOTE="$PROJECT_FIELD = '$PROJECT_VALUE' in project $PROJECT_OWNER/$PROJECT_NUMBER"
 
-  CANDIDATES=$(awk -F'\t' 'NR == FNR { if ($0 != "") keep[$0] = 1; next } ($1 in keep)' \
-    <(printf '%s\n' "$IN_SCOPE") <(printf '%s\n' "$CANDIDATES"))
+  note "--issue $OPT_ISSUE selects #$OPT_ISSUE directly; the backlog was not searched"
+  note "--issue $OPT_ISSUE bypassed the label narrowing (label '$LABEL')"
+  note "--issue $OPT_ISSUE bypassed the milestone narrowing ($MILESTONE_NOTE)"
+  note "--issue $OPT_ISSUE bypassed the project narrowing ($PROJECT_NOTE)"
+
+  ISSUE_JSON=$(gh issue view "$OPT_ISSUE" --repo "$REPO" --json number,title,state) \
+    || fail 4 "cannot read issue #$OPT_ISSUE in $REPO"
+  ISSUE_STATE=$(printf '%s' "$ISSUE_JSON" | jq -r '.state // ""') \
+    || fail 4 "the response for issue #$OPT_ISSUE in $REPO does not parse as JSON"
+  # A closed issue is refused rather than selected. The cycle ends by closing the
+  # issue it worked, so an already-closed one is either finished work or a typo,
+  # and both are worth a message rather than a worktree.
+  [ "$ISSUE_STATE" = OPEN ] \
+    || fail 4 "issue #$OPT_ISSUE in $REPO is ${ISSUE_STATE:-unreadable}, not OPEN"
+
+  CANDIDATES=$(printf '%s' "$ISSUE_JSON" | jq -r '"\(.number)\t\(.title)"') \
+    || fail 4 "the response for issue #$OPT_ISSUE in $REPO could not be read"
+  BLOCKED_SUBJECT="issue #$OPT_ISSUE, named with --issue,"
+else
+  # ----------------------------------------------------------------- list -----
+  # --limit is always passed. gh's default page size is 30, and on a longer
+  # backlog the issues past the first page do not error — they are simply absent,
+  # so the cycle reports an empty or blocked backlog that is neither.
+  #
+  # --milestone is passed only when one is in effect. An empty --milestone is not
+  # the same as no milestone filter, which is why this is an argument array
+  # rather than a string the caller interpolates.
+  LIST_ARGS=(--repo "$REPO" --state open --label "$LABEL" --limit "$LIMIT")
+  [ -n "$MILESTONE" ] && LIST_ARGS+=(--milestone "$MILESTONE")
+
+  CANDIDATES=$(gh issue list "${LIST_ARGS[@]}" \
+    --json number,title --jq 'sort_by(.number)[] | "\(.number)\t\(.title)"') \
+    || fail 4 "gh issue list failed for $REPO"
 
   if [ -z "$CANDIDATES" ]; then
     printf 'BACKLOG EMPTY\n'
-    note "no open issue in $REPO carries the label '$LABEL'${MILESTONE:+ in milestone '$MILESTONE'}$SCOPE_NOTE"
+    note "no open issue in $REPO carries the label '$LABEL'${MILESTONE:+ in milestone '$MILESTONE'}"
     exit 10
   fi
-  note "project scope leaves $(printf '%s\n' "$CANDIDATES" | grep -c .) candidate(s)$SCOPE_NOTE"
+
+  # -------------------------------------------------------------- scoping -----
+  # Applied before the dependency walk, so the walk sees only in-scope issues and
+  # cannot be held up by a blocker outside the scope it was asked for.
+  #
+  # The limit above still bounds the *label* query, not this one: on a backlog
+  # longer than select.limit, an in-scope issue can fall off the end before the
+  # scope is ever applied. That is why the limit defaults to 200 rather than to
+  # gh's page size of 30.
+  if [ -n "$PROJECT_VALUE" ]; then
+    # `|| exit $?` on both: a `fail` inside a command substitution exits only the
+    # subshell, and without this the script would carry on with an empty scope —
+    # which is the unscoped-selection failure this whole section exists to make
+    # impossible.
+    need_errfile
+    PROJECT_PAGES=$(project_fetch "$PROJECT_OWNER" "$PROJECT_NUMBER" "$PROJECT_FIELD") || exit $?
+    IN_SCOPE=$(project_items "$REPO" "$PROJECT_FIELD" "$PROJECT_VALUE" <<<"$PROJECT_PAGES") || exit $?
+
+    CANDIDATES=$(awk -F'\t' 'NR == FNR { if ($0 != "") keep[$0] = 1; next } ($1 in keep)' \
+      <(printf '%s\n' "$IN_SCOPE") <(printf '%s\n' "$CANDIDATES"))
+
+    if [ -z "$CANDIDATES" ]; then
+      printf 'BACKLOG EMPTY\n'
+      note "no open issue in $REPO carries the label '$LABEL'${MILESTONE:+ in milestone '$MILESTONE'}$SCOPE_NOTE"
+      exit 10
+    fi
+    note "project scope leaves $(printf '%s\n' "$CANDIDATES" | grep -c .) candidate(s)$SCOPE_NOTE"
+  fi
 fi
 
 # --------------------------------------------------------------- eligible -----
@@ -828,6 +1000,6 @@ while IFS=$'\t' read -r NUM TITLE; do
 # escape.
 done < <(printf '%s\n' "$CANDIDATES")
 
-printf 'BLOCKED — every open issue carrying the label '\''%s'\''%s has an unmet dependency:\n' "$LABEL" "$SCOPE_NOTE"
+printf 'BLOCKED — %s has an unmet dependency:\n' "$BLOCKED_SUBJECT"
 printf '%s' "$REASONS"
 exit 11

--- a/plugins/backlog/scripts/select-issue_test.sh
+++ b/plugins/backlog/scripts/select-issue_test.sh
@@ -927,6 +927,25 @@ checkr_fail '--issue and --all is refused' 'cannot be combined with --all' \
 checkr_fail 'an unknown argument is refused' "unknown argument '--milestones'" \
   story null - "$MILESTONES_ALL" --milestones v0.3.0
 
+# An empty value is never how a narrowing is cleared, and the remedy differs by
+# flag. Naming the wrong one — telling a caller to pass `--all` when what they
+# emptied was the label — is worse than naming none, because `--all` is a
+# different run that would have succeeded.
+checkr_fail 'an empty --milestone points at the clearing flags' 'pass --no-milestone-filter or --all' \
+  story null - "$MILESTONES_ALL" --milestone=
+
+checkr_fail 'an empty --project-value points at --no-project-filter' 'pass --no-project-filter or --all' \
+  story null - "$MILESTONES_ALL" --project-value=
+
+checkr_fail 'an empty --label says the label cannot be cleared' 'there is nothing to clear' \
+  story null - "$MILESTONES_ALL" --label=
+
+# The usage text every argument error prints. `--all` composes with `--label`,
+# so a flat `| --all` at the end of one line would tell the caller their valid
+# run is invalid.
+checkr_fail 'the usage text shows --all composing with --label' 'select-issue.sh [--label <name>] --all' \
+  story null - "$MILESTONES_ALL" --nonsense
+
 printf '\ncross-repository dependencies\n'
 
 # The dependency walk itself, end to end, under `dependencies.style` = `native`

--- a/plugins/backlog/scripts/select-issue_test.sh
+++ b/plugins/backlog/scripts/select-issue_test.sh
@@ -23,6 +23,14 @@
 # and a scope that was never applied both look like an ordinary backlog from the
 # outside, so each one has to be an exit 4 rather than an empty answer.
 #
+# **Runtime selectors.** Every case runs the *whole* script against a scratch
+# repository and a `gh` that answers from files, asserting which issue came back
+# rather than which message did. That is what covers the rules no seam can reach:
+# flag over config for the label, the milestone and the project scope; the
+# combinations that are refused rather than silently resolved; and an unknown
+# milestone, which `gh issue list` answers with `[]` and exit 0 — the failure that
+# reported a workable backlog as a drained one.
+#
 # Run: plugins/backlog/scripts/select-issue_test.sh
 # Exit 0 when every case matches, 1 otherwise.
 
@@ -645,6 +653,280 @@ checks_fail 'a scope flag and --no-project-filter is refused' 'cannot be combine
 checks_fail 'a bad --project-number blames the flag' '--project-number must be a positive integer' - \
   --project-owner z5labs --project-number fourteen --project-field Module --project-value workspace-ci
 
+printf '\nruntime selectors\n'
+
+# Every selector is a default in `.claude/backlog.json` that one run can
+# override, and this section is where that is asserted for the label and the
+# milestone — the two the config used to own outright.
+#
+# The milestone is the one with a measured failure behind it. avroc pinned
+# `select.milestone: "v0.2.0"`, the milestone was later deleted, and `gh issue
+# list --milestone v0.2.0` answered `[]` with exit 0 over an open, eligible,
+# unmilestoned story. That printed BACKLOG EMPTY and halted the loop on a
+# workable backlog, with nothing in the run pointing at the milestone. So an
+# unknown milestone is exit 4 naming the ones that exist, from the config as
+# readily as from the flag.
+#
+# The same shape as the scope-assembly section above: the whole script, a
+# scratch repository, a `gh` that answers from files, and an assertion on *which
+# issue* came back rather than on a message. Each fixture list holds a different
+# issue number, so a flag that never reached the query is a different answer and
+# not merely a different diagnostic.
+mkdir -p "$SCRATCH/sel/repo/.claude" "$SCRATCH/sel/bin" "$SCRATCH/sel/lists" \
+         "$SCRATCH/sel/views" "$SCRATCH/sel/pages"
+
+git init -q "$SCRATCH/sel/repo" >/dev/null 2>&1 \
+  || { printf 'cannot init a scratch repository\n' >&2; exit 1; }
+
+# `issue list` is answered by the label and milestone it was *given*, which is
+# what lets a case prove a flag reached the query. `api repos/.../milestones` and
+# `issue view` really run the `--jq` they were passed, so the fixtures are the
+# shapes GitHub returns rather than the answers the script wants.
+cat >"$SCRATCH/sel/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+case "$1 $2" in
+  'repo view') printf 'z5labs/devex\n' ;;
+  'issue list')
+    label="" milestone="" prev=""
+    for a in "$@"; do
+      case "$prev" in --label) label=$a ;; --milestone) milestone=$a ;; esac
+      prev=$a
+    done
+    f="$STUB_LISTS/$label#$milestone"
+    [ -f "$f" ] || { printf 'stub gh: no issue list for label=%s milestone=%s\n' "$label" "$milestone" >&2; exit 1; }
+    cat "$f" ;;
+  'issue view')
+    q="" prev=""
+    for a in "$@"; do [ "$prev" = --jq ] && q=$a; prev=$a; done
+    f="$STUB_VIEWS/$3"
+    [ -f "$f" ] || { printf 'stub gh: no issue %s\n' "$3" >&2; exit 1; }
+    if [ -n "$q" ]; then jq -r "$q" "$f"; else cat "$f"; fi ;;
+  'api graphql')
+    f=""
+    for a in "$@"; do case "$a" in field=*) f=${a#field=} ;; esac; done
+    if [ -n "$f" ] && [ -f "$STUB_PAGES/$f" ]; then cat "$STUB_PAGES/$f"; else cat "$STUB_PAGES/default"; fi ;;
+  'api '*)
+    # `--paginate` sits between `api` and the path, so the path is found by
+    # scanning rather than by position.
+    q="" path="" prev=""
+    for a in "$@"; do
+      [ "$prev" = --jq ] && q=$a
+      case "$a" in repos/*/milestones*) path=$a ;; esac
+      prev=$a
+    done
+    [ -n "$path" ] || { printf 'stub gh: unexpected api call: %s\n' "$*" >&2; exit 1; }
+    if [ -n "$q" ]; then jq -r "$q" "$STUB_MILESTONES"; else cat "$STUB_MILESTONES"; fi ;;
+  *) printf 'stub gh: unexpected call: %s\n' "$*" >&2; exit 1 ;;
+esac
+STUB
+chmod +x "$SCRATCH/sel/bin/gh"
+
+printf '288\tmilestoned v0.2.0\n' >"$SCRATCH/sel/lists/story#v0.2.0"
+printf '291\tmilestoned v0.3.0\n' >"$SCRATCH/sel/lists/story#v0.3.0"
+printf '302\tunmilestoned\n'      >"$SCRATCH/sel/lists/story#"
+printf '305\ta task, no milestone\n' >"$SCRATCH/sel/lists/task#"
+printf '307\ta task in v0.2.0\n'     >"$SCRATCH/sel/lists/task#v0.2.0"
+
+printf '{"number":302,"title":"unmilestoned","state":"OPEN"}\n'  >"$SCRATCH/sel/views/302"
+printf '{"number":404,"title":"already done","state":"CLOSED"}\n' >"$SCRATCH/sel/views/404"
+
+# Only 288 carries the pinned value, so a project scope that was *not* cleared
+# selects 288 or nothing — never the unmilestoned 302 the cleared run wants.
+page "[$(issue_item 288 z5labs/devex Todo),
+       $(issue_item 302 z5labs/devex Done)]" >"$SCRATCH/sel/pages/Status"
+page '[]' >"$SCRATCH/sel/pages/default"
+
+MILESTONES_ALL='[{"title":"v0.2.0"},{"title":"v0.3.0"}]'
+
+# sel_run <label> <milestone json> <project json|-> <milestones json> [args...]
+sel_run() {
+  local label=$1 milestone=$2 project=$3 milestones=$4
+  shift 4
+  local block=""
+  [ "$project" = - ] || block=",
+    \"project\": $project"
+  cat >"$SCRATCH/sel/repo/.claude/backlog.json" <<JSON
+{
+  "select": { "label": "$label", "milestone": $milestone, "limit": 200$block },
+  "dependencies": { "style": "none" },
+  "verify": ["true"],
+  "merge": { "label": "auto-merge", "workflow": "auto-merge.yaml" },
+  "review": { "required": true },
+  "worktreeDir": ".claude/worktrees"
+}
+JSON
+  printf '%s\n' "$milestones" >"$SCRATCH/sel/milestones"
+  RUN_OUT=$(cd "$SCRATCH/sel/repo" && PATH="$SCRATCH/sel/bin:$PATH" \
+    STUB_LISTS="$SCRATCH/sel/lists" STUB_VIEWS="$SCRATCH/sel/views" \
+    STUB_PAGES="$SCRATCH/sel/pages" STUB_MILESTONES="$SCRATCH/sel/milestones" \
+    "$SUT" "$@" 2>"$SCRATCH/sel/err")
+  RUN_RC=$?
+  RUN_ERR=$(tr '\n' ' ' <"$SCRATCH/sel/err")
+}
+
+# checkr <name> <expected issue number> <label> <milestone json> <project|-> <milestones json> [args...]
+checkr() {
+  local name=$1 want=$2
+  shift 2
+  sel_run "$@"
+  local got
+  got=$(printf '%s' "$RUN_OUT" | jq -r '.number // empty' 2>/dev/null)
+  if [ "$RUN_RC" -eq 0 ] && [ "$got" = "$want" ]; then
+    pass=$((pass + 1))
+    printf '  ok   %-58s [#%s]\n' "$name" "$got"
+  else
+    fail=$((fail + 1))
+    printf '  FAIL %-58s want [#%s] exit 0, got [%s] exit %d: %s\n' \
+      "$name" "$want" "${got:-<none>}" "$RUN_RC" "$RUN_ERR"
+  fi
+}
+
+# checkr_fail <name> <substring> <label> <milestone json> <project|-> <milestones json> [args...]
+checkr_fail() {
+  local name=$1 want=$2
+  shift 2
+  sel_run "$@"
+  case "$RUN_ERR" in
+    *"$want"*) ;;
+    *) fail=$((fail + 1))
+       printf '  FAIL %-58s message lacks [%s]: %s\n' "$name" "$want" "$RUN_ERR"
+       return ;;
+  esac
+  if [ "$RUN_RC" -eq 4 ]; then
+    pass=$((pass + 1))
+    printf '  ok   %-58s [exit 4]\n' "$name"
+  else
+    fail=$((fail + 1))
+    printf '  FAIL %-58s want exit 4, got exit %d\n' "$name" "$RUN_RC"
+  fi
+}
+
+# checkr_note <name> <substring of stderr> <label> <milestone json> <project|-> <milestones json> [args...]
+checkr_note() {
+  local name=$1 want=$2
+  shift 2
+  sel_run "$@"
+  case "$RUN_ERR" in
+    *"$want"*)
+      pass=$((pass + 1))
+      printf '  ok   %-58s [noted]\n' "$name" ;;
+    *) fail=$((fail + 1))
+       printf '  FAIL %-58s diagnostics lack [%s]: %s\n' "$name" "$want" "$RUN_ERR" ;;
+  esac
+}
+
+# Precedence, one key at a time. Every case answers with a different issue
+# number, so a flag that was accepted and then ignored fails here.
+checkr 'a configured milestone is used when no flag overrides it' 288 \
+  story '"v0.2.0"' - "$MILESTONES_ALL"
+
+checkr '--milestone overrides the configured milestone' 291 \
+  story '"v0.2.0"' - "$MILESTONES_ALL" --milestone v0.3.0
+
+checkr 'the --milestone=value form does the same' 291 \
+  story '"v0.2.0"' - "$MILESTONES_ALL" --milestone=v0.3.0
+
+checkr '--milestone names one where the config has none' 291 \
+  story null - "$MILESTONES_ALL" --milestone v0.3.0
+
+checkr '--no-milestone-filter drops the configured milestone' 302 \
+  story '"v0.2.0"' - "$MILESTONES_ALL" --no-milestone-filter
+
+checkr '--label overrides the configured label' 307 \
+  story '"v0.2.0"' - "$MILESTONES_ALL" --label task
+
+checkr '--label and --milestone compose' 305 \
+  story '"v0.2.0"' - "$MILESTONES_ALL" --label task --no-milestone-filter
+
+# One word for "no optional narrowing at all", so a caller does not have to know
+# which axes this repository happens to configure. 302 rather than 288 is the
+# assertion: had either narrowing survived, the pinned Status scope holds only
+# 288 and the v0.2.0 list holds only 288.
+checkr '--all drops the milestone and the project scope together' 302 \
+  story '"v0.2.0"' '{"owner":"z5labs","number":14,"field":"Status","value":"Todo"}' \
+  "$MILESTONES_ALL" --all
+
+# The label is not an optional narrowing but the definition of the backlog, so
+# `--all` leaves it alone and `--label` still applies beside it.
+checkr '--all keeps the label, and --label still applies' 305 \
+  story '"v0.2.0"' '{"owner":"z5labs","number":14,"field":"Status","value":"Todo"}' \
+  "$MILESTONES_ALL" --all --label task
+
+# The reported failure, as a test. A milestone that no longer exists has to be
+# exit 4 naming the ones that do — from the config, which is where the stale
+# value lived, and not only from the flag.
+checkr_fail 'an unknown --milestone names the milestones that exist' 'v0.2.0,v0.3.0' \
+  story null - "$MILESTONES_ALL" --milestone v0.9.9
+
+checkr_fail 'an unknown --milestone blames the flag' '--milestone names milestone' \
+  story null - "$MILESTONES_ALL" --milestone v0.9.9
+
+checkr_fail 'a stale configured milestone is refused, not empty' 'select.milestone names milestone' \
+  story '"v0.2.0"' - '[]'
+
+checkr_fail 'a repository with no milestones at all says so' 'no milestones at all' \
+  story '"v0.2.0"' - '[]'
+
+# Mutually exclusive combinations. Each would otherwise have to discard one of
+# the two silently, and discarding either is a run that is not the run asked for.
+checkr_fail '--milestone and --no-milestone-filter is refused' 'cannot be combined with --milestone' \
+  story null - "$MILESTONES_ALL" --milestone v0.3.0 --no-milestone-filter
+
+checkr_fail '--all and --milestone is refused' 'cannot be combined with --milestone' \
+  story null - "$MILESTONES_ALL" --all --milestone v0.3.0
+
+checkr_fail '--all and a project flag is refused' 'cannot be combined with --project-value' \
+  story null - "$MILESTONES_ALL" --all --project-value Todo
+
+checkr_fail '--all and --no-project-filter is refused' 'cannot be combined with --no-project-filter' \
+  story null - "$MILESTONES_ALL" --all --no-project-filter
+
+# `--issue` names one issue instead of searching for one. 302 is invisible to
+# both configured narrowings — it is unmilestoned and out of the pinned scope —
+# so selecting it is the whole assertion.
+checkr '--issue selects an issue the narrowings would have excluded' 302 \
+  story '"v0.2.0"' '{"owner":"z5labs","number":14,"field":"Status","value":"Todo"}' \
+  "$MILESTONES_ALL" --issue 302
+
+checkr 'the --issue=N form does the same' 302 \
+  story '"v0.2.0"' - "$MILESTONES_ALL" --issue=302
+
+# A run that selected an out-of-backlog issue has to say so. Without these lines
+# its diagnostics read exactly like a run that searched and found it at the top.
+checkr_note '--issue names the label narrowing it bypassed' "bypassed the label narrowing (label 'story')" \
+  story '"v0.2.0"' - "$MILESTONES_ALL" --issue 302
+
+checkr_note '--issue names the milestone narrowing it bypassed' "bypassed the milestone narrowing (milestone 'v0.2.0')" \
+  story '"v0.2.0"' - "$MILESTONES_ALL" --issue 302
+
+checkr_note '--issue names the project narrowing it bypassed' "bypassed the project narrowing (Status = 'Todo'" \
+  story '"v0.2.0"' '{"owner":"z5labs","number":14,"field":"Status","value":"Todo"}' \
+  "$MILESTONES_ALL" --issue 302
+
+checkr_note '--issue says the backlog was not searched' 'the backlog was not searched' \
+  story null - "$MILESTONES_ALL" --issue 302
+
+checkr_fail '--issue refuses a closed issue' 'is CLOSED, not OPEN' \
+  story null - "$MILESTONES_ALL" --issue 404
+
+checkr_fail '--issue refuses a number that is not one' 'must be a positive integer' \
+  story null - "$MILESTONES_ALL" --issue latest
+
+checkr_fail '--issue and --label is refused' 'cannot be combined with --label' \
+  story null - "$MILESTONES_ALL" --issue 302 --label task
+
+checkr_fail '--issue and --milestone is refused' 'cannot be combined with --milestone' \
+  story null - "$MILESTONES_ALL" --issue 302 --milestone v0.3.0
+
+checkr_fail '--issue and a project flag is refused' 'cannot be combined with --project-value' \
+  story null - "$MILESTONES_ALL" --issue 302 --project-value Todo
+
+checkr_fail '--issue and --all is refused' 'cannot be combined with --all' \
+  story null - "$MILESTONES_ALL" --issue 302 --all
+
+checkr_fail 'an unknown argument is refused' "unknown argument '--milestones'" \
+  story null - "$MILESTONES_ALL" --milestones v0.3.0
+
 printf '\ncross-repository dependencies\n'
 
 # The dependency walk itself, end to end, under `dependencies.style` = `native`
@@ -676,14 +958,25 @@ case "$1 $2" in
   'repo view')  printf 'z5labs/devex\n' ;;
   'issue list') cat "$STUB_ISSUES" ;;
   'issue view')
-    # dep_state. Under style `native` the body is never read, so this is the
-    # only thing that views an issue at all.
-    n=$3 repo="" prev=""
-    for a in "$@"; do [ "$prev" = --repo ] && repo=$a; prev=$a; done
-    printf '%s#%s\n' "$repo" "$n" >>"$STUB_CALLS"
+    # Two callers. `dep_state` asks for `--json state --jq .state` and is the
+    # only thing that views an issue at all under style `native`, where the body
+    # is never read. `--issue <n>` asks for `--json number,title,state` with no
+    # `--jq`, so the absence of one is what tells the two apart — and only the
+    # dep_state reads are counted, since the cache assertion is about those.
+    n=$3 repo="" q="" prev=""
+    for a in "$@"; do
+      [ "$prev" = --repo ] && repo=$a
+      [ "$prev" = --jq ] && q=$a
+      prev=$a
+    done
     f="$STUB_STATES/${repo//\//_}#$n"
     [ -f "$f" ] || { printf 'stub gh: cannot view %s#%s\n' "$repo" "$n" >&2; exit 1; }
-    cat "$f" ;;
+    if [ -n "$q" ]; then
+      printf '%s#%s\n' "$repo" "$n" >>"$STUB_CALLS"
+      cat "$f"
+    else
+      printf '{"number":%s,"title":"issue %s","state":"%s"}\n' "$n" "$n" "$(cat "$f")"
+    fi ;;
   'api graphql')
     n=""
     for a in "$@"; do case "$a" in number=*) n=${a#number=} ;; esac; done
@@ -711,24 +1004,26 @@ nreset() { rm -rf "$SCRATCH/deps" "$SCRATCH/states"; mkdir -p "$SCRATCH/deps" "$
 ndeps()  { npage "$2" "$1" >"$SCRATCH/deps/$1"; }          # <issue> <blockedBy nodes>
 nstate() { printf '%s\n' "$3" >"$SCRATCH/states/${1//\//_}#$2"; }  # <repo> <number> <state>
 
-# nrun <issue numbers, space separated>
+# nrun <issue numbers, space separated> [args...]
 nrun() {
   : >"$SCRATCH/nissues"
   local n
   for n in $1; do printf '%s\tissue %s\n' "$n" "$n" >>"$SCRATCH/nissues"; done
+  shift
   : >"$SCRATCH/calls"
   RUN_OUT=$(cd "$SCRATCH/nrepo" && PATH="$SCRATCH/nbin:$PATH" \
     STUB_ISSUES="$SCRATCH/nissues" STUB_DEPS="$SCRATCH/deps" \
     STUB_STATES="$SCRATCH/states" STUB_CALLS="$SCRATCH/calls" \
-    "$SUT" 2>"$SCRATCH/nerr")
+    "$SUT" "$@" 2>"$SCRATCH/nerr")
   RUN_RC=$?
   RUN_ERR=$(tr '\n' ' ' <"$SCRATCH/nerr")
 }
 
-# checkd <name> <expected issue number> <reason substring, or - for none> <issue numbers>
+# checkd <name> <expected issue number> <reason substring, or - for none> <issue numbers> [args...]
 checkd() {
   local name=$1 want=$2 reason=$3 got
-  nrun "$4"
+  shift 3
+  nrun "$@"
   got=$(printf '%s' "$RUN_OUT" | jq -r '.number // empty' 2>/dev/null)
   if [ "$RUN_RC" -ne 0 ] || [ "$got" != "$want" ]; then
     fail=$((fail + 1))
@@ -748,10 +1043,11 @@ checkd() {
   printf '  ok   %-58s [#%s]\n' "$name" "$got"
 }
 
-# checkd_blocked <name> <substring of the report> <issue numbers>
+# checkd_blocked <name> <substring of the report> <issue numbers> [args...]
 checkd_blocked() {
   local name=$1 want=$2 report
-  nrun "$3"
+  shift 2
+  nrun "$@"
   report=$(printf '%s' "$RUN_OUT" | tr '\n' ' ')
   case "$report" in
     *"$want"*) ;;
@@ -841,6 +1137,36 @@ else
   printf '  FAIL %-58s want 1 view, got %d: %s\n' \
     'a cross-repository state is read once and cached' "$CALLS" "$(tr '\n' ' ' <"$SCRATCH/calls")"
 fi
+
+# `--issue <n>` changes which issues are considered and nothing about whether the
+# one considered is workable — the dependency walk runs against it exactly as it
+# would have if the search had turned it up. Naming an issue is a statement about
+# order, not a licence to start something whose blockers are open.
+nreset
+ndeps 63 "[$(dep 328 z5labs/other)]"
+nstate z5labs/other 328 OPEN
+nstate z5labs/devex 63 OPEN
+checkd_blocked '--issue still walks the dependencies' \
+  'z5labs/other#328 is OPEN' '63 65' --issue 63
+
+# And the report blames the issue that was named rather than describing a
+# backlog search that never happened.
+checkd_blocked '--issue names itself in the BLOCKED report' \
+  'issue #63, named with --issue' '63 65' --issue 63
+
+nreset
+ndeps 63 "[$(dep 328 z5labs/other)]"
+nstate z5labs/other 328 CLOSED
+nstate z5labs/devex 63 OPEN
+checkd '--issue selects when its dependencies are all CLOSED' 63 - '63 65' --issue 63
+
+# Out of the listed backlog entirely — the case `--issue` exists for. #77 is not
+# in the issue list at all, so a run that quietly fell back to searching would
+# answer #63.
+nreset
+ndeps 77 '[]'
+nstate z5labs/devex 77 OPEN
+checkd '--issue reaches an issue the list never returned' 77 - '63 65' --issue 77
 
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/plugins/backlog/skills/next-issue/SKILL.md
+++ b/plugins/backlog/skills/next-issue/SKILL.md
@@ -15,7 +15,8 @@ default branch's protection rules; see step 9.
 Nothing about the repository is written into this skill. The repository slug and default
 branch are read from the repository itself (step 0); the label, milestone, optional project
 scope, dependency convention, verify commands, merge label and worktree directory are read
-from `.claude/backlog.json`.
+from `.claude/backlog.json` — where every selector among them is a **default** that an
+argument to step 1 can replace for this run alone.
 
 ## 0. Load the configuration
 
@@ -41,8 +42,8 @@ What each key is used for:
 
 | key | used at |
 | --- | --- |
-| `select.label`, `select.milestone`, `select.limit`, `select.project` | step 1 — read by `select-issue.sh`, not by you |
-| `dependencies.style` | step 1 — same |
+| `select.label`, `select.milestone`, `select.limit`, `select.project` | step 1 — read by `select-issue.sh`, not by you, and each one a **default** a flag on that call can override |
+| `dependencies.style` | step 1 — same, minus the override |
 | `verify` | step 4, the commands that gate the pull request |
 | `merge.label`, `merge.workflow` | step 9, handing the merge to GitHub |
 | `review.required` | steps 7 and 8, whether Copilot gates the merge |
@@ -84,11 +85,51 @@ exit code:
 | 0 | `{"number":N,"title":"…"}` | that is your issue — continue to step 2 |
 | 10 | `BACKLOG EMPTY` | print that line and stop. Do nothing else. |
 | 11 | `BLOCKED — …`, then a line per issue naming what holds it | print it and stop |
-| 4 | a message naming the problem | `BLOCKED`. The config or the environment is wrong, not the backlog — usually `.claude/backlog.json` is missing, unparseable, carries an unknown `dependencies.style`, or has an empty `verify`. A requested project scope that could not be resolved lands here too; see below. Point at `backlog:setup-backlog`. |
+| 4 | a message naming the problem | `BLOCKED`. The config or the environment is wrong, not the backlog — usually `.claude/backlog.json` is missing, unparseable, carries an unknown `dependencies.style`, or has an empty `verify`. A requested project scope that could not be resolved lands here too, as does a milestone that does not exist; see below. Point at `backlog:setup-backlog`. |
 
 The script walks candidates in ascending number order and takes the first whose every
 declared dependency is `CLOSED`. Its per-candidate reasoning goes to stderr, so a selection
 you did not expect can be explained without re-running anything.
+
+### Every selector is a runtime decision
+
+`.claude/backlog.json` holds the **default** for each selector and nothing more. Every one of
+them can be replaced for a single run by an argument to the call above:
+
+| argument | overrides | when you pass it |
+| --- | --- | --- |
+| `--label <name>` | `select.label` | you were asked to work a different label this run — `bug` on a repository whose backlog is normally `story` |
+| `--milestone <title>` | `select.milestone` | you were asked to drain a named milestone |
+| `--no-milestone-filter` | same, to nothing | you were asked to ignore the configured milestone |
+| `--project-value`, `--project-field`, `--project-owner`, `--project-number`, `--no-project-filter` | `select.project.*` | see the next section |
+| `--all` | the milestone **and** the project scope, both to nothing | you were asked for the whole labelled backlog, whatever narrowings this repository happens to configure |
+| `--issue <n>` | selection itself | you were asked to work one named issue rather than the next one |
+
+Pass an argument when, and only when, you were asked for what it expresses — the user named
+it, or `backlog:run-backlog` put it in your prompt. **Never infer one.** With nothing asked
+for, call the script with no arguments at all and let the config decide.
+
+Two rules the script enforces, both worth knowing before you are refused:
+
+- **A clearing argument never combines with a narrowing one.** `--milestone X
+  --no-milestone-filter` is exit 4, as `--no-project-filter` beside any `--project-*` flag
+  already was, and so is `--all` beside any of them: each pair would have to discard one of
+  the two silently, and either discard is a run that is not the run you were asked for.
+  `--all --label bug` is fine, because the label defines the backlog rather than narrowing
+  it.
+- **`--issue <n>` combines with nothing.** It bypasses the label, the milestone and the
+  project scope, and its stderr says so, one line per narrowing — a run that selected an
+  out-of-backlog issue has to read differently from one that searched and found it at the
+  top. The dependency walk still runs against it: an issue whose blockers are open comes back
+  exit 11 `BLOCKED` naming them, never selected.
+
+A **milestone that does not exist** is exit 4 naming the ones that do, whether it came from
+the flag or from the config. That check is there because `gh issue list --milestone` answers
+`[]` with exit 0 for a milestone that was deleted or renamed, and an empty candidate list
+prints `BACKLOG EMPTY` — which halts the loop as a success over a backlog that is fully
+workable. If that fires, the answer is a `--milestone` (or `--no-milestone-filter`) argument
+on this run and an issue against the repository whose config went stale; it is **not** a
+reason to edit `.claude/backlog.json` yourself.
 
 ### Scoping the run to one project field value
 
@@ -727,9 +768,10 @@ where it stands, `BLOCKED` says it needs a person.
 Stop and report — do not push through — if any of these happen:
 
 - `select-issue.sh` exits 4 — `.claude/backlog.json` is missing, does not parse, carries an
-  unknown `dependencies.style`, has an empty `verify`, or a requested project scope could not
-  be resolved. Never re-run it with a project flag dropped, widened or edited to get past the
-  last of those, and never edit `.claude/backlog.json` to get past it either.
+  unknown `dependencies.style`, has an empty `verify`, names a milestone that does not exist,
+  or a requested project scope could not be resolved. Never re-run it with an argument
+  dropped, widened or changed to get past the last two, and never edit
+  `.claude/backlog.json` to get past them either.
 - The same CI failure survives three fix attempts.
 - Acceptance criteria are ambiguous enough that two readings produce materially different
   public APIs.

--- a/plugins/backlog/skills/run-backlog/SKILL.md
+++ b/plugins/backlog/skills/run-backlog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: run-backlog
-description: Drive a repository's story backlog unattended, one issue at a time, by spawning a fresh `issue-worker` subagent per iteration and halting on `BACKLOG EMPTY`, on `BLOCKED`, or at a bounded iteration count. Use this whenever the user wants the backlog worked continuously rather than a single issue — "run the backlog", "work through the issues", "keep taking stories until you run out", "drain the milestone", "work through the workspace-ci stories", "work the In Progress stories", or a `/loop` that repeats the cycle. Takes an optional integer argument setting the maximum number of iterations, and optional `--project-value <value>`, `--project-field <name>`, `--project-owner <login>` and `--project-number <n>` arguments restricting the whole run to one value of one single-select field on a GitHub project. Skip this when the user wants exactly one issue (`backlog:next-issue`) or wants the repository bootstrapped first (`backlog:setup-backlog`).
+description: Drive a repository's story backlog unattended, one issue at a time, by spawning a fresh `issue-worker` subagent per iteration and halting on `BACKLOG EMPTY`, on `BLOCKED`, or at a bounded iteration count. Use this whenever the user wants the backlog worked continuously rather than a single issue — "run the backlog", "work through the issues", "keep taking stories until you run out", "drain the v0.3.0 milestone", "work through the workspace-ci stories", "work the In Progress stories", or a `/loop` that repeats the cycle. Takes an optional integer argument setting the maximum number of iterations, the bare word `all` meaning every optional narrowing is dropped, and optional `--label <name>`, `--milestone <title>`, `--no-milestone-filter`, `--project-value <value>`, `--project-field <name>`, `--project-owner <login>`, `--project-number <n>` and `--no-project-filter` arguments restricting the whole run. Skip this when the user wants exactly one issue (`backlog:next-issue`) or wants the repository bootstrapped first (`backlog:setup-backlog`).
 allowed-tools: Agent, SendMessage, Bash, Read, Glob, Grep, TaskCreate, TaskUpdate, ScheduleWakeup
 ---
 
@@ -29,28 +29,31 @@ Run these once, before the first iteration, and stop if any fails:
    changes you did not make are a stop condition for the cycle, so they are a stop condition
    for the loop; report what is dirty and let the user decide.
 3. **Auth.** `gh auth status`. An expired token turns every iteration into the same
-   opaque failure. If this run is scoped (below), the scopes it prints must include
-   **`read:project`** — `repo` does not imply it, and without it every iteration fails
-   identically at selection. `gh auth refresh -s read:project` grants it; report and stop
-   rather than dropping the scope and running the whole backlog.
+   opaque failure. If this run carries a **project** scope (below) — or the config pins one —
+   the scopes it prints must include **`read:project`**; `repo` does not imply it, and without
+   it every iteration fails identically at selection. `gh auth refresh -s read:project` grants
+   it; report and stop rather than dropping the scope and running the whole backlog. A run
+   narrowed only by milestone or label needs nothing beyond `repo`.
 
-Also settle the **bound** now. It is the skill's argument when one was given; otherwise
-default to **10** iterations. Say the number in your first message. An unbounded loop
-against a large backlog is not the user asking for autonomy, it is the user losing the
+Also settle the **bound** now. It is the skill's integer argument when one was given;
+otherwise default to **10** iterations. Say the number in your first message. An unbounded
+loop against a large backlog is not the user asking for autonomy, it is the user losing the
 chance to look at the first result before the twentieth lands on top of it.
 
-And settle the **scope**. A repository that groups its work by a single-select field on a
-GitHub project — `Module`, `Area`, `Component`, `Status` — can have the whole run restricted
-to one value of one such field:
+And settle the **selection arguments**. Everything the repository's `.claude/backlog.json`
+pins is a default that this run can replace, and the whole run then uses the same set:
 
 ```
 /run-backlog 5 --project-value workspace-ci
 /run-backlog 5 --project-field Status --project-value "In Progress"
+/run-backlog 5 --milestone v0.3.0
+/run-backlog 5 all
 ```
 
-The argument order does not matter; the integer is the bound and everything beginning
-`--project-` is the scope. Four are accepted, and they are exactly the ones
-`scripts/select-issue.sh` takes:
+The argument order does not matter. The integer is the bound, the bare word `all` is defined
+below, and every argument beginning `--` is passed through to selection. They are exactly the
+ones `scripts/select-issue.sh` takes, so a request the script cannot express is a request
+this skill cannot accept either:
 
 | argument | what it names | when the user has given you one |
 | --- | --- | --- |
@@ -58,22 +61,43 @@ The argument order does not matter; the integer is the bound and everything begi
 | `--project-field <name>` | which single-select to read it from | "work the **In Progress** stories" — a value on an axis other than the configured one |
 | `--project-owner <login>` | the board's owner | the repository's config has no `select.project`, or the user named another board |
 | `--project-number <n>` | the board's number | same |
+| `--no-project-filter` | no project scope, whatever the config pins | "ignore the module, work the lot" |
+| `--milestone <title>` | the milestone to drain | "drain v0.3.0" |
+| `--no-milestone-filter` | no milestone, whatever the config pins | "ignore the milestone" |
+| `--label <name>` | which label the backlog is | "work the **bug** backlog this time" |
 
 A user asking to "work through the workspace-ci stories" is asking for `--project-value`
 alone: the config already names the board and the usual axis. `--project-field` is what makes
-"work the In Progress stories" expressible without an edit to `.claude/backlog.json`, and
-`--project-owner`/`--project-number` cover the repository whose config names no board at all.
+"work the In Progress stories" expressible without an edit to `.claude/backlog.json`,
+`--project-owner`/`--project-number` cover the repository whose config names no board at all,
+and `--milestone` is what finally makes "drain the milestone" — advertised in this skill's own
+description for a long time before it was expressible — an actual request.
 
-**Every part of the scope is the user's to give — infer none of it.** Do not read the issues
-and guess a field, and do not guess which field a value belongs to when the user names only a
-value; if the value is not one of the configured field's options, selection fails at exit 4
-naming the real options, and that failure is the answer to report, not a prompt to try
-another field.
+### `all`
 
-With no scope given, pass nothing and let the config decide, which normally means the whole
-backlog. Say the scope in your first message alongside the bound — the field as well as the
-value, since the same value can exist on two of a board's fields — because every outcome
-below is then a statement about that scope and not about the backlog.
+`all` means **every optional narrowing is dropped**: no milestone, no project scope, whatever
+the config pins for either. It becomes `--all` on the selection call, one argument, and it
+exists so the user does not have to know which axes this particular repository happens to
+configure.
+
+It is defined here because it was reached for before it existed. A `/run-backlog all`
+invocation had to have a meaning invented for it at the driver — it was read as an iteration
+bound and quietly defaulted to 10 — which is a request answered by guessing. `all` is not a
+bound: `/run-backlog all` is ten iterations of the *unnarrowed* backlog, and
+`/run-backlog 3 all` is three of it. It does not touch the label, which says what the backlog
+is rather than narrowing it, so `all --label bug` is "the whole bug backlog" and is accepted.
+
+**Every selection argument is the user's to give — infer none of them.** Do not read the
+issues and guess a field, do not guess which field a value belongs to when the user names only
+a value, and do not supply a milestone the user did not name. If a value is not one of the
+configured field's options, or a milestone does not exist, selection fails at exit 4 naming
+the real options or the real milestones — and that failure is the answer to report, not a
+prompt to try another one.
+
+With nothing given, pass nothing and let the config decide, which normally means the whole
+backlog. Say the arguments in your first message alongside the bound — the field as well as
+the value, since the same value can exist on two of a board's fields — because every outcome
+below is then a statement about that selection and not about the backlog.
 
 ## 1. The loop
 
@@ -90,15 +114,16 @@ Agent(
 )
 ```
 
-When the run is scoped, add one more line to the prompt, repeating **every** project argument
-the run was given, verbatim and in full:
+When the run carries selection arguments, add one more line to the prompt, repeating **every**
+one of them, verbatim and in full:
 
 ```
            This run is scoped: pass --project-field Status --project-value "In Progress"
            to select-issue.sh at step 1.
 ```
 
-Every iteration gets all of them. Dropping one does not narrow that iteration:
+Every iteration gets all of them, `all` (as `--all`) included. Dropping one does not narrow
+that iteration:
 
 - Drop `--project-value` and the iteration widens to the whole backlog.
 - Drop `--project-field` and the iteration either falls back to the configured axis — a
@@ -107,9 +132,14 @@ Every iteration gets all of them. Dropping one does not narrow that iteration:
   issue and merges it, and nothing in its report will look wrong.
 - Drop `--project-owner` or `--project-number` on a repository whose config names no board
   and the iteration fails at exit 4 — loud, but it burns an iteration on every pass.
+- Drop `--milestone` or `--no-milestone-filter` and the iteration falls back to the
+  configured milestone, which is the quiet failure again: the run works a milestone the user
+  did not ask for, or reports the configured one empty and halts.
+- Drop `--label` and the iteration works a different backlog entirely.
+- Drop `--all` and every narrowing the user asked to be rid of comes back.
 
-So the rule is the same for all four, and it is the one already stated for the value: the
-scope you settled at preflight goes into every prompt unchanged, or the run stops.
+So the rule is the same for all of them, and it is the one already stated for the value: the
+arguments you settled at preflight go into every prompt unchanged, or the run stops.
 
 Check the agent types available to you before the first spawn. Depending on how the plugin
 was installed the worker may be listed as `issue-worker` or as `backlog:issue-worker`; use
@@ -222,20 +252,21 @@ columns are the only place a run that regressed is visible.
   no one holding them.
 - **Never widen the bound mid-run** because the backlog turned out to be longer. Finish,
   report, and let the user re-run.
-- **Never drop, widen or edit any part of the scope mid-run**, and never respond to a worker
-  that halted on a project failure by re-spawning it with a flag removed or a different field
-  or value. Dropping the value turns "work the workspace-ci stories" into "work the backlog";
-  dropping or changing the field turns it into "work some other dimension" — which is worse,
-  because it still looks scoped in the report. Both are the failure a scoped run exists to
-  prevent.
-- **Never edit `.claude/backlog.json` to make a scope resolve.** Every piece of the scope has
-  a flag, so a scope that will not assemble is a missing argument, not a missing config key.
-  Rewriting the repository's committed description of its own backlog to suit one run outlives
-  the run.
+- **Never drop, widen or edit any selection argument mid-run**, and never respond to a worker
+  that halted on a selection failure by re-spawning it with an argument removed or changed.
+  Dropping the value turns "work the workspace-ci stories" into "work the backlog"; dropping
+  or changing the field turns it into "work some other dimension" — which is worse, because it
+  still looks scoped in the report; dropping the milestone works a release the user did not
+  name. All of them are the failure a scoped run exists to prevent.
+- **Never edit `.claude/backlog.json` to make a selection resolve.** Every selector has an
+  argument, so a selection that will not assemble — an unresolvable scope, a milestone that no
+  longer exists — is a missing argument on this run and, at most, an issue to file against the
+  repository whose config went stale. Rewriting the repository's committed description of its
+  own backlog to suit one run outlives the run.
 
 ## 3. Report
 
-Close with the iteration table, the scope the run was under if it had one, the reason the
+Close with the iteration table, the selection arguments the run was under if it had any, the reason the
 loop stopped in its own words (`BACKLOG EMPTY`, `BLOCKED`, bound reached, worker failure,
 a worker that could not be got past `IN FLIGHT`),
 and — if anything merged without a review because `review.required` is `false` — that fact,

--- a/plugins/backlog/skills/setup-backlog/SKILL.md
+++ b/plugins/backlog/skills/setup-backlog/SKILL.md
@@ -123,10 +123,25 @@ either way and let the user choose; do not switch the style on their behalf.
 
 - `select.label` — the label the backlog uses. `gh label list --json name --jq '.[].name'`;
   if `story` exists, take it. If the repository clearly uses another (`feature`, `task`),
-  take that and say so. If none exists, `story`, and step 4 creates it.
-- `select.milestone` — `gh api repos/<repo>/milestones --jq '.[] | "\(.title) \(.open_issues)"'`.
-  Exactly one open milestone with open issues is a reasonable inference; anything else is
-  `null`, which means "every open issue with the label".
+  take that and say so. If none exists, `story`, and step 4 creates it. A run that wants
+  another for once passes `select-issue.sh --label <name>`, so this is a default and not a
+  commitment.
+- `select.milestone` — **`null`, unless the user asks for one.** Not inferred.
+
+  It used to be: "exactly one open milestone with open issues is a reasonable inference".
+  It is a reasonable inference *about the moment you ran it*, and that is the problem — the
+  value is a snapshot committed to a tracked file, and it decays silently as releases ship.
+  Measured: a repository bootstrapped mid-release-train got `select.milestone: "v0.2.0"`, the
+  milestone was later deleted, and every subsequent run reported `BACKLOG EMPTY` over an
+  open, eligible, unmilestoned story. `select-issue.sh` now refuses an unknown milestone
+  loudly rather than selecting from nothing, so the trap no longer swallows a run — but the
+  best value for a key that decays is the one that cannot.
+
+  If the user does want a milestone pinned, `gh api repos/<repo>/milestones --jq '.[] |
+  "\(.title) \(.open_issues)"'` lists the candidates. Write it, and say in the report that it
+  will need changing when that milestone closes, and that `select-issue.sh --milestone
+  <title>` and `--no-milestone-filter` override it per run so no edit is needed to work
+  another one.
 - `select.limit` — `200`.
 - `select.project` — **omit it unless the user asks.** It scopes selection to one value of a
   single-select field on a GitHub project (`Module`, `Area`, `Component`, `Status`), which is


### PR DESCRIPTION
Closes #376

`select.milestone` was the only selector in `backlog.json` with no way to override it for one
run, and a stale value in it reported a workable backlog as a drained one. `gh issue list
--milestone` does not object to a milestone that no longer exists — it answers `[]` with exit
0 — so `CANDIDATES` came back empty, `BACKLOG EMPTY` printed, and `run-backlog` halted on what
its own table calls "success, not failure" over an open, eligible story.

The repair is the principle `select.project` already followed: config is a **default**, never a
floor, and a value that cannot be resolved fails loudly instead of selecting from nothing.

## Acceptance criteria

- [x] `--milestone <title>` and `--no-milestone-filter`, on exactly the terms `--project-value`
      and `--no-project-filter` establish — including the refusal to combine a clearing flag
      with a narrowing one
- [x] A requested milestone is checked against the repository's milestones (`state=all`) before
      the issue query; an unknown title is `fail 4` naming the titles that exist
- [x] A milestone configured in `backlog.json` gets the same check, so avroc's `v0.2.0` reports
      a milestone that no longer exists rather than `BACKLOG EMPTY`
- [x] `--label <name>`, overriding `select.label` for one run
- [x] `--all` — one input meaning "no optional narrowing at all", clearing the milestone and
      the project scope together
- [x] `--issue <N>` selects that issue rather than searching, and the dependency walk still
      runs against it; unmet dependencies are exit 11 `BLOCKED` naming them
- [x] `--issue` states in its own diagnostics which of the label, milestone and project
      narrowings it bypassed — one stderr line each, whether or not that narrowing was
      configured
- [x] `select-issue_test.sh` covers each new flag, flag-over-config precedence for every key,
      the mutually-exclusive combinations and the unknown-milestone failure, offline
- [x] `backlog.schema.json` records for `select.milestone` and `select.label` that each is an
      overridable default, and which flag does it
- [x] `run-backlog` threads every new argument through to each iteration's worker prompt
      verbatim, under the rule it already stated for the four project flags
- [x] `run-backlog` defines `all` as an input, and its description now says "drain the **v0.3.0**
      milestone" — a request that is expressible at runtime
- [x] `next-issue` documents the new arguments where it documents the project ones, and its
      config table no longer implies `select.milestone` is read only from the config
- [x] `setup-backlog` no longer infers a milestone: it writes `null` unless the user asks, and
      records why a value there decays

## Judgment calls

- **`--all` does not clear the label.** The label defines what the backlog *is* rather than
  narrowing it — an issue without it was never backlog work — so `--all --label bug` is "the
  whole bug backlog" and is accepted, while `--all` beside any milestone or project flag is
  refused.
- **`all` in `run-backlog` maps to `--all`, and is not a bound.** `/run-backlog all` is ten
  iterations of the unnarrowed backlog; `/run-backlog 3 all` is three of it. This is the
  invocation that previously had a meaning invented for it at the driver.
- **`--issue` combines with nothing at all**, `--label` included. It bypasses every narrowing,
  so naming one beside it would be a run that thinks it narrowed a backlog it never read.
- **`--issue` refuses a closed issue** (exit 4). The cycle ends by closing the issue it worked,
  so an already-closed one is either finished work or a typo.
- **Milestones are read with `state=all`.** A closed milestone can still hold open issues, and
  naming one is a legitimate request.
- Plugin version bumped to `0.5.0`; plugin caches are version-keyed, so without it the change
  does not roll out.

## Verified

- `dagger check` — 3/3 OK
- `bash .github/scripts/verify-affected-modules.sh` — no daggerverse module changed
- `plugins/backlog/scripts/select-issue_test.sh` — **104 passed, 0 failed** (was 70; 34 new
  cases, all offline)
- Live smoke test against `z5labs/devex`: `--issue 376` selects #376 and prints all three
  bypass lines; `--milestone v9.9.9` exits 4 with `it has no milestones at all`

## Not in scope

`z5labs/avroc`'s own `.claude/backlog.json` still needs `select.milestone` set to `null`; that
is a change to another repository, and the issue notes it is not a substitute for the loud
failure landed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)