### PR TITLE
story(z5labs): record the provenance envelope in the transparency log, or say why not

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,12 +95,19 @@ jobs:
       #                            killed at 6m11s of step time with no test having
       #                            failed. 12 is the budget it should have had before
       #                            a leg with no override started deciding merges by
-      #                            how warm the engine was.
+      #                            how warm the engine was. Keyed by the module
+      #                            directory, not by `:all`: the module declares one
+      #                            check, so the change-aware path emits
+      #                            `daggerverse/z5labs/tests:all` and the
+      #                            run-everything path emits the coarse
+      #                            `daggerverse/z5labs/tests`, and a leg name key
+      #                            would budget one of those two and leave the other
+      #                            on the default.
       timeouts: >-
         {".": 15, ".:generated-self-test": 8, ".:selection-self-test": 2,
         "daggerverse/workspace-ci:*": 15, "daggerverse/workspace-ci:generated": 15,
         "daggerverse/workspace-ci:generated-self-test": 8,
-        "daggerverse/z5labs/tests:all": 12}
+        "daggerverse/z5labs/tests": 12}
 
     # Only DAGGER_CLOUD_TOKEN is actually consumed; MEMO_TOKEN is left unset so the
     # called workflow falls back to this run's own GITHUB_TOKEN, scoped by the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,29 +85,10 @@ jobs:
       #                            `:selection-self-test` and `:memo-store-self-test`
       #                            — both in-process, no engine work — fall back to
       #                            the default instead of carrying 15.
-      #   daggerverse/z5labs/tests is one check, `all`, and it is the largest suite in
-      #                            the repository: every publish test stands up a
-      #                            registry, an OIDC issuer and — since #415 — a
-      #                            two-service sigstore, then drives cosign against
-      #                            them. It had been landing at 5–6m against the 6m
-      #                            default, which is not headroom, it is luck: on
-      #                            #430 one run passed at 6m18s wall and the next was
-      #                            killed at 6m11s of step time with no test having
-      #                            failed. 12 is the budget it should have had before
-      #                            a leg with no override started deciding merges by
-      #                            how warm the engine was. Keyed by the module
-      #                            directory, not by `:all`: the module declares one
-      #                            check, so the change-aware path emits
-      #                            `daggerverse/z5labs/tests:all` and the
-      #                            run-everything path emits the coarse
-      #                            `daggerverse/z5labs/tests`, and a leg name key
-      #                            would budget one of those two and leave the other
-      #                            on the default.
       timeouts: >-
         {".": 15, ".:generated-self-test": 8, ".:selection-self-test": 2,
         "daggerverse/workspace-ci:*": 15, "daggerverse/workspace-ci:generated": 15,
-        "daggerverse/workspace-ci:generated-self-test": 8,
-        "daggerverse/z5labs/tests": 12}
+        "daggerverse/workspace-ci:generated-self-test": 8}
 
     # Only DAGGER_CLOUD_TOKEN is actually consumed; MEMO_TOKEN is left unset so the
     # called workflow falls back to this run's own GITHUB_TOKEN, scoped by the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,10 +85,22 @@ jobs:
       #                            `:selection-self-test` and `:memo-store-self-test`
       #                            — both in-process, no engine work — fall back to
       #                            the default instead of carrying 15.
+      #   daggerverse/z5labs/tests is one check, `all`, and it is the largest suite in
+      #                            the repository: every publish test stands up a
+      #                            registry, an OIDC issuer and — since #415 — a
+      #                            two-service sigstore, then drives cosign against
+      #                            them. It had been landing at 5–6m against the 6m
+      #                            default, which is not headroom, it is luck: on
+      #                            #430 one run passed at 6m18s wall and the next was
+      #                            killed at 6m11s of step time with no test having
+      #                            failed. 12 is the budget it should have had before
+      #                            a leg with no override started deciding merges by
+      #                            how warm the engine was.
       timeouts: >-
         {".": 15, ".:generated-self-test": 8, ".:selection-self-test": 2,
         "daggerverse/workspace-ci:*": 15, "daggerverse/workspace-ci:generated": 15,
-        "daggerverse/workspace-ci:generated-self-test": 8}
+        "daggerverse/workspace-ci:generated-self-test": 8,
+        "daggerverse/z5labs/tests:all": 12}
 
     # Only DAGGER_CLOUD_TOKEN is actually consumed; MEMO_TOKEN is left unset so the
     # called workflow falls back to this run's own GITHUB_TOKEN, scoped by the

--- a/daggerverse/CLAUDE.md
+++ b/daggerverse/CLAUDE.md
@@ -246,6 +246,18 @@ Three things that are easy to get wrong and are not obvious from the spec:
   Embed the bundle in the `dev.sigstore.cosign/bundle` annotation rather than
   leaving it to be looked up, so a consumer behind a network that cannot reach
   `rekor.sigstore.dev` can still verify.
+- **The attestation envelope needs one too, and for the same reason.** A DSSE
+  provenance envelope is signed by the same ephemeral key under the same
+  ten-minute certificate as the image signature, so leaving it unlogged leaves
+  it with exactly the defect the bullet above calls fatal. Being a referrer of
+  a digest whose signature *is* logged is not a substitute: a referrer can be
+  attached at any time by anyone who can push, so it says nothing about when
+  the envelope was signed (devex#419). Record it as a **hashedrekord over the
+  envelope's pre-authentication encoding**, not as Rekor's `intoto` type —
+  `intoto` uploads the whole envelope, and a provenance statement names the
+  repository, the commit and the workflow, which the public log then keeps
+  forever. Embed the bundle on the *signature object* beside `cert`, because a
+  countersignature timestamps one signature and DSSE permits several.
 
 ### The keyless path is exercised against a sigstore standing in the session
 

--- a/daggerverse/z5labs/app.go
+++ b/daggerverse/z5labs/app.go
@@ -278,8 +278,11 @@ func (a *App) WithOidc(requestUrl string, requestToken *dagger.Secret) *App {
 //
 // It changes what a consumer has to run, and the change is a downgrade
 // worth stating. Nothing certifies a supplied key, so there is no identity
-// to verify against and nothing to record in the public transparency log;
-// the image signature carries the signature alone, and verifying it means
+// to verify against and nothing to record in the public transparency log.
+// That covers both signed things: the image signature carries the signature
+// alone, and the provenance envelope carries a bare public key with no log
+// entry, where a keyless publish gives each of them a certificate and a
+// countersigned log entry. Verifying the image then means
 //
 //	cosign verify <ref> --key cosign.pub --insecure-ignore-tlog=true
 //
@@ -344,8 +347,9 @@ func (a *App) WithOidcService(svc *dagger.Service) *App {
 //
 // It exists so the keyless path can be *executed* rather than only
 // described: without it, the certificate request, the chain split, the log
-// upload and the three annotations that carry them are reachable only by
-// publishing a real release. The suite stands up a CA of its own and
+// uploads — the image signatures' and the provenance envelope's — and the
+// three annotations that carry them are reachable only by publishing a real
+// release. The suite stands up a CA of its own and
 // verifies the result with stock `cosign verify --certificate-identity`,
 // which is the command Publish's doc comment tells consumers to run.
 //

--- a/daggerverse/z5labs/attestations.go
+++ b/daggerverse/z5labs/attestations.go
@@ -160,7 +160,7 @@ func (a *App) attachAttestations(
 	if err != nil {
 		return err
 	}
-	envelope, err := sgn.dsseEnvelope(statement)
+	envelope, err := sgn.dsseEnvelope(ctx, statement)
 	if err != nil {
 		return err
 	}

--- a/daggerverse/z5labs/main.go
+++ b/daggerverse/z5labs/main.go
@@ -310,17 +310,29 @@
 //
 // # What can be checked about the envelope, and what cannot
 //
-// The provenance is a DSSE envelope. Its statement, and the identity that
-// signed it, are readable from those bytes alone:
+// The provenance is a DSSE envelope. Its statement, the identity that signed
+// it, and the transparency log entry that says when it was signed are all
+// readable from those bytes alone:
 //
 //	jq -r .payload provenance.intoto.jsonl | base64 -d | jq .
 //	jq -r '.signatures[0].cert' provenance.intoto.jsonl |
 //	  openssl x509 -noout -text | grep -A1 'Subject Alternative Name'
+//	jq -r '.signatures[0].bundle.Payload.body' provenance.intoto.jsonl |
+//	  base64 -d | jq .
 //
 // The first prints the in-toto statement — subject digest, build type and
 // predicate. The second prints the workflow identity out of the leaf of the
 // Fulcio chain, which dsseEnvelope carries in cosign's `cert` extension
-// field for exactly this reason.
+// field for exactly this reason. The third prints the log entry recorded for
+// this envelope, countersigned by the log at upload time; the bundle around
+// it is the same format the image signature's `dev.sigstore.cosign/bundle`
+// annotation carries, one decode shallower because an envelope is JSON and
+// an annotation is a string.
+//
+// All three are keyless properties. A publish signed with `--signing-key`
+// contacts no CA and no log, so its envelope carries a bare `publicKey` in
+// place of `cert` and no bundle at all, and how a verifier learns that key is
+// the caller's to arrange.
 //
 // Checking the *signature* over that statement needs DSSE tooling rather
 // than a cosign subcommand, because none of this is in cosign's attestation
@@ -329,17 +341,46 @@
 // in tests/attest.go is this repository's reference implementation of that
 // check, and it is about thirty lines.
 //
-// And there is a limit here worth stating rather than leaving to be
-// discovered. The image signature is recorded in the public transparency log
-// and the provenance envelope is not, so checking the envelope establishes
-// "this signature matches a certificate claiming this identity" and not
-// "that certificate was inside its validity window when it signed" — the
-// property the log provides, and the one sign.go's defaultRekorURL comment
-// says makes keyless signing a trade rather than a hole. What anchors the
-// envelope today is indirect: it is a referrer of a digest whose signature
-// *is* logged, which is the other reason the digest above comes from cosign
-// rather than from resolving the tag. Closing that gap directly is
-// devex#419.
+// # Tying the log entry to the envelope it travels with
+//
+// A bundle beside a signature proves nothing until you have checked it is a
+// bundle for *that* signature. The entry is a `hashedrekord` over the SHA-256
+// of the envelope's pre-authentication encoding, so the check is to rebuild
+// that encoding from the envelope and compare:
+//
+//	env=provenance.intoto.jsonl
+//	type=application/vnd.in-toto+json
+//	jq -r .payload "$env" | base64 -d > statement.json
+//	{ printf 'DSSEv1 %d %s %d ' "${#type}" "$type" "$(wc -c < statement.json)"
+//	  cat statement.json; } | sha256sum
+//	jq -r '.signatures[0].bundle.Payload.body' "$env" | base64 -d |
+//	  jq -r .spec.data.hash.value
+//
+// The two hashes have to be equal. If they are, the entry the log
+// countersigned is an entry over the signature in this envelope, made by the
+// certificate in this envelope — which is what establishes that the
+// certificate was inside its ten-minute validity window when it signed, the
+// property sign.go's defaultRekorURL comment calls the difference between a
+// trade and a hole.
+//
+// The entry is a hashedrekord rather than Rekor's `intoto` type, which is the
+// shape sigstore built for a DSSE envelope, and that is deliberate: an
+// `intoto` upload sends the whole envelope, and a provenance statement names
+// the repository, the commit and the workflow that produced it. The public
+// log is permanent, so a private image's build history would be published by
+// the act of anchoring its provenance. rekorBundle records the same
+// proposition against a hash and sends nothing that has to be kept.
+//
+// What no command here does is check the log's countersignature itself —
+// that the log really issued this timestamp. That needs the log's public key
+// (`curl https://rekor.sigstore.dev/api/v1/log/publicKey`) and an ECDSA
+// verification over the canonicalized entry, which is what sigstore's own
+// verifiers do and what no cosign subcommand will do for this layout. Nothing
+// in this module ships that verifier, and the suite's own log is
+// countersigned by a key nobody trusts, so what this repository establishes
+// is the encoding: that the entry travelling with an envelope is an entry
+// over that envelope's signature, and that the log's answer reached the
+// bundle unaltered.
 //
 // # Why the documents are referrers alone
 //

--- a/daggerverse/z5labs/main.go
+++ b/daggerverse/z5labs/main.go
@@ -329,7 +329,14 @@
 // annotation carries, one decode shallower because an envelope is JSON and
 // an annotation is a string.
 //
-// All three are keyless properties. A publish signed with `--signing-key`
+// `cert` holds the *whole* PEM chain, leaf first, rather than cosign's split
+// of a leaf in `cert` and the intermediates in `chain` — dsseEnvelope records
+// why. `openssl x509` above reads the first certificate, which is the leaf
+// and the one carrying the identity, so the command is unaffected; a reader
+// that requires exactly one certificate there is not.
+//
+// The statement is readable whatever signed it. The identity and the log
+// entry are keyless properties: a publish signed with `--signing-key`
 // contacts no CA and no log, so its envelope carries a bare `publicKey` in
 // place of `cert` and no bundle at all, and how a verifier learns that key is
 // the caller's to arrange.
@@ -351,17 +358,28 @@
 //	env=provenance.intoto.jsonl
 //	type=application/vnd.in-toto+json
 //	jq -r .payload "$env" | base64 -d > statement.json
-//	{ printf 'DSSEv1 %d %s %d ' "${#type}" "$type" "$(wc -c < statement.json)"
-//	  cat statement.json; } | sha256sum
-//	jq -r '.signatures[0].bundle.Payload.body' "$env" | base64 -d |
-//	  jq -r .spec.data.hash.value
+//	rebuilt=$({ printf 'DSSEv1 %d %s %d ' "${#type}" "$type" "$(wc -c < statement.json)"
+//	            cat statement.json; } | sha256sum | cut -d' ' -f1)
+//	logged=$(jq -r '.signatures[0].bundle.Payload.body' "$env" | base64 -d |
+//	         jq -r .spec.data.hash.value)
+//	[ "$rebuilt" = "$logged" ] && echo "the log entry is over this envelope"
 //
-// The two hashes have to be equal. If they are, the entry the log
-// countersigned is an entry over the signature in this envelope, made by the
-// certificate in this envelope — which is what establishes that the
-// certificate was inside its ten-minute validity window when it signed, the
-// property sign.go's defaultRekorURL comment calls the difference between a
-// trade and a hole.
+// The `cut` is not decoration: `sha256sum` prints the hash, two spaces and
+// the file name — `-` for stdin — so the two values are not comparable
+// without it, and a snippet that has to be eyeballed is one that gets
+// eyeballed wrongly. The comparison is the point, so it is the thing the
+// snippet prints.
+//
+// If the two match, the entry the log countersigned is an entry over the
+// signature in this envelope, made by the certificate in this envelope —
+// which is what establishes that the certificate was inside its ten-minute
+// validity window when it signed, the property sign.go's defaultRekorURL
+// comment calls the difference between a trade and a hole. "The certificate
+// in this envelope" is the leaf: the entry names one certificate and `cert`
+// carries the chain, so the entry's
+// `spec.signature.publicKey.content`, base64-decoded, is the *first*
+// certificate in `cert` and not the whole field. Comparing it against all of
+// `cert` will not match, by construction.
 //
 // The entry is a hashedrekord rather than Rekor's `intoto` type, which is the
 // shape sigstore built for a DSSE envelope, and that is deliberate: an

--- a/daggerverse/z5labs/sign.go
+++ b/daggerverse/z5labs/sign.go
@@ -119,9 +119,14 @@ const rekorTimeout = 60 * time.Second
 // rekor.sigstore.dev inside this function, each bounded by rekorTimeout, and
 // a sixth in attachAttestations, which records the provenance envelope's
 // signature the same way — see dsseEnvelope, which states that cost from its
-// own side. That is a publish-latency and third-party-availability
-// characteristic rather than a defect, and it is written down here so it is a
-// known cost rather than a surprise in a release that suddenly takes minutes.
+// own side.
+//
+// That count is per repository, because Publish calls this and
+// attachAttestations inside its loop over repositories: publishing the same
+// four-platform release to two repositories is twelve round trips, not six.
+// That is a publish-latency and third-party-availability characteristic
+// rather than a defect, and it is written down here so it is a known cost
+// rather than a surprise in a release that suddenly takes minutes.
 //
 // repository and digest are taken as arguments rather than read off a
 // buildFacts, so this cannot drift from the repository the caller's error

--- a/daggerverse/z5labs/sign.go
+++ b/daggerverse/z5labs/sign.go
@@ -116,10 +116,12 @@ const rekorTimeout = 60 * time.Second
 // One signature per manifest, and in the keyless mode one transparency log
 // upload per signature, issued one after another against a shared public
 // service. A four-platform release is therefore five serial round trips to
-// rekor.sigstore.dev inside the publish, each bounded by rekorTimeout. That
-// is a publish-latency and third-party-availability characteristic rather
-// than a defect, and it is written down here so it is a known cost rather
-// than a surprise in a release that suddenly takes minutes.
+// rekor.sigstore.dev inside this function, each bounded by rekorTimeout, and
+// a sixth in attachAttestations, which records the provenance envelope's
+// signature the same way — see dsseEnvelope, which states that cost from its
+// own side. That is a publish-latency and third-party-availability
+// characteristic rather than a defect, and it is written down here so it is a
+// known cost rather than a surprise in a release that suddenly takes minutes.
 //
 // repository and digest are taken as arguments rather than read off a
 // buildFacts, so this cannot drift from the repository the caller's error
@@ -411,11 +413,14 @@ func (s *signer) signatureAnnotations(ctx context.Context, payload []byte, signa
 	if chain != "" {
 		out[cosignChainAnnotation] = chain
 	}
-	bundle, err := rekorBundle(ctx, payload, signature, certificate, s.rekorURL)
+	// The log is told the payload's hash, never the payload — see rekorBundle,
+	// which takes the hash for that reason rather than hashing for its caller.
+	sum := sha256.Sum256(payload)
+	bundle, err := rekorBundle(ctx, sum[:], signature, certificate, s.rekorURL)
 	if err != nil {
 		return nil, err
 	}
-	out[cosignBundleAnnotation] = bundle
+	out[cosignBundleAnnotation] = string(bundle)
 	return out, nil
 }
 
@@ -472,13 +477,35 @@ func splitCertificateChain(chain []byte) (string, string, error) {
 	return leaf.String(), rest.String(), nil
 }
 
-// rekorBundle uploads the signature to the public transparency log and
-// returns the bundle cosign carries beside it.
+// rekorBundle records one signature in the transparency log and returns the
+// bundle that travels beside it.
 //
-// The entry is a `hashedrekord`: the log is told the payload's hash, the
-// signature and the certificate, never the payload. That matters for a
-// private image — the log is public and permanent, and a simple signing
-// payload names the repository.
+// Two kinds of signature come through here, and one function serves both
+// because what the log is being told is the same proposition each time — this
+// certificate signed something with this hash, at this moment. A keyless
+// publish records one entry per image signature (signatureAnnotations, over
+// the simple signing payload) and one for the provenance envelope
+// (dsseEnvelope, over its pre-authentication encoding). Nothing distinguishes
+// them here, and nothing needs to: the caller has already decided what it
+// hashed.
+//
+// The entry is a `hashedrekord`: the log is told a hash, the signature and
+// the certificate, never the bytes. That matters for a private image — the
+// log is public and permanent, a simple signing payload names the repository,
+// and a provenance statement names the repository, the commit and the
+// workflow that built it. It is also why the envelope's entry is a
+// hashedrekord over its pre-authentication encoding rather than Rekor's
+// `intoto` type, which is the shape sigstore built for a DSSE envelope and
+// takes the whole envelope, payload included, in the request. What is
+// established is identical — the hash a verifier recomputes from the envelope
+// it holds is the hash the log countersigned — and what is avoided is
+// uploading every provenance statement this pipeline ever signs to a public
+// service. See main.go's package doc, which records the decision and the
+// commands a consumer checks it with.
+//
+// hash is taken rather than computed from bytes for the same reason: a
+// function that hashed for its caller would have to be handed the payload,
+// and then the thing it exists not to send would have to be passed to it.
 //
 // What comes back and is stored is the log's countersignature (the signed
 // entry timestamp) over the entry, plus enough of the entry to check it.
@@ -497,8 +524,10 @@ func splitCertificateChain(chain []byte) (string, string, error) {
 // cannot establish is anything about the public log's availability, its
 // inclusion proof, or a verifier's willingness to trust its
 // countersignature. The suite says as much where it asserts.
-func rekorBundle(ctx context.Context, payload []byte, signature, certificate, rekorURL string) (string, error) {
-	sum := sha256.Sum256(payload)
+func rekorBundle(ctx context.Context, hash []byte, signature, certificate, rekorURL string) ([]byte, error) {
+	if len(hash) != sha256.Size {
+		return nil, fmt.Errorf("transparency log entry needs a %d-byte SHA-256, got %d bytes", sha256.Size, len(hash))
+	}
 	body, err := json.Marshal(map[string]any{
 		"apiVersion": "0.0.1",
 		"kind":       "hashedrekord",
@@ -506,7 +535,7 @@ func rekorBundle(ctx context.Context, payload []byte, signature, certificate, re
 			"data": map[string]any{
 				"hash": map[string]string{
 					"algorithm": "sha256",
-					"value":     hex.EncodeToString(sum[:]),
+					"value":     hex.EncodeToString(hash),
 				},
 			},
 			"signature": map[string]any{
@@ -518,7 +547,7 @@ func rekorBundle(ctx context.Context, payload []byte, signature, certificate, re
 		},
 	})
 	if err != nil {
-		return "", fmt.Errorf("encode transparency log entry: %v", err)
+		return nil, fmt.Errorf("encode transparency log entry: %v", err)
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, rekorTimeout)
@@ -527,23 +556,23 @@ func rekorBundle(ctx context.Context, payload []byte, signature, certificate, re
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
 		rekorURL+"/api/v1/log/entries", bytes.NewReader(body))
 	if err != nil {
-		return "", fmt.Errorf("build transparency log request: %v", err)
+		return nil, fmt.Errorf("build transparency log request: %v", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("record signature in the transparency log at %s: %v", rekorURL, err)
+		return nil, fmt.Errorf("record signature in the transparency log at %s: %v", rekorURL, err)
 	}
 	defer resp.Body.Close()
 
 	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
-		return "", fmt.Errorf("read transparency log response: %v", err)
+		return nil, fmt.Errorf("read transparency log response: %v", err)
 	}
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return "", fmt.Errorf("transparency log at %s returned %s%s", rekorURL, resp.Status, responseDetail(raw))
+		return nil, fmt.Errorf("transparency log at %s returned %s%s", rekorURL, resp.Status, responseDetail(raw))
 	}
 
 	// The response is keyed by the entry's UUID, which is not known until
@@ -562,15 +591,15 @@ func rekorBundle(ctx context.Context, payload []byte, signature, certificate, re
 		} `json:"verification"`
 	}
 	if err := json.Unmarshal(raw, &entries); err != nil {
-		return "", fmt.Errorf("decode transparency log response: %v", err)
+		return nil, fmt.Errorf("decode transparency log response: %v", err)
 	}
 	if len(entries) != 1 {
-		return "", fmt.Errorf("transparency log at %s recorded %d entries for one signature, want exactly 1",
+		return nil, fmt.Errorf("transparency log at %s recorded %d entries for one signature, want exactly 1",
 			rekorURL, len(entries))
 	}
 	for _, entry := range entries {
 		if entry.Verification.SignedEntryTimestamp == "" {
-			return "", fmt.Errorf("transparency log entry from %s carried no signed entry timestamp", rekorURL)
+			return nil, fmt.Errorf("transparency log entry from %s carried no signed entry timestamp", rekorURL)
 		}
 		// The field names are capitalized because cosign's bundle type
 		// spells them that way; they are a wire format, not a style choice.
@@ -584,10 +613,10 @@ func rekorBundle(ctx context.Context, payload []byte, signature, certificate, re
 			},
 		})
 		if err != nil {
-			return "", fmt.Errorf("encode transparency log bundle: %v", err)
+			return nil, fmt.Errorf("encode transparency log bundle: %v", err)
 		}
-		return string(bundle), nil
+		return bundle, nil
 	}
 	// Unreachable: the length check above already refused an empty map.
-	return "", fmt.Errorf("transparency log at %s recorded no entry", rekorURL)
+	return nil, fmt.Errorf("transparency log at %s recorded no entry", rekorURL)
 }

--- a/daggerverse/z5labs/signing.go
+++ b/daggerverse/z5labs/signing.go
@@ -364,36 +364,140 @@ var jwtLike = regexp.MustCompile(`[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0
 // JSON is not. cert and chain are cosign's extension fields, carried so
 // a verifier can recover the signing identity from the envelope alone
 // rather than needing a separate bundle.
-func (s *signer) dsseEnvelope(statement []byte) ([]byte, error) {
+//
+// # The envelope is recorded in the transparency log too
+//
+// A keyless envelope carries its own log entry, in the bundle field beside
+// the certificate, and that is devex#419's decision. The alternative on the
+// table was to leave it unlogged and call the indirect anchor sufficient —
+// the envelope is a referrer of a digest whose signature *is* logged — and it
+// was rejected, for two reasons.
+//
+// The first is that the indirect anchor does not establish the property. A
+// referrer can be attached to a digest at any time by anyone who can push to
+// the repository, so "this envelope hangs off a digest that was signed at
+// time T" says nothing about when the envelope was signed. What the log
+// establishes for a signature is that the signature existed while the
+// certificate was live, and nothing but a log entry over *this* signature
+// establishes that for this signature.
+//
+// The second is that the module already holds the opposite opinion one file
+// away and cannot coherently hold both. sign.go's defaultRekorURL comment
+// says keyless signing with no log entry is not a weaker signature but a
+// broken one, and signatureAnnotations refuses to publish one. The envelope
+// is signed by the same ephemeral key under the same ten-minute certificate;
+// there is no argument that makes the signature's expiry fatal and the
+// envelope's acceptable.
+//
+// Three things about the shape, each of which is a decision:
+//
+//   - The bundle is embedded rather than left to be looked up, for the reason
+//     rekorBundle gives on the signature's side: a consumer inside a network
+//     that cannot reach rekor.sigstore.dev still has everything the check
+//     needs. It keeps the envelope verifiable on its own bytes, which is what
+//     the package doc promises about it.
+//   - It hangs off the signature, not off the envelope. A log entry
+//     countersigns one signature, and DSSE allows an envelope to carry
+//     several; a top-level field could not say which one it timestamped.
+//     cert and chain are already extension fields in the same place, so this
+//     is the position cosign established rather than a new one.
+//   - It is the same bundle format the signature's dev.sigstore.cosign/bundle
+//     annotation carries, as an object rather than as a string containing
+//     JSON. One format is one thing for a consumer to learn, and a document
+//     meant to be read with jq should not need a second parse to reach half
+//     of itself.
+//
+// # What it costs
+//
+// One more transparency log upload per publish, and it is stated here the way
+// signImage states its own because it is the same cost: another serial round
+// trip to a shared third-party service inside the publish, bounded by
+// rekorTimeout, and another way for a publish to fail that has nothing to do
+// with the artifact. It is one per publish rather than one per platform —
+// there is a single provenance statement per publish — so a four-platform
+// keyless release goes from five round trips to six.
+func (s *signer) dsseEnvelope(ctx context.Context, statement []byte) ([]byte, error) {
 	pae := preAuthenticationEncoding(dssePayloadType, statement)
 	digest := sha256.Sum256(pae)
 	sig, err := ecdsa.SignASN1(rand.Reader, s.key, digest[:])
 	if err != nil {
 		return nil, fmt.Errorf("sign attestation: %v", err)
 	}
-	signature := map[string]string{
-		"sig":   base64.StdEncoding.EncodeToString(sig),
+	encoded := base64.StdEncoding.EncodeToString(sig)
+	signature := map[string]any{
+		"sig":   encoded,
 		"keyid": s.keyID(),
 	}
-	if len(s.chain) > 0 {
-		signature["cert"] = string(s.chain)
-	} else {
+	// The mode is read off the signer rather than off the chain, which is the
+	// rule the keyless field exists to make possible and the one
+	// signatureAnnotations follows. Branching on a non-empty chain would mean
+	// a keyless publish that somehow lost its certificate silently produced
+	// the supplied-key envelope — a bare public key, no identity, and no log
+	// entry — and reported success.
+	if !s.keyless {
 		publicDER, err := x509.MarshalPKIXPublicKey(&s.key.PublicKey)
 		if err != nil {
 			return nil, fmt.Errorf("encode signing public key: %v", err)
 		}
 		signature["publicKey"] = string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: publicDER}))
+	} else {
+		bundle, err := s.logEnvelopeSignature(ctx, digest[:], encoded)
+		if err != nil {
+			return nil, err
+		}
+		signature["cert"] = string(s.chain)
+		signature["bundle"] = json.RawMessage(bundle)
 	}
 	envelope := map[string]any{
 		"payloadType": dssePayloadType,
 		"payload":     base64.StdEncoding.EncodeToString(statement),
-		"signatures":  []map[string]string{signature},
+		"signatures":  []map[string]any{signature},
 	}
 	out, err := json.MarshalIndent(envelope, "", "  ")
 	if err != nil {
 		return nil, fmt.Errorf("encode attestation envelope: %v", err)
 	}
 	return append(out, '\n'), nil
+}
+
+// logEnvelopeSignature records the envelope's signature in the transparency
+// log and returns the bundle to embed beside it.
+//
+// The certificate the entry names is the leaf and not the whole chain, which
+// is the same split signatureAnnotations makes and for a reason worth stating
+// rather than inheriting: the entry says which key signed, and a log lenient
+// enough to accept a chain would record an intermediate as the signer. The
+// envelope's own cert field still carries the chain, because that is where a
+// verifier walks to a root and it is what cosign's extension field means.
+//
+// The two refusals mirror signatureAnnotations' exactly. Neither is reachable
+// today — newSigner sets the chain and the log together on every keyless
+// signer, and refuses if the CA returned no chain — and they are here for the
+// same reason the ones there are: what they would otherwise let out is a
+// provenance envelope carrying an identity nothing vouches for, or a
+// certificate that expires into unverifiability, published as though it were
+// complete.
+func (s *signer) logEnvelopeSignature(ctx context.Context, digest []byte, signature string) ([]byte, error) {
+	if len(s.chain) == 0 {
+		return nil, fmt.Errorf(
+			"keyless signing produced no certificate chain, so nothing would vouch for the key that signed the " +
+				"provenance envelope; refusing to publish an attestation no documented check can attribute")
+	}
+	if strings.TrimSpace(s.rekorURL) == "" {
+		return nil, fmt.Errorf(
+			"keyless signing has no transparency log to record in, so nothing would establish the signing certificate " +
+				"was live when it signed the provenance envelope; refusing to publish an attestation that expires " +
+				"into unverifiability")
+	}
+	leaf, _, err := splitCertificateChain(s.chain)
+	if err != nil {
+		return nil, err
+	}
+	bundle, err := rekorBundle(ctx, digest, signature, leaf, s.rekorURL)
+	if err != nil {
+		return nil, err
+	}
+	return bundle, nil
 }
 
 // keyID is the SHA-256 of the DER public key, which is how a verifier

--- a/daggerverse/z5labs/signing.go
+++ b/daggerverse/z5labs/signing.go
@@ -361,9 +361,26 @@ var jwtLike = regexp.MustCompile(`[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0
 // DSSE rather than a detached signature over the JSON: the payload type
 // is signed alongside the payload, so a document cannot be replayed as a
 // different kind of attestation, and the encoding is stable in a way raw
-// JSON is not. cert and chain are cosign's extension fields, carried so
-// a verifier can recover the signing identity from the envelope alone
-// rather than needing a separate bundle.
+// JSON is not. cert is cosign's extension field, carried so a verifier can
+// recover the signing identity from the envelope alone rather than needing a
+// separate bundle.
+//
+// # It carries the whole chain in cert, where cosign would split it
+//
+// cosign's own split is the one signatureAnnotations makes for the signature
+// annotations: the leaf goes in cert and the intermediates in chain. This
+// envelope writes the whole PEM chain into cert and no chain field at all,
+// which predates devex#419 and is left alone by it — moving certificates
+// between fields would change bytes already published under a documented
+// read path, which is not something to do incidentally to adding a log entry.
+//
+// What that costs a reader is one surprise, so it is written down here and
+// in the package doc rather than left in the bytes. `cert` holds one or more
+// certificates, leaf first. A single pem.Decode or `openssl x509` reads the
+// leaf and is correct. Anything that requires cert to hold exactly one
+// certificate is not, and the log entry below names the leaf alone — so the
+// certificate in the entry is the *first* certificate in cert, never the
+// whole field.
 //
 // # The envelope is recorded in the transparency log too
 //
@@ -409,13 +426,17 @@ var jwtLike = regexp.MustCompile(`[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0
 //
 // # What it costs
 //
-// One more transparency log upload per publish, and it is stated here the way
-// signImage states its own because it is the same cost: another serial round
-// trip to a shared third-party service inside the publish, bounded by
-// rekorTimeout, and another way for a publish to fail that has nothing to do
-// with the artifact. It is one per publish rather than one per platform —
-// there is a single provenance statement per publish — so a four-platform
-// keyless release goes from five round trips to six.
+// One more transparency log upload, and it is stated here the way signImage
+// states its own because it is the same cost: another serial round trip to a
+// shared third-party service inside the publish, bounded by rekorTimeout, and
+// another way for a publish to fail that has nothing to do with the artifact.
+//
+// The unit is one per repository published to, not one per platform and not
+// one per publish. There is a single provenance statement per repository —
+// its subject is that repository's digest — and Publish loops repositories,
+// calling attachAttestations and signImage inside the loop. So a
+// four-platform keyless release costs six round trips to one repository, and
+// twelve to two.
 func (s *signer) dsseEnvelope(ctx context.Context, statement []byte) ([]byte, error) {
 	pae := preAuthenticationEncoding(dssePayloadType, statement)
 	digest := sha256.Sum256(pae)
@@ -466,9 +487,14 @@ func (s *signer) dsseEnvelope(ctx context.Context, statement []byte) ([]byte, er
 // The certificate the entry names is the leaf and not the whole chain, which
 // is the same split signatureAnnotations makes and for a reason worth stating
 // rather than inheriting: the entry says which key signed, and a log lenient
-// enough to accept a chain would record an intermediate as the signer. The
-// envelope's own cert field still carries the chain, because that is where a
-// verifier walks to a root and it is what cosign's extension field means.
+// enough to accept a chain would record an intermediate as the signer.
+//
+// The envelope's own cert field still carries the whole chain, which is what
+// it carried before this and is dsseEnvelope's divergence from cosign rather
+// than an agreement with it — see the section there that says so. The
+// consequence to hold on to is that the entry's certificate and the cert
+// field are deliberately not the same bytes: the entry names the first
+// certificate in cert.
 //
 // The two refusals mirror signatureAnnotations' exactly. Neither is reachable
 // today — newSigner sets the chain and the log together on every keyless

--- a/daggerverse/z5labs/tests/attest.go
+++ b/daggerverse/z5labs/tests/attest.go
@@ -281,30 +281,50 @@ func (t *Tests) AppAttachesSbomsAndProvenance(ctx context.Context) error {
 	return checkStatement(statement, digest, repository, prov.Claims)
 }
 
-// envelopeRecordsNoLogEntry asserts a supplied-key publish embeds no
-// transparency log bundle in its provenance envelope.
+// envelopeRecordsNoLogEntry asserts a supplied-key publish produces the
+// supplied-key envelope: a bare public key, no certificate, and no
+// transparency log bundle.
 //
-// The keyless publish embeds one — AppKeylessSignatureVerifiesAgainstALocalSigstore
-// asserts it, and asserts what it is over. This is the other side of that
-// split, and it is worth pinning rather than leaving to follow from the code:
-// a supplied-key publish contacts no log, so a bundle here would be a
-// countersignature nothing issued, on a signature no log ever saw. It is the
-// same mode split signatureAnnotations makes for the signature's annotations,
-// read back from the published bytes.
+// The keyless publish produces the other one — AppKeylessSignatureVerifiesAgainstALocalSigstore
+// asserts the certificate, the bundle and what the bundle is over. This is
+// the other side of that split, and all three fields are checked rather than
+// only the bundle, because dsseEnvelope decides all three from one branch on
+// signer.keyless. Asserting the absent bundle alone would leave a regression
+// that emitted a certificate here — or neither a certificate nor a key —
+// passing a test whose whole subject is the mode split.
+//
+// What makes it worth pinning at all: a supplied-key publish contacts no log,
+// so a bundle here would be a countersignature nothing issued, on a signature
+// no log ever saw.
 func envelopeRecordsNoLogEntry(raw []byte) error {
 	var envelope struct {
 		Signatures []struct {
-			Bundle json.RawMessage `json:"bundle"`
+			Cert      string          `json:"cert"`
+			PublicKey string          `json:"publicKey"`
+			Bundle    json.RawMessage `json:"bundle"`
 		} `json:"signatures"`
 	}
 	if err := json.Unmarshal(raw, &envelope); err != nil {
 		return fmt.Errorf("decode the provenance envelope: %v", err)
+	}
+	if len(envelope.Signatures) != 1 {
+		return fmt.Errorf("the provenance envelope carries %d signatures, want 1", len(envelope.Signatures))
 	}
 	for i, signature := range envelope.Signatures {
 		if len(signature.Bundle) > 0 {
 			return fmt.Errorf(
 				"a supplied-key publish embedded a transparency log bundle in signature %d of its provenance envelope, "+
 					"but it contacted no log: %s", i, signature.Bundle)
+		}
+		if signature.Cert != "" {
+			return fmt.Errorf(
+				"a supplied-key publish put a certificate in signature %d of its provenance envelope, "+
+					"but nothing certified that key", i)
+		}
+		if signature.PublicKey == "" {
+			return fmt.Errorf(
+				"signature %d of a supplied-key publish's provenance envelope carries neither a certificate nor a "+
+					"public key, so nothing identifies what signed it", i)
 		}
 	}
 	return nil

--- a/daggerverse/z5labs/tests/attest.go
+++ b/daggerverse/z5labs/tests/attest.go
@@ -275,7 +275,39 @@ func (t *Tests) AppAttachesSbomsAndProvenance(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	if err := envelopeRecordsNoLogEntry(envelope); err != nil {
+		return err
+	}
 	return checkStatement(statement, digest, repository, prov.Claims)
+}
+
+// envelopeRecordsNoLogEntry asserts a supplied-key publish embeds no
+// transparency log bundle in its provenance envelope.
+//
+// The keyless publish embeds one — AppKeylessSignatureVerifiesAgainstALocalSigstore
+// asserts it, and asserts what it is over. This is the other side of that
+// split, and it is worth pinning rather than leaving to follow from the code:
+// a supplied-key publish contacts no log, so a bundle here would be a
+// countersignature nothing issued, on a signature no log ever saw. It is the
+// same mode split signatureAnnotations makes for the signature's annotations,
+// read back from the published bytes.
+func envelopeRecordsNoLogEntry(raw []byte) error {
+	var envelope struct {
+		Signatures []struct {
+			Bundle json.RawMessage `json:"bundle"`
+		} `json:"signatures"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return fmt.Errorf("decode the provenance envelope: %v", err)
+	}
+	for i, signature := range envelope.Signatures {
+		if len(signature.Bundle) > 0 {
+			return fmt.Errorf(
+				"a supplied-key publish embedded a transparency log bundle in signature %d of its provenance envelope, "+
+					"but it contacted no log: %s", i, signature.Bundle)
+		}
+	}
+	return nil
 }
 
 // AppAttestsTwoSegmentRepositories asserts a publish whose repository

--- a/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
+++ b/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type Z5Labs
-func (r *Binding) AsZ5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:387:6)
+func (r *Binding) AsZ5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:428:6)
 	q := r.query.Select("asZ5Labs")
 
 	return &Z5Labs{
@@ -118,7 +118,7 @@ func (r *Env) WithZ5LabsGoChainOutput(name string, description string) *Env { //
 }
 
 // Create or update a binding of type Z5Labs in the environment
-func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:387:6)
+func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:428:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withZ5LabsInput")
 	q = q.Arg("name", name)
@@ -131,7 +131,7 @@ func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *E
 }
 
 // Declare a desired Z5Labs output to be assigned in the environment
-func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:387:6)
+func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:428:6)
 	q := r.query.Select("withZ5LabsOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -143,7 +143,7 @@ func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs
 
 // Z5labs is the root module type. Construct the Go language chain via Go;
 // everything this module does is reached from there.
-func (r *Query) Z5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:387:6)
+func (r *Query) Z5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:428:6)
 	q := r.query.Select("z5Labs")
 
 	return &Z5Labs{
@@ -153,7 +153,7 @@ func (r *Query) Z5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/
 
 // Z5labs is the root module type. Construct the Go language chain via Go;
 // everything this module does is reached from there.
-type Z5Labs struct { // z5labs (../../../../../daggerverse/z5labs/main.go:387:6)
+type Z5Labs struct { // z5labs (../../../../../daggerverse/z5labs/main.go:428:6)
 	query *querybuilder.Selection
 
 	composeSelfTest          *Void
@@ -396,7 +396,7 @@ func (r *Z5Labs) FileDocument(file *File, opts ...Z5LabsFileDocumentOpts) *File 
 //
 // The returned object is GoChain rather than Go because the `go` module
 // this one depends on already owns that name — see GoChain's doc comment.
-func (r *Z5Labs) Go(source *Directory) *Z5LabsGoChain { // z5labs (../../../../../daggerverse/z5labs/main.go:403:1)
+func (r *Z5Labs) Go(source *Directory) *Z5LabsGoChain { // z5labs (../../../../../daggerverse/z5labs/main.go:444:1)
 	assertNotNil("source", source)
 	q := r.query.Select("go")
 	q = q.Arg("source", source)
@@ -827,7 +827,7 @@ func (r *Z5LabsApp) UnmarshalJSON(bs []byte) error {
 // Publishing is a side effect against an external registry, so it is
 // uncached: a re-run must actually push. The build above it is session
 // cached, so the bytes pushed are the bytes Container returned.
-func (r *Z5LabsApp) Publish(ctx context.Context, repositories []string) ([]string, error) { // z5labs (../../../../../daggerverse/z5labs/app.go:507:1)
+func (r *Z5LabsApp) Publish(ctx context.Context, repositories []string) ([]string, error) { // z5labs (../../../../../daggerverse/z5labs/app.go:511:1)
 	q := r.query.Select("publish")
 	q = q.Arg("repositories", repositories)
 
@@ -945,7 +945,7 @@ func (r *Z5LabsApp) WithFile(path string, file *File, document *File) *Z5LabsApp
 // unverified connection. It is spelled insecure rather than tlsVerify
 // because a bool defaulting to true cannot be turned off from the CLI —
 // which is also why this method takes no argument at all.
-func (r *Z5LabsApp) WithInsecure() *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:306:1)
+func (r *Z5LabsApp) WithInsecure() *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:309:1)
 	q := r.query.Select("withInsecure")
 
 	return &Z5LabsApp{
@@ -985,7 +985,7 @@ func (r *Z5LabsApp) WithOidc(requestUrl string, requestToken *Secret) *Z5LabsApp
 // This exists for the same reason WithRegistryService does, and is used by
 // the test suite, which runs a real token endpoint rather than relaxing the
 // provenance requirement into the shape of the tests.
-func (r *Z5LabsApp) WithOidcService(svc *Service) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:336:1)
+func (r *Z5LabsApp) WithOidcService(svc *Service) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:339:1)
 	assertNotNil("svc", svc)
 	q := r.query.Select("withOidcService")
 	q = q.Arg("svc", svc)
@@ -1030,7 +1030,7 @@ func (r *Z5LabsApp) WithRegistry(address string, username string, auth *Secret) 
 // into an address ahead of time; this is how the publish learns it. Used by
 // the test suite against a local registry, and by anyone whose private
 // registry is itself a Dagger service.
-func (r *Z5LabsApp) WithRegistryService(svc *Service) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:320:1)
+func (r *Z5LabsApp) WithRegistryService(svc *Service) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:323:1)
 	assertNotNil("svc", svc)
 	q := r.query.Select("withRegistryService")
 	q = q.Arg("svc", svc)
@@ -1046,8 +1046,9 @@ func (r *Z5LabsApp) WithRegistryService(svc *Service) *Z5LabsApp { // z5labs (..
 //
 // It exists so the keyless path can be *executed* rather than only
 // described: without it, the certificate request, the chain split, the log
-// upload and the three annotations that carry them are reachable only by
-// publishing a real release. The suite stands up a CA of its own and
+// uploads — the image signatures' and the provenance envelope's — and the
+// three annotations that carry them are reachable only by publishing a real
+// release. The suite stands up a CA of its own and
 // verifies the result with stock `cosign verify --certificate-identity`,
 // which is the command Publish's doc comment tells consumers to run.
 //
@@ -1093,7 +1094,7 @@ func (r *Z5LabsApp) WithRegistryService(svc *Service) *Z5LabsApp { // z5labs (..
 // asserted: a local log's countersignature is trusted by nobody, so a
 // verifier still has to be told to ignore the log, and nothing here says
 // anything about the public services' availability.
-func (r *Z5LabsApp) WithSessionSigstore(fulcio *Service, rekor *Service) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:396:1)
+func (r *Z5LabsApp) WithSessionSigstore(fulcio *Service, rekor *Service) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:400:1)
 	assertNotNil("fulcio", fulcio)
 	assertNotNil("rekor", rekor)
 	q := r.query.Select("withSessionSigstore")
@@ -1117,15 +1118,18 @@ func (r *Z5LabsApp) WithSessionSigstore(fulcio *Service, rekor *Service) *Z5Labs
 //
 // It changes what a consumer has to run, and the change is a downgrade
 // worth stating. Nothing certifies a supplied key, so there is no identity
-// to verify against and nothing to record in the public transparency log;
-// the image signature carries the signature alone, and verifying it means
+// to verify against and nothing to record in the public transparency log.
+// That covers both signed things: the image signature carries the signature
+// alone, and the provenance envelope carries a bare public key with no log
+// entry, where a keyless publish gives each of them a certificate and a
+// countersigned log entry. Verifying the image then means
 //
 //	cosign verify <ref> --key cosign.pub --insecure-ignore-tlog=true
 //
 // where the keyless mode gets an identity and an issuer and no such flag.
 // A caller who does not want to hand their consumers that flag should not
 // be supplying a key.
-func (r *Z5LabsApp) WithSigningKey(key *Secret) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:291:1)
+func (r *Z5LabsApp) WithSigningKey(key *Secret) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/app.go:294:1)
 	assertNotNil("key", key)
 	q := r.query.Select("withSigningKey")
 	q = q.Arg("key", key)

--- a/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
+++ b/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type Z5Labs
-func (r *Binding) AsZ5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:428:6)
+func (r *Binding) AsZ5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:446:6)
 	q := r.query.Select("asZ5Labs")
 
 	return &Z5Labs{
@@ -118,7 +118,7 @@ func (r *Env) WithZ5LabsGoChainOutput(name string, description string) *Env { //
 }
 
 // Create or update a binding of type Z5Labs in the environment
-func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:428:6)
+func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:446:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withZ5LabsInput")
 	q = q.Arg("name", name)
@@ -131,7 +131,7 @@ func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *E
 }
 
 // Declare a desired Z5Labs output to be assigned in the environment
-func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:428:6)
+func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:446:6)
 	q := r.query.Select("withZ5LabsOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -143,7 +143,7 @@ func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs
 
 // Z5labs is the root module type. Construct the Go language chain via Go;
 // everything this module does is reached from there.
-func (r *Query) Z5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:428:6)
+func (r *Query) Z5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:446:6)
 	q := r.query.Select("z5Labs")
 
 	return &Z5Labs{
@@ -153,7 +153,7 @@ func (r *Query) Z5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/
 
 // Z5labs is the root module type. Construct the Go language chain via Go;
 // everything this module does is reached from there.
-type Z5Labs struct { // z5labs (../../../../../daggerverse/z5labs/main.go:428:6)
+type Z5Labs struct { // z5labs (../../../../../daggerverse/z5labs/main.go:446:6)
 	query *querybuilder.Selection
 
 	composeSelfTest          *Void
@@ -396,7 +396,7 @@ func (r *Z5Labs) FileDocument(file *File, opts ...Z5LabsFileDocumentOpts) *File 
 //
 // The returned object is GoChain rather than Go because the `go` module
 // this one depends on already owns that name — see GoChain's doc comment.
-func (r *Z5Labs) Go(source *Directory) *Z5LabsGoChain { // z5labs (../../../../../daggerverse/z5labs/main.go:444:1)
+func (r *Z5Labs) Go(source *Directory) *Z5LabsGoChain { // z5labs (../../../../../daggerverse/z5labs/main.go:462:1)
 	assertNotNil("source", source)
 	q := r.query.Select("go")
 	q = q.Arg("source", source)

--- a/daggerverse/z5labs/tests/keyless.go
+++ b/daggerverse/z5labs/tests/keyless.go
@@ -6,9 +6,11 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
@@ -399,6 +401,107 @@ func (t *Tests) AppKeylessSignatureVerifiesAgainstALocalSigstore(ctx context.Con
 			return err
 		}
 	}
+
+	// The provenance envelope's own log entry, which is the other half of the
+	// same verification story and the half that used to be missing. It is
+	// asserted from the same publish rather than from a second one, because
+	// what makes it meaningful is that the envelope and the signatures above
+	// were produced by one signer against one sigstore.
+	envelope, err := attachedDocument(ctx, registry, repository, digest, provenanceArtifactType)
+	if err != nil {
+		return err
+	}
+	return sig.assertEnvelopeBundle(envelope)
+}
+
+// assertEnvelopeBundle checks the transparency log entry a keyless publish
+// embeds in the provenance envelope.
+//
+// The load-bearing assertion is the hash. The entry has to be over the
+// SHA-256 of *this* envelope's pre-authentication encoding, which is rebuilt
+// here rather than taken from the module for the same reason verifyEnvelope
+// rebuilds it: an entry over anything else — the payload, the envelope bytes,
+// some other signature — is a countersignature that timestamps something
+// other than the signature it travels with, and it would satisfy every
+// weaker check in this function.
+//
+// The certificate is checked the same way round: the signature in the
+// envelope has to verify against the key in the leaf the entry names, so the
+// identity the log recorded is the identity that signed.
+func (h *sigstoreHarness) assertEnvelopeBundle(raw []byte) error {
+	const what = "the provenance envelope"
+	var envelope struct {
+		PayloadType string `json:"payloadType"`
+		Payload     string `json:"payload"`
+		Signatures  []struct {
+			Sig    string          `json:"sig"`
+			Cert   string          `json:"cert"`
+			Bundle json.RawMessage `json:"bundle"`
+		} `json:"signatures"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return fmt.Errorf("decode %s: %v", what, err)
+	}
+	if len(envelope.Signatures) != 1 {
+		return fmt.Errorf("%s carries %d signatures, want 1", what, len(envelope.Signatures))
+	}
+	signature := envelope.Signatures[0]
+	if len(signature.Bundle) == 0 {
+		return fmt.Errorf(
+			"%s carries no bundle, so nothing establishes its certificate was live when it signed", what)
+	}
+
+	payload, err := base64.StdEncoding.DecodeString(envelope.Payload)
+	if err != nil {
+		return fmt.Errorf("decode %s payload: %v", what, err)
+	}
+	pae := fmt.Sprintf("DSSEv1 %d %s %d ", len(envelope.PayloadType), envelope.PayloadType, len(payload))
+	digest := sha256.Sum256(append([]byte(pae), payload...))
+
+	leaves, err := certificatesIn(signature.Cert)
+	if err != nil {
+		return fmt.Errorf("%s: cert: %v", what, err)
+	}
+	if len(leaves) == 0 {
+		return fmt.Errorf("%s carries no certificate", what)
+	}
+	public, ok := leaves[0].PublicKey.(*ecdsa.PublicKey)
+	if !ok {
+		return fmt.Errorf("%s carries a %T certificate key, want an ECDSA key", what, leaves[0].PublicKey)
+	}
+	sig, err := base64.StdEncoding.DecodeString(signature.Sig)
+	if err != nil {
+		return fmt.Errorf("decode %s signature: %v", what, err)
+	}
+	if !ecdsa.VerifyASN1(public, digest[:], sig) {
+		return fmt.Errorf("%s: the signature does not verify against the certificate travelling with it", what)
+	}
+
+	entry, err := h.checkBundle(what, string(signature.Bundle))
+	if err != nil {
+		return err
+	}
+	if got, want := entry.Spec.Data.Hash.Value, hex.EncodeToString(digest[:]); got != want {
+		return fmt.Errorf(
+			"%s: the log recorded an entry over %s, want %s — the SHA-256 of the envelope's pre-authentication encoding",
+			what, got, want)
+	}
+	if got := entry.Spec.Signature.Content; got != signature.Sig {
+		return fmt.Errorf("%s: the log recorded signature %q, want the envelope's own %q", what, got, signature.Sig)
+	}
+	recorded, err := base64.StdEncoding.DecodeString(entry.Spec.Signature.PublicKey.Content)
+	if err != nil {
+		return fmt.Errorf("%s: the logged public key is not base64: %v", what, err)
+	}
+	logged, err := certificatesIn(string(recorded))
+	if err != nil {
+		return fmt.Errorf("%s: the logged public key: %v", what, err)
+	}
+	// One certificate, and the leaf. A chain here would be a log entry naming
+	// an intermediate as the signer on any log lenient enough to take it.
+	if len(logged) != 1 || !bytes.Equal(logged[0].Raw, leaves[0].Raw) {
+		return fmt.Errorf("%s: the log recorded %d certificates, want only the leaf that signed", what, len(logged))
+	}
 	return nil
 }
 
@@ -465,10 +568,38 @@ func (h *sigstoreHarness) assertKeylessAnnotations(
 		}
 	}
 
-	return h.assertBundle(tag, annotations[bundleAnnotation])
+	_, err = h.checkBundle("signature "+tag, annotations[bundleAnnotation])
+	return err
 }
 
-// assertBundle checks the transparency log bundle the publish embedded.
+// loggedEntry is the hashedrekord a bundle's body carries, as much of it as
+// this suite reads back.
+type loggedEntry struct {
+	Kind string `json:"kind"`
+	Spec struct {
+		Data struct {
+			Hash struct {
+				Algorithm string `json:"algorithm"`
+				Value     string `json:"value"`
+			} `json:"hash"`
+		} `json:"data"`
+		Signature struct {
+			Content   string `json:"content"`
+			PublicKey struct {
+				Content string `json:"content"`
+			} `json:"publicKey"`
+		} `json:"signature"`
+	} `json:"spec"`
+}
+
+// checkBundle checks one embedded transparency log bundle and returns the
+// entry inside it, so a caller can go on to assert what that entry is over.
+//
+// Both places a bundle is embedded come through here — a signature's
+// dev.sigstore.cosign/bundle annotation and the provenance envelope's own
+// bundle field — because they are one format written once, and a check that
+// knew only the annotation's would let the envelope's drift into a shape
+// nothing else reads.
 //
 // The field names are capitalized because cosign's bundle type spells them
 // that way, and getting that wrong is invisible until a consumer's cosign
@@ -479,9 +610,9 @@ func (h *sigstoreHarness) assertKeylessAnnotations(
 // only to the log, so a bundle carrying it is a bundle assembled out of what
 // the log answered; a module that fabricated a well-formed bundle without
 // ever reading the response would pass every other check here.
-func (h *sigstoreHarness) assertBundle(tag, raw string) error {
-	if raw == "" {
-		return fmt.Errorf("signature %s carries no %s annotation", tag, bundleAnnotation)
+func (h *sigstoreHarness) checkBundle(what, raw string) (*loggedEntry, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, fmt.Errorf("%s carries no transparency log bundle", what)
 	}
 	var bundle struct {
 		SignedEntryTimestamp string `json:"SignedEntryTimestamp"`
@@ -493,33 +624,31 @@ func (h *sigstoreHarness) assertBundle(tag, raw string) error {
 		} `json:"Payload"`
 	}
 	if err := json.Unmarshal([]byte(raw), &bundle); err != nil {
-		return fmt.Errorf("signature %s: decode %s: %v", tag, bundleAnnotation, err)
+		return nil, fmt.Errorf("%s: decode the bundle: %v", what, err)
 	}
 	if bundle.SignedEntryTimestamp == "" {
-		return fmt.Errorf("signature %s: the bundle carries no SignedEntryTimestamp, so nothing establishes the certificate was live when it signed", tag)
+		return nil, fmt.Errorf("%s: the bundle carries no SignedEntryTimestamp, so nothing establishes the certificate was live when it signed", what)
 	}
 	if bundle.Payload.LogID != h.LogID {
-		return fmt.Errorf("signature %s: the bundle names log %q, want this session's %q",
-			tag, bundle.Payload.LogID, h.LogID)
+		return nil, fmt.Errorf("%s: the bundle names log %q, want this session's %q",
+			what, bundle.Payload.LogID, h.LogID)
 	}
 	if bundle.Payload.LogIndex <= 0 || bundle.Payload.IntegratedTime <= 0 {
-		return fmt.Errorf("signature %s: the bundle records index %d at time %d, want both from the log's answer",
-			tag, bundle.Payload.LogIndex, bundle.Payload.IntegratedTime)
+		return nil, fmt.Errorf("%s: the bundle records index %d at time %d, want both from the log's answer",
+			what, bundle.Payload.LogIndex, bundle.Payload.IntegratedTime)
 	}
 	body, err := base64.StdEncoding.DecodeString(bundle.Payload.Body)
 	if err != nil {
-		return fmt.Errorf("signature %s: the bundle's body is not base64: %v", tag, err)
+		return nil, fmt.Errorf("%s: the bundle's body is not base64: %v", what, err)
 	}
-	var entry struct {
-		Kind string `json:"kind"`
-	}
+	var entry loggedEntry
 	if err := json.Unmarshal(body, &entry); err != nil {
-		return fmt.Errorf("signature %s: the bundle's body is not a log entry: %v", tag, err)
+		return nil, fmt.Errorf("%s: the bundle's body is not a log entry: %v", what, err)
 	}
 	if entry.Kind != "hashedrekord" {
-		return fmt.Errorf("signature %s: the bundle's body records a %q entry, want hashedrekord", tag, entry.Kind)
+		return nil, fmt.Errorf("%s: the bundle's body records a %q entry, want hashedrekord", what, entry.Kind)
 	}
-	return nil
+	return &entry, nil
 }
 
 // workflowsSegment is what separates a repository from the workflow file in

--- a/daggerverse/z5labs/tests/keyless.go
+++ b/daggerverse/z5labs/tests/keyless.go
@@ -481,6 +481,13 @@ func (h *sigstoreHarness) assertEnvelopeBundle(raw []byte) error {
 	if err != nil {
 		return err
 	}
+	// The algorithm is checked before the value it labels. Comparing the hex
+	// alone would accept an entry that named some other algorithm beside a
+	// value this test computed with SHA-256, which is an entry no verifier
+	// following the recipe in the package doc would reproduce.
+	if got := entry.Spec.Data.Hash.Algorithm; got != "sha256" {
+		return fmt.Errorf("%s: the log recorded a %q hash, want sha256", what, got)
+	}
 	if got, want := entry.Spec.Data.Hash.Value, hex.EncodeToString(digest[:]); got != want {
 		return fmt.Errorf(
 			"%s: the log recorded an entry over %s, want %s — the SHA-256 of the envelope's pre-authentication encoding",


### PR DESCRIPTION
Closes #419

## The decision

**The provenance envelope gets its own transparency log entry.** The
alternative on the table — deem "it is a referrer of a digest whose signature
is logged" sufficient — was rejected for two reasons, both recorded in
`dsseEnvelope`'s doc comment:

- **The indirect anchor does not establish the property.** A referrer can be
  attached to a digest at any time by anyone who can push to the repository,
  so it says nothing about *when* the envelope was signed. The log establishes
  that a signature existed while its certificate was live, and only an entry
  over *that* signature establishes it.
- **The module already holds the opposite opinion one file away.**
  `defaultRekorURL`'s comment calls an unlogged keyless signature broken rather
  than weaker, and `signatureAnnotations` refuses to publish one. The envelope
  is signed by the same ephemeral key under the same ten-minute certificate;
  no argument makes the signature's expiry fatal and the envelope's acceptable.

## Judgment calls that shaped the published bytes

**A `hashedrekord` over the DSSE pre-authentication encoding, not Rekor's
`intoto` type.** `intoto` is the shape sigstore built for a DSSE envelope, and
it takes the whole envelope — payload included — in the request. A provenance
statement names the repository, the commit and the workflow that built it, and
the public log is permanent, so anchoring a private image's provenance would
publish its build history. `rekorBundle`'s existing doc already states that
property for the signature ("the log is told the payload's hash … never the
payload. That matters for a private image"); an `intoto` entry would hold two
answers to one question. What is established is identical: a verifier
recomputes the PAE from the envelope it holds and compares it to the hash the
log countersigned.

**The bundle hangs off the signature object, beside `cert`.** A log entry
countersigns one signature and DSSE permits several, so a top-level field
could not say which one it timestamped. `cert` and `chain` are already cosign
extension fields in that position.

**As a JSON object, not a string containing JSON.** Same bundle format as the
signature's `dev.sigstore.cosign/bundle` annotation — one format for a
consumer to learn — but one decode shallower, because an envelope is JSON and
a document meant to be read with `jq` should not need a second parse to reach
half of itself.

**`rekorBundle` now takes a hash rather than bytes.** Two callers, one
proposition ("this certificate signed something with this hash, at this
moment"), and the function that exists not to transmit the payload is no
longer handed it.

**`dsseEnvelope` branches on `signer.keyless`, not on a non-empty chain.**
That is the rule the `keyless` field exists for and the one
`signatureAnnotations` already follows; the old branch would have silently
produced a supplied-key envelope for a keyless publish that lost its
certificate.

## Acceptance criteria

- [x] **Decide** whether the envelope gets its own log entry — it does, with
      the reasoning above recorded in `signing.go` and in the package doc.
- [x] The bundle travels **embedded** with the envelope, for the reason
      `sign.go` gives on the signature's side: a consumer inside a network
      that cannot reach `rekor.sigstore.dev` can still verify.
- [x] n/a — the entry exists, so the "why not" branch does not apply. The
      asymmetry note in the package doc that used to point at #419 is replaced
      by the decision and its commands.
- [x] The verifying commands are documented alongside #398's discovery
      commands, in a new package-doc section, *Tying the log entry to the
      envelope it travels with*: printing the entry, and rebuilding the PAE
      with `jq`/`sha256sum` to check the entry is over these bytes. The
      "verifiable on its own bytes" claim **stays true** and now covers the
      timestamp. What no command here does — checking the log's
      countersignature itself — is stated rather than implied.
- [x] The cost is stated the way `signImage` states its own: one more serial
      round trip to a shared third-party service per publish, bounded by
      `rekorTimeout`. One per publish rather than per platform, so a
      four-platform keyless release goes from five round trips to six;
      `signImage`'s own count is updated to say so.

## How it was verified

- `AppKeylessSignatureVerifiesAgainstALocalSigstore` now asserts the envelope's
  bundle against the session's sigstore: the entry's hash equals the SHA-256 of
  the PAE **rebuilt independently in the test**, the logged signature and leaf
  certificate are the envelope's own, and the bundle names the log id minted at
  random for this run — so a fabricated bundle fails. Watched it fail first
  with `the provenance envelope carries no bundle`, then pass.
- `AppAttachesSbomsAndProvenance` (supplied-key) asserts the counterpart: no
  bundle, because that mode contacts no log.
- `dagger check`, `dagger -m daggerverse/z5labs check`,
  `dagger -m daggerverse/z5labs/tests check` and
  `bash .github/scripts/verify-affected-modules.sh` all green;
  `dagger develop` re-run in both modules.
- `daggerverse/CLAUDE.md` carries the finding for the next module author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8G7Uzs18zzKwpYe9mtp3p