### PR TITLE
story(z5labs): publish a release under a family of tags, and let a prerelease move none of them

### DIFF
--- a/daggerverse/z5labs/app.go
+++ b/daggerverse/z5labs/app.go
@@ -281,10 +281,24 @@ func (a *App) WithOidcService(svc *dagger.Service) *App {
 //
 // One manifest list is pushed per repository, naming every platform
 // variant, so a consumer pulls a repository and gets their architecture.
-// The returned references are `<address>/<repository>:<version>@<digest>`:
+// The returned references are `<address>/<repository>:<tag>@<digest>`:
 // pinned, because a tag is a mutable name and a caller anchoring a
 // deployment or a release note to what shipped has to be able to name
 // immutable bytes.
+//
+// # One release, a family of tags
+//
+// A release is published under every tag its version implies, not under the
+// version alone: `v1.2.3` also comes to name `v1.2`, `v1` and `latest`, so a
+// consumer can pin at the level of risk they want. Every tag of one release
+// names one digest — the same manifest list, pushed once — and one reference
+// comes back per tag, in the order the tags were written.
+//
+// A SemVer **prerelease** publishes its own full version tag and moves none
+// of the moving ones, and a version that is not SemVer publishes as a single
+// tag. versionTags derives the family and is where those rules are stated;
+// it is a pure function of the version, so what it cannot see — a release
+// published out of order walking `v1` backwards — is recorded there too.
 //
 // Every published digest carries an SPDX and a CycloneDX document per
 // platform and a signed SLSA provenance statement whose build identity
@@ -352,6 +366,16 @@ func (a *App) Publish(ctx context.Context, repositories []string) ([]string, err
 	if len(a.Variants) == 0 {
 		return nil, fmt.Errorf("this app carries no images to publish")
 	}
+	// The family is derived before the first byte moves, for the same reason
+	// the signer is: a version that cannot be a tag has no family and no
+	// single tag either, and learning that after the push is learning it from
+	// an untagged manifest. It also re-runs the version validation App made,
+	// which is what keeps the refusal of SemVer build metadata a property of
+	// publishing rather than of one constructor.
+	tags, err := versionTags(a.Version)
+	if err != nil {
+		return nil, err
+	}
 	// Provenance is resolved before the first byte is pushed, so a run that
 	// cannot produce it fails without leaving a half-attested image behind.
 	// It is also why this is not an "if configured" branch: an attestation
@@ -389,7 +413,7 @@ func (a *App) Publish(ctx context.Context, repositories []string) ([]string, err
 	for _, v := range a.Variants {
 		containers = append(containers, v.Container)
 	}
-	refs := make([]string, 0, len(repositories))
+	refs := make([]string, 0, len(repositories)*len(tags))
 	for _, repository := range repositories {
 		// Push, attach, then tag. The ordering is the whole subject of
 		// attachAttestations' doc comment; read that before changing it.
@@ -403,7 +427,7 @@ func (a *App) Publish(ctx context.Context, repositories []string) ([]string, err
 		}
 		facts := buildFacts{
 			Repository: repository,
-			Tags:       []string{a.Version},
+			Tags:       tags,
 			Digest:     digest,
 			Platforms:  a.platformNames(),
 			Pkg:        a.Pkg,
@@ -428,12 +452,21 @@ func (a *App) Publish(ctx context.Context, repositories []string) ([]string, err
 				err, digest, repository, alreadyPublished(refs))
 		}
 		// Only now does the release become something a consumer can name. The
-		// tag moves last because it is the only step whose effect is visible
-		// to anyone who did not push it.
-		if _, err := registry.Tag(ctx, repository, digest, a.Version); err != nil {
-			return nil, fmt.Errorf("tag %s as %s:%s%s: %v", digest, repository, a.Version, alreadyPublished(refs), err)
+		// tags move last because they are the only step whose effect is
+		// visible to anyone who did not push it.
+		//
+		// They are written narrowest first — the full version, then v1.2, then
+		// v1, then latest — because a failure part way through leaves the tags
+		// after it unmoved, and the wider a tag is the more consumers a
+		// half-finished release would have handed the new bytes to. The
+		// immutable one costs nothing to write first: it named no release
+		// before this one.
+		for _, tag := range tags {
+			if _, err := registry.Tag(ctx, repository, digest, tag); err != nil {
+				return nil, fmt.Errorf("tag %s as %s:%s%s: %v", digest, repository, tag, alreadyPublished(refs), err)
+			}
+			refs = append(refs, fmt.Sprintf("%s/%s:%s@%s", a.Registry, repository, tag, digest))
 		}
-		refs = append(refs, fmt.Sprintf("%s/%s:%s@%s", a.Registry, repository, a.Version, digest))
 	}
 	return refs, nil
 }

--- a/daggerverse/z5labs/app.go
+++ b/daggerverse/z5labs/app.go
@@ -300,6 +300,24 @@ func (a *App) WithOidcService(svc *dagger.Service) *App {
 // it is a pure function of the version, so what it cannot see — a release
 // published out of order walking `v1` backwards — is recorded there too.
 //
+// # How to read what comes back
+//
+// The references are grouped **repository-major**: every tag of the first
+// repository, in family order, then every tag of the second. The first
+// reference of each group is the immutable one — the full version — so the
+// reference a caller pins a deployment or a release note to is
+// `refs[i*len(family)]`, and a caller who does not want to know the family's
+// size can take the references whose tag is the version they passed.
+//
+// This was one reference per repository before the family existed, so a
+// caller indexing `refs[i]` per repository reads a tag of the first
+// repository now rather than the reference for `repositories[i]`. The
+// grouping is stated here because there is nowhere better: a structured
+// return — a repository, a digest and its tags — is the shape this wants,
+// and it is a schema object that every consumer of this module would have to
+// take a binding for, so it is worth doing deliberately rather than as part
+// of this change.
+//
 // Every published digest carries an SPDX and a CycloneDX document per
 // platform and a signed SLSA provenance statement whose build identity
 // comes from an exchanged workload identity token. A publish that cannot
@@ -425,6 +443,21 @@ func (a *App) Publish(ctx context.Context, repositories []string) ([]string, err
 		if err != nil {
 			return nil, fmt.Errorf("publish %s:%s%s: %v", repository, a.Version, alreadyPublished(refs), err)
 		}
+		// The predicate names the whole family, and the attach happens before
+		// any of it is written — so on a publish that fails part way through
+		// the tag loop below, the statement claims moving tags that never came
+		// to name this digest. That overclaim is not new: the attach has
+		// always preceded the tag, for the reason attachAttestations records,
+		// so the single-tag version made the same claim and merely made it
+		// all-or-nothing.
+		//
+		// It stays the family rather than shrinking to the immutable tag,
+		// because the field is what the release published under and a
+		// statement naming only v1.2.3 would be *wrong* about every successful
+		// publish rather than merely optimistic about a failed one. The
+		// failure is not silent either: Publish returns an error naming the
+		// tag it could not write, and the digest keeps every tag written
+		// before it.
 		facts := buildFacts{
 			Repository: repository,
 			Tags:       tags,

--- a/daggerverse/z5labs/dagger.gen.go
+++ b/daggerverse/z5labs/dagger.gen.go
@@ -548,6 +548,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Z5labs).ImageEnvironmentSelfTest(&parent, ctx)
+		case "VersionTagsSelfTest":
+			var parent Z5labs
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Z5labs).VersionTagsSelfTest(&parent, ctx)
 		default:
 			return nil, fmt.Errorf("unknown function %s", fnName)
 		}

--- a/daggerverse/z5labs/selftest.go
+++ b/daggerverse/z5labs/selftest.go
@@ -32,7 +32,15 @@ func (m *Z5labs) VersionTagsSelfTest(ctx context.Context) error {
 		// want is the exact family, or nil when the version has to be
 		// refused.
 		want []string
-		why  string
+		// wantErr is a substring the refusal has to carry, set on exactly the
+		// rows where want is nil. Checking the message rather than merely that
+		// an error came back is what keeps a refusal specific: three rows
+		// refused for three different reasons would all stay green under a
+		// validator that had started refusing everything, and the one that
+		// matters most — build metadata, refused rather than mangled — would
+		// read as covered while nothing checked which rule fired.
+		wantErr string
+		why     string
 	}{
 		{
 			version: "v1.2.3",
@@ -124,43 +132,50 @@ func (m *Z5labs) VersionTagsSelfTest(ctx context.Context) error {
 
 		{
 			version: "",
+			wantErr: "version is required",
 			why:     "an omitted version has no family and no single tag",
 		},
 		{
 			version: "1.0.0+build.7",
+			wantErr: "build metadata",
 			why:     "SemVer build metadata must not be re-admitted at publish time",
 		},
 		{
+			version: "1.0.0+build.7",
+			// Deliberately not the bare "1.0.0", which is a prefix of the
+			// rejected version the message already quotes: `release "1.0.0"`
+			// can only come from the stripped form, which is the tag two
+			// builds would silently share.
+			wantErr: `release "1.0.0"`,
+			why:     "the refusal has to name what the two builds would collapse to",
+		},
+		{
 			version: "release/v1.2.3",
+			wantErr: "not in the OCI tag charset",
 			why:     "a version outside the OCI tag charset",
 		},
 	}
 	for _, c := range cases {
-		got, err := versionTags(c.version)
+		tags, err := versionTags(c.version)
 		if c.want == nil {
 			if err == nil {
-				return fmt.Errorf("expected version %q to be refused (%s), got the tags %v", c.version, c.why, got)
+				return fmt.Errorf("expected version %q to be refused (%s), got the tags %v", c.version, c.why, tags)
+			}
+			if !strings.Contains(err.Error(), c.wantErr) {
+				return fmt.Errorf("expected the refusal of %q (%s) to carry %q, got: %v", c.version, c.why, c.wantErr, err)
 			}
 			continue
 		}
 		if err != nil {
 			return fmt.Errorf("expected version %q to derive %v (%s), got: %v", c.version, c.want, c.why, err)
 		}
-		if !slices.Equal(got, c.want) {
-			return fmt.Errorf("version %q (%s): want the tags %v, got %v", c.version, c.why, c.want, got)
+		if !slices.Equal(tags, c.want) {
+			return fmt.Errorf("version %q (%s): want the tags %v, got %v", c.version, c.why, c.want, tags)
 		}
-	}
 
-	// Three invariants that hold whatever the table says, checked over every
-	// accepted row rather than restated per case.
-	for _, c := range cases {
-		if c.want == nil {
-			continue
-		}
-		tags, err := versionTags(c.version)
-		if err != nil {
-			return fmt.Errorf("versionTags(%q): %v", c.version, err)
-		}
+		// Three invariants that hold whatever the table says, checked on every
+		// accepted row rather than restated per case.
+		//
 		// The version itself is always the first tag written. Publish relies
 		// on it: the immutable tag goes up before the moving ones, so a
 		// half-written family never leaves a moving tag ahead of the release

--- a/daggerverse/z5labs/selftest.go
+++ b/daggerverse/z5labs/selftest.go
@@ -3,8 +3,189 @@ package main
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 )
+
+// VersionTagsSelfTest checks the tag family a release is published under,
+// case by case, against the rule rather than against a release.
+//
+// It is a check of its own because the failure it guards is not one a
+// publish can show you. A derivation that moves a tag it should not have —
+// a prerelease that walks `v1`, a date-shaped version that invents a
+// `2026.08` — succeeds at the registry and is discovered by a consumer whose
+// `FROM` line resolved to something they never asked for, by which time it
+// is published and someone has pulled it. So every shape that distinguishes
+// the rule is stated here, including the accepting ones: a derivation that
+// published one tag for everything would pass a table of prereleases alone.
+//
+// It sits on the module rather than in tests/ for the same reason
+// ImageEnvironmentSelfTest does — the function is unexported — and because a
+// table of thirty versions costs one in-process call here and thirty
+// publishes there.
+//
+// +check
+// +cache="session"
+func (m *Z5labs) VersionTagsSelfTest(ctx context.Context) error {
+	cases := []struct {
+		version string
+		// want is the exact family, or nil when the version has to be
+		// refused.
+		want []string
+		why  string
+	}{
+		{
+			version: "v1.2.3",
+			want:    []string{"v1.2.3", "v1.2", "v1", "latest"},
+			why:     "the ordinary tagged release",
+		},
+		{
+			version: "1.2.3",
+			want:    []string{"1.2.3", "1.2", "1", "latest"},
+			why:     "the same release without the v prefix, which the family must not invent",
+		},
+		{
+			version: "v0.1.0",
+			want:    []string{"v0.1.0", "v0.1", "v0", "latest"},
+			why:     "a v0 release: the family is mechanical, and v0 is a level consumers pin at",
+		},
+		{
+			version: "v10.20.30",
+			want:    []string{"v10.20.30", "v10.20", "v10", "latest"},
+			why:     "multi-digit components, which a character-wise derivation would truncate",
+		},
+		{
+			version: "2026.8.12",
+			want:    []string{"2026.8.12", "2026.8", "2026", "latest"},
+			why:     "a date-shaped version that is also valid SemVer, so it gets the family",
+		},
+
+		{
+			version: "v1.3.0-rc.1",
+			want:    []string{"v1.3.0-rc.1"},
+			why:     "a prerelease publishes its own tag and moves none of the moving ones",
+		},
+		{
+			version: "1.0.0-0",
+			want:    []string{"1.0.0-0"},
+			why:     "a numeric prerelease identifier is still a prerelease",
+		},
+		{
+			version: "v2.0.0-alpha.1.2",
+			want:    []string{"v2.0.0-alpha.1.2"},
+			why:     "a dotted prerelease",
+		},
+		{
+			version: "v2.0.0-rc-1",
+			want:    []string{"v2.0.0-rc-1"},
+			why:     "a hyphen inside the prerelease, which the split must not treat as a second one",
+		},
+
+		{
+			version: "latest",
+			want:    []string{"latest"},
+			why:     "the moving tag named directly: not SemVer, so it publishes as itself and nothing else",
+		},
+		{
+			version: "abc1234-2026-01-01T00-00-00Z",
+			want:    []string{"abc1234-2026-01-01T00-00-00Z"},
+			why:     "the shape the old HEAD-derived version had, which is the behaviour the family must preserve",
+		},
+		{
+			version: "2026.08.12",
+			want:    []string{"2026.08.12"},
+			why:     `"08" is not a SemVer numeric identifier, so this moves nothing rather than inventing 2026.08`,
+		},
+		{
+			version: "v1.2",
+			want:    []string{"v1.2"},
+			why:     "two components is not SemVer: a caller releasing v1.2 is not asking for a v1 that moves",
+		},
+		{
+			version: "v1.2.3.4",
+			want:    []string{"v1.2.3.4"},
+			why:     "four components is not SemVer either",
+		},
+		{
+			version: "v1.2.3-",
+			want:    []string{"v1.2.3-"},
+			why:     "an empty prerelease is not SemVer, and the safe reading of an unparseable version is one tag",
+		},
+		{
+			version: "v01.2.3",
+			want:    []string{"v01.2.3"},
+			why:     "a leading zero is not a SemVer numeric identifier",
+		},
+		{
+			version: "_internal",
+			want:    []string{"_internal"},
+			why:     "a legal tag that is not a version at all",
+		},
+
+		{
+			version: "",
+			why:     "an omitted version has no family and no single tag",
+		},
+		{
+			version: "1.0.0+build.7",
+			why:     "SemVer build metadata must not be re-admitted at publish time",
+		},
+		{
+			version: "release/v1.2.3",
+			why:     "a version outside the OCI tag charset",
+		},
+	}
+	for _, c := range cases {
+		got, err := versionTags(c.version)
+		if c.want == nil {
+			if err == nil {
+				return fmt.Errorf("expected version %q to be refused (%s), got the tags %v", c.version, c.why, got)
+			}
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("expected version %q to derive %v (%s), got: %v", c.version, c.want, c.why, err)
+		}
+		if !slices.Equal(got, c.want) {
+			return fmt.Errorf("version %q (%s): want the tags %v, got %v", c.version, c.why, c.want, got)
+		}
+	}
+
+	// Three invariants that hold whatever the table says, checked over every
+	// accepted row rather than restated per case.
+	for _, c := range cases {
+		if c.want == nil {
+			continue
+		}
+		tags, err := versionTags(c.version)
+		if err != nil {
+			return fmt.Errorf("versionTags(%q): %v", c.version, err)
+		}
+		// The version itself is always the first tag written. Publish relies
+		// on it: the immutable tag goes up before the moving ones, so a
+		// half-written family never leaves a moving tag ahead of the release
+		// it points at.
+		if tags[0] != c.version {
+			return fmt.Errorf("version %q: expected its own tag first, got %v", c.version, tags)
+		}
+		// Every derived tag has to be publishable in its own right. A
+		// derivation that produced something outside the OCI tag charset would
+		// fail at the registry, after the image was pushed.
+		for _, tag := range tags {
+			if err := validateVersion(tag); err != nil {
+				return fmt.Errorf("version %q derived the tag %q, which cannot be an image tag: %v", c.version, tag, err)
+			}
+		}
+		// A duplicate would have the publish write one tag twice and report
+		// two references to it.
+		for i, tag := range tags {
+			if slices.Contains(tags[i+1:], tag) {
+				return fmt.Errorf("version %q derived %v, which repeats %q", c.version, tags, tag)
+			}
+		}
+	}
+	return nil
+}
 
 // ImageEnvironmentSelfTest checks the rule every published image is held to:
 // its environment is exactly the standardized set, and anything else — a

--- a/daggerverse/z5labs/tags.go
+++ b/daggerverse/z5labs/tags.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"strings"
+)
+
+// latestTag is the widest moving tag: whatever the most recent release
+// published. It is a fixed name rather than a configurable one because a
+// consumer who writes `FROM app` and gets `latest` is not reading this
+// module's configuration.
+const latestTag = "latest"
+
+// versionTags is the family of tags one release is published under, derived
+// from the version and from nothing else.
+//
+// # The family is the archetype's, not the caller's
+//
+// A consumer pins at the level of risk they are willing to take, and the
+// four levels are the same in every project:
+//
+//	v1.2.3   never moves
+//	v1.2     picks up patches
+//	v1       picks up minor releases
+//	latest   picks up everything
+//
+// Which of those exist is decided here rather than supplied by the caller,
+// because a family stated per project is one every project can get wrong —
+// and a consumer cannot tell a project that publishes no `v1` from one whose
+// `v1` has stopped moving. The cost is a project whose scheme is not SemVer,
+// and that case is served by the last rule below rather than by an option.
+//
+// # What the version says
+//
+//   - A SemVer release publishes the whole family, every tag naming one
+//     digest.
+//   - A SemVer *prerelease* publishes its own full version tag and nothing
+//     else. `v1.3.0-rc.1` is precisely the release that must not be handed to
+//     everybody pinning `v1`, which is what moving a moving tag would do.
+//   - A version that is not SemVer publishes as a single tag and moves
+//     nothing. That is the high-frequency-install case — no semantic
+//     versioning, many builds, a version like `abc1234-2026-01-01T00-00-00Z`
+//     — and it is a first-class use rather than a degraded one: it is also
+//     exactly the behaviour every caller had before this family existed.
+//
+// A `v` prefix is preserved rather than normalized away: `v1.2.3` gives
+// `v1.2` and `v1`, `1.2.3` gives `1.2` and `1`. Rewriting it would publish a
+// project's moving tags under names nobody in that project uses.
+//
+// # What a pure function of one version cannot see
+//
+// This derivation reads the version and never the registry, so it cannot
+// know that a *newer* release already moved the tags it is about to write.
+// Publishing v1.2.3 after v1.3.0 has shipped walks `v1` and `latest`
+// backwards, and every consumer pinning them is downgraded. Nothing here
+// prevents that, deliberately: the alternative is a publish that resolves
+// each moving tag first and silently declines to move some of them, which
+// makes "the release published" mean something different depending on what
+// was already there. Release in order, or publish the out-of-order release
+// as a prerelease, which moves nothing.
+//
+// The error is validateVersion's, unchanged. It is re-run here because
+// refusing SemVer build metadata is a property of publishing rather than of
+// one constructor: `+` is not in the OCI tag charset, so a version carrying
+// it has no tag family and no single tag either, and admitting it here would
+// undo the refusal App already made.
+func versionTags(version string) ([]string, error) {
+	if err := validateVersion(version); err != nil {
+		return nil, err
+	}
+	sv, ok := parseSemver(version)
+	if !ok || sv.Prerelease != "" {
+		return []string{version}, nil
+	}
+	return []string{
+		version,
+		sv.Prefix + sv.Major + "." + sv.Minor,
+		sv.Prefix + sv.Major,
+		latestTag,
+	}, nil
+}
+
+// semver is a version this module was able to read as SemVer. The numeric
+// fields stay strings because nothing here does arithmetic on them and
+// re-rendering an int is how "01" would quietly become "1".
+type semver struct {
+	// Prefix is "v" when the version carried one, and "" otherwise. It is
+	// carried so the derived tags spell the version the way the project
+	// does.
+	Prefix string
+	Major  string
+	Minor  string
+	Patch  string
+	// Prerelease is what followed the first "-", empty for a release.
+	Prerelease string
+}
+
+// parseSemver reads version as SemVer, reporting whether it could.
+//
+// It is deliberately strict — three numeric identifiers with no leading
+// zeros, and a well-formed prerelease if there is one — because failing to
+// parse is the *safe* outcome here: an unparsed version publishes one tag
+// and moves nothing, while a loose parse invents moving tags for a version
+// whose scheme this module guessed at. `2026.08.12` is the case that makes
+// the point: SemVer says "08" is not a numeric identifier, so a date-shaped
+// version publishes as itself rather than moving a `2026.08` nobody asked
+// for.
+//
+// Build metadata is refused rather than parsed. It cannot reach here through
+// versionTags, which validates first, but a parser that quietly accepted it
+// would make the refusal depend on call order.
+func parseSemver(version string) (semver, bool) {
+	var sv semver
+	rest := version
+	if strings.HasPrefix(rest, "v") {
+		sv.Prefix, rest = "v", rest[1:]
+	}
+	if strings.Contains(rest, "+") {
+		return semver{}, false
+	}
+	core, pre, hasPre := strings.Cut(rest, "-")
+	if hasPre {
+		if !isPrereleaseIdentifiers(pre) {
+			return semver{}, false
+		}
+		sv.Prerelease = pre
+	}
+	parts := strings.Split(core, ".")
+	if len(parts) != 3 {
+		return semver{}, false
+	}
+	for _, part := range parts {
+		if !isNumericIdentifier(part) {
+			return semver{}, false
+		}
+	}
+	sv.Major, sv.Minor, sv.Patch = parts[0], parts[1], parts[2]
+	return sv, true
+}
+
+// isNumericIdentifier reports whether s is a SemVer numeric identifier:
+// digits, and no leading zero unless the identifier is "0" itself.
+func isNumericIdentifier(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return len(s) == 1 || s[0] != '0'
+}
+
+// isPrereleaseIdentifiers reports whether s is a SemVer prerelease: one or
+// more dot-separated identifiers, each non-empty, each alphanumeric or
+// hyphen, and each numeric one without a leading zero.
+//
+// Everything it can see is already inside the OCI tag charset — validateVersion
+// ran first — so what this rules out is a shape that is not SemVer at all,
+// like the trailing hyphen in "1.0.0-" or the empty identifier in
+// "1.0.0-rc..1".
+func isPrereleaseIdentifiers(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, ident := range strings.Split(s, ".") {
+		if ident == "" {
+			return false
+		}
+		numeric := true
+		for i := 0; i < len(ident); i++ {
+			c := ident[i]
+			switch {
+			case c >= '0' && c <= '9':
+			case isTagAlnum(c) || c == '-':
+				numeric = false
+			default:
+				return false
+			}
+		}
+		if numeric && !isNumericIdentifier(ident) {
+			return false
+		}
+	}
+	return true
+}

--- a/daggerverse/z5labs/tags.go
+++ b/daggerverse/z5labs/tags.go
@@ -55,8 +55,21 @@ const latestTag = "latest"
 // prevents that, deliberately: the alternative is a publish that resolves
 // each moving tag first and silently declines to move some of them, which
 // makes "the release published" mean something different depending on what
-// was already there. Release in order, or publish the out-of-order release
-// as a prerelease, which moves nothing.
+// was already there.
+//
+// For a release published out of *sequence* — a re-run, a version tagged
+// late — the answer is to release in order, or to publish it as a
+// prerelease, which moves nothing. **A maintenance release is neither**, and
+// it is the case this rule genuinely does not serve: v1.9.1 published after
+// v2.0.0 is a backport, `v1.9` and `v1` moving forward is exactly right, and
+// `latest` regressing to a 1.x is exactly wrong. Publishing it as a
+// prerelease is not a workaround either, because that changes the immutable
+// tag consumers were told to pin. This module publishes `latest` anyway
+// today, because the family is the one the archetype states and a `latest`
+// that sometimes exists is worse than one that always does; devex#417 is
+// where the maintenance case gets decided, and until it does, a project
+// backporting across majors should know that its `latest` follows the last
+// publish rather than the highest version.
 //
 // The error is validateVersion's, unchanged. It is re-run here because
 // refusing SemVer build metadata is a property of publishing rather than of
@@ -89,7 +102,11 @@ type semver struct {
 	Prefix string
 	Major  string
 	Minor  string
-	Patch  string
+	// Patch is read by nothing: no tag in the family is derived from it,
+	// because the tag that would be is the version itself. It is kept so this
+	// type is the version rather than the part of it the family happens to
+	// use — a rule that compares two releases needs all three.
+	Patch string
 	// Prerelease is what followed the first "-", empty for a release.
 	Prerelease string
 }
@@ -119,7 +136,13 @@ func parseSemver(version string) (semver, bool) {
 	}
 	core, pre, hasPre := strings.Cut(rest, "-")
 	if hasPre {
-		if !isPrereleaseIdentifiers(pre) {
+		// The empty prerelease is checked here, beside the Cut, because it is
+		// the one malformed prerelease that can change what gets published:
+		// read as a release, "1.0.0-" would derive 1.0, 1 and latest. Every
+		// other shape isPrereleaseIdentifiers rejects publishes one tag
+		// whether it is rejected or accepted, so this is the check that has
+		// to sit next to the field it protects.
+		if pre == "" || !isPrereleaseIdentifiers(pre) {
 			return semver{}, false
 		}
 		sv.Prerelease = pre
@@ -155,10 +178,20 @@ func isNumericIdentifier(s string) bool {
 // more dot-separated identifiers, each non-empty, each alphanumeric or
 // hyphen, and each numeric one without a leading zero.
 //
-// Everything it can see is already inside the OCI tag charset — validateVersion
-// ran first — so what this rules out is a shape that is not SemVer at all,
-// like the trailing hyphen in "1.0.0-" or the empty identifier in
-// "1.0.0-rc..1".
+// **Nothing it rejects changes what gets published today**, and that is worth
+// stating plainly rather than leaving for someone to work out. A version
+// reaching here carries a "-", so it publishes one tag and moves nothing
+// whether this says "malformed prerelease, not SemVer" or "prerelease, so no
+// moving tags". The one case that did decide something — the empty
+// prerelease — is checked in parseSemver instead, next to the Cut that
+// produces it.
+//
+// So this is here as the definition rather than as a guard: a rule that ever
+// starts reading the prerelease — ordering two of them, deciding that
+// `-rc.1` and `-rc.2` share a moving tag — needs to know it is a prerelease
+// in the SemVer sense and not merely a string with a hyphen in it. Everything
+// it can see is already inside the OCI tag charset, because validateVersion
+// ran first.
 func isPrereleaseIdentifiers(s string) bool {
 	if s == "" {
 		return false

--- a/daggerverse/z5labs/tests/dagger.gen.go
+++ b/daggerverse/z5labs/tests/dagger.gen.go
@@ -255,6 +255,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).AppImagesCarryTheStandardEnvironment(&parent, ctx)
+		case "AppPrereleaseMovesNoMovingTags":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).AppPrereleaseMovesNoMovingTags(&parent, ctx)
 		case "AppPublishLeavesNoTagWhenAttachFails":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/z5labs/tests/dagger.gen.go
+++ b/daggerverse/z5labs/tests/dagger.gen.go
@@ -339,6 +339,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).AppRejectsSourceWithoutGitMetadata(&parent, ctx)
+		case "AppReleaseMovesTheMovingTags":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).AppReleaseMovesTheMovingTags(&parent, ctx)
 		case "AppSignatureDoesNotVerifyForAnotherKey":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
+++ b/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
@@ -125,6 +125,7 @@ type Z5Labs struct { // z5labs (../../../../../daggerverse/z5labs/main.go:59:6)
 
 	id                       *ID
 	imageEnvironmentSelfTest *Void
+	versionTagsSelfTest      *Void
 }
 
 func (r *Z5Labs) WithGraphQLQuery(q *querybuilder.Selection) *Z5Labs {
@@ -223,11 +224,36 @@ func (r *Z5Labs) UnmarshalJSON(bs []byte) error {
 //
 // It runs in process and needs no container, so it is cheap enough to be a
 // check of its own.
-func (r *Z5Labs) ImageEnvironmentSelfTest(ctx context.Context) error { // z5labs (../../../../../daggerverse/z5labs/selftest.go:31:1)
+func (r *Z5Labs) ImageEnvironmentSelfTest(ctx context.Context) error { // z5labs (../../../../../daggerverse/z5labs/selftest.go:212:1)
 	if r.imageEnvironmentSelfTest != nil {
 		return nil
 	}
 	q := r.query.Select("imageEnvironmentSelfTest")
+
+	return q.Execute(ctx)
+}
+
+// VersionTagsSelfTest checks the tag family a release is published under,
+// case by case, against the rule rather than against a release.
+//
+// It is a check of its own because the failure it guards is not one a
+// publish can show you. A derivation that moves a tag it should not have —
+// a prerelease that walks `v1`, a date-shaped version that invents a
+// `2026.08` — succeeds at the registry and is discovered by a consumer whose
+// `FROM` line resolved to something they never asked for, by which time it
+// is published and someone has pulled it. So every shape that distinguishes
+// the rule is stated here, including the accepting ones: a derivation that
+// published one tag for everything would pass a table of prereleases alone.
+//
+// It sits on the module rather than in tests/ for the same reason
+// ImageEnvironmentSelfTest does — the function is unexported — and because a
+// table of thirty versions costs one in-process call here and thirty
+// publishes there.
+func (r *Z5Labs) VersionTagsSelfTest(ctx context.Context) error { // z5labs (../../../../../daggerverse/z5labs/selftest.go:29:1)
+	if r.versionTagsSelfTest != nil {
+		return nil
+	}
+	q := r.query.Select("versionTagsSelfTest")
 
 	return q.Execute(ctx)
 }
@@ -410,10 +436,24 @@ func (r *Z5LabsApp) UnmarshalJSON(bs []byte) error {
 //
 // One manifest list is pushed per repository, naming every platform
 // variant, so a consumer pulls a repository and gets their architecture.
-// The returned references are `<address>/<repository>:<version>@<digest>`:
+// The returned references are `<address>/<repository>:<tag>@<digest>`:
 // pinned, because a tag is a mutable name and a caller anchoring a
 // deployment or a release note to what shipped has to be able to name
 // immutable bytes.
+//
+// # One release, a family of tags
+//
+// A release is published under every tag its version implies, not under the
+// version alone: `v1.2.3` also comes to name `v1.2`, `v1` and `latest`, so a
+// consumer can pin at the level of risk they want. Every tag of one release
+// names one digest — the same manifest list, pushed once — and one reference
+// comes back per tag, in the order the tags were written.
+//
+// A SemVer **prerelease** publishes its own full version tag and moves none
+// of the moving ones, and a version that is not SemVer publishes as a single
+// tag. versionTags derives the family and is where those rules are stated;
+// it is a pure function of the version, so what it cannot see — a release
+// published out of order walking `v1` backwards — is recorded there too.
 //
 // Every published digest carries an SPDX and a CycloneDX document per
 // platform and a signed SLSA provenance statement whose build identity
@@ -453,7 +493,7 @@ func (r *Z5LabsApp) UnmarshalJSON(bs []byte) error {
 // Publishing is a side effect against an external registry, so it is
 // uncached: a re-run must actually push. The build above it is session
 // cached, so the bytes pushed are the bytes Container returned.
-func (r *Z5LabsApp) Publish(ctx context.Context, repositories []string) ([]string, error) { // z5labs (../../../../../daggerverse/z5labs/app.go:329:1)
+func (r *Z5LabsApp) Publish(ctx context.Context, repositories []string) ([]string, error) { // z5labs (../../../../../daggerverse/z5labs/app.go:343:1)
 	q := r.query.Select("publish")
 	q = q.Arg("repositories", repositories)
 

--- a/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
+++ b/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
@@ -224,7 +224,7 @@ func (r *Z5Labs) UnmarshalJSON(bs []byte) error {
 //
 // It runs in process and needs no container, so it is cheap enough to be a
 // check of its own.
-func (r *Z5Labs) ImageEnvironmentSelfTest(ctx context.Context) error { // z5labs (../../../../../daggerverse/z5labs/selftest.go:212:1)
+func (r *Z5Labs) ImageEnvironmentSelfTest(ctx context.Context) error { // z5labs (../../../../../daggerverse/z5labs/selftest.go:227:1)
 	if r.imageEnvironmentSelfTest != nil {
 		return nil
 	}
@@ -455,6 +455,24 @@ func (r *Z5LabsApp) UnmarshalJSON(bs []byte) error {
 // it is a pure function of the version, so what it cannot see — a release
 // published out of order walking `v1` backwards — is recorded there too.
 //
+// # How to read what comes back
+//
+// The references are grouped **repository-major**: every tag of the first
+// repository, in family order, then every tag of the second. The first
+// reference of each group is the immutable one — the full version — so the
+// reference a caller pins a deployment or a release note to is
+// `refs[i*len(family)]`, and a caller who does not want to know the family's
+// size can take the references whose tag is the version they passed.
+//
+// This was one reference per repository before the family existed, so a
+// caller indexing `refs[i]` per repository reads a tag of the first
+// repository now rather than the reference for `repositories[i]`. The
+// grouping is stated here because there is nowhere better: a structured
+// return — a repository, a digest and its tags — is the shape this wants,
+// and it is a schema object that every consumer of this module would have to
+// take a binding for, so it is worth doing deliberately rather than as part
+// of this change.
+//
 // Every published digest carries an SPDX and a CycloneDX document per
 // platform and a signed SLSA provenance statement whose build identity
 // comes from an exchanged workload identity token. A publish that cannot
@@ -493,7 +511,7 @@ func (r *Z5LabsApp) UnmarshalJSON(bs []byte) error {
 // Publishing is a side effect against an external registry, so it is
 // uncached: a re-run must actually push. The build above it is session
 // cached, so the bytes pushed are the bytes Container returned.
-func (r *Z5LabsApp) Publish(ctx context.Context, repositories []string) ([]string, error) { // z5labs (../../../../../daggerverse/z5labs/app.go:343:1)
+func (r *Z5LabsApp) Publish(ctx context.Context, repositories []string) ([]string, error) { // z5labs (../../../../../daggerverse/z5labs/app.go:361:1)
 	q := r.query.Select("publish")
 	q = q.Arg("repositories", repositories)
 

--- a/daggerverse/z5labs/tests/main.go
+++ b/daggerverse/z5labs/tests/main.go
@@ -131,6 +131,7 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("AppPublishReturnsDigestPinnedReferences", t.AppPublishReturnsDigestPinnedReferences)
 	jobs = jobs.WithJob("AppPublishesEveryRepositoryNamed", t.AppPublishesEveryRepositoryNamed)
 	jobs = jobs.WithJob("AppPrereleaseMovesNoMovingTags", t.AppPrereleaseMovesNoMovingTags)
+	jobs = jobs.WithJob("AppReleaseMovesTheMovingTags", t.AppReleaseMovesTheMovingTags)
 	jobs = jobs.WithJob("AppPublishesTheContainersItReturned", t.AppPublishesTheContainersItReturned)
 	jobs = jobs.WithJob("AppPublishRefusesAnUnusableTarget", t.AppPublishRefusesAnUnusableTarget)
 	jobs = jobs.WithJob("AppRefusesPlaintextRegistryUnlessInsecure", t.AppRefusesPlaintextRegistryUnlessInsecure)
@@ -958,14 +959,21 @@ func (t *Tests) AppRebuildIsByteIdenticalPerPlatform(ctx context.Context) error 
 // rather than a value this pipeline computed, which is what makes it an
 // independent check.
 //
-// The tag listing is checked last, and exactly: a family with a fifth tag
-// in it — one derived from the branch, or a `v2.0.0` also published as
-// `stable` — would leave every assertion above true.
+// The tag listing is checked last, and exactly, per repository: a family with
+// a fifth tag in it — one derived from the branch, or a `v2.0.0` also
+// published as `stable` — would leave every assertion above true.
+//
+// What this does not cover is a moving tag actually moving; every tag here is
+// created rather than moved, because both repositories are fresh. That is
+// AppReleaseMovesTheMovingTags.
 func (t *Tests) AppPublishReturnsDigestPinnedReferences(ctx context.Context) error {
-	const (
-		version    = "v2.0.0"
-		repository = "hello"
-	)
+	const version = "v2.0.0"
+	// Two repositories, because the references are grouped repository-major
+	// over a nested loop and one repository cannot tell that grouping from the
+	// other one: a publish that derived the family once and applied it to the
+	// first repository only, or that interleaved the loops, would pass every
+	// assertion below against a single repository.
+	repositories := []string{"hello", "z5labs/hello-mirror"}
 	// Written out rather than derived, for the reason wantImagePath is: this
 	// is the contract with everyone who pins one of these names, so a test
 	// that asked the module what it derives would agree with whatever the
@@ -984,40 +992,125 @@ func (t *Tests) AppPublishReturnsDigestPinnedReferences(ctx context.Context) err
 		return err
 	}
 	app := dag.Z5Labs().Go(src).App(version, dagger.Z5LabsGoChainAppOpts{Platforms: []dagger.Platform{hostPlatform()}})
-	refs, err := publishable(app, svc, secret, prov).Publish(ctx, []string{repository})
+	refs, err := publishable(app, svc, secret, prov).Publish(ctx, []string{repositories[0], repositories[1]})
 	if err != nil {
 		return fmt.Errorf("Publish: %v", err)
 	}
-	if len(refs) != len(family) {
-		return fmt.Errorf("expected one reference per tag of the family %v, got %v", family, refs)
+	if len(refs) != len(repositories)*len(family) {
+		return fmt.Errorf("expected one reference per tag of the family %v in each of %v, got %v", family, repositories, refs)
 	}
-	stored, err := curlManifestDigest(ctx, svc, registryAlias, "ci", pwdHex, repository, version)
-	if err != nil {
-		return fmt.Errorf("read stored digest: %v", err)
-	}
-	for i, tag := range family {
-		want := fmt.Sprintf("%s:5000/%s:%s@%s", registryAlias, repository, tag, stored)
-		if refs[i] != want {
-			return fmt.Errorf("expected reference %d to be %q, got %q", i, want, refs[i])
+	for r, repository := range repositories {
+		stored, err := curlManifestDigest(ctx, svc, registryAlias, "ci", pwdHex, repository, version)
+		if err != nil {
+			return fmt.Errorf("read stored digest for %s: %v", repository, err)
 		}
+		for i, tag := range family {
+			// The index is where the repository-major grouping is asserted:
+			// tag-major references would put the mirror's v2.0.0 here.
+			ref := refs[r*len(family)+i]
+			want := fmt.Sprintf("%s:5000/%s:%s@%s", registryAlias, repository, tag, stored)
+			if ref != want {
+				return fmt.Errorf("expected reference %d to be %q, got %q (all: %v)", r*len(family)+i, want, ref, refs)
+			}
+			got, err := curlManifestDigest(ctx, svc, registryAlias, "ci", pwdHex, repository, tag)
+			if err != nil {
+				return fmt.Errorf("read stored digest for %s:%s: %v", repository, tag, err)
+			}
+			if got != stored {
+				return fmt.Errorf("%s:%s resolves to %s but %s:%s resolves to %s: one release has to be one digest under every tag of its family",
+					repository, version, stored, repository, tag, got)
+			}
+		}
+		tags, err := listTags(ctx, svc, registryAlias, "ci", pwdHex, repository)
+		if err != nil {
+			return fmt.Errorf("listTags %s: %v", repository, err)
+		}
+		release, _ := partitionTags(tags)
+		wantRelease := slices.Clone(family)
+		slices.Sort(wantRelease)
+		if !slices.Equal(release, wantRelease) {
+			return fmt.Errorf("%s: expected the release tags to be exactly %v, got %v (all tags: %v)",
+				repository, wantRelease, release, tags)
+		}
+	}
+	return nil
+}
+
+// AppReleaseMovesTheMovingTags asserts the other half of the family: a later
+// release takes the moving tags over, and leaves every earlier release's
+// immutable tags exactly where they were.
+//
+// Nothing else in this suite ever watches a moving tag *move*. A fresh
+// repository has `v1`, `latest` created rather than moved, and the prerelease
+// test asserts only that they stay put — so a re-tag that silently no-opped
+// over an existing name, or a registry that refused to overwrite one, would
+// leave every other assertion about the family true while consumers pinning
+// `v1` sat on the first release forever. That is the whole value proposition
+// of the family, and this is the test that can fail when it stops holding.
+//
+// The two releases differ in their minor version, so `v1.4` and `v1.5` are
+// each frozen to their own release while `v1` and `latest` follow the newer
+// one. That is the only interesting ordering property the family has: a wider
+// tag catching up while a narrower one does not.
+func (t *Tests) AppReleaseMovesTheMovingTags(ctx context.Context) error {
+	const (
+		first      = "v1.4.0"
+		second     = "v1.5.0"
+		repository = "hello"
+	)
+	src, err := gitFixture(ctx, helloDir(), "main", nil)
+	if err != nil {
+		return fmt.Errorf("gitFixture: %v", err)
+	}
+	svc, pwdHex, secret, err := localRegistry(ctx)
+	if err != nil {
+		return err
+	}
+	prov, err := newProvenanceHarness(ctx, "")
+	if err != nil {
+		return err
+	}
+	opts := dagger.Z5LabsGoChainAppOpts{Platforms: []dagger.Platform{hostPlatform()}}
+
+	firstRefs, err := publishable(dag.Z5Labs().Go(src).App(first, opts), svc, secret, prov).
+		Publish(ctx, []string{repository})
+	if err != nil {
+		return fmt.Errorf("Publish %s: %v", first, err)
+	}
+	firstDigest, err := digestOf(firstRefs[0])
+	if err != nil {
+		return err
+	}
+	secondRefs, err := publishable(dag.Z5Labs().Go(src).App(second, opts), svc, secret, prov).
+		Publish(ctx, []string{repository})
+	if err != nil {
+		return fmt.Errorf("Publish %s: %v", second, err)
+	}
+	secondDigest, err := digestOf(secondRefs[0])
+	if err != nil {
+		return err
+	}
+	if secondDigest == firstDigest {
+		return fmt.Errorf("both releases published the digest %s, so nothing below distinguishes a tag that moved from one that did not", firstDigest)
+	}
+
+	moved := map[string]string{
+		second:   secondDigest,
+		"v1.5":   secondDigest,
+		"v1":     secondDigest,
+		"latest": secondDigest,
+		first:    firstDigest,
+		"v1.4":   firstDigest,
+	}
+	for _, tag := range []string{second, "v1.5", "v1", "latest", first, "v1.4"} {
 		got, err := curlManifestDigest(ctx, svc, registryAlias, "ci", pwdHex, repository, tag)
 		if err != nil {
 			return fmt.Errorf("read stored digest for %s:%s: %v", repository, tag, err)
 		}
-		if got != stored {
-			return fmt.Errorf("%s:%s resolves to %s but %s:%s resolves to %s: one release has to be one digest under every tag of its family",
-				repository, version, stored, repository, tag, got)
+		if got != moved[tag] {
+			return fmt.Errorf("after publishing %s, expected %s:%s to resolve to %s, got %s",
+				second, repository, tag, moved[tag], got)
 		}
-	}
-	tags, err := listTags(ctx, svc, registryAlias, "ci", pwdHex, repository)
-	if err != nil {
-		return fmt.Errorf("listTags %s: %v", repository, err)
-	}
-	release, _ := partitionTags(tags)
-	wantRelease := slices.Clone(family)
-	slices.Sort(wantRelease)
-	if !slices.Equal(release, wantRelease) {
-		return fmt.Errorf("expected the release tags to be exactly %v, got %v (all tags: %v)", wantRelease, release, tags)
 	}
 	return nil
 }

--- a/daggerverse/z5labs/tests/main.go
+++ b/daggerverse/z5labs/tests/main.go
@@ -130,6 +130,7 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("AppRebuildIsByteIdenticalPerPlatform", t.AppRebuildIsByteIdenticalPerPlatform)
 	jobs = jobs.WithJob("AppPublishReturnsDigestPinnedReferences", t.AppPublishReturnsDigestPinnedReferences)
 	jobs = jobs.WithJob("AppPublishesEveryRepositoryNamed", t.AppPublishesEveryRepositoryNamed)
+	jobs = jobs.WithJob("AppPrereleaseMovesNoMovingTags", t.AppPrereleaseMovesNoMovingTags)
 	jobs = jobs.WithJob("AppPublishesTheContainersItReturned", t.AppPublishesTheContainersItReturned)
 	jobs = jobs.WithJob("AppPublishRefusesAnUnusableTarget", t.AppPublishRefusesAnUnusableTarget)
 	jobs = jobs.WithJob("AppRefusesPlaintextRegistryUnlessInsecure", t.AppRefusesPlaintextRegistryUnlessInsecure)
@@ -937,19 +938,39 @@ func (t *Tests) AppRebuildIsByteIdenticalPerPlatform(ctx context.Context) error 
 	return nil
 }
 
-// AppPublishReturnsDigestPinnedReferences asserts Publish reports what it
-// published, as references pinned to the digest the registry holds.
+// AppPublishReturnsDigestPinnedReferences asserts a release is published
+// under the whole family of tags its version implies, that every one of them
+// names one digest, and that Publish reports each as a digest-pinned
+// reference.
+//
+// The family is what lets a consumer pin at the level of risk they want —
+// `v2.0.0` never moves, `v2.0` picks up patches, `v2` picks up minor
+// releases, `latest` picks up everything — and the guarantee that makes it
+// worth anything is that they are one set of bytes rather than four
+// publishes that agree. So each tag's digest is read back from the registry
+// and compared, rather than the reported references being compared with each
+// other: a publish that pushed the image once per tag would satisfy every
+// assertion about the reference strings and none of this one.
 //
 // A tag is a mutable name, so a caller anchoring an attestation, a
 // deployment or a release note to a publish has to be handed something
-// immutable. The digest is checked against the registry's own view of what
-// it stored rather than against a value this pipeline computed, which is
-// what makes it an independent check.
+// immutable. The digests here are the registry's own view of what it stored
+// rather than a value this pipeline computed, which is what makes it an
+// independent check.
+//
+// The tag listing is checked last, and exactly: a family with a fifth tag
+// in it — one derived from the branch, or a `v2.0.0` also published as
+// `stable` — would leave every assertion above true.
 func (t *Tests) AppPublishReturnsDigestPinnedReferences(ctx context.Context) error {
 	const (
 		version    = "v2.0.0"
 		repository = "hello"
 	)
+	// Written out rather than derived, for the reason wantImagePath is: this
+	// is the contract with everyone who pins one of these names, so a test
+	// that asked the module what it derives would agree with whatever the
+	// module changed it to.
+	family := []string{"v2.0.0", "v2.0", "v2", "latest"}
 	src, err := gitFixture(ctx, helloDir(), "main", nil)
 	if err != nil {
 		return fmt.Errorf("gitFixture: %v", err)
@@ -967,16 +988,138 @@ func (t *Tests) AppPublishReturnsDigestPinnedReferences(ctx context.Context) err
 	if err != nil {
 		return fmt.Errorf("Publish: %v", err)
 	}
-	if len(refs) != 1 {
-		return fmt.Errorf("expected 1 reference for 1 repository and 1 tag, got %v", refs)
+	if len(refs) != len(family) {
+		return fmt.Errorf("expected one reference per tag of the family %v, got %v", family, refs)
 	}
 	stored, err := curlManifestDigest(ctx, svc, registryAlias, "ci", pwdHex, repository, version)
 	if err != nil {
 		return fmt.Errorf("read stored digest: %v", err)
 	}
-	want := fmt.Sprintf("%s:5000/%s:%s@%s", registryAlias, repository, version, stored)
-	if refs[0] != want {
-		return fmt.Errorf("expected the reference %q, got %q", want, refs[0])
+	for i, tag := range family {
+		want := fmt.Sprintf("%s:5000/%s:%s@%s", registryAlias, repository, tag, stored)
+		if refs[i] != want {
+			return fmt.Errorf("expected reference %d to be %q, got %q", i, want, refs[i])
+		}
+		got, err := curlManifestDigest(ctx, svc, registryAlias, "ci", pwdHex, repository, tag)
+		if err != nil {
+			return fmt.Errorf("read stored digest for %s:%s: %v", repository, tag, err)
+		}
+		if got != stored {
+			return fmt.Errorf("%s:%s resolves to %s but %s:%s resolves to %s: one release has to be one digest under every tag of its family",
+				repository, version, stored, repository, tag, got)
+		}
+	}
+	tags, err := listTags(ctx, svc, registryAlias, "ci", pwdHex, repository)
+	if err != nil {
+		return fmt.Errorf("listTags %s: %v", repository, err)
+	}
+	release, _ := partitionTags(tags)
+	wantRelease := slices.Clone(family)
+	slices.Sort(wantRelease)
+	if !slices.Equal(release, wantRelease) {
+		return fmt.Errorf("expected the release tags to be exactly %v, got %v (all tags: %v)", wantRelease, release, tags)
+	}
+	return nil
+}
+
+// AppPrereleaseMovesNoMovingTags asserts a prerelease publishes its own full
+// version tag and moves none of the tags a release left behind.
+//
+// This is the rule that keeps a release candidate from being handed to
+// everybody pinning `v1`, and it is only observable against a registry that
+// already holds a release: a prerelease published into an empty repository
+// leaves `v1` absent whether the rule holds or not, so the assertion would
+// pass over a publish that moves every moving tag it can find. So a release
+// goes up first, and what is checked is that the three moving tags still
+// resolve to *its* digest afterwards.
+//
+// The two publishes are different bytes by construction — the version is
+// stamped into the binary — and that is asserted rather than assumed,
+// because two identical digests would make every comparison below hold
+// trivially.
+func (t *Tests) AppPrereleaseMovesNoMovingTags(ctx context.Context) error {
+	const (
+		release    = "v1.4.0"
+		prerelease = "v1.5.0-rc.1"
+		repository = "hello"
+	)
+	src, err := gitFixture(ctx, helloDir(), "main", nil)
+	if err != nil {
+		return fmt.Errorf("gitFixture: %v", err)
+	}
+	svc, pwdHex, secret, err := localRegistry(ctx)
+	if err != nil {
+		return err
+	}
+	prov, err := newProvenanceHarness(ctx, "")
+	if err != nil {
+		return err
+	}
+	opts := dagger.Z5LabsGoChainAppOpts{Platforms: []dagger.Platform{hostPlatform()}}
+
+	releaseRefs, err := publishable(dag.Z5Labs().Go(src).App(release, opts), svc, secret, prov).
+		Publish(ctx, []string{repository})
+	if err != nil {
+		return fmt.Errorf("Publish %s: %v", release, err)
+	}
+	releaseDigest, err := digestOf(releaseRefs[0])
+	if err != nil {
+		return err
+	}
+
+	preRefs, err := publishable(dag.Z5Labs().Go(src).App(prerelease, opts), svc, secret, prov).
+		Publish(ctx, []string{repository})
+	if err != nil {
+		return fmt.Errorf("Publish %s: %v", prerelease, err)
+	}
+	if len(preRefs) != 1 {
+		return fmt.Errorf("expected the prerelease to publish one tag and nothing else, got %v", preRefs)
+	}
+	preDigest, err := digestOf(preRefs[0])
+	if err != nil {
+		return err
+	}
+	if preDigest == releaseDigest {
+		return fmt.Errorf("the release and the prerelease published the same digest %s, so nothing below distinguishes a moved tag from an unmoved one", preDigest)
+	}
+	want := fmt.Sprintf("%s:5000/%s:%s@%s", registryAlias, repository, prerelease, preDigest)
+	if preRefs[0] != want {
+		return fmt.Errorf("expected the prerelease reference %q, got %q", want, preRefs[0])
+	}
+
+	// The moving tags still name the release. This is the criterion.
+	for _, tag := range []string{"v1.4", "v1", "latest"} {
+		got, err := curlManifestDigest(ctx, svc, registryAlias, "ci", pwdHex, repository, tag)
+		if err != nil {
+			return fmt.Errorf("read stored digest for %s:%s: %v", repository, tag, err)
+		}
+		if got != releaseDigest {
+			return fmt.Errorf("%s moved %s:%s from the release %s to %s: a prerelease is handed only to whoever asked for it by name",
+				prerelease, repository, tag, releaseDigest, got)
+		}
+	}
+	// And it is pullable under its own name, which is the other half: a
+	// prerelease that moved nothing because it published nothing would pass
+	// the loop above.
+	got, err := curlManifestDigest(ctx, svc, registryAlias, "ci", pwdHex, repository, prerelease)
+	if err != nil {
+		return fmt.Errorf("read stored digest for %s:%s: %v", repository, prerelease, err)
+	}
+	if got != preDigest {
+		return fmt.Errorf("expected %s:%s to resolve to %s, got %s", repository, prerelease, preDigest, got)
+	}
+	// The listing rules out a moving tag invented for the prerelease under
+	// some other name — a `v1.5` derived from its core, which nothing above
+	// would notice because no release ever wrote one.
+	tags, err := listTags(ctx, svc, registryAlias, "ci", pwdHex, repository)
+	if err != nil {
+		return fmt.Errorf("listTags %s: %v", repository, err)
+	}
+	releaseTags, _ := partitionTags(tags)
+	wantRelease := []string{release, "v1.4", "v1", "latest", prerelease}
+	slices.Sort(wantRelease)
+	if !slices.Equal(releaseTags, wantRelease) {
+		return fmt.Errorf("expected the release tags to be exactly %v, got %v (all tags: %v)", wantRelease, releaseTags, tags)
 	}
 	return nil
 }
@@ -988,8 +1131,16 @@ func (t *Tests) AppPublishReturnsDigestPinnedReferences(ctx context.Context) err
 // goes to a public registry and to an internal mirror is one build, and
 // re-running the build per destination would publish bytes that are only
 // probably the same.
+//
+// The version is deliberately not SemVer, which makes this the check that
+// the one-tag-per-publish behaviour survives the tag family: a version this
+// module cannot read as SemVer publishes as itself and moves nothing at all.
+// That is the high-frequency-install case — no semantic versioning, many
+// builds — and this shape is the one the version used to be derived as, so
+// what is preserved here is precisely what every caller had before. The
+// family is AppPublishReturnsDigestPinnedReferences.
 func (t *Tests) AppPublishesEveryRepositoryNamed(ctx context.Context) error {
-	const version = "v1.5.0"
+	const version = "abc1234-2026-01-01T00-00-00Z"
 	repositories := []string{"hello", "z5labs/hello-mirror"}
 	src, err := gitFixture(ctx, helloDir(), "main", nil)
 	if err != nil {
@@ -1025,7 +1176,8 @@ func (t *Tests) AppPublishesEveryRepositoryNamed(ctx context.Context) error {
 	}
 	// The tag listing is the check that the version is the only tag a
 	// consumer can pull as a release: a publish deriving a second tag from
-	// the branch or the commit would still leave every assertion above true.
+	// the branch or the commit — or deriving a moving tag out of a version
+	// that is not SemVer — would still leave every assertion above true.
 	//
 	// The signature tags are the one exception, and they are checked rather
 	// than excused. Cosign's layout stores a signature under a tag it


### PR DESCRIPTION
Closes #395

A release now publishes under the family of tags its version implies, so a consumer can pin
at the level of risk they want: `v1.2.3` never moves, `v1.2` picks up patches, `v1` picks up
minor releases, `latest` picks up everything — all four naming one digest, pushed once.

## The decision the story asked for

**The family is fixed by the archetype, keyed off whether the supplied version parses as
SemVer** — the reading the issue's own update settled on, now that #404 has the caller state
the version:

- a SemVer release publishes the whole family;
- a SemVer **prerelease** publishes its own full version tag and moves none of the moving ones;
- a version that is **not** SemVer publishes as a single tag and moves nothing. That is the
  high-frequency-install case, and it is also exactly what every caller had before this
  family existed.

A `v` prefix is preserved rather than normalized (`v1.2.3` → `v1.2`, `v1`; `1.2.3` → `1.2`,
`1`), because rewriting it publishes a project's moving tags under names nobody in that
project uses.

## Acceptance criteria

- [x] **A release publishes one set of bytes under a family of tags, every tag resolving to
      one digest.** `Publish` pushes the manifest list once, attaches and signs it, and then
      writes every tag of the family onto that one digest, returning a digest-pinned
      reference per tag. `AppPublishReturnsDigestPinnedReferences` reads each tag's digest
      back *from the registry* and compares — a publish that pushed once per tag would
      satisfy every assertion about the returned strings and fail this one.
- [x] **A prerelease publishes its own full version tag and moves none of the moving tags.**
      `AppPrereleaseMovesNoMovingTags` publishes `v1.4.0`, then `v1.5.0-rc.1` into the same
      repository, and asserts `v1.4`, `v1` and `latest` all still resolve to the release's
      digest. The release goes first on purpose: against an empty repository the criterion is
      unfalsifiable.
- [x] **Decide whether the family is fixed or supplied.** Fixed by the archetype; see above
      and `versionTags`' doc comment, which states why a per-project family is one every
      project can get wrong.
- [x] **A version carrying SemVer build metadata is refused rather than mangled.** `Publish`
      re-runs `validateVersion` before the first byte moves rather than trusting the
      constructor, so the refusal is a property of publishing rather than of one call path.
      `parseSemver` refuses `+` independently, so no derivation can re-admit it.
- [x] **The derivation is checked by a table of cases rather than only by releasing.**
      `VersionTagsSelfTest` — a new in-process `+check` beside `ImageEnvironmentSelfTest` —
      runs twenty cases: releases, prereleases, `v`-prefixed and not, multi-digit,
      date-shaped versions on both sides of the leading-zero rule, malformed cores, and the
      three refusals. Plus three invariants over every accepted row: the version is always the
      first tag written, every derived tag is itself a legal OCI tag, and no tag repeats.
- [x] **The existing behaviour is preserved for callers who want one tag per ref.**
      `AppPublishesEveryRepositoryNamed` now publishes a non-SemVer version of exactly the
      shape the old HEAD-derived one had, and its existing assertion — the version is the only
      release tag in the listing — is what preserves it.

## Judgment calls

- **Tags are written narrowest first** (`v1.2.3`, `v1.2`, `v1`, `latest`). A failure part way
  through leaves the tags after it unmoved, and the wider the tag the more consumers a
  half-finished release would have handed the new bytes to. The full version costs nothing to
  write first — it named no release before this one — and it stays the tag `refs[0]` reports,
  which is what the attestation tests read.
- **Releasing out of order is documented, not prevented.** `versionTags` is a pure function of
  one version and cannot see that a newer release already moved `v1`, so publishing v1.2.3
  after v1.3.0 walks `v1` and `latest` backwards. The alternative — resolving each moving tag
  and silently declining to move some — makes "the release published" mean something different
  depending on what was already there, so the doc comment states the constraint and names the
  two ways out (release in order, or publish the out-of-order release as a prerelease).
- **`parseSemver` is strict, because failing to parse is the safe outcome.** An unparsed
  version publishes one tag and moves nothing; a loose parse invents moving tags for a scheme
  this module guessed at. `2026.08.12` is the case that makes the point — `08` is not a SemVer
  numeric identifier, so it publishes as itself rather than moving a `2026.08` nobody asked
  for — while `2026.8.12` does parse and does get a family.
- **The provenance predicate's `tags` now carries the whole family**, which is what that field
  says it holds: the tags the same bytes were published under.

## Verified

- `dagger check` — green (`ci:generated`, `ci:generated-self-test`, `ci:selection-self-test`).
- `bash .github/scripts/verify-affected-modules.sh` — green:
  `z-5-labs:image-environment-self-test`, the new `z-5-labs:version-tags-self-test`, and
  `tests:all` (30 tests, including the new `AppPrereleaseMovesNoMovingTags`).
- Bindings regenerated with `dagger develop` in `daggerverse/z5labs` and
  `daggerverse/z5labs/tests` after the last source edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
