### PR TITLE
story(issue-385): verify at setup that the reviewer App can actually mint a token for this repository

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -164,6 +164,22 @@ and whether Copilot code review is really enabled — reporting what it cannot f
 without repository-admin rights, and offering a second reviewer rung rather than
 a downgrade when Copilot is not there.
 
+The reviewer credential it verifies by **minting a token**, not by checking that
+a variable is exported. Setup is the one moment when a human is present and
+nothing has merged yet, and the mint performs in order the four things that can
+be individually wrong — the key does not sign, the ID and the key are two
+different Apps', the App is not installed on this repository, the installation
+lacks Pull requests: write — each of which gets its own sentence and its own
+remedy, pinned offline by
+[`scripts/app-token_test.sh`](backlog/scripts/app-token_test.sh). All four are
+exit 3 at rung time, because the roster only ever needed to know the rung cannot
+run; the operator needs to know which of the four, so the distinction lives in
+the message. Succeeding also prints the App's login, which is the identity the
+reviews will appear under. The merge credential cannot be checked that way — a
+repository secret's value is unreadable outside a workflow run — so its row
+stays a presence check and says so, and its first real proof is the first real
+merge.
+
 ## Convention
 
 Each plugin is a self-contained directory:

--- a/plugins/backlog/.claude-plugin/plugin.json
+++ b/plugins/backlog/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "backlog",
   "description": "Run a repository's story backlog unattended — one issue at a time, from selection through worktree, verification, pull request, an ordered roster of automated reviewers and label-driven auto merge",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "author": { "name": "z5labs" }
 }

--- a/plugins/backlog/scripts/app-token.sh
+++ b/plugins/backlog/scripts/app-token.sh
@@ -9,7 +9,8 @@
 #
 #        --check   preconditions only; makes no network call
 #        --login   the App's bot login, `<slug>[bot]`
-#        --token   an installation token for this repository
+#        --token   an installation token for this repository, minted only after
+#                  the installation is confirmed to grant Pull requests: write
 #
 # Environment, by default:
 #   BACKLOG_REVIEW_APP_ID   the reviewer App's numeric ID
@@ -84,12 +85,40 @@
 # `openssl` surfacing as an empty signature and a 401 is the failure this check
 # exists to convert into a sentence.
 #
+# Four things can be individually wrong, and each gets its own sentence. They
+# are not variations on one failure: no two of them share a remedy, and a
+# message that hedges between them sends its reader to the wrong settings page.
+#
+#   the key does not sign          `openssl dgst` fails or produces nothing
+#   the ID and the key are         `GET /app` rejects the JWT — the signature is
+#     two different Apps'          good and it is not this App's
+#   the App is not installed       `GET /repos/{owner}/{repo}/installation` 404s
+#     on this repository           with the JWT accepted a call earlier
+#   the installation is missing    the token exchange succeeds and the token it
+#     Pull requests: write         returns cannot post a review
+#
+# `--token` therefore calls `GET /app` on its way through, which `--login`
+# already did and `--token` previously skipped. It costs one cheap JWT request
+# per mint and it buys the second and third rows above being told apart: without
+# it both arrive as a failed installation lookup, and the only honest sentence
+# is "not installed, or the JWT was rejected" — a hedge between "install the App
+# here" and "you exported two halves of two Apps", which have no step in common.
+#
+# The fourth row is checked rather than left to fail later because the failure
+# it produces is a 403 on `POST /pulls/{pr}/reviews` — after the subagent has
+# read the diff and written the review. It stays exit 3, like the others: an
+# installation that cannot post a review is a rung that cannot run, and the
+# roster's job at that point is to fail over rather than to block.
+#
 # Exit codes:
 #   0  fine — for --check, the preconditions hold; otherwise stdout is the answer
 #   3  UNAVAILABLE: the rung is not configured on this machine at all, openssl
-#      is missing, or the App cannot be reached or is not installed on this
-#      repository. The caller treats this as a rung that is down, not as an
-#      error in the work.
+#      is missing, or the App cannot be reached, is not installed on this
+#      repository, or is installed without the one permission the rung uses. The
+#      caller treats this as a rung that is down, not as an error in the work.
+#      One exit code, four sentences: the roster only ever needed to know that
+#      the rung cannot run, and the operator needs to know which of the four it
+#      was, so the distinction lives in the message and not in the code.
 #   4  usage failure, or a credential that is CONFIGURED WRONG rather than
 #      absent — half a pair of names, half a pair of values, or the merge pair
 #      present with no reviewer pair. None of the three is a rung being down, and
@@ -200,7 +229,7 @@ if [ -z "$APP_ID" ]; then
   # Neither pair anywhere: the rung is simply not configured on this machine.
   # This one stays exit 3 and stays free, because it is the answer that lets a
   # roster of ["copilot", "local", "none"] reach `none` instead of blocking.
-  fail 3 "$ID_ENV and $KEY_ENV are not set in the environment"
+  fail 3 "$ID_ENV and $KEY_ENV are not set in the environment, so the local rung is not configured on this machine. This is an absent credential and not a wrong one -- nothing here names an App -- so there is nothing to correct unless the rung is wanted, in which case export the pair"
 fi
 
 case "$APP_ID" in
@@ -250,8 +279,8 @@ PAYLOAD=$(printf '{"iat":%d,"exp":%d,"iss":"%s"}' "$((NOW - 60))" "$((NOW + 540)
 
 UNSIGNED="$(printf '%s' "$HEADER" | b64url).$(printf '%s' "$PAYLOAD" | b64url)"
 SIGNATURE=$(printf '%s' "$UNSIGNED" | openssl dgst -sha256 -sign "$KEYFILE" -binary 2>/dev/null | b64url) \
-  || fail 3 "openssl could not sign the App JWT; check that $KEY_ENV is the reviewer App's RSA private key"
-[ -n "$SIGNATURE" ] || fail 3 "openssl produced no signature; check that $KEY_ENV is the reviewer App's RSA private key"
+  || fail 3 "openssl could not sign the App JWT with the key in $KEY_ENV; it has to be the App's unencrypted RSA private key -- the .pem GitHub hands you when you generate one -- and a truncated paste, a passphrase-protected key or a public key all land here"
+[ -n "$SIGNATURE" ] || fail 3 "openssl produced no signature from the key in $KEY_ENV; it has to be the App's unencrypted RSA private key -- the .pem GitHub hands you when you generate one -- and a truncated paste, a passphrase-protected key or a public key all land here"
 JWT="$UNSIGNED.$SIGNATURE"
 
 # `gh api -H Authorization:` rather than GH_TOKEN, because an App JWT has to be
@@ -259,9 +288,20 @@ JWT="$UNSIGNED.$SIGNATURE"
 # Authorization header the caller supplied alone.
 app_api() { gh api -H "Authorization: Bearer $JWT" "$@"; }
 
+# ------------------------------------------------------------- the app --------
+# `GET /app` is the JWT's own endpoint: it is answered by the App the ID names
+# and needs no installation anywhere, so it asks exactly one question — is this
+# signature this App's? Both modes ask it, and `--token` asks it before looking
+# for an installation on purpose. A JWT that GitHub will not accept and an App
+# that is simply not installed here produce the same 404 from the installation
+# lookup, and the remedies are "check the pair against one App's settings page"
+# and "install the App on this account" — which share no step, so a message that
+# offered both would be wrong for whichever reader acted on it.
+SLUG=$(app_api /app --jq .slug 2>/dev/null) || SLUG=""
+[ -n "$SLUG" ] && [ "$SLUG" != null ] \
+  || fail 3 "the App JWT was rejected by GET /app, so the ID in $ID_ENV and the key in $KEY_ENV are not two halves of one App -- the signature was produced, GitHub just does not accept it for App $APP_ID. Open one App's settings page and take both values from it, or the App has been deleted"
+
 if [ "$MODE" = --login ]; then
-  SLUG=$(app_api /app --jq .slug 2>/dev/null) || SLUG=""
-  [ -n "$SLUG" ] || fail 3 "the App JWT was rejected by GET /app; check $ID_ENV and $KEY_ENV are the same App"
   # A bot's login is its slug plus `[bot]`, and that is the login the review
   # appears under on the timeline — which is what the review gate filters on.
   printf '%s[bot]\n' "$SLUG"
@@ -270,14 +310,41 @@ fi
 
 REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null) || REPO=""
 [ -n "$REPO" ] || fail 3 "cannot resolve the repository slug from gh"
+OWNER=${REPO%%/*}
 
+# Not installed here, with the JWT already known good. This is the multi-account
+# failure, and it is a credential naming the WRONG App rather than a rung nobody
+# configured — the two are both exit 3 and the roster treats them alike, but
+# only one of them is a mistake, and the operator cannot act on a sentence that
+# will not say which they are looking at. So the message names the App that was
+# read, the account it would have to be installed on, and the alternative of
+# exporting the other account's pair instead.
 INSTALL_ID=$(app_api "/repos/$REPO/installation" --jq .id 2>/dev/null) || INSTALL_ID=""
 case "$INSTALL_ID" in
-  ''|null|*[!0-9]*) fail 3 "the reviewer App is not installed on $REPO, or its JWT was rejected; install it with Pull requests at read and write, which is all this rung calls" ;;
+  ''|null|*[!0-9]*)
+    fail 3 "$ID_ENV and $KEY_ENV name the App '$SLUG', and '$SLUG' is not installed on $REPO. The rung IS configured on this machine, so this is a credential pointing at an App that cannot act here rather than an absent one: either install '$SLUG' on the $OWNER account with Pull requests at read and write, which is all this rung calls, or export the pair belonging to the App already installed on $OWNER and name that pair in .claude/backlog.json under review.app.idEnv and review.app.keyEnv" ;;
 esac
 
-TOKEN=$(app_api --method POST "/app/installations/$INSTALL_ID/access_tokens" --jq .token 2>/dev/null) || TOKEN=""
-[ -n "$TOKEN" ] && [ "$TOKEN" != null ] \
-  || fail 3 "the App installation on $REPO issued no access token"
+# One POST, read twice. The response carries the grant beside the token, so
+# asking what the installation may do costs nothing here and a second call
+# everywhere else — and a second POST would mint a second token to throw away.
+RESPONSE=$(app_api --method POST "/app/installations/$INSTALL_ID/access_tokens" 2>/dev/null) || RESPONSE=""
+TOKEN=$(printf '%s' "$RESPONSE" | jq -r '.token // empty' 2>/dev/null) || TOKEN=""
+[ -n "$TOKEN" ] \
+  || fail 3 "the installation of '$SLUG' on $REPO issued no access token"
+
+# `unknown` is the response shape changing under us, and it is deliberately not
+# a failure: the rung works today without this key, and inventing an outage from
+# a field that moved would take down a reviewer that can still review.
+PULLS=$(printf '%s' "$RESPONSE" \
+  | jq -r 'if has("permissions") then (.permissions.pull_requests // "none") else "unknown" end' 2>/dev/null) \
+  || PULLS=unknown
+case "$PULLS" in
+  write|unknown|'') ;;
+  *)
+    GRANT="Pull requests at $PULLS"
+    [ "$PULLS" = none ] && GRANT="no Pull requests permission at all"
+    fail 3 "the installation of '$SLUG' on $REPO grants $GRANT, and the only call this rung makes is POST /repos/$REPO/pulls/{pr}/reviews, which needs write. Set Pull requests to Read and write on that installation -- it is the single permission the rung uses. Left alone, the review is written and then rejected with a 403, after the work of reading the diff has already been done" ;;
+esac
 
 printf '%s\n' "$TOKEN"

--- a/plugins/backlog/scripts/app-token_test.sh
+++ b/plugins/backlog/scripts/app-token_test.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+#
+# app-token_test.sh — the fixture corpus for app-token.sh's four sentences.
+#
+# The credential states that never reach GitHub are pinned in
+# `await-review_test.sh`, through all three doors that read them. This file is
+# the other half: what the mint says once it does reach GitHub, where four
+# different things can be wrong and no two of them share a remedy.
+#
+#   the key does not sign            regenerate or re-paste the .pem
+#   the ID and the key are two       take both values off one App's settings
+#     different Apps'                  page
+#   the App is not installed here    install it on this account, or export the
+#                                      other account's pair
+#   the installation lacks           raise Pull requests to Read and write
+#     Pull requests: write
+#
+# All four are exit 3, because the roster only ever needed to know that the rung
+# cannot run. That is exactly why they are asserted on the MESSAGE: the exit
+# code cannot tell them apart and was never meant to, so the distinction lives
+# in a string, and a string with no test on it is a string that drifts. The
+# case that matters most is the third — a credential naming an App installed on
+# the operator's *other* account is a misconfiguration, and reads identically to
+# an unconfigured rung unless the sentence says otherwise.
+#
+# Offline. `gh` is a stub answering from files, and the key is generated at run
+# time; there is no key material in this file.
+#
+# Run: plugins/backlog/scripts/app-token_test.sh
+# Exit 0 when every case matches, 1 otherwise.
+
+set -uo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+SUT="$HERE/app-token.sh"
+[ -x "$SUT" ] || { printf 'app-token.sh is not executable at %s\n' "$SUT" >&2; exit 1; }
+
+pass=0
+fail=0
+
+ok()  { pass=$((pass + 1)); printf '  ok   %-58s [%s]\n' "$1" "$2"; }
+bad() { fail=$((fail + 1)); printf '  FAIL %-58s %s\n' "$1" "$2"; }
+
+if ! command -v openssl >/dev/null 2>&1; then
+  printf 'openssl is not on PATH; every case here signs a JWT\n' >&2
+  exit 1
+fi
+
+SCRATCH=$(mktemp -d) || { printf 'cannot create a scratch directory\n' >&2; exit 1; }
+trap 'rm -rf "$SCRATCH"' EXIT
+mkdir -p "$SCRATCH/bin" "$SCRATCH/fx"
+FX="$SCRATCH/fx"
+
+openssl genrsa -out "$SCRATCH/app.pem" 2048 2>/dev/null \
+  || { printf 'cannot generate a test key\n' >&2; exit 1; }
+# A public key signs nothing, which is the cheapest honest way to reach the
+# openssl branch without shipping a corrupt PEM in a tracked file.
+openssl rsa -in "$SCRATCH/app.pem" -pubout -out "$SCRATCH/app.pub" 2>/dev/null
+
+# An empty fixture is the endpoint failing; a non-empty one is what it answers.
+# `--jq` is the caller's, so the stub prints what gh would have printed after
+# it — a bare value for the two `--jq` calls, and the whole body for the mint,
+# which app-token.sh now parses itself so it can read the grant beside the
+# token.
+cat >"$SCRATCH/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$FX/calls"
+case "$*" in
+  *"repo view"*)   printf 'acme/widgets\n'; exit 0 ;;
+  *access_tokens*) [ -s "$FX/token" ]   || exit 1; cat "$FX/token";   exit 0 ;;
+  *installation*)  [ -s "$FX/install" ] || exit 1; cat "$FX/install"; exit 0 ;;
+  */app*)          [ -s "$FX/app" ]     || exit 1; cat "$FX/app";     exit 0 ;;
+esac
+exit 1
+STUB
+chmod +x "$SCRATCH/bin/gh"
+
+# Every reviewer and merge name cleared, so a case is defined by what it sets
+# rather than by what the shell running the tests happened to export.
+CLEAR=(env -u BACKLOG_APP_ID -u BACKLOG_APP_KEY
+           -u BACKLOG_REVIEW_APP_ID -u BACKLOG_REVIEW_APP_KEY)
+
+# The App as GitHub would answer for it. Reset before each case.
+fixture() { # <slug> <installation id> <token body>
+  printf '%s' "$1" >"$FX/app"
+  printf '%s' "$2" >"$FX/install"
+  printf '%s' "$3" >"$FX/token"
+  : >"$FX/calls"
+}
+
+cred_env=(BACKLOG_REVIEW_APP_ID=123456)
+
+OUT=""
+ERR=""
+RC=0
+mint() { # <mode>
+  ( cd "$SCRATCH" && PATH="$SCRATCH/bin:$PATH" FX="$FX" \
+      exec "${CLEAR[@]}" "${cred_env[@]}" "$SUT" "$@" ) \
+    >"$SCRATCH/out" 2>"$SCRATCH/err"
+  RC=$?
+  OUT=$(cat "$SCRATCH/out")
+  ERR=$(cat "$SCRATCH/err")
+}
+
+# says <name> <expected exit> <substring the message must carry>...
+says() {
+  local name=$1 want=$2; shift 2
+  local needle missing=""
+  if [ "$RC" != "$want" ]; then
+    bad "$name" "want exit $want got $RC: $(printf '%s' "$ERR$OUT" | tr '\n' ' ' | cut -c1-140)"
+    return
+  fi
+  for needle in "$@"; do
+    printf '%s' "$ERR" | grep -qF -- "$needle" || missing="$missing '$needle'"
+  done
+  if [ -n "$missing" ]; then
+    bad "$name" "exit $want but the message never says$missing"
+  else
+    ok "$name" "exit $want"
+  fi
+}
+
+never_says() { # <name> <substring the message must NOT carry>
+  if printf '%s' "$ERR" | grep -qF -- "$2"; then
+    bad "$1 — and is not the other one" "the message still says '$2'"
+  else
+    ok "$1 — and is not the other one" "never says '$2'"
+  fi
+}
+
+calls() { grep -cE "$1" "$FX/calls" 2>/dev/null || true; }
+
+KEY="$SCRATCH/app.pem"
+GOOD_TOKEN='{"token":"ghs_fixture","permissions":{"pull_requests":"write"}}'
+
+# ------------------------------------------------------------- it works -------
+printf '\nthe mint, when everything is right\n'
+
+cred_env=(BACKLOG_REVIEW_APP_ID=123456 "BACKLOG_REVIEW_APP_KEY=$KEY")
+
+fixture reviewer-bot 4242 "$GOOD_TOKEN"
+mint --login
+if [ "$RC" = 0 ] && [ "$OUT" = 'reviewer-bot[bot]' ]; then
+  ok '--login is the bot login the review lands under' "$OUT"
+else
+  bad '--login is the bot login the review lands under' "exit $RC, stdout '$OUT'"
+fi
+
+fixture reviewer-bot 4242 "$GOOD_TOKEN"
+mint --token
+if [ "$RC" = 0 ] && [ "$OUT" = ghs_fixture ]; then
+  ok '--token is the token and nothing else' 'exit 0'
+else
+  bad '--token is the token and nothing else' "exit $RC, stdout '$OUT'"
+fi
+# One POST. The grant is read out of the response the mint already had, so
+# asking what the installation may do must not mint a second token to discard.
+if [ "$(calls access_tokens)" = 1 ]; then
+  ok 'the grant check costs no second mint' 'one POST'
+else
+  bad 'the grant check costs no second mint' "$(calls access_tokens) POSTs"
+fi
+
+# ----------------------------------------------------- the four sentences -----
+printf '\nthe four things that can be individually wrong\n'
+
+# 1. The key does not sign. No network at all: a JWT that was never produced
+#    cannot be rejected, so nothing here should reach GitHub.
+fixture reviewer-bot 4242 "$GOOD_TOKEN"
+cred_env=(BACKLOG_REVIEW_APP_ID=123456 "BACKLOG_REVIEW_APP_KEY=$SCRATCH/app.pub")
+mint --token
+says 'a key that will not sign names the key variable' 3 \
+  'BACKLOG_REVIEW_APP_KEY' 'unencrypted RSA private key'
+if [ "$(calls '/app|installation|access_tokens')" = 0 ]; then
+  ok 'a key that will not sign costs no App call' 'no request'
+else
+  bad 'a key that will not sign costs no App call' "reached $(tr '\n' ' ' <"$FX/calls")"
+fi
+
+cred_env=(BACKLOG_REVIEW_APP_ID=123456 "BACKLOG_REVIEW_APP_KEY=$KEY")
+
+# 2. The ID and the key are two different Apps'. `GET /app` is what says so, and
+#    it is asked before the installation lookup precisely so this does not
+#    arrive as "not installed".
+fixture '' 4242 "$GOOD_TOKEN"
+mint --token
+says 'a rejected JWT is two Apps, not one' 3 \
+  'not two halves of one App' 'BACKLOG_REVIEW_APP_ID' 'BACKLOG_REVIEW_APP_KEY'
+never_says 'a rejected JWT is two Apps, not one' 'is not installed on'
+if [ "$(calls installation)" = 0 ]; then
+  ok 'a rejected JWT never reaches the installation lookup' 'no request'
+else
+  bad 'a rejected JWT never reaches the installation lookup' 'it looked anyway'
+fi
+
+fixture '' 4242 "$GOOD_TOKEN"
+mint --login
+says '--login answers the same way' 3 'not two halves of one App'
+
+# 3. The App is not installed here — the multi-account failure. The sentence has
+#    to name the App that was read, the account it would have to be installed
+#    on, and the alternative of exporting the other account's pair, because the
+#    exit code it shares with an unconfigured rung says none of that.
+fixture reviewer-bot '' "$GOOD_TOKEN"
+mint --token
+says 'not installed names the App, the account and the pair' 3 \
+  "the App 'reviewer-bot'" 'not installed on acme/widgets' \
+  'on the acme account' 'review.app.idEnv'
+never_says 'not installed names the App, the account and the pair' \
+  'not configured on this machine'
+
+# 4. The installation is missing the one permission the rung uses. Checked here
+#    rather than left to a 403 on the review POST, which arrives after a
+#    subagent has read the diff and written the review.
+fixture reviewer-bot 4242 '{"token":"ghs_fixture","permissions":{"pull_requests":"read"}}'
+mint --token
+says 'a read-only installation says which grant it has' 3 \
+  'grants Pull requests at read' 'needs write'
+if [ -z "$OUT" ]; then
+  ok 'a rejected grant prints no token' 'stdout empty'
+else
+  bad 'a rejected grant prints no token' "stdout '$OUT'"
+fi
+
+fixture reviewer-bot 4242 '{"token":"ghs_fixture","permissions":{"issues":"read"}}'
+mint --token
+says 'no Pull requests grant at all says that instead' 3 \
+  'no Pull requests permission at all'
+
+# ------------------------------------------------------- and what is not ------
+printf '\nwhat must not be read as a failure\n'
+
+# A response shape that moved is not an outage. The rung worked before anything
+# read `permissions`, and inventing unavailability from a field that changed
+# would retire a reviewer that can still review.
+fixture reviewer-bot 4242 '{"token":"ghs_fixture"}'
+mint --token
+if [ "$RC" = 0 ] && [ "$OUT" = ghs_fixture ]; then
+  ok 'a response carrying no permissions still mints' 'exit 0'
+else
+  bad 'a response carrying no permissions still mints' "exit $RC, stdout '$OUT'"
+fi
+
+# The counterpart to case 3, and the reason its wording had to change: both are
+# exit 3, and only one of them is a mistake.
+fixture reviewer-bot 4242 "$GOOD_TOKEN"
+cred_env=()
+mint --token
+says 'no credentials at all is an unconfigured rung' 3 \
+  'not configured on this machine' 'an absent credential and not a wrong one'
+never_says 'no credentials at all is an unconfigured rung' 'is not installed on'
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/plugins/backlog/skills/setup-backlog/SKILL.md
+++ b/plugins/backlog/skills/setup-backlog/SKILL.md
@@ -301,6 +301,7 @@ other.
 | read by | the merge workflow, a `pull_request_target` job that checks out nothing | `scripts/app-token.sh`, inside an unattended agent that runs arbitrary shell |
 | needs | Contents, Pull requests and Issues at **write** | **Pull requests: write, and nothing else** |
 | its absence costs | branch cleanup after merge, and the linked-issue close | the `local` reviewer rung |
+| checked here by | the two names being present, which is all a secret store will show anyone | **minting a token**, which is the whole test |
 
 The grant differs because the *exposure* differs, not because the identity does. The reviewer
 key sits in a process environment anything can print with `env`, and the only
@@ -330,6 +331,20 @@ gh secret list --repo <repo> --json name --jq '[.[].name]'
 `BACKLOG_APP_ID` and `BACKLOG_APP_KEY` must both be present. A `403` here is **needs admin
 rights**, not a failure.
 
+**This is a presence check and nothing more, and the row has to say so.** A repository
+secret's value is readable only from inside a workflow run — that is the entire point of the
+store — so nothing here can sign a JWT with `BACKLOG_APP_KEY` the way the reviewer row below
+does. Two names present cannot tell a working App from an App ID and a PEM belonging to two
+different Apps, or from an App nobody ever installed on this repository. It is the strongest
+statement available, and it is a **weaker statement than the reviewer row's**; reporting the
+two side by side as if they were equally proven is the part that misleads.
+
+Say where the real proof is instead: the merge credential is verified by **the first real
+merge**, and the `::warning` in `assets/auto-merge.yaml` covers only the case where
+`BACKLOG_APP_ID` is unset — a credential that is present and wrong fails the
+`Mint a GitHub App installation token` step instead, which is loud but only once a pull
+request has reached it.
+
 When they are missing, report it as **needs a change** with the consequence stated — merged
 branches will accumulate with nothing to collect them, and the linked-issue close falls
 entirely to the cycle's own `finish-issue` step — and give the setup, which needs a human:
@@ -354,28 +369,88 @@ The `local` rung posts its review under an App identity, and it reads that App's
 private key from the *environment the loop runs in* — repository secrets reach the merge
 workflow, and they do not reach a loop running on a laptop. **Which two variables** it reads
 is `review.app` from step 1, defaulting to `BACKLOG_REVIEW_APP_ID` and
-`BACKLOG_REVIEW_APP_KEY`. So this one is not a repository lookup; ask the rung itself, which
-answers for the cost of three environment reads and no network call — passing the configured
-names, if the config carries any:
+`BACKLOG_REVIEW_APP_KEY`. So this one is not a repository lookup.
+
+**Mint a token.** Not "are the names exported?" — that answer was never in doubt, and a name
+is not a credential. Setup is the one moment in this plugin's life when a human is present
+and nothing has been merged yet, and the alternative to spending it here is learning the same
+thing from a line in a worker report, after the iterations have landed. Ask the rung to do
+the thing it will be asked to do in earnest:
 
 ```
-"${CLAUDE_PLUGIN_ROOT}/scripts/app-token.sh" --check
-"${CLAUDE_PLUGIN_ROOT}/scripts/app-token.sh" --id-env <review.app.idEnv> --key-env <review.app.keyEnv> --check
+"${CLAUDE_PLUGIN_ROOT}/scripts/app-token.sh" --login
+"${CLAUDE_PLUGIN_ROOT}/scripts/app-token.sh" --token >/dev/null
 ```
 
-- exit 0 → **ok**. The rung can run here.
-- exit 3 → **needs a change**, and the message says which: the reviewer pair is absent, or
-  `openssl` is not on PATH.
-- exit 4 → **needs a change**, and it is one of the two configuration mistakes below rather
-  than an absence. Quote the message; it names the variable to set.
+with `--id-env <review.app.idEnv> --key-env <review.app.keyEnv>` in front of the mode where
+the config carries a `review.app` block.
+
+**Redirect `--token` to `/dev/null`, and never put its output in the report.** What it prints
+is a live installation token, good for an hour and carrying Pull requests: write. The exit
+code is the whole answer; the token is a credential that has no business in a transcript.
+
+Two commands, because they prove two different things and their failures share no remedy.
+`--login` signs the JWT and calls `GET /app`: it proves the key signs and that the ID and the
+key are one App, and it prints who that App is. `--token` goes on to
+`GET /repos/<repo>/installation` and the token exchange: it proves the App is installed
+**here**, and that the installation grants what the rung actually calls.
+
+- **Both exit 0 → ok.** Report the login `--login` printed — `<slug>[bot]` — and say what it
+  is: **the identity every `local` review on this repository will be authored under**, the
+  name a human will see on the timeline beside the pull request. It is worth printing for its
+  own sake; an operator who expected a different bot there has learned something no exit code
+  would have told them.
+- **Any failure → needs a change**, with the matching sentence and remedy below. A `403` from
+  `gh` in the middle of it is **needs admin rights** as everywhere else: report the mint as
+  unverified rather than as failed.
+
+Four things can be individually wrong, and each has its own remedy. All four are exit 3,
+because the roster only ever needed to know the rung cannot run — so read the **message**,
+never the code, and quote it:
+
+| the message says | what is wrong | the remedy |
+| --- | --- | --- |
+| `openssl could not sign` / `produced no signature` | the key in the key variable is not the App's unencrypted RSA private key — a truncated paste, a passphrase-protected key, or a public key | download a fresh `.pem` from the App's settings page and re-export it, or point the variable at the file rather than pasting it |
+| `not two halves of one App` | the signature was produced and GitHub will not accept it for that App ID: the ID names one App and the key belongs to another | open **one** App's settings page and take both values from it. If the App was deleted, there is nothing to fix — create one |
+| `'<slug>' is not installed on <repo>` | the credential names a real App that cannot act here. This is the two-account failure, and it is a **wrong** credential rather than an absent one | install that App on the repository's account with **Pull requests: read and write**, or export the pair belonging to the App already installed there and name it in `review.app` — see the section below |
+| `grants Pull requests at read` / `no Pull requests permission at all` | the App is installed here and the installation is missing the one permission the rung uses | set Pull requests to **Read and write** on the installation. Left alone this surfaces as a 403 on the review POST, after a subagent has read the diff and written the review |
+
+Three more results are not the mint failing, and are reported differently:
+
+- `are not set in the environment ... not configured on this machine` → the rung is simply
+  **not configured here**, which is an absence and not a mistake. Report it as **needs a
+  change** only if the user wants the `local` rung; otherwise it is the expected state of a
+  machine that has never had an App, and the roster advances past it at zero cost. The
+  message says so in as many words, which is what keeps it from reading like the
+  wrong-App row above.
+- `openssl is not on PATH` → **this row's cause, and report it here.** It is not a separate
+  environment note for the operator to connect back to the reviewer themselves: an App JWT is
+  RS256-signed, so without `openssl` the `local` rung cannot run on this machine whatever the
+  credentials say. Install it, and the rest of the row becomes answerable.
+- **exit 4** → a configuration mistake rather than an absence: half the reviewer pair
+  exported, half a pair of *names* passed, or the merge pair present with no reviewer pair.
+  These are the two cases spelled out below; quote the message, which names the variable.
 
 Every message names the variable this repository is configured to read, never the default —
 so quote it verbatim. Paraphrasing it back to `BACKLOG_REVIEW_APP_ID` on a repository whose
 config says `Z5LABS_REVIEW_APP_ID` sends the user to export a variable nothing will read.
 
-This checks *your* environment, which is the loop's only if the user runs the loop from the
-same shell. Say which you checked, and ask if the loop runs somewhere else — a CI job, another
-machine — because there the answer is theirs to give and not yours to look up.
+**The mint is the only thing this check puts on the network.** Nothing else here goes looking
+for the reviewer App: no permissions endpoint, no installation listing, no scan for other Apps
+the account might own. The two commands above are the whole check, and they are enough because
+the mint already performs, in order, every step that can be individually wrong.
+
+**And it must never fail `setup-backlog`.** Capture the exit code, put the row in the report,
+and carry on with the rest of step 5 — a reviewer App that cannot mint is one row of a report,
+and the squash setting, the required checks and the Copilot verdict are all still worth
+printing. A setup run that stops here has told the operator less than one that finishes.
+
+This mints from *your* environment, which is the loop's only if the user runs the loop from
+the same shell. Say which you checked, and ask if the loop runs somewhere else — a CI job,
+another machine — because there the answer is theirs to give and not yours to look up. What
+you can hand them for that machine is `app-token.sh --check`, which is the precondition block
+alone and makes no request; it is a weaker answer than the mint, and on a host you cannot
+reach it is the only one available.
 
 Its setup, when it is its own App:
 
@@ -436,8 +511,8 @@ leave the union grant on the more exposed key with the decision written down now
 
 **The break every existing installation hits.** An environment that exports `BACKLOG_APP_ID`
 or `BACKLOG_APP_KEY` and *neither* reviewer variable is exit 4 with a sentence naming both —
-not a rung quietly going down. That is the `--check` above, and it is also what the first
-`local` review after this update does if nobody runs it. Report it whenever you see it: it
+not a rung quietly going down. The mint above stops there and says so, and it is also what the
+first `local` review after this update does if nobody runs it. Report it whenever you see it: it
 happens once, and the fix is the two exports above. Exporting half the reviewer pair is exit 4
 too, for the same reason — nobody sets one on purpose.
 
@@ -450,10 +525,13 @@ Say both credentials when you report this. An operator who adds the secrets and 
 working merge workflow and a `local` rung that silently never runs, which reads in a report as
 a Copilot outage that had no fallback.
 
-Minting an installation token needs **`openssl`** as well as `gh` and `jq`, because an App JWT
-is RS256-signed. `scripts/app-token.sh` checks for it and reports its absence as the rung
-being unavailable rather than failing inside a pipeline; mention it if `command -v openssl`
-comes back empty here.
+There is deliberately **no separate `openssl` note here.** Minting an installation token needs
+it as well as `gh` and `jq`, because an App JWT is RS256-signed — and that fact belongs to the
+reviewer row, which is the only thing in this plugin that signs one. `app-token.sh` reports its
+absence as that rung being unavailable, so it arrives already attached to the row it explains.
+A tool note in its own paragraph is a fact the operator has to connect back to the reviewer
+themselves, and the one who does not connect it reads a missing `openssl` and a broken reviewer
+as two problems.
 
 The loop still works with neither credential and no `openssl`. Nothing merges unreviewed and no
 issue goes unclosed — the cycle's own close covers that — so this is a degradation, not a
@@ -648,13 +726,29 @@ One report, covering:
 2. The workflow — copied, identical, or differing (with the diff).
 3. Labels — created or already present.
 4. The environment table: squash-only, required status checks, the reviewer roster, and the
-   two App credentials as **two rows with two consequences** —
-   `BACKLOG_APP_ID`/`BACKLOG_APP_KEY` as repository secrets (Contents, Pull requests and Issues
-   at write; absent, it costs branch cleanup and the linked-issue close) and the reviewer pair
-   in the loop's environment (Pull requests: write only; absent, it costs the `local` rung).
-   Never one row for both: they can be one App and they are still two rows, because they are
-   configured, exposed and rotated separately. Each **ok**, **needs a change**, or **needs
+   two App credentials as **two rows with two consequences**. Never one row for both: they can
+   be one App and they are still two rows, because they are configured, exposed, rotated —
+   and, as of this check, *verified* — separately. Each **ok**, **needs a change**, or **needs
    admin rights**, with the consequence spelled out for anything not ok.
+
+   **The merge credential** — `BACKLOG_APP_ID`/`BACKLOG_APP_KEY` as repository secrets;
+   Contents, Pull requests and Issues at write; absent, it costs branch cleanup and the
+   linked-issue close. Say in the row that this is a **presence check only**: the private key
+   is unreadable outside a workflow run, so nothing at setup can mint from it, and its first
+   real proof is the first real merge. Two names present is the strongest available statement
+   and it is a weaker one than the row below.
+
+   **The reviewer credential** — the pair in the loop's environment; Pull requests: write and
+   nothing else; absent, it costs the `local` rung. This row carries the **result of an actual
+   mint**, so say which of the two it is. On **ok**, print the App's login and name it as the
+   identity `local` reviews on this repository will be authored under. On a failure, give the
+   one sentence and the one remedy that match the message — a key that will not sign, an ID and
+   key from two Apps, an App not installed here, or an installation without Pull requests:
+   write — and never the other three.
+
+   The asymmetry is the point of showing both: one row was proven and one was looked up, and a
+   report that presents them as equally checked has told its reader something untrue about the
+   merge side.
 
    Name the reviewer pair by the variables **this repository** reads — `review.app`'s two
    names, or the defaults where it has no such block. A report naming the defaults on a


### PR DESCRIPTION
Closes #385

`setup-backlog` checked that the App credentials **exist**. It never checked that they
**work** — a `gh secret list` name lookup on the merge side, and nothing at all on the
reviewer side. Neither can tell a working credential from one naming an App that was never
installed on this repository, which is the failure an operator with two accounts hits, and
which reaches them as exit 3 mid-run: UNAVAILABLE, a rung that fails over, read after the
iterations have landed.

## Minting is the whole test

`skills/setup-backlog/SKILL.md` now mints, as two commands that prove two different things:

- `--login` signs the JWT and calls `GET /app` — the key signs, and the ID and the key are
  one App — and prints the login **every `local` review on this repository will be authored
  under**.
- `--token >/dev/null` goes on to the installation lookup and the token exchange — the App is
  installed *here*, and the installation grants what the rung calls. Its output is a live
  installation token, so the skill says in as many words to discard it and never to put it in
  the report.

Four failures, four sentences, four remedies, in a table the report reads from: the key does
not sign, the ID and the key are two different Apps', the App is not installed here, the
installation lacks `pull_requests: write`.

## Two distinctions in `scripts/app-token.sh`

- **`--token` calls `GET /app` before the installation lookup.** Without it, a rejected JWT
  and an App that is simply not installed both arrive as the same 404, and the only honest
  message hedges between "check the pair against one App's settings page" and "install the App
  on this account" — which share no step. Costs one cheap JWT request per mint.
- **The token exchange's response is read for `permissions.pull_requests`.** One POST, read
  twice. An installation missing the rung's single permission says so here rather than as a
  403 on `POST /pulls/{pr}/reviews`, after a subagent has read the diff and written the review.
  A response carrying no `permissions` key at all still mints — a shape that moved is not an
  outage.

Not-installed now names the App, the account it would have to be installed on, and the
alternative pair to export; the unconfigured case says it is an absent credential and not a
wrong one. **Exit codes are unchanged** — all of it is still 3, because the roster only ever
needed to know the rung cannot run. #377 is not re-litigated.

## The merge credential says what it is

Its private key is unreadable outside a workflow run, so nothing at setup can mint from it.
Its row now states that it is a presence check only, that it is a *weaker* check than the
reviewer's, and that its first real proof is the first real merge — rather than sitting beside
the reviewer's as if equally proven. `openssl` is folded into the reviewer row as its cause
rather than left as a separate note to connect back to it, and a failed mint never fails
`setup-backlog`.

## Verification

`plugins/backlog/scripts/app-token_test.sh` is new — 17 offline cases pinning the four
sentences, since an exit code that cannot tell them apart leaves the distinction living in a
string. It asserts each message carries its own wording, that not-installed and unconfigured
never read as each other, that a rejected JWT never reaches the installation lookup, that the
grant check costs no second mint, and that a rejected grant prints no token.

```
app-token_test.sh    17 passed, 0 failed
await-review_test.sh 79 passed, 0 failed
select-issue_test.sh 153 passed, 0 failed
await-checks_test.sh 15 passed, 0 failed
```

`plugins/backlog/.claude-plugin/plugin.json` bumped to `0.10.0` — the plugin cache is
version-keyed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
