### PR TITLE
story(backlog): make the reviewer an ordered roster that fails over when a rung is unavailable

### DIFF
--- a/.claude/backlog.json
+++ b/.claude/backlog.json
@@ -22,7 +22,7 @@
     "workflow": "auto-merge.yaml"
   },
   "review": {
-    "required": true
+    "reviewers": ["copilot", "local"]
   },
   "worktreeDir": ".claude/worktrees"
 }

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -13,8 +13,9 @@ tooling (`daggerverse/`, `ci/`) and the docs (`docs/`).
 ## `backlog`
 
 Takes one story issue from the backlog to a merged pull request — select,
-worktree, implement, verify, PR, wait for checks, get a Copilot review and
-answer it, label for auto merge, close the issue, clean up — then stops.
+worktree, implement, verify, PR, wait for checks, get a review from the
+configured roster and answer it, label for auto merge, close the issue, clean
+up — then stops.
 `run-backlog` repeats that with a fresh `issue-worker` subagent per iteration,
 so each issue starts from clean context, and halts on `BACKLOG EMPTY`, on
 `BLOCKED`, or at a bounded iteration count. A worker that hands back control
@@ -97,15 +98,31 @@ answer — exposed as `--classify` on stdin and pinned offline by
 check read as pending is a wait that times out; read as settled, it is a merge.
 
 The review gate is
-[`scripts/await-review.sh`](backlog/scripts/await-review.sh) — request, wait,
-and classify what landed, as `0 completed / 1 declined / 2 timed out / 3 could
-not request`. "Did Copilot review this?" looks like one question and is two, and
-the two used to sit sixty lines apart: the wait exited on the first `reviewed`
-event, while whether that review had *declined* the work was a separate command
-under its own heading. Copilot declines a pull request over 300 files with a
-review whose body says so, and that decline satisfies any `length > 0` test —
-which is how a cycle once merged with no review at all. The merge label is the
-assertion that a review completed, so the assertion is now an exit code.
+[`scripts/await-review.sh`](backlog/scripts/await-review.sh) — request from one
+rung, wait, and classify what landed, as `0 completed / 1 refused / 2 nothing
+yet / 3 unavailable`. "Did the reviewer review this?" looks like one question
+and is two, and the two used to sit sixty lines apart: the wait exited on the
+first `reviewed` event, while whether that review had *declined* the work was a
+separate command under its own heading. Copilot declines a pull request over 300
+files with a review whose body says so, and that decline satisfies any
+`length > 0` test — which is how a cycle once merged with no review at all. The
+merge label is the assertion that a review completed, so the assertion is now an
+exit code, pinned offline by
+[`scripts/await-review_test.sh`](backlog/scripts/await-review_test.sh).
+
+`review.reviewers` makes that gate an ordered roster — `["copilot", "local",
+"none"]` — tried in order and failing over on **availability alone**. It
+replaced a boolean whose two settings were "Copilot gates the merge" and
+"nothing does", which forced a repository whose monthly Copilot allowance had
+run out to choose between no loop and no review, permanently, in a tracked file.
+The `local` rung is an adversarial review by a fresh, context-free subagent,
+posted as a `COMMENT` review under a GitHub App identity by
+[`scripts/post-review.sh`](backlog/scripts/post-review.sh) — never under the
+operator's token, which opened the pull request — so it lands on the timeline
+as a `reviewed` event and one gate covers every rung. A rung that *refused* the
+work does not advance the roster: a reviewer with different limits is not a
+second opinion on work the first one could not read, and advancing there is
+precisely how unreviewable work reaches the default branch.
 
 The tail of the cycle is
 [`scripts/finish-issue.sh`](backlog/scripts/finish-issue.sh) rather than five
@@ -131,7 +148,8 @@ when they are absent.
 asked, installs the workflow, creates the labels, and then *verifies* the
 environment — squash-only merging, the default branch's required status checks,
 and whether Copilot code review is really enabled — reporting what it cannot fix
-without repository-admin rights.
+without repository-admin rights, and offering a second reviewer rung rather than
+a downgrade when Copilot is not there.
 
 ## Convention
 

--- a/plugins/backlog/.claude-plugin/plugin.json
+++ b/plugins/backlog/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "backlog",
-  "description": "Run a repository's story backlog unattended — one issue at a time, from selection through worktree, verification, pull request, Copilot review and label-driven auto merge",
-  "version": "0.5.0",
+  "description": "Run a repository's story backlog unattended — one issue at a time, from selection through worktree, verification, pull request, an ordered roster of automated reviewers and label-driven auto merge",
+  "version": "0.6.0",
   "author": { "name": "z5labs" }
 }

--- a/plugins/backlog/agents/issue-worker.md
+++ b/plugins/backlog/agents/issue-worker.md
@@ -1,7 +1,7 @@
 ---
 name: issue-worker
 description: Runs one iteration of the backlog cycle — invokes the `backlog:next-issue` skill, takes a single story issue from selection to a merged pull request, and returns that run's report verbatim. Spawned once per iteration by `backlog:run-backlog`; not usually invoked directly.
-tools: Skill, Bash, Read, Write, Edit, Glob, Grep, TaskCreate, TaskUpdate
+tools: Skill, Agent, Bash, Read, Write, Edit, Glob, Grep, TaskCreate, TaskUpdate
 ---
 
 You run **one** iteration of a repository's backlog cycle and then return.
@@ -17,6 +17,12 @@ If the `Skill` tool is not available to you, stop immediately and report `BLOCKE
 Skill tool is not granted to this agent; backlog:next-issue cannot be invoked`. There is no
 fallback: reconstructing the cycle from memory is how the footnotes that make it work get
 dropped.
+
+If your prompt names a **reviewer roster** — `--reviewers <a,b,c>` — or names rungs already
+found unavailable earlier in this run, carry both through to the skill's step 7 unchanged. The
+roster is ordered and the order is the policy: reordering it, or dropping a rung because the
+first one looked slow, is how a pull request ends up merged on a weaker assurance than the
+repository asked for.
 
 If your prompt names selection arguments — any of `--project-value`, `--project-field`,
 `--project-owner`, `--project-number`, `--no-project-filter`, `--label`, `--milestone`,
@@ -55,7 +61,15 @@ looking scoped. Either way your report will read like an ordinary successful ite
   makes no tool call at all is the single worst outcome available to you — it costs your
   caller your entire context and moves the cycle nowhere.
 - **Do not weaken a test to make it pass**, and do not label a pull request whose review
-  never completed.
+  never completed on some rung — or whose roster did not end at `none`.
+- **A reviewer that refused is not a reviewer to route around.** Only *unavailability*
+  advances the roster. A rung that read the work and said it could not review it has told you
+  something true about the work, and trying a reviewer with different limits is how
+  unreviewable work reaches the default branch.
+- **Never review your own diff.** If you cannot spawn a subagent for the `local` rung, that
+  rung is unavailable and you advance. A reviewer holding the context that produced the code
+  is not a second opinion, and a review you post under an App identity would look exactly like
+  one to everybody reading the pull request afterwards.
 - **Do not retry selection unscoped, or on other arguments.** If selection fails on the
   arguments you were given — an unresolvable project scope, a milestone that does not exist —
   that is a `BLOCKED` report. It is not a reason to drop an argument, try a different field,
@@ -79,8 +93,14 @@ not a conversation.
   it stands, and name the issue, the pull request and the gate you had reached; use `BLOCKED`
   when it needs a person.
 - On a completed iteration, name the issue number and title, the pull request number and
-  URL, the check result, whether the pull request reached `MERGED`, and whether Copilot
-  reviewed — or, when `review.required` is `false`, say plainly that the pull request merged
-  without a review.
+  URL, the check result, whether the pull request reached `MERGED`, and **which rung of the
+  roster reviewed it** — or, when the roster reached `none`, say plainly that the pull request
+  merged without a review.
+- Name **any rung that refused the request**, with its reason, on its own line and in a form
+  your driver can read back — `Reviewer: local (copilot unavailable: Copilot code review is
+  not enabled for this organisation)`. It threads those into the next iteration so the run
+  stops paying for a reviewer that is down. A rung that merely went *silent* does not belong
+  on that line: silence is what a slow reviewer looks like, and retiring one on it costs every
+  remaining iteration its best reviewer.
 - Keep it to a handful of lines. Detail belongs in the pull request, not in the caller's
   context.

--- a/plugins/backlog/agents/issue-worker.md
+++ b/plugins/backlog/agents/issue-worker.md
@@ -96,9 +96,11 @@ not a conversation.
   URL, the check result, whether the pull request reached `MERGED`, and **which rung of the
   roster reviewed it** — or, when the roster reached `none`, say plainly that the pull request
   merged without a review.
-- Name **any rung that refused the request**, with its reason, on its own line and in a form
-  your driver can read back — `Reviewer: local (copilot unavailable: Copilot code review is
-  not enabled for this organisation)`. It threads those into the next iteration so the run
+- Name **any rung you found UNAVAILABLE** — the gate's exit 3, the rung saying it cannot
+  review at all — with its reason, on its own line and in a form your driver can read back:
+  `Reviewer: local (copilot unavailable: Copilot code review is not enabled for this
+  organisation)`. A rung that **refused** the work is a different outcome and does not go
+  here; it halts you at `BLOCKED`. It threads those into the next iteration so the run
   stops paying for a reviewer that is down. A rung that merely went *silent* does not belong
   on that line: silence is what a slow reviewer looks like, and retiring one on it costs every
   remaining iteration its best reviewer.

--- a/plugins/backlog/assets/backlog.schema.json
+++ b/plugins/backlog/assets/backlog.schema.json
@@ -104,14 +104,19 @@
     },
     "review": {
       "type": "object",
-      "description": "Whether an automated review gates the merge. Only Copilot is modelled. There is deliberately no `reviewer` key — a field with exactly one legal value is an invitation to assume the other values work.",
+      "description": "Which automated reviewers gate the merge, in the order they are tried. This used to be one boolean, `required`, on the reasoning that a field with exactly one legal value invites you to assume the other values work. That reasoning was right while there was one reviewer and stopped being right the moment that reviewer acquired a monthly ceiling: with a boolean, a repository whose Copilot allowance has run out can only choose between *no loop* and *no review*, because `false` turns the review off permanently, in a tracked file, for every future run. An ordered roster makes an exhausted quota — or an outage, or an organisation that has never enabled Copilot — cost a **rung** rather than the run. `required` is not accepted any more: `scripts/select-issue.sh` fails at exit 4 naming the replacement, rather than equivalencing it silently, because a repository whose quota is the problem must not keep the old meaning without its owner learning the roster exists.",
       "additionalProperties": false,
-      "required": ["required"],
+      "required": ["reviewers"],
       "properties": {
-        "required": {
-          "type": "boolean",
-          "default": true,
-          "description": "`true`: request a Copilot review, wait for it, address it, and refuse to label the pull request if it declines or never arrives. `false`: skip the review steps entirely, for a repository where Copilot code review is not enabled. That is a deliberate downgrade rather than a silent one — the run's report has to say the pull request merged without a review."
+        "reviewers": {
+          "type": "array",
+          "minItems": 1,
+          "default": ["copilot"],
+          "description": "The reviewers to try, in order, failing over on **availability** only. A rung that reviewed the pull request and *refused* it — Copilot's \"wasn't able to review this pull request because it exceeds the maximum number of files (300)\" — has said something true about the work, and the cycle stops there: advancing past a refusal to a reviewer with different limits is exactly how unreviewable work reaches the default branch, which is the failure the decline check was added for. Only silence and an unreachable reviewer advance the roster. `scripts/select-issue.sh` validates this list before an issue is ever branched, so an unknown rung, an empty roster or a `none` that is not last fails at step 1 rather than forty minutes later with the implementation and CI already done.",
+          "items": {
+            "enum": ["copilot", "local", "none"],
+            "description": "`copilot`: request GitHub's Copilot code review, wait for it on the pull request timeline, and classify what lands. Unavailable when Copilot code review is not enabled for the organisation (the request is refused outright — one to three seconds, and remembered for the rest of the run) or when it accepts the request and posts nothing (inferred from silence after about twenty minutes, and *not* remembered, since silence is also what a slow-but-working reviewer looks like). `local`: an adversarial review produced by a fresh, context-free subagent and posted to the pull request as a `COMMENT` review under a GitHub App identity — never under the operator's token, which authored the pull request and would read as the author reviewing their own work. Unavailable, at zero network cost, when `BACKLOG_APP_ID`/`BACKLOG_APP_KEY` are absent from the environment, when `openssl` is not on PATH, or when the worker has no `Agent` tool to spawn the reviewer with; a worker that cannot spawn one treats this rung as unavailable rather than reviewing its own diff. `none`: merge unreviewed. Legal only in final position — a rung after it could never be reached, so a roster that puts it earlier is a mistake rather than a preference — and every run that reaches it says so in its report, naming each rung tried and why it was unavailable."
+          }
         }
       }
     },

--- a/plugins/backlog/scripts/app-token.sh
+++ b/plugins/backlog/scripts/app-token.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+#
+# app-token.sh — mint a GitHub App installation token, and say plainly when it
+# cannot be minted rather than failing somewhere inside a pipeline.
+#
+# Usage: app-token.sh --check     preconditions only; makes no network call
+#        app-token.sh --login     the App's bot login, `<slug>[bot]`
+#        app-token.sh --token     an installation token for this repository
+#
+# Environment:
+#   BACKLOG_APP_ID   the App's numeric ID
+#   BACKLOG_APP_KEY  its RSA private key — either the PEM text itself, or a
+#                    path to a file holding it
+#
+# The names match the repository secrets `backlog:setup-backlog` provisions for
+# the merge workflow, deliberately: it is the *same* App. What differs is
+# delivery — the workflow reads them as repository secrets, and the `local`
+# reviewer needs them in its own environment, on the laptop or in the job that
+# runs the loop.
+#
+# Why an App and not the operator's own token. The pull request under review was
+# opened by that token, so a review posted with it reads on the timeline as the
+# author reviewing their own work — which is not a review, however good the
+# comments are. A personal token also pins the reviewer to one workstation,
+# where an App installation is reachable from anywhere its two environment
+# variables are.
+#
+# Why `openssl` is checked rather than assumed. An App JWT is RS256, so minting
+# one is a signature and not a string operation, and `openssl` is a third
+# dependency for scripts that until now needed only `gh` and `jq`. A missing
+# `openssl` surfacing as an empty signature and a 401 is the failure this check
+# exists to convert into a sentence.
+#
+# Exit codes:
+#   0  fine — for --check, the preconditions hold; otherwise stdout is the answer
+#   3  UNAVAILABLE: a credential is absent, openssl is missing, or the App
+#      cannot be reached or is not installed on this repository. The caller
+#      treats this as a rung that is down, not as an error in the work.
+#   4  usage or precondition failure in the script's own arguments
+
+set -uo pipefail
+
+fail() { local code=$1; shift; printf 'app-token: %s\n' "$*" >&2; exit "$code"; }
+
+[ $# -eq 1 ] || fail 4 "usage: app-token.sh --check|--login|--token"
+
+MODE=$1
+case "$MODE" in
+  --check|--login|--token) ;;
+  *) fail 4 "unknown argument '$MODE'; usage: app-token.sh --check|--login|--token" ;;
+esac
+
+# ----------------------------------------------------------- preconditions ----
+# Ordered cheapest first, and every one of them names what is missing rather
+# than that something is. `--check` is exactly this block and nothing else, so a
+# caller can ask "is this rung available?" for the cost of three lookups and no
+# network at all.
+command -v gh >/dev/null 2>&1      || fail 3 "gh is not on PATH"
+command -v jq >/dev/null 2>&1      || fail 3 "jq is not on PATH"
+command -v openssl >/dev/null 2>&1 || fail 3 "openssl is not on PATH; an App JWT is RS256-signed, so it cannot be minted without one"
+
+[ -n "${BACKLOG_APP_ID:-}" ]  || fail 3 "BACKLOG_APP_ID is not set in the environment"
+[ -n "${BACKLOG_APP_KEY:-}" ] || fail 3 "BACKLOG_APP_KEY is not set in the environment"
+
+case "$BACKLOG_APP_ID" in
+  ''|*[!0-9]*) fail 3 "BACKLOG_APP_ID must be the App's numeric ID (got '$BACKLOG_APP_ID')" ;;
+esac
+
+[ "$MODE" = --check ] && exit 0
+
+# ------------------------------------------------------------------ key -------
+# The key arrives one of two ways and both are ordinary. A PEM pasted into an
+# environment variable is what a repository secret looks like when it reaches a
+# job; a path is what a laptop looks like. Guessing between them by content is
+# unnecessary — a path exists on disk and a PEM does not.
+KEYFILE=""
+CLEANUP=""
+if [ -f "$BACKLOG_APP_KEY" ]; then
+  KEYFILE=$BACKLOG_APP_KEY
+else
+  case "$BACKLOG_APP_KEY" in
+    *"BEGIN"*"PRIVATE KEY"*) ;;
+    *) fail 3 "BACKLOG_APP_KEY is neither a readable file nor a PEM private key" ;;
+  esac
+  KEYFILE=$(mktemp) || fail 3 "cannot create a temporary file for the App key"
+  CLEANUP=$KEYFILE
+  chmod 600 "$KEYFILE"
+  printf '%s\n' "$BACKLOG_APP_KEY" >"$KEYFILE"
+fi
+# shellcheck disable=SC2064
+[ -n "$CLEANUP" ] && trap "rm -f '$CLEANUP'" EXIT
+
+# ------------------------------------------------------------------ jwt -------
+# base64url, which is base64 with two characters swapped and the padding
+# dropped. `openssl base64 -A` rather than `base64 -w0`, because the latter is a
+# GNU spelling and this runs on macOS too.
+b64url() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
+
+NOW=$(date +%s)
+# 60s of backdating absorbs clock skew between here and GitHub, which rejects a
+# JWT issued in its future outright. Ten minutes is the maximum lifetime GitHub
+# accepts; nine is under it with room for the same skew at the other end.
+HEADER='{"alg":"RS256","typ":"JWT"}'
+PAYLOAD=$(printf '{"iat":%d,"exp":%d,"iss":"%s"}' "$((NOW - 60))" "$((NOW + 540))" "$BACKLOG_APP_ID")
+
+UNSIGNED="$(printf '%s' "$HEADER" | b64url).$(printf '%s' "$PAYLOAD" | b64url)"
+SIGNATURE=$(printf '%s' "$UNSIGNED" | openssl dgst -sha256 -sign "$KEYFILE" -binary 2>/dev/null | b64url) \
+  || fail 3 "openssl could not sign the App JWT; check that BACKLOG_APP_KEY is the App's RSA private key"
+[ -n "$SIGNATURE" ] || fail 3 "openssl produced no signature; check that BACKLOG_APP_KEY is the App's RSA private key"
+JWT="$UNSIGNED.$SIGNATURE"
+
+# `gh api -H Authorization:` rather than GH_TOKEN, because an App JWT has to be
+# presented as `Bearer` and gh spells its own token `token`. gh leaves an
+# Authorization header the caller supplied alone.
+app_api() { gh api -H "Authorization: Bearer $JWT" "$@"; }
+
+if [ "$MODE" = --login ]; then
+  SLUG=$(app_api /app --jq .slug 2>/dev/null) || SLUG=""
+  [ -n "$SLUG" ] || fail 3 "the App JWT was rejected by GET /app; check BACKLOG_APP_ID and BACKLOG_APP_KEY are the same App"
+  # A bot's login is its slug plus `[bot]`, and that is the login the review
+  # appears under on the timeline — which is what the review gate filters on.
+  printf '%s[bot]\n' "$SLUG"
+  exit 0
+fi
+
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null) || REPO=""
+[ -n "$REPO" ] || fail 3 "cannot resolve the repository slug from gh"
+
+INSTALL_ID=$(app_api "/repos/$REPO/installation" --jq .id 2>/dev/null) || INSTALL_ID=""
+case "$INSTALL_ID" in
+  ''|null|*[!0-9]*) fail 3 "the App is not installed on $REPO, or its JWT was rejected; install it with Contents, Pull requests and Issues at read and write" ;;
+esac
+
+TOKEN=$(app_api --method POST "/app/installations/$INSTALL_ID/access_tokens" --jq .token 2>/dev/null) || TOKEN=""
+[ -n "$TOKEN" ] && [ "$TOKEN" != null ] \
+  || fail 3 "the App installation on $REPO issued no access token"
+
+printf '%s\n' "$TOKEN"

--- a/plugins/backlog/scripts/await-review.sh
+++ b/plugins/backlog/scripts/await-review.sh
@@ -1,13 +1,19 @@
 #!/usr/bin/env bash
 #
-# await-review.sh — request Copilot's review, wait for it, and say what landed.
+# await-review.sh — request a review from one rung of the roster, wait for it,
+# and say what landed.
 #
-# Usage: await-review.sh <pr-number>
+# Usage: await-review.sh <pr-number> [<reviewer>]
+#        await-review.sh --classify <reviewer>   (stdin: a review as JSON)
+#
+# <reviewer> is `copilot` or `local`, defaulting to `copilot`. `none` is not a
+# reviewer to wait on — a roster that reaches it merges unreviewed, which is a
+# decision the cycle makes rather than a wait it performs.
 #
 # Why this is a script and not three numbered steps.
 #
-# "Did Copilot review this?" looks like one question and is two, and the cycle
-# used to answer them in places far enough apart that the second could be
+# "Did the reviewer review this?" looks like one question and is two, and the
+# cycle used to answer them in places far enough apart that the second could be
 # skipped. The wait was a polling loop that exited as soon as a `reviewed` event
 # appeared; whether that review had DECLINED the work — "Copilot wasn't able to
 # review this pull request because it exceeds the maximum number of files (300)"
@@ -21,7 +27,7 @@
 # assertion should be an exit code, not a thing remembered at the end of the
 # longest part of the run.
 #
-# Four findings are folded in here, each of which cost a debugging session:
+# Findings folded in here, each of which cost a debugging session:
 #
 #   * Copilot is a Bot, not a User. `reviewers[]=Copilot` on the REST endpoint
 #     returns 200 and does nothing; the GraphQL mutation takes `botIds`, and the
@@ -33,34 +39,128 @@
 #     pull request with a few pushes and check runs pushes the `reviewed` event
 #     off page one — where an unpaginated read reports nothing.
 #   * The login filter, because a `reviewed` event from anyone would otherwise
-#     end the wait. The repository owner glancing at the pull request while
-#     Copilot was still working would satisfy an unfiltered loop.
+#     end the wait. The repository owner glancing at the pull request while the
+#     reviewer was still working would satisfy an unfiltered loop.
 #
-# Idempotent: a Copilot review that has already landed is classified and
-# returned immediately, without requesting another. Re-running after a timeout
-# resumes the wait.
+# What the reviewer argument changed, and what it did not. Nothing about the
+# shape above is Copilot-specific — request, wait on the timeline, classify what
+# landed — so the login, the request and the decline wording are per-rung data
+# and the rest is shared. The `local` rung has no request step at all: its
+# review is produced by a subagent and POSTed by `post-review.sh` before this
+# script is called, so here it is a wait and a classification and nothing else.
+#
+# UNAVAILABILITY versus REFUSAL, which is the distinction the roster turns on.
+# A rung that reviewed the pull request and refused it has said something true
+# about the work, and advancing past it to a reviewer with different limits is
+# how unreviewable work reaches the default branch. So a refusal is exit 1 and
+# stops the cycle. Only a rung that cannot review at all — the request refused,
+# credentials absent, nothing posted inside the bound — advances the roster.
 #
 # Exit codes:
-#   0  a review completed — it left comments, or reported that it generated none
-#   1  the most recent Copilot review DECLINED the work; stdout is its body
-#   2  timed out waiting for a review
-#   3  the review could not be requested (Copilot code review not enabled here)
-#   4  usage or precondition failure
+#   0  a review COMPLETED — it left comments, or reported that it generated none
+#   1  the most recent review REFUSED the work; stdout is its body. BLOCKED:
+#      do not advance the roster and do not label the pull request
+#   2  nothing arrived yet. Not a verdict — call it again
+#   3  UNAVAILABLE, synchronously: the rung refused the request, or its
+#      preconditions are absent. Advance the roster, and remember this rung for
+#      the rest of the run — it told us it was down, in a second or two
+#   4  usage or precondition failure in the script's own arguments
 
 set -uo pipefail
 
+HERE=$(cd "$(dirname "$0")" && pwd)
+MINT="$HERE/app-token.sh"
+
 # Five minutes per call, deliberately: the caller waits by BLOCKING on this
 # script, so the bound has to fit inside a single foreground call rather than
-# span turns. Copilot routinely takes longer than that; exit 2 is the answer,
+# span turns. A reviewer routinely takes longer than that; exit 2 is the answer,
 # and the caller runs it again in the same turn.
 POLL_COUNT=${BACKLOG_REVIEW_POLL_COUNT:-20}
 POLL_SECONDS=${BACKLOG_REVIEW_POLL_SECONDS:-15}
-BOT_LOGIN='copilot-pull-request-reviewer[bot]'
 
 fail() { local code=$1; shift; printf 'await-review: %s\n' "$*" >&2; exit "$code"; }
 note() { printf 'await-review: %s\n' "$*" >&2; }
 
-[ $# -eq 1 ] || fail 4 "usage: await-review.sh <pr-number>"
+# ------------------------------------------------------------ the rungs -------
+# Per-rung data, and only the data. `REVIEWER_MATCH` is a case-insensitive
+# regular expression against the `reviewed` event's login, never an equality
+# test: Copilot has posted under more than one spelling, and matching loosely
+# on a name no human account uses is safer than matching exactly on one of them.
+REVIEWER=""
+REVIEWER_LOGIN=""
+REVIEWER_MATCH=""
+
+resolve_reviewer() { # <reviewer>
+  case "$1" in
+    copilot)
+      REVIEWER=copilot
+      REVIEWER_LOGIN='copilot-pull-request-reviewer[bot]'
+      REVIEWER_MATCH='copilot'
+      ;;
+    local)
+      REVIEWER=local
+      # The local rung IS the App, so its login has to come from the App rather
+      # than from a constant here. That lookup needs the credentials and
+      # openssl, which makes "the App is not configured in this environment"
+      # exit 3 before any waiting happens — a fallthrough, not a crash, and at
+      # the cost of one API call rather than five minutes.
+      REVIEWER_LOGIN=$("$MINT" --login) || exit $?
+      [ -n "$REVIEWER_LOGIN" ] || fail 3 "the backlog App reported no login; the local rung cannot be waited on"
+      REVIEWER_MATCH=$(printf '%s' "$REVIEWER_LOGIN" | sed 's/[][\\.^$*+?(){}|]/\\&/g')
+      ;;
+    none)
+      fail 4 "'none' is not a reviewer to wait on; a roster that reaches none merges unreviewed"
+      ;;
+    *)
+      fail 4 "unknown reviewer '$1'; the rungs are copilot and local"
+      ;;
+  esac
+}
+
+# A refusal satisfies any `length > 0` test, which is exactly how it was missed.
+# The apostrophe is matched loosely because GitHub has rendered it both as ' and
+# as a typographic quote.
+#
+# The wording is Copilot's, and it is matched for every rung on purpose: the
+# `local` reviewer is told to use the same sentence when it declines, so that
+# one classifier covers the roster. That is also why a generic `bot:<login>`
+# rung is deliberately out of scope — an unrecognised refusal from an unknown
+# bot would classify as a completed review and merge.
+refused() {
+  printf '%s' "$1" | grep -qiE "was(n.?t| not) able to review"
+}
+
+classify() { # <review json>
+  local state body
+  state=$(printf '%s' "$1" | jq -r '.state // ""' 2>/dev/null)
+  body=$(printf '%s' "$1" | jq -r '.body // ""' 2>/dev/null)
+  if refused "$body"; then
+    printf '%s\n' "$body"
+    fail 1 "$REVIEWER REFUSED to review PR #$PR; do not label it, and do not advance the roster"
+  fi
+  printf '%s review completed [%s]\n%s\n' "$REVIEWER" "$state" "$body"
+  exit 0
+}
+
+# The classification seam, so the rules above are pinned by fixtures rather than
+# by a live pull request. Everything else in this script is polling and a bound.
+if [ "${1:-}" = --classify ]; then
+  [ $# -eq 2 ] || fail 4 "usage: await-review.sh --classify <reviewer>  (a review as JSON on stdin)"
+  command -v jq >/dev/null 2>&1 || fail 4 "jq is not on PATH"
+  PR=0
+  case "$2" in
+    copilot) REVIEWER=copilot ;;
+    local)   REVIEWER=local ;;
+    none)    fail 4 "'none' is not a reviewer to wait on; a roster that reaches none merges unreviewed" ;;
+    *)       fail 4 "unknown reviewer '$2'; the rungs are copilot and local" ;;
+  esac
+  INPUT=$(cat)
+  [ -n "$INPUT" ] || fail 2 "nothing to classify"
+  classify "$INPUT"
+fi
+
+[ $# -ge 1 ] || fail 4 "usage: await-review.sh <pr-number> [<reviewer>]"
+[ $# -le 2 ] || fail 4 "usage: await-review.sh <pr-number> [<reviewer>]"
 PR=$1
 case "$PR" in ''|*[!0-9]*) fail 4 "pull request number must be an integer (got '$PR')" ;; esac
 
@@ -71,58 +171,54 @@ REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null) \
   || fail 4 "cannot resolve the repository slug from gh"
 [ -n "$REPO" ] || fail 4 "cannot resolve the repository slug from gh"
 
+resolve_reviewer "${2:-copilot}"
+
 # --------------------------------------------------------------- reading ------
-# The most recent Copilot review, as {state, body}, or nothing.
+# The most recent review by this rung, as {state, body}, or nothing.
 #
 # `jq -s` slurps the per-page objects back into one array before sorting.
 # Sorting inside --jq would sort each page separately and yield the last review
 # OF THE LAST PAGE rather than the last review.
+#
+# The login filter lives in the second jq rather than in gh's `--jq`, because
+# `gh api --jq` takes no `--arg` and the filter is now per-rung data. Splicing a
+# login into the filter text would put `backlog-bot[bot]`'s brackets inside a jq
+# string literal, where `\[` is not a legal escape and the whole expression
+# fails — silently, as "no review yet", which is the one failure mode a wait
+# cannot tell from a slow reviewer.
 latest_review() {
   gh api --paginate "repos/$REPO/issues/$PR/timeline" \
-    --jq '.[] | select(.event=="reviewed") | select(.user.login | test("copilot";"i"))' \
+    --jq '.[] | select(.event=="reviewed")' \
     2>/dev/null \
-  | jq -s 'sort_by(.submitted_at) | last // empty | {state: (.state // ""), body: (.body // "")}' \
+  | jq -s --arg match "$REVIEWER_MATCH" \
+      'map(select(.user.login // "" | test($match;"i")))
+       | sort_by(.submitted_at) | last // empty
+       | {state: (.state // ""), body: (.body // "")}' \
     2>/dev/null
-}
-
-# A decline satisfies any `length > 0` test, which is exactly how it was missed.
-# The apostrophe is matched loosely because GitHub has rendered it both as ' and
-# as a typographic quote.
-declined() {
-  printf '%s' "$1" | grep -qiE "was(n.?t| not) able to review"
-}
-
-classify() { # <review json>
-  local state body
-  state=$(printf '%s' "$1" | jq -r '.state // ""')
-  body=$(printf '%s' "$1" | jq -r '.body // ""')
-  if declined "$body"; then
-    printf '%s\n' "$body"
-    fail 1 "Copilot DECLINED to review PR #$PR; do not label it"
-  fi
-  printf 'copilot review completed [%s]\n%s\n' "$state" "$body"
-  exit 0
 }
 
 EXISTING=$(latest_review)
 if [ -n "$EXISTING" ]; then
-  note "a Copilot review is already on PR #$PR; not requesting another"
+  note "a $REVIEWER review is already on PR #$PR; not requesting another"
   classify "$EXISTING"
 fi
 
 # ------------------------------------------------------------- requesting -----
-# The bot's node ID is looked up by login rather than hard-coded, so a change on
-# GitHub's side surfaces here as a failed lookup instead of a silent no-op.
+# Only the rungs that have someone to ask. The local reviewer posts its own
+# review through post-review.sh before this script is reached, so there is
+# nothing to request and a request step would have nothing to fail on.
 requested() {
   gh api "repos/$REPO/pulls/$PR/requested_reviewers" \
     --jq '[.users[]?.login] + [.teams[]?.slug] | join(" ")' 2>/dev/null \
-  | grep -qi copilot
+  | grep -qiE "$REVIEWER_MATCH"
 }
 
+# The bot's node ID is looked up by login rather than hard-coded, so a change on
+# GitHub's side surfaces here as a failed lookup instead of a silent no-op.
 request_review() {
   local pr_id bot_id
   pr_id=$(gh pr view "$PR" --repo "$REPO" --json id --jq .id 2>/dev/null) || pr_id=""
-  bot_id=$(gh api "/users/$BOT_LOGIN" --jq .node_id 2>/dev/null) || bot_id=""
+  bot_id=$(gh api "/users/$REVIEWER_LOGIN" --jq .node_id 2>/dev/null) || bot_id=""
 
   if [ -n "$pr_id" ] && [ -n "$bot_id" ]; then
     if gh api graphql -f query='
@@ -131,8 +227,8 @@ request_review() {
           pullRequest { reviewRequests(first:10) { nodes {
             requestedReviewer { __typename ... on Bot { login } } } } }
         }
-      }' -f pr="$pr_id" -f bot="$bot_id" 2>/dev/null | grep -qi copilot; then
-      note "review requested via the GraphQL requestReviews mutation"
+      }' -f pr="$pr_id" -f bot="$bot_id" 2>/dev/null | grep -qiE "$REVIEWER_MATCH"; then
+      note "review requested from $REVIEWER via the GraphQL requestReviews mutation"
       return 0
     fi
     note "the GraphQL mutation did not take; falling back to REST"
@@ -142,17 +238,19 @@ request_review() {
   # returns 200 while doing nothing at all, and the wait below would then time
   # out on a review that was never requested.
   gh api --method POST "repos/$REPO/pulls/$PR/requested_reviewers" \
-    -f "reviewers[]=$BOT_LOGIN" >/dev/null 2>&1 || true
+    -f "reviewers[]=$REVIEWER_LOGIN" >/dev/null 2>&1 || true
 
   requested
 }
 
-if requested; then
-  note "Copilot is already a requested reviewer on PR #$PR"
+if [ "$REVIEWER" = local ]; then
+  note "the local rung posts its own review; nothing to request on PR #$PR"
+elif requested; then
+  note "$REVIEWER is already a requested reviewer on PR #$PR"
 elif request_review; then
-  note "Copilot is now a requested reviewer on PR #$PR"
+  note "$REVIEWER is now a requested reviewer on PR #$PR"
 else
-  fail 3 "could not request a Copilot review on PR #$PR; Copilot code review may not be enabled for this organisation"
+  fail 3 "could not request a $REVIEWER review on PR #$PR; Copilot code review may not be enabled for this organisation. This rung is unavailable: advance the roster and remember it"
 fi
 
 # ---------------------------------------------------------------- waiting -----
@@ -162,4 +260,4 @@ for _ in $(seq 1 "$POLL_COUNT"); do
   [ -n "$REVIEW" ] && classify "$REVIEW"
 done
 
-fail 2 "no Copilot review on PR #$PR after $((POLL_COUNT * POLL_SECONDS))s; re-run to keep waiting"
+fail 2 "no $REVIEWER review on PR #$PR after $((POLL_COUNT * POLL_SECONDS))s; re-run to keep waiting. Silence is not unavailability: a slow reviewer looks exactly like this, so do not retire this rung on it"

--- a/plugins/backlog/scripts/await-review.sh
+++ b/plugins/backlog/scripts/await-review.sh
@@ -61,9 +61,10 @@
 #   1  the most recent review REFUSED the work; stdout is its body. BLOCKED:
 #      do not advance the roster and do not label the pull request
 #   2  nothing arrived yet. Not a verdict — call it again
-#   3  UNAVAILABLE, synchronously: the rung refused the request, or its
-#      preconditions are absent. Advance the roster, and remember this rung for
-#      the rest of the run — it told us it was down, in a second or two
+#   3  UNAVAILABLE, synchronously: the request could not be placed, or the
+#      rung's preconditions are absent. Advance the roster, and remember this
+#      rung for the rest of the run — it told us it was down, in a second or
+#      two. Distinct from exit 1, which is the rung REFUSING the work
 #   4  usage or precondition failure in the script's own arguments
 
 set -uo pipefail

--- a/plugins/backlog/scripts/await-review_test.sh
+++ b/plugins/backlog/scripts/await-review_test.sh
@@ -1,0 +1,313 @@
+#!/usr/bin/env bash
+#
+# await-review_test.sh — the fixture corpus for await-review.sh.
+#
+# Three halves, all offline.
+#
+# **Classification.** Every case is a review the timeline can carry, fed to
+# `--classify`. This is the judgment the merge label rests on, and it is the
+# half with a failure already on record: Copilot answers a pull request over 300
+# files with a review whose body says it could not review it, that refusal
+# satisfies any `length > 0` test, and a cycle merged with no review at all. A
+# refusal read as a completed review is a merge; a completed review read as a
+# refusal is a needless BLOCKED. Neither is visible from the outside.
+#
+# **The reviewer argument.** The roster's whole premise is that a rung which
+# cannot review costs a rung rather than the run, so the three outcomes have to
+# be told apart: UNAVAILABLE (exit 3, advance and remember), REFUSED (exit 1,
+# stop — the rung looked at the work and said something true about it), and
+# nothing-yet (exit 2, ask again, and do not retire a reviewer that was merely
+# slow). The cases below drive the whole script against a `gh` that answers from
+# files, so the login filter is exercised rather than described.
+#
+# **The App identity.** The `local` rung waits on a review posted under the
+# backlog App's login, which it discovers by minting a JWT. Absent credentials
+# must be exit 3 at zero network cost — a fallthrough, not a crash — and present
+# ones must produce a login the timeline filter then uses. The key is generated
+# at run time; there is no key material in this file.
+#
+# Run: plugins/backlog/scripts/await-review_test.sh
+# Exit 0 when every case matches, 1 otherwise.
+
+set -uo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+SUT="$HERE/await-review.sh"
+[ -x "$SUT" ] || { printf 'await-review.sh is not executable at %s\n' "$SUT" >&2; exit 1; }
+
+pass=0
+fail=0
+
+ok()   { pass=$((pass + 1)); printf '  ok   %-58s [%s]\n' "$1" "$2"; }
+bad()  { fail=$((fail + 1)); printf '  FAIL %-58s %s\n' "$1" "$2"; }
+
+# ---------------------------------------------------------- classification ----
+
+# check <name> <reviewer> <expected exit> <review json>
+check() {
+  local name=$1 reviewer=$2 want=$3 json=$4 got out
+  out=$(printf '%s' "$json" | "$SUT" --classify "$reviewer" 2>&1)
+  got=$?
+  if [ "$got" = "$want" ]; then
+    ok "$name" "exit $got"
+  else
+    bad "$name" "want exit $want got $got: $(printf '%s' "$out" | tr '\n' ' ')"
+  fi
+}
+
+printf '\ncompleted — the only outcome that may label a pull request\n'
+
+check 'a review with findings' copilot 0 \
+'{"state":"COMMENTED","body":"Two issues below, both minor."}'
+
+check 'a review that generated no comments' copilot 0 \
+'{"state":"COMMENTED","body":"Copilot reviewed 3 out of 3 changed files and generated no comments."}'
+
+# An approval is still a completed review. The cycle never asks for one and the
+# local rung never posts one, but a human approving alongside the bot must not
+# turn into a different verdict.
+check 'an approving review' copilot 0 \
+'{"state":"APPROVED","body":"Looks right."}'
+
+check 'a review with an empty body' copilot 0 \
+'{"state":"COMMENTED","body":""}'
+
+# The local rung is classified by the same rules, which is what keeps one gate
+# over the whole roster.
+check 'a local review with findings' local 0 \
+'{"state":"COMMENTED","body":"The retry loop swallows the error."}'
+
+printf '\nrefused — BLOCKED, and the roster does NOT advance\n'
+
+# The one that was missed in the wild, verbatim.
+check 'the 300-file refusal' copilot 1 \
+'{"state":"COMMENTED","body":"Copilot wasn'"'"'t able to review this pull request because it exceeds the maximum number of files (300)."}'
+
+# GitHub has rendered the apostrophe both ways, and a classifier that only knows
+# the ASCII one merges the other.
+check 'the same refusal with a typographic apostrophe' copilot 1 \
+'{"state":"COMMENTED","body":"Copilot wasn’t able to review this pull request because it exceeds the maximum number of files (300)."}'
+
+check 'the refusal spelled out in full' copilot 1 \
+'{"state":"COMMENTED","body":"Copilot was not able to review this pull request."}'
+
+# The local reviewer is told to decline in the same words, so that one
+# classifier covers the roster rather than one per rung. A rung whose refusal
+# wording is unknown would classify as a completed review and merge, which is
+# why a generic bot rung is deliberately out of scope.
+check 'a local reviewer declining in the same words' local 1 \
+'{"state":"COMMENTED","body":"I was not able to review this pull request: the diff exceeds what fits in one context."}'
+
+# Prose that merely mentions reviewing is not a refusal. A classifier loose
+# enough to catch this one BLOCKS on ordinary review comments.
+check 'a comment that merely discusses reviewing' copilot 0 \
+'{"state":"COMMENTED","body":"I was able to review this quickly; the change is small."}'
+
+printf '\nnothing to classify\n'
+
+check 'an empty review' copilot 2 ''
+
+printf '\nusage\n'
+
+# usage_check <name> <expected exit> <args...>
+usage_check() {
+  local name=$1 want=$2; shift 2
+  "$SUT" "$@" >/dev/null 2>&1 </dev/null
+  local got=$?
+  if [ "$got" = "$want" ]; then ok "$name" "exit $got"; else bad "$name" "want exit $want got $got"; fi
+}
+
+usage_check 'no arguments' 4
+usage_check 'a pull request number that is not a number' 4 not-a-number
+usage_check 'more arguments than the usage takes' 4 12 copilot extra
+usage_check 'an unknown rung' 4 12 coderabbit
+# `none` is a roster decision, not a wait. Waiting on it would be waiting on
+# nobody, and the five minutes would look exactly like a slow reviewer.
+usage_check 'none is not a reviewer to wait on' 4 12 none
+usage_check '--classify needs a reviewer' 4 --classify
+usage_check '--classify rejects an unknown rung' 4 --classify coderabbit
+
+# --------------------------------------------------------------- the wait -----
+printf '\nthe wait, against a gh that answers from files\n'
+
+SCRATCH=$(mktemp -d) || { printf 'cannot create a scratch directory\n' >&2; exit 1; }
+trap 'rm -rf "$SCRATCH"' EXIT
+mkdir -p "$SCRATCH/bin" "$SCRATCH/fx"
+
+# The stub answers the six calls the script makes, and really runs the `--jq` it
+# was given for the timeline — the login filter is the thing under test, so it
+# must not be short-circuited by a stub that returns the answer directly.
+cat >"$SCRATCH/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+q="" path="" post=0 prev=""
+for a in "$@"; do
+  [ "$prev" = --jq ] && q=$a
+  case "$a" in
+    --method) post=1 ;;
+    repos/*/timeline|repos/*/requested_reviewers|/users/*|/app|/repos/*/installation|/app/installations/*/access_tokens) path=$a ;;
+  esac
+  prev=$a
+done
+jqf() { if [ -n "$q" ]; then jq -r "$q" "$1"; else cat "$1"; fi; }
+case "$1 $2" in
+  'repo view') printf 'z5labs/devex\n'; exit 0 ;;
+  'pr view')   printf 'PR_kwNODUMMY\n'; exit 0 ;;
+  'api graphql')
+    [ -f "$FX/graphql" ] || exit 1
+    cat "$FX/graphql"; exit 0 ;;
+esac
+case "$path" in
+  */timeline)             jqf "$FX/timeline" ;;
+  */requested_reviewers)
+    [ "$post" = 1 ] && exit 0
+    jqf "$FX/requested" ;;
+  /users/*)               [ -f "$FX/botid" ] || exit 1; jqf "$FX/botid" ;;
+  /app)                   printf 'backlog-bot\n' ;;
+  /repos/*/installation)  printf '4242\n' ;;
+  */access_tokens)        printf 'ghs_stubbed\n' ;;
+  *) printf 'stub gh: unexpected call: %s\n' "$*" >&2; exit 1 ;;
+esac
+STUB
+chmod +x "$SCRATCH/bin/gh"
+
+printf '{"users":[],"teams":[]}\n' >"$SCRATCH/fx/requested"
+
+reviewed() { # <login> <submitted_at> <body>
+  jq -nc --arg l "$1" --arg t "$2" --arg b "$3" \
+    '{event:"reviewed", submitted_at:$t, state:"COMMENTED", body:$b, user:{login:$l}}'
+}
+timeline() { printf '[%s]\n' "$(printf '%s,' "$@" | sed 's/,$//')" >"$SCRATCH/fx/timeline"; }
+
+# w_run <expected exit> <args...>  — one poll of zero seconds, so a wait that
+# is going to time out does so immediately.
+w_run() {
+  W_OUT=$(cd "$SCRATCH" && PATH="$SCRATCH/bin:$PATH" FX="$SCRATCH/fx" \
+    BACKLOG_REVIEW_POLL_COUNT=1 BACKLOG_REVIEW_POLL_SECONDS=0 \
+    "$SUT" "$@" 2>&1)
+  W_RC=$?
+}
+
+# checkw <name> <expected exit> <args...>
+checkw() {
+  local name=$1 want=$2; shift 2
+  w_run "$@"
+  if [ "$W_RC" = "$want" ]; then
+    ok "$name" "exit $W_RC"
+  else
+    bad "$name" "want exit $want got $W_RC: $(printf '%s' "$W_OUT" | tr '\n' ' ' | cut -c1-160)"
+  fi
+}
+
+rm -f "$SCRATCH/fx/graphql" "$SCRATCH/fx/botid"
+
+# A review already on the timeline is classified without requesting another,
+# which is what makes re-running after an exit 2 safe.
+timeline "$(reviewed 'copilot-pull-request-reviewer[bot]' '2026-01-01T00:00:00Z' 'one nit below')"
+checkw 'a completed review already on the timeline' 0 12 copilot
+
+timeline "$(reviewed 'Copilot' '2026-01-01T00:00:00Z' 'one nit below')"
+checkw 'the login filter is case-insensitive' 0 12 copilot
+
+timeline "$(reviewed 'copilot-pull-request-reviewer[bot]' '2026-01-01T00:00:00Z' "Copilot wasn't able to review this pull request because it exceeds the maximum number of files (300).")"
+checkw 'a refusal on the timeline stops the cycle' 1 12 copilot
+
+# The newest review wins, so an old refusal beside a newer completed review is
+# not misread — and neither is the reverse, which is the direction that merges.
+timeline \
+  "$(reviewed 'copilot-pull-request-reviewer[bot]' '2026-01-01T00:00:00Z' "Copilot wasn't able to review this pull request because it exceeds the maximum number of files (300).")" \
+  "$(reviewed 'copilot-pull-request-reviewer[bot]' '2026-01-02T00:00:00Z' 'reviewed after a rebase; one nit')"
+checkw 'a newer completed review supersedes an older refusal' 0 12 copilot
+
+timeline \
+  "$(reviewed 'copilot-pull-request-reviewer[bot]' '2026-01-02T00:00:00Z' "Copilot wasn't able to review this pull request because it exceeds the maximum number of files (300).")" \
+  "$(reviewed 'copilot-pull-request-reviewer[bot]' '2026-01-01T00:00:00Z' 'reviewed before the vendored tree landed')"
+checkw 'a newer refusal supersedes an older completed review' 1 12 copilot
+
+# Without the login filter the repository owner glancing at the pull request
+# ends the wait, and the merge label is then applied on a review that never
+# arrived. This is the case that says the filter is still there.
+timeline "$(reviewed 'carsonderr' '2026-01-01T00:00:00Z' 'nice work')"
+checkw 'a human review does not end the wait' 3 12 copilot
+
+# Nothing on the timeline and the request refused outright: the rung told us it
+# is down, in a second or two. That is exit 3 — advance the roster and remember
+# it — and it is the case an exhausted quota or a disabled organisation hits.
+timeline
+checkw 'a request that cannot be placed is unavailable' 3 12 copilot
+
+# The request took, and nothing has arrived yet. Silence is NOT unavailability:
+# a slow reviewer looks identical from here, and retiring it for the run on this
+# evidence is how a working reviewer gets dropped for three hours.
+printf '{"users":[{"login":"copilot-pull-request-reviewer[bot]"}],"teams":[]}\n' >"$SCRATCH/fx/requested"
+timeline
+checkw 'an accepted request with nothing posted yet is not a verdict' 2 12 copilot
+
+# The REST fallback is reached when the GraphQL mutation does not take, and it
+# is the path that only works with the full `...[bot]` login.
+printf '{"users":[],"teams":[]}\n' >"$SCRATCH/fx/requested"
+printf '{"node_id":"BOT_kwNODUMMY"}\n' >"$SCRATCH/fx/botid"
+printf '{"data":{"requestReviews":{"pullRequest":{"reviewRequests":{"nodes":[{"requestedReviewer":{"__typename":"Bot","login":"copilot-pull-request-reviewer"}}]}}}}}\n' >"$SCRATCH/fx/graphql"
+timeline
+checkw 'a request the mutation placed leaves the wait pending' 2 12 copilot
+
+# ------------------------------------------------------------ the App ---------
+printf '\nthe local rung and its App identity\n'
+
+rm -f "$SCRATCH/fx/graphql" "$SCRATCH/fx/botid"
+printf '{"users":[],"teams":[]}\n' >"$SCRATCH/fx/requested"
+
+# Credentials absent is a fallthrough, not a crash, and it costs no network call
+# at all — which is the whole reason the roster can afford to try this rung
+# first on a repository that has never configured the App.
+timeline
+W_OUT=$(cd "$SCRATCH" && PATH="$SCRATCH/bin:$PATH" FX="$SCRATCH/fx" \
+  BACKLOG_REVIEW_POLL_COUNT=1 BACKLOG_REVIEW_POLL_SECONDS=0 \
+  BACKLOG_APP_ID= BACKLOG_APP_KEY= "$SUT" 12 local 2>&1)
+W_RC=$?
+if [ "$W_RC" = 3 ]; then ok 'the local rung with no App credentials is unavailable' 'exit 3'
+else bad 'the local rung with no App credentials is unavailable' "want exit 3 got $W_RC: $(printf '%s' "$W_OUT" | tr '\n' ' ' | cut -c1-160)"; fi
+
+if command -v openssl >/dev/null 2>&1; then
+  # A real RSA key, generated here rather than committed. The App JWT is
+  # RS256-signed, so a stub cannot stand in for the signature step.
+  openssl genrsa -out "$SCRATCH/app.pem" 2048 >/dev/null 2>&1
+
+  # app_run <expected exit> <name>
+  app_run() {
+    local want=$1 name=$2
+    W_OUT=$(cd "$SCRATCH" && PATH="$SCRATCH/bin:$PATH" FX="$SCRATCH/fx" \
+      BACKLOG_REVIEW_POLL_COUNT=1 BACKLOG_REVIEW_POLL_SECONDS=0 \
+      BACKLOG_APP_ID=12345 BACKLOG_APP_KEY="$SCRATCH/app.pem" "$SUT" 12 local 2>&1)
+    W_RC=$?
+    if [ "$W_RC" = "$want" ]; then
+      ok "$name" "exit $W_RC"
+    else
+      bad "$name" "want exit $want got $W_RC: $(printf '%s' "$W_OUT" | tr '\n' ' ' | cut -c1-160)"
+    fi
+  }
+
+  # The stubbed `GET /app` answers `backlog-bot`, so the login the timeline is
+  # filtered on is `backlog-bot[bot]` — discovered, never hard-coded, because
+  # the App is the operator's and its slug is not this plugin's to know.
+  timeline "$(reviewed 'backlog-bot[bot]' '2026-01-01T00:00:00Z' 'the retry loop swallows the error')"
+  app_run 0 'a local review by the App is a completed review'
+
+  timeline "$(reviewed 'backlog-bot[bot]' '2026-01-01T00:00:00Z' 'I was not able to review this pull request.')"
+  app_run 1 'a local reviewer that declines still blocks'
+
+  # Copilot's review is not the local rung's review. Two rungs on one pull
+  # request is ordinary — the first went silent — and a filter that matched any
+  # bot would let the silent rung's absence be satisfied by the other one.
+  timeline "$(reviewed 'copilot-pull-request-reviewer[bot]' '2026-01-01T00:00:00Z' 'one nit')"
+  app_run 2 'another bot review does not satisfy the local rung'
+
+  # Nothing posted: the local rung has no request step, so this is plainly "not
+  # yet" rather than "could not be requested".
+  timeline
+  app_run 2 'the local rung with nothing posted yet is not a verdict'
+else
+  printf '  skip openssl is not on PATH; the App identity cases need it\n'
+fi
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/plugins/backlog/scripts/post-review.sh
+++ b/plugins/backlog/scripts/post-review.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+#
+# post-review.sh — post a review to a pull request under the backlog App's
+# identity, so that a review produced locally lands where every other review
+# lands.
+#
+# Usage: post-review.sh --preflight
+#        post-review.sh <pr-number> <body-file> [<comments-file>]
+#
+# `--preflight` answers "can this rung run at all?" with no network call and no
+# subagent spawned. That ordering is the point: the `local` reviewer costs a
+# fresh agent and a whole diff, and finding out afterwards that the credentials
+# were never there is the expensive way to learn it.
+#
+# <body-file> holds the review's summary, as markdown. <comments-file>, when
+# given, holds a JSON array of inline comments in the shape the reviews endpoint
+# takes — `[{"path":"a/b.go","line":42,"side":"RIGHT","body":"…"}]`.
+#
+# Why the review is POSTed rather than kept in the run's transcript.
+#
+#   * Visibility. A review that exists only in an agent's context cannot be read
+#     by anyone else with repository access, and cannot be read later.
+#   * Uniformity. A posted review is a `reviewed` event on the pull request
+#     timeline, which is exactly what `await-review.sh` polls. One gate then
+#     covers every rung of the roster, and "was this reviewed?" stays an exit
+#     code rather than something an agent asserts at the end of the longest part
+#     of the cycle.
+#
+# The review is always a `COMMENT`, never `APPROVE` or `REQUEST_CHANGES`. An
+# App approving the pull request the loop just opened would satisfy a
+# required-review protection rule, which would let the loop manufacture its own
+# approval; `COMMENT` says what it found and leaves the gate where it was.
+#
+# Exit codes:
+#   0  the review was posted (or, for --preflight, the rung can run)
+#   1  the review could not be posted for a reason that is not availability —
+#      a rejected payload, a transient GitHub failure. This pull request goes
+#      without this rung; the rung itself is NOT remembered as down.
+#   3  UNAVAILABLE: credentials, openssl or the App installation are missing.
+#      The caller advances the roster and remembers the rung for the run.
+#   4  usage failure
+
+set -uo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+MINT="$HERE/app-token.sh"
+
+fail() { local code=$1; shift; printf 'post-review: %s\n' "$*" >&2; exit "$code"; }
+note() { printf 'post-review: %s\n' "$*" >&2; }
+
+[ $# -ge 1 ] || fail 4 "usage: post-review.sh --preflight | post-review.sh <pr-number> <body-file> [<comments-file>]"
+[ -x "$MINT" ] || fail 4 "app-token.sh is not executable at $MINT"
+
+if [ "$1" = --preflight ]; then
+  [ $# -eq 1 ] || fail 4 "--preflight takes no other argument"
+  "$MINT" --check || exit $?
+  note "the App credentials and openssl are present; the local reviewer can run"
+  exit 0
+fi
+
+[ $# -ge 2 ] || fail 4 "usage: post-review.sh <pr-number> <body-file> [<comments-file>]"
+[ $# -le 3 ] || fail 4 "usage: post-review.sh <pr-number> <body-file> [<comments-file>]"
+
+PR=$1
+BODY_FILE=$2
+COMMENTS_FILE=${3:-}
+
+case "$PR" in ''|*[!0-9]*) fail 4 "pull request number must be an integer (got '$PR')" ;; esac
+[ -f "$BODY_FILE" ] || fail 4 "no review body at $BODY_FILE"
+[ -s "$BODY_FILE" ] || fail 4 "the review body at $BODY_FILE is empty; a review with nothing to say still has to say so"
+
+command -v gh >/dev/null 2>&1 || fail 4 "gh is not on PATH"
+command -v jq >/dev/null 2>&1 || fail 4 "jq is not on PATH"
+
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null) || REPO=""
+[ -n "$REPO" ] || fail 4 "cannot resolve the repository slug from gh"
+
+if [ -n "$COMMENTS_FILE" ]; then
+  [ -f "$COMMENTS_FILE" ] || fail 4 "no inline comments at $COMMENTS_FILE"
+  jq -e 'type == "array"' "$COMMENTS_FILE" >/dev/null 2>&1 \
+    || fail 4 "$COMMENTS_FILE must hold a JSON array of inline comments"
+fi
+
+TOKEN=$("$MINT" --token) || exit $?
+[ -n "$TOKEN" ] || fail 3 "the App issued no installation token"
+
+PAYLOAD=$(mktemp) || fail 1 "cannot create a temporary file for the review payload"
+trap 'rm -f "$PAYLOAD" "$PAYLOAD.err"' EXIT
+
+build_payload() { # <with-comments: 1|0>
+  if [ "$1" = 1 ] && [ -n "$COMMENTS_FILE" ]; then
+    jq -n --rawfile body "$BODY_FILE" --slurpfile comments "$COMMENTS_FILE" \
+      '{event: "COMMENT", body: $body, comments: $comments[0]}' >"$PAYLOAD"
+  else
+    jq -n --rawfile body "$BODY_FILE" '{event: "COMMENT", body: $body}' >"$PAYLOAD"
+  fi
+}
+
+post() {
+  GH_TOKEN=$TOKEN GITHUB_TOKEN=$TOKEN \
+    gh api --method POST "repos/$REPO/pulls/$PR/reviews" --input "$PAYLOAD" --jq .id
+}
+
+build_payload 1
+if ID=$(post 2>"$PAYLOAD.err"); then
+  printf '%s\n' "$ID"
+  note "posted a COMMENT review on PR #$PR as the backlog App"
+  exit 0
+fi
+
+# The whole review is rejected when any one inline comment does not land on a
+# line the diff actually changed, and the reviewer subagent is working from a
+# unified diff rather than from the API's position model — so this is the
+# expected failure, not an exceptional one. Losing every finding because one
+# line number was off by a hunk is the outcome worth avoiding; the summary
+# carries the findings either way.
+if [ -n "$COMMENTS_FILE" ]; then
+  note "the review was rejected with its inline comments ($(tr -d '\n' <"$PAYLOAD.err" | cut -c1-200)); retrying with the summary alone"
+  build_payload 0
+  if ID=$(post 2>"$PAYLOAD.err"); then
+    printf '%s\n' "$ID"
+    note "posted a COMMENT review on PR #$PR as the backlog App, without its inline comments"
+    exit 0
+  fi
+fi
+
+fail 1 "could not post a review on PR #$PR: $(tr -d '\n' <"$PAYLOAD.err" | cut -c1-300)"

--- a/plugins/backlog/scripts/select-issue.sh
+++ b/plugins/backlog/scripts/select-issue.sh
@@ -691,6 +691,9 @@ LIMIT=$(jq -r '.select.limit // ""' "$CFG")
 PROJECT_KIND=$(jq -r 'if (.select.project // null) == null then "absent" else (.select.project | type) end' "$CFG")
 STYLE=$(jq -r '.dependencies.style // ""' "$CFG")
 VERIFY_N=$(jq -r 'if (.verify | type) == "array" then (.verify | length) else -1 end' "$CFG")
+REVIEW_REQUIRED=$(jq -r 'if ((.review | type) == "object") and (.review | has("required")) then (.review.required | tostring) else "" end' "$CFG")
+REVIEWERS_KIND=$(jq -r 'if (.review | type) != "object" then "no-review" elif ((.review | has("reviewers")) | not) then "absent" else (.review.reviewers | type) end' "$CFG")
+REVIEWERS=$(jq -r 'if (.review.reviewers | type) == "array" then (.review.reviewers | map(tostring) | join(" ")) else "" end' "$CFG")
 
 # Flag over config, for the same reason the project keys work that way: the
 # config describes the repository's backlog, and a run is not entitled to rewrite
@@ -715,6 +718,52 @@ esac
 # nothing local ever looked at, and selection is the first chance to say so.
 [ "$VERIFY_N" -ge 1 ] 2>/dev/null \
   || fail 4 "$CFG: verify must be a non-empty array of commands; run backlog:setup-backlog"
+
+# The reviewer roster, checked in the same place and for the same reason. An
+# unknown rung or a `none` that is not last would otherwise surface at step 7 —
+# forty minutes in, with the implementation written, CI green and a pull request
+# already open — and the only remedy at that point is an edit to this file,
+# which is the one thing a run is not allowed to do to get itself unstuck.
+#
+# `review.required` is refused rather than translated. The migration is
+# mechanical, which is exactly what makes translating it silently the wrong
+# move: the key changed because a repository whose Copilot quota is exhausted
+# has to *learn* that a roster exists, and a config that keeps working unchanged
+# is a config nobody reads.
+if [ -n "$REVIEW_REQUIRED" ]; then
+  case "$REVIEW_REQUIRED" in
+    false) WANT_ROSTER='["none"]' ;;
+    *)     WANT_ROSTER='["copilot"]' ;;
+  esac
+  fail 4 "$CFG: review.required is no longer read; replace it with review.reviewers, an ordered roster tried in order -- $REVIEW_REQUIRED becomes $WANT_ROSTER, and [\"copilot\",\"local\",\"none\"] is what fails over instead of blocking"
+fi
+case "$REVIEWERS_KIND" in
+  array) ;;
+  no-review) fail 4 "$CFG: review must be an object holding a reviewers array; run backlog:setup-backlog" ;;
+  absent)    fail 4 "$CFG: review.reviewers is missing; set it to an ordered roster, [\"copilot\"] at minimum" ;;
+  *)         fail 4 "$CFG: review.reviewers must be an array of rung names (found a $REVIEWERS_KIND)" ;;
+esac
+[ -n "$REVIEWERS" ] \
+  || fail 4 "$CFG: review.reviewers is empty; a roster with no rungs can never review and can never merge, so say which is meant -- [\"copilot\"] to gate, [\"none\"] to merge unreviewed on purpose"
+
+REVIEWER_COUNT=0
+for RUNG in $REVIEWERS; do
+  REVIEWER_COUNT=$((REVIEWER_COUNT + 1))
+  case "$RUNG" in
+    copilot|local|none) ;;
+    *) fail 4 "$CFG: review.reviewers names an unknown rung '$RUNG'; the rungs are copilot, local and none" ;;
+  esac
+done
+# `none` last is a downgrade its operator chose. `none` anywhere else is a rung
+# nothing can follow -- the roster reads as though it has a fallback when the
+# fallback is unreachable, which is the worse of the two ways to be wrong.
+REVIEWER_POS=0
+for RUNG in $REVIEWERS; do
+  REVIEWER_POS=$((REVIEWER_POS + 1))
+  [ "$RUNG" = none ] && [ "$REVIEWER_POS" -ne "$REVIEWER_COUNT" ] \
+    && fail 4 "$CFG: review.reviewers has 'none' at position $REVIEWER_POS of $REVIEWER_COUNT; none merges unreviewed, so no rung after it can ever run -- move it last, or drop the rungs behind it"
+done
+note "reviewer roster: ${REVIEWERS// / -> }"
 
 # The scope is whatever the config pins, unless this run says otherwise. Absent
 # from both, no project call is made at all and selection is exactly what it was

--- a/plugins/backlog/scripts/select-issue.sh
+++ b/plugins/backlog/scripts/select-issue.sh
@@ -693,7 +693,16 @@ STYLE=$(jq -r '.dependencies.style // ""' "$CFG")
 VERIFY_N=$(jq -r 'if (.verify | type) == "array" then (.verify | length) else -1 end' "$CFG")
 REVIEW_REQUIRED=$(jq -r 'if ((.review | type) == "object") and (.review | has("required")) then (.review.required | tostring) else "" end' "$CFG")
 REVIEWERS_KIND=$(jq -r 'if (.review | type) != "object" then "no-review" elif ((.review | has("reviewers")) | not) then "absent" else (.review.reviewers | type) end' "$CFG")
-REVIEWERS=$(jq -r 'if (.review.reviewers | type) == "array" then (.review.reviewers | map(tostring) | join(" ")) else "" end' "$CFG")
+# One rung per line, and read back a line at a time. Joining them into a string
+# and letting the shell split it would make `["copilot local"]` -- one element,
+# not a roster -- validate as two legal rungs, and would let a rung containing a
+# glob character expand against the working directory on the way past.
+REVIEWERS_LIST=()
+REVIEWER_COUNT=0
+while IFS= read -r RUNG; do
+  REVIEWERS_LIST[$REVIEWER_COUNT]=$RUNG
+  REVIEWER_COUNT=$((REVIEWER_COUNT + 1))
+done < <(jq -r 'if (.review.reviewers | type) == "array" then (.review.reviewers[] | tostring) else empty end' "$CFG")
 
 # Flag over config, for the same reason the project keys work that way: the
 # config describes the repository's backlog, and a run is not entitled to rewrite
@@ -743,27 +752,28 @@ case "$REVIEWERS_KIND" in
   absent)    fail 4 "$CFG: review.reviewers is missing; set it to an ordered roster, [\"copilot\"] at minimum" ;;
   *)         fail 4 "$CFG: review.reviewers must be an array of rung names (found a $REVIEWERS_KIND)" ;;
 esac
-[ -n "$REVIEWERS" ] \
+[ "$REVIEWER_COUNT" -ge 1 ] \
   || fail 4 "$CFG: review.reviewers is empty; a roster with no rungs can never review and can never merge, so say which is meant -- [\"copilot\"] to gate, [\"none\"] to merge unreviewed on purpose"
 
-REVIEWER_COUNT=0
-for RUNG in $REVIEWERS; do
-  REVIEWER_COUNT=$((REVIEWER_COUNT + 1))
+# One pass. `none` last is a downgrade its operator chose; `none` anywhere else
+# is a rung nothing can follow -- the roster reads as though it has a fallback
+# when the fallback is unreachable, which is the worse of the two ways to be
+# wrong.
+ROSTER=""
+REVIEWER_POS=0
+while [ "$REVIEWER_POS" -lt "$REVIEWER_COUNT" ]; do
+  RUNG=${REVIEWERS_LIST[$REVIEWER_POS]}
+  REVIEWER_POS=$((REVIEWER_POS + 1))
   case "$RUNG" in
-    copilot|local|none) ;;
+    copilot|local) ;;
+    none)
+      [ "$REVIEWER_POS" -eq "$REVIEWER_COUNT" ] \
+        || fail 4 "$CFG: review.reviewers has 'none' at position $REVIEWER_POS of $REVIEWER_COUNT; none merges unreviewed, so no rung after it can ever run -- move it last, or drop the rungs behind it" ;;
     *) fail 4 "$CFG: review.reviewers names an unknown rung '$RUNG'; the rungs are copilot, local and none" ;;
   esac
+  ROSTER="${ROSTER:+$ROSTER -> }$RUNG"
 done
-# `none` last is a downgrade its operator chose. `none` anywhere else is a rung
-# nothing can follow -- the roster reads as though it has a fallback when the
-# fallback is unreachable, which is the worse of the two ways to be wrong.
-REVIEWER_POS=0
-for RUNG in $REVIEWERS; do
-  REVIEWER_POS=$((REVIEWER_POS + 1))
-  [ "$RUNG" = none ] && [ "$REVIEWER_POS" -ne "$REVIEWER_COUNT" ] \
-    && fail 4 "$CFG: review.reviewers has 'none' at position $REVIEWER_POS of $REVIEWER_COUNT; none merges unreviewed, so no rung after it can ever run -- move it last, or drop the rungs behind it"
-done
-note "reviewer roster: ${REVIEWERS// / -> }"
+note "reviewer roster: $ROSTER"
 
 # The scope is whatever the config pins, unless this run says otherwise. Absent
 # from both, no project call is made at all and selection is exactly what it was

--- a/plugins/backlog/scripts/select-issue_test.sh
+++ b/plugins/backlog/scripts/select-issue_test.sh
@@ -1011,6 +1011,20 @@ roster_fail 'a bot: rung is not a rung yet' "unknown rung 'bot:coderabbit-ai'" \
 roster_fail 'an empty roster says which of the two is meant' 'review.reviewers is empty' \
   '{ "reviewers": [] }'
 
+# REGRESSION: the rungs were joined into a string and split by the shell, so one
+# element holding two words validated as two legal rungs — a roster nobody wrote
+# and every rung of it reachable. Word splitting also let a rung containing a
+# glob expand against the working directory on the way past, which is the same
+# defect wearing a different hat.
+roster_fail 'one element holding two rungs is one unknown rung' "unknown rung 'copilot local'" \
+  '{ "reviewers": ["copilot local"] }'
+
+roster_fail 'a rung that is a glob is not expanded' "unknown rung '*'" \
+  '{ "reviewers": ["*"] }'
+
+roster_fail 'an empty string is a rung, and an unknown one' "unknown rung ''" \
+  '{ "reviewers": [""] }'
+
 # `none` last is a downgrade its operator chose; `none` first is a roster whose
 # fallbacks can never run, which reads as though it has them.
 roster_fail 'none before another rung is refused' "'none' at position 1 of 2" \

--- a/plugins/backlog/scripts/select-issue_test.sh
+++ b/plugins/backlog/scripts/select-issue_test.sh
@@ -43,6 +43,11 @@ SUT="$HERE/select-issue.sh"
 pass=0
 fail=0
 
+# The review roster every harness below writes unless a case replaces it. It is
+# a variable rather than a literal because the roster is now validated at
+# selection, so an invalid one has to be expressible in a fixture.
+REVIEW_BLOCK='{ "reviewers": ["copilot"] }'
+
 # check <name> <style> <expected refs, space separated> <body>
 check() {
   local name=$1 style=$2 want=$3 body=$4 got
@@ -557,7 +562,7 @@ run_sut() {
   "dependencies": { "style": "none" },
   "verify": ["true"],
   "merge": { "label": "auto-merge", "workflow": "auto-merge.yaml" },
-  "review": { "required": true },
+  "review": $REVIEW_BLOCK,
   "worktreeDir": ".claude/worktrees"
 }
 JSON
@@ -751,7 +756,7 @@ sel_run() {
   "dependencies": { "style": "none" },
   "verify": ["true"],
   "merge": { "label": "auto-merge", "workflow": "auto-merge.yaml" },
-  "review": { "required": true },
+  "review": $REVIEW_BLOCK,
   "worktreeDir": ".claude/worktrees"
 }
 JSON
@@ -946,6 +951,99 @@ checkr_fail 'an empty --label says the label cannot be cleared' 'there is nothin
 checkr_fail 'the usage text shows --all composing with --label' 'select-issue.sh [--label <name>] --all' \
   story null - "$MILESTONES_ALL" --nonsense
 
+printf '\nthe reviewer roster\n'
+
+# The roster is validated here, at selection, rather than at step 7 where it is
+# read. Everything wrong with it is wrong before an issue is branched, and by
+# step 7 the implementation is written, CI is green and a pull request is open —
+# at which point the only remedy is an edit to `.claude/backlog.json`, which is
+# the one move a run is not allowed to make to get itself unstuck. Same
+# reasoning as the empty `verify` check, and the same place in the script.
+#
+# `roster_fail <name> <substring> <review json>` and `roster_ok` both run the
+# whole script; a roster that passes has to still select an issue, so a check
+# that rejects everything cannot pass this section by accident.
+roster_run() { # <review json> [args...]
+  local review=$1; shift
+  REVIEW_BLOCK=$review sel_run story null - "$MILESTONES_ALL" "$@"
+}
+
+roster_ok() { # <name> <review json>
+  roster_run "$2"
+  if [ "$RUN_RC" -eq 0 ]; then
+    pass=$((pass + 1))
+    printf '  ok   %-58s [accepted]\n' "$1"
+  else
+    fail=$((fail + 1))
+    printf '  FAIL %-58s want exit 0, got exit %d: %s\n' "$1" "$RUN_RC" "$RUN_ERR"
+  fi
+}
+
+roster_fail() { # <name> <substring> <review json>
+  roster_run "$3"
+  case "$RUN_ERR" in
+    *"$2"*) ;;
+    *) fail=$((fail + 1))
+       printf '  FAIL %-58s message lacks [%s]: %s\n' "$1" "$2" "$RUN_ERR"
+       return ;;
+  esac
+  if [ "$RUN_RC" -eq 4 ]; then
+    pass=$((pass + 1)); printf '  ok   %-58s [exit 4]\n' "$1"
+  else
+    fail=$((fail + 1)); printf '  FAIL %-58s want exit 4, got exit %d\n' "$1" "$RUN_RC"
+  fi
+}
+
+roster_ok 'a single-rung roster'            '{ "reviewers": ["copilot"] }'
+roster_ok 'a roster that fails over'        '{ "reviewers": ["copilot", "local"] }'
+roster_ok 'a roster ending in none'         '{ "reviewers": ["copilot", "local", "none"] }'
+roster_ok 'none alone, an unreviewed merge chosen on purpose' '{ "reviewers": ["none"] }'
+
+roster_fail 'an unknown rung names the rungs that exist' "unknown rung 'coderabbit'" \
+  '{ "reviewers": ["copilot", "coderabbit"] }'
+
+# The out-of-scope bot rung, reached for before it exists. It has to fail here
+# rather than at step 7, where an unrecognised refusal from an unknown bot would
+# classify as a completed review and merge.
+roster_fail 'a bot: rung is not a rung yet' "unknown rung 'bot:coderabbit-ai'" \
+  '{ "reviewers": ["copilot", "bot:coderabbit-ai"] }'
+
+roster_fail 'an empty roster says which of the two is meant' 'review.reviewers is empty' \
+  '{ "reviewers": [] }'
+
+# `none` last is a downgrade its operator chose; `none` first is a roster whose
+# fallbacks can never run, which reads as though it has them.
+roster_fail 'none before another rung is refused' "'none' at position 1 of 2" \
+  '{ "reviewers": ["none", "copilot"] }'
+
+roster_fail 'none in the middle is refused' "'none' at position 2 of 3" \
+  '{ "reviewers": ["copilot", "none", "local"] }'
+
+roster_fail 'a missing roster points at the key' 'review.reviewers is missing' \
+  '{ }'
+
+roster_fail 'a roster that is not an array' 'must be an array of rung names' \
+  '{ "reviewers": "copilot" }'
+
+# The migration. `required` is mechanical to translate, which is exactly why it
+# is refused rather than translated: this key changed because a repository whose
+# Copilot quota is exhausted has to learn a roster exists, and a config that
+# keeps working unchanged is a config nobody reads.
+roster_fail 'review.required is refused, not equivalenced' 'review.required is no longer read' \
+  '{ "required": true }'
+
+roster_fail 'review.required true names its replacement' '["copilot"]' \
+  '{ "required": true }'
+
+roster_fail 'review.required false names its replacement' '["none"]' \
+  '{ "required": false }'
+
+# A config carrying both is the half-done migration, and it is the dangerous
+# one: `reviewers` would be read and `required` would sit there looking
+# authoritative to whoever next opens the file.
+roster_fail 'a config carrying both is still refused' 'review.required is no longer read' \
+  '{ "required": true, "reviewers": ["copilot"] }'
+
 printf '\ncross-repository dependencies\n'
 
 # The dependency walk itself, end to end, under `dependencies.style` = `native`
@@ -1013,7 +1111,7 @@ cat >"$SCRATCH/nrepo/.claude/backlog.json" <<'JSON'
   "dependencies": { "style": "native" },
   "verify": ["true"],
   "merge": { "label": "auto-merge", "workflow": "auto-merge.yaml" },
-  "review": { "required": true },
+  "review": { "reviewers": ["copilot"] },
   "worktreeDir": ".claude/worktrees"
 }
 JSON

--- a/plugins/backlog/skills/next-issue/SKILL.md
+++ b/plugins/backlog/skills/next-issue/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: next-issue
-description: Take exactly one eligible story issue from the backlog through the full development cycle — select it, branch a worktree, implement the acceptance criteria, run the repository's verify commands, open a pull request, wait for checks, get a Copilot review and answer it, then label the pull request for GitHub to auto merge, close the issue and clean up. Use this whenever the user asks to "work the backlog", "take the next issue", "do the next story", "pick up the next ticket", or runs the backlog loop; it is also what the `issue-worker` agent invokes on every iteration of `backlog:run-backlog`. Everything repository-specific comes from `.claude/backlog.json`. Skip this when the user names a specific issue to explore rather than to land, or when they want the backlog bootstrapped rather than worked — that is `backlog:setup-backlog`.
-allowed-tools: Bash, Read, Write, Edit, Glob, Grep, TaskCreate, TaskUpdate, EnterWorktree, ExitWorktree
+description: Take exactly one eligible story issue from the backlog through the full development cycle — select it, branch a worktree, implement the acceptance criteria, run the repository's verify commands, open a pull request, wait for checks, get a review from the configured roster and answer it, then label the pull request for GitHub to auto merge, close the issue and clean up. Use this whenever the user asks to "work the backlog", "take the next issue", "do the next story", "pick up the next ticket", or runs the backlog loop; it is also what the `issue-worker` agent invokes on every iteration of `backlog:run-backlog`. Everything repository-specific comes from `.claude/backlog.json`. Skip this when the user names a specific issue to explore rather than to land, or when they want the backlog bootstrapped rather than worked — that is `backlog:setup-backlog`.
+allowed-tools: Agent, Bash, Read, Write, Edit, Glob, Grep, TaskCreate, TaskUpdate, EnterWorktree, ExitWorktree
 ---
 
 # next-issue
@@ -46,7 +46,7 @@ What each key is used for:
 | `dependencies.style` | step 1 — same, minus the override |
 | `verify` | step 4, the commands that gate the pull request |
 | `merge.label`, `merge.workflow` | step 9, handing the merge to GitHub |
-| `review.required` | steps 7 and 8, whether Copilot gates the merge |
+| `review.reviewers` | steps 7 and 8, the ordered roster of reviewers that gates the merge |
 | `worktreeDir` | steps 2 and 10, where the worktree lives |
 
 Read the file for the four keys you use directly. The first three rows belong to step 1's
@@ -428,7 +428,7 @@ the gate you had reached —
 
 ```
 "${CLAUDE_PLUGIN_ROOT}/scripts/await-checks.sh" <pr>          # step 6
-"${CLAUDE_PLUGIN_ROOT}/scripts/await-review.sh" <pr>          # step 7 — idempotent
+"${CLAUDE_PLUGIN_ROOT}/scripts/await-review.sh" <pr> <rung>   # step 7 — idempotent
 gh pr view <pr> --repo <repo> --json state,autoMergeRequest   # step 9
 "${CLAUDE_PLUGIN_ROOT}/scripts/finish-issue.sh" <n> <pr> issue-<n>   # step 10 — guarded
 ```
@@ -442,49 +442,153 @@ the blocking call. The no-polling rule above is about not polling *alongside* a 
 with no wait running, that single query is exactly the right move, and doing nothing is the
 one response that cannot be right.
 
-## 7. The Copilot review — one call
+## 7. The review — walk the roster
 
-**If `review.required` is `false`, skip this step and step 8 entirely** and go to step 9.
-Nothing here is optional when it is `true`.
+`review.reviewers` is an **ordered roster**, tried in order and failing over on availability:
+`["copilot"]`, `["copilot", "local"]`, `["copilot", "local", "none"]`. `select-issue.sh`
+already validated it at step 1, so by the time you are here the rungs are known and `none`,
+if present, is last.
 
-Requesting the review, waiting for it, and deciding whether what landed *is* a review are one
-call — a blocking `Bash` call, the same shape as step 6's, with the Bash tool's `timeout` set
-to `330000` and the script bounding itself at five minutes:
+Two things can override the configured roster, and both come from your prompt rather than
+from the repository:
+
+- `--reviewers <a,b,c>` replaces the roster for this run. `backlog:run-backlog` passes it when
+  a month's Copilot allowance has run out and editing a tracked file in every repository is
+  not the remedy. It is not yours to widen, reorder or drop.
+- A list of rungs **already found unavailable earlier in this run**. Skip those without
+  probing them: the driver only carries forward rungs that refused a request synchronously,
+  and re-probing one costs a few seconds per iteration while re-waiting on one costs twenty
+  minutes.
+
+**If the first rung you have left is `none`, skip this step and step 8 entirely** and go to
+step 9. Nothing here is optional for any other rung.
+
+### The distinction the whole roster turns on
+
+**Unavailability advances the roster. Refusal does not.**
+
+A rung that reviewed the pull request and *refused* it — Copilot's `"wasn't able to review
+this pull request because it exceeds the maximum number of files (300)"` — has said something
+true about the work. Advancing past that to a reviewer with different limits is exactly how
+unreviewable work reaches the default branch, which is the failure the decline check was
+added for: a vendored test suite pushed a pull request past the file limit, Copilot declined,
+a naive `length > 0` check passed, and the cycle merged with no review at all. So a refusal is
+`BLOCKED` and the roster stops. This is the conservative reading, chosen deliberately.
+
+### `copilot`
+
+One blocking `Bash` call, the same shape as step 6's, with the Bash tool's `timeout` set to
+`330000` and the script bounding itself at five minutes:
 
 ```
-"${CLAUDE_PLUGIN_ROOT}/scripts/await-review.sh" <pr>
+"${CLAUDE_PLUGIN_ROOT}/scripts/await-review.sh" <pr> copilot
 ```
 
 This is the longest wait in the cycle and the one that has attracted busy-waiting. Step 6's
 rules hold here unchanged: not `Monitor`, not `run_in_background`, and not turns of your own.
 
+### `local`
+
+An adversarial review, produced by a fresh subagent that has never seen your implementation,
+and posted to the pull request under the backlog App's identity. Four steps, in this order:
+
+**1. Preflight, before anything is spawned.**
+
+```
+"${CLAUDE_PLUGIN_ROOT}/scripts/post-review.sh" --preflight
+```
+
+Exit 3 means the rung is unavailable — `BACKLOG_APP_ID`/`BACKLOG_APP_KEY` absent from the
+environment, or `openssl` not on PATH. That is a fallthrough, not a crash, and it costs no
+network call: advance the roster and record the rung. The preflight is first because
+everything after it costs a fresh agent and a whole diff, and learning afterwards that the
+App was never configured is the expensive way to learn it.
+
+If the `Agent` tool is not available to you, the rung is unavailable too. Record it and
+advance — **do not review your own diff.** A reviewer holding the context that produced the
+code is not a second opinion, and a review it posts under an App identity would look exactly
+like one.
+
+**2. Spawn the reviewer.** A `general-purpose` subagent, given the diff and nothing else:
+
+```
+gh pr diff <pr> > /tmp/pr-<pr>.diff
+```
+
+Its prompt gives it the diff, the pull request title and the issue's acceptance criteria, and
+says plainly that it must not read the repository for the code's rationale — the point of the
+rung is a reader who was not there. Ask it to return **only** JSON:
+
+```json
+{"body": "<markdown summary>",
+ "comments": [{"path": "a/b.go", "line": 42, "side": "RIGHT", "body": "<finding>"}]}
+```
+
+Tell it to look for correctness defects, missing test coverage of the acceptance criteria,
+error paths that swallow failures, and public API it would find hard to use — and to say so
+in the summary when it found nothing, rather than inventing a finding. And tell it that if it
+cannot review the diff at all, its `body` must say **"I was not able to review this pull
+request"** and why: that is the wording the gate classifies as a refusal, and a rung that
+cannot say "I refuse" in a form the gate recognises is a rung whose refusals merge.
+
+**3. Post it.**
+
+```
+"${CLAUDE_PLUGIN_ROOT}/scripts/post-review.sh" <pr> <body-file> <comments-file>
+```
+
+Exit 3 is unavailable (advance and record). Exit 1 is a post that failed for a reason that is
+not availability — advance the roster, but do **not** record the rung as down; nothing about
+the rung is broken.
+
+**4. Wait on it through the same gate as every other rung.**
+
+```
+"${CLAUDE_PLUGIN_ROOT}/scripts/await-review.sh" <pr> local
+```
+
+That last call is not ceremony. A posted review is a `reviewed` event on the timeline, which
+is what the gate polls, so **one exit code covers every rung** and "was this reviewed?" never
+becomes something you assert at the end of the longest part of the cycle.
+
+### The exit table — identical for both rungs
+
 | exit | meaning | what you do |
 | --- | --- | --- |
-| 0 | a review **completed** — it left comments, or reported it generated none. stdout is its body | continue to step 8 |
-| 1 | the most recent review **declined** the work; stdout is why | `BLOCKED`, and do **not** label. If it is the 300-file limit, say so and suggest how the work could be split |
-| 2 | the five minutes were up with no review yet | **run it again**, in the same turn. It resumes: a review already requested is not requested twice, and one already posted is classified immediately. Copilot routinely takes longer than one call, so this is the expected outcome, not a fault. After four re-runs — about twenty minutes with nothing posted — `BLOCKED` |
-| 3 | the review could not be requested — Copilot code review is probably not enabled for this organisation | `BLOCKED`, naming that |
+| 0 | a review **completed** — it left comments, or reported it generated none. stdout is its body | continue to step 8. Note which rung it was; your report names it |
+| 1 | the most recent review **REFUSED** the work; stdout is why | `BLOCKED`, and do **not** label and do **not** advance the roster. If it is the 300-file limit, say so and suggest how the work could be split |
+| 2 | the bound was up with no review yet | **run it again**, in the same turn. It resumes: a review already requested is not requested twice, and one already posted is classified immediately. After **four** re-runs — about twenty minutes with nothing posted — this rung is unavailable *for this pull request*: advance the roster. Do **not** report it as having refused, and do not tell the driver to retire it. Silence is exactly what a slow-but-working reviewer looks like |
+| 3 | **UNAVAILABLE**, synchronously — the request was refused, or the rung's preconditions are absent | advance the roster, and **record the rung** with the reason. Your report names it, and the driver carries it into the next iteration so ten iterations do not each spend a minute rediscovering it |
 | 4 | usage or precondition failure | `BLOCKED`; the plugin or the environment is wrong, not the pull request |
 
-**Only exit 0 lets you label the pull request in step 9.**
+**Only exit 0 lets you label the pull request in step 9** — on some rung, or the roster
+reaching `none`.
 
-### Why this is a script
+### Reaching the end of the roster
 
-"Did Copilot review this?" looks like one question and is two, and the cycle used to answer
-them in places far enough apart that the second could be skipped. The wait was a polling loop
-that exited on the first `reviewed` event; whether that review had *declined* the work was a
-separate command sixty lines further down, under its own heading. Copilot posts a review
-whose body declines — most often `"Copilot wasn't able to review this pull request because it
-exceeds the maximum number of files (300)"` — and that decline satisfies any `length > 0`
-test. It has been missed in the wild: a vendored test suite pushed a pull request past the
-limit, Copilot declined, the check passed, and the cycle merged with no review at all.
+If every rung is exhausted and the last one was **not** `none`, that is `BLOCKED`. Name each
+rung tried and why each was unavailable, so the reader can tell "Copilot's quota is gone" from
+"the App is not installed here" without opening the run.
+
+If the last rung **is** `none`, the pull request merges unreviewed. That is legal — the
+operator wrote it into the roster — and it is not silent: step 9 labels, and your report says
+plainly that the merge was unreviewed and names every rung that was tried and why each failed.
+
+### Why the gate is a script
+
+"Did the reviewer review this?" looks like one question and is two, and the cycle used to
+answer them in places far enough apart that the second could be skipped. The wait was a
+polling loop that exited on the first `reviewed` event; whether that review had *declined* the
+work was a separate command sixty lines further down, under its own heading. Copilot posts a
+review whose body declines, and that decline satisfies any `length > 0` test. It has been
+missed in the wild, exactly as described above.
 
 The label in step 9 **is** the assertion that a review completed. Making it an exit code is
 what stops that assertion depending on an agent remembering a second question at the very end
 of the longest part of the cycle.
 
-Four findings live inside the script rather than in prose here, each of which cost a
-debugging session:
+Findings that live inside the script rather than in prose here, each of which cost a debugging
+session:
 
 - Copilot is a **Bot**, not a User. The GraphQL mutation takes `botIds`; a bare
   `reviewers[]=Copilot` on the REST endpoint returns 200 while doing nothing, and the wait
@@ -498,22 +602,29 @@ debugging session:
   finding is made of.
 - `--paginate`, because the timeline returns thirty events per page and a pull request with a
   few pushes and check runs pushes the `reviewed` event off page one.
-- A case-insensitive `copilot` login filter, without which the repository owner glancing at
-  the pull request ends the wait and step 9 decides on a review that never arrived.
+- A login filter per rung, without which the repository owner glancing at the pull request
+  ends the wait and step 9 decides on a review that never arrived — and, since the `local`
+  rung's login is the App's, without which Copilot's review would satisfy the local rung's
+  wait and one review would count as two.
+- The `local` rung's login is **discovered** from the App rather than written down. The App is
+  the operator's and its slug is not this plugin's to know.
 
-Re-running is safe: a Copilot review already on the pull request is classified and returned
-without requesting another, and the newest review wins, so an old decline sitting beside a
-newer completed review is not misread.
+`scripts/await-review_test.sh` is the offline fixture corpus for the classification and for
+the unavailable/refused/nothing-yet split; a change to those rules belongs there, not here.
 
-Every finding above is a reason the wait is *inside* a script rather than in your hands. None
-of them is a reason to look in on the script while it runs — a review that has not landed yet
-reads exactly like one that never will, from your side, and the script is the thing that can
-tell those apart. Re-run it after an exit 2; do not go looking at the review endpoints in
-between.
+Re-running the gate is safe on either rung: a review already on the pull request is classified
+and returned without requesting another, and the newest review wins, so an old refusal sitting
+beside a newer completed review is not misread.
+
+None of those findings is a reason to look in on the script while it runs — a review that has
+not landed yet reads exactly like one that never will, from your side, and the script is the
+thing that can tell those apart. Re-run it after an exit 2; do not go looking at the review
+endpoints in between.
 
 ## 8. Address the review
 
-**Skipped entirely when `review.required` is `false`.**
+**Skipped entirely when the roster reached `none`.** The comments are addressed identically
+whoever left them, so nothing below asks which rung reviewed.
 
 Step 7 already printed the summary body on stdout. What it does not carry is the inline
 comments, which is what you are here for:
@@ -522,8 +633,11 @@ comments, which is what you are here for:
 gh api repos/<repo>/pulls/<pr>/comments --jq '.[] | "[\(.id)] \(.path):\(.line)\n\(.body)"'
 ```
 
-An empty result is normal — a review whose body says it `generated no comments` still counts
-as having reviewed, and step 7 exited 0 on it. If you want the summary again, take it from
+An empty result is normal — a review whose body says it generated no comments still counts
+as having reviewed, and step 7 exited 0 on it. The `local` rung's inline comments arrive here
+too: `post-review.sh` posts them with the summary, and drops them and keeps the summary if
+GitHub rejects a line that is not in the diff, so a review with findings in its body and none
+inline is an ordinary outcome rather than a lost one. If you want the summary again, take it from
 step 7's output rather than from `pulls/<pr>/reviews`, which lags (see step 7) and will
 happily return an empty array for a review that landed.
 
@@ -564,8 +678,8 @@ immediately, if they have already passed — and leaves it open if one fails.
 Apply the label only when **both** hold:
 
 1. Checks are green, and
-2. **either** `review.required` is `false`, **or** step 7 exited **0** — a review actually
-   completed, and every comment it left is now addressed or answered.
+2. **either** a review completed on some rung — step 7 exited **0** — and every comment it
+   left is now addressed or answered, **or** the roster reached `none`.
 
 This is not a formality to route around: the label **is** the assertion that you verified
 both conditions, and adding it without having done so is the same failure as merging
@@ -577,12 +691,15 @@ label gate plus the branch protection rule — rather than in a decision made mi
 visible only in a transcript. It is also what lets the loop run unattended: an agent merging
 on its own is blocked, and labelling is not.
 
-When `review.required` is `true`, any exit from step 7 other than 0 — declined (1), timed out
-(2), never requested (3) — is **not** a completed review. Do **not** label the pull request. Leave it open, leave the worktree in place, and stop with a report beginning
-`BLOCKED` that names the pull request and why the review is missing, so the user can tell a
-pull request that needs a human look from one that merged on its own. Sending unreviewed
-work to the default branch is the one step of this cycle that is not yours to take
-unilaterally.
+No exit from step 7 other than 0 is a completed review. A **refusal** (1) is `BLOCKED`
+outright. Silence (2) and unavailability (3) send you to the next rung, and if the roster runs
+out without reaching `none` they are `BLOCKED` too. In every one of those cases: do **not**
+label the pull request. Leave it open, leave the worktree in place, and stop with a report
+beginning `BLOCKED` that names the pull request, every rung tried and why each failed, so the
+user can tell a pull request that needs a human look from one that merged on its own. Sending
+unreviewed work to the default branch is the one step of this cycle that is not yours to take
+unilaterally — unless the operator wrote `none` into the roster, which is the only way it
+becomes theirs to have taken.
 
 If the pull request is unreviewable because it exceeds the 300-file limit, say so in the
 `BLOCKED` report and suggest how the work could be split; do not label it anyway.
@@ -738,10 +855,22 @@ public API. If the run was scoped, name the scope in full — the field as well 
 because the same value can exist on more than one of a board's fields. An outcome from a
 scoped backlog says nothing about the rest of it.
 
-- When `review.required` is `true`: whether Copilot reviewed and what it flagged.
-- When `review.required` is `false`: say plainly that **the pull request merged without a
-  review**, because `review.required` is `false`. Do not leave that to be inferred from the
-  absence of a review line.
+- **Which rung reviewed**, by name, and what it flagged. `copilot` and `local` are different
+  assurances and a report that says only "reviewed" hides which one was had.
+- **Any rung that refused the request**, by name and with the reason — Copilot code review not
+  enabled, the App credentials absent. Your driver carries those forward into the next
+  iteration, so this line is load bearing rather than decorative. Say it in a form it can
+  read back:
+
+  ```
+  Reviewer: local (copilot unavailable: Copilot code review is not enabled for this organisation)
+  ```
+
+  A rung that merely went **silent** does not go on that line. Silence is what a slow reviewer
+  looks like, and retiring one on it costs every remaining iteration its best reviewer.
+- When the roster reached `none`: say plainly that **the pull request merged without a
+  review**, and name every rung tried and why each was unavailable. Do not leave that to be
+  inferred from the absence of a review line.
 
 If you stopped early, say exactly where and why, beginning the report with `BLOCKED`.
 
@@ -768,8 +897,10 @@ where it stands, `BLOCKED` says it needs a person.
 Stop and report — do not push through — if any of these happen:
 
 - `select-issue.sh` exits 4 — `.claude/backlog.json` is missing, does not parse, carries an
-  unknown `dependencies.style`, has an empty `verify`, names a milestone that does not exist,
-  or a requested project scope could not be resolved. Never re-run it with an argument
+  unknown `dependencies.style`, has an empty `verify`, carries a `review.reviewers` roster
+  naming an unknown rung or putting `none` anywhere but last, still carries the retired
+  `review.required`, names a milestone that does not exist, or a requested project scope could
+  not be resolved. Never re-run it with an argument
   dropped, widened or changed to get past the last two, and never edit
   `.claude/backlog.json` to get past them either.
 - The same CI failure survives three fix attempts.
@@ -778,8 +909,10 @@ Stop and report — do not push through — if any of these happen:
 - Landing the pull request would require a force-push, a branch-protection override, or
   discarding someone else's commits.
 - `git status` in the main checkout is dirty with changes you did not make.
-- `review.required` is `true` and `await-review.sh` exited 1 or 3 — the review declined, or
-  could not be requested at all.
+- `await-review.sh` exited 1 on any rung — a reviewer looked at the work and refused it. This
+  one does **not** advance the roster: a reviewer with different limits is not a second
+  opinion on work the first one could not read.
+- The roster is exhausted without a completed review and without reaching `none`.
 - A wait's exit 2 outlasts its re-run budget: six for `await-checks.sh`, four for
   `await-review.sh`, three for `finish-issue.sh`. An exit 2 on its own is not a stop
   condition — it is the wait asking to be called again, in the same turn — but a gate that

--- a/plugins/backlog/skills/next-issue/SKILL.md
+++ b/plugins/backlog/skills/next-issue/SKILL.md
@@ -455,10 +455,10 @@ from the repository:
 - `--reviewers <a,b,c>` replaces the roster for this run. `backlog:run-backlog` passes it when
   a month's Copilot allowance has run out and editing a tracked file in every repository is
   not the remedy. It is not yours to widen, reorder or drop.
-- A list of rungs **already found unavailable earlier in this run**. Skip those without
-  probing them: the driver only carries forward rungs that refused a request synchronously,
-  and re-probing one costs a few seconds per iteration while re-waiting on one costs twenty
-  minutes.
+- A list of rungs **already found UNAVAILABLE earlier in this run**. Skip those without
+  probing them: the driver only carries forward rungs that reported themselves unavailable
+  synchronously, and re-probing one costs a few seconds per iteration while re-waiting on one
+  costs twenty minutes.
 
 **If the first rung you have left is `none`, skip this step and step 8 entirely** and go to
 step 9. Nothing here is optional for any other rung.
@@ -857,8 +857,9 @@ scoped backlog says nothing about the rest of it.
 
 - **Which rung reviewed**, by name, and what it flagged. `copilot` and `local` are different
   assurances and a report that says only "reviewed" hides which one was had.
-- **Any rung that refused the request**, by name and with the reason — Copilot code review not
-  enabled, the App credentials absent. Your driver carries those forward into the next
+- **Any rung you found UNAVAILABLE** — the gate's exit 3 — by name and with the reason:
+  Copilot code review not enabled, the App credentials absent. Not a rung that **refused** the
+  work; that one halts you at `BLOCKED` and never reaches a report like this. Your driver carries those forward into the next
   iteration, so this line is load bearing rather than decorative. Say it in a form it can
   read back:
 

--- a/plugins/backlog/skills/run-backlog/SKILL.md
+++ b/plugins/backlog/skills/run-backlog/SKILL.md
@@ -159,12 +159,13 @@ to selection:
            place of review.reviewers.
 ```
 
-And when earlier iterations found a rung **unavailable**, name those rungs and their reasons —
+And when earlier iterations found a rung **UNAVAILABLE**, name those rungs and their reasons —
 see below for which ones qualify:
 
 ```
-           These reviewer rungs already refused a request this run and are not worth probing
-           again: copilot (Copilot code review is not enabled for this organisation).
+           These reviewer rungs already reported themselves UNAVAILABLE this run and are not
+           worth probing again: copilot (Copilot code review is not enabled for this
+           organisation).
 ```
 
 Every iteration gets all of them, `all` (as `--all`) included. Dropping one does not narrow
@@ -224,17 +225,19 @@ enough that you can still see all of it at the end.
 
 ### Remembering a rung that is down, and not remembering one that is slow
 
-A worker's report names any rung that **refused a request**. Accumulate those across the run
-and thread them into every subsequent worker prompt, exactly as you thread the selection
-arguments. The memory belongs here and nowhere else: every iteration is a fresh subagent, so
+A worker's report names any rung it found **UNAVAILABLE** — the gate's exit 3, which is the
+rung saying it cannot review at all. That is a different outcome from a rung that **refused**
+the work (exit 1), which halts the worker rather than being carried anywhere. Accumulate the
+unavailable ones across the run and thread them into every subsequent worker prompt, exactly
+as you thread the selection arguments. The memory belongs here and nowhere else: every iteration is a fresh subagent, so
 no worker can carry it, and a state file on disk would outlive the run and keep a rung retired
 after its quota reset overnight.
 
 Two failures read alike in a report and are not alike, and only the first is remembered:
 
-- **The rung refused the request.** Synchronous — the mutation, the REST fallback, the
-  re-check, or, for the `local` rung, credentials absent from the environment at zero network
-  cost. One to three seconds, and the rung *told us* it was down. Re-probing it across ten
+- **The rung reported itself UNAVAILABLE.** Synchronous — the mutation, the REST fallback,
+  the re-check, or, for the `local` rung, credentials absent from the environment at zero
+  network cost. One to three seconds, and the rung *told us* it was down. Re-probing it across ten
   iterations costs about thirty seconds in total; not remembering it costs nothing much
   either, which is why this is cheap insurance rather than a load-bearing optimisation.
 - **Nothing arrived.** Inferred from silence, after five minutes and four re-runs. Silence is

--- a/plugins/backlog/skills/run-backlog/SKILL.md
+++ b/plugins/backlog/skills/run-backlog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: run-backlog
-description: Drive a repository's story backlog unattended, one issue at a time, by spawning a fresh `issue-worker` subagent per iteration and halting on `BACKLOG EMPTY`, on `BLOCKED`, or at a bounded iteration count. Use this whenever the user wants the backlog worked continuously rather than a single issue — "run the backlog", "work through the issues", "keep taking stories until you run out", "drain the v0.3.0 milestone", "work through the workspace-ci stories", "work the In Progress stories", or a `/loop` that repeats the cycle. Takes an optional integer argument setting the maximum number of iterations, the bare word `all` meaning every optional narrowing is dropped, and optional `--label <name>`, `--milestone <title>`, `--no-milestone-filter`, `--project-value <value>`, `--project-field <name>`, `--project-owner <login>`, `--project-number <n>` and `--no-project-filter` arguments restricting the whole run. Skip this when the user wants exactly one issue (`backlog:next-issue`) or wants the repository bootstrapped first (`backlog:setup-backlog`).
+description: Drive a repository's story backlog unattended, one issue at a time, by spawning a fresh `issue-worker` subagent per iteration and halting on `BACKLOG EMPTY`, on `BLOCKED`, or at a bounded iteration count. Use this whenever the user wants the backlog worked continuously rather than a single issue — "run the backlog", "work through the issues", "keep taking stories until you run out", "drain the v0.3.0 milestone", "work through the workspace-ci stories", "work the In Progress stories", or a `/loop` that repeats the cycle. Takes an optional integer argument setting the maximum number of iterations, the bare word `all` meaning every optional narrowing is dropped, and optional `--label <name>`, `--milestone <title>`, `--no-milestone-filter`, `--project-value <value>`, `--project-field <name>`, `--project-owner <login>`, `--project-number <n>` and `--no-project-filter` arguments restricting the whole run, and an optional `--reviewers <a,b,c>` argument replacing the configured reviewer roster for one run. Skip this when the user wants exactly one issue (`backlog:next-issue`) or wants the repository bootstrapped first (`backlog:setup-backlog`).
 allowed-tools: Agent, SendMessage, Bash, Read, Glob, Grep, TaskCreate, TaskUpdate, ScheduleWakeup
 ---
 
@@ -48,12 +48,14 @@ pins is a default that this run can replace, and the whole run then uses the sam
 /run-backlog 5 --project-field Status --project-value "In Progress"
 /run-backlog 5 --milestone v0.3.0
 /run-backlog 5 all
+/run-backlog 5 --reviewers copilot,local
 ```
 
-The argument order does not matter. The integer is the bound, the bare word `all` is defined
-below, and every argument beginning `--` is passed through to selection. They are exactly the
-ones `scripts/select-issue.sh` takes, so a request the script cannot express is a request
-this skill cannot accept either:
+The argument order does not matter. The integer is the bound and the bare word `all` is
+defined below. Every argument beginning `--` **except `--reviewers`** is passed through to
+selection, and those are exactly the ones `scripts/select-issue.sh` takes, so a request the
+script cannot express is a request this skill cannot accept either. `--reviewers` is the one
+that goes elsewhere — to step 7 of each worker — and it has its own section below:
 
 | argument | what it names | when the user has given you one |
 | --- | --- | --- |
@@ -99,6 +101,33 @@ backlog. Say the arguments in your first message alongside the bound — the fie
 the value, since the same value can exist on two of a board's fields — because every outcome
 below is then a statement about that selection and not about the backlog.
 
+### `--reviewers`
+
+`--reviewers copilot,local,none` replaces the repository's `review.reviewers` roster for this
+run. It is not a selection argument — it goes to step 7 of each worker rather than to
+`select-issue.sh` — but it is settled here with the others, and it is threaded into every
+worker prompt on exactly the same terms.
+
+It exists because a reviewer can be *unavailable through no fault of the configuration*, which
+is what separates it from every selector above. A monthly Copilot allowance runs out on a
+date nobody chose; an organisation has an outage. The configured roster is right for the
+repository and wrong for this month, and the alternative to a per-run override is editing a
+tracked file in every repository the operator runs the loop against — and then remembering to
+edit it back.
+
+Do not invent one. With nothing given, pass nothing: the repository's roster is the default
+and it is usually correct. `--reviewers none` is the shape to be careful with — it is the
+whole run merging unreviewed, so say so in your first message and again in the closing report,
+rather than only in the per-iteration rows.
+
+Check it before the first spawn, against the same three rules `scripts/select-issue.sh`
+applies to the configured roster: every rung is one of `copilot`, `local` and `none`; the list
+is not empty; and `none`, if present, is last, because no rung after it can ever run. A roster
+that breaks one of those is a stop, not a thing to correct on the user's behalf — say which
+rule and what they gave you. Checking it here rather than letting the first worker discover it
+is the same reasoning that put the config's roster check at selection: a bad roster should
+cost a sentence, not an implementation and a green pull request.
+
 ## 1. The loop
 
 For each iteration up to the bound:
@@ -120,6 +149,22 @@ one of them, verbatim and in full:
 ```
            This run is scoped: pass --project-field Status --project-value "In Progress"
            to select-issue.sh at step 1.
+```
+
+When the run carries `--reviewers`, add a line for it too, and it goes to step 7 rather than
+to selection:
+
+```
+           This run's reviewer roster is --reviewers copilot,local,none. Use it at step 7 in
+           place of review.reviewers.
+```
+
+And when earlier iterations found a rung **unavailable**, name those rungs and their reasons —
+see below for which ones qualify:
+
+```
+           These reviewer rungs already refused a request this run and are not worth probing
+           again: copilot (Copilot code review is not enabled for this organisation).
 ```
 
 Every iteration gets all of them, `all` (as `--all`) included. Dropping one does not narrow
@@ -172,10 +217,35 @@ Also halt if:
 - The bound is reached. Say so plainly: a loop that stopped at its bound with work left is a
   different outcome from a drained backlog, and the user's next move differs.
 
-Record per iteration: issue number and title, pull request number, merged / blocked, how many
-times the worker had to be resumed, and the token cost the agent result reports for that
-worker. Nothing else. Keep the running list short enough that you can still see all of it at
-the end.
+Record per iteration: issue number and title, pull request number, merged / blocked, **which
+rung of the roster reviewed it**, how many times the worker had to be resumed, and the token
+cost the agent result reports for that worker. Nothing else. Keep the running list short
+enough that you can still see all of it at the end.
+
+### Remembering a rung that is down, and not remembering one that is slow
+
+A worker's report names any rung that **refused a request**. Accumulate those across the run
+and thread them into every subsequent worker prompt, exactly as you thread the selection
+arguments. The memory belongs here and nowhere else: every iteration is a fresh subagent, so
+no worker can carry it, and a state file on disk would outlive the run and keep a rung retired
+after its quota reset overnight.
+
+Two failures read alike in a report and are not alike, and only the first is remembered:
+
+- **The rung refused the request.** Synchronous — the mutation, the REST fallback, the
+  re-check, or, for the `local` rung, credentials absent from the environment at zero network
+  cost. One to three seconds, and the rung *told us* it was down. Re-probing it across ten
+  iterations costs about thirty seconds in total; not remembering it costs nothing much
+  either, which is why this is cheap insurance rather than a load-bearing optimisation.
+- **Nothing arrived.** Inferred from silence, after five minutes and four re-runs. Silence is
+  also exactly what a slow-but-working reviewer looks like. Remembering this one retires a
+  working reviewer for the rest of the run, and re-probing it costs three hours and twenty
+  minutes across ten iterations — so it is re-probed every iteration anyway, and never
+  recorded.
+
+A worker that says a rung went silent is not reporting a rung that is down. If a report is
+ambiguous, do not record the rung: the cost of an extra probe is seconds and the cost of a
+wrong retirement is every remaining iteration's review quality.
 
 ### A worker that comes back mid-cycle
 
@@ -252,6 +322,10 @@ columns are the only place a run that regressed is visible.
   no one holding them.
 - **Never widen the bound mid-run** because the backlog turned out to be longer. Finish,
   report, and let the user re-run.
+- **Never reorder or shorten the reviewer roster**, and never add `none` to it because a rung
+  went quiet. The order is the operator's policy about what assurance the default branch gets,
+  and a run that appends `none` to keep moving has decided that on their behalf. A roster that
+  runs out is a `BLOCKED` worker and a halted loop, which is the correct outcome.
 - **Never drop, widen or edit any selection argument mid-run**, and never respond to a worker
   that halted on a selection failure by re-spawning it with an argument removed or changed.
   Dropping the value turns "work the workspace-ci stories" into "work the backlog"; dropping
@@ -266,15 +340,18 @@ columns are the only place a run that regressed is visible.
 
 ## 3. Report
 
-Close with the iteration table, the selection arguments the run was under if it had any, the reason the
-loop stopped in its own words (`BACKLOG EMPTY`, `BLOCKED`, bound reached, worker failure,
-a worker that could not be got past `IN FLIGHT`),
-and — if anything merged without a review because `review.required` is `false` — that fact,
-once, for the whole run.
+Close with the iteration table, the selection arguments and the reviewer roster the run was
+under if it had either, the reason the loop stopped in its own words (`BACKLOG EMPTY`,
+`BLOCKED`, bound reached, worker failure, a worker that could not be got past `IN FLIGHT`),
+every rung found unavailable during the run with its reason, and — if anything merged because
+the roster reached `none` — that fact, once, for the whole run.
 
-The table carries the token cost per iteration, so keep that column in the closing report
-rather than summarising it away. It is what makes the next run comparable to this one, and
-the only signal that separates an expensive iteration from a busy-waiting one.
+The table carries the token cost per iteration and the rung that reviewed each one, so keep
+both columns in the closing report rather than summarising them away. The cost column is what
+makes the next run comparable to this one, and the only signal that separates an expensive
+iteration from a busy-waiting one; the reviewer column is what shows a run that quietly
+degraded from `copilot` to `local` halfway through, which the outcomes alone look identical
+under.
 
 ## Running it on a schedule
 

--- a/plugins/backlog/skills/setup-backlog/SKILL.md
+++ b/plugins/backlog/skills/setup-backlog/SKILL.md
@@ -162,8 +162,17 @@ either way and let the user choose; do not switch the style on their behalf.
 - `merge.label` / `merge.workflow` — `auto-merge` and `auto-merge.yaml`, matching the asset
   step 3 installs. If you change either, change both, plus the `github.event.label.name`
   guard inside the workflow.
-- `review.required` — `true` unless step 5 finds Copilot code review is not enabled; see
-  there.
+- `review.reviewers` — an **ordered roster**, tried in order and failing over on
+  availability. `["copilot"]` is the floor. Offer `["copilot", "local"]` where the App from
+  the section below is configured — a second rung costs nothing until the first one is
+  unavailable, and an exhausted monthly Copilot allowance then costs a rung rather than the
+  run. Add a trailing `"none"` only if the user asks for it; see step 5.
+
+  There is no `required` key any more, and `select-issue.sh` refuses a config that still
+  carries one rather than translating it. If you are diffing an existing config that has it,
+  say so as a migration and give the mapping: `true` becomes `["copilot"]`, `false` becomes
+  `["none"]`, and `["copilot", "local", "none"]` is what the boolean could never express —
+  fail over, then fall back — which is the reason the key changed.
 - `worktreeDir` — `.claude/worktrees`.
 
 Write the result to `.claude/backlog.json`, validated against
@@ -273,6 +282,22 @@ entirely to the cycle's own `finish-issue` step — and give the setup, which ne
    **Read and write**.
 3. Add its App ID as `BACKLOG_APP_ID` and its PEM private key as `BACKLOG_APP_KEY`.
 
+The **same App backs the `local` reviewer**, and that rung needs the credentials somewhere
+else. Repository secrets reach the merge workflow; they do not reach a loop running on a
+laptop. So `BACKLOG_APP_ID` and `BACKLOG_APP_KEY` must also be present in the *environment the
+loop runs in* — the same two names, deliberately — or `local` is unavailable there and falls
+through. `pull_requests: write` is what `POST /repos/{owner}/{repo}/pulls/{pr}/reviews`
+requires, which the permissions above already cover.
+
+Say both halves when you report this. An operator who adds the secrets and stops has a working
+merge workflow and a `local` rung that silently never runs, which reads in a report as a
+Copilot outage that had no fallback.
+
+Minting an installation token needs **`openssl`** as well as `gh` and `jq`, because an App JWT
+is RS256-signed. `scripts/app-token.sh` checks for it and reports its absence as the rung
+being unavailable rather than failing inside a pipeline; mention it if `command -v openssl`
+comes back empty here.
+
 The loop still works without it. Nothing merges unreviewed and no issue goes unclosed — the
 cycle's own close covers that — so this is a degradation, not a blocker. Report it as one.
 
@@ -357,9 +382,19 @@ Report the verdict with its basis attached — "inferred from N recent pull requ
 that instead of guessing, and note that the definitive test is the first real cycle, where
 `backlog:next-issue` requests a review and either gets one or reports `BLOCKED`.
 
-If the evidence says Copilot does not review here, that is what `review.required: false` is
-for. Offer it explicitly as a downgrade, not a default: with it, pull requests merge with no
-review at all, and every run says so in its report.
+If the evidence says Copilot does not review here, **offer a second rung before offering a
+downgrade.** `review.reviewers: ["copilot", "local"]` keeps a review on every pull request
+where a bare `["copilot"]` would block: the `local` rung is an adversarial review by a fresh,
+context-free subagent, posted under the App identity from the section above, and it needs
+nothing from GitHub's Copilot subscription. Its cost is the App's credentials in the loop's
+environment and a subagent per pull request.
+
+`["copilot", "local", "none"]` — or a bare `["none"]` — is the downgrade, and it is a
+different offer. Make it explicitly and never as a default: with `none` in the roster, a pull
+request that no rung could review merges with no review at all, and every run that reaches it
+says so in its report. That is a deliberate downgrade rather than a silent one, which is the
+whole reason `none` has to be spelled out in the roster rather than being what happens when
+the roster runs out.
 
 ## 6. Offer the permission allow-list
 
@@ -445,7 +480,7 @@ and an agent writing its own authorisation is not one:
     "autoMode": {
       "allow": [
         "$defaults",
-        "The backlog loop in this repository is authorized by the repository owner to run unattended. Spawning a subagent per story issue is expected. Landing a pull request once CI passes and Copilot's automated review has landed is the intended workflow: no human approval is required on these pull requests by design, and their absence is not a reason to block. A subagent reporting that it landed such a pull request without human review is reporting the expected outcome, not a policy violation, and must not cause subsequent iterations to be denied."
+        "The backlog loop in this repository is authorized by the repository owner to run unattended. Spawning a subagent per story issue is expected. Landing a pull request once CI passes and the configured automated review has landed is the intended workflow: no human approval is required on these pull requests by design, and their absence is not a reason to block. A subagent reporting that it landed such a pull request without human review is reporting the expected outcome, not a policy violation, and must not cause subsequent iterations to be denied."
       ]
     }
   }
@@ -460,7 +495,8 @@ One report, covering:
    `verify` and `dependencies.style` with the evidence each came from.
 2. The workflow — copied, identical, or differing (with the diff).
 3. Labels — created or already present.
-4. The environment table: squash-only, required status checks, Copilot. Each **ok**,
+4. The environment table: squash-only, required status checks, the reviewer roster and the
+   App credentials the `local` rung needs. Each **ok**,
    **needs a change**, or **needs admin rights**, with the consequence spelled out for
    anything not ok.
 5. Permissions — written where, or declined.


### PR DESCRIPTION
Closes #377

`review` held one boolean. Its two settings were "Copilot gates the merge" and "nothing does",
so a repository whose monthly Copilot allowance had run out could only choose between *no loop*
and *no review* — permanently, in a tracked file, for every future run. `review.reviewers`
replaces it with an ordered roster, tried in order and failing over on **availability**:

```json
"review": { "reviewers": ["copilot", "local", "none"] }
```

## Acceptance criteria

- [x] `review.reviewers` replaces `review.required` in `assets/backlog.schema.json` — ordered,
      non-empty, `minItems: 1`, default `["copilot"]`, each rung documented as what it costs when
      it is unavailable, and `none` legal only last (enforced in `select-issue.sh`, since JSON
      Schema cannot express "only in final position" without a `contains`/`items` contortion that
      reads worse than the check it replaces).
- [x] `scripts/select-issue.sh` reads and validates the roster immediately after the `verify`
      check, and `fail 4`s naming the offending value on an unknown rung, an empty roster, a
      non-array, a missing key, or a `none` that is not last — before any issue is selected.
- [x] A config still carrying `review.required` fails at that same point naming its replacement
      (`true` → `["copilot"]`, `false` → `["none"]`), and a config carrying *both* fails too — the
      half-done migration is the dangerous one, since `required` would sit there looking
      authoritative to whoever next opened the file.
- [x] `scripts/await-review.sh` takes the reviewer as an argument. `copilot` is unchanged;
      `local` discovers its login from the App. Exits now tell **unavailable** (3, advance and
      remember), **refused** (1, `BLOCKED`, do not advance) and **nothing arrived yet** (2,
      re-run, and never remembered) apart.
- [x] A `local` rung runs an adversarial review in a fresh subagent that receives the diff and
      no implementation context, and posts it as a `COMMENT` review with inline comments under a
      GitHub App identity.
- [x] The App credentials are read from `BACKLOG_APP_ID`/`BACKLOG_APP_KEY` — the same names
      `setup-backlog` provisions as repository secrets — and their absence makes the rung
      unavailable at **zero network calls**.
- [x] `openssl` is a checked precondition of the token mint, reported as `app-token: openssl is
      not on PATH` alongside the existing `gh`/`jq` checks.
- [x] Step 7 walks the roster; its exit table states for every outcome whether it advances,
      blocks or completes. Steps 8 and 9 read "the review".
- [x] Step 9's labelling condition is "a review completed on some rung, or the roster reached
      `none`", and reaching `none` is an unreviewed merge stated in the report naming every rung
      tried and why each was unavailable.
- [x] `agents/issue-worker.md` and `skills/next-issue/SKILL.md` both gain the `Agent` tool; a
      worker that cannot spawn one treats `local` as unavailable rather than reviewing its own
      diff.
- [x] The worker's report names the reviewing rung and any rung that refused the request, in the
      line form its driver reads back.
- [x] `run-backlog` accumulates refused rungs and threads them into each subsequent prompt
      verbatim; rungs that merely went silent are re-probed every iteration.
- [x] `run-backlog` accepts `--reviewers <a,b,c>` and its report carries a reviewer column
      alongside the cost column.
- [x] `setup-backlog` writes `review.reviewers`, gives the migration mapping when it diffs a
      config carrying `required`, and its Copilot check offers a second rung *before* the `none`
      downgrade.
- [x] `setup-backlog`'s App section states that the same App backs the `local` reviewer and that
      the credentials must reach the *loop's environment*, not only the repository's secrets.
- [x] `scripts/select-issue_test.sh` covers roster validation against fixtures, no network.
- [x] `scripts/await-review_test.sh` is new — 32 cases, no network.
- [x] `.claude-plugin/plugin.json` bumped to `0.6.0`; its description no longer names Copilot as
      *the* reviewer.

## Judgment calls that shaped the public surface

**The `local` rung is three scripts and a subagent, not one script.** `post-review.sh
--preflight` answers "can this rung run?" with no network call and nothing spawned, the agent
produces the review, `post-review.sh` posts it, and then `await-review.sh <pr> local` waits on
it through **the same gate as every other rung**. That last call looks redundant and is the
point: a posted review is a `reviewed` event on the timeline, so one exit code covers the whole
roster and "was this reviewed?" never becomes something an agent asserts at the end of the
longest part of the cycle.

**The review is always `COMMENT`, never `APPROVE`.** An App approving the pull request the loop
just opened would satisfy a required-review protection rule — the loop manufacturing its own
approval. `COMMENT` says what it found and leaves the gate where it was.

**A refusal does not advance the roster.** Only unavailability does. This is the conservative
reading the issue asks for, and it is why the decline classifier is applied to *every* rung
rather than only to Copilot: the `local` reviewer is instructed to decline in the same words, so
one classifier covers the roster. A rung whose refusal wording is unknown would classify as a
completed review and merge — which is exactly why the generic `bot:<login>` rung stays deferred
to #378, and why `bot:coderabbit-ai` has a fixture asserting it is rejected at selection today.

**The login filter moved out of `gh api --jq` into the second `jq`.** `gh api --jq` takes no
`--arg`, and splicing `backlog-bot[bot]` into the filter text puts `\[` inside a jq string
literal, where it is not a legal escape. The expression then fails *silently* and reads as "no
review yet" — the one failure mode a wait cannot tell from a slow reviewer. There is a fixture
for it (`a local review by the App is a completed review`).

**`inline comments are best-effort`.** GitHub rejects the whole review if any one inline comment
lands on a line the diff did not change, and the reviewer subagent works from a unified diff
rather than the API's position model — so `post-review.sh` retries with the summary alone and
says so on stderr. Losing every finding because one line number was off by a hunk is the outcome
worth avoiding.

**This repository's own config migrated to `["copilot", "local"]`**, not to `[..., "none"]`. It
had to migrate in this PR or `select-issue.sh` would refuse it on the next iteration. Without
`BACKLOG_APP_ID`/`BACKLOG_APP_KEY` in the loop's environment the `local` rung is unavailable and
the effective behaviour is exactly what `required: true` gave — a review still gates every
merge — but the failover is now one environment variable away rather than a schema change away.

Note for whoever runs the loop next: plugin caches are version-keyed, so this only takes effect
once the `0.6.0` cache is installed. A cached `0.5.x` reading the new config finds no
`review.required`; it will not mis-merge (the roster check is in `0.6.0`'s `select-issue.sh`),
but the review step should be watched on the first iteration after the bump.

## Verified

- `dagger check` — pass.
- `bash .github/scripts/verify-affected-modules.sh` — pass (no daggerverse module changed).
- `plugins/backlog/scripts/select-issue_test.sh` — 123 passed, 0 failed (was 108; +15 roster
  cases).
- `plugins/backlog/scripts/await-review_test.sh` — 32 passed, 0 failed (new).
- `plugins/backlog/scripts/await-checks_test.sh` — 15 passed, 0 failed (unchanged).
- `bash -n` on all five scripts.

The three plugin suites are not wired into `dagger check` — a pre-existing gap, not one this
change introduces — so they were run by hand and their counts are above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
