### PR TITLE
fix(update-dagger): stop the check-enumeration guard aborting on a checkless module

### DIFF
--- a/.github/workflows/update-dagger.yml
+++ b/.github/workflows/update-dagger.yml
@@ -123,7 +123,16 @@ jobs:
               echo "::error::Module.checks for $mod diverges from 'dagger check -l' at this Dagger version; the planner may under-run CI. Reconcile before merging." >&2
               rc=1
             fi
-            count=$(( count + $(printf '%s\n' "$stable" | grep -c .) ))
+            # Plenty of modules legitimately declare no checks of their own --
+            # the root module and every service module keep theirs in a sibling
+            # tests/ module -- so an empty $stable is the normal case, not a
+            # failure. Count with awk rather than `grep -c .`: grep exits 1 when
+            # it matches nothing, that status becomes the status of the
+            # assignment, and the step runs under `bash -e` (a GitHub default
+            # that `set -uo pipefail` does not turn off), so the first
+            # checkless module would abort the whole guard with a bare exit 1 --
+            # no diff, no ::error::, nothing to read. awk always exits 0.
+            count=$(( count + $(printf '%s\n' "$stable" | awk 'NF { n++ } END { print n + 0 }') ))
           done < <(find . -name dagger.json -not -path './.git/*' | sort)
           [ "$rc" -eq 0 ] && echo "check enumeration agrees ($count checks)"
           exit "$rc"


### PR DESCRIPTION
## What happened

The [Update Dagger run for v0.21.8](https://github.com/z5labs/devex/actions/runs/31656190743) failed in **`Verify Module.checks still matches 'dagger check -l'`** — without reporting a single divergence, and without reaching 53 of the 55 modules it is meant to compare.

## Root cause

The guard tallies how many checks it verified:

```bash
count=$(( count + $(printf '%s\n' "$stable" | grep -c .) ))
```

`grep -c` exits **1** when it matches nothing. That status becomes the status of the assignment — the exit status of a simple command consisting only of assignments is the status of its last command substitution. The step runs under GitHub's default `shell: /usr/bin/bash -e {0}`, and `set -uo pipefail` does **not** turn `-e` off. So the assignment took the whole step down.

An empty `$stable` is the normal case, not an error: the root module and every service module keep their checks in a sibling `tests/` module. `find` walks `./dagger.json` then `./daggerverse/bruno`, and bruno is the first module with no checks of its own — so the guard died three seconds in, on its second module, leaving a bare `Process completed with exit code 1` with no diff and no `::error::` to read.

Reproduced in isolation:

```console
$ bash -e -c 'set -uo pipefail; count=0; stable=""; count=$(( count + $(printf "%s\n" "$stable" | grep -c .) )); echo reached'
EXIT=1        # "reached" never prints
```

Confirmed against v0.21.8 that bruno is genuinely checkless on both sides — `dagger check -l -m ./daggerverse/bruno` prints only the `Name Description` header, and the `Module.checks` enumeration is likewise empty. The two agreed; only the counting failed.

## Fix

Count with `awk`, which always exits 0:

```bash
count=$(( count + $(printf '%s\n' "$stable" | awk 'NF { n++ } END { print n + 0 }') ))
```

`-e` stays deliberately rather than adding `set +e` — it is what makes a genuine `dagger check` crash fail loudly instead of silently reading as "no checks, agrees". The bug was the counting, not the strictness. A comment at the call site records the trap.

This is the only `grep -c` of its kind across `.github/workflows/`.

## Verification

Ran the fixed step over all 55 tracked modules against Dagger v0.21.8 locally. It completes, and `Module.checks` agrees with `dagger check -l` everywhere:

```
rc=0 modules=55 checks=71
STEP EXIT=0
```

So the v0.21.8 bump has no real divergence — the guard just never survived a checkless module. Since `workflow_dispatch` reads the workflow from the default branch, this needs to land before a re-run of *Update Dagger* gets past the step.

> [!NOTE]
> The commit message on this branch says "84 modules"; the correct count is 55, as above. A force-push to correct it is blocked by a local permission rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)