### PR TITLE
story(z5labs): compose one app's payload into another's image, and publish it attested

### DIFF
--- a/daggerverse/z5labs/app.go
+++ b/daggerverse/z5labs/app.go
@@ -75,15 +75,40 @@ type App struct {
 	//
 	// +private
 	Variants []*variant
-	// ContributedPaths are the image paths a caller has contributed content
-	// at, in the order they were contributed. It is what makes a second
-	// contribution overlapping the first refusable — see contribute.go —
-	// and it is a field rather than something derived from the variants
-	// because a variant's contributions are named for error messages and
-	// a language chain's are named after a binary rather than a path.
+	// ContributedPaths are the image paths something has been placed at
+	// since the images were built, in the order they were placed, each
+	// beside what holds it. It is what makes a second contribution
+	// overlapping the first refusable — see contribute.go — and it is a
+	// field rather than something derived from the variants because a
+	// variant's contributions are named for error messages and a language
+	// chain's are named after a binary rather than a path.
+	//
+	// The holder travels with the path because it is the whole content of
+	// the refusal: "something is already contributed at /usr/local/bin/gen"
+	// tells a caller nothing they can act on, while "the entry of the
+	// application composed at /usr/local/bin/gen" tells them which call to
+	// go and look at.
 	//
 	// +private
-	ContributedPaths []string
+	ContributedPaths []occupied
+	// Payload is what this application's constructor declared makes it
+	// runnable: the paths it put in every image and which of them is the
+	// entry. It is what crosses when this App is composed into another's
+	// image, and it is a declaration rather than anything read back off a
+	// container — compose.go records why reading the entrypoint instead
+	// fails silently in four different ways.
+	//
+	// +private
+	Payload appPayload
+	// Composed are the applications composed into this one, each with the
+	// path its entry landed at in these images and the version it was built
+	// under. Publish executes every one of them before it pushes anything,
+	// and records them in the provenance predicate's internal parameters —
+	// which is the only place that says which release of a plugin shipped,
+	// since the derived image is published under the base's version.
+	//
+	// +private
+	Composed []composedApp
 
 	// +private
 	Registry string
@@ -133,6 +158,13 @@ type variant struct {
 // why it runs where it runs.
 type contribution struct {
 	Name string
+	// Path is where in the image the bytes live. It is what composition
+	// reads to move a contribution into a derived image, and it is carried
+	// beside Name rather than replacing it because the two differ for an
+	// application's own executable: Name is what it is called, which is what
+	// an error message about its document should say, and Path is where it
+	// is, which is what a copy needs.
+	Path string
 	File *dagger.File
 	// Content is the file that entered the image: an application's own
 	// executable, or a contributed file. Nil for a directory contribution.
@@ -462,6 +494,15 @@ func (a *App) Publish(ctx context.Context, repositories []string) ([]string, err
 	if err := a.assertImageEnvironment(ctx); err != nil {
 		return nil, err
 	}
+	// A composed payload is proven complete by running it, and nothing about
+	// its API shape can establish the same thing. It happens here, with
+	// everything else that has to be true before the first byte moves, so a
+	// payload that cannot start fails the publish instead of failing in front
+	// of a consumer. compose.go carries what the check can and cannot tell
+	// apart.
+	if err := a.assertComposedPayloadsRun(ctx); err != nil {
+		return nil, err
+	}
 	// Force the builds before the first byte moves. Everything above this
 	// reads image *config*, which resolves without compiling anything, so
 	// without this the first thing to solve the build graph is the push —
@@ -523,6 +564,7 @@ func (a *App) Publish(ctx context.Context, repositories []string) ([]string, err
 			SourceURI:  a.SourceURI,
 			Commit:     a.Commit,
 			Version:    a.Version,
+			Composed:   a.Composed,
 		}
 		if err := a.attachAttestations(ctx, registry, sgn, facts, boms); err != nil {
 			// "no tag" rather than "nothing": the digest in this very message

--- a/daggerverse/z5labs/compose.go
+++ b/daggerverse/z5labs/compose.go
@@ -206,45 +206,107 @@ func (a *App) WithApp(
 			return nil, fmt.Errorf("withApp cannot compose this application: the %s images %v", pair.Base.Platform, err)
 		}
 	}
-	// Nothing above this line has changed anything. Every refusal is made
-	// before the first variant is touched, so a WithApp that fails leaves the
-	// App exactly as it found it rather than half composed.
-	destinations := make(map[string]string, len(crossings))
-	for _, c := range crossings {
-		destinations[c.From] = c.To
+	placements, err := composedPlacements(from, pairs, crossings)
+	if err != nil {
+		return nil, err
 	}
-	for _, pair := range pairs {
-		for _, c := range pair.From.Contributions {
-			to, ok := destinations[c.Path]
-			if !ok {
-				// Unreachable while every contribution is made through the
-				// paths composedCrossings reads. It is an error rather than a
-				// silent skip because the thing it would skip is bytes: an
-				// image missing a file its documents describe is exactly what
-				// this seam refuses everywhere else.
-				return nil, fmt.Errorf(
-					"withApp: the composed application carries %s in its %s image, which its declaration does not account for",
-					c.Path, pair.From.Platform)
-			}
-			pair.Base.Container = placeContribution(pair.Base.Container, to, to == destinations[from.Payload.Entry], c)
+	// Only now is anything changed. Every refusal above is made before the
+	// first variant is touched — including the per-variant ones, which is why
+	// the placements are worked out for every platform before any of them is
+	// applied. A WithApp that failed part way through the platforms would
+	// leave behind an image set that disagreed with itself, which is the one
+	// state worse than not composing at all.
+	for i, pair := range pairs {
+		for _, p := range placements[i] {
+			pair.Base.Container = placeContribution(pair.Base.Container, p.To, p.Entry, p.Source)
 			pair.Base.Contributions = append(pair.Base.Contributions, contribution{
-				Name:    c.Name,
-				Path:    to,
-				File:    c.File,
-				Content: c.Content,
-				Tree:    c.Tree,
+				Name:    p.Source.Name,
+				Path:    p.To,
+				File:    p.Source.File,
+				Content: p.Source.Content,
+				Tree:    p.Source.Tree,
 			})
 		}
 	}
 	for _, c := range crossings {
 		a.ContributedPaths = append(a.ContributedPaths, occupied{Path: c.To, Holder: c.Holder})
 	}
+	// The composed application's own entry, and then everything that had
+	// already been composed into it. The order matters no more than the order
+	// of the crossings does, but it is stable, which is what keeps a predicate
+	// a pure function of what was built.
 	a.Composed = append(a.Composed, composedApp{
-		Entry:   destinations[from.Payload.Entry],
+		Entry:   composedEntryPath(from.Payload.Entry),
 		Version: from.Version,
 	})
 	a.Composed = append(a.Composed, from.Composed...)
 	return a, nil
+}
+
+// placement is one contribution of the composed application, resolved to where
+// it lands in the derived image and whether it lands executable.
+type placement struct {
+	To     string
+	Entry  bool
+	Source contribution
+}
+
+// composedPlacements resolves every platform's contributions to placements, and
+// refuses a set that does not account for exactly what was declared.
+//
+// It is separate from applying them because it is fallible, and applying them
+// is not: worked out first, a refusal for the last platform cannot leave the
+// first one already composed.
+//
+// Both directions of the accounting are checked and they catch different
+// failures. A contribution the declaration does not cover would land nowhere,
+// silently. A declared path no contribution carries is worse: nothing lands,
+// and the path is still recorded as composed, named in the provenance and
+// counted among the image's contents — a document about bytes that are not in
+// the image, which is the exact failure this whole seam is built to refuse.
+func composedPlacements(from *App, pairs []variantPair, crossings []crossing) ([][]placement, error) {
+	destinations := make(map[string]string, len(crossings))
+	for _, c := range crossings {
+		destinations[c.From] = c.To
+	}
+	// Every path that has to land executable: the composed application's own
+	// entry, and every entry that had already been composed into it. Without
+	// the second, composing a *derived* image — which the seam explicitly
+	// allows — would carry its plugins across as ordinary read-only
+	// contributions and strip the one bit that makes them runnable. That
+	// failure is caught at publish, but it is caught as a payload that will
+	// not start, which blames the payload rather than the composition.
+	entries := map[string]bool{destinations[from.Payload.Entry]: true}
+	for _, c := range from.Composed {
+		if to, ok := destinations[c.Entry]; ok {
+			entries[to] = true
+		}
+	}
+	out := make([][]placement, 0, len(pairs))
+	for _, pair := range pairs {
+		placed := make(map[string]bool, len(crossings))
+		resolved := make([]placement, 0, len(pair.From.Contributions))
+		for _, c := range pair.From.Contributions {
+			to, ok := destinations[c.Path]
+			if !ok {
+				return nil, fmt.Errorf(
+					"withApp: the composed application carries %s in its %s image, which its declaration does not account for",
+					c.Path, pair.From.Platform)
+			}
+			placed[c.Path] = true
+			resolved = append(resolved, placement{To: to, Entry: entries[to], Source: c})
+		}
+		for _, c := range crossings {
+			if !placed[c.From] {
+				return nil, fmt.Errorf(
+					"withApp: the composed application declares %s, which its %s image carries nothing for; "+
+						"composing it would record a path in the derived image's documents that no byte in the image answers to",
+					c.From, pair.From.Platform)
+			}
+		}
+		out = append(out, resolved)
+	}
+	return out, nil
 }
 
 // crossing is one thing a composed application brings into the derived image:

--- a/daggerverse/z5labs/compose.go
+++ b/daggerverse/z5labs/compose.go
@@ -1,0 +1,571 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	imagepath "path"
+	"sort"
+	"strings"
+
+	"dagger/z-5-labs/internal/dagger"
+)
+
+// Composing one application's payload into another's image.
+//
+// A base image carrying a CLI, plus a derived image per plugin that adds one
+// executable and changes nothing else, is a shape two adopters hand-rolled an
+// entire image build for because the archetype had nowhere to put a second
+// executable. WithApp is that seam. The derived image is the same program as
+// the base wearing one more executable, so it inherits the base's entrypoint,
+// its user, its environment and its executable directory rather than restating
+// any of them — a derived image that quietly became a *different* program
+// wearing the base's filesystem is the failure this whole file is written to
+// prevent.
+//
+// # The producing chain declares its payload; composition never infers it
+//
+// The unit that crosses is a payload: the paths that make an application
+// runnable, plus which one is the entry. Only whatever built the application
+// can know that, so it is declared — AppBuilder records the entry it packaged
+// — and WithApp reads the declaration.
+//
+// It deliberately does not read the entrypoint, which is the rejected design
+// and is wrong in four ways that all fail silently. `ep[0]` is a PATH lookup
+// rather than a path for ["python", "/app/main.py"]; later elements can be
+// paths that would be dropped (["/app/server", "--config", "/etc/app.toml"]);
+// an application driven by Cmd has no ep[0] at all; and a CGO_ENABLED=1 Go
+// binary or a `java -jar` needs a loader that lives in the source image. In
+// every one of those the image publishes, the attestation is well-formed, and
+// it dies on first exec.
+//
+// occupiedPaths still reads the entrypoint, and that is not the same thing. It
+// answers "what is already in this image" for the collision rules; nothing
+// there decides what crosses.
+//
+// # Where each thing lands
+//
+// The composed application's **entry** lands in the standardized plugin
+// directory, under its own file name. That directory is the one part of the
+// image an extension is meant to fill — build.go's appPluginDir comment has
+// been promising exactly that since before there was a way to fill it — and it
+// is what makes `ghcr.io/z5labs/avroc-gen-go` the base image plus
+// /usr/local/bin/avroc-gen-go and nothing else. It is emphatically not appDir:
+// that holds the application's own binary, the one the inherited entrypoint
+// names.
+//
+// Everything else the composed application carries lands **at its own path**.
+// A complete application is what may be composed, not a slim carrier that only
+// makes sense once merged, so a `from` whose image holds /etc/thing.conf puts
+// it at /etc/thing.conf here too. The hazard is not that a path is unobvious;
+// it is that two things want one path, and that is detectable — see the
+// collision rules below.
+//
+// # What is refused, and why each refusal is a real failure
+//
+//   - A **platform mismatch**. Every platform of the derived image is built
+//     from the matching platform of the base, and a set that does not match
+//     exactly is refused in both directions: a missing one would ship an index
+//     whose arm64 manifest holds an amd64 executable, which fails at exec time
+//     with the kernel's message and for nobody here, and an extra one would
+//     silently discard a platform the caller built.
+//   - A **path collision**, with the base or with an application composed
+//     earlier. The image would hold one thing while its documents describe
+//     two, which is the undetectable incompleteness the contribution mechanism
+//     exists to prevent, arriving through composition instead.
+//   - A **conflicting environment variable**. Environment is image-level and
+//     there is no namespacing, so two payloads wanting different values of one
+//     variable cannot coexist. Last-writer-wins would give one of them an
+//     environment it was never built for, silently.
+//   - A **declared payload of more than one file**, for now. The restriction
+//     is a check on the declaration rather than a limit of the seam: a
+//     single-executable payload is what every chain produces today, and a
+//     tree-shaped payload gets a refusal naming what is wrong instead of a
+//     silently broken published image.
+//
+// # Completeness is proven by running it
+//
+// No API shape establishes that a payload is complete. A script's imports, a
+// template opened on the first request, a dlopen, a CA bundle read at connect
+// time — enumerating a payload is always a guess. So Publish executes the
+// entry of every composed payload in the derived image before the first byte
+// moves, and the contract is that a payload runs under the base's environment
+// with nothing added. assertComposedPayloadsRun carries the mechanism and what
+// it can and cannot tell apart.
+
+// appPayload is what an application's constructor declared makes it runnable
+// inside its image.
+//
+// It is declared rather than derived, and that is the whole point: the only
+// thing that can know which paths make an application runnable is whatever put
+// them there. AppBuilder records the executable it packaged; a chain producing
+// an interpreted application would record its tree, and would owe a document
+// covering that tree the same way every contribution owes one.
+//
+// The type is unexported and the field carrying it is +private, so nothing
+// here reaches the schema. Its own fields are exported because the round trip
+// across a call boundary is encoding/json.
+type appPayload struct {
+	// Entry is the absolute path in the application's own image that is
+	// exec'd. It is empty for an App no constructor declared one for, which
+	// is a state no constructor in this module produces.
+	Entry string
+	// Files is every path the constructor declared, Entry included. It is a
+	// separate field rather than Entry alone because the payload is the unit
+	// that crosses and a payload is not always one file — the first-version
+	// restriction is a check on this slice, and a check on a field that could
+	// only ever hold one thing would be a tautology.
+	Files []string
+}
+
+// composedApp is one application composed into another: where its entry landed
+// in the derived image and which release it came from.
+//
+// The version is carried because it is the one fact about the composed
+// application that nothing else records. The SBOM says which module versions
+// went into that executable and the derived image is published under the
+// base's version, so without this nothing anywhere says which release of the
+// plugin shipped.
+type composedApp struct {
+	// Entry is the absolute path in the *derived* image, which is what
+	// Publish execs.
+	Entry string
+	// Version is the version the composed application was built under.
+	Version string
+}
+
+// WithApp composes another application's payload into every platform of this
+// one's image.
+//
+// The result is an ordinary App: published, annotated, signed and attested
+// exactly like any other, to a repository of its own that has nothing to do
+// with any binary's name. What comes out is the base program wearing one more
+// executable — it keeps the base's entrypoint, user, environment and
+// executable directory, and it is published under the base's version, because
+// the release it belongs to is the base's release.
+//
+// from's entry lands in the standardized plugin directory under its own file
+// name, so a base image whose CLI discovers plugins on the PATH finds it
+// without either side agreeing on anything but that directory. Everything else
+// from carries — its contributed files and directories — lands at its own
+// path. The file comment above records why the entry is read from the
+// declaration rather than from the entrypoint, and it is the single most
+// important thing about this method.
+//
+// There is no path argument and nothing is inferred. A composed application is
+// composed whole or refused: see the file comment for the four refusals and
+// why each is a failure that would otherwise publish cleanly and die on first
+// exec.
+//
+// Composition is not restricted to applications this module compiled, and a
+// derived image may be composed into in turn — the payload of the result is
+// the union of both sides', the collision surface grows and the semantics do
+// not. What gets nothing from this seam is an out-of-pipeline image built
+// `FROM` a published base: a stranger's Dockerfile adds bytes with no document
+// and has no mechanism to produce one, so that image's attestation describes
+// the base and nothing else.
+//
+// +cache="session"
+func (a *App) WithApp(
+	ctx context.Context,
+	// The application whose payload is composed into this one's image.
+	from *App,
+) (*App, error) {
+	if from == nil {
+		return nil, fmt.Errorf("withApp requires an application to compose")
+	}
+	if err := composablePayload(from.Payload); err != nil {
+		return nil, fmt.Errorf("withApp cannot compose this application: %v", err)
+	}
+	pairs, err := matchPlatforms(a.Variants, from.Variants)
+	if err != nil {
+		return nil, fmt.Errorf("withApp cannot compose this application: %v", err)
+	}
+	crossings := composedCrossings(from)
+	taken, err := a.occupiedPaths(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, c := range crossings {
+		if why := overlappingPath(c.To, taken); why != "" {
+			return nil, fmt.Errorf(
+				"withApp cannot put %s at %s: %s, and content that landed on top of it would leave the image's documents "+
+					"describing bytes that are not in it", c.Holder, c.To, why)
+		}
+		taken = append(taken, occupied{Path: c.To, Holder: c.Holder})
+	}
+	for _, pair := range pairs {
+		baseEnv, err := containerEnv(ctx, pair.Base.Container)
+		if err != nil {
+			return nil, fmt.Errorf("read the %s image's environment: %v", pair.Base.Platform, err)
+		}
+		fromEnv, err := containerEnv(ctx, pair.From.Container)
+		if err != nil {
+			return nil, fmt.Errorf("read the composed %s image's environment: %v", pair.From.Platform, err)
+		}
+		if err := composedEnvConflict(baseEnv, fromEnv); err != nil {
+			return nil, fmt.Errorf("withApp cannot compose this application: the %s images %v", pair.Base.Platform, err)
+		}
+	}
+	// Nothing above this line has changed anything. Every refusal is made
+	// before the first variant is touched, so a WithApp that fails leaves the
+	// App exactly as it found it rather than half composed.
+	destinations := make(map[string]string, len(crossings))
+	for _, c := range crossings {
+		destinations[c.From] = c.To
+	}
+	for _, pair := range pairs {
+		for _, c := range pair.From.Contributions {
+			to, ok := destinations[c.Path]
+			if !ok {
+				// Unreachable while every contribution is made through the
+				// paths composedCrossings reads. It is an error rather than a
+				// silent skip because the thing it would skip is bytes: an
+				// image missing a file its documents describe is exactly what
+				// this seam refuses everywhere else.
+				return nil, fmt.Errorf(
+					"withApp: the composed application carries %s in its %s image, which its declaration does not account for",
+					c.Path, pair.From.Platform)
+			}
+			pair.Base.Container = placeContribution(pair.Base.Container, to, to == destinations[from.Payload.Entry], c)
+			pair.Base.Contributions = append(pair.Base.Contributions, contribution{
+				Name:    c.Name,
+				Path:    to,
+				File:    c.File,
+				Content: c.Content,
+				Tree:    c.Tree,
+			})
+		}
+	}
+	for _, c := range crossings {
+		a.ContributedPaths = append(a.ContributedPaths, occupied{Path: c.To, Holder: c.Holder})
+	}
+	a.Composed = append(a.Composed, composedApp{
+		Entry:   destinations[from.Payload.Entry],
+		Version: from.Version,
+	})
+	a.Composed = append(a.Composed, from.Composed...)
+	return a, nil
+}
+
+// crossing is one thing a composed application brings into the derived image:
+// where it lives in its own image, where it lands here, and what to call it in
+// a refusal.
+type crossing struct {
+	From   string
+	To     string
+	Holder string
+}
+
+// composedCrossings is everything from brings, and where each of it lands.
+//
+// The entry moves — from appDir in its own image to the plugin directory here
+// — and everything else keeps its path. That asymmetry is the design: the
+// entry is the one thing whose location is a property of the *relationship*
+// between the two images, because the base's CLI has to be able to find it,
+// while a contributed file's path is a property of the application that
+// contributed it.
+func composedCrossings(from *App) []crossing {
+	entry := composedEntryPath(from.Payload.Entry)
+	out := make([]crossing, 0, 1+len(from.ContributedPaths))
+	out = append(out, crossing{
+		From:   from.Payload.Entry,
+		To:     entry,
+		Holder: "the entry of the application composed at " + entry,
+	})
+	for _, p := range from.ContributedPaths {
+		out = append(out, crossing{
+			From:   p.Path,
+			To:     p.Path,
+			Holder: p.Holder + ", brought in by the application composed at " + entry,
+		})
+	}
+	return out
+}
+
+// composedEntryPath is where a composed application's entry lands: the
+// standardized plugin directory, under the entry's own file name.
+func composedEntryPath(entry string) string {
+	return appPluginDir + "/" + imagepath.Base(entry)
+}
+
+// placeContribution copies one of the composed application's contributions
+// into the derived image at to.
+//
+// The modes and the owner are re-applied here rather than inherited from the
+// source image, and both are the module's rather than either application's —
+// the same rule contribute.go states, reached through a different door. The
+// entry gets the executable mode because it is the one file in the payload
+// that is exec'd; everything else gets the read-only mode its own contribution
+// got.
+func placeContribution(ctr *dagger.Container, to string, isEntry bool, c contribution) *dagger.Container {
+	if c.Tree != nil {
+		return ctr.WithDirectory(to, normalizedTree(c.Tree), dagger.ContainerWithDirectoryOpts{
+			Owner: appOwner,
+		})
+	}
+	mode := contributedFileMode
+	if isEntry {
+		mode = entryMode
+	}
+	return ctr.WithFile(to, c.Content, dagger.ContainerWithFileOpts{
+		Owner:       appOwner,
+		Permissions: mode,
+	})
+}
+
+// variantPair is one platform's base variant beside the composed
+// application's variant for the same platform.
+type variantPair struct {
+	Base *variant
+	From *variant
+}
+
+// matchPlatforms pairs every base variant with the composed application's
+// variant for the same platform, and refuses a set that does not match
+// exactly.
+//
+// Both directions are refused and neither is pedantry. A platform the composed
+// application does not carry would publish an index whose manifest for that
+// architecture holds an executable built for another one — the failure arrives
+// at exec time, with the kernel's message, in front of a consumer. A platform
+// the *base* does not carry is a variant the caller built and paid for that
+// would be dropped without a word.
+//
+// The message names both sides in the order they were built, because a caller
+// looking at "linux/amd64" alone cannot tell which side is missing it.
+func matchPlatforms(base, from []*variant) ([]variantPair, error) {
+	if len(base) == 0 {
+		return nil, fmt.Errorf("this application carries no images to compose into")
+	}
+	if len(from) == 0 {
+		return nil, fmt.Errorf("the application being composed carries no images")
+	}
+	byPlatform := make(map[dagger.Platform]*variant, len(from))
+	for _, v := range from {
+		byPlatform[v.Platform] = v
+	}
+	pairs := make([]variantPair, 0, len(base))
+	var missing []string
+	for _, v := range base {
+		other, ok := byPlatform[v.Platform]
+		if !ok {
+			missing = append(missing, string(v.Platform))
+			continue
+		}
+		delete(byPlatform, v.Platform)
+		pairs = append(pairs, variantPair{Base: v, From: other})
+	}
+	extra := make([]string, 0, len(byPlatform))
+	for p := range byPlatform {
+		extra = append(extra, string(p))
+	}
+	sort.Strings(extra)
+	if len(missing) > 0 || len(extra) > 0 {
+		return nil, fmt.Errorf(
+			"every platform of the derived image has to be built from the matching platform of the application composed into it, "+
+				"and this image carries %s while that one carries %s%s",
+			strings.Join(platformsOf(base), ", "), strings.Join(platformsOf(from), ", "), mismatchDetail(missing, extra))
+	}
+	return pairs, nil
+}
+
+// platformsOf names a variant set's platforms in the order they were built.
+func platformsOf(variants []*variant) []string {
+	out := make([]string, 0, len(variants))
+	for _, v := range variants {
+		out = append(out, string(v.Platform))
+	}
+	return out
+}
+
+// mismatchDetail says which way round the mismatch is, so the reader does not
+// have to diff two lists themselves.
+func mismatchDetail(missing, extra []string) string {
+	var parts []string
+	if len(missing) > 0 {
+		parts = append(parts, "nothing would be composed into "+strings.Join(missing, ", "))
+	}
+	if len(extra) > 0 {
+		parts = append(parts, "the payload built for "+strings.Join(extra, ", ")+" would be discarded")
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return " — " + strings.Join(parts, ", and ")
+}
+
+// composablePayload reports why a declared payload cannot be composed, or nil
+// when it can.
+//
+// The restriction is the first version's, and it is deliberately a check on
+// the *declaration* rather than a limit of the seam: everything below this
+// function handles a payload of any shape, and every chain that exists today
+// declares exactly one file. A chain that declared a tree would need a
+// document covering that tree, and would need this refusal replaced by
+// whatever proves the tree is complete — so until then a tree gets a message
+// naming what is wrong instead of an image that publishes and does not run.
+//
+// It is a free function over a declaration rather than a method reading an
+// App, and that is what makes the multi-file branch testable at all: nothing
+// in this module's public API can declare a payload of more than one file
+// today, so driving it end to end is impossible and the branch would be
+// deletable with every test still green. ComposeSelfTest drives it in process.
+// diffImageEnv is split the same way, for the same reason.
+func composablePayload(p appPayload) error {
+	if p.Entry == "" {
+		return fmt.Errorf(
+			"it declares no payload, so there is nothing to compose; an application built by this module always declares one, " +
+				"and one that does not was assembled some other way")
+	}
+	if len(p.Files) > 1 {
+		return fmt.Errorf(
+			"its declared payload is %s, and composing more than one file is not supported yet; "+
+				"a payload of one executable is what every chain produces today, and a tree-shaped one needs a document "+
+				"covering the tree before it can be composed rather than published broken",
+			strings.Join(p.Files, ", "))
+	}
+	if len(p.Files) == 1 && p.Files[0] != p.Entry {
+		return fmt.Errorf(
+			"its declared payload is %s while its entry is %s, so the file that would be exec'd is not one it declared",
+			p.Files[0], p.Entry)
+	}
+	return nil
+}
+
+// containerEnv reads one image's environment as a map.
+func containerEnv(ctx context.Context, ctr *dagger.Container) (map[string]string, error) {
+	vars, err := ctr.EnvVariables(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]string, len(vars))
+	for i := range vars {
+		name, err := vars[i].Name(ctx)
+		if err != nil {
+			return nil, err
+		}
+		value, err := vars[i].Value(ctx)
+		if err != nil {
+			return nil, err
+		}
+		out[name] = value
+	}
+	return out, nil
+}
+
+// composedEnvConflict reports why two images' environments cannot coexist in
+// one image, or nil when they can.
+//
+// Equality rather than containment, in both directions, which is the same rule
+// diffImageEnv holds a published image to and for a stronger reason here.
+// Environment is image-level and has no namespacing, so there is no way to
+// give two payloads different values of one variable — and a variable one side
+// declares and the other does not is not a free addition either: the derived
+// image inherits the base's environment, so carrying it would restate the
+// base's environment and dropping it would run a payload without something it
+// declared it needed. Both are silent. Refusing is not.
+//
+// It is a free function over two maps for the reason composablePayload is one:
+// no caller-facing seam can put a variable on an image today — see the package
+// doc's "Environment is a runtime concern" — so every branch here is driven in
+// process by ComposeSelfTest rather than by building two applications that
+// cannot disagree.
+func composedEnvConflict(base, from map[string]string) error {
+	for _, name := range sortedKeys(from) {
+		value, ok := base[name]
+		if !ok {
+			return fmt.Errorf(
+				"disagree about %s: the application being composed declares %s=%q and the base declares no %s, "+
+					"and a derived image inherits the base's environment rather than restating it",
+				name, name, from[name], name)
+		}
+		if value != from[name] {
+			return fmt.Errorf(
+				"disagree about %s: the base declares %s=%q and the application being composed declares %s=%q, "+
+					"and one image has one environment",
+				name, name, value, name, from[name])
+		}
+	}
+	for _, name := range sortedKeys(base) {
+		if _, ok := from[name]; !ok {
+			return fmt.Errorf(
+				"disagree about %s: the base declares %s=%q and the application being composed declares no %s, "+
+					"so it would run under an environment it was not built for",
+				name, name, base[name], name)
+		}
+	}
+	return nil
+}
+
+// execRefusal reports why the runtime could not start entry, and whether that
+// is what happened at all.
+//
+// This is the whole of the "run it to prove it is complete" check, and it is a
+// string match because the exit code cannot answer the question. Measured on
+// Dagger v0.21.8: an exec that never starts — a binary for another
+// architecture, a dynamically linked executable whose loader is not in the
+// image — comes back through ReturnTypeAny as **exit code 1** with the
+// runtime's own message on stderr, which is indistinguishable by exit code
+// alone from a CLI that exits 1 because it was run with no arguments. Refusing
+// on a non-zero exit would therefore refuse most working CLIs, and accepting
+// exit 1 would accept every payload this check exists to catch.
+//
+// What is matched is the prefix the Go runtime writes before the process
+// exists at all: "fork/exec <the exact path we asked for>: ". The program
+// contributed nothing to stderr in that case, because it never ran. A program
+// that ran and chose to print that exact prefix, with its own absolute path in
+// it, would fail the publish with a message quoting what it printed — an
+// outcome worth having over the alternative, which is a silent pass for
+// everything above.
+//
+// The limit worth stating: this proves the entry *starts*, not that it works.
+// A payload missing a template it opens on the first request still publishes.
+// That is the honest boundary of a smoke test, and it is a long way past what
+// inspecting an API shape can establish.
+func execRefusal(entry, stderr string) (string, bool) {
+	prefix := "fork/exec " + entry + ": "
+	if !strings.HasPrefix(stderr, prefix) {
+		return "", false
+	}
+	reason, _, _ := strings.Cut(strings.TrimPrefix(stderr, prefix), "\n")
+	return strings.TrimSpace(reason), true
+}
+
+// assertComposedPayloadsRun executes the entry of every composed payload in
+// every platform's derived image, and refuses to publish one that cannot
+// start.
+//
+// It runs at publish time, beside the other things that have to be true before
+// the first byte moves, and for the same reason: a payload that cannot run is
+// an image that publishes cleanly, attests cleanly and dies in front of a
+// consumer. Doing it here rather than in WithApp also keeps composition lazy —
+// a chained builder that forced every platform's build would turn a call that
+// costs nothing into one that costs a full cross-compile, which is the reason
+// withVariantNamed exists.
+//
+// The entry is run with no arguments and no stdin, because the contract being
+// checked is that a payload runs under the base's environment with *nothing*
+// added. Any exit code passes; only a failure to start does not. The cost that
+// buys is real and is accepted knowingly: an entry that blocks forever when
+// run with no arguments blocks the publish. A payload composed into a base is
+// an extension the base's CLI invokes, and one that cannot be started and left
+// to exit is one no consumer can drive either.
+func (a *App) assertComposedPayloadsRun(ctx context.Context) error {
+	for _, c := range a.Composed {
+		for _, v := range a.Variants {
+			stderr, err := v.Container.
+				WithExec([]string{c.Entry}, dagger.ContainerWithExecOpts{Expect: dagger.ReturnTypeAny}).
+				Stderr(ctx)
+			if err != nil {
+				return fmt.Errorf("refusing to publish: running %s in the %s image: %v", c.Entry, v.Platform, err)
+			}
+			if reason, refused := execRefusal(c.Entry, stderr); refused {
+				return fmt.Errorf(
+					"refusing to publish: %s could not be started in the %s image (%s); a composed payload has to run under "+
+						"the base's environment with nothing added, and this one needs something the image does not have",
+					c.Entry, v.Platform, reason)
+			}
+		}
+	}
+	return nil
+}

--- a/daggerverse/z5labs/composeselftest.go
+++ b/daggerverse/z5labs/composeselftest.go
@@ -44,7 +44,109 @@ func (m *Z5labs) ComposeSelfTest(ctx context.Context) error {
 	if err := checkExecRefusals(); err != nil {
 		return err
 	}
-	return checkComposedCrossings()
+	if err := checkComposedCrossings(); err != nil {
+		return err
+	}
+	return checkComposeWiring(ctx)
+}
+
+// checkComposeWiring drives WithApp itself over the refusals whose rules the
+// tables above check in isolation.
+//
+// It exists because a rule and its wiring are two things, and two of these
+// rules have no route in through the public API at all: nothing caller-facing
+// can declare a multi-file payload or put an environment variable on an image,
+// so `composablePayload` and `composedEnvConflict` could be left unreferenced
+// by WithApp and every other test here would still pass. That is the failure
+// mode a table alone cannot see.
+//
+// The applications are constructed as struct literals rather than through a
+// constructor, which is the whole reason this is a module self-test and not a
+// test in tests/: nothing outside this package can build an App that is wrong
+// in these particular ways, and an assertion that cannot be driven is an
+// assertion that gets deleted.
+//
+// The containers are real, because the environment check reads them. They are
+// empty containers with variables set and nothing else, so no image is built
+// and nothing is compiled.
+func checkComposeWiring(ctx context.Context) error {
+	const platform = dagger.Platform("linux/amd64")
+	build := func(entry string, env map[string]string, mutate func(*App)) *App {
+		ctr := dag.Container(dagger.ContainerOpts{Platform: platform})
+		for _, name := range sortedKeys(env) {
+			ctr = ctr.WithEnvVariable(name, env[name])
+		}
+		app := &App{
+			Version: "v1.0.0",
+			Variants: []*variant{{
+				Platform:      platform,
+				Container:     ctr,
+				Contributions: []contribution{{Name: "gen", Path: entry}},
+			}},
+			Payload: appPayload{Entry: entry, Files: []string{entry}},
+		}
+		if mutate != nil {
+			mutate(app)
+		}
+		return app
+	}
+	standard := map[string]string{"PATH": appPath}
+
+	cases := []struct {
+		base, from *App
+		refusal    string
+		why        string
+	}{
+		{
+			base:    build("/app/hello", standard, nil),
+			from:    build("/app/gen", map[string]string{"PATH": "/opt/bin"}, nil),
+			refusal: "one image has one environment",
+			why:     "an environment conflict, which no caller-facing seam can produce and which last-writer-wins would hide",
+		},
+		{
+			base: build("/app/hello", standard, nil),
+			from: build("/app/gen", standard, func(a *App) {
+				a.Payload.Files = []string{"/app/gen", "/app/lib/runtime.so"}
+			}),
+			refusal: "composing more than one file is not supported yet",
+			why:     "a multi-file declared payload, which no constructor here can produce",
+		},
+		{
+			base: build("/app/hello", standard, nil),
+			from: build("/app/gen", standard, func(a *App) {
+				// A declaration naming an entry, and a variant carrying
+				// something else entirely: everything the variant does carry
+				// is accounted for, so only the other direction can see this.
+				a.ContributedPaths = []occupied{{Path: "/etc/thing.conf", Holder: contributedHolder}}
+				a.Variants[0].Contributions = []contribution{{Name: "thing.conf", Path: "/etc/thing.conf"}}
+			}),
+			refusal: "carries nothing for",
+			why:     "a declaration whose entry no contribution answers to, which would record a composed path holding no bytes",
+		},
+	}
+	for _, c := range cases {
+		if _, err := c.base.WithApp(ctx, c.from); err == nil {
+			return fmt.Errorf("expected withApp to refuse %s, got nil", c.why)
+		} else if !strings.Contains(err.Error(), c.refusal) {
+			return fmt.Errorf("expected the refusal of %s to mention %q, got: %v", c.why, c.refusal, err)
+		}
+	}
+
+	// A refusal must leave the base untouched. It is checked on the last case
+	// above rather than on a case of its own because the refusal that fires
+	// latest is the one with the most work already done behind it.
+	base := build("/app/hello", standard, nil)
+	from := build("/app/gen", standard, func(a *App) {
+		a.Variants[0].Contributions[0].Path = "/app/somewhere-else"
+	})
+	if _, err := base.WithApp(ctx, from); err == nil {
+		return fmt.Errorf("expected withApp to refuse a declaration nothing answers to, got nil")
+	}
+	if len(base.Variants[0].Contributions) != 1 || len(base.ContributedPaths) != 0 || len(base.Composed) != 0 {
+		return fmt.Errorf("a refused withApp left the base holding %d contributions, %d paths and %d composed applications, want 1, 0 and 0",
+			len(base.Variants[0].Contributions), len(base.ContributedPaths), len(base.Composed))
+	}
+	return nil
 }
 
 // checkComposablePayloads drives composablePayload over every shape of

--- a/daggerverse/z5labs/composeselftest.go
+++ b/daggerverse/z5labs/composeselftest.go
@@ -1,0 +1,374 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"dagger/z-5-labs/internal/dagger"
+)
+
+// ComposeSelfTest checks the rules that decide whether one application's
+// payload may be composed into another's image.
+//
+// It sits on the module rather than in tests/ for the reason
+// ImageEnvironmentSelfTest and ContributionPathSelfTest record, and here the
+// reason is stronger than economy. Two of these rules cannot be driven through
+// the public API at all: no constructor in this module can declare a payload
+// of more than one file, and no caller-facing seam can put an environment
+// variable on an image — so a multi-file payload and a conflicting variable
+// are branches that would be unexecutable end to end, and therefore deletable
+// tomorrow with every test still green. Split out as free functions over
+// declarations and maps, every branch runs in process.
+//
+// The end-to-end half — that the refusals really are wired into WithApp, that
+// a composed payload lands where the plugin directory promises, and that the
+// derived image is published, annotated and attested like any other — is in
+// tests/, where it costs a pair of applications instead of a table.
+//
+// It runs in process and needs no container, so it is cheap enough to be a
+// check of its own.
+//
+// +check
+// +cache="session"
+func (m *Z5labs) ComposeSelfTest(ctx context.Context) error {
+	if err := checkComposablePayloads(); err != nil {
+		return err
+	}
+	if err := checkComposedEnvConflicts(); err != nil {
+		return err
+	}
+	if err := checkPlatformMatching(); err != nil {
+		return err
+	}
+	if err := checkExecRefusals(); err != nil {
+		return err
+	}
+	return checkComposedCrossings()
+}
+
+// checkComposablePayloads drives composablePayload over every shape of
+// declaration that decides a rule.
+func checkComposablePayloads() error {
+	cases := []struct {
+		payload appPayload
+		// refusal is a substring the refusal must carry, and "" means the
+		// payload has to be accepted.
+		refusal string
+		why     string
+	}{
+		{
+			payload: appPayload{Entry: "/app/gen", Files: []string{"/app/gen"}},
+			why:     "the ordinary case: one executable, which is what every chain produces today",
+		},
+		{
+			payload: appPayload{},
+			refusal: "declares no payload",
+			why:     "an App no constructor in this module produced",
+		},
+		{
+			payload: appPayload{Entry: "/app/gen", Files: []string{"/app/gen", "/app/lib/runtime.so"}},
+			refusal: "composing more than one file is not supported yet",
+			why:     "a tree-shaped payload, which is refused rather than published broken",
+		},
+		{
+			payload: appPayload{Entry: "/app/gen", Files: []string{"/app/other"}},
+			refusal: "the file that would be exec'd is not one it declared",
+			why:     "a declaration that does not cover its own entry",
+		},
+	}
+	for _, c := range cases {
+		err := composablePayload(c.payload)
+		if c.refusal == "" {
+			if err != nil {
+				return fmt.Errorf("expected the payload %v to be composable (%s), got: %v", c.payload.Files, c.why, err)
+			}
+			continue
+		}
+		if err == nil {
+			return fmt.Errorf("expected the payload %v to be refused (%s), got nil", c.payload.Files, c.why)
+		}
+		if !strings.Contains(err.Error(), c.refusal) {
+			return fmt.Errorf("expected the refusal of %v to mention %q (%s), got: %v", c.payload.Files, c.refusal, c.why, err)
+		}
+	}
+	// The multi-file refusal has to name what is wrong rather than merely
+	// report that something is: a caller told only "unsupported" has no way
+	// to find out which file made it so.
+	err := composablePayload(appPayload{Entry: "/app/gen", Files: []string{"/app/gen", "/app/lib/runtime.so"}})
+	if err == nil {
+		return fmt.Errorf("expected a multi-file payload to be refused, got nil")
+	}
+	for _, want := range []string{"/app/gen", "/app/lib/runtime.so"} {
+		if !strings.Contains(err.Error(), want) {
+			return fmt.Errorf("expected the multi-file refusal to name %s, got: %v", want, err)
+		}
+	}
+	return nil
+}
+
+// checkComposedEnvConflicts drives composedEnvConflict over the three ways two
+// environments can fail to be one environment, and the one way they cannot.
+func checkComposedEnvConflicts() error {
+	standard := map[string]string{"PATH": appPath}
+	cases := []struct {
+		base, from map[string]string
+		refusal    string
+		why        string
+	}{
+		{
+			base: standard,
+			from: map[string]string{"PATH": appPath},
+			why:  "the ordinary case: both sides carry the standardized environment and nothing else",
+		},
+		{
+			base: map[string]string{},
+			from: map[string]string{},
+			why:  "two images that declare nothing agree about nothing to disagree over",
+		},
+		{
+			base:    map[string]string{"PATH": appPath},
+			from:    map[string]string{"PATH": "/opt/bin"},
+			refusal: "one image has one environment",
+			why:     "the same variable with two values, which last-writer-wins would resolve silently",
+		},
+		{
+			base:    map[string]string{"PATH": appPath},
+			from:    map[string]string{"PATH": appPath, "PYTHONPATH": "/app/lib"},
+			refusal: "the base declares no PYTHONPATH",
+			why:     "a variable only the composed payload declares, which the derived image would have to restate the base's environment to carry",
+		},
+		{
+			base:    map[string]string{"PATH": appPath, "JAVA_HOME": "/opt/java"},
+			from:    map[string]string{"PATH": appPath},
+			refusal: "it would run under an environment it was not built for",
+			why:     "a variable only the base declares, which the payload never saw",
+		},
+	}
+	for _, c := range cases {
+		err := composedEnvConflict(c.base, c.from)
+		if c.refusal == "" {
+			if err != nil {
+				return fmt.Errorf("expected %v and %v to compose (%s), got: %v", c.base, c.from, c.why, err)
+			}
+			continue
+		}
+		if err == nil {
+			return fmt.Errorf("expected %v and %v to be refused (%s), got nil", c.base, c.from, c.why)
+		}
+		if !strings.Contains(err.Error(), c.refusal) {
+			return fmt.Errorf("expected the refusal of %v and %v to mention %q (%s), got: %v", c.base, c.from, c.refusal, c.why, err)
+		}
+	}
+	// The value disagreement has to quote both values. A caller told only
+	// which variable disagrees still has to go and read two images to find
+	// out how.
+	err := composedEnvConflict(map[string]string{"PATH": "/a"}, map[string]string{"PATH": "/b"})
+	if err == nil {
+		return fmt.Errorf("expected two values of PATH to be refused, got nil")
+	}
+	for _, want := range []string{`"/a"`, `"/b"`} {
+		if !strings.Contains(err.Error(), want) {
+			return fmt.Errorf("expected the refusal to quote %s, got: %v", want, err)
+		}
+	}
+	return nil
+}
+
+// checkPlatformMatching drives matchPlatforms over the sets that pair and the
+// sets that cannot.
+//
+// The containers are nil throughout: matchPlatforms decides on platforms
+// alone, which is what lets the rule be checked without building an image per
+// row.
+func checkPlatformMatching() error {
+	variants := func(platforms ...dagger.Platform) []*variant {
+		out := make([]*variant, 0, len(platforms))
+		for _, p := range platforms {
+			out = append(out, &variant{Platform: p})
+		}
+		return out
+	}
+	cases := []struct {
+		base, from []*variant
+		refusal    string
+		why        string
+	}{
+		{
+			base: variants("linux/amd64", "linux/arm64"),
+			from: variants("linux/amd64", "linux/arm64"),
+			why:  "the ordinary case",
+		},
+		{
+			base: variants("linux/amd64", "linux/arm64"),
+			from: variants("linux/arm64", "linux/amd64"),
+			why:  "the same set in another order, which is the same set",
+		},
+		{
+			base: variants("linux/amd64"),
+			from: variants("linux/amd64"),
+			why:  "a single-platform application, which is not a degenerate case",
+		},
+		{
+			base:    variants("linux/amd64", "linux/arm64"),
+			from:    variants("linux/amd64"),
+			refusal: "nothing would be composed into linux/arm64",
+			why:     "a platform the payload was not built for, which would ship an index holding an executable for another architecture",
+		},
+		{
+			base:    variants("linux/amd64"),
+			from:    variants("linux/amd64", "linux/arm64"),
+			refusal: "the payload built for linux/arm64 would be discarded",
+			why:     "a platform only the payload carries, which would be dropped without a word",
+		},
+		{
+			base:    nil,
+			from:    variants("linux/amd64"),
+			refusal: "carries no images to compose into",
+			why:     "an application with no variants at all",
+		},
+		{
+			base:    variants("linux/amd64"),
+			from:    nil,
+			refusal: "the application being composed carries no images",
+			why:     "a payload with no variants at all",
+		},
+	}
+	for _, c := range cases {
+		pairs, err := matchPlatforms(c.base, c.from)
+		if c.refusal == "" {
+			if err != nil {
+				return fmt.Errorf("expected %v and %v to pair (%s), got: %v", platformsOf(c.base), platformsOf(c.from), c.why, err)
+			}
+			if len(pairs) != len(c.base) {
+				return fmt.Errorf("expected %d pairs (%s), got %d", len(c.base), c.why, len(pairs))
+			}
+			// Every pair has to be one platform on both sides. Pairing a
+			// base variant with the wrong architecture's payload is the exact
+			// failure this function exists to make impossible, and a length
+			// check alone would not see it.
+			for i, pair := range pairs {
+				if pair.Base.Platform != c.base[i].Platform {
+					return fmt.Errorf("expected pair %d to be built from %s, got %s", i, c.base[i].Platform, pair.Base.Platform)
+				}
+				if pair.From.Platform != pair.Base.Platform {
+					return fmt.Errorf("paired the %s image with a %s payload", pair.Base.Platform, pair.From.Platform)
+				}
+			}
+			continue
+		}
+		if err == nil {
+			return fmt.Errorf("expected %v and %v to be refused (%s), got nil", platformsOf(c.base), platformsOf(c.from), c.why)
+		}
+		if !strings.Contains(err.Error(), c.refusal) {
+			return fmt.Errorf("expected the refusal to mention %q (%s), got: %v", c.refusal, c.why, err)
+		}
+	}
+	return nil
+}
+
+// checkExecRefusals drives execRefusal over what the runtime writes when a
+// payload cannot be started, and over what a payload that did start writes.
+//
+// The two refused rows are the messages measured on Dagger v0.21.8 for the
+// two failures this check exists to catch: an executable built for another
+// architecture, and a dynamically linked one whose loader is not in the image.
+// Both come back through ReturnTypeAny as exit code 1, which is why the exit
+// code is not what decides.
+func checkExecRefusals() error {
+	const entry = "/usr/local/bin/gen"
+	cases := []struct {
+		stderr string
+		reason string
+		why    string
+	}{
+		{
+			stderr: "fork/exec " + entry + ": exec format error\n",
+			reason: "exec format error",
+			why:    "an executable built for another architecture",
+		},
+		{
+			stderr: "fork/exec " + entry + ": no such file or directory\n",
+			reason: "no such file or directory",
+			why:    "a dynamically linked executable whose loader is not in the image",
+		},
+		{
+			stderr: "",
+			why:    "a payload that started and said nothing",
+		},
+		{
+			stderr: "usage: gen [flags]\n",
+			why:    "a CLI that started, printed its usage and exited non-zero, which is not a failure to start",
+		},
+		{
+			stderr: "fork/exec /usr/local/bin/other: exec format error\n",
+			why:    "the runtime's message about some other path, which says nothing about this entry",
+		},
+		{
+			stderr: "warning: fork/exec " + entry + ": exec format error\n",
+			why:    "a payload that ran and mentioned the message rather than being the subject of it",
+		},
+	}
+	for _, c := range cases {
+		reason, refused := execRefusal(entry, c.stderr)
+		if c.reason == "" {
+			if refused {
+				return fmt.Errorf("expected %q to be read as a payload that started (%s), got refused with %q", c.stderr, c.why, reason)
+			}
+			continue
+		}
+		if !refused {
+			return fmt.Errorf("expected %q to be read as a failure to start (%s), got accepted", c.stderr, c.why)
+		}
+		if reason != c.reason {
+			return fmt.Errorf("expected the reason for %q to be %q (%s), got %q", c.stderr, c.reason, c.why, reason)
+		}
+	}
+	return nil
+}
+
+// checkComposedCrossings drives composedCrossings over an application carrying
+// an entry and contributions of its own.
+//
+// The two things asserted are the two halves of the placement rule, and they
+// are not symmetric: the entry *moves*, from the executable directory in its
+// own image to the plugin directory here, because the base's CLI has to be
+// able to find it; everything else keeps its own path, because a complete
+// application is what may be composed.
+func checkComposedCrossings() error {
+	from := &App{
+		Payload: appPayload{Entry: "/app/gen", Files: []string{"/app/gen"}},
+		ContributedPaths: []occupied{
+			{Path: "/etc/thing.conf", Holder: contributedHolder},
+			{Path: "/srv/templates", Holder: contributedHolder},
+		},
+	}
+	got := composedCrossings(from)
+	want := []crossing{
+		{From: "/app/gen", To: appPluginDir + "/gen"},
+		{From: "/etc/thing.conf", To: "/etc/thing.conf"},
+		{From: "/srv/templates", To: "/srv/templates"},
+	}
+	if len(got) != len(want) {
+		return fmt.Errorf("expected %d things to cross, got %d", len(want), len(got))
+	}
+	for i, w := range want {
+		if got[i].From != w.From || got[i].To != w.To {
+			return fmt.Errorf("expected %s to land at %s, got %s landing at %s", w.From, w.To, got[i].From, got[i].To)
+		}
+		// The holder is what a collision refusal reads out, so every crossing
+		// has to name the application it came from rather than leave the
+		// reader to guess which composition put it there.
+		if !strings.Contains(got[i].Holder, appPluginDir+"/gen") {
+			return fmt.Errorf("expected the holder of %s to name the composed application, got %q", w.To, got[i].Holder)
+		}
+	}
+	// The entry must not stay in the executable directory: that is the
+	// application's own binary's home in every image, and an entry landing
+	// there would collide with the base's binary on the very first
+	// composition rather than sitting on the PATH where the base can find it.
+	if strings.HasPrefix(got[0].To, appDir+"/") {
+		return fmt.Errorf("expected the composed entry to leave %s, got %s", appDir, got[0].To)
+	}
+	return nil
+}

--- a/daggerverse/z5labs/contribute.go
+++ b/daggerverse/z5labs/contribute.go
@@ -172,9 +172,9 @@ func (a *App) WithFile(
 			Owner:       appOwner,
 			Permissions: contributedFileMode,
 		})
-		v.Contributions = append(v.Contributions, contribution{Name: clean, File: document, Content: file})
+		v.Contributions = append(v.Contributions, contribution{Name: clean, Path: clean, File: document, Content: file})
 	}
-	a.ContributedPaths = append(a.ContributedPaths, clean)
+	a.ContributedPaths = append(a.ContributedPaths, occupied{Path: clean, Holder: contributedHolder})
 	return a, nil
 }
 
@@ -216,9 +216,9 @@ func (a *App) WithDirectory(
 		v.Container = v.Container.WithDirectory(clean, tree, dagger.ContainerWithDirectoryOpts{
 			Owner: appOwner,
 		})
-		v.Contributions = append(v.Contributions, contribution{Name: clean, File: document, Tree: dir})
+		v.Contributions = append(v.Contributions, contribution{Name: clean, Path: clean, File: document, Tree: dir})
 	}
-	a.ContributedPaths = append(a.ContributedPaths, clean)
+	a.ContributedPaths = append(a.ContributedPaths, occupied{Path: clean, Holder: contributedHolder})
 	return a, nil
 }
 
@@ -266,6 +266,12 @@ type occupied struct {
 	Holder string
 }
 
+// contributedHolder is what WithFile and WithDirectory record as holding the
+// path they landed at. Composition records something more specific — which
+// application brought the bytes — which is the reason the holder is carried
+// with the path rather than assumed by whatever reads the list.
+const contributedHolder = "content already contributed"
+
 // occupiedPaths is every path in the image that something already holds: the
 // entrypoint each variant runs, and everything contributed before now.
 //
@@ -278,9 +284,7 @@ type occupied struct {
 // App state is a value that can disagree with them.
 func (a *App) occupiedPaths(ctx context.Context) ([]occupied, error) {
 	out := make([]occupied, 0, len(a.ContributedPaths)+len(a.Variants))
-	for _, p := range a.ContributedPaths {
-		out = append(out, occupied{Path: p, Holder: "content already contributed"})
-	}
+	out = append(out, a.ContributedPaths...)
 	for _, v := range a.Variants {
 		entrypoint, err := v.Container.Entrypoint(ctx)
 		if err != nil {

--- a/daggerverse/z5labs/dagger.gen.go
+++ b/daggerverse/z5labs/dagger.gen.go
@@ -156,7 +156,9 @@ func (r App) MarshalJSON() ([]byte, error) {
 		SourceURI           string
 		Pkg                 string
 		Variants            []*variant
-		ContributedPaths    []string
+		ContributedPaths    []occupied
+		Payload             appPayload
+		Composed            []composedApp
 		Registry            string
 		RegistryUsername    string
 		RegistryAuth        *dagger.Secret
@@ -173,6 +175,8 @@ func (r App) MarshalJSON() ([]byte, error) {
 	concrete.Pkg = r.Pkg
 	concrete.Variants = r.Variants
 	concrete.ContributedPaths = r.ContributedPaths
+	concrete.Payload = r.Payload
+	concrete.Composed = r.Composed
 	concrete.Registry = r.Registry
 	concrete.RegistryUsername = r.RegistryUsername
 	concrete.RegistryAuth = r.RegistryAuth
@@ -192,7 +196,9 @@ func (r *App) UnmarshalJSON(bs []byte) error {
 		SourceURI           string
 		Pkg                 string
 		Variants            []*variant
-		ContributedPaths    []string
+		ContributedPaths    []occupied
+		Payload             appPayload
+		Composed            []composedApp
 		Registry            string
 		RegistryUsername    string
 		RegistryAuth        *dagger.Secret
@@ -213,6 +219,8 @@ func (r *App) UnmarshalJSON(bs []byte) error {
 	r.Pkg = concrete.Pkg
 	r.Variants = concrete.Variants
 	r.ContributedPaths = concrete.ContributedPaths
+	r.Payload = concrete.Payload
+	r.Composed = concrete.Composed
 	r.Registry = concrete.Registry
 	r.RegistryUsername = concrete.RegistryUsername
 	r.RegistryAuth = concrete.RegistryAuth
@@ -379,6 +387,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*App).Publish(&parent, ctx, repositories)
+		case "WithApp":
+			var parent App
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var from *App
+			if inputArgs["from"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["from"]), &from)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg from", err))
+				}
+			}
+			return (*App).WithApp(&parent, ctx, from)
 		case "WithDirectory":
 			var parent App
 			err = json.Unmarshal(parentJSON, &parent)
@@ -688,6 +710,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Z5labs).App(&parent, version), nil
+		case "ComposeSelfTest":
+			var parent Z5labs
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Z5labs).ComposeSelfTest(&parent, ctx)
 		case "ContributionPathSelfTest":
 			var parent Z5labs
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/z5labs/main.go
+++ b/daggerverse/z5labs/main.go
@@ -63,6 +63,8 @@
 //
 // Contributing files and directories to an image is a different question and
 // has a different answer: App.WithFile and App.WithDirectory, in contribute.go.
+// Putting another *application's* executable in one is a third: App.WithApp,
+// in compose.go, which is what fills the plugin directory named above.
 //
 // # Prebuilt executables, and languages with no chain
 //
@@ -121,6 +123,62 @@
 // annotation and no revision, source or created annotation, and its provenance
 // records the publish and the image and no source tree. A language chain
 // records those because it observed them.
+//
+// # Composing one application into another
+//
+// App.WithApp puts another application's payload into this one's image. It is
+// what fills the plugin directory the image contract has been promising, and
+// it is the shape a CLI with a generator per language actually ships as:
+//
+//	ghcr.io/z5labs/avroc              the base: the CLI, and nothing else
+//	ghcr.io/z5labs/avroc-gen-go       the base plus /usr/local/bin/avroc-gen-go
+//	ghcr.io/z5labs/avroc-gen-java     the base plus /usr/local/bin/avroc-gen-java
+//
+// Each derived image is published to a repository of its own — a repository is
+// stated to Publish and is nothing to do with any binary's name — and every
+// one of them is annotated, signed and attested exactly like the base.
+//
+//	base := dag.Z5Labs().Go(src).App("v1.2.3")
+//	derived := base.WithApp(generator)
+//
+// The derived image is the same program as the base wearing one more
+// executable, and everything about that sentence is enforced. It inherits the
+// base's entrypoint, user, environment and executable directory rather than
+// restating any of them, and it is published under the base's version, because
+// the release it belongs to is the base's release — which is why the composed
+// application's own version is recorded in the provenance predicate, as the
+// only thing anywhere that says which release of the plugin shipped.
+//
+// What crosses is a *payload*: the paths that make an application runnable,
+// plus which one is the entry, declared by whatever constructed it. The entry
+// lands in the plugin directory under its own file name, so a base whose CLI
+// discovers extensions on the PATH finds it. Everything else the composed
+// application carries — its own contributed files and directories — lands at
+// its own path, because a complete application is what may be composed rather
+// than a slim carrier that only makes sense once merged.
+//
+// Composition never reads the entrypoint to decide what crosses, and that is
+// the single most important thing about it: `ep[0]` is a PATH lookup rather
+// than a path for an interpreted application, later elements can be paths that
+// would be dropped, an application driven by Cmd has no `ep[0]` at all, and a
+// CGO_ENABLED=1 binary needs a loader that lives in the image it came out of.
+// Every one of those publishes cleanly, attests cleanly and dies on first
+// exec. compose.go carries the whole rule.
+//
+// Four things are refused rather than resolved, each because the alternative
+// is silent: a platform set that does not match exactly in both directions, a
+// path collision with the base or with an application composed earlier, an
+// environment variable the two sides disagree about, and — for now — a
+// declared payload of more than one file. And because no API shape can
+// establish that a payload is complete, Publish executes the entry of every
+// composed payload in the derived image before the first byte is pushed: a
+// payload that cannot run under the base's environment with nothing added
+// fails the build rather than the consumer.
+//
+// An image built out of pipeline with a `FROM <published-ref>` line gets none
+// of this, and the reason is precise rather than vague: a stranger's
+// Dockerfile adds bytes with no document and has no mechanism to produce one,
+// so that image's attestations describe the base and nothing else.
 //
 // # Versions
 //

--- a/daggerverse/z5labs/prebuilt.go
+++ b/daggerverse/z5labs/prebuilt.go
@@ -334,6 +334,11 @@ func (b *AppBuilder) Build(ctx context.Context) (*App, error) {
 		SourceURI: b.SourceURI,
 	}, b.Version)
 
+	// Every variant's entry is called the same thing — variantConflict refuses
+	// a set where it is not — so the entry path is one value for the whole
+	// application, which is exactly what makes it declarable.
+	entryPath := appDir + "/" + b.Variants[0].Name
+
 	variants := make([]*variant, 0, len(b.Variants))
 	for _, p := range b.Variants {
 		variants = append(variants, &variant{
@@ -344,7 +349,7 @@ func (b *AppBuilder) Build(ctx context.Context) (*App, error) {
 			// contribution into the documents it attaches. Carrying the entry
 			// itself beside the document is what lets that publish check the
 			// document is about these bytes — see digest.go.
-			Contributions: []contribution{{Name: p.Name, File: p.Document, Content: p.Entry}},
+			Contributions: []contribution{{Name: p.Name, Path: entryPath, File: p.Document, Content: p.Entry}},
 		})
 	}
 	return &App{
@@ -353,6 +358,13 @@ func (b *AppBuilder) Build(ctx context.Context) (*App, error) {
 		SourceURI: b.SourceURI,
 		Pkg:       b.Pkg,
 		Variants:  variants,
+		// The payload is declared here because this is the only place that
+		// knows it: the constructor put the executable in the image, so it is
+		// the only party that can say which paths make the application
+		// runnable and which of them is exec'd. Composition reads this and
+		// never the entrypoint — compose.go says why that distinction is the
+		// whole design.
+		Payload: appPayload{Entry: entryPath, Files: []string{entryPath}},
 	}, nil
 }
 

--- a/daggerverse/z5labs/provenance.go
+++ b/daggerverse/z5labs/provenance.go
@@ -47,6 +47,9 @@ type buildFacts struct {
 	Commit string
 	// Version is the version stamped into the binary.
 	Version string
+	// Composed are the applications composed into this image, each with
+	// where its entry landed and the version it was built under.
+	Composed []composedApp
 }
 
 // provenanceStatement renders the in-toto statement for one published
@@ -127,6 +130,21 @@ func externalParameters(identity *workloadIdentity, facts buildFacts) map[string
 // in a predicate reads as a package whose name is the empty string rather
 // than as a build that had none — the same reason the source annotation is
 // absent rather than blank when a tree has no origin.
+//
+// composed is where a derived image says which releases of which payloads it
+// carries, and it is here rather than anywhere else for a reason worth
+// stating. The image is published under the *base's* version, and the SBOM
+// says which module versions went into each executable — so without this,
+// nothing anywhere names the release of the plugin that shipped.
+//
+// It is an internal parameter and not a resolved dependency, because it is the
+// builder's own record of what it put in the image rather than something an
+// identity provider vouched for. The base's published digest is deliberately
+// not recorded beside it: composition layers onto the in-session base rather
+// than pulling a published reference, so at the moment the derived image is
+// built there is no base digest — one exists only if somebody separately
+// published the base, and a predicate whose completeness depended on an
+// unrelated publish would be worse than one that does not claim it.
 func internalParameters(facts buildFacts) map[string]any {
 	out := map[string]any{
 		"platforms": facts.Platforms,
@@ -134,6 +152,16 @@ func internalParameters(facts buildFacts) map[string]any {
 	}
 	if facts.Pkg != "" {
 		out["pkg"] = facts.Pkg
+	}
+	if len(facts.Composed) > 0 {
+		composed := make([]map[string]any, 0, len(facts.Composed))
+		for _, c := range facts.Composed {
+			composed = append(composed, map[string]any{
+				"entry":   c.Entry,
+				"version": c.Version,
+			})
+		}
+		out["composed"] = composed
 	}
 	return out
 }

--- a/daggerverse/z5labs/tests/compose.go
+++ b/daggerverse/z5labs/tests/compose.go
@@ -1,0 +1,512 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"dagger/tests/internal/dagger"
+)
+
+// Composing one application's payload into another's image.
+//
+// The self-tests on the module drive the rules — which payloads may be
+// composed, which platform sets pair, which environments cannot coexist, and
+// what a failure to start looks like on stderr. What is here is the half those
+// cannot reach: that the rules really are wired into WithApp, that a composed
+// payload lands where the plugin directory promises and runs there, that a
+// complete application's own files come along at their own paths, and that the
+// derived image is published, annotated and attested like any other.
+//
+// The composed applications are assembled with the generic constructor rather
+// than the Go chain, and that is deliberate: the shape this seam exists for is
+// a base CLI plus a generator per language, and the generators are routinely
+// artifacts somebody else built. Nothing here gives the Go chain a special
+// path into composition, because it does not have one.
+//
+// wantPluginName is the file name every plugin fixture is composed under, and
+// wantComposedEntry is where it has to land. The path is written out rather
+// than assembled from the module's constants for the reason wantImagePath is:
+// it is the contract a base image's plugin discovery is written against, and a
+// test that imported the module's constant would agree with whatever the
+// module changed it to.
+const (
+	wantPluginName    = "gen"
+	wantComposedEntry = "/usr/local/bin/gen"
+)
+
+// composedPlugin assembles the plugin fixture as an App, one prebuilt
+// executable per platform, ready to be composed into a base.
+func composedPlugin(name, version string, platforms []dagger.Platform) *dagger.Z5LabsApp {
+	return prebuiltApp(pluginDir(), name, version, platforms).Build()
+}
+
+// AppComposesAnotherAppsPayload asserts that a composed payload lands in the
+// plugin directory of every platform's image, with the module's own mode and
+// ownership, and that the derived image is otherwise the base unchanged.
+//
+// Both halves are the point, and the second is the one this seam exists to
+// protect. A derived image that quietly became a *different* program wearing
+// the base's filesystem is the failure the whole design refuses, so the
+// entrypoint, the environment and the base's own binary are all asserted to
+// have survived rather than been restated: a composition that rebuilt the
+// image around the plugin would satisfy every assertion about where the plugin
+// landed.
+//
+// Two platforms are built because composing into the host's variant alone
+// would be invisible in a single-platform test and would ship an arm64 release
+// whose plugin is missing — or, worse, holds an amd64 executable, which is the
+// failure devex#397 names.
+//
+// The plugin is then run two ways on the host's variant: by its absolute path,
+// which proves it landed executable, and by its bare name, which proves it is
+// on the PATH where a base image's plugin discovery will look for it. The
+// second is the whole contract and the first alone would not establish it.
+func (t *Tests) AppComposesAnotherAppsPayload(ctx context.Context) error {
+	const (
+		baseVersion   = "v3.0.0"
+		pluginVersion = "v0.4.1"
+	)
+	src, err := gitFixture(ctx, helloDir(), "main", nil)
+	if err != nil {
+		return fmt.Errorf("gitFixture: %v", err)
+	}
+	platforms := []dagger.Platform{"linux/amd64", "linux/arm64"}
+	base := dag.Z5Labs().Go(src).App(baseVersion, dagger.Z5LabsGoChainAppOpts{Platforms: platforms})
+	derived := base.WithApp(composedPlugin(wantPluginName, pluginVersion, platforms))
+
+	for _, platform := range platforms {
+		ctr := derived.Container(platform)
+
+		modes, err := statInImage(ctx, ctr, []string{wantComposedEntry, "/app/hello"})
+		if err != nil {
+			return fmt.Errorf("%s: %v", platform, err)
+		}
+		if got, want := modes[wantComposedEntry], wantEntryMode+" "+wantOwner; got != want {
+			return fmt.Errorf("%s: %s is %q, want %q", platform, wantComposedEntry, got, want)
+		}
+		// The base's own binary is still there, still executable and still
+		// owned the same way. A composition that replaced the image rather
+		// than adding to it would drop it and every assertion about the
+		// plugin would still pass.
+		if got, want := modes["/app/hello"], wantEntryMode+" "+wantOwner; got != want {
+			return fmt.Errorf("%s: the base's own binary is %q, want %q", platform, got, want)
+		}
+
+		entrypoint, err := ctr.Entrypoint(ctx)
+		if err != nil {
+			return fmt.Errorf("%s: read entrypoint: %v", platform, err)
+		}
+		if len(entrypoint) != 1 || entrypoint[0] != "/app/hello" {
+			return fmt.Errorf("%s: the derived image's entrypoint is %v, want the base's [/app/hello]", platform, entrypoint)
+		}
+		if err := assertStandardEnvironment(ctx, ctr, string(platform)); err != nil {
+			return err
+		}
+	}
+
+	host := derived.Container(hostPlatform())
+	out, err := host.WithExec([]string{}, dagger.ContainerWithExecOpts{UseEntrypoint: true}).Stdout(ctx)
+	if err != nil {
+		return fmt.Errorf("run the derived image's entrypoint: %w", err)
+	}
+	if out != "hello\n" {
+		return fmt.Errorf("the derived image's entrypoint printed %q, want the base's %q", out, "hello\n")
+	}
+	out, err = host.WithExec([]string{wantComposedEntry}).Stdout(ctx)
+	if err != nil {
+		return fmt.Errorf("run %s: %w", wantComposedEntry, err)
+	}
+	if out != "plugin ok\n" {
+		return fmt.Errorf("%s printed %q, want %q", wantComposedEntry, out, "plugin ok\n")
+	}
+	// By bare name, which resolves through the image's PATH. This is what a
+	// base image's plugin discovery does, and it is the reason the composed
+	// entry goes to the plugin directory rather than anywhere else.
+	out, err = host.WithExec([]string{wantPluginName}).Stdout(ctx)
+	if err != nil {
+		return fmt.Errorf("run %s through the image's PATH: %w", wantPluginName, err)
+	}
+	if out != "plugin ok\n" {
+		return fmt.Errorf("%s on the PATH printed %q, want %q", wantPluginName, out, "plugin ok\n")
+	}
+
+	// Composing into an app must not reach back into the app it was derived
+	// from: the base is still publishable on its own, holding its binary and
+	// nothing else.
+	entries, err := base.Container(hostPlatform()).Rootfs().Glob(ctx, "**")
+	if err != nil {
+		return fmt.Errorf("list the base rootfs: %v", err)
+	}
+	if got := onlyFiles(entries); len(got) != 1 || !strings.HasPrefix(got[0], "app/") {
+		return fmt.Errorf("the base app holds %v after a composition, want the built binary alone", got)
+	}
+	return nil
+}
+
+// AppComposesACompleteApplication asserts that the application being composed
+// may be a complete one — an executable plus the tree it needs — and that its
+// own contributions come along at their own paths.
+//
+// This is the half of the design that keeps a composable application
+// buildable, testable and publishable the way every other application is,
+// rather than a slim carrier that only makes sense once merged. The payload
+// fixture is useless without the tree beside it, so running it in the derived
+// image is what proves nothing was silently discarded: the entry alone would
+// land, run, and fail.
+func (t *Tests) AppComposesACompleteApplication(ctx context.Context) error {
+	const (
+		baseVersion   = "v3.1.0"
+		payloadName   = "payload"
+		treePath      = "/srv/payload"
+		greetingBytes = "hi\n"
+	)
+	src, err := gitFixture(ctx, helloDir(), "main", nil)
+	if err != nil {
+		return fmt.Errorf("gitFixture: %v", err)
+	}
+	platform := hostPlatform()
+	tree := dag.Directory().
+		WithNewFile("greeting.txt", greetingBytes).
+		WithNewFile("data/extra.txt", "extra\n")
+	complete := prebuiltApp(payloadDir(), payloadName, "v1.2.3", []dagger.Platform{platform}).
+		Build().
+		WithDirectory(treePath, tree, dag.Z5Labs().DirectoryDocument(tree, treePath))
+	derived := dag.Z5Labs().Go(src).
+		App(baseVersion, dagger.Z5LabsGoChainAppOpts{Platforms: []dagger.Platform{platform}}).
+		WithApp(complete)
+	ctr := derived.Container(platform)
+
+	// The tree kept its own path. There is no obvious other answer — a
+	// contributed /etc/thing.conf belongs at /etc/thing.conf — and the program
+	// reads it from a constant, so a composition that relocated it would fail
+	// here rather than anywhere the relocation could be observed.
+	out, err := ctr.WithExec([]string{"/usr/local/bin/" + payloadName}).Stdout(ctx)
+	if err != nil {
+		return fmt.Errorf("run the composed payload: %w", err)
+	}
+	if want := "hi data/extra.txt,greeting.txt\n"; out != want {
+		return fmt.Errorf("the composed payload printed %q, want %q", out, want)
+	}
+
+	// And the tree carries the module's mode and ownership here too. It is
+	// re-applied on the way in rather than inherited from the image it came
+	// out of, so a composition that copied the source image's metadata across
+	// would show up as the wrong owner rather than as a missing file.
+	modes, err := statInImage(ctx, ctr, []string{treePath, treePath + "/greeting.txt"})
+	if err != nil {
+		return err
+	}
+	for _, p := range []string{treePath, treePath + "/greeting.txt"} {
+		if got, want := modes[p], wantDirectoryMode+" "+wantOwner; got != want {
+			return fmt.Errorf("%s is %q, want %q", p, got, want)
+		}
+	}
+	return nil
+}
+
+// AppRefusesToComposeAcrossPlatforms asserts that a platform set which does
+// not match exactly is refused, in both directions.
+//
+// A platform the payload was not built for would publish an index whose
+// manifest for that architecture holds an executable for another one: the
+// failure arrives at exec time, with the kernel's message, in front of a
+// consumer, and nothing in the manifest list says anything is wrong. A
+// platform only the payload carries is a variant the caller built and would
+// have dropped without a word. Neither can be resolved by picking a side.
+func (t *Tests) AppRefusesToComposeAcrossPlatforms(ctx context.Context) error {
+	src, err := gitFixture(ctx, helloDir(), "main", nil)
+	if err != nil {
+		return fmt.Errorf("gitFixture: %v", err)
+	}
+	both := []dagger.Platform{"linux/amd64", "linux/arm64"}
+	one := []dagger.Platform{"linux/amd64"}
+
+	cases := []struct {
+		base, plugin []dagger.Platform
+		want         string
+		why          string
+	}{
+		{base: both, plugin: one, want: "nothing would be composed into linux/arm64", why: "a platform the payload was not built for"},
+		{base: one, plugin: both, want: "the payload built for linux/arm64 would be discarded", why: "a platform only the payload carries"},
+	}
+	for _, c := range cases {
+		app := dag.Z5Labs().Go(src).App("v4.0.0", dagger.Z5LabsGoChainAppOpts{Platforms: c.base})
+		_, err := app.WithApp(composedPlugin(wantPluginName, "v0.1.0", c.plugin)).ID(ctx)
+		if err == nil {
+			return fmt.Errorf("expected %s to be refused (%s), got nil", c.why, c.why)
+		}
+		if !strings.Contains(err.Error(), c.want) {
+			return fmt.Errorf("expected the refusal of %s to mention %q, got: %s", c.why, c.want, err.Error())
+		}
+	}
+	return nil
+}
+
+// AppRefusesToComposeOntoOccupiedPaths asserts that a collision is refused and
+// that the refusal names both sides.
+//
+// Both sides, because a caller told only that a path is taken has to go and
+// find out by what — and the two cases here are told apart by nothing else.
+// Composing the same plugin twice collides with an application composed
+// earlier; contributing a file where a plugin already is collides the other
+// way round, through the seam that was there first. Either way the image would
+// hold one thing while its documents describe two, which is the undetectable
+// incompleteness this whole mechanism exists to prevent.
+func (t *Tests) AppRefusesToComposeOntoOccupiedPaths(ctx context.Context) error {
+	src, err := gitFixture(ctx, helloDir(), "main", nil)
+	if err != nil {
+		return fmt.Errorf("gitFixture: %v", err)
+	}
+	platforms := []dagger.Platform{hostPlatform()}
+	app := dag.Z5Labs().Go(src).App("v5.0.0", dagger.Z5LabsGoChainAppOpts{Platforms: platforms}).
+		WithApp(composedPlugin(wantPluginName, "v0.1.0", platforms))
+
+	_, err = app.WithApp(composedPlugin(wantPluginName, "v0.2.0", platforms)).ID(ctx)
+	if err == nil {
+		return fmt.Errorf("expected composing a second application whose entry is called %s to be refused, got nil", wantPluginName)
+	}
+	for _, want := range []string{wantComposedEntry, "the entry of the application composed at"} {
+		if !strings.Contains(err.Error(), want) {
+			return fmt.Errorf("expected the collision refusal to mention %q, got: %s", want, err.Error())
+		}
+	}
+
+	note := dag.Directory().WithNewFile("note", "note\n").File("note")
+	_, err = app.WithFile(wantComposedEntry, note, dag.Z5Labs().FileDocument(note)).ID(ctx)
+	if err == nil {
+		return fmt.Errorf("expected contributing a file at %s to be refused, got nil", wantComposedEntry)
+	}
+	if !strings.Contains(err.Error(), "the entry of the application composed at") {
+		return fmt.Errorf("expected the refusal to name what holds %s, got: %s", wantComposedEntry, err.Error())
+	}
+	return nil
+}
+
+// AppRefusesToPublishAPayloadThatCannotRun asserts that the entry of every
+// composed payload is executed in the derived image before the first byte is
+// pushed, and that one which cannot start fails the build.
+//
+// This is the criterion no API shape can establish. Enumerating a payload is
+// always a guess — a script's imports, a template opened on the first request,
+// a dlopen, a loader that lives in the image the executable came out of — so
+// completeness is proven by running it. The fixture here is the crudest
+// version of the same failure: bytes that are not an executable at all, which
+// come back from the runtime as an exec format error, exactly as an executable
+// built for another architecture does.
+//
+// The refusal has to happen before the push, so the registry is probed
+// afterwards: an image published and then reported as broken is one a consumer
+// can already have pulled.
+func (t *Tests) AppRefusesToPublishAPayloadThatCannotRun(ctx context.Context) error {
+	const (
+		version    = "v6.0.0"
+		repository = "z5labs/broken"
+	)
+	src, err := gitFixture(ctx, helloDir(), "main", nil)
+	if err != nil {
+		return fmt.Errorf("gitFixture: %v", err)
+	}
+	headSha, err := headFullSha(ctx, src)
+	if err != nil {
+		return err
+	}
+	svc, pwdHex, secret, err := localRegistry(ctx)
+	if err != nil {
+		return err
+	}
+	prov, err := newProvenanceHarness(ctx, headSha)
+	if err != nil {
+		return err
+	}
+	platform := hostPlatform()
+	// An entry that is not an executable, packaged exactly the way a real one
+	// is: the module never inspects the bytes, which is the point — nothing
+	// short of running them can tell a payload that works from one that does
+	// not.
+	notAnExecutable := dag.Directory().
+		WithNewFile(wantPluginName, "#!/nonexistent/interpreter\n", dagger.DirectoryWithNewFileOpts{Permissions: 0o555}).
+		File(wantPluginName)
+	broken := dag.Z5Labs().App("v0.0.1").
+		WithVariant(platform, notAnExecutable, dag.Z5Labs().FileDocument(notAnExecutable)).
+		Build()
+	derived := dag.Z5Labs().Go(src).
+		App(version, dagger.Z5LabsGoChainAppOpts{Platforms: []dagger.Platform{platform}}).
+		WithApp(broken)
+
+	_, err = publishable(derived, svc, secret, prov).Publish(ctx, []string{repository})
+	if err == nil {
+		return fmt.Errorf("expected a publish of an image whose composed payload cannot start to be refused, got nil")
+	}
+	for _, want := range []string{wantComposedEntry, "could not be started"} {
+		if !strings.Contains(err.Error(), want) {
+			return fmt.Errorf("expected the refusal to mention %q, got: %s", want, err.Error())
+		}
+	}
+	code, err := curlProbeManifest(ctx, svc, registryAlias, "ci", pwdHex, repository, version)
+	if err != nil {
+		return fmt.Errorf("curl probe: %v", err)
+	}
+	if code == 200 {
+		return fmt.Errorf("Publish refused the publish but manifest %s is present in the registry", version)
+	}
+	return nil
+}
+
+// AppComposedImageStaysAttested asserts that a derived image publishes to a
+// repository of its own, and that its documents and its provenance describe
+// what is actually in it — both sides' payloads, per platform.
+//
+// The repository is deliberately neither application's binary name. A derived
+// image is published as `avroc-gen-go` while the executables inside it are
+// called `avroc` and `avroc-gen-go`, so a publish that derived the repository
+// from anything in the image would be wrong for exactly the shape this seam
+// exists to serve.
+//
+// The document assertion is the union, and it is what makes composition
+// honest: an SBOM that accounted for the base and not the plugin would be
+// well-formed, would attach cleanly and would be indistinguishable from a
+// complete one. The provenance assertion covers the one fact nothing else
+// records — the derived image carries the base's version, so without the
+// composed entry in the predicate nothing anywhere says which release of the
+// plugin shipped.
+func (t *Tests) AppComposedImageStaysAttested(ctx context.Context) error {
+	const (
+		baseVersion   = "v12.0.0"
+		pluginVersion = "v0.9.7"
+		repository    = "z5labs/hello-gen"
+	)
+	src, err := gitFixture(ctx, helloDir(), "main", nil)
+	if err != nil {
+		return fmt.Errorf("gitFixture: %v", err)
+	}
+	headSha, err := headFullSha(ctx, src)
+	if err != nil {
+		return err
+	}
+	svc, _, secret, err := localRegistry(ctx)
+	if err != nil {
+		return err
+	}
+	prov, err := newProvenanceHarness(ctx, headSha)
+	if err != nil {
+		return err
+	}
+	platforms := []dagger.Platform{hostPlatform()}
+	derived := dag.Z5Labs().Go(src).
+		App(baseVersion, dagger.Z5LabsGoChainAppOpts{Platforms: platforms}).
+		WithApp(composedPlugin(wantPluginName, pluginVersion, platforms))
+
+	refs, err := publishable(derived, svc, secret, prov).Publish(ctx, []string{repository})
+	if err != nil {
+		return fmt.Errorf("Publish: %v", err)
+	}
+	digest, err := digestOf(refs[0])
+	if err != nil {
+		return err
+	}
+	registry := testRegistry(svc, secret)
+
+	spdxRaw, _, err := attachedSbom(ctx, registry, repository, digest, spdxArtifactType)
+	if err != nil {
+		return err
+	}
+	cdxRaw, _, err := attachedSbom(ctx, registry, repository, digest, cycloneDxArtifactType)
+	if err != nil {
+		return err
+	}
+	spdx, err := readPublishedSpdx(spdxRaw)
+	if err != nil {
+		return err
+	}
+	cdx, err := readPublishedCycloneDx(cdxRaw)
+	if err != nil {
+		return err
+	}
+	// Both payloads, and nothing else. The names are the ones each side
+	// contributed under: the base's binary and the plugin's, which is what a
+	// consumer reading the document sees in the image.
+	want := []string{wantPluginName, "hello"}
+	for what, doc := range map[string]publishedSbom{"SPDX": spdx, "CycloneDX": cdx} {
+		got := append([]string{}, doc.Contained...)
+		if len(got) != len(want) {
+			return fmt.Errorf("the %s document says the derived image contains %v, want %v", what, got, want)
+		}
+		for _, name := range want {
+			if doc.Components[name] == "" {
+				return fmt.Errorf("the %s document lists no checksum for %s; it has %v", what, name, doc.Components)
+			}
+		}
+	}
+	for name, sum := range spdx.Components {
+		if cdx.Components[name] != sum {
+			return fmt.Errorf("the two documents disagree about %s: SPDX has %q, CycloneDX has %q", name, sum, cdx.Components[name])
+		}
+	}
+
+	envelope, err := attachedDocument(ctx, registry, repository, digest, provenanceArtifactType)
+	if err != nil {
+		return err
+	}
+	statement, err := verifyEnvelope(envelope, prov.Public)
+	if err != nil {
+		return err
+	}
+	if err := checkStatement(statement, digest, repository, prov.Claims); err != nil {
+		return err
+	}
+	if err := checkComposedInProvenance(statement, wantComposedEntry, pluginVersion, baseVersion); err != nil {
+		return err
+	}
+	return nil
+}
+
+// checkComposedInProvenance asserts the predicate records every composed
+// payload, and that the image is still published under the base's version.
+//
+// The version pair is asserted together on purpose. The derived image carries
+// the base's version because the release it belongs to is the base's release,
+// and that decision is exactly what makes the composed entry's version load
+// bearing: drop it and the only version anywhere is the base's, so nothing
+// says which release of the plugin a consumer is running.
+func checkComposedInProvenance(statement map[string]any, entry, pluginVersion, baseVersion string) error {
+	predicate, err := object(statement["predicate"], "predicate")
+	if err != nil {
+		return err
+	}
+	definition, err := object(predicate["buildDefinition"], "predicate.buildDefinition")
+	if err != nil {
+		return err
+	}
+	internal, err := object(definition["internalParameters"], "predicate.buildDefinition.internalParameters")
+	if err != nil {
+		return err
+	}
+	if got, _ := internal["version"].(string); got != baseVersion {
+		return fmt.Errorf("the predicate says the image was published as %q, want the base's version %q", got, baseVersion)
+	}
+	raw, ok := internal["composed"].([]any)
+	if !ok {
+		return fmt.Errorf("the predicate records no composed payloads; internalParameters is %v", internal)
+	}
+	if len(raw) != 1 {
+		return fmt.Errorf("the predicate records %d composed payloads, want 1", len(raw))
+	}
+	composed, err := object(raw[0], "predicate.buildDefinition.internalParameters.composed[0]")
+	if err != nil {
+		return err
+	}
+	if got, _ := composed["entry"].(string); got != entry {
+		return fmt.Errorf("the predicate says the composed payload landed at %q, want %q", got, entry)
+	}
+	if got, _ := composed["version"].(string); got != pluginVersion {
+		return fmt.Errorf("the predicate says the composed payload is %q, want %q", got, pluginVersion)
+	}
+	return nil
+}
+
+// pluginDir returns the composition fixture: a main package that prints
+// something no other fixture prints.
+func pluginDir() *dagger.Directory {
+	return dag.CurrentModule().Source().Directory("fixtures/plugin")
+}

--- a/daggerverse/z5labs/tests/compose.go
+++ b/daggerverse/z5labs/tests/compose.go
@@ -205,6 +205,75 @@ func (t *Tests) AppComposesACompleteApplication(ctx context.Context) error {
 	return nil
 }
 
+// AppComposesADerivedImage asserts that an application that has already been
+// composed into may itself be composed, and that the plugins it picked up on
+// the way stay runnable.
+//
+// A derived image is an ordinary App, so composing one is a documented use and
+// the payload of the result is the union of both sides'. The failure this test
+// exists for is that the union is not uniform: the composed application's own
+// entry is declared, while a plugin it picked up earlier travels as an ordinary
+// contribution — so a composition that decided what lands executable from the
+// declaration alone would carry the earlier plugin across read-only and strip
+// the one bit that makes it runnable. That failure is caught at publish, as a
+// payload that will not start, which blames the payload rather than the
+// composition; so it is caught here, where the mode can be read.
+//
+// Every executable in the final image is run rather than merely stat'd, and by
+// bare name where it is on the PATH. A mode assertion alone would not catch a
+// plugin that landed executable and unreachable.
+func (t *Tests) AppComposesADerivedImage(ctx context.Context) error {
+	inner, err := gitFixture(ctx, helloDir(), "main", nil)
+	if err != nil {
+		return fmt.Errorf("gitFixture: %v", err)
+	}
+	outer, err := gitFixture(ctx, stampedDir(), "main", nil)
+	if err != nil {
+		return fmt.Errorf("gitFixture: %v", err)
+	}
+	platforms := []dagger.Platform{hostPlatform()}
+	derived := dag.Z5Labs().Go(inner).
+		App("v7.0.0", dagger.Z5LabsGoChainAppOpts{Platforms: platforms}).
+		WithApp(composedPlugin(wantPluginName, "v0.3.0", platforms))
+	composed := dag.Z5Labs().Go(outer).
+		App("v8.0.0", dagger.Z5LabsGoChainAppOpts{Platforms: platforms}).
+		WithApp(derived)
+	ctr := composed.Container(hostPlatform())
+
+	// The outer application's own binary, the application composed into it,
+	// and the plugin that application had already picked up. All three are
+	// executables and all three have to land as one.
+	paths := []string{"/app/stamped", "/usr/local/bin/hello", wantComposedEntry}
+	modes, err := statInImage(ctx, ctr, paths)
+	if err != nil {
+		return err
+	}
+	for _, p := range paths {
+		if got, want := modes[p], wantEntryMode+" "+wantOwner; got != want {
+			return fmt.Errorf("%s is %q, want %q", p, got, want)
+		}
+	}
+	// The outer image's entrypoint is still its own, not either of the
+	// applications composed into it.
+	entrypoint, err := ctr.Entrypoint(ctx)
+	if err != nil {
+		return fmt.Errorf("read entrypoint: %v", err)
+	}
+	if len(entrypoint) != 1 || entrypoint[0] != "/app/stamped" {
+		return fmt.Errorf("the twice-derived image's entrypoint is %v, want [/app/stamped]", entrypoint)
+	}
+	for name, want := range map[string]string{"hello": "hello\n", wantPluginName: "plugin ok\n"} {
+		out, err := ctr.WithExec([]string{name}).Stdout(ctx)
+		if err != nil {
+			return fmt.Errorf("run %s through the image's PATH: %w", name, err)
+		}
+		if out != want {
+			return fmt.Errorf("%s printed %q, want %q", name, out, want)
+		}
+	}
+	return nil
+}
+
 // AppRefusesToComposeAcrossPlatforms asserts that a platform set which does
 // not match exactly is refused, in both directions.
 //
@@ -234,7 +303,7 @@ func (t *Tests) AppRefusesToComposeAcrossPlatforms(ctx context.Context) error {
 		app := dag.Z5Labs().Go(src).App("v4.0.0", dagger.Z5LabsGoChainAppOpts{Platforms: c.base})
 		_, err := app.WithApp(composedPlugin(wantPluginName, "v0.1.0", c.plugin)).ID(ctx)
 		if err == nil {
-			return fmt.Errorf("expected %s to be refused (%s), got nil", c.why, c.why)
+			return fmt.Errorf("expected a base carrying %v and a payload carrying %v to be refused (%s), got nil", c.base, c.plugin, c.why)
 		}
 		if !strings.Contains(err.Error(), c.want) {
 			return fmt.Errorf("expected the refusal of %s to mention %q, got: %s", c.why, c.want, err.Error())

--- a/daggerverse/z5labs/tests/dagger.gen.go
+++ b/daggerverse/z5labs/tests/dagger.gen.go
@@ -255,6 +255,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).AppComposesACompleteApplication(&parent, ctx)
+		case "AppComposesADerivedImage":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).AppComposesADerivedImage(&parent, ctx)
 		case "AppComposesAnotherAppsPayload":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/z5labs/tests/dagger.gen.go
+++ b/daggerverse/z5labs/tests/dagger.gen.go
@@ -241,6 +241,27 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).AppBuilderRefusesAnInconsistentVariantSet(&parent, ctx)
+		case "AppComposedImageStaysAttested":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).AppComposedImageStaysAttested(&parent, ctx)
+		case "AppComposesACompleteApplication":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).AppComposesACompleteApplication(&parent, ctx)
+		case "AppComposesAnotherAppsPayload":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).AppComposesAnotherAppsPayload(&parent, ctx)
 		case "AppContainerRunsTheEntrypoint":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -395,6 +416,27 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).AppRefusesPlaintextRegistryUnlessInsecure(&parent, ctx)
+		case "AppRefusesToComposeAcrossPlatforms":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).AppRefusesToComposeAcrossPlatforms(&parent, ctx)
+		case "AppRefusesToComposeOntoOccupiedPaths":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).AppRefusesToComposeOntoOccupiedPaths(&parent, ctx)
+		case "AppRefusesToPublishAPayloadThatCannotRun":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).AppRefusesToPublishAPayloadThatCannotRun(&parent, ctx)
 		case "AppRefusesToPublishWithoutProvenanceMachinery":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/z5labs/tests/fixtures/plugin/go.mod
+++ b/daggerverse/z5labs/tests/fixtures/plugin/go.mod
@@ -1,0 +1,3 @@
+module example.com/plugin
+
+go 1.23

--- a/daggerverse/z5labs/tests/fixtures/plugin/main.go
+++ b/daggerverse/z5labs/tests/fixtures/plugin/main.go
@@ -1,0 +1,14 @@
+// Command plugin is the composition fixture: an executable that exists to be
+// composed into another application's image.
+//
+// It prints something no other fixture prints, so a test can tell "the plugin
+// ran" from "the base's own binary ran" — the two land in one image and an
+// assertion that could not distinguish them would pass for a composition that
+// copied nothing at all.
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("plugin ok")
+}

--- a/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
+++ b/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type Z5Labs
-func (r *Binding) AsZ5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:329:6)
+func (r *Binding) AsZ5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:387:6)
 	q := r.query.Select("asZ5Labs")
 
 	return &Z5Labs{
@@ -118,7 +118,7 @@ func (r *Env) WithZ5LabsGoChainOutput(name string, description string) *Env { //
 }
 
 // Create or update a binding of type Z5Labs in the environment
-func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:329:6)
+func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:387:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withZ5LabsInput")
 	q = q.Arg("name", name)
@@ -131,7 +131,7 @@ func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *E
 }
 
 // Declare a desired Z5Labs output to be assigned in the environment
-func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:329:6)
+func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:387:6)
 	q := r.query.Select("withZ5LabsOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -143,7 +143,7 @@ func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs
 
 // Z5labs is the root module type. Construct the Go language chain via Go;
 // everything this module does is reached from there.
-func (r *Query) Z5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:329:6)
+func (r *Query) Z5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:387:6)
 	q := r.query.Select("z5Labs")
 
 	return &Z5Labs{
@@ -153,9 +153,10 @@ func (r *Query) Z5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/
 
 // Z5labs is the root module type. Construct the Go language chain via Go;
 // everything this module does is reached from there.
-type Z5Labs struct { // z5labs (../../../../../daggerverse/z5labs/main.go:329:6)
+type Z5Labs struct { // z5labs (../../../../../daggerverse/z5labs/main.go:387:6)
 	query *querybuilder.Selection
 
+	composeSelfTest          *Void
 	contributionPathSelfTest *Void
 	id                       *ID
 	imageEnvironmentSelfTest *Void
@@ -214,6 +215,35 @@ func (r *Z5Labs) App(version string) *Z5LabsAppBuilder { // z5labs (../../../../
 	return &Z5LabsAppBuilder{
 		query: q,
 	}
+}
+
+// ComposeSelfTest checks the rules that decide whether one application's
+// payload may be composed into another's image.
+//
+// It sits on the module rather than in tests/ for the reason
+// ImageEnvironmentSelfTest and ContributionPathSelfTest record, and here the
+// reason is stronger than economy. Two of these rules cannot be driven through
+// the public API at all: no constructor in this module can declare a payload
+// of more than one file, and no caller-facing seam can put an environment
+// variable on an image — so a multi-file payload and a conflicting variable
+// are branches that would be unexecutable end to end, and therefore deletable
+// tomorrow with every test still green. Split out as free functions over
+// declarations and maps, every branch runs in process.
+//
+// The end-to-end half — that the refusals really are wired into WithApp, that
+// a composed payload lands where the plugin directory promises, and that the
+// derived image is published, annotated and attested like any other — is in
+// tests/, where it costs a pair of applications instead of a table.
+//
+// It runs in process and needs no container, so it is cheap enough to be a
+// check of its own.
+func (r *Z5Labs) ComposeSelfTest(ctx context.Context) error { // z5labs (../../../../../daggerverse/z5labs/composeselftest.go:34:1)
+	if r.composeSelfTest != nil {
+		return nil
+	}
+	q := r.query.Select("composeSelfTest")
+
+	return q.Execute(ctx)
 }
 
 // ContributionPathSelfTest checks the rules that decide where a caller may
@@ -366,7 +396,7 @@ func (r *Z5Labs) FileDocument(file *File, opts ...Z5LabsFileDocumentOpts) *File 
 //
 // The returned object is GoChain rather than Go because the `go` module
 // this one depends on already owns that name — see GoChain's doc comment.
-func (r *Z5Labs) Go(source *Directory) *Z5LabsGoChain { // z5labs (../../../../../daggerverse/z5labs/main.go:345:1)
+func (r *Z5Labs) Go(source *Directory) *Z5LabsGoChain { // z5labs (../../../../../daggerverse/z5labs/main.go:403:1)
 	assertNotNil("source", source)
 	q := r.query.Select("go")
 	q = q.Arg("source", source)
@@ -601,7 +631,7 @@ func (r *Z5LabsApp) WithGraphQLQuery(q *querybuilder.Selection) *Z5LabsApp {
 // nothing here promises that the second invocation reuses the first's
 // containers. A caller that needs one build inspected and then published
 // chains both onto one call.
-func (r *Z5LabsApp) Container(platform Platform) *Container { // z5labs (../../../../../daggerverse/z5labs/app.go:161:1)
+func (r *Z5LabsApp) Container(platform Platform) *Container { // z5labs (../../../../../daggerverse/z5labs/app.go:193:1)
 	q := r.query.Select("container")
 	q = q.Arg("platform", platform)
 
@@ -613,7 +643,7 @@ func (r *Z5LabsApp) Container(platform Platform) *Container { // z5labs (../../.
 // Containers returns every platform's image, in the order the platforms
 // were given to App. Same guarantee, and the same session bound, as
 // Container.
-func (r *Z5LabsApp) Containers(ctx context.Context) ([]Container, error) { // z5labs (../../../../../daggerverse/z5labs/app.go:175:1)
+func (r *Z5LabsApp) Containers(ctx context.Context) ([]Container, error) { // z5labs (../../../../../daggerverse/z5labs/app.go:207:1)
 	q := r.query.Select("containers")
 
 	q = q.Select("id")
@@ -797,7 +827,7 @@ func (r *Z5LabsApp) UnmarshalJSON(bs []byte) error {
 // Publishing is a side effect against an external registry, so it is
 // uncached: a re-run must actually push. The build above it is session
 // cached, so the bytes pushed are the bytes Container returned.
-func (r *Z5LabsApp) Publish(ctx context.Context, repositories []string) ([]string, error) { // z5labs (../../../../../daggerverse/z5labs/app.go:405:1)
+func (r *Z5LabsApp) Publish(ctx context.Context, repositories []string) ([]string, error) { // z5labs (../../../../../daggerverse/z5labs/app.go:437:1)
 	q := r.query.Select("publish")
 	q = q.Arg("repositories", repositories)
 
@@ -805,6 +835,46 @@ func (r *Z5LabsApp) Publish(ctx context.Context, repositories []string) ([]strin
 
 	q = q.Bind(&response)
 	return response, q.Execute(ctx)
+}
+
+// WithApp composes another application's payload into every platform of this
+// one's image.
+//
+// The result is an ordinary App: published, annotated, signed and attested
+// exactly like any other, to a repository of its own that has nothing to do
+// with any binary's name. What comes out is the base program wearing one more
+// executable — it keeps the base's entrypoint, user, environment and
+// executable directory, and it is published under the base's version, because
+// the release it belongs to is the base's release.
+//
+// from's entry lands in the standardized plugin directory under its own file
+// name, so a base image whose CLI discovers plugins on the PATH finds it
+// without either side agreeing on anything but that directory. Everything else
+// from carries — its contributed files and directories — lands at its own
+// path. The file comment above records why the entry is read from the
+// declaration rather than from the entrypoint, and it is the single most
+// important thing about this method.
+//
+// There is no path argument and nothing is inferred. A composed application is
+// composed whole or refused: see the file comment for the four refusals and
+// why each is a failure that would otherwise publish cleanly and die on first
+// exec.
+//
+// Composition is not restricted to applications this module compiled, and a
+// derived image may be composed into in turn — the payload of the result is
+// the union of both sides', the collision surface grows and the semantics do
+// not. What gets nothing from this seam is an out-of-pipeline image built
+// `FROM` a published base: a stranger's Dockerfile adds bytes with no document
+// and has no mechanism to produce one, so that image's attestation describes
+// the base and nothing else.
+func (r *Z5LabsApp) WithApp(from *Z5LabsApp) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/compose.go:168:1)
+	assertNotNil("from", from)
+	q := r.query.Select("withApp")
+	q = q.Arg("from", from)
+
+	return &Z5LabsApp{
+		query: q,
+	}
 }
 
 // WithDirectory contributes a directory tree to every platform's image at
@@ -875,7 +945,7 @@ func (r *Z5LabsApp) WithFile(path string, file *File, document *File) *Z5LabsApp
 // unverified connection. It is spelled insecure rather than tlsVerify
 // because a bool defaulting to true cannot be turned off from the CLI —
 // which is also why this method takes no argument at all.
-func (r *Z5LabsApp) WithInsecure() *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:265:1)
+func (r *Z5LabsApp) WithInsecure() *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:297:1)
 	q := r.query.Select("withInsecure")
 
 	return &Z5LabsApp{
@@ -895,7 +965,7 @@ func (r *Z5LabsApp) WithInsecure() *Z5LabsApp { // z5labs (../../../../../dagger
 // Every identifying field in the provenance comes out of the exchanged
 // token's claims, because anything a caller could have supplied attests to
 // nothing.
-func (r *Z5LabsApp) WithOidc(requestUrl string, requestToken *Secret) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:222:1)
+func (r *Z5LabsApp) WithOidc(requestUrl string, requestToken *Secret) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:254:1)
 	assertNotNil("requestToken", requestToken)
 	q := r.query.Select("withOidc")
 	q = q.Arg("requestUrl", requestUrl)
@@ -915,7 +985,7 @@ func (r *Z5LabsApp) WithOidc(requestUrl string, requestToken *Secret) *Z5LabsApp
 // This exists for the same reason WithRegistryService does, and is used by
 // the test suite, which runs a real token endpoint rather than relaxing the
 // provenance requirement into the shape of the tests.
-func (r *Z5LabsApp) WithOidcService(svc *Service) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:295:1)
+func (r *Z5LabsApp) WithOidcService(svc *Service) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:327:1)
 	assertNotNil("svc", svc)
 	q := r.query.Select("withOidcService")
 	q = q.Arg("svc", svc)
@@ -941,7 +1011,7 @@ func (r *Z5LabsApp) WithOidcService(svc *Service) *Z5LabsApp { // z5labs (../../
 // undirected takes the default seven-day TTL and can hand a later session a
 // stale object built from arguments it only appears to share — a registry
 // service, for one, whose engine-assigned address is long gone.
-func (r *Z5LabsApp) WithRegistry(address string, username string, auth *Secret) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:201:1)
+func (r *Z5LabsApp) WithRegistry(address string, username string, auth *Secret) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:233:1)
 	assertNotNil("auth", auth)
 	q := r.query.Select("withRegistry")
 	q = q.Arg("address", address)
@@ -960,7 +1030,7 @@ func (r *Z5LabsApp) WithRegistry(address string, username string, auth *Secret) 
 // into an address ahead of time; this is how the publish learns it. Used by
 // the test suite against a local registry, and by anyone whose private
 // registry is itself a Dagger service.
-func (r *Z5LabsApp) WithRegistryService(svc *Service) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:279:1)
+func (r *Z5LabsApp) WithRegistryService(svc *Service) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:311:1)
 	assertNotNil("svc", svc)
 	q := r.query.Select("withRegistryService")
 	q = q.Arg("svc", svc)
@@ -990,7 +1060,7 @@ func (r *Z5LabsApp) WithRegistryService(svc *Service) *Z5LabsApp { // z5labs (..
 // where the keyless mode gets an identity and an issuer and no such flag.
 // A caller who does not want to hand their consumers that flag should not
 // be supplying a key.
-func (r *Z5LabsApp) WithSigningKey(key *Secret) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:250:1)
+func (r *Z5LabsApp) WithSigningKey(key *Secret) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:282:1)
 	assertNotNil("key", key)
 	q := r.query.Select("withSigningKey")
 	q = q.Arg("key", key)

--- a/daggerverse/z5labs/tests/main.go
+++ b/daggerverse/z5labs/tests/main.go
@@ -157,6 +157,7 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("AppRefusesADocumentThatDescribesOtherBytes", t.AppRefusesADocumentThatDescribesOtherBytes)
 	jobs = jobs.WithJob("AppComposesAnotherAppsPayload", t.AppComposesAnotherAppsPayload)
 	jobs = jobs.WithJob("AppComposesACompleteApplication", t.AppComposesACompleteApplication)
+	jobs = jobs.WithJob("AppComposesADerivedImage", t.AppComposesADerivedImage)
 	jobs = jobs.WithJob("AppRefusesToComposeAcrossPlatforms", t.AppRefusesToComposeAcrossPlatforms)
 	jobs = jobs.WithJob("AppRefusesToComposeOntoOccupiedPaths", t.AppRefusesToComposeOntoOccupiedPaths)
 	jobs = jobs.WithJob("AppRefusesToPublishAPayloadThatCannotRun", t.AppRefusesToPublishAPayloadThatCannotRun)

--- a/daggerverse/z5labs/tests/main.go
+++ b/daggerverse/z5labs/tests/main.go
@@ -155,6 +155,12 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("AppFromPrebuiltComposesATreeShapedPayload", t.AppFromPrebuiltComposesATreeShapedPayload)
 	jobs = jobs.WithJob("AppBuilderRefusesAnInconsistentVariantSet", t.AppBuilderRefusesAnInconsistentVariantSet)
 	jobs = jobs.WithJob("AppRefusesADocumentThatDescribesOtherBytes", t.AppRefusesADocumentThatDescribesOtherBytes)
+	jobs = jobs.WithJob("AppComposesAnotherAppsPayload", t.AppComposesAnotherAppsPayload)
+	jobs = jobs.WithJob("AppComposesACompleteApplication", t.AppComposesACompleteApplication)
+	jobs = jobs.WithJob("AppRefusesToComposeAcrossPlatforms", t.AppRefusesToComposeAcrossPlatforms)
+	jobs = jobs.WithJob("AppRefusesToComposeOntoOccupiedPaths", t.AppRefusesToComposeOntoOccupiedPaths)
+	jobs = jobs.WithJob("AppRefusesToPublishAPayloadThatCannotRun", t.AppRefusesToPublishAPayloadThatCannotRun)
+	jobs = jobs.WithJob("AppComposedImageStaysAttested", t.AppComposedImageStaysAttested)
 
 	return jobs.Run(ctx)
 }


### PR DESCRIPTION
Closes #397

`App.WithApp` puts another application's payload into this one's image, so a
base CLI plus a generator per language ships as a base image and a derived
image per plugin — the shape `z5labs/avroc` and `Zaba505/cpybkc` hand-rolled an
entire image build for because the archetype had nowhere to put a second
executable.

```go
base    := dag.Z5Labs().Go(src).App("v1.2.3")
derived := base.WithApp(generator)   // no path argument, nothing inferred
```

## Acceptance criteria

- [x] **An `App`'s image can carry another `App`'s payload, published, annotated and attested like any other.** `AppComposedImageStaysAttested` publishes a derived image, reads both SBOMs and the signed provenance back out of the registry.
- [x] **The payload is declared by whatever constructed the `App`; composition never reads `Entrypoint`.** `App.Payload` is an `appPayload` declared by `AppBuilder.Build` — the only place that knows which paths it put in the image. `compose.go`'s file comment records the four ways reading `ep[0]` fails silently.
- [x] **The derived image inherits the base's entrypoint, user, environment and executable directory.** Composition only ever calls `WithFile`/`WithDirectory` on the base container; it never touches `WithEntrypoint`, `WithEnvVariable`, `WithUser` or `appDir`. `AppComposesAnotherAppsPayload` asserts the entrypoint, the environment and the base's own binary all survive.
- [x] **Every platform of the derived image is built from the matching platform of the base; a mismatch is refused.** `matchPlatforms`, refusing in both directions. `AppRefusesToComposeAcrossPlatforms` plus a table in `ComposeSelfTest`.
- [x] **`from` may be a complete application; its files and directories come along at their own paths.** `AppComposesACompleteApplication` composes the tree-shaped `payload` fixture and *runs* it in the derived image — the program is useless without its tree, so a discarded directory fails the test rather than passing it.
- [x] **A path collision fails and names both sides.** `ContributedPaths` now carries an `occupied{Path, Holder}` so the refusal says *what* holds the path. `AppRefusesToComposeOntoOccupiedPaths` covers both directions: a second composition onto an earlier one, and a `WithFile` onto a composed entry.
- [x] **A conflicting environment variable fails rather than last-writer-wins.** `composedEnvConflict`, equality in both directions.
- [x] **The entry of every composed payload is executed in the derived image before publish.** `assertComposedPayloadsRun`, in `Publish` beside the other pre-push refusals. `AppRefusesToPublishAPayloadThatCannotRun` also probes the registry afterwards, because a refusal after the push is not a refusal.
- [x] **The provenance and SBOMs describe the derived image and everything in it.** The composed application's contributions are appended to each variant's contribution list, so the existing per-platform assembly produces the union with no second code path.
- [x] **The derived image publishes to its own repository, independently of any binary name.** Asserted by publishing to `z5labs/hello-gen` from an image holding `hello` and `gen`.
- [x] **First version: a declared payload of more than one file is refused, naming what is wrong.** `composablePayload`.

## Judgment calls

- **`WithApp`**, as the issue leaned. `WithExecutable` promises one file and a payload is not one.
- **Every image is a base; no `Base` type and no flag.** The commitment #401 worried about is already made for every image this module publishes — `build.go` fixes the PATH, the plugin directory, the executable directory and the owner UID, and `assertImageEnvironment` enforces it at publish. A second concept would promise exactly what the first already does, and #400 rules out the flag.
- **The composed entry lands in `appPluginDir` (`/usr/local/bin`), not `appDir`.** That directory has been documented as "the one directory an extension's executables land in" since before there was a way to fill it, and it is what makes `ghcr.io/z5labs/avroc-gen-go` literally the base plus `/usr/local/bin/avroc-gen-go`. `appDir` holds the application's own binary, which the inherited entrypoint names.
- **The derived image carries the base's version**; `from`'s version is recorded in the provenance predicate's `internalParameters.composed`. It is the only thing anywhere that says which release of the plugin shipped, since the SBOM reports module versions and the image tag reports the base's release.
- **The predicate does not name a base digest.** Composition layers onto the in-session base rather than pulling a published reference, so at build time there is no base digest — one exists only if somebody separately published the base, and a predicate whose completeness depended on an unrelated publish is worse than one that does not claim it.
- **The run check matches the runtime's stderr, not the exit code.** Measured on Dagger v0.21.8: an exec that never starts comes back through `ReturnTypeAny` as **exit code 1** with `fork/exec <path>: exec format error` (or `no such file or directory`) on stderr — indistinguishable by exit code from a CLI that exits 1 on no arguments. Refusing on non-zero would refuse most working CLIs; accepting exit 1 would accept every payload the check exists to catch. `execRefusal` is a pure function with a six-row table in `ComposeSelfTest`, including two negative controls.
- **Two rules live in module self-tests rather than `tests/`.** No constructor here can declare a multi-file payload and no caller-facing seam can set an environment variable, so those branches are unexecutable end to end and would be deletable with every test still green — the same split `diffImageEnv` already uses.

## Verification

- `dagger check` — green (3 checks, including `ci:generated`).
- `bash .github/scripts/verify-affected-modules.sh` — green: 6 `z5labs` self-tests and `tests:all` (66 jobs).
- The two Dagger behaviours above were spiked directly against the engine before being relied on: cross-platform exec works under emulation, and `ReturnTypeAny` reports a failed exec as exit code 1 with the runtime's message on stderr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)