### PR TITLE
story(z5labs): verify the codegen constraints the new module API depends on

### DIFF
--- a/daggerverse/CLAUDE.md
+++ b/daggerverse/CLAUDE.md
@@ -244,6 +244,84 @@ cache field and is unaffected — which is why `Client.Export` (returns a
 `Chan`, `Default`, `Package`, and the rest of the Go keyword list as
 scalar-returning method names.
 
+The **object**-returning counterpart is safe, and this has now been measured
+rather than assumed (devex#402, Dagger v0.21.8). A method
+`func (m *Z5labs) Go(source *dagger.Directory) *Go` — keyword as both the
+method name and the returned object's name — generates, compiles and runs in
+a consumer module. The returned object namespaces to `<Module><Object>`:
+
+```go
+func (r *Z5Labs) Go(source *Directory) *Z5LabsGo   // consumer binding
+```
+
+so the keyword never appears anywhere it could be parsed as one. Adding a
+scalar-returning `Go` method to *any* object in the same module breaks the
+consumer immediately, with `expected '}', found 'go'` — so the rule is about
+the return type, not the name in isolation. A keyword-named object with only
+object-returning and non-keyword scalar methods is fine.
+
+### Unexported types are where module-object state belongs
+
+A module object's fields are serialized across every call boundary, which
+raises the question of whether a field holding a slice of structs needs
+those structs registered as Dagger object types. It does not, and unexported
+is strictly the better choice (measured in devex#402):
+
+```go
+type App struct {
+    Version  string     // +private
+    Variants []*variant // +private
+}
+
+type variant struct {
+    Platform  dagger.Platform
+    Container *dagger.Container
+    Documents []document
+}
+```
+
+`variant` and `document` are unexported, so **nothing about them reaches the
+schema** — the consumer's generated bindings contain no `Z5LabsVariant` and
+no `Z5LabsDocument`, only the methods of `App` itself. The state still
+round-trips intact, including `*dagger.Container` and `*dagger.File` fields,
+which travel as IDs and resolve on the far side. Verified both by chained
+resolution and by an explicit `ID()` → `LoadZ5LabsAppFromID()` round trip,
+across three platforms, with the containers and files still readable
+afterwards.
+
+Two consequences:
+
+- **The field-naming rules do not apply to unexported types.** A field
+  literally named `Type` on `document` — the name that breaks dependency
+  codegen outright on an *exported* struct — is harmless here, because there
+  is no schema object for it to collide in. Confirmed by trying it. Name
+  these fields for the code, not for the generator.
+- Their fields still need to be **exported**, and getting this wrong fails
+  silently and late. The round trip is `encoding/json`, so an unexported
+  field is dropped on the way out and comes back zero. Codegen still
+  succeeds and the consumer still compiles; the module then panics at
+  runtime with `invalid memory address or nil pointer dereference` the first
+  time it touches the field — measured, with a lower-cased `file
+  *dagger.File`. The struct is unexported; its fields are not.
+
+Prefer this to registering a helper object type. A registered one adds a
+schema object with no methods that a caller can see and must ignore, and it
+drags the naming rules along with it.
+
+### `[]dagger.Platform` parameters carry variants intact
+
+Nothing in this repo took a `dagger.Platform` as an *input* before — every
+use constructed one — so it was unverified whether a slice of them survived
+a call boundary. It does, order preserved and variant preserved:
+`linux/amd64`, `linux/arm64` and `linux/arm/v7` all arrive byte-identical to
+what the caller passed (devex#402). `Platform` is a string scalar in the
+schema, so the three-component variant form is not special-cased anywhere.
+
+One ergonomic wrinkle when round-tripping a *dependency's* object by ID: the
+generated `ID()` on a dependency type returns the generic `dagger.ID`, not
+the specific one, so `LoadZ5LabsAppFromID` needs an explicit
+`dagger.Z5LabsAppID(id)` conversion. Own-module types are unaffected.
+
 ### Method parameters named `r` collide with the generated receiver
 
 The codegen renders methods as `func (r *<Type>) Method(<args>) ...`,

--- a/daggerverse/CLAUDE.md
+++ b/daggerverse/CLAUDE.md
@@ -246,31 +246,48 @@ scalar-returning method names.
 
 The **object**-returning counterpart is safe, and this has now been measured
 rather than assumed (devex#402, Dagger v0.21.8). A method
-`func (m *Z5labs) Go(source *dagger.Directory) *Go` — keyword as both the
-method name and the returned object's name — generates, compiles and runs in
-a consumer module. The returned object namespaces to `<Module><Object>`:
+`func (m *Z5labs) Go(source *dagger.Directory) *Go` — the name as both the
+method and the returned object's type — generates, compiles and runs in a
+consumer module:
 
 ```go
-func (r *Z5Labs) Go(source *Directory) *Z5LabsGo   // consumer binding
+// source:   func (m *Z5labs) Go(source *dagger.Directory) *Go
+// consumer: func (r *Z5Labs) Go(source *Directory) *Z5LabsGo
 ```
 
-so the keyword never appears anywhere it could be parsed as one. Adding a
-scalar-returning `Go` method to *any* object in the same module breaks the
-consumer immediately, with `expected '}', found 'go'` — so the rule is about
-the return type, not the name in isolation. A keyword-named object with only
-object-returning and non-keyword scalar methods is fine.
+The reason is the cache field described just above, and nothing else. A
+method name is emitted as a capitalized identifier, which is never a Go
+keyword — `Go` is a legal identifier, only lowercase `go` is reserved. What
+breaks is the *lowercased* cache field a scalar-returning method emits
+(`go *string`), so a method that returns an object emits no field and there
+is nothing to collide. The returned type namespacing to `Z5LabsGo` is a real
+observation but not the mechanism; a type named `Go` would have been fine
+too.
+
+So the rule is about the **return type**, not the name in isolation, and it
+is per generated method rather than per module: adding a scalar-returning
+`Go` method to any object — measured on a second object, not the keyword-named
+one — breaks that object's generated type with `expected '}', found 'go'`.
+A keyword-named object carrying only object-returning and non-keyword scalar
+methods is fine.
+
+Worth knowing while reading that pair: the schema name is derived from
+the **module name**, not from the Go type's spelling. Module `z5labs` gives
+`Z5Labs` in the bindings even though the Go source declares `type Z5labs
+struct{}`, and secondary objects namespace onto that same normalized prefix.
+The casing difference is the generator's, not a typo.
 
 ### Unexported types are where module-object state belongs
 
 A module object's fields are serialized across every call boundary, which
 raises the question of whether a field holding a slice of structs needs
-those structs registered as Dagger object types. It does not, and unexported
-is strictly the better choice (measured in devex#402):
+those structs registered as Dagger object types. It does not — unexported
+Go structs round-trip fine (measured in devex#402):
 
 ```go
 type App struct {
     Version  string     // +private
-    Variants []*variant // +private
+    Variants []*variant // +private   <- the +private is load bearing
 }
 
 type variant struct {
@@ -278,16 +295,39 @@ type variant struct {
     Container *dagger.Container
     Documents []document
 }
+
+type document struct {
+    Name string
+    Type string        // safe here; see below
+    File *dagger.File
+}
 ```
 
-`variant` and `document` are unexported, so **nothing about them reaches the
-schema** — the consumer's generated bindings contain no `Z5LabsVariant` and
-no `Z5LabsDocument`, only the methods of `App` itself. The state still
-round-trips intact, including `*dagger.Container` and `*dagger.File` fields,
-which travel as IDs and resolve on the far side. Verified both by chained
-resolution and by an explicit `ID()` → `LoadZ5LabsAppFromID()` round trip,
-across three platforms, with the containers and files still readable
-afterwards.
+**Nothing about `variant` or `document` reaches the schema** — the consumer's
+generated bindings contain no `Z5LabsVariant` and no `Z5LabsDocument`, only
+the methods of `App` itself. The state round-trips intact, `*dagger.Container`
+and `*dagger.File` included; those travel as IDs and resolve on the far side.
+Verified both by chained resolution and by an explicit `ID()` →
+`LoadZ5LabsAppFromID()` round trip, across three platforms, with the
+containers and files still readable afterwards.
+
+One ergonomic wrinkle when doing that ID round trip on a *dependency's*
+object: the generated `ID()` on a dependency type returns the generic
+`dagger.ID`, not the specific one, so `LoadZ5LabsAppFromID` needs an explicit
+`dagger.Z5LabsAppID(id)` conversion. Own-module types are unaffected.
+
+What keeps them out of the schema is that **no exposed API signature
+references them** — not the lowercase initial by itself. Drop the `+private`
+from `Variants` and you are asking the generator to expose a field whose type
+it cannot register, which fails in the module's *own* `dagger develop`, before
+any consumer is involved:
+
+```
+Error: generate code: template: module.go.tmpl:96:3: ... cannot code-generate
+unexported type variant
+```
+
+Measured, because the causal link is easy to state backwards.
 
 Two consequences:
 
@@ -298,15 +338,21 @@ Two consequences:
   these fields for the code, not for the generator.
 - Their fields still need to be **exported**, and getting this wrong fails
   silently and late. The round trip is `encoding/json`, so an unexported
-  field is dropped on the way out and comes back zero. Codegen still
-  succeeds and the consumer still compiles; the module then panics at
-  runtime with `invalid memory address or nil pointer dereference` the first
-  time it touches the field — measured, with a lower-cased `file
-  *dagger.File`. The struct is unexported; its fields are not.
+  field is dropped on the way out and comes back as the zero value. Codegen
+  still succeeds and the consumer still compiles. With a pointer, slice, map
+  or interface field you at least get a crash the first time you touch it —
+  measured, with a lower-cased `file *dagger.File`, giving `invalid memory
+  address or nil pointer dereference`. With a scalar you get **no** crash: an
+  unexported `count int` or `name string` comes back `0` or `""` and the
+  module computes on wrong data indefinitely. The panic is the lucky
+  outcome. The struct is unexported; its fields are not.
 
-Prefer this to registering a helper object type. A registered one adds a
-schema object with no methods that a caller can see and must ignore, and it
-drags the naming rules along with it.
+The registered alternative was never run — the criteria for this spike called
+for it only if the unexported form failed, and it did not — so what follows is
+reasoning rather than measurement: a registered helper type would add a schema
+object with no methods that callers can see and must ignore, and would drag
+the exported-field naming rules along with it. On that basis prefer the
+unexported form, bearing in mind the silent-zeroing trap above is the price.
 
 ### `[]dagger.Platform` parameters carry variants intact
 
@@ -315,12 +361,14 @@ use constructed one — so it was unverified whether a slice of them survived
 a call boundary. It does, order preserved and variant preserved:
 `linux/amd64`, `linux/arm64` and `linux/arm/v7` all arrive byte-identical to
 what the caller passed (devex#402). `Platform` is a string scalar in the
-schema, so the three-component variant form is not special-cased anywhere.
+schema, so nothing rewrites the variant component in transit across a call
+boundary.
 
-One ergonomic wrinkle when round-tripping a *dependency's* object by ID: the
-generated `ID()` on a dependency type returns the generic `dagger.ID`, not
-the specific one, so `LoadZ5LabsAppFromID` needs an explicit
-`dagger.Z5LabsAppID(id)` conversion. Own-module types are unaffected.
+That is a statement about **parameter marshaling only**. Platform values are
+normalized in containerd-style handling elsewhere in the stack, and this
+spike says nothing about what `WithPlatform`, image building or a
+`Platform()`-returning call do with a `linux/arm/v7`; treat those as
+untested.
 
 ### Method parameters named `r` collide with the generated receiver
 


### PR DESCRIPTION
Closes #402

Verifies the three codegen constraints the App API proposed in discussion #400 rests on. **All three hold, and the proposed shape stands unchanged** — including the one flagged as *"the one unknown that could change the shape"*.

Measured against **Dagger v0.21.8**, with a throwaway two-module pair (a dep faithful to the proposed `Z5labs`/`Go`/`App` shape, and a consumer that installs it). Only a consumer's `dagger develop` surfaces these, which is why the spike is two modules rather than one.

## 1. `Go` as a method and object name — works

`func (m *Z5labs) Go(source *dagger.Directory) *Go` generates, compiles and runs in a consumer. The object namespaces exactly as predicted:

```go
func (r *Z5Labs) Go(source *Directory) *Z5LabsGo   // consumer binding
```

The keyword never lands anywhere it could be parsed as one. The guardrail was confirmed from the other side too: adding a **scalar**-returning `Go` method to any object in the module breaks the consumer immediately with

```
error formatting generated code: 311:9: expected '}', found 'go'
```

So the rule is about the *return type*, not the name in isolation.

## 2. `[]dagger.Platform` as a parameter — works

Crosses the boundary intact, order and variant preserved:

```
constraint 2 OK: linux/amd64|linux/arm64|linux/arm/v7
```

`Platform` is a string scalar in the schema, so the three-component variant form is not special-cased.

## 3. `App`'s internal state can be UNEXPORTED — works, and is the better choice

The open question was whether the per-platform state must be a registered Dagger object type. It must not — unexported Go structs round-trip fine:

```go
type App struct {
    Version  string     // +private
    Variants []*variant // +private
}
type variant struct {
    Platform  dagger.Platform
    Container *dagger.Container
    Documents []document
}
```

- Consumer bindings contain **no** `Z5LabsVariant` and **no** `Z5LabsDocument` — none of it reaches the schema.
- State survives with `*dagger.Container` and `*dagger.File` intact, verified both by chained resolution *and* by an explicit `ID()` → `LoadZ5LabsAppFromID()` round trip, across three platforms.
- Consequently **the field-naming rules do not apply**. A field literally named `Type` — the name that breaks dependency codegen on an exported struct — is harmless here. Confirmed by trying it. `ArtifactType` is therefore a free choice, not a requirement.

One trap found while verifying: the element type's **fields** must still be exported. The round trip is `encoding/json`, so a lower-cased field is dropped silently — codegen succeeds, the consumer compiles, and the module panics at runtime with `invalid memory address or nil pointer dereference` on first touch. Recorded because it fails late and looks like anything but a naming problem.

## Acceptance criteria

- [x] A module exposing `Z5labs.Go(source) *Go`, with `Go` carrying a scalar method (`Ci`) and an object-returning method (`App`), installed as a dependency of a second module whose `dagger develop` completes clean and compiles.
- [x] `[]dagger.Platform` called across a module boundary, values intact, `linux/arm/v7` included.
- [x] A module object with a slice field whose element type holds a `*dagger.Container` and a `*dagger.File` round-trips with state intact — **the unexported form worked, so the exported/registered fallback was not needed**.
- [x] The alternative shape is recorded alongside each. Nothing failed, so what is recorded instead is where each boundary actually lies — the scalar-vs-object return-type rule, and the exported-field requirement.
- [x] Findings land in discussion #400 and the generalizing ones in `daggerverse/CLAUDE.md`.
- [x] The verification modules are not left in the tree — they were built outside the repository entirely, so this PR touches one file.

## Judgment calls

- **The spike lived outside the repo.** The criteria ask that the modules not be left in the tree; building them outside means there is no deletion commit to get wrong, and the diff here is documentation only.
- **Two claims were tested that the issue did not ask for** — the scalar-`Go` break and the unexported-*field* trap. Both are the boundary of a rule the design will be relied on, and "this works" is much less useful without knowing where it stops.

## Verified

- `dagger check` — pass (3 checks)
- `bash .github/scripts/verify-affected-modules.sh` — pass (no module changed)
