### PR TITLE
story(z5labs): sign the published image, not only its provenance

### DIFF
--- a/daggerverse/CLAUDE.md
+++ b/daggerverse/CLAUDE.md
@@ -145,6 +145,52 @@ Two rules that follow, and that are easy to undo by accident:
   service and exchanges a real token; only the signing key differs from
   production, where an ephemeral key is certified by the public sigstore CA.
 
+## Signing an image: copy cosign's layout, do not design one
+
+A signature is worth exactly what the command that verifies it is worth, and
+the command a consumer already has is `cosign verify`. So `daggerverse/z5labs`
+writes cosign's layout rather than something of its own: for a manifest at
+`sha256:<hex>`, a one-layer OCI **image** manifest under the tag
+`sha256-<hex>.sig` in the same repository, the layer holding the simple-signing
+payload under `application/vnd.dev.cosign.simplesigning.v1+json` and the
+signature living in the layer's annotations.
+
+Three things that are easy to get wrong and are not obvious from the spec:
+
+- **Sign the index *and* every per-platform manifest.** A consumer verifies the
+  tag, which resolves to the manifest list; their runtime then pulls the
+  per-platform manifest, a different digest the index signature says nothing
+  about. Signing only the index leaves `cosign verify <tag>` passing over bytes
+  nothing checked, which is worse than not signing. This is what cosign's own
+  `--recursive` is for.
+- **The signature manifest needs a real image config**
+  (`application/vnd.oci.image.config.v1+json` over `{}`), not the OCI empty
+  descriptor `oras.PackManifest` picks. Readers go through
+  go-containerregistry's image type; the artifact-manifest shape is legal OCI
+  and is not what they parse. `daggerverse/oci`'s `PushLayer` exists for
+  exactly this and assembles the manifest by hand.
+- **Keyless signing needs a transparency log entry, not just a certificate.**
+  The Fulcio certificate binding the ephemeral key to a workload identity lives
+  for minutes, so by verification time it has expired and nothing establishes it
+  was valid when it signed. The Rekor entry's countersignature is what does.
+  Embed the bundle in the `dev.sigstore.cosign/bundle` annotation rather than
+  leaving it to be looked up, so a consumer behind a network that cannot reach
+  `rekor.sigstore.dev` can still verify.
+
+### zot parses any tag ending in `.sig`, and a short digest panics it
+
+The `oci` test suite runs against **zot**, not `registry:2`, and zot inspects
+every pushed tag to decide whether it is a cosign signature
+(`zot/pkg/meta.isSignature`). It assumes a full-length digest and slices
+`tag[:71]`, so a made-up short tag like `sha256-0123456789abcdef.sig` panics the
+handler. What reaches the client is `500 Internal Server Error` with an empty
+body — which reads as a malformed manifest and is a malformed *tag*.
+
+Compute signature tags from a digest the registry just returned, in tests as
+well as in production. Half an hour went into the manifest before the trace was
+read; `dagger trace <id> --progress=plain` had the panic and its stack in it all
+along.
+
 ## Function name mangling
 
 Go method names get re-cased for the GraphQL API: acronyms become uppercase in

--- a/daggerverse/oci/README.md
+++ b/daggerverse/oci/README.md
@@ -35,6 +35,7 @@ a cached `PushImage` would report success without uploading anything.
 - [Registry](#registry) — bind a registry host and its credentials
 - [PushImage](#pushimage) — publish container variants as an image or manifest list
 - [PushArtifact](#pushartifact) — publish a directory as an OCI artifact
+- [PushLayer](#pushlayer) — publish one file as a tagged, annotated single-layer manifest
 - [Copy](#copy) — copy a reference into this registry, all manifests intact
 - [Attach](#attach) — upload a referrer against a subject manifest
 - [Referrers](#referrers) — list what is attached to a subject
@@ -237,6 +238,48 @@ named by its path in the standard `org.opencontainers.image.title`
 annotation. Layers are ordered by path, so the same directory always produces
 the same manifest. One tar layer for the whole tree would make
 [Fetch](#fetch) return an archive rather than the bytes that went in.
+
+### PushLayer
+
+Pushes one file to `repository:tag` as a single-layer OCI image manifest, with
+a caller-chosen layer media type and caller-chosen layer annotations, and
+returns the manifest digest.
+
+```go
+digest, err := reg.PushLayer(ctx, "z5labs/myapp", "sha256-<hex>.sig", payload,
+    "application/vnd.dev.cosign.simplesigning.v1+json",
+    dagger.OciRegistryPushLayerOpts{Annotations: `{"dev.cosignproject.cosign/signature":"..."}`})
+```
+
+It exists for the consumers that read a document's meaning off the *layer*
+rather than off the manifest: they resolve a tag they computed themselves,
+take the one layer whose media type they recognise, and read the rest out of
+that layer's annotations. Cosign's signature layout is the one this repository
+publishes — `daggerverse/z5labs` signs every published manifest this way — but
+nothing in this module knows that.
+
+Three things differ from [PushArtifact](#pushartifact) and [Attach](#attach),
+and each is why neither could be stretched to cover it:
+
+- The layer's media type is the caller's. The other two give every layer
+  `application/octet-stream`, which is right for a document fetched by digest
+  and wrong for one found by filtering layers on their type.
+- The layer's annotations are the caller's. The other two set the standard
+  title annotation and nothing else, so there is nowhere to put a signature.
+- The config is a real empty image config rather than the OCI empty descriptor
+  `oras.PackManifest` would choose. These readers go through
+  go-containerregistry's image type, which expects an image manifest carrying
+  an image config; the artifact-manifest shape is legal OCI and is not what
+  they parse.
+
+`annotations` is a JSON object of string values rather than a map because
+codegen has no map type. Anything else — a JSON number, a bare string, a list
+— is refused rather than coerced, because an annotation the caller did not
+write is where this layout keeps the signature.
+
+The manifest is addressed by tag, so pushing the same tag twice replaces it.
+That is the difference from [Attach](#attach), where each call adds another
+referrer, and it is what a caller re-signing a digest wants.
 
 ### Copy
 

--- a/daggerverse/oci/artifact.go
+++ b/daggerverse/oci/artifact.go
@@ -141,6 +141,12 @@ func (reg *Registry) PushArtifact(
 // it — which is what a caller re-signing a digest wants, and is the
 // difference from Attach, where each call adds a referrer.
 //
+// The content is held in memory whole, exactly as Attach and PushArtifact
+// hold theirs, so this is sized for documents — signatures, payloads,
+// attestations — and not for image layers. Streaming would be a change to
+// all three rather than to this one, since a caller cannot tell them apart
+// on that axis today.
+//
 // +cache="never"
 func (reg *Registry) PushLayer(
 	ctx context.Context,
@@ -149,7 +155,9 @@ func (reg *Registry) PushLayer(
 	// Tag to push under. Callers of this function normally compute it from
 	// a digest rather than taking it from a human.
 	tag string,
-	// The bytes to push: one file, one layer.
+	// The bytes to push: one file, one layer. It is read into memory whole,
+	// as Attach and PushArtifact read theirs, so this is for documents
+	// rather than for image layers.
 	content *dagger.File,
 	// The layer's media type, which is what a consumer filters layers on.
 	mediaType string,
@@ -246,16 +254,36 @@ func (reg *Registry) PushLayer(
 // as. Empty means none, which is different from an empty object only in
 // that neither is an error.
 //
-// The value type is string rather than any: an annotation is a string by
-// the OCI spec, and silently stringifying a number here would produce a
-// manifest whose annotation a caller never wrote.
+// Everything that is not an object of strings is refused rather than
+// coerced, because an annotation a caller did not write is where this
+// layout keeps the signature. Two of those are things `json.Unmarshal` into
+// a `map[string]string` accepts silently, and both are why the decode goes
+// through `*string` rather than `string`:
+//
+//   - `null` unmarshals into a nil map, so a caller who plainly meant to set
+//     something gets a push with no annotations and no error, indistinguishable
+//     from having passed nothing at all.
+//   - `{"dev.cosignproject.cosign/signature":null}` unmarshals cleanly too —
+//     JSON null into a string is a documented no-op — leaving the key present
+//     with an empty value. That is the coercion this refuses, on the key that
+//     holds the signature.
 func decodeAnnotations(raw string) (map[string]string, error) {
 	if strings.TrimSpace(raw) == "" {
 		return nil, nil
 	}
-	var out map[string]string
-	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+	var decoded map[string]*string
+	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
 		return nil, fmt.Errorf("annotations must be a JSON object of string values: %v", err)
+	}
+	if decoded == nil {
+		return nil, errors.New("annotations must be a JSON object of string values, and null is not one")
+	}
+	out := make(map[string]string, len(decoded))
+	for name, value := range decoded {
+		if value == nil {
+			return nil, fmt.Errorf("annotations must be a JSON object of string values, but %q is null", name)
+		}
+		out[name] = *value
 	}
 	return out, nil
 }

--- a/daggerverse/oci/artifact.go
+++ b/daggerverse/oci/artifact.go
@@ -14,6 +14,7 @@ import (
 
 	"dagger/oci/internal/dagger"
 
+	specs "github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
 	orascontent "oras.land/oras-go/v2/content"
@@ -104,6 +105,159 @@ func (reg *Registry) PushArtifact(
 		return "", c.scrub(fmt.Errorf("push artifact to %s: %v", c.ref(repository, tag), err))
 	}
 	return manifest.Digest.String(), nil
+}
+
+// PushLayer pushes one file to repository:tag as a single-layer OCI image
+// manifest and returns the manifest digest.
+//
+// It exists because two families of consumer read a document's meaning off
+// the *layer* rather than off the manifest: they resolve a tag whose name
+// they compute themselves, take the one layer whose media type they
+// recognise, and read the rest out of that layer's annotations. Cosign's
+// signature layout is the one this repository needs — `sha256-<hex>.sig`,
+// one `application/vnd.dev.cosign.simplesigning.v1+json` layer, the
+// signature in an annotation beside it — but nothing here knows that. This
+// function is handed a tag, some bytes, a media type and a set of
+// annotations, exactly as Attach is handed a file and an artifact type, and
+// that is all it ever learns.
+//
+// The three ways it differs from PushArtifact and Attach, each of which is
+// why neither of those could be stretched to cover it:
+//
+//   - The layer's media type is the caller's. PushArtifact gives every layer
+//     application/octet-stream, which is right for a document a consumer
+//     fetches by digest and wrong for one a consumer finds by filtering
+//     layers on their type.
+//   - The layer's annotations are the caller's. Both of the others set the
+//     standard title annotation and nothing else, so there is nowhere to put
+//     a signature.
+//   - The config is a real empty image config rather than the OCI empty
+//     descriptor oras.PackManifest would choose. Readers of this layout go
+//     through go-containerregistry's image type, which expects an image
+//     manifest carrying an image config; the artifact-manifest shape is
+//     legal OCI and is not what they parse.
+//
+// The manifest is addressed by tag, so pushing the same tag twice replaces
+// it — which is what a caller re-signing a digest wants, and is the
+// difference from Attach, where each call adds a referrer.
+//
+// +cache="never"
+func (reg *Registry) PushLayer(
+	ctx context.Context,
+	// Repository to push to.
+	repository string,
+	// Tag to push under. Callers of this function normally compute it from
+	// a digest rather than taking it from a human.
+	tag string,
+	// The bytes to push: one file, one layer.
+	content *dagger.File,
+	// The layer's media type, which is what a consumer filters layers on.
+	mediaType string,
+	// Annotations to set on the layer, as a JSON object whose values are
+	// strings. Empty sets none. It is JSON rather than a map because codegen
+	// has no map type.
+	//
+	// +optional
+	annotations string,
+) (string, error) {
+	if err := validateRepository(repository); err != nil {
+		return "", err
+	}
+	if err := validateTag(tag); err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(mediaType) == "" {
+		return "", errors.New("mediaType is required")
+	}
+	if content == nil {
+		return "", errors.New("content is required")
+	}
+	layerAnnotations, err := decodeAnnotations(annotations)
+	if err != nil {
+		return "", err
+	}
+
+	c, err := reg.connect(ctx)
+	if err != nil {
+		return "", err
+	}
+	repo, err := c.repository(repository)
+	if err != nil {
+		return "", err
+	}
+
+	work, err := os.MkdirTemp("", "oci-push-layer-*")
+	if err != nil {
+		return "", fmt.Errorf("create work dir: %v", err)
+	}
+	defer os.RemoveAll(work)
+
+	path := filepath.Join(work, "content")
+	if _, err := content.Export(ctx, path); err != nil {
+		return "", fmt.Errorf("export layer content: %v", err)
+	}
+	data, err := os.ReadFile(path) //nolint:gosec // path is this function's own temp dir
+	if err != nil {
+		return "", fmt.Errorf("read layer content: %v", err)
+	}
+
+	store := memory.New()
+	// "{}" rather than an empty body: an image config is a JSON document,
+	// and a reader that parses it should find a document rather than a
+	// parse error. It is the same config cosign writes.
+	config := []byte("{}")
+	configDesc := orascontent.NewDescriptorFromBytes(ocispec.MediaTypeImageConfig, config)
+	if err := store.Push(ctx, configDesc, bytes.NewReader(config)); err != nil {
+		return "", fmt.Errorf("stage image config: %v", err)
+	}
+	layerDesc := orascontent.NewDescriptorFromBytes(mediaType, data)
+	layerDesc.Annotations = layerAnnotations
+	if err := store.Push(ctx, layerDesc, bytes.NewReader(data)); err != nil {
+		return "", fmt.Errorf("stage layer: %v", err)
+	}
+
+	// Assembled and marshalled here rather than handed to oras.PackManifest,
+	// because PackManifest owns the config and the artifactType and this
+	// function's whole purpose is that its caller owns the shape.
+	manifest := ocispec.Manifest{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: ocispec.MediaTypeImageManifest,
+		Config:    configDesc,
+		Layers:    []ocispec.Descriptor{layerDesc},
+	}
+	manifestBytes, err := json.Marshal(manifest)
+	if err != nil {
+		return "", fmt.Errorf("encode layer manifest: %v", err)
+	}
+	manifestDesc := orascontent.NewDescriptorFromBytes(ocispec.MediaTypeImageManifest, manifestBytes)
+	if err := store.Push(ctx, manifestDesc, bytes.NewReader(manifestBytes)); err != nil {
+		return "", fmt.Errorf("stage layer manifest: %v", err)
+	}
+	if err := store.Tag(ctx, manifestDesc, tag); err != nil {
+		return "", fmt.Errorf("tag layer manifest: %v", err)
+	}
+	if _, err := oras.Copy(ctx, store, tag, repo, tag, oras.DefaultCopyOptions); err != nil {
+		return "", c.scrub(fmt.Errorf("push layer to %s: %v", c.ref(repository, tag), err))
+	}
+	return manifestDesc.Digest.String(), nil
+}
+
+// decodeAnnotations reads the JSON object PushLayer takes its annotations
+// as. Empty means none, which is different from an empty object only in
+// that neither is an error.
+//
+// The value type is string rather than any: an annotation is a string by
+// the OCI spec, and silently stringifying a number here would produce a
+// manifest whose annotation a caller never wrote.
+func decodeAnnotations(raw string) (map[string]string, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	var out map[string]string
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		return nil, fmt.Errorf("annotations must be a JSON object of string values: %v", err)
+	}
+	return out, nil
 }
 
 // Attach uploads content as an OCI referrer of subject and returns the

--- a/daggerverse/oci/dagger.gen.go
+++ b/daggerverse/oci/dagger.gen.go
@@ -526,6 +526,48 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Registry).PushImageUntagged(&parent, ctx, repository, variants)
+		case "PushLayer":
+			var parent Registry
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var repository string
+			if inputArgs["repository"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["repository"]), &repository)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg repository", err))
+				}
+			}
+			var tag string
+			if inputArgs["tag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["tag"]), &tag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg tag", err))
+				}
+			}
+			var content *dagger.File
+			if inputArgs["content"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["content"]), &content)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg content", err))
+				}
+			}
+			var mediaType string
+			if inputArgs["mediaType"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["mediaType"]), &mediaType)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg mediaType", err))
+				}
+			}
+			var annotations string
+			if inputArgs["annotations"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["annotations"]), &annotations)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg annotations", err))
+				}
+			}
+			return (*Registry).PushLayer(&parent, ctx, repository, tag, content, mediaType, annotations)
 		case "Referrers":
 			var parent Registry
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/oci/tests/dagger.gen.go
+++ b/daggerverse/oci/tests/dagger.gen.go
@@ -346,6 +346,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).PushImageUntaggedPublishesNoTag(&parent, ctx)
+		case "PushLayerCarriesMediaTypeAndAnnotations":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).PushLayerCarriesMediaTypeAndAnnotations(&parent, ctx)
+		case "PushLayerRejectsMalformedAnnotations":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).PushLayerRejectsMalformedAnnotations(&parent, ctx)
 		case "PushSucceedsAgainstPlaintextRegistryWhenInsecure":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/oci/tests/internal/dagger/oci.gen.go
+++ b/daggerverse/oci/tests/internal/dagger/oci.gen.go
@@ -307,6 +307,7 @@ type OciRegistry struct { // oci (../../../../../daggerverse/oci/main.go:148:6)
 	pushArtifact      *string
 	pushImage         *string
 	pushImageUntagged *string
+	pushLayer         *string
 	referrers         *string
 	resolve           *string
 	tag               *string
@@ -325,7 +326,7 @@ func (r *OciRegistry) WithGraphQLQuery(q *querybuilder.Selection) *OciRegistry {
 // subject is a manifest digest in this repository; it is resolved first, so
 // attaching to something that is not there fails naming the digest rather
 // than leaving a dangling referrer behind.
-func (r *OciRegistry) Attach(ctx context.Context, repository string, subject string, content *File, artifactType string) (string, error) { // oci (../../../../../daggerverse/oci/artifact.go:117:1)
+func (r *OciRegistry) Attach(ctx context.Context, repository string, subject string, content *File, artifactType string) (string, error) { // oci (../../../../../daggerverse/oci/artifact.go:271:1)
 	assertNotNil("content", content)
 	if r.attach != nil {
 		return *r.attach, nil
@@ -480,7 +481,7 @@ func (r *OciRegistry) Manifest(ctx context.Context, repository string, reference
 // org.opencontainers.image.title annotation is its path relative to the
 // directory root. Layers are ordered by that path so the same directory
 // always produces the same manifest.
-func (r *OciRegistry) PushArtifact(ctx context.Context, repository string, tag string, contents *Directory, artifactType string) (string, error) { // oci (../../../../../daggerverse/oci/artifact.go:44:1)
+func (r *OciRegistry) PushArtifact(ctx context.Context, repository string, tag string, contents *Directory, artifactType string) (string, error) { // oci (../../../../../daggerverse/oci/artifact.go:45:1)
 	assertNotNil("contents", contents)
 	if r.pushArtifact != nil {
 		return *r.pushArtifact, nil
@@ -564,12 +565,78 @@ func (r *OciRegistry) PushImageUntagged(ctx context.Context, repository string, 
 	return response, q.Execute(ctx)
 }
 
+// OciRegistryPushLayerOpts contains options for OciRegistry.PushLayer
+type OciRegistryPushLayerOpts struct {
+	//
+	// Annotations to set on the layer, as a JSON object whose values are
+	// strings. Empty sets none. It is JSON rather than a map because codegen
+	// has no map type.
+	//
+	Annotations string // oci (../../../../../daggerverse/oci/artifact.go:161:2)
+}
+
+// PushLayer pushes one file to repository:tag as a single-layer OCI image
+// manifest and returns the manifest digest.
+//
+// It exists because two families of consumer read a document's meaning off
+// the *layer* rather than off the manifest: they resolve a tag whose name
+// they compute themselves, take the one layer whose media type they
+// recognise, and read the rest out of that layer's annotations. Cosign's
+// signature layout is the one this repository needs — `sha256-<hex>.sig`,
+// one `application/vnd.dev.cosign.simplesigning.v1+json` layer, the
+// signature in an annotation beside it — but nothing here knows that. This
+// function is handed a tag, some bytes, a media type and a set of
+// annotations, exactly as Attach is handed a file and an artifact type, and
+// that is all it ever learns.
+//
+// The three ways it differs from PushArtifact and Attach, each of which is
+// why neither of those could be stretched to cover it:
+//
+//   - The layer's media type is the caller's. PushArtifact gives every layer
+//     application/octet-stream, which is right for a document a consumer
+//     fetches by digest and wrong for one a consumer finds by filtering
+//     layers on their type.
+//   - The layer's annotations are the caller's. Both of the others set the
+//     standard title annotation and nothing else, so there is nowhere to put
+//     a signature.
+//   - The config is a real empty image config rather than the OCI empty
+//     descriptor oras.PackManifest would choose. Readers of this layout go
+//     through go-containerregistry's image type, which expects an image
+//     manifest carrying an image config; the artifact-manifest shape is
+//     legal OCI and is not what they parse.
+//
+// The manifest is addressed by tag, so pushing the same tag twice replaces
+// it — which is what a caller re-signing a digest wants, and is the
+// difference from Attach, where each call adds a referrer.
+func (r *OciRegistry) PushLayer(ctx context.Context, repository string, tag string, content *File, mediaType string, opts ...OciRegistryPushLayerOpts) (string, error) { // oci (../../../../../daggerverse/oci/artifact.go:145:1)
+	assertNotNil("content", content)
+	if r.pushLayer != nil {
+		return *r.pushLayer, nil
+	}
+	q := r.query.Select("pushLayer")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `annotations` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Annotations) {
+			q = q.Arg("annotations", opts[i].Annotations)
+		}
+	}
+	q = q.Arg("repository", repository)
+	q = q.Arg("tag", tag)
+	q = q.Arg("content", content)
+	q = q.Arg("mediaType", mediaType)
+
+	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
 // OciRegistryReferrersOpts contains options for OciRegistry.Referrers
 type OciRegistryReferrersOpts struct {
 	//
 	// Restrict the listing to one artifact type. Empty lists them all.
 	//
-	ArtifactType string // oci (../../../../../daggerverse/oci/artifact.go:222:2)
+	ArtifactType string // oci (../../../../../daggerverse/oci/artifact.go:376:2)
 }
 
 // Referrers lists the artifacts attached to subject as a JSON array of OCI
@@ -579,7 +646,7 @@ type OciRegistryReferrersOpts struct {
 // map type, so annotations could not be modelled; and a module object
 // returned from a never-cached call detaches in Dagger v0.21, so lazily
 // reading its fields fails.
-func (r *OciRegistry) Referrers(ctx context.Context, repository string, subject string, opts ...OciRegistryReferrersOpts) (string, error) { // oci (../../../../../daggerverse/oci/artifact.go:213:1)
+func (r *OciRegistry) Referrers(ctx context.Context, repository string, subject string, opts ...OciRegistryReferrersOpts) (string, error) { // oci (../../../../../daggerverse/oci/artifact.go:367:1)
 	if r.referrers != nil {
 		return *r.referrers, nil
 	}

--- a/daggerverse/oci/tests/internal/dagger/oci.gen.go
+++ b/daggerverse/oci/tests/internal/dagger/oci.gen.go
@@ -326,7 +326,7 @@ func (r *OciRegistry) WithGraphQLQuery(q *querybuilder.Selection) *OciRegistry {
 // subject is a manifest digest in this repository; it is resolved first, so
 // attaching to something that is not there fails naming the digest rather
 // than leaving a dangling referrer behind.
-func (r *OciRegistry) Attach(ctx context.Context, repository string, subject string, content *File, artifactType string) (string, error) { // oci (../../../../../daggerverse/oci/artifact.go:271:1)
+func (r *OciRegistry) Attach(ctx context.Context, repository string, subject string, content *File, artifactType string) (string, error) { // oci (../../../../../daggerverse/oci/artifact.go:299:1)
 	assertNotNil("content", content)
 	if r.attach != nil {
 		return *r.attach, nil
@@ -572,7 +572,7 @@ type OciRegistryPushLayerOpts struct {
 	// strings. Empty sets none. It is JSON rather than a map because codegen
 	// has no map type.
 	//
-	Annotations string // oci (../../../../../daggerverse/oci/artifact.go:161:2)
+	Annotations string // oci (../../../../../daggerverse/oci/artifact.go:169:2)
 }
 
 // PushLayer pushes one file to repository:tag as a single-layer OCI image
@@ -608,7 +608,13 @@ type OciRegistryPushLayerOpts struct {
 // The manifest is addressed by tag, so pushing the same tag twice replaces
 // it — which is what a caller re-signing a digest wants, and is the
 // difference from Attach, where each call adds a referrer.
-func (r *OciRegistry) PushLayer(ctx context.Context, repository string, tag string, content *File, mediaType string, opts ...OciRegistryPushLayerOpts) (string, error) { // oci (../../../../../daggerverse/oci/artifact.go:145:1)
+//
+// The content is held in memory whole, exactly as Attach and PushArtifact
+// hold theirs, so this is sized for documents — signatures, payloads,
+// attestations — and not for image layers. Streaming would be a change to
+// all three rather than to this one, since a caller cannot tell them apart
+// on that axis today.
+func (r *OciRegistry) PushLayer(ctx context.Context, repository string, tag string, content *File, mediaType string, opts ...OciRegistryPushLayerOpts) (string, error) { // oci (../../../../../daggerverse/oci/artifact.go:151:1)
 	assertNotNil("content", content)
 	if r.pushLayer != nil {
 		return *r.pushLayer, nil
@@ -636,7 +642,7 @@ type OciRegistryReferrersOpts struct {
 	//
 	// Restrict the listing to one artifact type. Empty lists them all.
 	//
-	ArtifactType string // oci (../../../../../daggerverse/oci/artifact.go:376:2)
+	ArtifactType string // oci (../../../../../daggerverse/oci/artifact.go:404:2)
 }
 
 // Referrers lists the artifacts attached to subject as a JSON array of OCI
@@ -646,7 +652,7 @@ type OciRegistryReferrersOpts struct {
 // map type, so annotations could not be modelled; and a module object
 // returned from a never-cached call detaches in Dagger v0.21, so lazily
 // reading its fields fails.
-func (r *OciRegistry) Referrers(ctx context.Context, repository string, subject string, opts ...OciRegistryReferrersOpts) (string, error) { // oci (../../../../../daggerverse/oci/artifact.go:367:1)
+func (r *OciRegistry) Referrers(ctx context.Context, repository string, subject string, opts ...OciRegistryReferrersOpts) (string, error) { // oci (../../../../../daggerverse/oci/artifact.go:395:1)
 	if r.referrers != nil {
 		return *r.referrers, nil
 	}

--- a/daggerverse/oci/tests/main.go
+++ b/daggerverse/oci/tests/main.go
@@ -71,6 +71,8 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("CopyPreservesAllManifests", t.CopyPreservesAllManifests)
 	jobs = jobs.WithJob("PushArtifactThenFetchRoundTripsContent", t.PushArtifactThenFetchRoundTripsContent)
 	jobs = jobs.WithJob("AttachThenFetchRoundTripsContent", t.AttachThenFetchRoundTripsContent)
+	jobs = jobs.WithJob("PushLayerCarriesMediaTypeAndAnnotations", t.PushLayerCarriesMediaTypeAndAnnotations)
+	jobs = jobs.WithJob("PushLayerRejectsMalformedAnnotations", t.PushLayerRejectsMalformedAnnotations)
 	jobs = jobs.WithJob("ReferrersListsAttachedArtifacts", t.ReferrersListsAttachedArtifacts)
 	jobs = jobs.WithJob("ReferrersFiltersByArtifactType", t.ReferrersFiltersByArtifactType)
 	jobs = jobs.WithJob("AttachFailsForUnknownSubject", t.AttachFailsForUnknownSubject)
@@ -646,11 +648,152 @@ func (t *Tests) AttachThenFetchRoundTripsContent(ctx context.Context) error {
 	return nil
 }
 
+// PushLayerCarriesMediaTypeAndAnnotations asserts that a layer pushed under
+// a tag arrives with the media type and the annotations the caller asked
+// for, inside an image manifest carrying an image config.
+//
+// Every one of those is load bearing rather than decorative. The consumers
+// this function exists for — cosign's signature layout is the one this
+// repository publishes — find a document by resolving a tag they computed,
+// filtering layers on a media type they recognise and reading the rest out
+// of that layer's annotations, so a push that dropped any of the three
+// would produce something a verifier reports as unsigned rather than as
+// malformed. The config media type is asserted for the same reason: those
+// readers parse an image, and the artifact-manifest shape oras would
+// otherwise choose is legal OCI that they do not accept.
+func (t *Tests) PushLayerCarriesMediaTypeAndAnnotations(ctx context.Context) error {
+	reg, err := newRegistry(ctx)
+	if err != nil {
+		return err
+	}
+	repo, err := uniqueName(ctx, "pushlayer")
+	if err != nil {
+		return err
+	}
+	payload, err := uniqueName(ctx, "payload")
+	if err != nil {
+		return err
+	}
+	annotation, err := uniqueName(ctx, "annotation")
+	if err != nil {
+		return err
+	}
+
+	const (
+		mediaType = "application/vnd.example.signature.v1+json"
+		key       = "dev.example/signature"
+	)
+	annotations, err := json.Marshal(map[string]string{key: annotation})
+	if err != nil {
+		return fmt.Errorf("encode annotations: %v", err)
+	}
+
+	// The tag is computed from a real published digest rather than made up,
+	// because a registry may read it. zot parses any tag ending in ".sig"
+	// as cosign's, and a short stand-in digest panics it into a 500 with no
+	// message — which reads as a broken push and is a broken tag. Every
+	// caller of PushLayer computes the tag from a digest it just got back,
+	// so the test does too.
+	subject, err := reg.client().PushImage(ctx, repo, "v1", []*dagger.Container{baseImage("linux/amd64")})
+	if err != nil {
+		return fmt.Errorf("PushImage: %v", err)
+	}
+	tag := strings.ReplaceAll(subject, ":", "-") + ".sig"
+
+	content := dag.Directory().WithNewFile("payload.json", payload).File("payload.json")
+	digest, err := reg.client().PushLayer(ctx, repo, tag, content, mediaType,
+		dagger.OciRegistryPushLayerOpts{Annotations: string(annotations)})
+	if err != nil {
+		return fmt.Errorf("PushLayer: %v", err)
+	}
+
+	// Read back by tag rather than by the digest that was returned: the tag
+	// is how every consumer of this layout arrives, so resolving it is part
+	// of what is being asserted, and comparing the two says the returned
+	// digest is the thing the tag names.
+	raw, err := reg.client().Manifest(ctx, repo, tag)
+	if err != nil {
+		return fmt.Errorf("Manifest of %s: %v", tag, err)
+	}
+	resolved, err := reg.client().Resolve(ctx, repo, tag)
+	if err != nil {
+		return fmt.Errorf("Resolve %s: %v", tag, err)
+	}
+	if resolved != digest {
+		return fmt.Errorf("tag %s resolves to %s, but PushLayer returned %s", tag, resolved, digest)
+	}
+
+	manifest, err := decodeManifest(raw)
+	if err != nil {
+		return err
+	}
+	if manifest.MediaType != "application/vnd.oci.image.manifest.v1+json" {
+		return fmt.Errorf("manifest media type: want an image manifest, got %q (manifest %s)", manifest.MediaType, raw)
+	}
+	if manifest.Config.MediaType != "application/vnd.oci.image.config.v1+json" {
+		return fmt.Errorf("config media type: want an image config, got %q (manifest %s)", manifest.Config.MediaType, raw)
+	}
+	if len(manifest.Layers) != 1 {
+		return fmt.Errorf("want exactly one layer, got %d (manifest %s)", len(manifest.Layers), raw)
+	}
+	layer := manifest.Layers[0]
+	if layer.MediaType != mediaType {
+		return fmt.Errorf("layer media type: want %q, got %q (manifest %s)", mediaType, layer.MediaType, raw)
+	}
+	if layer.Annotations[key] != annotation {
+		return fmt.Errorf("layer annotation %s: want %q, got %q (manifest %s)", key, annotation, layer.Annotations[key], raw)
+	}
+
+	got, err := reg.client().Fetch(repo, layer.Digest).Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("Fetch %s: %v", layer.Digest, err)
+	}
+	if got != payload {
+		return fmt.Errorf("layer contents: want %q, got %q", payload, got)
+	}
+	return nil
+}
+
+// PushLayerRejectsMalformedAnnotations asserts the annotations
+// argument fails loudly on anything that is not a JSON object of strings.
+//
+// It is a string because codegen has no map type, which makes it the one
+// argument of this function a caller can get subtly wrong. Accepting a JSON
+// number by stringifying it, or accepting a bare string by ignoring it,
+// would put an annotation on a published manifest that the caller never
+// wrote — and annotations are where this layout keeps the signature.
+func (t *Tests) PushLayerRejectsMalformedAnnotations(ctx context.Context) error {
+	reg, err := newRegistry(ctx)
+	if err != nil {
+		return err
+	}
+	repo, err := uniqueName(ctx, "pushlayer-bad")
+	if err != nil {
+		return err
+	}
+	content := dag.Directory().WithNewFile("payload.json", "{}").File("payload.json")
+
+	for _, annotations := range []string{`"not an object"`, `{"n":1}`, `[]`, `not json at all`} {
+		_, err := reg.client().PushLayer(ctx, repo, "v1", content, "application/json",
+			dagger.OciRegistryPushLayerOpts{Annotations: annotations})
+		if err == nil {
+			return fmt.Errorf("PushLayer accepted annotations %s", annotations)
+		}
+		if !strings.Contains(err.Error(), "JSON object of string values") {
+			return fmt.Errorf("PushLayer with annotations %s failed with %v, which does not say what the argument should have been", annotations, err)
+		}
+	}
+	return nil
+}
+
 // ociManifest is the slice of an OCI manifest these tests read back.
 type ociManifest struct {
 	MediaType    string `json:"mediaType"`
 	ArtifactType string `json:"artifactType"`
-	Layers       []struct {
+	Config       struct {
+		MediaType string `json:"mediaType"`
+	} `json:"config"`
+	Layers []struct {
 		MediaType   string            `json:"mediaType"`
 		Digest      string            `json:"digest"`
 		Annotations map[string]string `json:"annotations"`

--- a/daggerverse/oci/tests/main.go
+++ b/daggerverse/oci/tests/main.go
@@ -773,7 +773,15 @@ func (t *Tests) PushLayerRejectsMalformedAnnotations(ctx context.Context) error 
 	}
 	content := dag.Directory().WithNewFile("payload.json", "{}").File("payload.json")
 
-	for _, annotations := range []string{`"not an object"`, `{"n":1}`, `[]`, `not json at all`} {
+	// null and a null value are in this table because they are the two the
+	// obvious implementation accepts silently: JSON null unmarshals into a
+	// nil map, and a null value into a string is a documented no-op that
+	// leaves the key present and empty. A table without them cannot tell a
+	// correct implementation from that one.
+	for _, annotations := range []string{
+		`"not an object"`, `{"n":1}`, `[]`, `not json at all`,
+		`null`, `{"dev.example/signature":null}`,
+	} {
 		_, err := reg.client().PushLayer(ctx, repo, "v1", content, "application/json",
 			dagger.OciRegistryPushLayerOpts{Annotations: annotations})
 		if err == nil {

--- a/daggerverse/z5labs/app.go
+++ b/daggerverse/z5labs/app.go
@@ -423,7 +423,7 @@ func (a *App) Publish(ctx context.Context, repositories []string) ([]string, err
 		// reason signImage records: it is the only one that writes a tag of
 		// its own, so it gets the smallest window in which a later failure
 		// can leave one behind.
-		if err := a.signImage(ctx, registry, sgn, facts); err != nil {
+		if err := a.signImage(ctx, registry, sgn, repository, digest); err != nil {
 			return nil, fmt.Errorf("%v; %s was left untagged in %s, so no tag resolves to it%s",
 				err, digest, repository, alreadyPublished(refs))
 		}

--- a/daggerverse/z5labs/app.go
+++ b/daggerverse/z5labs/app.go
@@ -206,6 +206,17 @@ func (a *App) WithOidc(requestUrl string, requestToken *dagger.Secret) *App {
 // Leaving it unset is keyless signing and is what a normal CI publish
 // should do.
 //
+// It changes what a consumer has to run, and the change is a downgrade
+// worth stating. Nothing certifies a supplied key, so there is no identity
+// to verify against and nothing to record in the public transparency log;
+// the image signature carries the signature alone, and verifying it means
+//
+//	cosign verify <ref> --key cosign.pub --insecure-ignore-tlog=true
+//
+// where the keyless mode gets an identity and an issuer and no such flag.
+// A caller who does not want to hand their consumers that flag should not
+// be supplying a key.
+//
 // +cache="session"
 func (a *App) WithSigningKey(key *dagger.Secret) *App {
 	a.SigningKey = key
@@ -280,6 +291,21 @@ func (a *App) WithOidcService(svc *dagger.Service) *App {
 // comes from an exchanged workload identity token. A publish that cannot
 // produce provenance fails rather than publishing without it — see
 // newSigner.
+//
+// The image is signed too, and not merely the provenance statement about
+// it: the manifest list and every per-platform manifest beneath it each
+// carry a cosign signature, so a consumer runs
+//
+//	cosign verify <address>/<repository>:<version> \
+//	  --certificate-identity-regexp '^https://github.com/<owner>/<repo>/\.github/workflows/' \
+//	  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+//
+// against the tag, and the same command against any per-platform digest
+// their runtime resolved. Both pass, which is the point of signing every
+// manifest rather than only the one the tag names — see signImage. A
+// publish that cannot sign fails in the same way and for the same reason as
+// one that cannot attest. WithSigningKey changes the verifying command; its
+// doc comment says how.
 //
 // Within one repository the tag is the last thing written: the manifest list
 // goes up under its own digest, the attestations are attached to that digest,
@@ -390,6 +416,14 @@ func (a *App) Publish(ctx context.Context, repositories []string) ([]string, err
 			// resolves, and a caller who wants to look at what was left behind
 			// should be able to. What the ordering buys is that no *name*
 			// reaches it, so nobody arrives at it by pulling a release.
+			return nil, fmt.Errorf("%v; %s was left untagged in %s, so no tag resolves to it%s",
+				err, digest, repository, alreadyPublished(refs))
+		}
+		// The image itself is signed last of the fallible steps, for the
+		// reason signImage records: it is the only one that writes a tag of
+		// its own, so it gets the smallest window in which a later failure
+		// can leave one behind.
+		if err := a.signImage(ctx, registry, sgn, facts); err != nil {
 			return nil, fmt.Errorf("%v; %s was left untagged in %s, so no tag resolves to it%s",
 				err, digest, repository, alreadyPublished(refs))
 		}

--- a/daggerverse/z5labs/internal/dagger/oci.gen.go
+++ b/daggerverse/z5labs/internal/dagger/oci.gen.go
@@ -326,7 +326,7 @@ func (r *OciRegistry) WithGraphQLQuery(q *querybuilder.Selection) *OciRegistry {
 // subject is a manifest digest in this repository; it is resolved first, so
 // attaching to something that is not there fails naming the digest rather
 // than leaving a dangling referrer behind.
-func (r *OciRegistry) Attach(ctx context.Context, repository string, subject string, content *File, artifactType string) (string, error) { // oci (../../../../daggerverse/oci/artifact.go:271:1)
+func (r *OciRegistry) Attach(ctx context.Context, repository string, subject string, content *File, artifactType string) (string, error) { // oci (../../../../daggerverse/oci/artifact.go:299:1)
 	assertNotNil("content", content)
 	if r.attach != nil {
 		return *r.attach, nil
@@ -572,7 +572,7 @@ type OciRegistryPushLayerOpts struct {
 	// strings. Empty sets none. It is JSON rather than a map because codegen
 	// has no map type.
 	//
-	Annotations string // oci (../../../../daggerverse/oci/artifact.go:161:2)
+	Annotations string // oci (../../../../daggerverse/oci/artifact.go:169:2)
 }
 
 // PushLayer pushes one file to repository:tag as a single-layer OCI image
@@ -608,7 +608,13 @@ type OciRegistryPushLayerOpts struct {
 // The manifest is addressed by tag, so pushing the same tag twice replaces
 // it — which is what a caller re-signing a digest wants, and is the
 // difference from Attach, where each call adds a referrer.
-func (r *OciRegistry) PushLayer(ctx context.Context, repository string, tag string, content *File, mediaType string, opts ...OciRegistryPushLayerOpts) (string, error) { // oci (../../../../daggerverse/oci/artifact.go:145:1)
+//
+// The content is held in memory whole, exactly as Attach and PushArtifact
+// hold theirs, so this is sized for documents — signatures, payloads,
+// attestations — and not for image layers. Streaming would be a change to
+// all three rather than to this one, since a caller cannot tell them apart
+// on that axis today.
+func (r *OciRegistry) PushLayer(ctx context.Context, repository string, tag string, content *File, mediaType string, opts ...OciRegistryPushLayerOpts) (string, error) { // oci (../../../../daggerverse/oci/artifact.go:151:1)
 	assertNotNil("content", content)
 	if r.pushLayer != nil {
 		return *r.pushLayer, nil
@@ -636,7 +642,7 @@ type OciRegistryReferrersOpts struct {
 	//
 	// Restrict the listing to one artifact type. Empty lists them all.
 	//
-	ArtifactType string // oci (../../../../daggerverse/oci/artifact.go:376:2)
+	ArtifactType string // oci (../../../../daggerverse/oci/artifact.go:404:2)
 }
 
 // Referrers lists the artifacts attached to subject as a JSON array of OCI
@@ -646,7 +652,7 @@ type OciRegistryReferrersOpts struct {
 // map type, so annotations could not be modelled; and a module object
 // returned from a never-cached call detaches in Dagger v0.21, so lazily
 // reading its fields fails.
-func (r *OciRegistry) Referrers(ctx context.Context, repository string, subject string, opts ...OciRegistryReferrersOpts) (string, error) { // oci (../../../../daggerverse/oci/artifact.go:367:1)
+func (r *OciRegistry) Referrers(ctx context.Context, repository string, subject string, opts ...OciRegistryReferrersOpts) (string, error) { // oci (../../../../daggerverse/oci/artifact.go:395:1)
 	if r.referrers != nil {
 		return *r.referrers, nil
 	}

--- a/daggerverse/z5labs/internal/dagger/oci.gen.go
+++ b/daggerverse/z5labs/internal/dagger/oci.gen.go
@@ -307,6 +307,7 @@ type OciRegistry struct { // oci (../../../../daggerverse/oci/main.go:148:6)
 	pushArtifact      *string
 	pushImage         *string
 	pushImageUntagged *string
+	pushLayer         *string
 	referrers         *string
 	resolve           *string
 	tag               *string
@@ -325,7 +326,7 @@ func (r *OciRegistry) WithGraphQLQuery(q *querybuilder.Selection) *OciRegistry {
 // subject is a manifest digest in this repository; it is resolved first, so
 // attaching to something that is not there fails naming the digest rather
 // than leaving a dangling referrer behind.
-func (r *OciRegistry) Attach(ctx context.Context, repository string, subject string, content *File, artifactType string) (string, error) { // oci (../../../../daggerverse/oci/artifact.go:117:1)
+func (r *OciRegistry) Attach(ctx context.Context, repository string, subject string, content *File, artifactType string) (string, error) { // oci (../../../../daggerverse/oci/artifact.go:271:1)
 	assertNotNil("content", content)
 	if r.attach != nil {
 		return *r.attach, nil
@@ -480,7 +481,7 @@ func (r *OciRegistry) Manifest(ctx context.Context, repository string, reference
 // org.opencontainers.image.title annotation is its path relative to the
 // directory root. Layers are ordered by that path so the same directory
 // always produces the same manifest.
-func (r *OciRegistry) PushArtifact(ctx context.Context, repository string, tag string, contents *Directory, artifactType string) (string, error) { // oci (../../../../daggerverse/oci/artifact.go:44:1)
+func (r *OciRegistry) PushArtifact(ctx context.Context, repository string, tag string, contents *Directory, artifactType string) (string, error) { // oci (../../../../daggerverse/oci/artifact.go:45:1)
 	assertNotNil("contents", contents)
 	if r.pushArtifact != nil {
 		return *r.pushArtifact, nil
@@ -564,12 +565,78 @@ func (r *OciRegistry) PushImageUntagged(ctx context.Context, repository string, 
 	return response, q.Execute(ctx)
 }
 
+// OciRegistryPushLayerOpts contains options for OciRegistry.PushLayer
+type OciRegistryPushLayerOpts struct {
+	//
+	// Annotations to set on the layer, as a JSON object whose values are
+	// strings. Empty sets none. It is JSON rather than a map because codegen
+	// has no map type.
+	//
+	Annotations string // oci (../../../../daggerverse/oci/artifact.go:161:2)
+}
+
+// PushLayer pushes one file to repository:tag as a single-layer OCI image
+// manifest and returns the manifest digest.
+//
+// It exists because two families of consumer read a document's meaning off
+// the *layer* rather than off the manifest: they resolve a tag whose name
+// they compute themselves, take the one layer whose media type they
+// recognise, and read the rest out of that layer's annotations. Cosign's
+// signature layout is the one this repository needs — `sha256-<hex>.sig`,
+// one `application/vnd.dev.cosign.simplesigning.v1+json` layer, the
+// signature in an annotation beside it — but nothing here knows that. This
+// function is handed a tag, some bytes, a media type and a set of
+// annotations, exactly as Attach is handed a file and an artifact type, and
+// that is all it ever learns.
+//
+// The three ways it differs from PushArtifact and Attach, each of which is
+// why neither of those could be stretched to cover it:
+//
+//   - The layer's media type is the caller's. PushArtifact gives every layer
+//     application/octet-stream, which is right for a document a consumer
+//     fetches by digest and wrong for one a consumer finds by filtering
+//     layers on their type.
+//   - The layer's annotations are the caller's. Both of the others set the
+//     standard title annotation and nothing else, so there is nowhere to put
+//     a signature.
+//   - The config is a real empty image config rather than the OCI empty
+//     descriptor oras.PackManifest would choose. Readers of this layout go
+//     through go-containerregistry's image type, which expects an image
+//     manifest carrying an image config; the artifact-manifest shape is
+//     legal OCI and is not what they parse.
+//
+// The manifest is addressed by tag, so pushing the same tag twice replaces
+// it — which is what a caller re-signing a digest wants, and is the
+// difference from Attach, where each call adds a referrer.
+func (r *OciRegistry) PushLayer(ctx context.Context, repository string, tag string, content *File, mediaType string, opts ...OciRegistryPushLayerOpts) (string, error) { // oci (../../../../daggerverse/oci/artifact.go:145:1)
+	assertNotNil("content", content)
+	if r.pushLayer != nil {
+		return *r.pushLayer, nil
+	}
+	q := r.query.Select("pushLayer")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `annotations` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Annotations) {
+			q = q.Arg("annotations", opts[i].Annotations)
+		}
+	}
+	q = q.Arg("repository", repository)
+	q = q.Arg("tag", tag)
+	q = q.Arg("content", content)
+	q = q.Arg("mediaType", mediaType)
+
+	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
 // OciRegistryReferrersOpts contains options for OciRegistry.Referrers
 type OciRegistryReferrersOpts struct {
 	//
 	// Restrict the listing to one artifact type. Empty lists them all.
 	//
-	ArtifactType string // oci (../../../../daggerverse/oci/artifact.go:222:2)
+	ArtifactType string // oci (../../../../daggerverse/oci/artifact.go:376:2)
 }
 
 // Referrers lists the artifacts attached to subject as a JSON array of OCI
@@ -579,7 +646,7 @@ type OciRegistryReferrersOpts struct {
 // map type, so annotations could not be modelled; and a module object
 // returned from a never-cached call detaches in Dagger v0.21, so lazily
 // reading its fields fails.
-func (r *OciRegistry) Referrers(ctx context.Context, repository string, subject string, opts ...OciRegistryReferrersOpts) (string, error) { // oci (../../../../daggerverse/oci/artifact.go:213:1)
+func (r *OciRegistry) Referrers(ctx context.Context, repository string, subject string, opts ...OciRegistryReferrersOpts) (string, error) { // oci (../../../../daggerverse/oci/artifact.go:367:1)
 	if r.referrers != nil {
 		return *r.referrers, nil
 	}

--- a/daggerverse/z5labs/sign.go
+++ b/daggerverse/z5labs/sign.go
@@ -1,0 +1,469 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"dagger/z-5-labs/internal/dagger"
+)
+
+// The cosign signature layout this module writes.
+//
+// It is cosign's rather than something z5labs invented, and that is the
+// whole decision. A signature is worth exactly what the command verifying
+// it is worth, and the command a consumer already has is:
+//
+//	cosign verify ghcr.io/<owner>/<app>:<version> \
+//	  --certificate-identity-regexp '^https://github.com/<owner>/<repo>/\.github/workflows/' \
+//	  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+//
+// Publishing a signature stock cosign cannot read would mean publishing a
+// verifier alongside it, and a verification story that ships with its own
+// verifier is one nobody runs. So the layout is copied, not designed: for
+// a manifest at digest `sha256:<hex>`, a one-layer OCI image manifest is
+// pushed to the tag `sha256-<hex>.sig` in the same repository, its layer
+// holding the simple-signing payload and its annotations holding the
+// signature and the certificate that vouches for the key.
+//
+// The alternative was the OCI 1.1 referrers form, which cosign writes under
+// `--registry-referrers-mode=oci-1-1` and reads only under
+// `--experimental-oci11`. It is the better shape — a signature is a
+// referrer of the thing it signs, and the tag scheme is a workaround for
+// registries that had no referrers API — and it is rejected here for one
+// reason: it is not what a consumer's `cosign verify` reads today. Revisit
+// when reading it stops needing a flag.
+const (
+	// simpleSigningMediaType is the layer media type cosign takes a
+	// signature payload out of.
+	simpleSigningMediaType = "application/vnd.dev.cosign.simplesigning.v1+json"
+	// cosignSignatureType is the `critical.type` of every simple signing
+	// payload, and is part of the signed bytes: a payload cannot be
+	// replayed as some other kind of claim about the same digest.
+	cosignSignatureType = "cosign container image signature"
+	// signatureTagSuffix completes the tag a signature lands on.
+	signatureTagSuffix = ".sig"
+
+	// The annotations cosign reads beside the payload. The signature key is
+	// spelled `dev.cosignproject.cosign/...` and the rest
+	// `dev.sigstore.cosign/...`; the inconsistency is upstream's and
+	// copying it exactly is the point.
+	cosignSignatureAnnotation   = "dev.cosignproject.cosign/signature"
+	cosignCertificateAnnotation = "dev.sigstore.cosign/certificate"
+	cosignChainAnnotation       = "dev.sigstore.cosign/chain"
+	cosignBundleAnnotation      = "dev.sigstore.cosign/bundle"
+)
+
+// defaultRekorURL is the public sigstore transparency log.
+//
+// Keyless signing without a log entry is not a weaker version of keyless
+// signing, it is a broken one: the certificate that binds the ephemeral key
+// to a workload identity lives for ten minutes, so by the time anybody
+// verifies, it has expired and nothing establishes that it was valid when
+// it signed. The log entry is what does — it is countersigned by the log at
+// upload time, so a verifier checks "this signature existed while the
+// certificate was live" rather than having to trust a clock. That is the
+// property that makes signing.go's "no key this pipeline has to manage"
+// a trade rather than a hole.
+const defaultRekorURL = "https://rekor.sigstore.dev"
+
+// rekorTimeout bounds the log upload for the same reason fulcioTimeout
+// bounds the certificate request.
+const rekorTimeout = 60 * time.Second
+
+// signImage signs the published manifest list and every per-platform
+// manifest beneath it.
+//
+// # Why every manifest and not just the one the tag names
+//
+// A consumer verifies `<repo>:<version>`, which resolves to the manifest
+// list, and their runtime then pulls the per-platform manifest for their
+// architecture — a different digest, which the index signature says nothing
+// about. Signing only the index leaves the bytes that actually run
+// unsigned while `cosign verify` against the tag still passes, which is the
+// worst available outcome: a verification that reports success over
+// something it did not check. So each digest is signed on its own, and
+// `cosign verify <repo>@<per-platform digest>` passes too.
+//
+// This is what cosign's own `--recursive` does, and the reason it exists.
+//
+// # Where it runs
+//
+// After the attestations and before the tag, which keeps Publish's rule
+// that no *name* reaches an image until everything that can fail has
+// succeeded. The signature manifests are themselves tagged — the layout
+// requires it, the tag is computed from the digest — so a publish that
+// fails after this point leaves `sha256-<hex>.sig` tags behind pointing at
+// a signature for a manifest no release tag resolves to. That is why this
+// step is last rather than first: it is the only one that can leave a name
+// behind at all, so it gets the smallest window. The leftovers are inert —
+// nothing resolves to them without already knowing the digest, and a
+// re-publish of the same bytes overwrites them.
+func (a *App) signImage(
+	ctx context.Context,
+	registry *dagger.OciRegistry,
+	sgn *signer,
+	facts buildFacts,
+) error {
+	digests, err := signableDigests(ctx, registry, facts.Repository, facts.Digest)
+	if err != nil {
+		return err
+	}
+	// The reference recorded in every payload is the repository, without a
+	// tag and without a digest. That is what cosign writes, and it is the
+	// only honest choice for the per-platform manifests: they are reachable
+	// under no tag of their own, so naming one in their payload would put a
+	// claim in the signed bytes that does not resolve. What ties a payload
+	// to a specific manifest is the digest beside it, which is the field
+	// cosign checks.
+	reference := a.Registry + "/" + facts.Repository
+	for _, digest := range digests {
+		if err := a.signManifest(ctx, registry, sgn, facts.Repository, reference, digest); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// signManifest signs one manifest digest and pushes the signature.
+func (a *App) signManifest(
+	ctx context.Context,
+	registry *dagger.OciRegistry,
+	sgn *signer,
+	repository, reference, digest string,
+) error {
+	payload, err := simpleSigningPayload(reference, digest)
+	if err != nil {
+		return err
+	}
+	signature, err := sgn.signBytes(payload)
+	if err != nil {
+		return fmt.Errorf("sign %s: %v", digest, err)
+	}
+	annotations, err := sgn.signatureAnnotations(ctx, payload, signature)
+	if err != nil {
+		return fmt.Errorf("sign %s: %v", digest, err)
+	}
+	encoded, err := json.Marshal(annotations)
+	if err != nil {
+		return fmt.Errorf("encode signature annotations for %s: %v", digest, err)
+	}
+	// The payload is content-addressed by writeWorkdirFile, so two digests
+	// signed in one publish do not collide on one path despite sharing a
+	// file name.
+	file, err := writeWorkdirFile("signature.json", payload)
+	if err != nil {
+		return fmt.Errorf("write signature payload for %s: %v", digest, err)
+	}
+	tag, err := signatureTag(digest)
+	if err != nil {
+		return err
+	}
+	_, err = registry.PushLayer(ctx, repository, tag, file, simpleSigningMediaType,
+		dagger.OciRegistryPushLayerOpts{Annotations: string(encoded)})
+	if err != nil {
+		return fmt.Errorf("push signature for %s to %s:%s: %v", digest, repository, tag, err)
+	}
+	return nil
+}
+
+// signableDigests is the published digest followed by every manifest listed
+// beneath it, which is the set a recursive signature has to cover.
+//
+// A single-platform publish stores a bare image manifest rather than an
+// index; that has no `manifests` array, so the set is the one digest and
+// the recursion costs nothing. Reading the manifest back rather than
+// deriving the children from a.Variants is deliberate: the child digests
+// are the registry's account of what it stored, and a signature over
+// anything else would be a signature over what this module believed it had
+// pushed.
+func signableDigests(ctx context.Context, registry *dagger.OciRegistry, repository, digest string) ([]string, error) {
+	raw, err := registry.Manifest(ctx, repository, digest)
+	if err != nil {
+		return nil, fmt.Errorf("read manifest %s from %s: %v", digest, repository, err)
+	}
+	var doc struct {
+		Manifests []struct {
+			Digest string `json:"digest"`
+		} `json:"manifests"`
+	}
+	if err := json.Unmarshal([]byte(raw), &doc); err != nil {
+		return nil, fmt.Errorf("decode manifest %s from %s: %v", digest, repository, err)
+	}
+	out := []string{digest}
+	for _, child := range doc.Manifests {
+		if strings.TrimSpace(child.Digest) == "" {
+			return nil, fmt.Errorf("manifest %s in %s lists an entry with no digest", digest, repository)
+		}
+		out = append(out, child.Digest)
+	}
+	return out, nil
+}
+
+// signatureTag is the tag a signature for digest lands on: the digest with
+// its algorithm separator turned into a dash, plus ".sig".
+//
+// A registry tag cannot contain a colon, which is the entire reason the
+// layout is spelled this way rather than as the digest itself.
+func signatureTag(digest string) (string, error) {
+	algorithm, encoded, ok := strings.Cut(digest, ":")
+	if !ok || algorithm == "" || encoded == "" {
+		return "", fmt.Errorf("manifest digest %q is not <algorithm>:<hex>", digest)
+	}
+	return algorithm + "-" + encoded + signatureTagSuffix, nil
+}
+
+// simpleSigningPayload renders the document that gets signed.
+//
+// The shape is Red Hat's "simple signing" payload, which cosign adopted and
+// which is why the field names read like a Docker reference rather than
+// like anything in this repository. It is rendered from typed structs so
+// the bytes are the same on every run and so a field cannot be quietly
+// dropped by a map literal typo.
+func simpleSigningPayload(reference, digest string) ([]byte, error) {
+	if strings.TrimSpace(reference) == "" {
+		return nil, fmt.Errorf("signature payload requires an image reference")
+	}
+	if _, encoded, ok := strings.Cut(digest, ":"); !ok || encoded == "" {
+		return nil, fmt.Errorf("manifest digest %q is not <algorithm>:<hex>", digest)
+	}
+	type identity struct {
+		DockerReference string `json:"docker-reference"`
+	}
+	type image struct {
+		DockerManifestDigest string `json:"docker-manifest-digest"`
+	}
+	type critical struct {
+		Identity identity `json:"identity"`
+		Image    image    `json:"image"`
+		Kind     string   `json:"type"`
+	}
+	// Optional is present and null rather than absent, which is what cosign
+	// emits. It is where cosign puts `--annotations`; this module sets none,
+	// because everything a caller could annotate an image with is already in
+	// the provenance predicate, where it is attested rather than asserted.
+	payload := struct {
+		Critical critical `json:"critical"`
+		Optional any      `json:"optional"`
+	}{
+		Critical: critical{
+			Identity: identity{DockerReference: reference},
+			Image:    image{DockerManifestDigest: digest},
+			Kind:     cosignSignatureType,
+		},
+	}
+	out, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("encode signature payload: %v", err)
+	}
+	return out, nil
+}
+
+// signBytes signs a payload the way cosign does — ECDSA over its SHA-256,
+// ASN.1 DER, base64 — and returns the annotation value.
+//
+// Note what is *not* here: no DSSE wrapper. The attestations are DSSE
+// because a verifier has to be stopped from replaying an in-toto statement
+// as some other kind of document; a simple signing payload names its own
+// type in the signed bytes, so it carries that property itself. Wrapping it
+// anyway would produce something cosign cannot read, which is the one
+// property this layout exists to have.
+func (s *signer) signBytes(payload []byte) (string, error) {
+	digest := sha256.Sum256(payload)
+	sig, err := ecdsa.SignASN1(rand.Reader, s.key, digest[:])
+	if err != nil {
+		return "", fmt.Errorf("sign payload: %v", err)
+	}
+	return base64.StdEncoding.EncodeToString(sig), nil
+}
+
+// signatureAnnotations is what goes on the signature layer beside the
+// payload: always the signature, and in the keyless mode the certificate
+// chain and the transparency log entry that make it verifiable by identity
+// rather than by key.
+//
+// The two modes produce two different verifying commands, and both are
+// written down rather than one being treated as the real one:
+//
+//   - Keyless, which is what a CI publish does:
+//
+//     cosign verify <ref> \
+//     --certificate-identity-regexp '^https://github.com/<owner>/<repo>/\.github/workflows/' \
+//     --certificate-oidc-issuer https://token.actions.githubusercontent.com
+//
+//   - A caller-supplied key, which is for a build that cannot reach the
+//     public CA. There is no certificate to bind the key to an identity and
+//     no log entry, so the verifier needs the public key and has to be told
+//     not to look for one:
+//
+//     cosign verify <ref> --key cosign.pub --insecure-ignore-tlog=true
+//
+// The second is weaker and says so: `--insecure-ignore-tlog` is spelled the
+// way it is on purpose, and a caller who does not want to hand their
+// consumers that flag should not be supplying a key.
+func (s *signer) signatureAnnotations(ctx context.Context, payload []byte, signature string) (map[string]string, error) {
+	out := map[string]string{cosignSignatureAnnotation: signature}
+	if len(s.chain) == 0 {
+		return out, nil
+	}
+	certificate, chain, err := splitCertificateChain(s.chain)
+	if err != nil {
+		return nil, err
+	}
+	out[cosignCertificateAnnotation] = certificate
+	if chain != "" {
+		out[cosignChainAnnotation] = chain
+	}
+	bundle, err := rekorBundle(ctx, payload, signature, certificate)
+	if err != nil {
+		return nil, err
+	}
+	out[cosignBundleAnnotation] = bundle
+	return out, nil
+}
+
+// splitCertificateChain separates the leaf certificate from the
+// intermediates, because cosign reads them from two different annotations:
+// the leaf is the identity, the rest is how a verifier walks to a root.
+func splitCertificateChain(chain []byte) (string, string, error) {
+	var leaf bytes.Buffer
+	var rest bytes.Buffer
+	remaining := chain
+	for {
+		block, tail := pem.Decode(remaining)
+		if block == nil {
+			break
+		}
+		remaining = tail
+		target := &rest
+		if leaf.Len() == 0 {
+			target = &leaf
+		}
+		if err := pem.Encode(target, block); err != nil {
+			return "", "", fmt.Errorf("re-encode signing certificate: %v", err)
+		}
+	}
+	if leaf.Len() == 0 {
+		return "", "", fmt.Errorf("signing certificate chain carried no PEM certificate")
+	}
+	return leaf.String(), rest.String(), nil
+}
+
+// rekorBundle uploads the signature to the public transparency log and
+// returns the bundle cosign carries beside it.
+//
+// The entry is a `hashedrekord`: the log is told the payload's hash, the
+// signature and the certificate, never the payload. That matters for a
+// private image — the log is public and permanent, and a simple signing
+// payload names the repository.
+//
+// What comes back and is stored is the log's countersignature (the signed
+// entry timestamp) over the entry, plus enough of the entry to check it.
+// That is what a verifier uses to establish the certificate was valid at
+// signing time without contacting the log at all, which is why the bundle
+// is embedded rather than left to be looked up: a consumer verifying from
+// inside a network that cannot reach rekor.sigstore.dev still can.
+//
+// Like fulcioCertificate, this is a part of the publish path the test suite
+// cannot exercise — it needs the live public log, and the suite runs against
+// a registry with no sigstore beside it. The suite covers the layout and the
+// signature by driving the supplied-key mode, where neither this nor a
+// certificate exists; what is untested here is the HTTP shape of one
+// request.
+func rekorBundle(ctx context.Context, payload []byte, signature, certificate string) (string, error) {
+	sum := sha256.Sum256(payload)
+	body, err := json.Marshal(map[string]any{
+		"apiVersion": "0.0.1",
+		"kind":       "hashedrekord",
+		"spec": map[string]any{
+			"data": map[string]any{
+				"hash": map[string]string{
+					"algorithm": "sha256",
+					"value":     hex.EncodeToString(sum[:]),
+				},
+			},
+			"signature": map[string]any{
+				"content": signature,
+				"publicKey": map[string]string{
+					"content": base64.StdEncoding.EncodeToString([]byte(certificate)),
+				},
+			},
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("encode transparency log entry: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, rekorTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		defaultRekorURL+"/api/v1/log/entries", bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("build transparency log request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("record signature in the transparency log at %s: %v", defaultRekorURL, err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", fmt.Errorf("read transparency log response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return "", fmt.Errorf("transparency log at %s returned %s", defaultRekorURL, resp.Status)
+	}
+
+	// The response is keyed by the entry's UUID, which is not known until
+	// the log assigns it, so the one entry is taken out of a map of one
+	// rather than read from a named field.
+	var entries map[string]struct {
+		Body           string `json:"body"`
+		IntegratedTime int64  `json:"integratedTime"`
+		LogID          string `json:"logID"`
+		LogIndex       int64  `json:"logIndex"`
+		Verification   struct {
+			SignedEntryTimestamp string `json:"signedEntryTimestamp"`
+		} `json:"verification"`
+	}
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		return "", fmt.Errorf("decode transparency log response: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.Verification.SignedEntryTimestamp == "" {
+			return "", fmt.Errorf("transparency log entry from %s carried no signed entry timestamp", defaultRekorURL)
+		}
+		// The field names are capitalized because cosign's bundle type
+		// spells them that way; they are a wire format, not a style choice.
+		bundle, err := json.Marshal(map[string]any{
+			"SignedEntryTimestamp": entry.Verification.SignedEntryTimestamp,
+			"Payload": map[string]any{
+				"body":           entry.Body,
+				"integratedTime": entry.IntegratedTime,
+				"logIndex":       entry.LogIndex,
+				"logID":          entry.LogID,
+			},
+		})
+		if err != nil {
+			return "", fmt.Errorf("encode transparency log bundle: %v", err)
+		}
+		return string(bundle), nil
+	}
+	return "", fmt.Errorf("transparency log at %s recorded no entry", defaultRekorURL)
+}

--- a/daggerverse/z5labs/sign.go
+++ b/daggerverse/z5labs/sign.go
@@ -110,13 +110,28 @@ const rekorTimeout = 60 * time.Second
 // behind at all, so it gets the smallest window. The leftovers are inert —
 // nothing resolves to them without already knowing the digest, and a
 // re-publish of the same bytes overwrites them.
+//
+// # What it costs
+//
+// One signature per manifest, and in the keyless mode one transparency log
+// upload per signature, issued one after another against a shared public
+// service. A four-platform release is therefore five serial round trips to
+// rekor.sigstore.dev inside the publish, each bounded by rekorTimeout. That
+// is a publish-latency and third-party-availability characteristic rather
+// than a defect, and it is written down here so it is a known cost rather
+// than a surprise in a release that suddenly takes minutes.
+//
+// repository and digest are taken as arguments rather than read off a
+// buildFacts, so this cannot drift from the repository the caller's error
+// messages name. Publish rebuilds its facts per repository, which made the
+// two agree; agreeing by construction is better than agreeing by care.
 func (a *App) signImage(
 	ctx context.Context,
 	registry *dagger.OciRegistry,
 	sgn *signer,
-	facts buildFacts,
+	repository, digest string,
 ) error {
-	digests, err := signableDigests(ctx, registry, facts.Repository, facts.Digest)
+	digests, err := signableDigests(ctx, registry, repository, digest)
 	if err != nil {
 		return err
 	}
@@ -127,9 +142,9 @@ func (a *App) signImage(
 	// claim in the signed bytes that does not resolve. What ties a payload
 	// to a specific manifest is the digest beside it, which is the field
 	// cosign checks.
-	reference := a.Registry + "/" + facts.Repository
-	for _, digest := range digests {
-		if err := a.signManifest(ctx, registry, sgn, facts.Repository, reference, digest); err != nil {
+	reference := a.Registry + "/" + repository
+	for _, target := range digests {
+		if err := a.signManifest(ctx, registry, sgn, repository, reference, target); err != nil {
 			return err
 		}
 	}
@@ -188,6 +203,24 @@ func (a *App) signManifest(
 // are the registry's account of what it stored, and a signature over
 // anything else would be a signature over what this module believed it had
 // pushed.
+//
+// # It walks exactly one level, and refuses rather than assuming
+//
+// An index whose child is itself an index would leave the innermost
+// manifests — the ones a runtime actually pulls — unsigned, while
+// `cosign verify <tag>` kept passing. That is the failure this whole
+// function exists to close, reintroduced one level down, so a nested index
+// is an error rather than something walked past. Nothing this pipeline
+// pushes can produce one: PushImageUntagged writes a flat index of the
+// platform variants. The check is here because "cannot happen today" and
+// "is checked" are different, and only one of them survives a change to the
+// producer.
+//
+// Duplicates are collapsed. An index listing one digest twice would
+// otherwise sign it twice and push the same tag twice — harmless, since the
+// second push replaces the first, but it would make the number of signature
+// tags disagree with the number of distinct manifests, which is what the
+// suite compares against.
 func signableDigests(ctx context.Context, registry *dagger.OciRegistry, repository, digest string) ([]string, error) {
 	raw, err := registry.Manifest(ctx, repository, digest)
 	if err != nil {
@@ -195,20 +228,45 @@ func signableDigests(ctx context.Context, registry *dagger.OciRegistry, reposito
 	}
 	var doc struct {
 		Manifests []struct {
-			Digest string `json:"digest"`
+			MediaType string `json:"mediaType"`
+			Digest    string `json:"digest"`
 		} `json:"manifests"`
 	}
 	if err := json.Unmarshal([]byte(raw), &doc); err != nil {
 		return nil, fmt.Errorf("decode manifest %s from %s: %v", digest, repository, err)
 	}
 	out := []string{digest}
+	seen := map[string]bool{digest: true}
 	for _, child := range doc.Manifests {
 		if strings.TrimSpace(child.Digest) == "" {
 			return nil, fmt.Errorf("manifest %s in %s lists an entry with no digest", digest, repository)
 		}
+		if isIndexMediaType(child.MediaType) {
+			return nil, fmt.Errorf(
+				"manifest %s in %s lists %s, which is itself an index; signing it without descending would leave the manifests beneath it unsigned while a verify against the tag still passed",
+				digest, repository, child.Digest)
+		}
+		if seen[child.Digest] {
+			continue
+		}
+		seen[child.Digest] = true
 		out = append(out, child.Digest)
 	}
 	return out, nil
+}
+
+// isIndexMediaType reports whether a descriptor names a manifest list.
+// Both spellings are here because a registry serves whichever the pusher
+// wrote, and a check that knew only the OCI one would walk past a Docker
+// manifest list.
+func isIndexMediaType(mediaType string) bool {
+	switch mediaType {
+	case "application/vnd.oci.image.index.v1+json",
+		"application/vnd.docker.distribution.manifest.list.v2+json":
+		return true
+	default:
+		return false
+	}
 }
 
 // signatureTag is the tag a signature for digest lands on: the digest with
@@ -314,8 +372,21 @@ func (s *signer) signBytes(payload []byte) (string, error) {
 // consumers that flag should not be supplying a key.
 func (s *signer) signatureAnnotations(ctx context.Context, payload []byte, signature string) (map[string]string, error) {
 	out := map[string]string{cosignSignatureAnnotation: signature}
-	if len(s.chain) == 0 {
+	if !s.keyless {
 		return out, nil
+	}
+	// The mode is read off the signer, never off the chain, and a keyless
+	// signer without one is a refusal rather than a quieter signature. What
+	// it would otherwise publish is a signature with no certificate and no
+	// log entry: the identity command in Publish's doc comment has nothing
+	// to check, and the supplied-key command has no public key to be given,
+	// so the image ships signed and verifiable by nobody. Unreachable today,
+	// because fulcioCertificate refuses an empty chain — which is exactly
+	// why it costs nothing to say so here as well.
+	if len(s.chain) == 0 {
+		return nil, fmt.Errorf(
+			"keyless signing produced no certificate chain, so nothing would vouch for the signing key; " +
+				"refusing to publish a signature no documented verify command can check")
 	}
 	certificate, chain, err := splitCertificateChain(s.chain)
 	if err != nil {
@@ -336,7 +407,23 @@ func (s *signer) signatureAnnotations(ctx context.Context, payload []byte, signa
 // splitCertificateChain separates the leaf certificate from the
 // intermediates, because cosign reads them from two different annotations:
 // the leaf is the identity, the rest is how a verifier walks to a root.
+//
+// It is strict about two things that a lenient parse would swallow, and both
+// matter because what is being assembled is the identity half of a
+// signature — the half a verifier decides whom to trust from.
+//
+//   - A block that is not a CERTIFICATE is refused rather than skipped or
+//     published. A lenient reader hands whatever came first to
+//     dev.sigstore.cosign/certificate, so a PKCS#7 body or a key
+//     concatenated into the response would be published as the signing
+//     identity.
+//   - Bytes left over after the last block are refused. pem.Decode stops at
+//     the first byte it cannot parse, so a chain whose second certificate
+//     is truncated would otherwise yield a leaf, an empty chain and no
+//     error — a signature no verifier can walk to a root, published as
+//     though it were complete.
 func splitCertificateChain(chain []byte) (string, string, error) {
+	const certificateBlock = "CERTIFICATE"
 	var leaf bytes.Buffer
 	var rest bytes.Buffer
 	remaining := chain
@@ -344,6 +431,11 @@ func splitCertificateChain(chain []byte) (string, string, error) {
 		block, tail := pem.Decode(remaining)
 		if block == nil {
 			break
+		}
+		if block.Type != certificateBlock {
+			return "", "", fmt.Errorf(
+				"signing certificate chain carries a %q PEM block where a %s was expected",
+				block.Type, certificateBlock)
 		}
 		remaining = tail
 		target := &rest
@@ -356,6 +448,11 @@ func splitCertificateChain(chain []byte) (string, string, error) {
 	}
 	if leaf.Len() == 0 {
 		return "", "", fmt.Errorf("signing certificate chain carried no PEM certificate")
+	}
+	if len(bytes.TrimSpace(remaining)) > 0 {
+		return "", "", fmt.Errorf(
+			"signing certificate chain carries %d trailing bytes that are not a PEM block, so it is incomplete",
+			len(bytes.TrimSpace(remaining)))
 	}
 	return leaf.String(), rest.String(), nil
 }
@@ -432,7 +529,10 @@ func rekorBundle(ctx context.Context, payload []byte, signature, certificate str
 
 	// The response is keyed by the entry's UUID, which is not known until
 	// the log assigns it, so the one entry is taken out of a map of one
-	// rather than read from a named field.
+	// rather than read from a named field. "Of one" is checked rather than
+	// assumed: ranging a map of two and returning from the first iteration
+	// would pick one of them by hash order, so a log that ever answered with
+	// more than one entry would embed a bundle chosen at random.
 	var entries map[string]struct {
 		Body           string `json:"body"`
 		IntegratedTime int64  `json:"integratedTime"`
@@ -444,6 +544,10 @@ func rekorBundle(ctx context.Context, payload []byte, signature, certificate str
 	}
 	if err := json.Unmarshal(raw, &entries); err != nil {
 		return "", fmt.Errorf("decode transparency log response: %v", err)
+	}
+	if len(entries) != 1 {
+		return "", fmt.Errorf("transparency log at %s recorded %d entries for one signature, want exactly 1",
+			defaultRekorURL, len(entries))
 	}
 	for _, entry := range entries {
 		if entry.Verification.SignedEntryTimestamp == "" {
@@ -465,5 +569,6 @@ func rekorBundle(ctx context.Context, payload []byte, signature, certificate str
 		}
 		return string(bundle), nil
 	}
+	// Unreachable: the length check above already refused an empty map.
 	return "", fmt.Errorf("transparency log at %s recorded no entry", defaultRekorURL)
 }

--- a/daggerverse/z5labs/signing.go
+++ b/daggerverse/z5labs/signing.go
@@ -40,6 +40,18 @@ const dssePayloadType = "application/vnd.in-toto+json"
 // together with the certificate chain that says whose key it is.
 type signer struct {
 	key *ecdsa.PrivateKey
+	// keyless says which mode produced this signer, and is not inferred
+	// from any other field.
+	//
+	// It exists because "keyless" and "has a certificate chain" are two
+	// propositions, and the code that reads them apart is the code that
+	// decides whether a signature carries an identity at all. Inferring the
+	// mode from an empty chain means a keyless publish that somehow lost its
+	// certificate publishes a signature with no certificate and no log
+	// entry — verifiable by neither documented command — and reports
+	// success. That is the refusal in newSigner quietly becoming
+	// conditional, which is the one thing it exists not to be.
+	keyless bool
 	// chain is the PEM certificate chain binding key to an identity.
 	// Empty for a caller-supplied signing key, where the caller owns the
 	// question of how a verifier learns the public key.
@@ -90,7 +102,7 @@ func newSigner(ctx context.Context, idTokenRequestURL string, idTokenRequestToke
 	if err != nil {
 		return nil, err
 	}
-	return &signer{key: key, chain: chain, identity: identity}, nil
+	return &signer{key: key, keyless: true, chain: chain, identity: identity}, nil
 }
 
 // parseSigningKey reads a PEM-encoded EC private key out of a secret.

--- a/daggerverse/z5labs/tests/attest.go
+++ b/daggerverse/z5labs/tests/attest.go
@@ -359,6 +359,13 @@ func (t *Tests) AppAttestsTwoSegmentRepositories(ctx context.Context) error {
 // until somebody goes looking, so the pipeline that quietly drops it is
 // the one nobody notices. The registry is checked afterwards to confirm
 // the refusal happened before the push and not after it.
+//
+// It is the *image signature's* refusal too, and deliberately not a second
+// test. One signer signs the provenance envelope and the image, and it is
+// resolved once before the first byte moves, so "cannot attest" and "cannot
+// sign" are the same failure at the same moment. Splitting them would mean
+// two refusals to keep in agreement, and the way they would drift is one of
+// them quietly becoming conditional.
 func (t *Tests) AppRefusesToPublishWithoutProvenanceMachinery(ctx context.Context) error {
 	const (
 		version    = "v6.0.0"

--- a/daggerverse/z5labs/tests/dagger.gen.go
+++ b/daggerverse/z5labs/tests/dagger.gen.go
@@ -262,6 +262,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).AppPublishLeavesNoTagWhenAttachFails(&parent, ctx)
+		case "AppPublishLeavesNoTagWhenSigningFails":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).AppPublishLeavesNoTagWhenSigningFails(&parent, ctx)
 		case "AppPublishRefusesAnUnusableTarget":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/z5labs/tests/dagger.gen.go
+++ b/daggerverse/z5labs/tests/dagger.gen.go
@@ -325,6 +325,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).AppRejectsSourceWithoutGitMetadata(&parent, ctx)
+		case "AppSignatureDoesNotVerifyForAnotherKey":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).AppSignatureDoesNotVerifyForAnotherKey(&parent, ctx)
+		case "AppSignsEveryPublishedManifest":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).AppSignsEveryPublishedManifest(&parent, ctx)
 		case "AppStampsEveryPlatformVariant":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/z5labs/tests/internal/dagger/oci.gen.go
+++ b/daggerverse/z5labs/tests/internal/dagger/oci.gen.go
@@ -307,6 +307,7 @@ type OciRegistry struct { // oci (../../../../../daggerverse/oci/main.go:148:6)
 	pushArtifact      *string
 	pushImage         *string
 	pushImageUntagged *string
+	pushLayer         *string
 	referrers         *string
 	resolve           *string
 	tag               *string
@@ -325,7 +326,7 @@ func (r *OciRegistry) WithGraphQLQuery(q *querybuilder.Selection) *OciRegistry {
 // subject is a manifest digest in this repository; it is resolved first, so
 // attaching to something that is not there fails naming the digest rather
 // than leaving a dangling referrer behind.
-func (r *OciRegistry) Attach(ctx context.Context, repository string, subject string, content *File, artifactType string) (string, error) { // oci (../../../../../daggerverse/oci/artifact.go:117:1)
+func (r *OciRegistry) Attach(ctx context.Context, repository string, subject string, content *File, artifactType string) (string, error) { // oci (../../../../../daggerverse/oci/artifact.go:271:1)
 	assertNotNil("content", content)
 	if r.attach != nil {
 		return *r.attach, nil
@@ -480,7 +481,7 @@ func (r *OciRegistry) Manifest(ctx context.Context, repository string, reference
 // org.opencontainers.image.title annotation is its path relative to the
 // directory root. Layers are ordered by that path so the same directory
 // always produces the same manifest.
-func (r *OciRegistry) PushArtifact(ctx context.Context, repository string, tag string, contents *Directory, artifactType string) (string, error) { // oci (../../../../../daggerverse/oci/artifact.go:44:1)
+func (r *OciRegistry) PushArtifact(ctx context.Context, repository string, tag string, contents *Directory, artifactType string) (string, error) { // oci (../../../../../daggerverse/oci/artifact.go:45:1)
 	assertNotNil("contents", contents)
 	if r.pushArtifact != nil {
 		return *r.pushArtifact, nil
@@ -564,12 +565,78 @@ func (r *OciRegistry) PushImageUntagged(ctx context.Context, repository string, 
 	return response, q.Execute(ctx)
 }
 
+// OciRegistryPushLayerOpts contains options for OciRegistry.PushLayer
+type OciRegistryPushLayerOpts struct {
+	//
+	// Annotations to set on the layer, as a JSON object whose values are
+	// strings. Empty sets none. It is JSON rather than a map because codegen
+	// has no map type.
+	//
+	Annotations string // oci (../../../../../daggerverse/oci/artifact.go:161:2)
+}
+
+// PushLayer pushes one file to repository:tag as a single-layer OCI image
+// manifest and returns the manifest digest.
+//
+// It exists because two families of consumer read a document's meaning off
+// the *layer* rather than off the manifest: they resolve a tag whose name
+// they compute themselves, take the one layer whose media type they
+// recognise, and read the rest out of that layer's annotations. Cosign's
+// signature layout is the one this repository needs — `sha256-<hex>.sig`,
+// one `application/vnd.dev.cosign.simplesigning.v1+json` layer, the
+// signature in an annotation beside it — but nothing here knows that. This
+// function is handed a tag, some bytes, a media type and a set of
+// annotations, exactly as Attach is handed a file and an artifact type, and
+// that is all it ever learns.
+//
+// The three ways it differs from PushArtifact and Attach, each of which is
+// why neither of those could be stretched to cover it:
+//
+//   - The layer's media type is the caller's. PushArtifact gives every layer
+//     application/octet-stream, which is right for a document a consumer
+//     fetches by digest and wrong for one a consumer finds by filtering
+//     layers on their type.
+//   - The layer's annotations are the caller's. Both of the others set the
+//     standard title annotation and nothing else, so there is nowhere to put
+//     a signature.
+//   - The config is a real empty image config rather than the OCI empty
+//     descriptor oras.PackManifest would choose. Readers of this layout go
+//     through go-containerregistry's image type, which expects an image
+//     manifest carrying an image config; the artifact-manifest shape is
+//     legal OCI and is not what they parse.
+//
+// The manifest is addressed by tag, so pushing the same tag twice replaces
+// it — which is what a caller re-signing a digest wants, and is the
+// difference from Attach, where each call adds a referrer.
+func (r *OciRegistry) PushLayer(ctx context.Context, repository string, tag string, content *File, mediaType string, opts ...OciRegistryPushLayerOpts) (string, error) { // oci (../../../../../daggerverse/oci/artifact.go:145:1)
+	assertNotNil("content", content)
+	if r.pushLayer != nil {
+		return *r.pushLayer, nil
+	}
+	q := r.query.Select("pushLayer")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `annotations` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Annotations) {
+			q = q.Arg("annotations", opts[i].Annotations)
+		}
+	}
+	q = q.Arg("repository", repository)
+	q = q.Arg("tag", tag)
+	q = q.Arg("content", content)
+	q = q.Arg("mediaType", mediaType)
+
+	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
 // OciRegistryReferrersOpts contains options for OciRegistry.Referrers
 type OciRegistryReferrersOpts struct {
 	//
 	// Restrict the listing to one artifact type. Empty lists them all.
 	//
-	ArtifactType string // oci (../../../../../daggerverse/oci/artifact.go:222:2)
+	ArtifactType string // oci (../../../../../daggerverse/oci/artifact.go:376:2)
 }
 
 // Referrers lists the artifacts attached to subject as a JSON array of OCI
@@ -579,7 +646,7 @@ type OciRegistryReferrersOpts struct {
 // map type, so annotations could not be modelled; and a module object
 // returned from a never-cached call detaches in Dagger v0.21, so lazily
 // reading its fields fails.
-func (r *OciRegistry) Referrers(ctx context.Context, repository string, subject string, opts ...OciRegistryReferrersOpts) (string, error) { // oci (../../../../../daggerverse/oci/artifact.go:213:1)
+func (r *OciRegistry) Referrers(ctx context.Context, repository string, subject string, opts ...OciRegistryReferrersOpts) (string, error) { // oci (../../../../../daggerverse/oci/artifact.go:367:1)
 	if r.referrers != nil {
 		return *r.referrers, nil
 	}

--- a/daggerverse/z5labs/tests/internal/dagger/oci.gen.go
+++ b/daggerverse/z5labs/tests/internal/dagger/oci.gen.go
@@ -326,7 +326,7 @@ func (r *OciRegistry) WithGraphQLQuery(q *querybuilder.Selection) *OciRegistry {
 // subject is a manifest digest in this repository; it is resolved first, so
 // attaching to something that is not there fails naming the digest rather
 // than leaving a dangling referrer behind.
-func (r *OciRegistry) Attach(ctx context.Context, repository string, subject string, content *File, artifactType string) (string, error) { // oci (../../../../../daggerverse/oci/artifact.go:271:1)
+func (r *OciRegistry) Attach(ctx context.Context, repository string, subject string, content *File, artifactType string) (string, error) { // oci (../../../../../daggerverse/oci/artifact.go:299:1)
 	assertNotNil("content", content)
 	if r.attach != nil {
 		return *r.attach, nil
@@ -572,7 +572,7 @@ type OciRegistryPushLayerOpts struct {
 	// strings. Empty sets none. It is JSON rather than a map because codegen
 	// has no map type.
 	//
-	Annotations string // oci (../../../../../daggerverse/oci/artifact.go:161:2)
+	Annotations string // oci (../../../../../daggerverse/oci/artifact.go:169:2)
 }
 
 // PushLayer pushes one file to repository:tag as a single-layer OCI image
@@ -608,7 +608,13 @@ type OciRegistryPushLayerOpts struct {
 // The manifest is addressed by tag, so pushing the same tag twice replaces
 // it — which is what a caller re-signing a digest wants, and is the
 // difference from Attach, where each call adds a referrer.
-func (r *OciRegistry) PushLayer(ctx context.Context, repository string, tag string, content *File, mediaType string, opts ...OciRegistryPushLayerOpts) (string, error) { // oci (../../../../../daggerverse/oci/artifact.go:145:1)
+//
+// The content is held in memory whole, exactly as Attach and PushArtifact
+// hold theirs, so this is sized for documents — signatures, payloads,
+// attestations — and not for image layers. Streaming would be a change to
+// all three rather than to this one, since a caller cannot tell them apart
+// on that axis today.
+func (r *OciRegistry) PushLayer(ctx context.Context, repository string, tag string, content *File, mediaType string, opts ...OciRegistryPushLayerOpts) (string, error) { // oci (../../../../../daggerverse/oci/artifact.go:151:1)
 	assertNotNil("content", content)
 	if r.pushLayer != nil {
 		return *r.pushLayer, nil
@@ -636,7 +642,7 @@ type OciRegistryReferrersOpts struct {
 	//
 	// Restrict the listing to one artifact type. Empty lists them all.
 	//
-	ArtifactType string // oci (../../../../../daggerverse/oci/artifact.go:376:2)
+	ArtifactType string // oci (../../../../../daggerverse/oci/artifact.go:404:2)
 }
 
 // Referrers lists the artifacts attached to subject as a JSON array of OCI
@@ -646,7 +652,7 @@ type OciRegistryReferrersOpts struct {
 // map type, so annotations could not be modelled; and a module object
 // returned from a never-cached call detaches in Dagger v0.21, so lazily
 // reading its fields fails.
-func (r *OciRegistry) Referrers(ctx context.Context, repository string, subject string, opts ...OciRegistryReferrersOpts) (string, error) { // oci (../../../../../daggerverse/oci/artifact.go:367:1)
+func (r *OciRegistry) Referrers(ctx context.Context, repository string, subject string, opts ...OciRegistryReferrersOpts) (string, error) { // oci (../../../../../daggerverse/oci/artifact.go:395:1)
 	if r.referrers != nil {
 		return *r.referrers, nil
 	}

--- a/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
+++ b/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
@@ -421,6 +421,21 @@ func (r *Z5LabsApp) UnmarshalJSON(bs []byte) error {
 // produce provenance fails rather than publishing without it — see
 // newSigner.
 //
+// The image is signed too, and not merely the provenance statement about
+// it: the manifest list and every per-platform manifest beneath it each
+// carry a cosign signature, so a consumer runs
+//
+//	cosign verify <address>/<repository>:<version> \
+//	  --certificate-identity-regexp '^https://github.com/<owner>/<repo>/\.github/workflows/' \
+//	  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+//
+// against the tag, and the same command against any per-platform digest
+// their runtime resolved. Both pass, which is the point of signing every
+// manifest rather than only the one the tag names — see signImage. A
+// publish that cannot sign fails in the same way and for the same reason as
+// one that cannot attest. WithSigningKey changes the verifying command; its
+// doc comment says how.
+//
 // Within one repository the tag is the last thing written: the manifest list
 // goes up under its own digest, the attestations are attached to that digest,
 // and only then does the tag come to name it. So a publish that fails leaves
@@ -438,7 +453,7 @@ func (r *Z5LabsApp) UnmarshalJSON(bs []byte) error {
 // Publishing is a side effect against an external registry, so it is
 // uncached: a re-run must actually push. The build above it is session
 // cached, so the bytes pushed are the bytes Container returned.
-func (r *Z5LabsApp) Publish(ctx context.Context, repositories []string) ([]string, error) { // z5labs (../../../../../daggerverse/z5labs/app.go:303:1)
+func (r *Z5LabsApp) Publish(ctx context.Context, repositories []string) ([]string, error) { // z5labs (../../../../../daggerverse/z5labs/app.go:329:1)
 	q := r.query.Select("publish")
 	q = q.Arg("repositories", repositories)
 
@@ -456,7 +471,7 @@ func (r *Z5LabsApp) Publish(ctx context.Context, repositories []string) ([]strin
 // unverified connection. It is spelled insecure rather than tlsVerify
 // because a bool defaulting to true cannot be turned off from the CLI —
 // which is also why this method takes no argument at all.
-func (r *Z5LabsApp) WithInsecure() *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:225:1)
+func (r *Z5LabsApp) WithInsecure() *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:236:1)
 	q := r.query.Select("withInsecure")
 
 	return &Z5LabsApp{
@@ -496,7 +511,7 @@ func (r *Z5LabsApp) WithOidc(requestUrl string, requestToken *Secret) *Z5LabsApp
 // This exists for the same reason WithRegistryService does, and is used by
 // the test suite, which runs a real token endpoint rather than relaxing the
 // provenance requirement into the shape of the tests.
-func (r *Z5LabsApp) WithOidcService(svc *Service) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:255:1)
+func (r *Z5LabsApp) WithOidcService(svc *Service) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:266:1)
 	assertNotNil("svc", svc)
 	q := r.query.Select("withOidcService")
 	q = q.Arg("svc", svc)
@@ -541,7 +556,7 @@ func (r *Z5LabsApp) WithRegistry(address string, username string, auth *Secret) 
 // into an address ahead of time; this is how the publish learns it. Used by
 // the test suite against a local registry, and by anyone whose private
 // registry is itself a Dagger service.
-func (r *Z5LabsApp) WithRegistryService(svc *Service) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:239:1)
+func (r *Z5LabsApp) WithRegistryService(svc *Service) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:250:1)
 	assertNotNil("svc", svc)
 	q := r.query.Select("withRegistryService")
 	q = q.Arg("svc", svc)
@@ -560,7 +575,18 @@ func (r *Z5LabsApp) WithRegistryService(svc *Service) *Z5LabsApp { // z5labs (..
 // token's claims say. Use it for a build that cannot reach a public CA.
 // Leaving it unset is keyless signing and is what a normal CI publish
 // should do.
-func (r *Z5LabsApp) WithSigningKey(key *Secret) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:210:1)
+//
+// It changes what a consumer has to run, and the change is a downgrade
+// worth stating. Nothing certifies a supplied key, so there is no identity
+// to verify against and nothing to record in the public transparency log;
+// the image signature carries the signature alone, and verifying it means
+//
+//	cosign verify <ref> --key cosign.pub --insecure-ignore-tlog=true
+//
+// where the keyless mode gets an identity and an issuer and no such flag.
+// A caller who does not want to hand their consumers that flag should not
+// be supplying a key.
+func (r *Z5LabsApp) WithSigningKey(key *Secret) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:221:1)
 	assertNotNil("key", key)
 	q := r.query.Select("withSigningKey")
 	q = q.Arg("key", key)

--- a/daggerverse/z5labs/tests/main.go
+++ b/daggerverse/z5labs/tests/main.go
@@ -134,6 +134,7 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("AppPublishRefusesAnUnusableTarget", t.AppPublishRefusesAnUnusableTarget)
 	jobs = jobs.WithJob("AppRefusesPlaintextRegistryUnlessInsecure", t.AppRefusesPlaintextRegistryUnlessInsecure)
 	jobs = jobs.WithJob("AppPublishLeavesNoTagWhenAttachFails", t.AppPublishLeavesNoTagWhenAttachFails)
+	jobs = jobs.WithJob("AppPublishLeavesNoTagWhenSigningFails", t.AppPublishLeavesNoTagWhenSigningFails)
 	jobs = jobs.WithJob("AppAnnotatesEveryPlatformVariant", t.AppAnnotatesEveryPlatformVariant)
 	jobs = jobs.WithJob("AppAttachesSbomsAndProvenance", t.AppAttachesSbomsAndProvenance)
 	jobs = jobs.WithJob("AppAttestsTwoSegmentRepositories", t.AppAttestsTwoSegmentRepositories)
@@ -1032,24 +1033,33 @@ func (t *Tests) AppPublishesEveryRepositoryNamed(ctx context.Context) error {
 	// signature under any other name is one `cosign verify` never finds —
 	// and the set is asserted to be exactly the manifests that were
 	// published, index and platforms alike.
-	tags, err := listTags(ctx, svc, registryAlias, "ci", pwdHex, "hello")
-	if err != nil {
-		return fmt.Errorf("listTags: %v", err)
-	}
-	release, signatures := partitionTags(tags)
-	if len(release) != 1 || release[0] != version {
-		return fmt.Errorf("expected the version to be the only release tag, got %v (all tags: %v)", release, tags)
-	}
-	digest, err := digestOf(refs[0])
-	if err != nil {
-		return err
-	}
-	wantSignatures, err := signatureTagsFor(ctx, testRegistry(svc, secret), "hello", digest)
-	if err != nil {
-		return err
-	}
-	if !slices.Equal(signatures, wantSignatures) {
-		return fmt.Errorf("signature tags: want %v, got %v (all tags: %v)", wantSignatures, signatures, tags)
+	// Every repository, not just the first. Signing into the wrong
+	// repository, or signing the first one twice and the second not at all,
+	// is the most plausible way this loses its way — and a check scoped to
+	// refs[0] and a hardcoded name would be green for all of it.
+	registry := testRegistry(svc, secret)
+	for i, repository := range repositories {
+		tags, err := listTags(ctx, svc, registryAlias, "ci", pwdHex, repository)
+		if err != nil {
+			return fmt.Errorf("listTags %s: %v", repository, err)
+		}
+		release, signatures := partitionTags(tags)
+		if len(release) != 1 || release[0] != version {
+			return fmt.Errorf("%s: expected the version to be the only release tag, got %v (all tags: %v)",
+				repository, release, tags)
+		}
+		digest, err := digestOf(refs[i])
+		if err != nil {
+			return err
+		}
+		wantSignatures, err := signatureTagsFor(ctx, registry, repository, digest)
+		if err != nil {
+			return err
+		}
+		if !slices.Equal(signatures, wantSignatures) {
+			return fmt.Errorf("%s: signature tags: want %v, got %v (all tags: %v)",
+				repository, wantSignatures, signatures, tags)
+		}
 	}
 	return nil
 }

--- a/daggerverse/z5labs/tests/main.go
+++ b/daggerverse/z5labs/tests/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"regexp"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -1021,15 +1022,34 @@ func (t *Tests) AppPublishesEveryRepositoryNamed(ctx context.Context) error {
 			return fmt.Errorf("expected reference %d to name %s:%s pinned to a digest, got %q", i, repository, version, refs[i])
 		}
 	}
-	// The tag listing is the check that the version is the only tag: a
-	// publish deriving a second tag from the branch or the commit would
-	// still leave every assertion above true.
+	// The tag listing is the check that the version is the only tag a
+	// consumer can pull as a release: a publish deriving a second tag from
+	// the branch or the commit would still leave every assertion above true.
+	//
+	// The signature tags are the one exception, and they are checked rather
+	// than excused. Cosign's layout stores a signature under a tag it
+	// computes from the digest, so those names are load bearing — a
+	// signature under any other name is one `cosign verify` never finds —
+	// and the set is asserted to be exactly the manifests that were
+	// published, index and platforms alike.
 	tags, err := listTags(ctx, svc, registryAlias, "ci", pwdHex, "hello")
 	if err != nil {
 		return fmt.Errorf("listTags: %v", err)
 	}
-	if len(tags) != 1 || tags[0] != version {
-		return fmt.Errorf("expected the version to be the only published tag, got %v", tags)
+	release, signatures := partitionTags(tags)
+	if len(release) != 1 || release[0] != version {
+		return fmt.Errorf("expected the version to be the only release tag, got %v (all tags: %v)", release, tags)
+	}
+	digest, err := digestOf(refs[0])
+	if err != nil {
+		return err
+	}
+	wantSignatures, err := signatureTagsFor(ctx, testRegistry(svc, secret), "hello", digest)
+	if err != nil {
+		return err
+	}
+	if !slices.Equal(signatures, wantSignatures) {
+		return fmt.Errorf("signature tags: want %v, got %v (all tags: %v)", wantSignatures, signatures, tags)
 	}
 	return nil
 }

--- a/daggerverse/z5labs/tests/main.go
+++ b/daggerverse/z5labs/tests/main.go
@@ -138,6 +138,8 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("AppAttestsTwoSegmentRepositories", t.AppAttestsTwoSegmentRepositories)
 	jobs = jobs.WithJob("AppRefusesToPublishWithoutProvenanceMachinery", t.AppRefusesToPublishWithoutProvenanceMachinery)
 	jobs = jobs.WithJob("AppRedactsCredentialsFromTheSourceAnnotation", t.AppRedactsCredentialsFromTheSourceAnnotation)
+	jobs = jobs.WithJob("AppSignsEveryPublishedManifest", t.AppSignsEveryPublishedManifest)
+	jobs = jobs.WithJob("AppSignatureDoesNotVerifyForAnotherKey", t.AppSignatureDoesNotVerifyForAnotherKey)
 
 	return jobs.Run(ctx)
 }

--- a/daggerverse/z5labs/tests/ordering.go
+++ b/daggerverse/z5labs/tests/ordering.go
@@ -53,6 +53,44 @@ const brokenReferrersProxy = `server {
 }
 `
 
+// brokenSignaturesProxy is a registry that accepts images and attestations
+// and refuses signatures.
+//
+// It is the mirror of brokenReferrersProxy and exists to reach the one
+// failure that stand-in cannot: a publish that gets all the way past the
+// attach and then cannot sign. The refusal is aimed at the ".sig" suffix,
+// which is the only thing in the whole publish that tells a signature push
+// apart from an image push, a referrer push or a tag move by its URL alone —
+// they are otherwise all `PUT /v2/<repo>/manifests/<something>`.
+//
+// The referrers tag schema is deliberately still allowed: it is spelled
+// "sha256-<hex>" with no suffix, so the attaches land normally and the
+// publish reaches the signing step with every attestation already in the
+// registry. That is what makes the resulting assertion about signing and not
+// about attaching.
+const brokenSignaturesProxy = `server {
+    listen 5000;
+    server_name _;
+    client_max_body_size 0;
+
+    location ~ "\.sig$" {
+        return 405;
+    }
+
+    location / {
+        proxy_pass http://registry:5000;
+        proxy_set_header Host $http_host;
+        proxy_request_buffering off;
+        proxy_read_timeout 300s;
+    }
+}
+`
+
+// brokenSignaturesRegistry is localRegistry behind brokenSignaturesProxy.
+func brokenSignaturesRegistry(ctx context.Context) (*dagger.Service, string, *dagger.Secret, error) {
+	return proxiedRegistry(ctx, brokenSignaturesProxy)
+}
+
 // brokenReferrersRegistry is localRegistry with that proxy in front of it: a
 // registry a publish can push an image to and cannot attach anything to.
 //
@@ -65,6 +103,12 @@ const brokenReferrersProxy = `server {
 // shared across tests and across sessions, and one test's pushes would land in
 // another's registry.
 func brokenReferrersRegistry(ctx context.Context) (*dagger.Service, string, *dagger.Secret, error) {
+	return proxiedRegistry(ctx, brokenReferrersProxy)
+}
+
+// proxiedRegistry stands up localRegistry behind one of the nginx configs
+// above, and is what both stand-ins are built out of.
+func proxiedRegistry(ctx context.Context, config string) (*dagger.Service, string, *dagger.Secret, error) {
 	upstream, pwdHex, secret, err := localRegistry(ctx)
 	if err != nil {
 		return nil, "", nil, err
@@ -76,7 +120,7 @@ func brokenReferrersRegistry(ctx context.Context) (*dagger.Service, string, *dag
 	svc := dag.Container().From(proxyImage).
 		WithEnvVariable("NONCE", nonce).
 		WithServiceBinding("registry", upstream).
-		WithNewFile("/etc/nginx/conf.d/default.conf", brokenReferrersProxy).
+		WithNewFile("/etc/nginx/conf.d/default.conf", config).
 		WithExposedPort(5000).
 		AsService(dagger.ContainerAsServiceOpts{
 			UseEntrypoint: true,
@@ -290,6 +334,112 @@ func (t *Tests) AppPublishLeavesNoTagWhenAttachFails(ctx context.Context) error 
 	if resolved != incumbent {
 		return fmt.Errorf("the failed publish moved %s:%s from %s to %s: a release that attested was replaced by one that did not",
 			published, version, incumbent, resolved)
+	}
+	return nil
+}
+
+// AppPublishLeavesNoTagWhenSigningFails asserts a publish that cannot sign
+// leaves no tag a consumer can pull.
+//
+// This is the half of the story's fifth acceptance criterion that
+// AppRefusesToPublishWithoutProvenanceMachinery does not reach. That one
+// covers the refusal that fires before the first byte moves, when the
+// machinery to sign was never supplied. This one covers the other shape
+// entirely: the machinery is present, the image is pushed, every attestation
+// lands, and *then* the signature cannot be written. Nothing before this
+// exercised that path, and it is the one where "fails rather than publishing
+// unsigned" is a claim about ordering rather than about validation.
+//
+// The stand-in refuses only ".sig" pushes, so the attaches succeed and the
+// failure is unambiguously the signature. What is asserted afterwards is the
+// same pair as the attach test: no tag resolves, and the manifest really is
+// in the registry — because a publish that had simply never pushed would
+// satisfy the first half on its own.
+func (t *Tests) AppPublishLeavesNoTagWhenSigningFails(ctx context.Context) error {
+	const (
+		version    = "v4.3.0"
+		repository = "hello"
+	)
+	src, err := gitFixture(ctx, helloDir(), "main", nil)
+	if err != nil {
+		return fmt.Errorf("gitFixture: %v", err)
+	}
+	svc, pwdHex, secret, err := brokenSignaturesRegistry(ctx)
+	if err != nil {
+		return err
+	}
+	prov, err := newProvenanceHarness(ctx, "")
+	if err != nil {
+		return err
+	}
+
+	// Which failure path this ran over is a checked fact rather than a claim.
+	// A stand-in that quietly started accepting signature pushes would make
+	// every assertion below pass over a publish that succeeded.
+	hex, err := dag.Random().Sha256(ctx)
+	if err != nil {
+		return fmt.Errorf("random sha256 (signature tag): %v", err)
+	}
+	code, err := curlProbeManifest(ctx, svc, registryAlias, "ci", pwdHex, repository, "sha256-"+hex+".sig")
+	if err != nil {
+		return fmt.Errorf("probe a signature tag: %v", err)
+	}
+	if code != 405 {
+		return fmt.Errorf("the stand-in answered a signature tag with %d, want 405: "+
+			"it is not refusing signatures, so this test would pass over a publish that succeeded", code)
+	}
+	// And that it refuses *only* those. If it were refusing referrers too the
+	// publish would fail at the attach, and this test would be a second copy
+	// of AppPublishLeavesNoTagWhenAttachFails wearing a different name.
+	code, err = curlProbeManifest(ctx, svc, registryAlias, "ci", pwdHex, repository, "sha256-"+hex)
+	if err != nil {
+		return fmt.Errorf("probe a referrers tag: %v", err)
+	}
+	if code == 405 {
+		return fmt.Errorf("the stand-in refuses the referrers tag as well, so a publish would fail at the attach "+
+			"and this test would say nothing about signing (got %d)", code)
+	}
+
+	app := dag.Z5Labs().Go(src).App(version, dagger.Z5LabsGoChainAppOpts{Platforms: []dagger.Platform{hostPlatform()}})
+	_, pubErr := publishable(app, svc, secret, prov).Publish(ctx, []string{repository})
+	if pubErr == nil {
+		return fmt.Errorf("expected Publish to fail against a registry that refuses signatures, got nil")
+	}
+	// The failure has to be the signature. A publish that fell over on the
+	// push or the attach would leave no tag either, and would prove nothing
+	// about what this test is for.
+	if !strings.Contains(pubErr.Error(), "signature") {
+		return fmt.Errorf("expected the failure to name the signature, got: %s", pubErr.Error())
+	}
+	if !strings.Contains(pubErr.Error(), "untagged") {
+		return fmt.Errorf("expected the failure to say the digest was left untagged, got: %s", pubErr.Error())
+	}
+
+	tags, err := tagListing(ctx, svc, registryAlias, "ci", pwdHex, repository)
+	if err != nil {
+		return err
+	}
+	// Signature tags are excluded rather than counted: the publish signs the
+	// index before it reaches whatever it could not sign, so a partial set of
+	// them is expected and is not something a consumer can pull as a release.
+	// What must not exist is a release tag.
+	release, _ := partitionTags(tags)
+	if len(release) != 0 {
+		return fmt.Errorf("signing failed but %s carries the release tags %v, want none", repository, release)
+	}
+
+	match := untaggedDigest.FindStringSubmatch(pubErr.Error())
+	if match == nil {
+		return fmt.Errorf("the failure names no untagged digest, so nothing can check what was left behind: %s", pubErr.Error())
+	}
+	digest := match[1]
+	code, err = curlProbeManifest(ctx, svc, registryAlias, "ci", pwdHex, repository, digest)
+	if err != nil {
+		return fmt.Errorf("curl probe %s@%s: %v", repository, digest, err)
+	}
+	if code != 200 {
+		return fmt.Errorf("the failure said %s was left untagged in %s, but the registry answers %d for it",
+			digest, repository, code)
 	}
 	return nil
 }

--- a/daggerverse/z5labs/tests/sign.go
+++ b/daggerverse/z5labs/tests/sign.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+
+	"dagger/tests/internal/dagger"
+)
+
+// cosignImage is the upstream cosign release, pinned. It is the whole point
+// of these tests: what makes a signature worth publishing is that a command
+// a consumer already has can check it, so the checking is done by cosign
+// itself and never by a verifier written here. A hand-rolled reader would
+// pass over a layout cosign rejects, which is exactly the failure being
+// guarded against.
+const cosignImage = "ghcr.io/sigstore/cosign/cosign:v2.4.1"
+
+// AppSignsEveryPublishedManifest asserts that stock `cosign verify` passes
+// against the published tag and against every per-platform manifest
+// beneath it.
+//
+// Both halves matter and the second is the one that is easy to lose. A
+// consumer verifies the tag, which resolves to the manifest list; their
+// runtime then pulls the per-platform manifest for its architecture, a
+// different digest the index signature says nothing about. Signing the
+// index alone would leave this test's first assertion passing and its
+// second failing — a verification reporting success over bytes it never
+// checked, which is worse than no signature at all.
+//
+// It runs in the supplied-key mode, because a session with no sigstore
+// beside it cannot get a Fulcio certificate. What that costs is stated
+// rather than hidden: the certificate, the identity and the transparency
+// log entry are untested here, exactly as fulcioCertificate and rekorBundle
+// say. What it covers is everything else — the payload, the signature over
+// it, the annotations, the manifest shape and the tag cosign computes to
+// find them, all of it read by cosign rather than asserted against this
+// module's own idea of the layout.
+func (t *Tests) AppSignsEveryPublishedManifest(ctx context.Context) error {
+	const (
+		version    = "v9.0.0"
+		repository = "z5labs/signed"
+	)
+	src, err := gitFixture(ctx, helloDir(), "main", nil)
+	if err != nil {
+		return fmt.Errorf("gitFixture: %v", err)
+	}
+	headSha, err := headFullSha(ctx, src)
+	if err != nil {
+		return err
+	}
+	svc, password, secret, err := localRegistry(ctx)
+	if err != nil {
+		return err
+	}
+	prov, err := newProvenanceHarness(ctx, headSha)
+	if err != nil {
+		return err
+	}
+
+	// Two platforms, so the publish produces a real manifest list with real
+	// children. One platform may be stored as a bare manifest, which would
+	// make the recursive half of this test assert nothing.
+	app := dag.Z5Labs().Go(src).App(version, dagger.Z5LabsGoChainAppOpts{
+		Platforms: []dagger.Platform{"linux/amd64", "linux/arm64"},
+	})
+	refs, err := publishable(app, svc, secret, prov).Publish(ctx, []string{repository})
+	if err != nil {
+		return fmt.Errorf("Publish: %v", err)
+	}
+	digest, err := digestOf(refs[0])
+	if err != nil {
+		return err
+	}
+
+	registry := testRegistry(svc, secret)
+	index, err := fetchManifest(ctx, registry, repository, digest)
+	if err != nil {
+		return err
+	}
+	if len(index.Manifests) < 2 {
+		return fmt.Errorf("published manifest %s lists %d children, want the two platforms that were built",
+			digest, len(index.Manifests))
+	}
+
+	verifier, err := cosignVerifier(ctx, svc, password, prov.Public)
+	if err != nil {
+		return err
+	}
+	// The tag first, which is what a consumer types, then every child, which
+	// is what their runtime actually pulls.
+	references := []string{fmt.Sprintf("%s:5000/%s:%s", registryAlias, repository, version)}
+	for _, child := range index.Manifests {
+		references = append(references, fmt.Sprintf("%s:5000/%s@%s", registryAlias, repository, child.Digest))
+	}
+	for _, reference := range references {
+		if err := verifier.verify(ctx, reference); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// AppSignatureDoesNotVerifyForAnotherKey asserts `cosign verify` fails when
+// the key it is given is not the one that signed.
+//
+// Without it every assertion in AppSignsEveryPublishedManifest could be
+// satisfied by a cosign invocation that checks nothing — a wrong flag, a
+// missing digest, a verifier that resolves nothing and reports success. A
+// green verification is only evidence if the same command goes red when the
+// signature does not belong to the key.
+func (t *Tests) AppSignatureDoesNotVerifyForAnotherKey(ctx context.Context) error {
+	const (
+		version    = "v9.1.0"
+		repository = "z5labs/signed-elsewhere"
+	)
+	src, err := gitFixture(ctx, helloDir(), "main", nil)
+	if err != nil {
+		return fmt.Errorf("gitFixture: %v", err)
+	}
+	headSha, err := headFullSha(ctx, src)
+	if err != nil {
+		return err
+	}
+	svc, password, secret, err := localRegistry(ctx)
+	if err != nil {
+		return err
+	}
+	prov, err := newProvenanceHarness(ctx, headSha)
+	if err != nil {
+		return err
+	}
+	// A second harness only for its key: an independently generated one,
+	// never a mutation of the first, so nothing about the two can coincide.
+	other, err := newProvenanceHarness(ctx, headSha)
+	if err != nil {
+		return err
+	}
+
+	app := dag.Z5Labs().Go(src).App(version, dagger.Z5LabsGoChainAppOpts{Platforms: []dagger.Platform{hostPlatform()}})
+	if _, err := publishable(app, svc, secret, prov).Publish(ctx, []string{repository}); err != nil {
+		return fmt.Errorf("Publish: %v", err)
+	}
+
+	verifier, err := cosignVerifier(ctx, svc, password, other.Public)
+	if err != nil {
+		return err
+	}
+	reference := fmt.Sprintf("%s:5000/%s:%s", registryAlias, repository, version)
+	if err := verifier.verify(ctx, reference); err == nil {
+		return fmt.Errorf("cosign verified %s against a key that did not sign it", reference)
+	}
+	return nil
+}
+
+// cosign is a container holding the cosign CLI, a registry credential and
+// the public key to verify against.
+type cosign struct {
+	ctr *dagger.Container
+}
+
+// cosignVerifier builds that container.
+//
+// The credential goes in as a docker config rather than on the command
+// line, because that is the only way cosign takes one: it authenticates
+// through go-containerregistry's keychain, which reads $DOCKER_CONFIG. The
+// whole config is mounted as a secret, because the file holds
+// base64("ci:<password>") — a `withNewFile` would put those bytes in the
+// call arguments, which is where a trace reads them from.
+func cosignVerifier(ctx context.Context, svc *dagger.Service, password string, key *ecdsa.PublicKey) (*cosign, error) {
+	der, err := x509.MarshalPKIXPublicKey(key)
+	if err != nil {
+		return nil, fmt.Errorf("encode verification key: %v", err)
+	}
+	publicPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})
+
+	config, err := json.Marshal(map[string]any{
+		"auths": map[string]any{
+			registryAlias + ":5000": map[string]string{
+				"auth": base64.StdEncoding.EncodeToString([]byte("ci:" + password)),
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("encode docker config: %v", err)
+	}
+	// The secret's name is an independent random, never derived from what it
+	// holds: names show up in traces where values do not.
+	nameHex, err := dag.Random().Sha256(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("random sha256 (secret name): %v", err)
+	}
+
+	ctr := dag.Container().From(cosignImage).
+		WithServiceBinding(registryAlias, svc).
+		WithNewFile("/keys/cosign.pub", string(publicPEM)).
+		// 0444 rather than the 0400 default: the cosign image runs as a
+		// non-root user, and a secret readable only by root is one cosign
+		// reports as a missing credential.
+		WithMountedSecret("/docker/config.json",
+			dag.SetSecret("z5labs-cosign-docker-config-"+nameHex[:16], string(config)),
+			dagger.ContainerWithMountedSecretOpts{Mode: 0o444}).
+		WithEnvVariable("DOCKER_CONFIG", "/docker").
+		WithEnvVariable("HOME", "/tmp")
+	return &cosign{ctr: ctr}, nil
+}
+
+// verify runs `cosign verify` against one reference.
+//
+// The flags are the ones a consumer of a supplied-key publish is told to
+// run in WithSigningKey's doc comment, plus the two that exist only because
+// the registry under test speaks plain HTTP. Nothing here weakens the check
+// itself: --insecure-ignore-tlog is what the supplied-key mode genuinely
+// requires, and adding it silently to the keyless mode is the failure this
+// naming is meant to make obvious.
+func (c *cosign) verify(ctx context.Context, reference string) error {
+	_, err := c.ctr.
+		WithExec([]string{
+			"verify",
+			"--key", "/keys/cosign.pub",
+			"--insecure-ignore-tlog=true",
+			"--allow-http-registry",
+			"--allow-insecure-registry",
+			reference,
+		}, dagger.ContainerWithExecOpts{UseEntrypoint: true}).
+		Sync(ctx)
+	if err != nil {
+		return fmt.Errorf("cosign verify %s: %v", reference, err)
+	}
+	return nil
+}

--- a/daggerverse/z5labs/tests/sign.go
+++ b/daggerverse/z5labs/tests/sign.go
@@ -100,7 +100,7 @@ func (t *Tests) AppSignsEveryPublishedManifest(ctx context.Context) error {
 		references = append(references, fmt.Sprintf("%s:5000/%s@%s", registryAlias, repository, child.Digest))
 	}
 	for _, reference := range references {
-		if err := verifier.verify(ctx, reference); err != nil {
+		if err := verifier.mustVerify(ctx, reference); err != nil {
 			return err
 		}
 	}
@@ -153,8 +153,23 @@ func (t *Tests) AppSignatureDoesNotVerifyForAnotherKey(ctx context.Context) erro
 		return err
 	}
 	reference := fmt.Sprintf("%s:5000/%s:%s", registryAlias, repository, version)
-	if err := verifier.verify(ctx, reference); err == nil {
+	code, stderr, err := verifier.verify(ctx, reference)
+	if err != nil {
+		return err
+	}
+	if code == 0 {
 		return fmt.Errorf("cosign verified %s against a key that did not sign it", reference)
+	}
+	// The message, not merely the exit code. Cosign exits non-zero for a
+	// pull failure, an unknown flag and an unreachable registry too, and
+	// every one of those would also break the positive test — but silently,
+	// leaving this test green over a command that verified nothing. The
+	// signature-mismatch wording is the only outcome that says the
+	// verification actually ran and actually rejected.
+	const want = "no matching signatures"
+	if !strings.Contains(stderr, want) {
+		return fmt.Errorf("cosign rejected %s but not for a signature mismatch: wanted %q in its output, got exit %d and: %s",
+			reference, want, code, stderr)
 	}
 	return nil
 }
@@ -255,7 +270,8 @@ func cosignVerifier(ctx context.Context, svc *dagger.Service, password string, k
 	return &cosign{ctr: ctr}, nil
 }
 
-// verify runs `cosign verify` against one reference.
+// verify runs `cosign verify` against one reference and returns cosign's
+// own exit code and stderr.
 //
 // The flags are the ones a consumer of a supplied-key publish is told to
 // run in WithSigningKey's doc comment, plus the two that exist only because
@@ -263,19 +279,44 @@ func cosignVerifier(ctx context.Context, svc *dagger.Service, password string, k
 // itself: --insecure-ignore-tlog is what the supplied-key mode genuinely
 // requires, and adding it silently to the keyless mode is the failure this
 // naming is meant to make obvious.
-func (c *cosign) verify(ctx context.Context, reference string) error {
-	_, err := c.ctr.
-		WithExec([]string{
-			"verify",
-			"--key", "/keys/cosign.pub",
-			"--insecure-ignore-tlog=true",
-			"--allow-http-registry",
-			"--allow-insecure-registry",
-			reference,
-		}, dagger.ContainerWithExecOpts{UseEntrypoint: true}).
-		Sync(ctx)
+//
+// The exec is allowed to fail rather than raising, because a caller
+// asserting that a verification *fails* has to be able to say why it
+// failed. Treating any error as the expected one would let an image that
+// could not be pulled, or a flag this cosign does not know, stand in for a
+// signature that did not match — and then the negative test passes while
+// proving nothing about the positive one.
+func (c *cosign) verify(ctx context.Context, reference string) (int, string, error) {
+	ctr := c.ctr.WithExec([]string{
+		"verify",
+		"--key", "/keys/cosign.pub",
+		"--insecure-ignore-tlog=true",
+		"--allow-http-registry",
+		"--allow-insecure-registry",
+		reference,
+	}, dagger.ContainerWithExecOpts{
+		UseEntrypoint: true,
+		Expect:        dagger.ReturnTypeAny,
+	})
+	code, err := ctr.ExitCode(ctx)
 	if err != nil {
-		return fmt.Errorf("cosign verify %s: %v", reference, err)
+		return 0, "", fmt.Errorf("run cosign verify %s: %v", reference, err)
+	}
+	stderr, err := ctr.Stderr(ctx)
+	if err != nil {
+		return 0, "", fmt.Errorf("read cosign stderr for %s: %v", reference, err)
+	}
+	return code, stderr, nil
+}
+
+// mustVerify fails unless cosign reports the reference verified.
+func (c *cosign) mustVerify(ctx context.Context, reference string) error {
+	code, stderr, err := c.verify(ctx, reference)
+	if err != nil {
+		return err
+	}
+	if code != 0 {
+		return fmt.Errorf("cosign verify %s exited %d: %s", reference, code, stderr)
 	}
 	return nil
 }

--- a/daggerverse/z5labs/tests/sign.go
+++ b/daggerverse/z5labs/tests/sign.go
@@ -8,6 +8,8 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"sort"
+	"strings"
 
 	"dagger/tests/internal/dagger"
 )
@@ -156,6 +158,50 @@ func (t *Tests) AppSignatureDoesNotVerifyForAnotherKey(ctx context.Context) erro
 	}
 	return nil
 }
+
+// signatureTagsFor is the tags cosign computes to find the signatures of a
+// published digest and of every manifest beneath it, sorted.
+//
+// It is derived from what the registry holds rather than from the module's
+// own idea of the layout, so a test comparing against it is asserting that
+// a signature exists for each manifest that was really published.
+func signatureTagsFor(ctx context.Context, registry *dagger.OciRegistry, repository, digest string) ([]string, error) {
+	index, err := fetchManifest(ctx, registry, repository, digest)
+	if err != nil {
+		return nil, err
+	}
+	out := []string{strings.ReplaceAll(digest, ":", "-") + signatureTagSuffix}
+	for _, child := range index.Manifests {
+		out = append(out, strings.ReplaceAll(child.Digest, ":", "-")+signatureTagSuffix)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// partitionTags splits a repository's tags into the release tags and the
+// signature tags.
+//
+// Signature tags are told apart by the suffix, which is cosign's rule and
+// not this suite's: a consumer's tooling makes the same split, and a test
+// that used a different one would pass over a layout cosign could not read.
+func partitionTags(tags []string) (release, signatures []string) {
+	for _, tag := range tags {
+		if strings.HasSuffix(tag, signatureTagSuffix) {
+			signatures = append(signatures, tag)
+			continue
+		}
+		release = append(release, tag)
+	}
+	sort.Strings(release)
+	sort.Strings(signatures)
+	return release, signatures
+}
+
+// signatureTagSuffix is what cosign appends to the digest-derived tag it
+// stores a signature under. Spelled out here rather than imported from the
+// module, so a rename there is a test failure rather than a silent
+// agreement between two halves of one codebase.
+const signatureTagSuffix = ".sig"
 
 // cosign is a container holding the cosign CLI, a registry credential and
 // the public key to verify against.


### PR DESCRIPTION
Closes #394

`App.Publish` attached a signed SLSA provenance statement and two SBOMs per
platform, and nothing signed the image itself — so `cosign verify` against a
published tag found nothing to verify. It does now.

## What a consumer runs

Keyless, which is what a CI publish does:

```console
cosign verify ghcr.io/<owner>/<app>:<version> \
  --certificate-identity-regexp '^https://github.com/<owner>/<repo>/\.github/workflows/' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com
```

With a caller-supplied key (`withSigningKey`, for a build that cannot reach the
public CA) there is no certified identity and no log entry, so it is the weaker
command and says so:

```console
cosign verify <ref> --key cosign.pub --insecure-ignore-tlog=true
```

Both are written into the doc comments on `Publish` and `WithSigningKey`.

## Acceptance criteria

- [x] **The published image is signed, not only its provenance envelope.**
      `signImage` writes cosign's signature layout: for a manifest at
      `sha256:<hex>`, a one-layer OCI image manifest under `sha256-<hex>.sig`
      holding the simple-signing payload, with the signature in the layer's
      annotations.
- [x] **The signature covers the manifest list and every per-platform manifest
      beneath it.** The child digests are read back from the registry — the
      registry's account of what it stored, not this module's account of what it
      pushed — and each is signed on its own. `AppSignsEveryPublishedManifest`
      runs stock `cosign verify` against the tag *and* against every child
      digest.
- [x] **Recorded in a public transparency log.** Keyless signing uploads a
      `hashedrekord` to `rekor.sigstore.dev` and embeds the returned bundle in
      the `dev.sigstore.cosign/bundle` annotation, so a verifier that cannot
      reach the log can still establish that the ten-minute Fulcio certificate
      was live when it signed. The supplied-key mode records nothing — there is
      no certified identity to record — which is why its verifying command
      carries `--insecure-ignore-tlog`.
- [x] **Decided: stock `cosign verify`.** See below.
- [x] **A publish that cannot sign fails rather than publishing unsigned.** One
      signer signs the provenance and the image, resolved before the first byte
      moves, so "cannot attest" and "cannot sign" are the same refusal at the
      same moment — the one
      `AppRefusesToPublishWithoutProvenanceMachinery` already asserts. A
      signature failure after the push returns before the tag is written, so it
      leaves an untagged manifest exactly as an attach failure does.

## Judgment calls

**Cosign's layout, copied rather than designed.** A signature is worth what the
command verifying it is worth. The OCI 1.1 referrers form is the better shape —
a signature *is* a referrer of what it signs — and it is rejected because
reading it still needs `--experimental-oci11`. Recorded in `sign.go` so it can
be revisited rather than rediscovered.

**Signing runs last of the fallible steps, after the attestations and before the
tag.** It is the only step that writes a name of its own, so it gets the
smallest window in which a later failure can leave one behind.

**New: `oci.Registry.PushLayer`.** The layout needs a tag-addressed single-layer
manifest with a caller-chosen layer media type and layer annotations, which
neither `PushArtifact` nor `Attach` can express — both fix the layer media type
and set only the title annotation, and `oras.PackManifest` picks an
artifact-manifest shape that go-containerregistry's readers do not parse. The
`oci` module still learns nothing about what the bytes mean: it is handed a tag,
some bytes, a media type and annotations.

**`AppPublishesEveryRepositoryNamed` was made stricter, not looser.** Signature
tags made "the version is the only tag" false. Rather than relaxing it, the
listing is now split: exactly one release tag, and the signature tags must be
exactly the manifests that were published.

## How it was verified

- `dagger check` — green.
- `bash .github/scripts/verify-affected-modules.sh` — `daggerverse/oci` and
  `daggerverse/z5labs`, both modules and both test suites, green.
- The two new z5labs tests run the real `cosign` CLI
  (`ghcr.io/sigstore/cosign/cosign:v2.4.1`) against the local registry, so the
  layout is judged by the tool a consumer has rather than by a reader written
  here. The negative control verifies against an independently generated key and
  requires cosign to fail, so a green run is evidence rather than a no-op.
- Two new `oci` tests cover `PushLayer`'s manifest shape and its rejection of
  malformed annotations.

Untested, and stated rather than hidden: the Fulcio certificate request and the
Rekor upload both need the live public sigstore, which a session running against
a local registry does not have. The suite drives the supplied-key mode, which
exercises the payload, the signature, the annotations, the manifest shape and
the tag — everything except who vouches for the key.

One finding worth carrying, now in `daggerverse/CLAUDE.md`: the `oci` suite runs
against **zot**, which parses any tag ending in `.sig` as cosign's and slices
`tag[:71]`. A short stand-in digest panics the handler into a `500` with an empty
body, which reads as a malformed manifest and is a malformed tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)