### PR TITLE
story(z5labs): construct an App from prebuilt executables, with no language chain

### DIFF
--- a/daggerverse/z5labs/annotations.go
+++ b/daggerverse/z5labs/annotations.go
@@ -40,11 +40,22 @@ const (
 //   - version is the caller's version. It is always set now: it used to be
 //     present only when a tag pointed at HEAD, because that was the only
 //     case in which the pipeline had a version worth the name.
+//
+// Every key but the version is omitted when the fact behind it was never
+// observed, and the source key has always been. An App assembled from
+// prebuilt executables read no working tree, so it has no revision and no
+// commit time; a key present and blank would be worse than an absent one for
+// exactly the reason the source key already gives, because a consumer cannot
+// tell it apart from a revision that really is "". A language chain always
+// has all three — gitFacts refuses a tree that cannot supply them — so
+// nothing about the Go path changes here.
 func ociAnnotations(facts gitState, version string) map[string]string {
-	out := map[string]string{
-		annotationRevision: facts.SHA,
-		annotationCreated:  facts.Created,
-		annotationVersion:  version,
+	out := map[string]string{annotationVersion: version}
+	if facts.SHA != "" {
+		out[annotationRevision] = facts.SHA
+	}
+	if facts.Created != "" {
+		out[annotationCreated] = facts.Created
 	}
 	if facts.SourceURI != "" {
 		out[annotationSource] = facts.SourceURI

--- a/daggerverse/z5labs/app.go
+++ b/daggerverse/z5labs/app.go
@@ -123,9 +123,22 @@ type variant struct {
 // Name is not published. It names the contribution in an error, which is
 // the whole reason it is carried: a publish that fails because one document
 // of five will not parse has to be able to say which one.
+//
+// The bytes themselves are carried beside the document, in exactly one of
+// Content and Tree, and that is what turns an asserted document into a
+// checkable one: a publish hashes them and refuses a document naming some
+// other digest. Before this they were not held at all — the image had them and
+// nothing connected them to the document — so a document about the wrong
+// artifact was undetectable by construction. digest.go carries the rule and
+// why it runs where it runs.
 type contribution struct {
 	Name string
 	File *dagger.File
+	// Content is the file that entered the image: an application's own
+	// executable, or a contributed file. Nil for a directory contribution.
+	Content *dagger.File
+	// Tree is the directory that entered the image. Nil for everything else.
+	Tree *dagger.Directory
 }
 
 // Container returns the image built for platform.

--- a/daggerverse/z5labs/build.go
+++ b/daggerverse/z5labs/build.go
@@ -186,24 +186,38 @@ func (g *GoChain) buildBinaryForPlatform(platform, pkg, binaryName, version, com
 	}).File(binaryName)
 }
 
-// imageForPlatform packages binary as a scratch image pinned to platform.
-// The platform option creates an empty container; we do not call
+// imageForEntry packages entry as a scratch image pinned to platform. The
+// platform option creates an empty container; we do not call
 // From("scratch") because Docker's "scratch" is a base name, not a pullable
 // image.
 //
-// The entrypoint is the binary's absolute path, so the app runs whatever
+// The entrypoint is the executable's absolute path, so the app runs whatever
 // PATH says. The PATH is the module's standardized value and is set here
 // rather than anywhere a caller can reach — see the constants above.
+//
+// The entry lands owned by the image's non-root user and read-only, which is
+// the same treatment every contributed byte gets and for the same reason: an
+// image whose files the application can rewrite is one whose published digest
+// stops describing what is running. It is 0555 rather than 0444 because this
+// is the one file in the image that is exec'd.
+//
+// This is the only place an image is built, and everything reaches it —
+// GoChain.App by way of AppBuilder, and AppBuilder by way of a caller's
+// prebuilt executable. A caller-supplied entrypoint is not an exemption from
+// any of the above; it is the same code with a different file in it.
 //
 // annotations are applied per variant rather than to the manifest list a
 // publish assembles from them: a caller pulls one platform, and an
 // annotation that lived only on the index would be invisible to everything
 // that resolved a platform first. Keys are applied in sorted order so two
 // builds of one commit produce the same manifest bytes.
-func imageForPlatform(platform dagger.Platform, binaryName string, binary *dagger.File, annotations map[string]string) *dagger.Container {
-	entrypoint := appDir + "/" + binaryName
+func imageForEntry(platform dagger.Platform, name string, entry *dagger.File, annotations map[string]string) *dagger.Container {
+	entrypoint := appDir + "/" + name
 	ctr := dag.Container(dagger.ContainerOpts{Platform: platform}).
-		WithFile(entrypoint, binary).
+		WithFile(entrypoint, entry, dagger.ContainerWithFileOpts{
+			Owner:       appOwner,
+			Permissions: entryMode,
+		}).
 		WithEnvVariable("PATH", appPath).
 		WithEntrypoint([]string{entrypoint})
 	keys := make([]string, 0, len(annotations))

--- a/daggerverse/z5labs/contribute.go
+++ b/daggerverse/z5labs/contribute.go
@@ -43,19 +43,21 @@ import (
 // carries the assembly; Z5labs.FileDocument and Z5labs.DirectoryDocument
 // produce a document for content whose ecosystem has no module able to.
 //
-// What is enforced is that a document arrives, that it parses as SPDX 2.3 and
-// that it describes exactly one thing — not that it describes *these* bytes.
-// Nothing here compares the document's checksums against the content beside
-// it, so a caller who passes the wrong document publishes an SBOM about bytes
-// that are not in the image. That is a deliberate limit rather than an
-// oversight, and it is the same limit every contribution has always had: a
-// language chain's own document is produced from the binary it built, and this
-// module has no way to re-derive an arbitrary ecosystem's document to check it
-// against. What the seam removes is the *undescribed* contribution, which is
-// the case nothing downstream could even ask about. A wrong document is at
-// least a claim someone made, in a signed artifact, checkable against the image
-// by anyone who pulls it. The paved path is honest by construction, because the
-// two helpers above compute their digests from the content themselves.
+// What is enforced is that a document arrives, that it parses as SPDX 2.3, that
+// it describes exactly one thing, and that the thing it describes is *these*
+// bytes: a publish hashes the contributed content and refuses a document naming
+// any other digest. That last check was not here at first — the limit stated in
+// this comment was that a caller passing the wrong document published an SBOM
+// about bytes that are not in the image — and devex#410 closed it, because an
+// asserted document is only worth something if something can tell it apart from
+// a worthless one. digest.go carries the rule, and why it runs at publish time.
+//
+// What is still not enforced is what is *inside* a document. Nothing here can
+// re-derive an arbitrary ecosystem's dependency graph, so a supplier can
+// overstate what their own artifact is made of. That is a claim someone made,
+// in a signed artifact, checkable by anyone who pulls the image — a different
+// thing from a document about some other artifact entirely, which is no longer
+// publishable.
 //
 // # The directories on the way are the image's, not the contribution's
 //
@@ -170,7 +172,7 @@ func (a *App) WithFile(
 			Owner:       appOwner,
 			Permissions: contributedFileMode,
 		})
-		v.Contributions = append(v.Contributions, contribution{Name: clean, File: document})
+		v.Contributions = append(v.Contributions, contribution{Name: clean, File: document, Content: file})
 	}
 	a.ContributedPaths = append(a.ContributedPaths, clean)
 	return a, nil
@@ -214,7 +216,7 @@ func (a *App) WithDirectory(
 		v.Container = v.Container.WithDirectory(clean, tree, dagger.ContainerWithDirectoryOpts{
 			Owner: appOwner,
 		})
-		v.Contributions = append(v.Contributions, contribution{Name: clean, File: document})
+		v.Contributions = append(v.Contributions, contribution{Name: clean, File: document, Tree: dir})
 	}
 	a.ContributedPaths = append(a.ContributedPaths, clean)
 	return a, nil

--- a/daggerverse/z5labs/dagger.gen.go
+++ b/daggerverse/z5labs/dagger.gen.go
@@ -73,6 +73,46 @@ func (r *Z5labs) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
+func (r AppBuilder) MarshalJSON() ([]byte, error) {
+	var concrete struct {
+		Version   string
+		Commit    string
+		SourceURI string
+		Created   string
+		Pkg       string
+		Variants  []*pendingVariant
+	}
+	concrete.Version = r.Version
+	concrete.Commit = r.Commit
+	concrete.SourceURI = r.SourceURI
+	concrete.Created = r.Created
+	concrete.Pkg = r.Pkg
+	concrete.Variants = r.Variants
+	return json.Marshal(&concrete)
+}
+
+func (r *AppBuilder) UnmarshalJSON(bs []byte) error {
+	var concrete struct {
+		Version   string
+		Commit    string
+		SourceURI string
+		Created   string
+		Pkg       string
+		Variants  []*pendingVariant
+	}
+	err := json.Unmarshal(bs, &concrete)
+	if err != nil {
+		return err
+	}
+	r.Version = concrete.Version
+	r.Commit = concrete.Commit
+	r.SourceURI = concrete.SourceURI
+	r.Created = concrete.Created
+	r.Pkg = concrete.Pkg
+	r.Variants = concrete.Variants
+	return nil
+}
+
 func (r GoChain) MarshalJSON() ([]byte, error) {
 	var concrete struct {
 		Source      *dagger.Directory
@@ -496,6 +536,46 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 		default:
 			return nil, fmt.Errorf("unknown function %s", fnName)
 		}
+	case "AppBuilder":
+		switch fnName {
+		case "Build":
+			var parent AppBuilder
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*AppBuilder).Build(&parent, ctx)
+		case "WithVariant":
+			var parent AppBuilder
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var platform dagger.Platform
+			if inputArgs["platform"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["platform"]), &platform)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg platform", err))
+				}
+			}
+			var entry *dagger.File
+			if inputArgs["entry"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["entry"]), &entry)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg entry", err))
+				}
+			}
+			var document *dagger.File
+			if inputArgs["document"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["document"]), &document)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg document", err))
+				}
+			}
+			return (*AppBuilder).WithVariant(&parent, ctx, platform, entry, document)
+		default:
+			return nil, fmt.Errorf("unknown function %s", fnName)
+		}
 	case "GoChain":
 		switch fnName {
 		case "App":
@@ -587,6 +667,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 		}
 	case "Z5labs":
 		switch fnName {
+		case "App":
+			var parent Z5labs
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var version string
+			if inputArgs["version"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["version"]), &version)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg version", err))
+				}
+			}
+			return (*Z5labs).App(&parent, version), nil
 		case "ContributionPathSelfTest":
 			var parent Z5labs
 			err = json.Unmarshal(parentJSON, &parent)
@@ -692,6 +786,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Z5labs).ImageSbomSelfTest(&parent, ctx)
+		case "VariantSetSelfTest":
+			var parent Z5labs
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Z5labs).VariantSetSelfTest(&parent, ctx)
 		case "VersionTagsSelfTest":
 			var parent Z5labs
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/z5labs/dagger.gen.go
+++ b/daggerverse/z5labs/dagger.gen.go
@@ -572,7 +572,14 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg document", err))
 				}
 			}
-			return (*AppBuilder).WithVariant(&parent, ctx, platform, entry, document)
+			var name string
+			if inputArgs["name"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["name"]), &name)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg name", err))
+				}
+			}
+			return (*AppBuilder).WithVariant(&parent, ctx, platform, entry, document, name)
 		default:
 			return nil, fmt.Errorf("unknown function %s", fnName)
 		}

--- a/daggerverse/z5labs/digest.go
+++ b/daggerverse/z5labs/digest.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// A document is a claim, and this is what makes the claim checkable.
+//
+// Some documents cannot disagree with what they describe: `dag.Go().Spdx`
+// derives an SBOM from the compiled binary through debug/buildinfo, so the
+// document and the artifact come from one read. Every other document this
+// module accepts is asserted — a caller's SPDX for a certificate bundle, a
+// vendor's for a prebuilt CLI — and an asserted document about the wrong bytes
+// is well-formed, attaches cleanly, and is indistinguishable from a right one.
+// That is the concern devex#409 left open and devex#410 closes.
+//
+// The mitigation is deliberately the cheapest one that is worth anything:
+// **require the document to name the SHA-256 of the content it accompanies,
+// and verify it.** It applies to every contribution by the same rule — the
+// executable a variant is built around, a contributed file, a contributed tree
+// — and it applies to `dag.Go().Spdx` too, which already names the binary's
+// digest, so the paved path needs no exception.
+//
+// # What it establishes, and what it does not
+//
+// It establishes that the document is about *these* bytes. It does not
+// establish that the components listed inside it are the ones really in those
+// bytes: nothing here can re-derive an arbitrary ecosystem's dependency graph,
+// and a module that pretended to would be inventing an answer. So a supplier
+// can still overstate what is inside their own artifact. What they can no
+// longer do is hand over a document about something else entirely — which was
+// the case nothing downstream could even ask about, because the document named
+// no digest to compare and the image named no document to compare it to.
+//
+// # Why the check runs at publish rather than at the contributing call
+//
+// Verifying means hashing the content, and hashing means resolving it. A
+// language chain's contribution is a binary that has not been compiled yet, so
+// a check at the contributing call would force every platform's cross-compile
+// inside App — turning a constructor that costs nothing into one that costs a
+// full build, and taking with it the property that "an app nobody publishes
+// costs no scan".
+//
+// resolveContributions is where it goes instead: the one place that already
+// reads and parses every document, before the first byte is pushed, for
+// exactly the reason this check exists. It is not a weaker position. There is
+// no route to a registry that does not pass through it, and everything
+// fallible about assembly failing in one call is what keeps a half-attested
+// image from being possible at all.
+//
+// # A directory's digest is this module's convention
+//
+// A file has one obvious digest and a tree does not, so the digest a directory
+// contribution's document must name is the one Z5labs.DirectoryDocument
+// computes: the SHA-256 over the sorted list of the tree's paths and their
+// SHA-256s, which is treeDigest. It is stable, it is a pure function of the
+// tree, and two directories that differ anywhere differ in it. A document
+// produced somewhere else with some other notion of a tree checksum will be
+// refused, and the refusal says what was expected — which is the right outcome
+// for a value nothing else could interpret.
+
+// verifyContributionDigest refuses a contribution whose document is about
+// bytes other than the ones entering the image.
+//
+// The two failures are kept apart because they send the reader to different
+// places: a document that names no digest is a document that cannot be checked
+// at all, usually produced by hand or by a tool that does not fill the field,
+// while a digest that disagrees is a document about the wrong artifact.
+func verifyContributionDigest(ctx context.Context, c contribution, subject bomPackage) error {
+	want := strings.ToLower(strings.TrimSpace(subject.Sha256))
+	if want == "" {
+		return fmt.Errorf(
+			"names no SHA-256 for what it describes, so nothing connects it to the bytes in the image; "+
+				"a contribution's document has to name the digest of the content it accompanies, and %s produces one that does",
+			documentHelperFor(c))
+	}
+	got, err := contentDigest(ctx, c)
+	if err != nil {
+		return err
+	}
+	if got != want {
+		return fmt.Errorf(
+			"describes other bytes: it names SHA-256 %s and what entered the image hashes to %s",
+			want, got)
+	}
+	return nil
+}
+
+// documentHelperFor names the helper that would have produced a checkable
+// document for this contribution, so the refusal ends somewhere useful rather
+// than in a restatement of the rule.
+func documentHelperFor(c contribution) string {
+	if c.Tree != nil {
+		return "directoryDocument"
+	}
+	return "fileDocument"
+}
+
+// contentDigest is the digest a contribution's document has to name: the
+// SHA-256 of a file's bytes, or this module's tree digest for a directory.
+//
+// The content is exported to the module's own filesystem and hashed there,
+// which is the runtime-I/O pattern the rest of this module uses and is the
+// same thing FileDocument and DirectoryDocument already do to *produce* a
+// document. Reading the digest off Dagger instead is not an option: a
+// Directory's or File's Dagger digest identifies a node in the build graph and
+// is not the SHA-256 of anything an SPDX document could name.
+func contentDigest(ctx context.Context, c contribution) (string, error) {
+	work, err := os.MkdirTemp("", "z5labs-verify-*")
+	if err != nil {
+		return "", fmt.Errorf("create work dir: %v", err)
+	}
+	defer os.RemoveAll(work)
+	path := filepath.Join(work, "content")
+
+	switch {
+	case c.Content != nil:
+		if _, err := c.Content.Export(ctx, path); err != nil {
+			return "", fmt.Errorf("read the contributed bytes to check the document against them: %v", err)
+		}
+		sum256, _, err := fileDigests(path)
+		if err != nil {
+			return "", fmt.Errorf("hash the contributed bytes: %v", err)
+		}
+		return sum256, nil
+	case c.Tree != nil:
+		if _, err := c.Tree.Export(ctx, path); err != nil {
+			return "", fmt.Errorf("read the contributed tree to check the document against it: %v", err)
+		}
+		files, err := walkTree(path)
+		if err != nil {
+			return "", fmt.Errorf("hash the contributed tree: %v", err)
+		}
+		if len(files) == 0 {
+			return "", fmt.Errorf("holds no files, so there is nothing for a document to describe")
+		}
+		return treeDigest(files), nil
+	}
+	// Unreachable through the public API: every method that appends a
+	// contribution carries the content beside the document. It is an error
+	// rather than a silent pass because the alternative is a way for a future
+	// contribution path to opt out of the check by forgetting to fill a
+	// field, which is precisely the kind of hole this file exists to close.
+	return "", fmt.Errorf(
+		"entered the image with no content recorded beside its document, so the document cannot be checked against it; " +
+			"this is a defect in the module rather than in the contribution")
+}

--- a/daggerverse/z5labs/digest.go
+++ b/daggerverse/z5labs/digest.go
@@ -70,7 +70,7 @@ import (
 // places: a document that names no digest is a document that cannot be checked
 // at all, usually produced by hand or by a tool that does not fill the field,
 // while a digest that disagrees is a document about the wrong artifact.
-func verifyContributionDigest(ctx context.Context, c contribution, subject bomPackage) error {
+func verifyContributionDigest(ctx context.Context, seen digestCache, c contribution, subject bomPackage) error {
 	want := strings.ToLower(strings.TrimSpace(subject.Sha256))
 	if want == "" {
 		return fmt.Errorf(
@@ -78,7 +78,7 @@ func verifyContributionDigest(ctx context.Context, c contribution, subject bomPa
 				"a contribution's document has to name the digest of the content it accompanies, and %s produces one that does",
 			documentHelperFor(c))
 	}
-	got, err := contentDigest(ctx, c)
+	got, err := seen.digestOf(ctx, c)
 	if err != nil {
 		return err
 	}
@@ -98,6 +98,50 @@ func documentHelperFor(c contribution) string {
 		return "directoryDocument"
 	}
 	return "fileDocument"
+}
+
+// digestCache memoises one publish's content digests, keyed on the content
+// itself.
+//
+// It is not a micro-optimization. WithFile and WithDirectory append the *same*
+// contribution — one handle, one document — to every variant, because the bytes
+// are platform-neutral by construction. resolveContributions walks per variant,
+// so without this a contributed certificate bundle or asset tree is exported
+// into the module's own filesystem and hashed once per platform: twice for the
+// default pair, and more for every architecture added. The entry contribution
+// is genuinely per-variant and is unaffected either way, because its handles
+// differ.
+//
+// The key is the content handle rather than a digest of it, which is what makes
+// the lookup free: two variants carrying one contribution carry one pointer.
+// Two *distinct* handles over identical bytes miss the cache and are hashed
+// twice, which is correct and cheap enough — the alternative is hashing to find
+// out whether hashing was needed.
+type digestCache map[any]string
+
+// digestOf is contentDigest, answered from the cache when this publish has
+// already hashed the same content.
+func (dc digestCache) digestOf(ctx context.Context, c contribution) (string, error) {
+	var key any
+	switch {
+	case c.Content != nil:
+		key = c.Content
+	case c.Tree != nil:
+		key = c.Tree
+	}
+	if key != nil {
+		if got, ok := dc[key]; ok {
+			return got, nil
+		}
+	}
+	got, err := contentDigest(ctx, c)
+	if err != nil {
+		return "", err
+	}
+	if key != nil {
+		dc[key] = got
+	}
+	return got, nil
 }
 
 // contentDigest is the digest a contribution's document has to name: the

--- a/daggerverse/z5labs/go.go
+++ b/daggerverse/z5labs/go.go
@@ -225,9 +225,16 @@ func (g *GoChain) App(
 	if err != nil {
 		return nil, err
 	}
-	annotations := ociAnnotations(facts, version)
-
-	variants := make([]*variant, 0, len(platforms))
+	// The App is assembled through the generic constructor rather than beside
+	// it. That is what keeps the two from drifting: there is one place an
+	// image is built, one place a variant set is validated and one place an
+	// empty one is refused, and every Go build exercises all of it. The
+	// consequence is accepted knowingly — anything Z5labs.App cannot express,
+	// this chain cannot express either — and the build facts below are not a
+	// counterexample: they go through an unexported seam precisely because
+	// they are things the chain *observed*, and a caller who could state them
+	// would be asserting a provenance nobody can check.
+	builder := newAppBuilder(version).withBuildFacts(facts, pkg)
 	for _, platform := range platforms {
 		binary := g.buildBinaryForPlatform(string(platform), pkg, binaryName, version, facts.ShortSHA)
 		// The document describing the binary is generated here, by the
@@ -245,22 +252,23 @@ func (g *GoChain) App(
 		// simply not what an image is assembled from.
 		//
 		// Nothing is evaluated yet: dag.Go().Spdx returns a lazy
-		// *dagger.File, so an app nobody publishes costs no scan.
-		variants = append(variants, &variant{
-			Platform:  platform,
-			Container: imageForPlatform(platform, binaryName, binary, annotations),
-			Contributions: []contribution{
-				{Name: binaryName, File: dag.Go().Spdx(binary, g.Source)},
-			},
-		})
+		// *dagger.File, so an app nobody publishes costs no scan. That is
+		// also why the document's digest is checked at publish rather than
+		// here — see digest.go.
+		//
+		// The name is stated rather than read off the binary, which is the
+		// one thing this path does not share with WithVariant: reading a
+		// *dagger.File's name resolves it, and resolving a binary that has
+		// not been compiled would force every platform's cross-compile here.
+		// The chain already knows the name — it came out of go.mod — so it
+		// says so. withVariantNamed records the same thing from the other
+		// side.
+		builder, err = builder.withVariantNamed(platform, binaryName, binary, dag.Go().Spdx(binary, g.Source))
+		if err != nil {
+			return nil, err
+		}
 	}
-	return &App{
-		Version:   version,
-		Commit:    facts.SHA,
-		SourceURI: annotations[annotationSource],
-		Pkg:       pkg,
-		Variants:  variants,
-	}, nil
+	return builder.Build(ctx)
 }
 
 // defaultPlatforms is the pair every z5labs application is built for

--- a/daggerverse/z5labs/main.go
+++ b/daggerverse/z5labs/main.go
@@ -1,12 +1,17 @@
 // Package main implements the z5labs daggerverse module: opinionated CI
 // and release pipelines for Go projects.
 //
-// There is one entry point, Z5labs.Go, and everything hangs off it. The
-// chain it returns carries the standardized checks over a source tree and
-// its terminal Ci runs them; its other terminal, App, cross-compiles the
-// application, packages one image per platform and hands back an App whose
-// Publish pushes them. A library is a source tree you never call App on,
-// which is why there is no library archetype.
+// There are two entry points. Z5labs.Go is the Go language chain: it carries
+// the standardized checks over a source tree and its terminal Ci runs them,
+// while its other terminal, App, cross-compiles the application, packages one
+// image per platform and hands back an App whose Publish pushes them. A
+// library is a source tree you never call App on, which is why there is no
+// library archetype.
+//
+// Z5labs.App is the other, and it is the general one: an App assembled from
+// executables this module did not build. See "Prebuilt executables, and
+// languages with no chain" below. Z5labs.Go is built on it rather than beside
+// it, so there is one image build, one variant-set validation and one publish.
 //
 // # The image contract
 //
@@ -52,11 +57,61 @@
 //
 // The one case that genuinely cannot move is a variable whose value is a fact
 // about the image's own filesystem layout, for a program whose source you do
-// not control. That belongs to whoever assembled the payload it points at,
-// which is devex#410, and not to a helper here.
+// not control. That belongs to whoever assembled the payload it points at —
+// the caller of Z5labs.App, who chose where the payload landed — and not to a
+// helper here.
 //
 // Contributing files and directories to an image is a different question and
 // has a different answer: App.WithFile and App.WithDirectory, in contribute.go.
+//
+// # Prebuilt executables, and languages with no chain
+//
+// Z5labs.App builds an application out of executables this module did not
+// compile. It is the seam for three things the Go chain cannot reach: a
+// prebuilt or vendor executable, a language whose chain nobody has written
+// yet, and a payload shape — an entry plus the files it needs to run — that no
+// single Go binary produces.
+//
+//	dagger call app --version=v1.2.3 \
+//	  with-variant --platform=linux/amd64 --entry=./dist/app-amd64 --document=./dist/app-amd64.spdx.json \
+//	  with-variant --platform=linux/arm64 --entry=./dist/app-arm64 --document=./dist/app-arm64.spdx.json \
+//	  build \
+//	  with-registry --address=ghcr.io --username=... --auth=env:TOKEN \
+//	  publish --repositories=owner/app
+//
+// What comes back from Build is the same App a language chain produces, so
+// everything above and below this section applies to it unchanged: the same
+// PATH and executable directory, the same non-root ownership and read-only
+// modes, the same per-platform annotations, the same assembled SBOMs and the
+// same signed provenance. Nothing about supplying the executable yourself is
+// an exemption — the module still builds the image around it.
+//
+// Three properties of it are worth stating rather than leaving to be found.
+//
+// **Every variant names its platform, and nothing is inferred.** A
+// *dagger.File carries no architecture, so there is deliberately no helper
+// that takes an executable and works out where it belongs: one that did would
+// admit an index whose arm64 manifest holds an amd64 binary, which fails at
+// exec time with the kernel's message and for nobody here. A single-platform
+// application is expressible and is not a degenerate case.
+//
+// **Its documents are asserted rather than derived.** A Go binary's SBOM comes
+// out of the compiled artifact and cannot disagree with it; a document handed
+// to WithVariant is a claim its supplier made. What keeps the claim honest is
+// that it has to name the SHA-256 of the content it accompanies and a publish
+// checks it, so a document about other bytes fails the publish rather than
+// shipping. What that does not establish is whether the components listed
+// inside it are really in the artifact — that remains the supplier's
+// assertion, in a signed artifact, checkable by anyone who pulls the image.
+// The same check now applies to WithFile and WithDirectory.
+//
+// **It records no build identity.** There is no commit, origin or build-time
+// argument, because a build identity a caller could have supplied identifies
+// nothing — the same rule that keeps a repository parameter off the
+// provenance. So an application assembled this way carries the version
+// annotation and no revision, source or created annotation, and its provenance
+// records the publish and the image and no source tree. A language chain
+// records those because it observed them.
 //
 // # Versions
 //

--- a/daggerverse/z5labs/main.go
+++ b/daggerverse/z5labs/main.go
@@ -73,11 +73,20 @@
 // single Go binary produces.
 //
 //	dagger call app --version=v1.2.3 \
-//	  with-variant --platform=linux/amd64 --entry=./dist/app-amd64 --document=./dist/app-amd64.spdx.json \
-//	  with-variant --platform=linux/arm64 --entry=./dist/app-arm64 --document=./dist/app-arm64.spdx.json \
+//	  with-variant --platform=linux/amd64 --entry=./dist/app-amd64 \
+//	    --document=./dist/app-amd64.spdx.json --name=app \
+//	  with-variant --platform=linux/arm64 --entry=./dist/app-arm64 \
+//	    --document=./dist/app-arm64.spdx.json --name=app \
 //	  build \
 //	  with-registry --address=ghcr.io --username=... --auth=env:TOKEN \
 //	  publish --repositories=owner/app
+//
+// The `--name` is doing real work there and is the flag most likely to be left
+// out. A release pipeline names its cross-compiled artifacts per platform, and
+// the entry has to land at one path in every variant or the entrypoint differs
+// per architecture — so a set contributed with per-platform file names and no
+// `--name` is refused rather than resolved by picking one. Leave it out only
+// when the file is already called what the application should be called.
 //
 // What comes back from Build is the same App a language chain produces, so
 // everything above and below this section applies to it unchanged: the same

--- a/daggerverse/z5labs/prebuilt.go
+++ b/daggerverse/z5labs/prebuilt.go
@@ -201,9 +201,19 @@ func (b *AppBuilder) withBuildFacts(facts gitState, pkg string) *AppBuilder {
 // nobody here. Nothing in this module infers a platform from a file.
 //
 // entry becomes the image's entrypoint. It lands in the standardized
-// executable directory under its own file name, mode 0555, owned by the
-// image's non-root user — the same treatment a compiled binary gets, because
-// it goes through the same code.
+// executable directory, mode 0555, owned by the image's non-root user — the
+// same treatment a compiled binary gets, because it goes through the same
+// code.
+//
+// name is what it lands as, and it defaults to the file's own name. Supply one
+// when the artifact's file name is not what the application should be called,
+// which is the common case for prebuilt binaries: a release pipeline names its
+// cross-compiled artifacts app-amd64 and app-arm64, and the entry has to be
+// one path in every variant or the entrypoint differs per architecture. Given
+// no name and per-platform file names, this refuses the set rather than
+// picking one — so `--name` is how a normal `dist/` directory is contributed,
+// and the default is for the case where the file is already called the right
+// thing.
 //
 // document is an SPDX 2.3 JSON document describing the executable, and it is
 // required for the reason every contribution's is: the SBOM a publish attaches
@@ -236,19 +246,28 @@ func (b *AppBuilder) WithVariant(
 	entry *dagger.File,
 	// An SPDX 2.3 JSON document describing the executable.
 	document *dagger.File,
+	// What the executable is called in the image. Defaults to the file's
+	// own name.
+	//
+	// +optional
+	name string,
 ) (*AppBuilder, error) {
 	if entry == nil {
 		return nil, fmt.Errorf("withVariant requires an executable to package")
 	}
-	rawName, err := entry.Name(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("read the name of the executable contributed for %s: %v", platform, err)
+	raw := name
+	if raw == "" {
+		fileName, err := entry.Name(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("read the name of the executable contributed for %s: %v", platform, err)
+		}
+		raw = fileName
 	}
-	name, err := validateEntryName(rawName)
+	resolved, err := validateEntryName(raw)
 	if err != nil {
 		return nil, err
 	}
-	return b.withVariantNamed(platform, name, entry, document)
+	return b.withVariantNamed(platform, resolved, entry, document)
 }
 
 // withVariantNamed is WithVariant once the entry's name is known.
@@ -387,14 +406,29 @@ func variantConflict(platform dagger.Platform, name string, taken []variantKey) 
 // A name carrying a separator is the case worth naming: the entry lands at
 // appDir plus its name, so "bin/hello" would put the executable a directory
 // deeper than the layout this module promises, and "../hello" would put it
-// somewhere else entirely. The name comes from the file rather than from an
-// argument, so this is a check on what a caller's file was called rather than
-// on what they typed — which is why the message says which name it was.
+// somewhere else entirely. The name is either what the caller passed or what
+// their file was called, so the message quotes it rather than naming an
+// argument.
+//
+// Surrounding whitespace is refused rather than trimmed, and this is the one
+// place that rule differs from the contribution paths in contribute.go — those
+// take " /srv/data" literally because the caller typed a path and putting
+// content somewhere other than where they said is the failure that file exists
+// to avoid. Here the name is not a path a caller chose, it is the last segment
+// of an entrypoint they cannot override, and "/app/ hello" is invisible in
+// `docker inspect` and wrong in every COPY --from= line written against it.
+// Neither trimming nor accepting is right; refusing is.
 func validateEntryName(name string) (string, error) {
 	if strings.TrimSpace(name) == "" {
 		return "", fmt.Errorf(
 			"withVariant: the executable has no file name, and the image's entrypoint is named after it; " +
-				"give the file a name before contributing it")
+				"give the file a name or pass one to withVariant")
+	}
+	if name != strings.TrimSpace(name) {
+		return "", fmt.Errorf(
+			"withVariant: %q opens or closes with whitespace, and the entrypoint would be %s/%s — a path that is legal, "+
+				"invisible in an image inspection, and wrong in every COPY --from= line written against it",
+			name, appDir, name)
 	}
 	if strings.ContainsRune(name, '/') {
 		return "", fmt.Errorf(

--- a/daggerverse/z5labs/prebuilt.go
+++ b/daggerverse/z5labs/prebuilt.go
@@ -1,0 +1,408 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"dagger/z-5-labs/internal/dagger"
+)
+
+// Building an App out of executables this module did not compile.
+//
+// GoChain.App was the only way to get an App, which left three things with no
+// way in: a prebuilt or vendor executable, a language whose chain nobody has
+// written yet, and the payload shapes the contribution seam has to handle but
+// which no Go build produces. Z5labs.App is the seam for all three, and
+// GoChain.App is built on it rather than beside it — so the generic path is
+// exercised by every Go build and there is no second code path to drift.
+//
+// The consequence of that is accepted knowingly and is worth stating plainly:
+// anything this constructor cannot express, no language chain can express
+// either.
+//
+// # Why this is a builder, when devex#404 deleted the last one
+//
+// One file is one platform and Dagger takes no map parameters, so a
+// multi-platform App cannot arrive in a single call. That leaves a
+// constructor, a repeated per-platform contribution and a terminal — a builder
+// in all but name — and it is chosen rather than fallen into.
+//
+// The alternative was Z5labs.App returning an *App directly, with WithVariant
+// hanging off App beside WithFile and WithDirectory. It is rejected because an
+// App is the thing that has variants: WithFile applies content to every
+// variant there is, so a contribution made before the first variant would land
+// on nothing at all, silently, and an App with no variants would exist for as
+// long as the caller kept chaining. AppBuilder makes the zero-variant state
+// unrepresentable in an App — Build is the only way to get one and it refuses
+// an empty set — which is also the only place "constructing with zero variants
+// fails" can be true.
+//
+// The intermediate is therefore a distinct registered type, and its name is
+// AppBuilder. The generated schema names it Z5LabsAppBuilder; neither
+// dependency of this module (go, oci) owns that name, and Build returns an
+// object rather than a scalar, so it emits no lowercased cache field to
+// collide with a Go keyword. Both of those are codegen landmines
+// daggerverse/CLAUDE.md records rather than things worth rediscovering.
+//
+// # Build identity is not an argument, here or anywhere
+//
+// AppBuilder takes no commit, no source URI and no build time. That is not a
+// gap in what it can express: a build identity a caller could have supplied
+// identifies nothing, which is the same rule that keeps a repository parameter
+// off the provenance. A language chain records those facts because it observed
+// them — GoChain read HEAD out of the tree it compiled — so it sets them
+// through an unexported seam that no caller can reach. An App assembled from
+// prebuilt executables observed nothing, so its provenance records the publish
+// and the image and says nothing about a source, which is the honest answer.
+//
+// # Documents are asserted, and checked against the bytes
+//
+// A Go binary's document is derived from the artifact by
+// `dag.Go().Spdx`, so it cannot disagree with what it describes. A document
+// handed to WithVariant can. The mitigation is the same one every contribution
+// now carries: the document has to name the SHA-256 of the content it
+// accompanies, and a publish verifies it. See digest.go.
+
+// AppBuilder assembles an App from executables somebody else built: one
+// entry per platform, each with the document describing it, terminated by
+// Build.
+//
+// Construct it with Z5labs.App. The file comment above records why the
+// intermediate type exists at all and why it is this shape.
+type AppBuilder struct {
+	// Version is what every image will be published under. It is validated
+	// by Build rather than by the constructor, because the constructor has
+	// no way to report an error.
+	//
+	// +private
+	Version string
+	// Commit, SourceURI, Created and Pkg are the build facts a language
+	// chain observed. They are empty for an App assembled from prebuilt
+	// executables and there is deliberately no caller-facing way to set
+	// them — see the file comment.
+	//
+	// +private
+	Commit string
+	// +private
+	SourceURI string
+	// +private
+	Created string
+	// +private
+	Pkg string
+	// Variants are the entries contributed so far, in the order they were
+	// contributed. The +private is load bearing: pendingVariant is an
+	// unexported type, so exposing this field would ask the generator to
+	// register a schema object it cannot build.
+	//
+	// +private
+	Variants []*pendingVariant
+}
+
+// pendingVariant is one platform's executable, waiting for Build to package
+// it. Its fields are exported because the round trip across a call boundary
+// is encoding/json and an unexported field comes back as its zero value.
+type pendingVariant struct {
+	Platform dagger.Platform
+	// Name is the entry's file name, which becomes the last segment of the
+	// image's entrypoint. It is read from the file rather than taken as an
+	// argument: the file already has a name, and a second one to keep in
+	// agreement with it is a way for the two to disagree.
+	Name     string
+	Entry    *dagger.File
+	Document *dagger.File
+}
+
+// entryMode is the mode an application's own executable lands with.
+//
+// Read-and-execute, never write, and the same read-only rule every
+// contribution follows — an image whose files the application can rewrite is
+// one whose published digest stops describing what is running. It is 0555
+// rather than the 0444 a contributed file gets for the obvious reason: this
+// one is exec'd.
+const entryMode = 0o555
+
+// App begins an application assembled from executables this module did not
+// build: a prebuilt binary, a vendor's CLI, or the output of a language whose
+// chain nobody has written yet.
+//
+// What comes back is a builder. Add one variant per platform with WithVariant
+// and finish with Build, which is what refuses an empty set. The App that
+// comes out is the same App a language chain produces — the same publish, the
+// same hardening, the same annotations, the same SBOMs and the same signed
+// provenance — because GoChain.App is built on this constructor rather than
+// beside it.
+//
+// version is the version every image is published under, and the same rules
+// apply as to GoChain.App's: it has to be usable as an OCI tag, and SemVer
+// build metadata is refused rather than mangled. It is validated by Build.
+//
+// # What this seam is for, and what it is not
+//
+// It is for packaging bytes somebody else produced with the hardening, the
+// multi-platform publish, the annotations and the attestations this pipeline
+// gives everything else. It is not a way to hand this module an image: the
+// module still builds the image around the executable, applies the modes and
+// the ownership and pins the layout, so what a caller supplies is bounded and
+// every part of it is reachable by an exec of the entry. A caller-supplied
+// *container* is a different and unbounded thing, and is refused — see
+// contribute.go, which turned down the same offer for the same reason.
+//
+// # Its documents are asserted rather than derived
+//
+// Say this out loud rather than leaving it to be found. A Go binary's SBOM is
+// derived from the compiled artifact, so it cannot disagree with what it
+// describes. A document handed to WithVariant is a claim its supplier made.
+// What keeps the claim honest is that it has to name the SHA-256 of the
+// executable it accompanies and a publish checks it, so a document about other
+// bytes fails the publish instead of shipping. What it cannot check is whether
+// the components listed inside that document are the ones really linked into
+// the executable; that is the supplier's assertion, in a signed artifact,
+// checkable by anyone who pulls the image.
+//
+// +cache="session"
+func (m *Z5labs) App(
+	// The version every image is published under. Any OCI-tag-safe string;
+	// SemVer build metadata is refused.
+	version string,
+) *AppBuilder {
+	return newAppBuilder(version)
+}
+
+// newAppBuilder is the constructor GoChain.App shares with Z5labs.App, so
+// that "the Go chain is built on the generic constructor" is a property of
+// the code rather than a claim in a comment.
+func newAppBuilder(version string) *AppBuilder {
+	return &AppBuilder{Version: version}
+}
+
+// withBuildFacts records what a language chain observed about the build.
+//
+// Unexported, and that is the whole point: nothing here is a caller's to
+// state. GoChain read these out of the working tree it compiled, so it may
+// say them; a caller with a prebuilt executable observed nothing and would be
+// asserting a provenance nobody can check.
+func (b *AppBuilder) withBuildFacts(facts gitState, pkg string) *AppBuilder {
+	b.Commit = facts.SHA
+	b.SourceURI = facts.SourceURI
+	b.Created = facts.Created
+	b.Pkg = pkg
+	return b
+}
+
+// WithVariant contributes one platform's executable, and the document
+// describing it.
+//
+// platform is stated rather than inferred, and that is the rule the whole
+// design turns on. A *dagger.File carries no architecture, so a helper that
+// took an executable and worked out where it belonged would silently admit
+// the failure devex#397 exists to refuse: an index whose arm64 manifest holds
+// an amd64 binary, which fails at exec time with the kernel's message and for
+// nobody here. Nothing in this module infers a platform from a file.
+//
+// entry becomes the image's entrypoint. It lands in the standardized
+// executable directory under its own file name, mode 0555, owned by the
+// image's non-root user — the same treatment a compiled binary gets, because
+// it goes through the same code.
+//
+// document is an SPDX 2.3 JSON document describing the executable, and it is
+// required for the reason every contribution's is: the SBOM a publish attaches
+// accounts for the whole image, and a helper admitting undescribed content
+// would make that contract true by the letter and false in substance.
+// Z5labs.FileDocument produces one for an executable whose ecosystem has no
+// module able to; a Go binary should carry dag.Go().Spdx instead.
+//
+// # What is refused, and why each one is a real failure
+//
+// A platform contributed twice, because the second would silently replace the
+// first and the App would ship fewer architectures than it was asked for. A
+// platform that is not GOOS/GOARCH, because it cannot name a manifest. And an
+// entry whose file name differs from the entries already contributed, because
+// the entrypoint would then be a different path per architecture — a consumer
+// who overrides the entrypoint, or writes a COPY --from= line against the
+// image, would be right on one platform and wrong on another with nothing in
+// the manifest list to say so.
+//
+// A single-platform App is expressible and is not a degenerate case: one
+// WithVariant and a Build is a complete application, published as one variant
+// rather than as a multi-platform index pretending to be one.
+//
+// +cache="session"
+func (b *AppBuilder) WithVariant(
+	ctx context.Context,
+	// The platform this executable was built for, e.g. linux/arm64.
+	platform dagger.Platform,
+	// The executable, which becomes the image's entrypoint.
+	entry *dagger.File,
+	// An SPDX 2.3 JSON document describing the executable.
+	document *dagger.File,
+) (*AppBuilder, error) {
+	if entry == nil {
+		return nil, fmt.Errorf("withVariant requires an executable to package")
+	}
+	rawName, err := entry.Name(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("read the name of the executable contributed for %s: %v", platform, err)
+	}
+	name, err := validateEntryName(rawName)
+	if err != nil {
+		return nil, err
+	}
+	return b.withVariantNamed(platform, name, entry, document)
+}
+
+// withVariantNamed is WithVariant once the entry's name is known.
+//
+// The split exists for one reason and it is not tidiness. Reading a name off a
+// *dagger.File resolves that file, and a language chain's entry is a binary
+// that has not been compiled yet — so a chain going through WithVariant would
+// force every platform's cross-compile inside App, turning a constructor that
+// costs nothing into one that costs a full build. A chain already knows what
+// its artifact is called (GoChain reads it out of go.mod), so it says so and
+// keeps the laziness. Everything after this point is shared.
+func (b *AppBuilder) withVariantNamed(platform dagger.Platform, name string, entry, document *dagger.File) (*AppBuilder, error) {
+	if document == nil {
+		return nil, fmt.Errorf(
+			"withVariant requires a document describing the executable: every byte that enters an image arrives with one, " +
+				"and fileDocument produces one for content whose ecosystem has none")
+	}
+	if _, _, err := parsePlatform(string(platform)); err != nil {
+		return nil, fmt.Errorf("withVariant: %v", err)
+	}
+	if why := variantConflict(platform, name, b.variantKeys()); why != "" {
+		return nil, fmt.Errorf("withVariant cannot contribute %s for %s: %s", name, platform, why)
+	}
+	b.Variants = append(b.Variants, &pendingVariant{
+		Platform: platform,
+		Name:     name,
+		Entry:    entry,
+		Document: document,
+	})
+	return b, nil
+}
+
+// Build packages every contributed executable as an image and returns the
+// application.
+//
+// This is where an empty variant set is refused. An App with no variants is
+// publishable-looking and publishes nothing, and — because WithFile and
+// WithDirectory apply content to every variant there is — it would swallow
+// every contribution made to it without a word. Build existing is what keeps
+// that state out of an App entirely.
+//
+// The version is validated here rather than by the constructor, which has no
+// way to report an error. Publish validates it a third time, which is what
+// keeps the refusal of SemVer build metadata a property of publishing rather
+// than of one constructor.
+//
+// +cache="session"
+func (b *AppBuilder) Build(ctx context.Context) (*App, error) {
+	if err := validateVersion(b.Version); err != nil {
+		return nil, err
+	}
+	if len(b.Variants) == 0 {
+		return nil, fmt.Errorf(
+			"build requires at least one variant: call withVariant with a platform, the executable built for it " +
+				"and the document describing that executable")
+	}
+	// The annotations are a function of what was observed and of the version,
+	// so an App assembled from prebuilt executables carries the version alone
+	// rather than a revision and a build time nobody can check. ociAnnotations
+	// omits what it was not given.
+	annotations := ociAnnotations(gitState{
+		SHA:       b.Commit,
+		Created:   b.Created,
+		SourceURI: b.SourceURI,
+	}, b.Version)
+
+	variants := make([]*variant, 0, len(b.Variants))
+	for _, p := range b.Variants {
+		variants = append(variants, &variant{
+			Platform:  p.Platform,
+			Container: imageForEntry(p.Platform, p.Name, p.Entry, annotations),
+			// The executable is a contribution like any other: it is one of
+			// the things in the image, and Publish assembles every
+			// contribution into the documents it attaches. Carrying the entry
+			// itself beside the document is what lets that publish check the
+			// document is about these bytes — see digest.go.
+			Contributions: []contribution{{Name: p.Name, File: p.Document, Content: p.Entry}},
+		})
+	}
+	return &App{
+		Version:   b.Version,
+		Commit:    b.Commit,
+		SourceURI: b.SourceURI,
+		Pkg:       b.Pkg,
+		Variants:  variants,
+	}, nil
+}
+
+// variantKey is one contributed variant reduced to the two things the
+// conflict rules read. It exists so those rules are a pure function over
+// strings, which is what makes them drivable by a self-test without building
+// an application per row.
+type variantKey struct {
+	Platform string
+	Name     string
+}
+
+// variantKeys is the set contributed so far, in contribution order.
+func (b *AppBuilder) variantKeys() []variantKey {
+	out := make([]variantKey, 0, len(b.Variants))
+	for _, p := range b.Variants {
+		out = append(out, variantKey{Platform: string(p.Platform), Name: p.Name})
+	}
+	return out
+}
+
+// variantConflict reports why a variant cannot join the set, or "" when it
+// can. The reason is a noun phrase, because it is read as the subject of the
+// refusal.
+//
+// The duplicate platform is looked for across the whole set before any name
+// is, so that a set which is wrong in both ways reports the one that is
+// nearer the caller's mistake: contributing arm64 twice is a typo in the
+// platform, and reporting it as a naming disagreement sends the reader to the
+// wrong argument.
+func variantConflict(platform dagger.Platform, name string, taken []variantKey) string {
+	for _, other := range taken {
+		if other.Platform == string(platform) {
+			return "an executable for that platform was already contributed, and the second would replace it"
+		}
+	}
+	for _, other := range taken {
+		if other.Name != name {
+			return fmt.Sprintf(
+				"the executable contributed for %s is called %s, and an entrypoint that differs per architecture "+
+					"is one a consumer cannot write a COPY --from= line or an entrypoint override against",
+				other.Platform, other.Name)
+		}
+	}
+	return ""
+}
+
+// validateEntryName refuses a file name that cannot be the last segment of an
+// entrypoint, and returns the one that can.
+//
+// A name carrying a separator is the case worth naming: the entry lands at
+// appDir plus its name, so "bin/hello" would put the executable a directory
+// deeper than the layout this module promises, and "../hello" would put it
+// somewhere else entirely. The name comes from the file rather than from an
+// argument, so this is a check on what a caller's file was called rather than
+// on what they typed — which is why the message says which name it was.
+func validateEntryName(name string) (string, error) {
+	if strings.TrimSpace(name) == "" {
+		return "", fmt.Errorf(
+			"withVariant: the executable has no file name, and the image's entrypoint is named after it; " +
+				"give the file a name before contributing it")
+	}
+	if strings.ContainsRune(name, '/') {
+		return "", fmt.Errorf(
+			"withVariant: %q is not a file name, and the executable lands in %s under its own name; "+
+				"contribute the file itself rather than a path to it", name, appDir)
+	}
+	if name == "." || name == ".." {
+		return "", fmt.Errorf("withVariant: %q is not a file name", name)
+	}
+	return name, nil
+}

--- a/daggerverse/z5labs/prebuiltselftest.go
+++ b/daggerverse/z5labs/prebuiltselftest.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"dagger/z-5-labs/internal/dagger"
+)
+
+// VariantSetSelfTest checks the rules that decide which sets of prebuilt
+// executables can become an application, and which cannot.
+//
+// It sits on the module for the reason ContributionPathSelfTest and
+// ImageEnvironmentSelfTest do: the rules are unexported pure functions, and
+// driving every branch of them through the public API would mean compiling a
+// real executable per row of the tables below. The end-to-end half — that the
+// refusals really are wired into WithVariant and Build, and that an accepted
+// set produces an image that runs — is in tests/, where it costs one
+// application instead of a dozen.
+//
+// It runs in process and needs no container, so it is cheap enough to be a
+// check of its own.
+//
+// +check
+// +cache="session"
+func (m *Z5labs) VariantSetSelfTest(ctx context.Context) error {
+	if err := checkEntryNames(); err != nil {
+		return err
+	}
+	return checkVariantConflicts()
+}
+
+// checkEntryNames drives validateEntryName, which decides what may become the
+// last segment of an image's entrypoint.
+//
+// The name is not something a caller types — it is read off the file they
+// contributed — so every refusal here is about a file whose name cannot
+// describe a place in the image. A name carrying a separator is the one that
+// matters: the entry lands at appDir plus its name, so accepting one would put
+// the executable outside the layout every published image promises, with the
+// entrypoint still pointing at it and nothing saying so.
+func checkEntryNames() error {
+	cases := []struct {
+		name string
+		// want is the accepted name, and "" when the name has to be refused.
+		want string
+		// refusal is a substring the refusal must carry.
+		refusal string
+		why     string
+	}{
+		{name: "hello", want: "hello", why: "the ordinary case"},
+		{name: "hello-service", want: "hello-service", why: "a name with a dash"},
+		{name: "my.app", want: "my.app", why: "a name with a dot, which is not a path"},
+
+		{name: "", refusal: "no file name", why: "a file with no name at all"},
+		{name: "   ", refusal: "no file name", why: "whitespace, which is not a name"},
+		{
+			name:    "bin/hello",
+			refusal: "is not a file name",
+			why:     "a path, which would land the executable a directory below the standardized one",
+		},
+		{
+			name:    "../hello",
+			refusal: "is not a file name",
+			why:     "a path that climbs out of the executable directory entirely",
+		},
+		{name: "/hello", refusal: "is not a file name", why: "an absolute path"},
+		{name: ".", refusal: "is not a file name", why: "the current directory"},
+		{name: "..", refusal: "is not a file name", why: "the parent directory"},
+	}
+	for _, c := range cases {
+		got, err := validateEntryName(c.name)
+		if c.want != "" {
+			if err != nil {
+				return fmt.Errorf("expected %q to be accepted (%s), got: %v", c.name, c.why, err)
+			}
+			if got != c.want {
+				return fmt.Errorf("expected %q (%s) to be accepted as %q, got %q", c.name, c.why, c.want, got)
+			}
+			continue
+		}
+		if err == nil {
+			return fmt.Errorf("expected %q to be refused (%s), got nil", c.name, c.why)
+		}
+		if !strings.Contains(err.Error(), c.refusal) {
+			return fmt.Errorf("expected the refusal of %q (%s) to carry %q, got: %v", c.name, c.why, c.refusal, err)
+		}
+	}
+	return nil
+}
+
+// checkVariantConflicts drives variantConflict, which is the rule that a set
+// of executables has to agree with itself.
+//
+// Two failures, and they are different failures. A platform contributed twice
+// means the second silently replaces the first, so the application ships fewer
+// architectures than it was asked for — the same class of loss as a
+// contribution landing on top of another. An entry name that differs per
+// platform means the entrypoint is a different path per architecture, which a
+// consumer overriding the entrypoint or writing a COPY --from= line is right
+// about on one platform and wrong about on another.
+//
+// Which one is reported when a set is wrong in both ways is asserted too. A
+// duplicated platform is a typo in the platform argument, and telling that
+// caller their names disagree sends them to look at the wrong thing.
+func checkVariantConflicts() error {
+	taken := []variantKey{
+		{Platform: "linux/amd64", Name: "hello"},
+		{Platform: "linux/arm64", Name: "hello"},
+	}
+	cases := []struct {
+		platform dagger.Platform
+		name     string
+		taken    []variantKey
+		// hit is a substring the refusal must carry, or "" when the variant
+		// has to be accepted.
+		hit string
+		why string
+	}{
+		{platform: "linux/arm/v7", name: "hello", taken: taken, why: "a third architecture, named consistently"},
+		{platform: "linux/amd64", name: "hello", why: "the first variant of an empty set"},
+		{platform: "linux/amd64", name: "anything", why: "the first variant names the set, so nothing can disagree yet"},
+
+		{
+			platform: "linux/amd64",
+			name:     "hello",
+			taken:    taken,
+			hit:      "already contributed",
+			why:      "a platform contributed twice, where the second would replace the first",
+		},
+		{
+			platform: "linux/arm/v7",
+			name:     "hello-arm",
+			taken:    taken,
+			hit:      "is called hello",
+			why:      "an entry whose name disagrees, leaving the entrypoint per-architecture",
+		},
+		{
+			platform: "linux/amd64",
+			name:     "hello-amd",
+			taken:    taken,
+			hit:      "already contributed",
+			why:      "wrong in both ways at once: the duplicated platform is reported, because that is the caller's typo",
+		},
+	}
+	for _, c := range cases {
+		got := variantConflict(c.platform, c.name, c.taken)
+		if c.hit == "" {
+			if got != "" {
+				return fmt.Errorf("expected %s/%s (%s) to be accepted, got %q", c.platform, c.name, c.why, got)
+			}
+			continue
+		}
+		if !strings.Contains(got, c.hit) {
+			return fmt.Errorf("expected the refusal of %s/%s (%s) to carry %q, got %q", c.platform, c.name, c.why, c.hit, got)
+		}
+	}
+	return nil
+}

--- a/daggerverse/z5labs/prebuiltselftest.go
+++ b/daggerverse/z5labs/prebuiltselftest.go
@@ -28,7 +28,64 @@ func (m *Z5labs) VariantSetSelfTest(ctx context.Context) error {
 	if err := checkEntryNames(); err != nil {
 		return err
 	}
-	return checkVariantConflicts()
+	if err := checkVariantConflicts(); err != nil {
+		return err
+	}
+	return checkUncheckableDocuments(ctx)
+}
+
+// checkUncheckableDocuments drives the two branches of the digest check that
+// decide a document cannot be checked at all, as distinct from one that
+// disagrees.
+//
+// Neither is reachable from the test suite, and that is the reason they are
+// here rather than there. A document naming no SHA-256 cannot be produced by
+// FileDocument or DirectoryDocument — both always fill the field — so driving
+// it end to end would mean shipping a deliberately deficient SPDX fixture; and
+// a contribution carrying no content at all is a defect in this module that no
+// public method can produce. Both would otherwise be deletable with every test
+// still green, and the first is the branch most likely to fire in the field,
+// because an SPDX 2.3 package element is perfectly valid with no checksum and
+// a hand-written or vendor-supplied document routinely has none.
+//
+// Both return before any content is read, so this costs no container and no
+// I/O — which is what lets them be checked at all.
+func checkUncheckableDocuments(ctx context.Context) error {
+	cases := []struct {
+		contribution contribution
+		subject      bomPackage
+		refusal      string
+		why          string
+	}{
+		{
+			contribution: contribution{Name: "/etc/ssl/certs/ca-certificates.crt", Content: &dagger.File{}},
+			subject:      bomPackage{Name: "ca-certificates"},
+			refusal:      "names no SHA-256",
+			why:          "a well-formed document with no checksum, which is legal SPDX and connects to nothing",
+		},
+		{
+			contribution: contribution{Name: "/srv/templates", Tree: &dagger.Directory{}},
+			subject:      bomPackage{Name: "templates"},
+			refusal:      "directoryDocument",
+			why:          "the same, for a tree: the refusal names the helper that would have produced a checkable document",
+		},
+		{
+			contribution: contribution{Name: "hello"},
+			subject:      bomPackage{Name: "hello", Sha256: "0123456789abcdef"},
+			refusal:      "defect in the module",
+			why:          "a contribution carrying no content, which no public method can produce and which must never pass silently",
+		},
+	}
+	for _, c := range cases {
+		err := verifyContributionDigest(ctx, digestCache{}, c.contribution, c.subject)
+		if err == nil {
+			return fmt.Errorf("expected %s to be refused, got nil", c.why)
+		}
+		if !strings.Contains(err.Error(), c.refusal) {
+			return fmt.Errorf("expected the refusal of %s to carry %q, got: %v", c.why, c.refusal, err)
+		}
+	}
+	return nil
 }
 
 // checkEntryNames drives validateEntryName, which decides what may become the

--- a/daggerverse/z5labs/provenance.go
+++ b/daggerverse/z5labs/provenance.go
@@ -121,12 +121,21 @@ func externalParameters(identity *workloadIdentity, facts buildFacts) map[string
 // internalParameters are the builder's own choices: things the pipeline
 // decided, which a verifier may want to see but must not confuse with
 // anything the identity provider vouched for.
+//
+// pkg is omitted rather than published empty when there is none. An App
+// assembled from prebuilt executables compiled no package, and a `"pkg": ""`
+// in a predicate reads as a package whose name is the empty string rather
+// than as a build that had none — the same reason the source annotation is
+// absent rather than blank when a tree has no origin.
 func internalParameters(facts buildFacts) map[string]any {
-	return map[string]any{
-		"pkg":       facts.Pkg,
+	out := map[string]any{
 		"platforms": facts.Platforms,
 		"version":   facts.Version,
 	}
+	if facts.Pkg != "" {
+		out["pkg"] = facts.Pkg
+	}
+	return out
 }
 
 // resolvedDependencies records the source tree the build actually read.

--- a/daggerverse/z5labs/sbom.go
+++ b/daggerverse/z5labs/sbom.go
@@ -257,6 +257,17 @@ func (a *App) resolveContributions(ctx context.Context) ([]variantBom, error) {
 			if err != nil {
 				return nil, fmt.Errorf("the document describing %s in the %s image: %v", c.Name, v.Platform, err)
 			}
+			// The document is checked against the bytes it claims to describe
+			// here, and only here. A document naming some other artifact's
+			// digest is well-formed, attaches cleanly and is
+			// indistinguishable from a right one once published, so it has to
+			// be refused before the push rather than reported afterwards.
+			// digest.go records what the check does and does not establish,
+			// and why it lives at publish time rather than at the
+			// contributing call.
+			if err := verifyContributionDigest(ctx, c, bom.Subject); err != nil {
+				return nil, fmt.Errorf("the document describing %s in the %s image %v", c.Name, v.Platform, err)
+			}
 			parsed = append(parsed, *bom)
 		}
 		out = append(out, variantBom{Platform: v.Platform, Contributions: parsed})

--- a/daggerverse/z5labs/sbom.go
+++ b/daggerverse/z5labs/sbom.go
@@ -230,6 +230,10 @@ type variantBom struct {
 // attached, and it is indistinguishable from a complete one.
 func (a *App) resolveContributions(ctx context.Context) ([]variantBom, error) {
 	out := make([]variantBom, 0, len(a.Variants))
+	// One cache for the whole publish. A file or directory contributed once is
+	// carried by every variant, so without it the same bytes are exported and
+	// hashed once per platform; see digestCache.
+	seen := digestCache{}
 	for _, v := range a.Variants {
 		if len(v.Contributions) == 0 {
 			return nil, fmt.Errorf(
@@ -265,7 +269,7 @@ func (a *App) resolveContributions(ctx context.Context) ([]variantBom, error) {
 			// digest.go records what the check does and does not establish,
 			// and why it lives at publish time rather than at the
 			// contributing call.
-			if err := verifyContributionDigest(ctx, c, bom.Subject); err != nil {
+			if err := verifyContributionDigest(ctx, seen, c, bom.Subject); err != nil {
 				return nil, fmt.Errorf("the document describing %s in the %s image %v", c.Name, v.Platform, err)
 			}
 			parsed = append(parsed, *bom)

--- a/daggerverse/z5labs/tests/dagger.gen.go
+++ b/daggerverse/z5labs/tests/dagger.gen.go
@@ -234,6 +234,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).AppBuildTagsReachTheCompiler(&parent, ctx)
+		case "AppBuilderRefusesAnInconsistentVariantSet":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).AppBuilderRefusesAnInconsistentVariantSet(&parent, ctx)
 		case "AppContainerRunsTheEntrypoint":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -276,6 +283,27 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).AppDocumentHelpersDescribeContentWithNoEcosystem(&parent, ctx)
+		case "AppFromPrebuiltComposesATreeShapedPayload":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).AppFromPrebuiltComposesATreeShapedPayload(&parent, ctx)
+		case "AppFromPrebuiltExecutablesIsHardenedLikeAnyOther":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).AppFromPrebuiltExecutablesIsHardenedLikeAnyOther(&parent, ctx)
+		case "AppFromPrebuiltExecutablesPublishesAttested":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).AppFromPrebuiltExecutablesPublishesAttested(&parent, ctx)
 		case "AppImagesCarryTheStandardEnvironment":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -346,6 +374,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).AppRedactsCredentialsFromTheSourceAnnotation(&parent, ctx)
+		case "AppRefusesADocumentThatDescribesOtherBytes":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).AppRefusesADocumentThatDescribesOtherBytes(&parent, ctx)
 		case "AppRefusesContributionsThatCollide":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/z5labs/tests/fixtures/payload/go.mod
+++ b/daggerverse/z5labs/tests/fixtures/payload/go.mod
@@ -1,0 +1,3 @@
+module example.com/payload
+
+go 1.23

--- a/daggerverse/z5labs/tests/fixtures/payload/main.go
+++ b/daggerverse/z5labs/tests/fixtures/payload/main.go
@@ -1,0 +1,51 @@
+// Command payload is the tree-shaped-payload fixture: an executable that is
+// useless without the files beside it in the image.
+//
+// It exists so a test can assert that an App assembled from a prebuilt
+// executable plus the tree it needs really composes — the entry alone would
+// pass an exec check while the files it depends on were missing, which is the
+// failure a single-file payload can never surface.
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// payloadDir is where the test contributes the tree. It is a constant in the
+// program rather than an environment variable because a layout fact for a
+// program you do control belongs in the program — the archetype's package doc
+// makes the same point from the other side.
+const payloadDir = "/srv/payload"
+
+func main() {
+	var names []string
+	err := filepath.WalkDir(payloadDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(payloadDir, path)
+		if err != nil {
+			return err
+		}
+		names = append(names, rel)
+		return nil
+	})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "payload:", err)
+		os.Exit(1)
+	}
+	greeting, err := os.ReadFile(filepath.Join(payloadDir, "greeting.txt"))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "payload:", err)
+		os.Exit(1)
+	}
+	sort.Strings(names)
+	fmt.Printf("%s %s\n", strings.TrimSpace(string(greeting)), strings.Join(names, ","))
+}

--- a/daggerverse/z5labs/tests/internal/dagger/dagger.gen.go
+++ b/daggerverse/z5labs/tests/internal/dagger/dagger.gen.go
@@ -363,6 +363,9 @@ type Void string
 type WorkspaceID string
 
 // A unique identifier for an object.
+type Z5LabsAppBuilderID string
+
+// A unique identifier for an object.
 type Z5LabsAppID string
 
 // A unique identifier for an object.
@@ -13458,6 +13461,16 @@ func (r *Query) LoadWorkspaceFromID(id WorkspaceID) *Workspace {
 	q = q.Arg("id", id)
 
 	return &Workspace{
+		query: q,
+	}
+}
+
+// Load a Z5LabsAppBuilder from its ID.
+func (r *Query) LoadZ5LabsAppBuilderFromID(id Z5LabsAppBuilderID) *Z5LabsAppBuilder {
+	q := r.query.Select("loadZ5LabsAppBuilderFromID")
+	q = q.Arg("id", id)
+
+	return &Z5LabsAppBuilder{
 		query: q,
 	}
 }

--- a/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
+++ b/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type Z5Labs
-func (r *Binding) AsZ5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:320:6)
+func (r *Binding) AsZ5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:329:6)
 	q := r.query.Select("asZ5Labs")
 
 	return &Z5Labs{
@@ -118,7 +118,7 @@ func (r *Env) WithZ5LabsGoChainOutput(name string, description string) *Env { //
 }
 
 // Create or update a binding of type Z5Labs in the environment
-func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:320:6)
+func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:329:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withZ5LabsInput")
 	q = q.Arg("name", name)
@@ -131,7 +131,7 @@ func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *E
 }
 
 // Declare a desired Z5Labs output to be assigned in the environment
-func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:320:6)
+func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:329:6)
 	q := r.query.Select("withZ5LabsOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -143,7 +143,7 @@ func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs
 
 // Z5labs is the root module type. Construct the Go language chain via Go;
 // everything this module does is reached from there.
-func (r *Query) Z5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:320:6)
+func (r *Query) Z5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:329:6)
 	q := r.query.Select("z5Labs")
 
 	return &Z5Labs{
@@ -153,7 +153,7 @@ func (r *Query) Z5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/
 
 // Z5labs is the root module type. Construct the Go language chain via Go;
 // everything this module does is reached from there.
-type Z5Labs struct { // z5labs (../../../../../daggerverse/z5labs/main.go:320:6)
+type Z5Labs struct { // z5labs (../../../../../daggerverse/z5labs/main.go:329:6)
 	query *querybuilder.Selection
 
 	contributionPathSelfTest *Void
@@ -366,7 +366,7 @@ func (r *Z5Labs) FileDocument(file *File, opts ...Z5LabsFileDocumentOpts) *File 
 //
 // The returned object is GoChain rather than Go because the `go` module
 // this one depends on already owns that name — see GoChain's doc comment.
-func (r *Z5Labs) Go(source *Directory) *Z5LabsGoChain { // z5labs (../../../../../daggerverse/z5labs/main.go:336:1)
+func (r *Z5Labs) Go(source *Directory) *Z5LabsGoChain { // z5labs (../../../../../daggerverse/z5labs/main.go:345:1)
 	assertNotNil("source", source)
 	q := r.query.Select("go")
 	q = q.Arg("source", source)
@@ -1047,7 +1047,7 @@ func (r *Z5LabsAppBuilder) WithGraphQLQuery(q *querybuilder.Selection) *Z5LabsAp
 // way to report an error. Publish validates it a third time, which is what
 // keeps the refusal of SemVer build metadata a property of publishing rather
 // than of one constructor.
-func (r *Z5LabsAppBuilder) Build() *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/prebuilt.go:299:1)
+func (r *Z5LabsAppBuilder) Build() *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/prebuilt.go:318:1)
 	q := r.query.Select("build")
 
 	return &Z5LabsApp{
@@ -1104,6 +1104,15 @@ func (r *Z5LabsAppBuilder) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
+// Z5LabsAppBuilderWithVariantOpts contains options for Z5LabsAppBuilder.WithVariant
+type Z5LabsAppBuilderWithVariantOpts struct {
+	//
+	// What the executable is called in the image. Defaults to the file's
+	// own name.
+	//
+	Name string // z5labs (../../../../../daggerverse/z5labs/prebuilt.go:253:2)
+}
+
 // WithVariant contributes one platform's executable, and the document
 // describing it.
 //
@@ -1115,9 +1124,19 @@ func (r *Z5LabsAppBuilder) UnmarshalJSON(bs []byte) error {
 // nobody here. Nothing in this module infers a platform from a file.
 //
 // entry becomes the image's entrypoint. It lands in the standardized
-// executable directory under its own file name, mode 0555, owned by the
-// image's non-root user — the same treatment a compiled binary gets, because
-// it goes through the same code.
+// executable directory, mode 0555, owned by the image's non-root user — the
+// same treatment a compiled binary gets, because it goes through the same
+// code.
+//
+// name is what it lands as, and it defaults to the file's own name. Supply one
+// when the artifact's file name is not what the application should be called,
+// which is the common case for prebuilt binaries: a release pipeline names its
+// cross-compiled artifacts app-amd64 and app-arm64, and the entry has to be
+// one path in every variant or the entrypoint differs per architecture. Given
+// no name and per-platform file names, this refuses the set rather than
+// picking one — so `--name` is how a normal `dist/` directory is contributed,
+// and the default is for the case where the file is already called the right
+// thing.
 //
 // document is an SPDX 2.3 JSON document describing the executable, and it is
 // required for the reason every contribution's is: the SBOM a publish attaches
@@ -1140,10 +1159,16 @@ func (r *Z5LabsAppBuilder) UnmarshalJSON(bs []byte) error {
 // A single-platform App is expressible and is not a degenerate case: one
 // WithVariant and a Build is a complete application, published as one variant
 // rather than as a multi-platform index pretending to be one.
-func (r *Z5LabsAppBuilder) WithVariant(platform Platform, entry *File, document *File) *Z5LabsAppBuilder { // z5labs (../../../../../daggerverse/z5labs/prebuilt.go:231:1)
+func (r *Z5LabsAppBuilder) WithVariant(platform Platform, entry *File, document *File, opts ...Z5LabsAppBuilderWithVariantOpts) *Z5LabsAppBuilder { // z5labs (../../../../../daggerverse/z5labs/prebuilt.go:241:1)
 	assertNotNil("entry", entry)
 	assertNotNil("document", document)
 	q := r.query.Select("withVariant")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `name` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Name) {
+			q = q.Arg("name", opts[i].Name)
+		}
+	}
 	q = q.Arg("platform", platform)
 	q = q.Arg("entry", entry)
 	q = q.Arg("document", document)

--- a/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
+++ b/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type Z5Labs
-func (r *Binding) AsZ5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:265:6)
+func (r *Binding) AsZ5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:320:6)
 	q := r.query.Select("asZ5Labs")
 
 	return &Z5Labs{
@@ -27,11 +27,44 @@ func (r *Binding) AsZ5LabsApp() *Z5LabsApp { // z5labs (../../../../../daggerver
 	}
 }
 
+// Retrieve the binding value, as type Z5LabsAppBuilder
+func (r *Binding) AsZ5LabsAppBuilder() *Z5LabsAppBuilder { // z5labs (../../../../../daggerverse/z5labs/prebuilt.go:73:6)
+	q := r.query.Select("asZ5LabsAppBuilder")
+
+	return &Z5LabsAppBuilder{
+		query: q,
+	}
+}
+
 // Retrieve the binding value, as type Z5LabsGoChain
 func (r *Binding) AsZ5LabsGoChain() *Z5LabsGoChain { // z5labs (../../../../../daggerverse/z5labs/go.go:36:6)
 	q := r.query.Select("asZ5LabsGoChain")
 
 	return &Z5LabsGoChain{
+		query: q,
+	}
+}
+
+// Create or update a binding of type Z5LabsAppBuilder in the environment
+func (r *Env) WithZ5LabsAppBuilderInput(name string, value *Z5LabsAppBuilder, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/prebuilt.go:73:6)
+	assertNotNil("value", value)
+	q := r.query.Select("withZ5LabsAppBuilderInput")
+	q = q.Arg("name", name)
+	q = q.Arg("value", value)
+	q = q.Arg("description", description)
+
+	return &Env{
+		query: q,
+	}
+}
+
+// Declare a desired Z5LabsAppBuilder output to be assigned in the environment
+func (r *Env) WithZ5LabsAppBuilderOutput(name string, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/prebuilt.go:73:6)
+	q := r.query.Select("withZ5LabsAppBuilderOutput")
+	q = q.Arg("name", name)
+	q = q.Arg("description", description)
+
+	return &Env{
 		query: q,
 	}
 }
@@ -85,7 +118,7 @@ func (r *Env) WithZ5LabsGoChainOutput(name string, description string) *Env { //
 }
 
 // Create or update a binding of type Z5Labs in the environment
-func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:265:6)
+func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:320:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withZ5LabsInput")
 	q = q.Arg("name", name)
@@ -98,7 +131,7 @@ func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *E
 }
 
 // Declare a desired Z5Labs output to be assigned in the environment
-func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:265:6)
+func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:320:6)
 	q := r.query.Select("withZ5LabsOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -110,7 +143,7 @@ func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs
 
 // Z5labs is the root module type. Construct the Go language chain via Go;
 // everything this module does is reached from there.
-func (r *Query) Z5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:265:6)
+func (r *Query) Z5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:320:6)
 	q := r.query.Select("z5Labs")
 
 	return &Z5Labs{
@@ -120,18 +153,65 @@ func (r *Query) Z5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/
 
 // Z5labs is the root module type. Construct the Go language chain via Go;
 // everything this module does is reached from there.
-type Z5Labs struct { // z5labs (../../../../../daggerverse/z5labs/main.go:265:6)
+type Z5Labs struct { // z5labs (../../../../../daggerverse/z5labs/main.go:320:6)
 	query *querybuilder.Selection
 
 	contributionPathSelfTest *Void
 	id                       *ID
 	imageEnvironmentSelfTest *Void
 	imageSbomSelfTest        *Void
+	variantSetSelfTest       *Void
 	versionTagsSelfTest      *Void
 }
 
 func (r *Z5Labs) WithGraphQLQuery(q *querybuilder.Selection) *Z5Labs {
 	return &Z5Labs{
+		query: q,
+	}
+}
+
+// App begins an application assembled from executables this module did not
+// build: a prebuilt binary, a vendor's CLI, or the output of a language whose
+// chain nobody has written yet.
+//
+// What comes back is a builder. Add one variant per platform with WithVariant
+// and finish with Build, which is what refuses an empty set. The App that
+// comes out is the same App a language chain produces — the same publish, the
+// same hardening, the same annotations, the same SBOMs and the same signed
+// provenance — because GoChain.App is built on this constructor rather than
+// beside it.
+//
+// version is the version every image is published under, and the same rules
+// apply as to GoChain.App's: it has to be usable as an OCI tag, and SemVer
+// build metadata is refused rather than mangled. It is validated by Build.
+//
+// # What this seam is for, and what it is not
+//
+// It is for packaging bytes somebody else produced with the hardening, the
+// multi-platform publish, the annotations and the attestations this pipeline
+// gives everything else. It is not a way to hand this module an image: the
+// module still builds the image around the executable, applies the modes and
+// the ownership and pins the layout, so what a caller supplies is bounded and
+// every part of it is reachable by an exec of the entry. A caller-supplied
+// *container* is a different and unbounded thing, and is refused — see
+// contribute.go, which turned down the same offer for the same reason.
+//
+// # Its documents are asserted rather than derived
+//
+// Say this out loud rather than leaving it to be found. A Go binary's SBOM is
+// derived from the compiled artifact, so it cannot disagree with what it
+// describes. A document handed to WithVariant is a claim its supplier made.
+// What keeps the claim honest is that it has to name the SHA-256 of the
+// executable it accompanies and a publish checks it, so a document about other
+// bytes fails the publish instead of shipping. What it cannot check is whether
+// the components listed inside that document are the ones really linked into
+// the executable; that is the supplier's assertion, in a signed artifact,
+// checkable by anyone who pulls the image.
+func (r *Z5Labs) App(version string) *Z5LabsAppBuilder { // z5labs (../../../../../daggerverse/z5labs/prebuilt.go:164:1)
+	q := r.query.Select("app")
+	q = q.Arg("version", version)
+
+	return &Z5LabsAppBuilder{
 		query: q,
 	}
 }
@@ -286,7 +366,7 @@ func (r *Z5Labs) FileDocument(file *File, opts ...Z5LabsFileDocumentOpts) *File 
 //
 // The returned object is GoChain rather than Go because the `go` module
 // this one depends on already owns that name — see GoChain's doc comment.
-func (r *Z5Labs) Go(source *Directory) *Z5LabsGoChain { // z5labs (../../../../../daggerverse/z5labs/main.go:281:1)
+func (r *Z5Labs) Go(source *Directory) *Z5LabsGoChain { // z5labs (../../../../../daggerverse/z5labs/main.go:336:1)
 	assertNotNil("source", source)
 	q := r.query.Select("go")
 	q = q.Arg("source", source)
@@ -400,6 +480,28 @@ func (r *Z5Labs) ImageSbomSelfTest(ctx context.Context) error { // z5labs (../..
 	return q.Execute(ctx)
 }
 
+// VariantSetSelfTest checks the rules that decide which sets of prebuilt
+// executables can become an application, and which cannot.
+//
+// It sits on the module for the reason ContributionPathSelfTest and
+// ImageEnvironmentSelfTest do: the rules are unexported pure functions, and
+// driving every branch of them through the public API would mean compiling a
+// real executable per row of the tables below. The end-to-end half — that the
+// refusals really are wired into WithVariant and Build, and that an accepted
+// set produces an image that runs — is in tests/, where it costs one
+// application instead of a dozen.
+//
+// It runs in process and needs no container, so it is cheap enough to be a
+// check of its own.
+func (r *Z5Labs) VariantSetSelfTest(ctx context.Context) error { // z5labs (../../../../../daggerverse/z5labs/prebuiltselftest.go:27:1)
+	if r.variantSetSelfTest != nil {
+		return nil
+	}
+	q := r.query.Select("variantSetSelfTest")
+
+	return q.Execute(ctx)
+}
+
 // VersionTagsSelfTest checks the tag family a release is published under,
 // case by case, against the rule rather than against a release.
 //
@@ -499,7 +601,7 @@ func (r *Z5LabsApp) WithGraphQLQuery(q *querybuilder.Selection) *Z5LabsApp {
 // nothing here promises that the second invocation reuses the first's
 // containers. A caller that needs one build inspected and then published
 // chains both onto one call.
-func (r *Z5LabsApp) Container(platform Platform) *Container { // z5labs (../../../../../daggerverse/z5labs/app.go:148:1)
+func (r *Z5LabsApp) Container(platform Platform) *Container { // z5labs (../../../../../daggerverse/z5labs/app.go:161:1)
 	q := r.query.Select("container")
 	q = q.Arg("platform", platform)
 
@@ -511,7 +613,7 @@ func (r *Z5LabsApp) Container(platform Platform) *Container { // z5labs (../../.
 // Containers returns every platform's image, in the order the platforms
 // were given to App. Same guarantee, and the same session bound, as
 // Container.
-func (r *Z5LabsApp) Containers(ctx context.Context) ([]Container, error) { // z5labs (../../../../../daggerverse/z5labs/app.go:162:1)
+func (r *Z5LabsApp) Containers(ctx context.Context) ([]Container, error) { // z5labs (../../../../../daggerverse/z5labs/app.go:175:1)
 	q := r.query.Select("containers")
 
 	q = q.Select("id")
@@ -695,7 +797,7 @@ func (r *Z5LabsApp) UnmarshalJSON(bs []byte) error {
 // Publishing is a side effect against an external registry, so it is
 // uncached: a re-run must actually push. The build above it is session
 // cached, so the bytes pushed are the bytes Container returned.
-func (r *Z5LabsApp) Publish(ctx context.Context, repositories []string) ([]string, error) { // z5labs (../../../../../daggerverse/z5labs/app.go:392:1)
+func (r *Z5LabsApp) Publish(ctx context.Context, repositories []string) ([]string, error) { // z5labs (../../../../../daggerverse/z5labs/app.go:405:1)
 	q := r.query.Select("publish")
 	q = q.Arg("repositories", repositories)
 
@@ -720,7 +822,7 @@ func (r *Z5LabsApp) Publish(ctx context.Context, repositories []string) ([]strin
 // carries one file element per file in the tree, because "the contribution is
 // described" and "every file in the image is accounted for" are different
 // promises and only the second one is the point.
-func (r *Z5LabsApp) WithDirectory(path string, dir *Directory, document *File) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/contribute.go:196:1)
+func (r *Z5LabsApp) WithDirectory(path string, dir *Directory, document *File) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/contribute.go:198:1)
 	assertNotNil("dir", dir)
 	assertNotNil("document", document)
 	q := r.query.Select("withDirectory")
@@ -752,7 +854,7 @@ func (r *Z5LabsApp) WithDirectory(path string, dir *Directory, document *File) *
 // this — a raw file carries no platform, so a helper landing one in the
 // executable directory would silently admit a binary built for the wrong
 // architecture. Platform-specific executables arrive as an App instead.
-func (r *Z5LabsApp) WithFile(path string, file *File, document *File) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/contribute.go:152:1)
+func (r *Z5LabsApp) WithFile(path string, file *File, document *File) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/contribute.go:154:1)
 	assertNotNil("file", file)
 	assertNotNil("document", document)
 	q := r.query.Select("withFile")
@@ -773,7 +875,7 @@ func (r *Z5LabsApp) WithFile(path string, file *File, document *File) *Z5LabsApp
 // unverified connection. It is spelled insecure rather than tlsVerify
 // because a bool defaulting to true cannot be turned off from the CLI —
 // which is also why this method takes no argument at all.
-func (r *Z5LabsApp) WithInsecure() *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:252:1)
+func (r *Z5LabsApp) WithInsecure() *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:265:1)
 	q := r.query.Select("withInsecure")
 
 	return &Z5LabsApp{
@@ -793,7 +895,7 @@ func (r *Z5LabsApp) WithInsecure() *Z5LabsApp { // z5labs (../../../../../dagger
 // Every identifying field in the provenance comes out of the exchanged
 // token's claims, because anything a caller could have supplied attests to
 // nothing.
-func (r *Z5LabsApp) WithOidc(requestUrl string, requestToken *Secret) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:209:1)
+func (r *Z5LabsApp) WithOidc(requestUrl string, requestToken *Secret) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:222:1)
 	assertNotNil("requestToken", requestToken)
 	q := r.query.Select("withOidc")
 	q = q.Arg("requestUrl", requestUrl)
@@ -813,7 +915,7 @@ func (r *Z5LabsApp) WithOidc(requestUrl string, requestToken *Secret) *Z5LabsApp
 // This exists for the same reason WithRegistryService does, and is used by
 // the test suite, which runs a real token endpoint rather than relaxing the
 // provenance requirement into the shape of the tests.
-func (r *Z5LabsApp) WithOidcService(svc *Service) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:282:1)
+func (r *Z5LabsApp) WithOidcService(svc *Service) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:295:1)
 	assertNotNil("svc", svc)
 	q := r.query.Select("withOidcService")
 	q = q.Arg("svc", svc)
@@ -839,7 +941,7 @@ func (r *Z5LabsApp) WithOidcService(svc *Service) *Z5LabsApp { // z5labs (../../
 // undirected takes the default seven-day TTL and can hand a later session a
 // stale object built from arguments it only appears to share — a registry
 // service, for one, whose engine-assigned address is long gone.
-func (r *Z5LabsApp) WithRegistry(address string, username string, auth *Secret) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:188:1)
+func (r *Z5LabsApp) WithRegistry(address string, username string, auth *Secret) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:201:1)
 	assertNotNil("auth", auth)
 	q := r.query.Select("withRegistry")
 	q = q.Arg("address", address)
@@ -858,7 +960,7 @@ func (r *Z5LabsApp) WithRegistry(address string, username string, auth *Secret) 
 // into an address ahead of time; this is how the publish learns it. Used by
 // the test suite against a local registry, and by anyone whose private
 // registry is itself a Dagger service.
-func (r *Z5LabsApp) WithRegistryService(svc *Service) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:266:1)
+func (r *Z5LabsApp) WithRegistryService(svc *Service) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:279:1)
 	assertNotNil("svc", svc)
 	q := r.query.Select("withRegistryService")
 	q = q.Arg("svc", svc)
@@ -888,7 +990,7 @@ func (r *Z5LabsApp) WithRegistryService(svc *Service) *Z5LabsApp { // z5labs (..
 // where the keyless mode gets an identity and an issuer and no such flag.
 // A caller who does not want to hand their consumers that flag should not
 // be supplying a key.
-func (r *Z5LabsApp) WithSigningKey(key *Secret) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:237:1)
+func (r *Z5LabsApp) WithSigningKey(key *Secret) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:250:1)
 	assertNotNil("key", key)
 	q := r.query.Select("withSigningKey")
 	q = q.Arg("key", key)
@@ -901,6 +1003,159 @@ func (r *Z5LabsApp) WithSigningKey(key *Secret) *Z5LabsApp { // z5labs (../../..
 // AsNode returns this Z5LabsApp as a Node.
 // This is a local type conversion — no GraphQL call.
 func (r *Z5LabsApp) AsNode() Node {
+	return &NodeClient{
+		query: r.query,
+	}
+}
+
+// AppBuilder assembles an App from executables somebody else built: one
+// entry per platform, each with the document describing it, terminated by
+// Build.
+//
+// Construct it with Z5labs.App. The file comment above records why the
+// intermediate type exists at all and why it is this shape.
+type Z5LabsAppBuilder struct { // z5labs (../../../../../daggerverse/z5labs/prebuilt.go:73:6)
+	query *querybuilder.Selection
+
+	id *ID
+}
+type WithZ5LabsAppBuilderFunc func(r *Z5LabsAppBuilder) *Z5LabsAppBuilder
+
+// With calls the provided function with current Z5LabsAppBuilder.
+//
+// This is useful for reusability and readability by not breaking the calling chain.
+func (r *Z5LabsAppBuilder) With(f WithZ5LabsAppBuilderFunc) *Z5LabsAppBuilder {
+	return f(r)
+}
+
+func (r *Z5LabsAppBuilder) WithGraphQLQuery(q *querybuilder.Selection) *Z5LabsAppBuilder {
+	return &Z5LabsAppBuilder{
+		query: q,
+	}
+}
+
+// Build packages every contributed executable as an image and returns the
+// application.
+//
+// This is where an empty variant set is refused. An App with no variants is
+// publishable-looking and publishes nothing, and — because WithFile and
+// WithDirectory apply content to every variant there is — it would swallow
+// every contribution made to it without a word. Build existing is what keeps
+// that state out of an App entirely.
+//
+// The version is validated here rather than by the constructor, which has no
+// way to report an error. Publish validates it a third time, which is what
+// keeps the refusal of SemVer build metadata a property of publishing rather
+// than of one constructor.
+func (r *Z5LabsAppBuilder) Build() *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/prebuilt.go:299:1)
+	q := r.query.Select("build")
+
+	return &Z5LabsApp{
+		query: q,
+	}
+}
+
+// A unique identifier for this Z5LabsAppBuilder.
+func (r *Z5LabsAppBuilder) ID(ctx context.Context) (ID, error) {
+	if r.id != nil {
+		return *r.id, nil
+	}
+	q := r.query.Select("id")
+
+	var response ID
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// XXX_GraphQLType is an internal function. It returns the native GraphQL type name
+func (r *Z5LabsAppBuilder) XXX_GraphQLType() string {
+	return "Z5LabsAppBuilder"
+}
+
+// XXX_GraphQLIDType is an internal function. It returns the native GraphQL type name for the ID of this object
+func (r *Z5LabsAppBuilder) XXX_GraphQLIDType() string {
+	return "ID"
+}
+
+// XXX_GraphQLID is an internal function. It returns the underlying type ID
+func (r *Z5LabsAppBuilder) XXX_GraphQLID(ctx context.Context) (string, error) {
+	id, err := r.ID(ctx)
+	if err != nil {
+		return "", err
+	}
+	return string(id), nil
+}
+
+func (r *Z5LabsAppBuilder) MarshalJSON() ([]byte, error) {
+	id, err := r.ID(marshalCtx)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(id)
+}
+func (r *Z5LabsAppBuilder) UnmarshalJSON(bs []byte) error {
+	var id string
+	err := json.Unmarshal(bs, &id)
+	if err != nil {
+		return err
+	}
+	*r = Z5LabsAppBuilder{query: selectNode(dag.query, id, "Z5LabsAppBuilder")}
+	return nil
+}
+
+// WithVariant contributes one platform's executable, and the document
+// describing it.
+//
+// platform is stated rather than inferred, and that is the rule the whole
+// design turns on. A *dagger.File carries no architecture, so a helper that
+// took an executable and worked out where it belonged would silently admit
+// the failure devex#397 exists to refuse: an index whose arm64 manifest holds
+// an amd64 binary, which fails at exec time with the kernel's message and for
+// nobody here. Nothing in this module infers a platform from a file.
+//
+// entry becomes the image's entrypoint. It lands in the standardized
+// executable directory under its own file name, mode 0555, owned by the
+// image's non-root user — the same treatment a compiled binary gets, because
+// it goes through the same code.
+//
+// document is an SPDX 2.3 JSON document describing the executable, and it is
+// required for the reason every contribution's is: the SBOM a publish attaches
+// accounts for the whole image, and a helper admitting undescribed content
+// would make that contract true by the letter and false in substance.
+// Z5labs.FileDocument produces one for an executable whose ecosystem has no
+// module able to; a Go binary should carry dag.Go().Spdx instead.
+//
+// # What is refused, and why each one is a real failure
+//
+// A platform contributed twice, because the second would silently replace the
+// first and the App would ship fewer architectures than it was asked for. A
+// platform that is not GOOS/GOARCH, because it cannot name a manifest. And an
+// entry whose file name differs from the entries already contributed, because
+// the entrypoint would then be a different path per architecture — a consumer
+// who overrides the entrypoint, or writes a COPY --from= line against the
+// image, would be right on one platform and wrong on another with nothing in
+// the manifest list to say so.
+//
+// A single-platform App is expressible and is not a degenerate case: one
+// WithVariant and a Build is a complete application, published as one variant
+// rather than as a multi-platform index pretending to be one.
+func (r *Z5LabsAppBuilder) WithVariant(platform Platform, entry *File, document *File) *Z5LabsAppBuilder { // z5labs (../../../../../daggerverse/z5labs/prebuilt.go:231:1)
+	assertNotNil("entry", entry)
+	assertNotNil("document", document)
+	q := r.query.Select("withVariant")
+	q = q.Arg("platform", platform)
+	q = q.Arg("entry", entry)
+	q = q.Arg("document", document)
+
+	return &Z5LabsAppBuilder{
+		query: q,
+	}
+}
+
+// AsNode returns this Z5LabsAppBuilder as a Node.
+// This is a local type conversion — no GraphQL call.
+func (r *Z5LabsAppBuilder) AsNode() Node {
 	return &NodeClient{
 		query: r.query,
 	}

--- a/daggerverse/z5labs/tests/main.go
+++ b/daggerverse/z5labs/tests/main.go
@@ -150,6 +150,11 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("AppRedactsCredentialsFromTheSourceAnnotation", t.AppRedactsCredentialsFromTheSourceAnnotation)
 	jobs = jobs.WithJob("AppSignsEveryPublishedManifest", t.AppSignsEveryPublishedManifest)
 	jobs = jobs.WithJob("AppSignatureDoesNotVerifyForAnotherKey", t.AppSignatureDoesNotVerifyForAnotherKey)
+	jobs = jobs.WithJob("AppFromPrebuiltExecutablesIsHardenedLikeAnyOther", t.AppFromPrebuiltExecutablesIsHardenedLikeAnyOther)
+	jobs = jobs.WithJob("AppFromPrebuiltExecutablesPublishesAttested", t.AppFromPrebuiltExecutablesPublishesAttested)
+	jobs = jobs.WithJob("AppFromPrebuiltComposesATreeShapedPayload", t.AppFromPrebuiltComposesATreeShapedPayload)
+	jobs = jobs.WithJob("AppBuilderRefusesAnInconsistentVariantSet", t.AppBuilderRefusesAnInconsistentVariantSet)
+	jobs = jobs.WithJob("AppRefusesADocumentThatDescribesOtherBytes", t.AppRefusesADocumentThatDescribesOtherBytes)
 
 	return jobs.Run(ctx)
 }

--- a/daggerverse/z5labs/tests/prebuilt.go
+++ b/daggerverse/z5labs/tests/prebuilt.go
@@ -1,0 +1,518 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"dagger/tests/internal/dagger"
+)
+
+// The generic constructor's tests: an App built from executables the
+// archetype did not compile.
+//
+// Every executable below is produced by calling the `go` module directly,
+// which is what makes these tests mean anything. The point of Z5labs.App is
+// that a binary from outside this pipeline — somebody else's CLI, a Rust or
+// Zig build, a vendor artifact — gets the same hardening, the same
+// multi-platform publish, the same annotations and the same attestations, so a
+// test that reached for the Go chain to get its input would be testing the
+// chain again. Nothing here is a git working tree either; there is no HEAD to
+// read, which is the honest shape of a prebuilt payload.
+//
+// wantEntryMode is the mode an application's own executable lands with. It is
+// written out here rather than read from the module for the reason
+// wantFileMode is: it is a property of every image this pipeline publishes,
+// and a test importing the module's constant would agree with whatever the
+// module changed it to.
+const wantEntryMode = "555"
+
+// prebuiltEntry compiles dir for platform outside the archetype and returns
+// the executable, exactly as a caller with a binary from anywhere else would
+// hold one.
+func prebuiltEntry(dir *dagger.Directory, name string, platform dagger.Platform) *dagger.File {
+	return dag.Go().Build(dir, dagger.GoBuildOpts{
+		Pkg:          ".",
+		ArtifactName: name,
+		Platform:     string(platform),
+		DisableCgo:   true,
+		Trimpath:     true,
+		Strip:        true,
+	}).File(name)
+}
+
+// prebuiltApp assembles an App from one prebuilt executable per platform,
+// each with the document the module's own helper produces for content whose
+// ecosystem has none.
+//
+// The document comes from FileDocument rather than from a literal because that
+// is the path an adopter takes, and because it computes the executable's
+// SHA-256 itself — which is what the publish checks the document against.
+func prebuiltApp(dir *dagger.Directory, name, version string, platforms []dagger.Platform) *dagger.Z5LabsAppBuilder {
+	builder := dag.Z5Labs().App(version)
+	for _, platform := range platforms {
+		entry := prebuiltEntry(dir, name, platform)
+		builder = builder.WithVariant(platform, entry, dag.Z5Labs().FileDocument(entry, dagger.Z5LabsFileDocumentOpts{
+			License: "Apache-2.0",
+			Name:    name,
+			Version: version,
+		}))
+	}
+	return builder
+}
+
+// AppFromPrebuiltExecutablesIsHardenedLikeAnyOther asserts that an App built
+// with no language chain involved produces exactly the image the chain
+// produces: the standardized executable directory and PATH, the module's mode
+// and ownership on the entry, nothing else in the filesystem, and an
+// entrypoint that runs.
+//
+// The hardening is the whole reason this seam exists rather than being left to
+// each project's hand-rolled Dockerfile, so it is asserted rather than assumed.
+// A caller-supplied entrypoint is not an exemption from any of it: the module
+// still builds the image around the executable, which is exactly what
+// distinguishes a bounded seam from the caller-supplied *container* that
+// devex#400 refused.
+//
+// Both platforms are read because packaging only the host's would be invisible
+// in a single-platform test and would ship an arm64 release built around an
+// amd64 binary — the failure devex#397 names, and the reason no platform here
+// is ever inferred from a file.
+func (t *Tests) AppFromPrebuiltExecutablesIsHardenedLikeAnyOther(ctx context.Context) error {
+	const (
+		version = "v1.0.0"
+		name    = "hello"
+	)
+	platforms := []dagger.Platform{"linux/amd64", "linux/arm64"}
+	app := prebuiltApp(helloDir(), name, version, platforms).Build()
+
+	entrypoint := "/app/" + name
+	for _, platform := range platforms {
+		ctr := app.Container(platform)
+
+		got, err := ctr.Entrypoint(ctx)
+		if err != nil {
+			return fmt.Errorf("%s: read the entrypoint: %v", platform, err)
+		}
+		if len(got) != 1 || got[0] != entrypoint {
+			return fmt.Errorf("%s: entrypoint is %v, want [%s]", platform, got, entrypoint)
+		}
+		if err := assertStandardEnvironment(ctx, ctr, string(platform)); err != nil {
+			return err
+		}
+
+		// The executable is owned by the non-root user and is read-and-execute
+		// rather than writable, which is the one thing a caller cannot state
+		// and the reason the module builds the image rather than accepting one.
+		modes, err := statInImage(ctx, ctr, []string{entrypoint})
+		if err != nil {
+			return fmt.Errorf("%s: %v", platform, err)
+		}
+		want := wantEntryMode + " " + wantOwner
+		if modes[entrypoint] != want {
+			return fmt.Errorf("%s: %s is %q, want %q", platform, entrypoint, modes[entrypoint], want)
+		}
+
+		// Nothing else is in the image. A seam that quietly brought a shell, a
+		// loader or a package database with it would be a bigger surface than
+		// the one this pipeline promises, and it would not show up in any
+		// assertion above.
+		entries, err := ctr.Rootfs().Glob(ctx, "**")
+		if err != nil {
+			return fmt.Errorf("%s: list the rootfs: %v", platform, err)
+		}
+		files := onlyFiles(entries)
+		if len(files) != 1 || files[0] != strings.TrimPrefix(entrypoint, "/") {
+			return fmt.Errorf("%s: the image holds %v, want the contributed executable alone", platform, files)
+		}
+	}
+
+	// One platform can actually be run here, and running it is what proves the
+	// mode and the ownership are compatible with the entrypoint rather than
+	// merely correct-looking.
+	out, err := app.Container(hostPlatform()).
+		WithExec([]string{}, dagger.ContainerWithExecOpts{UseEntrypoint: true}).
+		Stdout(ctx)
+	if err != nil {
+		return fmt.Errorf("run the prebuilt app image's entrypoint: %v", err)
+	}
+	if out != "hello\n" {
+		return fmt.Errorf("expected %q, got %q", "hello\n", out)
+	}
+	return nil
+}
+
+// AppFromPrebuiltExecutablesPublishesAttested asserts that an App assembled
+// from prebuilt executables publishes exactly like one a language chain
+// produced: both SBOMs and the signed provenance attached to the published
+// digest, and the image annotated.
+//
+// This is the criterion the whole story turns on — "published, annotated and
+// attested exactly like one Go.App produced" — and it is checked by reading
+// the registry rather than the module, because what a consumer can fetch is
+// the only thing that counts.
+//
+// The annotations are asserted in both directions. The version is present,
+// because the caller stated it. The revision, the source and the created time
+// are *absent*, because nothing observed them: an App assembled from prebuilt
+// bytes read no working tree, and a key present and blank would be
+// indistinguishable to a consumer from a revision that really is "". The same
+// silence shows up in the predicate, which records no source and no package.
+func (t *Tests) AppFromPrebuiltExecutablesPublishesAttested(ctx context.Context) error {
+	const (
+		version    = "v2.0.0"
+		name       = "hello"
+		repository = "z5labs/prebuilt"
+	)
+	svc, _, secret, err := localRegistry(ctx)
+	if err != nil {
+		return err
+	}
+	prov, err := newProvenanceHarness(ctx, "")
+	if err != nil {
+		return err
+	}
+	platform := hostPlatform()
+	app := prebuiltApp(helloDir(), name, version, []dagger.Platform{platform}).Build()
+	refs, err := publishable(app, svc, secret, prov).Publish(ctx, []string{repository})
+	if err != nil {
+		return fmt.Errorf("Publish: %v", err)
+	}
+	digest, err := digestOf(refs[0])
+	if err != nil {
+		return err
+	}
+	registry := testRegistry(svc, secret)
+
+	for _, artifactType := range []string{spdxArtifactType, cycloneDxArtifactType, provenanceArtifactType} {
+		found, err := referrersOf(ctx, registry, repository, digest, artifactType)
+		if err != nil {
+			return err
+		}
+		if len(found) != 1 {
+			return fmt.Errorf("expected exactly 1 referrer of type %s on %s, got %d", artifactType, digest, len(found))
+		}
+	}
+
+	// The document describes the image and says the image contains the
+	// executable that was handed in, which is the assembly working over a
+	// contribution no language chain produced.
+	spdxRaw, _, err := attachedSbom(ctx, registry, repository, digest, spdxArtifactType)
+	if err != nil {
+		return err
+	}
+	spdx, err := readPublishedSpdx(spdxRaw)
+	if err != nil {
+		return err
+	}
+	if hexDigest := strings.TrimPrefix(digest, "sha256:"); spdx.SubjectSha256 != hexDigest {
+		return fmt.Errorf("the SPDX document's subject carries checksum %q, want the published digest %s",
+			spdx.SubjectSha256, hexDigest)
+	}
+	if len(spdx.Contained) != 1 || spdx.Contained[0] != name {
+		return fmt.Errorf("the SPDX document says the image contains %v, want the prebuilt executable alone", spdx.Contained)
+	}
+
+	envelope, err := attachedDocument(ctx, registry, repository, digest, provenanceArtifactType)
+	if err != nil {
+		return err
+	}
+	statement, err := verifyEnvelope(envelope, prov.Public)
+	if err != nil {
+		return err
+	}
+	if err := checkStatement(statement, digest, repository, prov.Claims); err != nil {
+		return err
+	}
+	if err := assertNoSourceClaimed(statement); err != nil {
+		return err
+	}
+
+	index, err := fetchManifest(ctx, registry, repository, digest)
+	if err != nil {
+		return err
+	}
+	// A single-platform publish stores an index naming one variant or a bare
+	// manifest, and which one is the registry's business; the annotations are
+	// on the variant either way.
+	variants := []string{digest}
+	if len(index.Manifests) > 0 {
+		variants = nil
+		for _, entry := range index.Manifests {
+			variants = append(variants, entry.Digest)
+		}
+	}
+	for _, reference := range variants {
+		got, err := fetchManifest(ctx, registry, repository, reference)
+		if err != nil {
+			return err
+		}
+		if want := version; got.Annotations["org.opencontainers.image.version"] != want {
+			return fmt.Errorf("%s: expected the version annotation %q, got %q",
+				reference, want, got.Annotations["org.opencontainers.image.version"])
+		}
+		for _, key := range []string{
+			"org.opencontainers.image.revision",
+			"org.opencontainers.image.source",
+			"org.opencontainers.image.created",
+		} {
+			if value, ok := got.Annotations[key]; ok {
+				return fmt.Errorf(
+					"%s: expected no %s annotation on an app assembled from prebuilt executables, got %q; "+
+						"nothing observed a source, and a blank key reads as an empty value rather than as an absent one",
+					reference, key, value)
+			}
+		}
+	}
+	return nil
+}
+
+// assertNoSourceClaimed checks that a predicate for an App assembled from
+// prebuilt executables claims no source tree and no package.
+//
+// It is the other half of "build identity is not an argument". The constructor
+// takes no commit and no origin, so the honest predicate says nothing about
+// either — and a future seam that let a caller state one would go red here
+// rather than shipping a provenance that records what somebody typed.
+func assertNoSourceClaimed(statement map[string]any) error {
+	predicate, err := object(statement["predicate"], "predicate")
+	if err != nil {
+		return err
+	}
+	definition, err := object(predicate["buildDefinition"], "predicate.buildDefinition")
+	if err != nil {
+		return err
+	}
+	if got, ok := definition["resolvedDependencies"]; ok && got != nil {
+		return fmt.Errorf("expected no resolvedDependencies for an app assembled from prebuilt executables, got %v", got)
+	}
+	internal, err := object(definition["internalParameters"], "predicate.buildDefinition.internalParameters")
+	if err != nil {
+		return err
+	}
+	if got, ok := internal["pkg"]; ok {
+		return fmt.Errorf("expected no pkg in the predicate for an app that compiled nothing, got %v", got)
+	}
+	return nil
+}
+
+// AppFromPrebuiltComposesATreeShapedPayload asserts the payload shape a
+// language chain cannot produce: an executable plus the files it needs to run.
+//
+// This is what devex#410 exists to unblock. The contribution seam was designed
+// around payloads that might be a *tree* — an entry and the content beside it
+// — and the reason the single-file assumption looked safe for so long is that
+// Go was the only chain there was, so every payload was one static binary.
+// With the generic constructor the suite can assemble a tree payload and put
+// the composition, the collision refusal and the exec check over it, without
+// waiting for a second language chain to exist.
+//
+// The fixture is an executable that is *useless* without the tree: it lists
+// what it found and reads a file out of it, so an image where the entry landed
+// and the tree did not fails here rather than passing an exec check that only
+// proves the binary starts.
+func (t *Tests) AppFromPrebuiltComposesATreeShapedPayload(ctx context.Context) error {
+	const (
+		version  = "v1.2.3"
+		name     = "payload"
+		treePath = "/srv/payload"
+	)
+	platform := hostPlatform()
+	tree := dag.Directory().
+		WithNewFile("greeting.txt", "hello from the payload\n").
+		WithNewFile("data/rows.csv", "a,b\n1,2\n")
+	app := prebuiltApp(payloadDir(), name, version, []dagger.Platform{platform}).Build().
+		WithDirectory(treePath, tree, dag.Z5Labs().DirectoryDocument(tree, treePath))
+
+	// Composition: the entry and everything it needs are both in the image,
+	// and the program says so by reading them.
+	out, err := app.Container(platform).
+		WithExec([]string{}, dagger.ContainerWithExecOpts{UseEntrypoint: true}).
+		Stdout(ctx)
+	if err != nil {
+		return fmt.Errorf("run the tree-payload image: %v", err)
+	}
+	const want = "hello from the payload data/rows.csv,greeting.txt\n"
+	if out != want {
+		return fmt.Errorf("expected %q, got %q", want, out)
+	}
+
+	// The tree lands with the module's own mode and owner, exactly as it does
+	// on an app a language chain built. Nothing about the payload arriving
+	// prebuilt relaxes that.
+	entrypoint := "/app/" + name
+	modes, err := statInImage(ctx, app.Container(platform), []string{
+		entrypoint, treePath, treePath + "/greeting.txt", treePath + "/data/rows.csv",
+	})
+	if err != nil {
+		return err
+	}
+	wantModes := map[string]string{
+		entrypoint:                  wantEntryMode + " " + wantOwner,
+		treePath:                    wantDirectoryMode + " " + wantOwner,
+		treePath + "/greeting.txt":  wantDirectoryMode + " " + wantOwner,
+		treePath + "/data/rows.csv": wantDirectoryMode + " " + wantOwner,
+	}
+	var wrong []string
+	for _, path := range sortedNames(wantModes) {
+		if modes[path] != wantModes[path] {
+			wrong = append(wrong, fmt.Sprintf("%s is %q, want %q", path, modes[path], wantModes[path]))
+		}
+	}
+	if len(wrong) > 0 {
+		return fmt.Errorf("%s", strings.Join(wrong, "; "))
+	}
+
+	// The collision refusal reaches a prebuilt entry too. The entrypoint is
+	// read off the container rather than assumed by the module, so this is the
+	// end-to-end half of a rule whose table lives in
+	// Z5labs.ContributionPathSelfTest — and the case that matters here is that
+	// the protected path is one no language chain named.
+	stray := dag.Directory().WithNewFile("stray", "stray\n").File("stray")
+	strayDoc := dag.Z5Labs().FileDocument(stray, dagger.Z5LabsFileDocumentOpts{Name: "stray"})
+	for _, collision := range []struct {
+		path string
+		hit  string
+		why  string
+	}{
+		{path: entrypoint, hit: "already there", why: "on top of the prebuilt entrypoint itself"},
+		{path: treePath + "/greeting.txt", hit: "inside " + treePath, why: "inside the contributed payload tree"},
+	} {
+		if _, err := app.WithFile(collision.path, stray, strayDoc).ID(ctx); err == nil {
+			return fmt.Errorf("expected contributing %s (%s) to be refused, got nil", collision.path, collision.why)
+		} else if !strings.Contains(err.Error(), collision.hit) {
+			return fmt.Errorf("expected the refusal of %s (%s) to carry %q, got: %v",
+				collision.path, collision.why, collision.hit, err)
+		}
+	}
+	return nil
+}
+
+// AppBuilderRefusesAnInconsistentVariantSet asserts the refusals that make an
+// App from prebuilt executables trustworthy, through the real API.
+//
+// The rules themselves are a table in Z5labs.VariantSetSelfTest, which costs
+// no build. What cannot be checked in process is that they are wired into
+// WithVariant and Build at all — and the empty set especially, because an App
+// with no variants is the one that would swallow every contribution made to it
+// in silence and publish nothing.
+func (t *Tests) AppBuilderRefusesAnInconsistentVariantSet(ctx context.Context) error {
+	const (
+		version = "v1.0.0"
+		name    = "hello"
+	)
+	amd64 := prebuiltEntry(helloDir(), name, "linux/amd64")
+	amd64Doc := dag.Z5Labs().FileDocument(amd64, dagger.Z5LabsFileDocumentOpts{Name: name})
+	other := prebuiltEntry(helloDir(), "hello-arm", "linux/arm64")
+	otherDoc := dag.Z5Labs().FileDocument(other, dagger.Z5LabsFileDocumentOpts{Name: "hello-arm"})
+
+	cases := []struct {
+		builder *dagger.Z5LabsAppBuilder
+		refusal string
+		why     string
+	}{
+		{
+			builder: dag.Z5Labs().App(version),
+			refusal: "at least one variant",
+			why:     "an app with no executables at all, which would publish nothing and swallow every contribution",
+		},
+		{
+			builder: dag.Z5Labs().App(version).
+				WithVariant("linux/amd64", amd64, amd64Doc).
+				WithVariant("linux/amd64", amd64, amd64Doc),
+			refusal: "already contributed",
+			why:     "one platform twice, where the second silently replaces the first",
+		},
+		{
+			builder: dag.Z5Labs().App(version).
+				WithVariant("linux/amd64", amd64, amd64Doc).
+				WithVariant("linux/arm64", other, otherDoc),
+			refusal: "is called hello",
+			why:     "entries named differently, leaving the entrypoint a different path per architecture",
+		},
+		// A malformed platform is deliberately absent from this table, and the
+		// absence is a finding rather than an omission. Platform is a scalar
+		// the engine normalizes containerd-style before a module sees it, so a
+		// bare "linux" arrives as "linux/amd64" and is accepted — the module's
+		// own shape check never sees a value it could refuse. Asserting a
+		// refusal here would have been asserting against the engine, and the
+		// check that remains in the module is the guard for the callers inside
+		// it, where no normalization happens.
+		{
+			builder: dag.Z5Labs().App("1.0.0+build.1").WithVariant("linux/amd64", amd64, amd64Doc),
+			refusal: "build metadata",
+			why:     "a version that cannot be an image tag, refused by the terminal like any other",
+		},
+	}
+	for _, c := range cases {
+		_, err := c.builder.Build().ID(ctx)
+		if err == nil {
+			return fmt.Errorf("expected %s to be refused, got nil", c.why)
+		}
+		if !strings.Contains(err.Error(), c.refusal) {
+			return fmt.Errorf("expected the refusal of %s to carry %q, got: %v", c.why, c.refusal, err)
+		}
+	}
+	return nil
+}
+
+// AppRefusesADocumentThatDescribesOtherBytes asserts a publish refuses a
+// contribution whose document names some other artifact's digest.
+//
+// This is the mitigation that makes an asserted document worth having. A
+// language chain's document is derived from the artifact and cannot disagree
+// with it; everything the generic constructor and the contribution helpers
+// accept is a claim someone made, and before this a claim about entirely
+// different bytes was well-formed, attached cleanly and indistinguishable from
+// a right one. The refusal happens before anything is pushed, which is checked
+// by looking for the tag afterwards — a document verified after the push would
+// leave a published release to be retracted rather than a publish that failed.
+func (t *Tests) AppRefusesADocumentThatDescribesOtherBytes(ctx context.Context) error {
+	const (
+		version    = "v4.0.0"
+		name       = "hello"
+		repository = "z5labs/mismatched"
+	)
+	svc, pwdHex, secret, err := localRegistry(ctx)
+	if err != nil {
+		return err
+	}
+	prov, err := newProvenanceHarness(ctx, "")
+	if err != nil {
+		return err
+	}
+	platform := hostPlatform()
+
+	// The document is a real, well-formed SPDX document produced by the
+	// module's own helper — it is simply about a different file. That is the
+	// case worth refusing: a malformed document was already refused, and a
+	// document nobody could parse was never the risk.
+	elsewhere := dag.Directory().WithNewFile("elsewhere", "not what is in the image\n").File("elsewhere")
+	entry := prebuiltEntry(helloDir(), name, platform)
+	app := dag.Z5Labs().App(version).
+		WithVariant(platform, entry, dag.Z5Labs().FileDocument(elsewhere, dagger.Z5LabsFileDocumentOpts{Name: name})).
+		Build()
+
+	_, err = publishable(app, svc, secret, prov).Publish(ctx, []string{repository})
+	if err == nil {
+		return fmt.Errorf("expected a publish whose document describes other bytes to be refused, got nil")
+	}
+	if !strings.Contains(err.Error(), "describes other bytes") {
+		return fmt.Errorf("expected the refusal to say the document describes other bytes, got: %v", err)
+	}
+
+	code, err := curlProbeManifest(ctx, svc, registryAlias, "ci", pwdHex, repository, version)
+	if err != nil {
+		return fmt.Errorf("probe the registry after the refusal: %v", err)
+	}
+	if code == 200 {
+		return fmt.Errorf("Publish refused the publish but manifest %s:%s is present in the registry", repository, version)
+	}
+	return nil
+}
+
+// payloadDir returns the tree-shaped-payload fixture: a main package that is
+// useless without the files contributed beside it.
+func payloadDir() *dagger.Directory {
+	return dag.CurrentModule().Source().Directory("fixtures/payload")
+}

--- a/daggerverse/z5labs/tests/prebuilt.go
+++ b/daggerverse/z5labs/tests/prebuilt.go
@@ -48,15 +48,23 @@ func prebuiltEntry(dir *dagger.Directory, name string, platform dagger.Platform)
 // The document comes from FileDocument rather than from a literal because that
 // is the path an adopter takes, and because it computes the executable's
 // SHA-256 itself — which is what the publish checks the document against.
+//
+// The artifacts are named **per platform** — app-linux-amd64, app-linux-arm64 —
+// and the name the image uses is stated separately, because that is how a real
+// `dist/` directory looks and it is the case the archetype exists to package.
+// A helper that compiled every platform's artifact under one file name would
+// make the entry-name agreement rule vacuous here and would have hidden that
+// the documented CLI invocation did not work.
 func prebuiltApp(dir *dagger.Directory, name, version string, platforms []dagger.Platform) *dagger.Z5LabsAppBuilder {
 	builder := dag.Z5Labs().App(version)
 	for _, platform := range platforms {
-		entry := prebuiltEntry(dir, name, platform)
+		artifact := name + "-" + strings.ReplaceAll(string(platform), "/", "-")
+		entry := prebuiltEntry(dir, artifact, platform)
 		builder = builder.WithVariant(platform, entry, dag.Z5Labs().FileDocument(entry, dagger.Z5LabsFileDocumentOpts{
 			License: "Apache-2.0",
 			Name:    name,
 			Version: version,
-		}))
+		}), dagger.Z5LabsAppBuilderWithVariantOpts{Name: name})
 	}
 	return builder
 }
@@ -293,6 +301,19 @@ func assertNoSourceClaimed(statement map[string]any) error {
 	if got, ok := internal["pkg"]; ok {
 		return fmt.Errorf("expected no pkg in the predicate for an app that compiled nothing, got %v", got)
 	}
+	// externalParameters is checked too, and separately, because only
+	// internalParameters was made conditional. The source key there is derived
+	// from the identity token's claims rather than from the build facts, so it
+	// is absent for a token that names no commit — this asserts that rather
+	// than assuming it, which is what would catch a future change routing a
+	// build fact into it and publishing a blank one.
+	external, err := object(definition["externalParameters"], "predicate.buildDefinition.externalParameters")
+	if err != nil {
+		return err
+	}
+	if got, ok := external["source"]; ok {
+		return fmt.Errorf("expected no source in the predicate for an app assembled from prebuilt executables, got %v", got)
+	}
 	return nil
 }
 
@@ -443,6 +464,28 @@ func (t *Tests) AppBuilderRefusesAnInconsistentVariantSet(ctx context.Context) e
 			refusal: "build metadata",
 			why:     "a version that cannot be an image tag, refused by the terminal like any other",
 		},
+		{
+			builder: dag.Z5Labs().App(version).WithVariant("linux/amd64", amd64, amd64Doc,
+				dagger.Z5LabsAppBuilderWithVariantOpts{Name: " hello"}),
+			refusal: "whitespace",
+			why:     "a name that opens with whitespace, giving an entrypoint invisible in an image inspection",
+		},
+	}
+
+	// The stated name is what makes a normal per-platform `dist/` directory
+	// contributable, so the agreement it buys is asserted rather than only its
+	// refusals: two differently-named artifacts, one name, one entrypoint.
+	named := dag.Z5Labs().App(version).
+		WithVariant("linux/amd64", amd64, amd64Doc, dagger.Z5LabsAppBuilderWithVariantOpts{Name: name}).
+		WithVariant("linux/arm64", other, otherDoc, dagger.Z5LabsAppBuilderWithVariantOpts{Name: name})
+	for _, platform := range []dagger.Platform{"linux/amd64", "linux/arm64"} {
+		got, err := named.Build().Container(platform).Entrypoint(ctx)
+		if err != nil {
+			return fmt.Errorf("%s: read the entrypoint of a set contributed under a stated name: %v", platform, err)
+		}
+		if want := "/app/" + name; len(got) != 1 || got[0] != want {
+			return fmt.Errorf("%s: entrypoint is %v, want [%s]", platform, got, want)
+		}
 	}
 	for _, c := range cases {
 		_, err := c.builder.Build().ID(ctx)
@@ -483,30 +526,57 @@ func (t *Tests) AppRefusesADocumentThatDescribesOtherBytes(ctx context.Context) 
 	}
 	platform := hostPlatform()
 
-	// The document is a real, well-formed SPDX document produced by the
-	// module's own helper — it is simply about a different file. That is the
+	// Every document below is a real, well-formed SPDX document produced by the
+	// module's own helper — each is simply about something else. That is the
 	// case worth refusing: a malformed document was already refused, and a
 	// document nobody could parse was never the risk.
+	//
+	// Both kinds of content are driven, because they are checked by different
+	// code. A file's digest is the SHA-256 of its bytes; a tree's is this
+	// module's digest over the sorted list of its paths and their digests, and
+	// the two sides of that convention — DirectoryDocument computing it and the
+	// publish recomputing it — are the pair most able to drift apart.
 	elsewhere := dag.Directory().WithNewFile("elsewhere", "not what is in the image\n").File("elsewhere")
+	otherTree := dag.Directory().WithNewFile("index.html", "a different tree entirely\n")
 	entry := prebuiltEntry(helloDir(), name, platform)
-	app := dag.Z5Labs().App(version).
-		WithVariant(platform, entry, dag.Z5Labs().FileDocument(elsewhere, dagger.Z5LabsFileDocumentOpts{Name: name})).
-		Build()
+	entryDoc := dag.Z5Labs().FileDocument(entry, dagger.Z5LabsFileDocumentOpts{Name: name})
+	tree := dag.Directory().WithNewFile("index.html", "<!doctype html>\n")
 
-	_, err = publishable(app, svc, secret, prov).Publish(ctx, []string{repository})
-	if err == nil {
-		return fmt.Errorf("expected a publish whose document describes other bytes to be refused, got nil")
+	cases := []struct {
+		app  *dagger.Z5LabsApp
+		what string
+	}{
+		{
+			app: dag.Z5Labs().App(version).
+				WithVariant(platform, entry, dag.Z5Labs().FileDocument(elsewhere, dagger.Z5LabsFileDocumentOpts{Name: name})).
+				Build(),
+			what: "an executable whose document is about another file",
+		},
+		{
+			app: dag.Z5Labs().App(version).
+				WithVariant(platform, entry, entryDoc).
+				Build().
+				WithDirectory("/srv/templates", tree, dag.Z5Labs().DirectoryDocument(otherTree, "/srv/templates")),
+			what: "a contributed tree whose document is about another tree",
+		},
 	}
-	if !strings.Contains(err.Error(), "describes other bytes") {
-		return fmt.Errorf("expected the refusal to say the document describes other bytes, got: %v", err)
-	}
-
-	code, err := curlProbeManifest(ctx, svc, registryAlias, "ci", pwdHex, repository, version)
-	if err != nil {
-		return fmt.Errorf("probe the registry after the refusal: %v", err)
-	}
-	if code == 200 {
-		return fmt.Errorf("Publish refused the publish but manifest %s:%s is present in the registry", repository, version)
+	for i, c := range cases {
+		target := fmt.Sprintf("%s-%d", repository, i)
+		_, err := publishable(c.app, svc, secret, prov).Publish(ctx, []string{target})
+		if err == nil {
+			return fmt.Errorf("expected a publish carrying %s to be refused, got nil", c.what)
+		}
+		if !strings.Contains(err.Error(), "describes other bytes") {
+			return fmt.Errorf("expected the refusal of %s to say the document describes other bytes, got: %v", c.what, err)
+		}
+		code, err := curlProbeManifest(ctx, svc, registryAlias, "ci", pwdHex, target, version)
+		if err != nil {
+			return fmt.Errorf("probe the registry after the refusal of %s: %v", c.what, err)
+		}
+		if code == 200 {
+			return fmt.Errorf("the publish carrying %s was refused but manifest %s:%s is present in the registry",
+				c.what, target, version)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #410

`Go.App` was the only way to get an `App`. `Z5labs.App` is the general one: an
application assembled from executables this module did not compile — a prebuilt
or vendor binary, a language whose chain nobody has written yet, and the
tree-shaped payloads no single Go build produces.

```
dagger call app --version=v1.2.3 \
  with-variant --platform=linux/amd64 --entry=./dist/app-amd64 --document=./dist/app-amd64.spdx.json \
  with-variant --platform=linux/arm64 --entry=./dist/app-arm64 --document=./dist/app-arm64.spdx.json \
  build \
  with-registry --address=ghcr.io --username=... --auth=env:TOKEN \
  publish --repositories=owner/app
```

## Acceptance criteria

- [x] **An `App` can be constructed with no language chain involved, from prebuilt
      executables, and published, annotated and attested exactly like one `Go.App`
      produced.** `AppFromPrebuiltExecutablesPublishesAttested` publishes one and reads
      both SBOMs, the signed provenance and the annotations back off the registry.
- [x] **Every variant names its platform explicitly; nothing infers a platform from a
      file; a single-platform `App` is expressible.** `WithVariant` takes the platform
      as an argument and there is no file-based executable helper, for the reason #397
      gives. One `WithVariant` plus a `Build` is a complete application.
- [x] **Constructing with zero variants fails, and so does a contribution set whose
      platforms do not agree.** `Build` refuses an empty set; `WithVariant` refuses a
      platform contributed twice and an entry whose name disagrees with the set's.
      Table in `Z5labs.VariantSetSelfTest`, wiring in
      `AppBuilderRefusesAnInconsistentVariantSet`.
- [x] **Every contribution arrives with a document, and the document names the digest
      of the content it accompanies. A mismatch fails rather than publishing a document
      that describes something else.** `digest.go`; applies to `WithVariant`, `WithFile`
      and `WithDirectory` alike. `AppRefusesADocumentThatDescribesOtherBytes` asserts
      the refusal and that nothing reached the registry.
- [x] **The constructed image is hardened identically — `65532:65532`, the module's
      modes and ownership, no writable surface, the standardized executable directory
      and `PATH`.** One `imageForEntry` builds every image, and the entry now lands
      `0555` owned by `65532:65532` — which the Go path did not do before this change.
      Asserted in `AppFromPrebuiltExecutablesIsHardenedLikeAnyOther`, including that the
      image holds nothing else.
- [x] **Decide the chained shape, and name it.** See below.
- [x] **`Go.App` is built on this constructor.** `GoChain.App` assembles through
      `AppBuilder`; there is one image build, one variant-set validation and one place
      an empty set is refused.
- [x] **The test suite exercises a tree-shaped payload.**
      `AppFromPrebuiltComposesATreeShapedPayload`: a prebuilt entry that is *useless*
      without the tree beside it, asserting the composition (it runs and reads them),
      the path-collision refusal over a prebuilt entrypoint, and the modes and owner on
      both.
- [x] **Documented as the seam for prebuilt binaries and for languages without a
      chain, including the honest statement about asserted documents.** New package-doc
      section "Prebuilt executables, and languages with no chain".

## The decisions

**The intermediate is a distinct registered type, `AppBuilder`.** The alternative —
`Z5labs.App` returning `*App` with `WithVariant` beside `WithFile` — is rejected
because an `App` is the thing that *has* variants: `WithFile` applies content to
every variant there is, so a contribution made before the first variant would land
on nothing at all, silently, and a zero-variant `App` would exist for as long as the
caller kept chaining. `Build` is the only place "constructing with zero variants
fails" can be true. Verified against a consumer `dagger develop`: the schema type is
`Z5LabsAppBuilder`, neither dependency (`go`, `oci`) owns the name, and `Build`
returns an object so it emits no lowercased cache field.

**Build identity is not an argument.** `AppBuilder` takes no commit, origin or build
time — an identity a caller could supply identifies nothing, the same rule that keeps
a repository parameter off the provenance. `GoChain` records what it *observed*
through an unexported seam. So a prebuilt `App` carries the version annotation alone
(no revision/source/created, absent rather than blank) and a predicate with no
`resolvedDependencies` and no `pkg`. Both asserted.

**The digest check runs at publish, not at the contributing call.** Verifying means
hashing, and hashing means resolving; a check at `WithVariant` would force every
platform's cross-compile inside `App` and cost the property that an app nobody
publishes costs no scan. `resolveContributions` already reads every document before
the first byte moves, and there is no route to a registry that avoids it.

**The Go path states its entry name rather than reading it off the file**, via an
unexported `withVariantNamed`. Reading a `*dagger.File`'s name resolves it; the chain
already knows the name from `go.mod`.

## Behaviour changes to existing paths

- A Go application's binary now lands `0555` owned by `65532:65532` instead of
  root-owned. Same hardening every contribution already had.
- `org.opencontainers.image.revision`/`.created` are omitted when unobserved. No
  change to the Go path, which always has them.
- `pkg` is omitted from the provenance predicate when empty, likewise.
- A contributed file or directory whose document names another artifact's digest is
  now refused at publish. Documents from `FileDocument`, `DirectoryDocument` and
  `dag.Go().Spdx` all already name the right digest.

## One finding

A malformed platform cannot reach the module's shape check from the API boundary:
`Platform` is normalized containerd-style by the engine, so a bare `linux` arrives as
`linux/amd64` and is accepted. The refusal case is left out of the table with a
comment saying why, rather than asserted against the engine.

## Verified

- `dagger check` — green
- `bash .github/scripts/verify-affected-modules.sh` — `daggerverse/z5labs` (5 self-tests)
  and `daggerverse/z5labs/tests` (`all`, 42 tests) both green
- Each new test run individually first

🤖 Generated with [Claude Code](https://claude.com/claude-code)