### PR TITLE
chore(backlog): read the reviewer App from Z5LABS_REVIEW_APP_*

### DIFF
--- a/.claude/backlog.json
+++ b/.claude/backlog.json
@@ -22,7 +22,11 @@
     "workflow": "auto-merge.yaml"
   },
   "review": {
-    "reviewers": ["copilot", "local"]
+    "reviewers": ["copilot", "local"],
+    "app": {
+      "idEnv": "Z5LABS_REVIEW_APP_ID",
+      "keyEnv": "Z5LABS_REVIEW_APP_KEY"
+    }
   },
   "worktreeDir": ".claude/worktrees"
 }


### PR DESCRIPTION
## What

Adds a `review.app` block to `.claude/backlog.json` naming the two environment variables the backlog loop's `local` review rung reads its GitHub App credentials from:

```json
"app": {
  "idEnv": "Z5LABS_REVIEW_APP_ID",
  "keyEnv": "Z5LABS_REVIEW_APP_KEY"
}
```

**Names only.** The App ID and private key stay in the environment and reach no tracked file, which is what makes this key safe to commit.

## Why

With no `review.app` block the rung falls back to `BACKLOG_REVIEW_APP_ID` / `BACKLOG_REVIEW_APP_KEY`. This repository's reviewer App is exported under `Z5LABS_REVIEW_APP_*`, so the rung probed a pair that is genuinely unset and reported itself **UNAVAILABLE**.

That outcome is indistinguishable from a real outage — the roster reads exit 3 as a rung that is *down* and advances past it. Two consequences, depending on the roster:

- On a roster ending in `none`, a config mismatch would end in an **unreviewed merge**.
- On this repository's roster — `["copilot", "local"]` — it exhausted the roster and **blocked** the cycle, leaving a green pull request (#407) open and unlabeled.

Observed on a `/backlog:run-backlog` pass scoped to `Module=z5labs`: iteration 1 reached the review gate with all checks green and halted there, having found neither rung usable.

## Verification

- `jq` validates the file and `.review.app` resolves.
- Both `Z5LABS_REVIEW_APP_ID` and `Z5LABS_REVIEW_APP_KEY` are exported in the loop's environment; the `BACKLOG_REVIEW_APP_*` pair is not.
- Config-only change — no module source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)