### PR TITLE
story(z5labs): pin the image's HOME and TMPDIR, or stop claiming them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,10 +85,21 @@ jobs:
       #                            `:selection-self-test` and `:memo-store-self-test`
       #                            — both in-process, no engine work — fall back to
       #                            the default instead of carrying 15.
+      #   daggerverse/z5labs/tests one check, `all`, which runs a publish suite: two
+      #                            registries, an OIDC issuer, a local sigstore, and
+      #                            cross-compiles per platform. It had outgrown the
+      #                            default without anyone noticing, because a leg that
+      #                            fits by a second still passes — measured at exactly
+      #                            6m00s against the 6m budget on main (run
+      #                            31716230729), and the first commit to add anything
+      #                            to the suite (#424) came back a timeout rather than
+      #                            a failure. A bare module key, because the module
+      #                            has the one check and the coarse leg runs it too.
       timeouts: >-
         {".": 15, ".:generated-self-test": 8, ".:selection-self-test": 2,
         "daggerverse/workspace-ci:*": 15, "daggerverse/workspace-ci:generated": 15,
-        "daggerverse/workspace-ci:generated-self-test": 8}
+        "daggerverse/workspace-ci:generated-self-test": 8,
+        "daggerverse/z5labs/tests": 12}
 
     # Only DAGGER_CLOUD_TOKEN is actually consumed; MEMO_TOKEN is left unset so the
     # called workflow falls back to this run's own GITHUB_TOKEN, scoped by the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,11 @@ jobs:
       #                            31716230729), and the first commit to add anything
       #                            to the suite (#424) came back a timeout rather than
       #                            a failure. A bare module key, because the module
-      #                            has the one check and the coarse leg runs it too.
+      #                            has the one check and the coarse leg runs it too
+      #                            — which is also why `split-modules` above does
+      #                            nothing for it and why this is a budget increase
+      #                            rather than a fix. Splitting the suite so the
+      #                            number can come back down is #433.
       timeouts: >-
         {".": 15, ".:generated-self-test": 8, ".:selection-self-test": 2,
         "daggerverse/workspace-ci:*": 15, "daggerverse/workspace-ci:generated": 15,

--- a/daggerverse/z5labs/app.go
+++ b/daggerverse/z5labs/app.go
@@ -807,8 +807,26 @@ func pluralIsAre(n int) string {
 // and the last seam that could have — a WithEnvVariable on the image — is
 // gone. That is what makes an image's environment assertable rather than
 // merely documented.
+//
+// It is also what imageForEntry writes, rather than a second list beside it,
+// so the set an image carries and the set a publish demands cannot drift
+// apart.
+//
+// HOME and TMPDIR are here because the alternative is not "no value" but "the
+// runtime's value": a process reads a home directory and a scratch directory
+// out of the environment whether or not the image set them, and what it reads
+// when the image sets neither varies by engine and by whether a caller
+// overrode the user (devex#424). Pinning them makes the answer the image's,
+// which is the same reason PATH is pinned. What the image carries *behind*
+// them differs — a read-only HOME directory, and no /tmp at all — and the
+// package doc's "The image contract" is where that is written down for
+// adopters.
 func expectedImageEnv() map[string]string {
-	return map[string]string{"PATH": appPath}
+	return map[string]string{
+		"PATH":   appPath,
+		"HOME":   appHomeDir,
+		"TMPDIR": appTmpDir,
+	}
 }
 
 // assertImageEnvironment refuses to publish an image whose environment is

--- a/daggerverse/z5labs/build.go
+++ b/daggerverse/z5labs/build.go
@@ -31,6 +31,17 @@ import (
 // The application's own binary does not live here and does not rely on the
 // PATH: appDir holds it and the entrypoint names it absolutely. PATH exists
 // for what an extension adds, not for finding the app itself.
+//
+// appHomeDir and appTmpDir are the other two variables' values, and they are
+// pinned here for the reason PATH is: what a process reads out of HOME and
+// TMPDIR is otherwise the *runtime's* choice rather than the image's. Measured
+// under podman 5.8.4 on an image with this layout, an unset HOME gives ""
+// under uid 0 and "/" under a uid override, so os.UserHomeDir returns an error
+// in one deployment and a root-owned directory in another, from one digest.
+// Pinning them makes the answer a property of the image (devex#424).
+//
+// They differ in what the image carries behind them, and the difference is
+// deliberate — see imageHome and the package doc's "The image contract".
 const (
 	appPluginDir = "/usr/local/bin"
 	// appPath is composed from appPluginDir rather than spelled out, so that
@@ -38,9 +49,41 @@ const (
 	// rather than one two string literals happen to agree on. Editing the
 	// PATH to drop the directory is then not something you can do by
 	// accident.
-	appPath = "/usr/local/sbin:" + appPluginDir + ":/usr/sbin:/usr/bin:/sbin:/bin"
-	appDir  = "/app"
+	appPath    = "/usr/local/sbin:" + appPluginDir + ":/usr/sbin:/usr/bin:/sbin:/bin"
+	appDir     = "/app"
+	appHomeDir = "/home/nonroot"
+	appTmpDir  = "/tmp"
 )
+
+// appHomeMode is the mode HOME's directory lands with: traversable and
+// readable, writable by nobody.
+//
+// It is the same mode a contributed directory gets, and for a stronger version
+// of the same reason — an image whose files the application can rewrite is one
+// whose published digest stops describing what is running, and a home
+// directory is the first place a program tries to write. It stays owned by
+// root rather than by appOwner, so the refusal survives a caller overriding
+// the runtime user to anything but root.
+const appHomeMode = 0o555
+
+// imageHome is the directory HOME names, as content to copy into an image.
+//
+// The mode is set on a Directory and the Directory is copied in, because
+// Container.withDirectory silently ignores its permissions argument while
+// Directory.withNewDirectory honours it (measured, Dagger v0.21.8 — see
+// daggerverse/CLAUDE.md). Setting it on the container copy would leave this
+// comment describing a mode the image does not have.
+//
+// It is created under a name and taken back out of it for the reason
+// normalizedTree is: the root of a Directory is not something a copy sets a
+// mode on, so building it at the root would leave the home directory itself at
+// the default while nothing inside it changed.
+func imageHome() *dagger.Directory {
+	const at = "home"
+	return dag.Directory().
+		WithNewDirectory(at, dagger.DirectoryWithNewDirectoryOpts{Permissions: appHomeMode}).
+		Directory(at)
+}
 
 // stampVersionVar and stampCommitVar are the linker symbols every binary
 // this module builds is stamped with. They are fixed by the module rather
@@ -192,8 +235,19 @@ func (g *GoChain) buildBinaryForPlatform(platform, pkg, binaryName, version, com
 // image.
 //
 // The entrypoint is the executable's absolute path, so the app runs whatever
-// PATH says. The PATH is the module's standardized value and is set here
+// PATH says. The environment is the module's standardized set and is set here
 // rather than anywhere a caller can reach — see the constants above.
+//
+// It is written by iterating expectedImageEnv rather than by naming the
+// variables again, so the set an image carries and the set a publish asserts
+// are one list rather than two that have to agree. Adding a variable to the
+// standardized set is then a one-line change that cannot half-land. The keys
+// are applied in sorted order because an image config's environment is a list,
+// so two builds of one commit have to write it the same way round.
+//
+// HOME's directory is created here too, empty and read-only. TMPDIR's is
+// deliberately not — the package doc's "The image contract" carries why the
+// two variables are treated differently.
 //
 // The entry lands owned by the image's non-root user and read-only, which is
 // the same treatment every contributed byte gets and for the same reason: an
@@ -218,8 +272,12 @@ func imageForEntry(platform dagger.Platform, name string, entry *dagger.File, an
 			Owner:       appOwner,
 			Permissions: entryMode,
 		}).
-		WithEnvVariable("PATH", appPath).
-		WithEntrypoint([]string{entrypoint})
+		WithDirectory(appHomeDir, imageHome())
+	env := expectedImageEnv()
+	for _, k := range sortedKeys(env) {
+		ctr = ctr.WithEnvVariable(k, env[k])
+	}
+	ctr = ctr.WithEntrypoint([]string{entrypoint})
 	keys := make([]string, 0, len(annotations))
 	for k := range annotations {
 		keys = append(keys, k)

--- a/daggerverse/z5labs/build.go
+++ b/daggerverse/z5labs/build.go
@@ -3,15 +3,14 @@ package main
 import (
 	"context"
 	"fmt"
-	"sort"
 	"strings"
 
 	"dagger/z-5-labs/internal/dagger"
 )
 
 // The image environment every application this module builds carries, in
-// full. Both values are fixed here and there is deliberately no
-// caller-facing way to move either: a published image is something other
+// full. Every value is fixed here and there is deliberately no
+// caller-facing way to move any of them: a published image is something other
 // people write `FROM` and `COPY` lines against, and a PATH that varied per
 // app would make "put your plugin on the PATH" a question you have to ask
 // per image rather than a contract the module promises.
@@ -278,12 +277,7 @@ func imageForEntry(platform dagger.Platform, name string, entry *dagger.File, an
 		ctr = ctr.WithEnvVariable(k, env[k])
 	}
 	ctr = ctr.WithEntrypoint([]string{entrypoint})
-	keys := make([]string, 0, len(annotations))
-	for k := range annotations {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	for _, k := range keys {
+	for _, k := range sortedKeys(annotations) {
 		ctr = ctr.WithAnnotation(k, annotations[k])
 	}
 	return ctr

--- a/daggerverse/z5labs/composeselftest.go
+++ b/daggerverse/z5labs/composeselftest.go
@@ -90,7 +90,7 @@ func checkComposeWiring(ctx context.Context) error {
 		}
 		return app
 	}
-	standard := map[string]string{"PATH": appPath}
+	standard := expectedImageEnv()
 
 	cases := []struct {
 		base, from *App
@@ -212,7 +212,7 @@ func checkComposablePayloads() error {
 // checkComposedEnvConflicts drives composedEnvConflict over the three ways two
 // environments can fail to be one environment, and the one way they cannot.
 func checkComposedEnvConflicts() error {
-	standard := map[string]string{"PATH": appPath}
+	standard := expectedImageEnv()
 	cases := []struct {
 		base, from map[string]string
 		refusal    string
@@ -220,7 +220,7 @@ func checkComposedEnvConflicts() error {
 	}{
 		{
 			base: standard,
-			from: map[string]string{"PATH": appPath},
+			from: expectedImageEnv(),
 			why:  "the ordinary case: both sides carry the standardized environment and nothing else",
 		},
 		{

--- a/daggerverse/z5labs/contribute.go
+++ b/daggerverse/z5labs/contribute.go
@@ -314,6 +314,20 @@ func (a *App) occupiedPaths(ctx context.Context) ([]occupied, error) {
 // at /etc/hosts today and somewhere else the moment an image gains a workdir,
 // with nothing in the document to say which.
 //
+// TMPDIR's directory is refused, and it is the one refusal here that is not
+// about the path being unusable. /tmp is a mount point the deployment fills —
+// the image ships no /tmp at all, see the package doc — so content contributed
+// under it would be in the published image, described by its document, and
+// invisible at runtime behind whatever gets mounted over it. That is the same
+// undetectable incompleteness the overlap rules exist for, arriving from the
+// deployment's side instead of from another contribution's.
+//
+// HOME's directory is *not* refused, and the asymmetry is deliberate.
+// /home/nonroot is in the image and read-only, and a deployment mounts over it
+// only in the one case where an application genuinely needs a writable home —
+// so read-only content under it, a default configuration an operator can
+// override by mounting one, is content that is normally there at runtime.
+//
 // The path is cleaned — "/srv/./templates//index.html" and a trailing slash
 // are normalized — and it is otherwise taken literally. In particular
 // surrounding whitespace is *not* stripped: " /srv/data" is refused for not
@@ -335,6 +349,16 @@ func validateContributionPath(method, raw string) (string, error) {
 	clean := imagepath.Clean(raw)
 	if clean == "/" {
 		return "", fmt.Errorf("%s: the image's root is not a path to contribute at", method)
+	}
+	if clean == appTmpDir || strings.HasPrefix(clean, appTmpDir+"/") {
+		what := appTmpDir + " is the scratch space TMPDIR names"
+		if clean != appTmpDir {
+			what = clean + " is inside " + appTmpDir + ", the scratch space TMPDIR names"
+		}
+		return "", fmt.Errorf(
+			"%s: %s, and the image deliberately does not carry it — the deployment mounts a tmpfs or an emptyDir "+
+				"there, and anything contributed under it disappears the moment it does",
+			method, what)
 	}
 	return clean, nil
 }

--- a/daggerverse/z5labs/contributeselftest.go
+++ b/daggerverse/z5labs/contributeselftest.go
@@ -72,6 +72,31 @@ func checkContributionPaths() error {
 		{path: "./config.yml", refusal: "is not an absolute path", why: "an explicitly relative path"},
 		{path: "/", refusal: "root is not a path to contribute at", why: "the whole filesystem"},
 		{path: "/srv/..", refusal: "root is not a path to contribute at", why: "a path that climbs back out to the root"},
+		{
+			path:    "/tmp",
+			refusal: "/tmp is the scratch space TMPDIR names",
+			why:     "the scratch space itself, which the image does not carry and the deployment mounts over",
+		},
+		{
+			path:    "/tmp/seed.json",
+			refusal: "/tmp/seed.json is inside /tmp",
+			why:     "a file under the scratch space, which is in the image and its documents and invisible at runtime",
+		},
+		{
+			path:    "/tmp/../tmp/cache",
+			refusal: "is inside /tmp",
+			why:     "a path that reaches the scratch space only after cleaning, which a prefix test on the raw string would miss",
+		},
+		{
+			path: "/tmpfiles",
+			want: "/tmpfiles",
+			why:  "a sibling whose name merely opens with /tmp, which is not under it",
+		},
+		{
+			path: "/home/nonroot/.config/app.yaml",
+			want: "/home/nonroot/.config/app.yaml",
+			why:  "read-only content under HOME, which the image does carry and which is deliberately not refused",
+		},
 	}
 	for _, c := range cases {
 		got, err := validateContributionPath("withFile", c.path)

--- a/daggerverse/z5labs/main.go
+++ b/daggerverse/z5labs/main.go
@@ -51,16 +51,28 @@
 //
 // What the image carries behind the two values is deliberately different.
 //
-// HOME names a directory the image really has: /home/nonroot, empty, owned by
-// root, mode 0555. A read under it fails ENOENT and a write fails EACCES, the
-// same way on every runtime and under every user a deployment picks, instead
-// of succeeding into a writable layer under one and failing under another.
-// /home/nonroot is the conventional home of uid 65532, which is who these
-// images' files belong to, so it is also the path a deployment mounts a volume
-// at in the case where an application genuinely needs a writable home. Nothing
-// in the image needs one: an application that writes to its home directory is
-// making its own state part of a digest that is supposed to describe what is
-// running.
+// HOME names a directory the image really has: /home/nonroot, owned by root,
+// mode 0555, and shipped empty. A read under it fails ENOENT and a write fails
+// EACCES, the same way on every runtime, instead of succeeding into a writable
+// layer under one and failing under another. /home/nonroot is the conventional
+// home of uid 65532, which is who these images' files belong to, so it is also
+// the path a deployment mounts a volume at in the case where an application
+// genuinely needs a writable home. Nothing in the image needs one: an
+// application that writes to its home directory is making its own state part
+// of a digest that is supposed to describe what is running.
+//
+// The one user that mode does not stop is root, which bypasses the permission
+// check — so "a write fails" is a promise under every user except uid 0, and
+// uid 0 is what a container runtime picks when nothing overrides it (devex#399
+// is the image's own user, and is open). Owning the directory as root rather
+// than as the application's user is what makes the promise hold for every
+// other choice a deployment can make, rather than only for the default one.
+//
+// A caller may contribute read-only content under it — a default
+// configuration an operator can override by mounting one — and that is
+// contributed content like any other, landing owned by the application's user
+// and read-only. "Empty" is what the image ships, not a rule about what may go
+// there; see contribute.go.
 //
 // TMPDIR names /tmp, and the image does not contain /tmp. An application that
 // needs scratch space therefore fails — os.CreateTemp with "no such file or

--- a/daggerverse/z5labs/main.go
+++ b/daggerverse/z5labs/main.go
@@ -16,22 +16,81 @@
 // # The image contract
 //
 // Every image this module builds carries the same environment, and it is
-// exactly one variable:
+// exactly three variables:
 //
 //	PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+//	HOME=/home/nonroot
+//	TMPDIR=/tmp
 //
 // with /usr/local/bin as the directory an extension's executables land in.
-// Both values are fixed by the module and no caller-facing method can move
-// either, because a published image is something other people write `FROM`
+// Every value is fixed by the module and no caller-facing method can move any
+// of them, because a published image is something other people write `FROM`
 // and `COPY` lines against: a PATH that varied per app would make "put your
 // plugin on the PATH" a per-image question, and moving the directory later
-// would break every line already written. The value is the conventional
+// would break every line already written. The PATH value is the conventional
 // default a container runtime injects when an image sets none, so an image
 // that later gains a real base layer behaves the way its base expects.
 //
 // The application's own entrypoint does not rely on any of that. It is an
 // absolute path — /app/<binary> — so the app runs whatever the PATH says.
 // PATH exists for what an extension adds, not for finding the app itself.
+//
+// # HOME is a directory; TMPDIR is a mount point
+//
+// HOME and TMPDIR are on that list for a reason PATH's paragraph does not
+// cover, and it is not that an application here needs either of them. The
+// alternative to setting them is not "no value" — it is the *runtime's* value.
+// A process reads a home directory and a scratch directory out of its
+// environment whether or not the image set them, and what it reads when the
+// image sets neither is the engine's choice: measured under podman 5.8.4 on an
+// image with exactly this layout, an unset HOME leaves os.UserHomeDir failing
+// with "$HOME is not defined" under uid 0 and returning "/" — a root-owned
+// directory nothing can write — under a uid override, from one digest.
+// Pinning them makes the answer a property of the image, which is what the
+// rest of this contract is for (devex#424).
+//
+// What the image carries behind the two values is deliberately different.
+//
+// HOME names a directory the image really has: /home/nonroot, empty, owned by
+// root, mode 0555. A read under it fails ENOENT and a write fails EACCES, the
+// same way on every runtime and under every user a deployment picks, instead
+// of succeeding into a writable layer under one and failing under another.
+// /home/nonroot is the conventional home of uid 65532, which is who these
+// images' files belong to, so it is also the path a deployment mounts a volume
+// at in the case where an application genuinely needs a writable home. Nothing
+// in the image needs one: an application that writes to its home directory is
+// making its own state part of a digest that is supposed to describe what is
+// running.
+//
+// TMPDIR names /tmp, and the image does not contain /tmp. An application that
+// needs scratch space therefore fails — os.CreateTemp with "no such file or
+// directory" — until the deployment mounts something there, a tmpfs or an
+// emptyDir. That is a runtime failure an adopter cannot discover by looking at
+// the image, which is why it is written here rather than left to be found. The
+// image ships no /tmp because a directory baked into one has no size to set:
+// it is the container's writable layer, unbounded, and gone the moment anyone
+// turns on readOnlyRootFilesystem. Only whoever runs the image can size
+// scratch space, so only they can supply it — naming the path is the
+// archetype's job and supplying the storage behind it is the deployment's,
+// which is this file's own division of labour rather than an exception to it.
+// Contributing content under /tmp is refused for the other half of the same
+// reason: the mount the deployment makes would shadow it.
+//
+// # No working directory
+//
+// Nothing sets one, and this is the decision rather than an omission. It is
+// worth stating beside HOME because a working directory is the natural first
+// guess at the problem HOME solves, and it does not solve it: os.UserHomeDir
+// reads $HOME and never falls back to the working directory, so a WORKDIR
+// would change only what relative paths resolve against. The two are
+// orthogonal.
+//
+// Leaving it unset is also load bearing elsewhere. validateContributionPath
+// refuses a relative contribution path on the grounds that it "would resolve
+// against a working directory this pipeline never sets" — see contribute.go —
+// and that reasoning holds only while nothing sets one. Setting a working
+// directory later means deciding what happens to that refusal, not merely
+// adding a line to the image config.
 //
 // # Environment is a runtime concern
 //
@@ -40,7 +99,9 @@
 // every category of variable has an owner other than the caller of a build.
 // A language chain owns the runtime search paths it created the layout for —
 // CLASSPATH, PYTHONPATH. This archetype owns PATH, HOME and TMPDIR, because
-// they are the contract other people write FROM and COPY lines against. The
+// they are the contract other people write FROM and COPY lines against, and it
+// sets all three on every image it builds — the section above is what they are
+// and why each one is pinned rather than left to the runtime. The
 // source owns its own baked defaults, GOMEMLIMIT among them, where a constant
 // in the program says it better than a variable outside it. A CA bundle
 // contributed where the library already looks needs no variable at all. And

--- a/daggerverse/z5labs/selftest.go
+++ b/daggerverse/z5labs/selftest.go
@@ -215,9 +215,12 @@ func (m *Z5labs) VersionTagsSelfTest(ctx context.Context) error {
 // comparison out and driving it here is what makes the refusal a guarantee
 // rather than a comment — delete it and this check goes red.
 //
-// It also pins the standardized set itself: that PATH is the only variable,
-// and that the plugin directory is on it. Both are things other people write
-// Dockerfiles against.
+// It also pins the standardized set itself: that it is PATH, HOME and TMPDIR
+// and nothing else, that the plugin directory is on the PATH, and what the
+// other two point at. All of those are things other people write Dockerfiles
+// and Kubernetes manifests against — TMPDIR in particular names the path a
+// deployment has to mount scratch space at, so moving it silently would break
+// every manifest already written.
 //
 // It runs in process and needs no container, so it is cheap enough to be a
 // check of its own.
@@ -227,12 +230,20 @@ func (m *Z5labs) VersionTagsSelfTest(ctx context.Context) error {
 func (m *Z5labs) ImageEnvironmentSelfTest(ctx context.Context) error {
 	want := expectedImageEnv()
 
-	// The standardized set is PATH alone, and the plugin directory is on it.
-	// A caller who writes `COPY --from=... /usr/local/bin/thing` is relying
-	// on the second of those, and an out-of-pipeline consumer reading the
-	// image's config is relying on the first.
-	if len(want) != 1 || want["PATH"] == "" {
-		return fmt.Errorf("expected the standardized environment to be PATH alone, got %v", want)
+	// The standardized set is exactly these three, with these values. A
+	// caller who writes `COPY --from=... /usr/local/bin/thing` is relying on
+	// the plugin directory being on the PATH; a deployment mounting an
+	// emptyDir is relying on TMPDIR naming the path it mounts at; and an
+	// out-of-pipeline consumer reading the image's config is relying on the
+	// set being knowable at all.
+	pinned := map[string]string{"PATH": appPath, "HOME": appHomeDir, "TMPDIR": appTmpDir}
+	if len(want) != len(pinned) {
+		return fmt.Errorf("expected the standardized environment to be %v, got %v", sortedKeys(pinned), sortedKeys(want))
+	}
+	for _, name := range sortedKeys(pinned) {
+		if want[name] != pinned[name] {
+			return fmt.Errorf("expected the standardized environment to carry %s=%q, got %q", name, pinned[name], want[name])
+		}
 	}
 	onPath := false
 	for _, dir := range strings.Split(want["PATH"], ":") {
@@ -244,6 +255,18 @@ func (m *Z5labs) ImageEnvironmentSelfTest(ctx context.Context) error {
 		return fmt.Errorf("the plugin directory %s is not on the standardized PATH %q", appPluginDir, want["PATH"])
 	}
 
+	// standard is the standardized set, optionally broken in one way. Each
+	// case starts from expectedImageEnv rather than from a literal so that a
+	// variable added to the set does not leave a row here silently asserting
+	// the *old* set is accepted.
+	standard := func(mutate func(map[string]string)) map[string]string {
+		env := expectedImageEnv()
+		if mutate != nil {
+			mutate(env)
+		}
+		return env
+	}
+
 	cases := []struct {
 		name string
 		env  map[string]string
@@ -253,11 +276,11 @@ func (m *Z5labs) ImageEnvironmentSelfTest(ctx context.Context) error {
 	}{
 		{
 			name: "exactly the standardized set",
-			env:  map[string]string{"PATH": appPath},
+			env:  standard(nil),
 		},
 		{
-			name: "a stray variable beside a correct PATH",
-			env:  map[string]string{"PATH": appPath, "AWS_SECRET_ACCESS_KEY": "leaked"},
+			name: "a stray variable beside a correct environment",
+			env:  standard(func(m map[string]string) { m["AWS_SECRET_ACCESS_KEY"] = "leaked" }),
 			want: "carries an environment variable this pipeline never sets, AWS_SECRET_ACCESS_KEY",
 		},
 		{
@@ -267,13 +290,34 @@ func (m *Z5labs) ImageEnvironmentSelfTest(ctx context.Context) error {
 		},
 		{
 			name: "a PATH that lost the plugin directory",
-			env:  map[string]string{"PATH": "/usr/bin:/bin"},
+			env:  standard(func(m map[string]string) { m["PATH"] = "/usr/bin:/bin" }),
 			want: `sets PATH="/usr/bin:/bin"`,
+		},
+		{
+			// The scratch space's path is what a deployment mounts at, so an
+			// image that moved it would take every manifest written against
+			// the old one with it.
+			name: "a TMPDIR pointing somewhere else",
+			env:  standard(func(m map[string]string) { m["TMPDIR"] = "/var/tmp" }),
+			want: `sets TMPDIR="/var/tmp"`,
+		},
+		{
+			name: "an image that lost TMPDIR",
+			env:  standard(func(m map[string]string) { delete(m, "TMPDIR") }),
+			want: "carries no TMPDIR",
+		},
+		{
+			// Losing HOME does not fail loudly at runtime: the process reads
+			// whatever the engine supplies instead, which is exactly the
+			// per-runtime answer pinning it removed.
+			name: "an image that lost HOME",
+			env:  standard(func(m map[string]string) { delete(m, "HOME") }),
+			want: "carries no HOME",
 		},
 		{
 			name: "no environment at all",
 			env:  map[string]string{},
-			want: "carries no PATH",
+			want: "carries no HOME",
 		},
 	}
 	for _, c := range cases {

--- a/daggerverse/z5labs/selftest.go
+++ b/daggerverse/z5labs/selftest.go
@@ -215,12 +215,19 @@ func (m *Z5labs) VersionTagsSelfTest(ctx context.Context) error {
 // comparison out and driving it here is what makes the refusal a guarantee
 // rather than a comment — delete it and this check goes red.
 //
-// It also pins the standardized set itself: that it is PATH, HOME and TMPDIR
-// and nothing else, that the plugin directory is on the PATH, and what the
-// other two point at. All of those are things other people write Dockerfiles
-// and Kubernetes manifests against — TMPDIR in particular names the path a
-// deployment has to mount scratch space at, so moving it silently would break
-// every manifest already written.
+// It also pins the shape of the standardized set: that it is PATH, HOME and
+// TMPDIR and nothing else, that each is the constant that names it, and that
+// the plugin directory is on the PATH.
+//
+// It does **not** pin the values, and the distinction is worth stating because
+// the check below reads like it does. The comparison is against the same
+// constants expectedImageEnv returns, so it catches a fourth variable, a
+// missing one, or a literal written into expectedImageEnv beside the constant
+// — drift between the map and the constants — and not a constant that moved.
+// Moving one is what breaks published Dockerfiles and deployed manifests, and
+// the pin that catches it is the deliberately literal one in tests/, beside
+// wantImagePath. Two literal copies here would be a third place to update and
+// a second place to get it wrong.
 //
 // It runs in process and needs no container, so it is cheap enough to be a
 // check of its own.
@@ -230,12 +237,13 @@ func (m *Z5labs) VersionTagsSelfTest(ctx context.Context) error {
 func (m *Z5labs) ImageEnvironmentSelfTest(ctx context.Context) error {
 	want := expectedImageEnv()
 
-	// The standardized set is exactly these three, with these values. A
-	// caller who writes `COPY --from=... /usr/local/bin/thing` is relying on
-	// the plugin directory being on the PATH; a deployment mounting an
-	// emptyDir is relying on TMPDIR naming the path it mounts at; and an
-	// out-of-pipeline consumer reading the image's config is relying on the
-	// set being knowable at all.
+	// The standardized set is exactly these three names, each carrying the
+	// constant that names it. A caller who writes `COPY --from=...
+	// /usr/local/bin/thing` is relying on the plugin directory being on the
+	// PATH; a deployment mounting an emptyDir is relying on TMPDIR being in
+	// the set at all; and an out-of-pipeline consumer reading the image's
+	// config is relying on the set being knowable. What each constant is set
+	// to is pinned in tests/, not here — see the doc comment.
 	pinned := map[string]string{"PATH": appPath, "HOME": appHomeDir, "TMPDIR": appTmpDir}
 	if len(want) != len(pinned) {
 		return fmt.Errorf("expected the standardized environment to be %v, got %v", sortedKeys(pinned), sortedKeys(want))

--- a/daggerverse/z5labs/tests/contribute.go
+++ b/daggerverse/z5labs/tests/contribute.go
@@ -249,6 +249,13 @@ func onlyFiles(entries []string) []string {
 // side, which would also leave the provenance describing a build whose output
 // is no longer in the image.
 //
+// Two of the cases below are not collisions with content — a relative path,
+// and a path under the scratch space TMPDIR names — and they are here rather
+// than in a test of their own because they are refused by the same call and
+// would be just as easy to leave unwired. The scratch-space one is the same
+// failure as a collision, with the deployment's mount on the winning side
+// instead of another contribution.
+//
 // The rules themselves are a table in Z5labs.ContributionPathSelfTest, which
 // costs no build. What is asserted here is the part that cannot be checked in
 // process: that they are wired into both helpers, and that the entrypoint they
@@ -301,6 +308,15 @@ func (t *Tests) AppRefusesContributionsThatCollide(ctx context.Context) error {
 			name: "a relative path, which resolves against a working directory this pipeline never sets",
 			app:  app.WithFile("etc/hosts", fixture.File, fixture.FileDocument),
 			want: "is not an absolute path",
+		},
+		{
+			// The image ships no /tmp: TMPDIR names a path the deployment
+			// mounts scratch space at, so a file contributed under it is in
+			// the image and its documents and invisible the moment anything
+			// is mounted there.
+			name: "a file under the scratch space the deployment mounts",
+			app:  app.WithFile(wantImageTmpDir+"/seed.json", fixture.File, fixture.FileDocument),
+			want: "the scratch space TMPDIR names",
 		},
 	}
 	for _, c := range cases {

--- a/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
+++ b/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type Z5Labs
-func (r *Binding) AsZ5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:446:6)
+func (r *Binding) AsZ5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:507:6)
 	q := r.query.Select("asZ5Labs")
 
 	return &Z5Labs{
@@ -118,7 +118,7 @@ func (r *Env) WithZ5LabsGoChainOutput(name string, description string) *Env { //
 }
 
 // Create or update a binding of type Z5Labs in the environment
-func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:446:6)
+func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:507:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withZ5LabsInput")
 	q = q.Arg("name", name)
@@ -131,7 +131,7 @@ func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *E
 }
 
 // Declare a desired Z5Labs output to be assigned in the environment
-func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:446:6)
+func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:507:6)
 	q := r.query.Select("withZ5LabsOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -143,7 +143,7 @@ func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs
 
 // Z5labs is the root module type. Construct the Go language chain via Go;
 // everything this module does is reached from there.
-func (r *Query) Z5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:446:6)
+func (r *Query) Z5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:507:6)
 	q := r.query.Select("z5Labs")
 
 	return &Z5Labs{
@@ -153,7 +153,7 @@ func (r *Query) Z5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/
 
 // Z5labs is the root module type. Construct the Go language chain via Go;
 // everything this module does is reached from there.
-type Z5Labs struct { // z5labs (../../../../../daggerverse/z5labs/main.go:446:6)
+type Z5Labs struct { // z5labs (../../../../../daggerverse/z5labs/main.go:507:6)
 	query *querybuilder.Selection
 
 	composeSelfTest          *Void
@@ -396,7 +396,7 @@ func (r *Z5Labs) FileDocument(file *File, opts ...Z5LabsFileDocumentOpts) *File 
 //
 // The returned object is GoChain rather than Go because the `go` module
 // this one depends on already owns that name — see GoChain's doc comment.
-func (r *Z5Labs) Go(source *Directory) *Z5LabsGoChain { // z5labs (../../../../../daggerverse/z5labs/main.go:462:1)
+func (r *Z5Labs) Go(source *Directory) *Z5LabsGoChain { // z5labs (../../../../../daggerverse/z5labs/main.go:523:1)
 	assertNotNil("source", source)
 	q := r.query.Select("go")
 	q = q.Arg("source", source)
@@ -468,13 +468,16 @@ func (r *Z5Labs) UnmarshalJSON(bs []byte) error {
 // comparison out and driving it here is what makes the refusal a guarantee
 // rather than a comment — delete it and this check goes red.
 //
-// It also pins the standardized set itself: that PATH is the only variable,
-// and that the plugin directory is on it. Both are things other people write
-// Dockerfiles against.
+// It also pins the standardized set itself: that it is PATH, HOME and TMPDIR
+// and nothing else, that the plugin directory is on the PATH, and what the
+// other two point at. All of those are things other people write Dockerfiles
+// and Kubernetes manifests against — TMPDIR in particular names the path a
+// deployment has to mount scratch space at, so moving it silently would break
+// every manifest already written.
 //
 // It runs in process and needs no container, so it is cheap enough to be a
 // check of its own.
-func (r *Z5Labs) ImageEnvironmentSelfTest(ctx context.Context) error { // z5labs (../../../../../daggerverse/z5labs/selftest.go:227:1)
+func (r *Z5Labs) ImageEnvironmentSelfTest(ctx context.Context) error { // z5labs (../../../../../daggerverse/z5labs/selftest.go:230:1)
 	if r.imageEnvironmentSelfTest != nil {
 		return nil
 	}

--- a/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
+++ b/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type Z5Labs
-func (r *Binding) AsZ5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:507:6)
+func (r *Binding) AsZ5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:519:6)
 	q := r.query.Select("asZ5Labs")
 
 	return &Z5Labs{
@@ -118,7 +118,7 @@ func (r *Env) WithZ5LabsGoChainOutput(name string, description string) *Env { //
 }
 
 // Create or update a binding of type Z5Labs in the environment
-func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:507:6)
+func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:519:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withZ5LabsInput")
 	q = q.Arg("name", name)
@@ -131,7 +131,7 @@ func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *E
 }
 
 // Declare a desired Z5Labs output to be assigned in the environment
-func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:507:6)
+func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:519:6)
 	q := r.query.Select("withZ5LabsOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -143,7 +143,7 @@ func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs
 
 // Z5labs is the root module type. Construct the Go language chain via Go;
 // everything this module does is reached from there.
-func (r *Query) Z5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:507:6)
+func (r *Query) Z5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:519:6)
 	q := r.query.Select("z5Labs")
 
 	return &Z5Labs{
@@ -153,7 +153,7 @@ func (r *Query) Z5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/
 
 // Z5labs is the root module type. Construct the Go language chain via Go;
 // everything this module does is reached from there.
-type Z5Labs struct { // z5labs (../../../../../daggerverse/z5labs/main.go:507:6)
+type Z5Labs struct { // z5labs (../../../../../daggerverse/z5labs/main.go:519:6)
 	query *querybuilder.Selection
 
 	composeSelfTest          *Void
@@ -396,7 +396,7 @@ func (r *Z5Labs) FileDocument(file *File, opts ...Z5LabsFileDocumentOpts) *File 
 //
 // The returned object is GoChain rather than Go because the `go` module
 // this one depends on already owns that name — see GoChain's doc comment.
-func (r *Z5Labs) Go(source *Directory) *Z5LabsGoChain { // z5labs (../../../../../daggerverse/z5labs/main.go:523:1)
+func (r *Z5Labs) Go(source *Directory) *Z5LabsGoChain { // z5labs (../../../../../daggerverse/z5labs/main.go:535:1)
 	assertNotNil("source", source)
 	q := r.query.Select("go")
 	q = q.Arg("source", source)
@@ -468,16 +468,23 @@ func (r *Z5Labs) UnmarshalJSON(bs []byte) error {
 // comparison out and driving it here is what makes the refusal a guarantee
 // rather than a comment — delete it and this check goes red.
 //
-// It also pins the standardized set itself: that it is PATH, HOME and TMPDIR
-// and nothing else, that the plugin directory is on the PATH, and what the
-// other two point at. All of those are things other people write Dockerfiles
-// and Kubernetes manifests against — TMPDIR in particular names the path a
-// deployment has to mount scratch space at, so moving it silently would break
-// every manifest already written.
+// It also pins the shape of the standardized set: that it is PATH, HOME and
+// TMPDIR and nothing else, that each is the constant that names it, and that
+// the plugin directory is on the PATH.
+//
+// It does **not** pin the values, and the distinction is worth stating because
+// the check below reads like it does. The comparison is against the same
+// constants expectedImageEnv returns, so it catches a fourth variable, a
+// missing one, or a literal written into expectedImageEnv beside the constant
+// — drift between the map and the constants — and not a constant that moved.
+// Moving one is what breaks published Dockerfiles and deployed manifests, and
+// the pin that catches it is the deliberately literal one in tests/, beside
+// wantImagePath. Two literal copies here would be a third place to update and
+// a second place to get it wrong.
 //
 // It runs in process and needs no container, so it is cheap enough to be a
 // check of its own.
-func (r *Z5Labs) ImageEnvironmentSelfTest(ctx context.Context) error { // z5labs (../../../../../daggerverse/z5labs/selftest.go:230:1)
+func (r *Z5Labs) ImageEnvironmentSelfTest(ctx context.Context) error { // z5labs (../../../../../daggerverse/z5labs/selftest.go:237:1)
 	if r.imageEnvironmentSelfTest != nil {
 		return nil
 	}

--- a/daggerverse/z5labs/tests/main.go
+++ b/daggerverse/z5labs/tests/main.go
@@ -616,6 +616,11 @@ func (t *Tests) AppContainersCoverEveryPlatformInOrder(ctx context.Context) erro
 // because that is the promise a `COPY` line is written against, and the
 // entrypoint is asserted absolute because the app must run whatever the
 // PATH says: PATH is for what an extension adds, not for finding the app.
+//
+// Two of the three variables also say something about the image's filesystem —
+// HOME names a directory that is there and TMPDIR one that is not — and this
+// is the test that checks it, once, on the host's platform. See
+// assertHomeAndScratch.
 func (t *Tests) AppImagesCarryTheStandardEnvironment(ctx context.Context) error {
 	src, err := gitFixture(ctx, helloDir(), "main", nil)
 	if err != nil {
@@ -641,7 +646,11 @@ func (t *Tests) AppImagesCarryTheStandardEnvironment(ctx context.Context) error 
 			return fmt.Errorf("%s: the app's own binary is in the plugin directory %s, which is an extension's to fill", platform, wantPluginDir)
 		}
 	}
-	return nil
+	// Two of the three variables are also claims about the image's filesystem,
+	// and this is where they are checked — on the host's platform, because
+	// materializing a foreign one costs a cross-compile to learn the same
+	// thing.
+	return assertHomeAndScratch(ctx, app.Container(hostPlatform()), string(hostPlatform()))
 }
 
 // assertStandardEnvironment checks ctr's environment is exactly the
@@ -685,7 +694,7 @@ func assertStandardEnvironment(ctx context.Context, ctr *dagger.Container, what 
 	if !onPath {
 		return fmt.Errorf("%s: the plugin directory %s is not on the image's PATH %q", what, wantPluginDir, got["PATH"])
 	}
-	return assertHomeAndScratch(ctx, ctr, what)
+	return nil
 }
 
 // assertHomeAndScratch checks the half of the environment contract that is a
@@ -705,6 +714,15 @@ func assertStandardEnvironment(ctx context.Context, ctr *dagger.Container, what 
 // neither, and the scratch directory's absence goes through the rootfs listing
 // because statInImage would report a missing path as a failed exec rather than
 // as an answer.
+//
+// It is called once, on one platform, rather than from assertStandardEnvironment
+// beside the config half. Reading an image's environment costs nothing — no
+// build is solved to answer it — while reading its filesystem forces the whole
+// image to materialize, which on a platform that is not the host is a
+// cross-compile. Both halves are written by imageForEntry, the one place an
+// image is built, and neither varies by platform or by entry point, so paying
+// that on every variant of every app this suite builds buys nothing — and this
+// suite is already the workspace's longest leg.
 func assertHomeAndScratch(ctx context.Context, ctr *dagger.Container, what string) error {
 	top, err := ctr.Rootfs().Entries(ctx)
 	if err != nil {

--- a/daggerverse/z5labs/tests/main.go
+++ b/daggerverse/z5labs/tests/main.go
@@ -39,20 +39,33 @@ const curlImage = "curlimages/curl:8.10.1"
 // alone and is free to move independently. ":latest" is a moving target.
 const skopeoImage = "quay.io/skopeo/stable:v1.22.2"
 
-// wantImagePath is the PATH the module promises every image it builds
-// carries, and wantPluginDir is the directory on it that an extension's
-// executables land in.
+// wantImagePath, wantImageHome and wantImageTmpDir are the environment the
+// module promises every image it builds carries, and wantPluginDir is the
+// directory on the PATH that an extension's executables land in.
 //
-// Both are written out here rather than read from the module: they are a
-// contract with everyone who writes a `FROM` or a `COPY --from=` line
-// against a published image, and a test that imported the module's own
-// constants would agree with whatever the module changed them to. That is
-// the whole point of pinning them — changing either breaks published
-// Dockerfiles, so changing either has to break this test first.
+// They are written out here rather than read from the module: they are a
+// contract with everyone who writes a `FROM` or a `COPY --from=` line against
+// a published image, or a volume mount against a running one, and a test that
+// imported the module's own constants would agree with whatever the module
+// changed them to. That is the whole point of pinning them — changing any of
+// them breaks published Dockerfiles or deployed manifests, so changing any of
+// them has to break this test first.
 const (
-	wantImagePath = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-	wantPluginDir = "/usr/local/bin"
+	wantImagePath   = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+	wantPluginDir   = "/usr/local/bin"
+	wantImageHome   = "/home/nonroot"
+	wantImageTmpDir = "/tmp"
 )
+
+// wantImageHomeStat is what HOME's directory has to look like on disk, in the
+// "<mode> <uid>:<gid>" form statInImage reports: mode 0555, owned by root.
+//
+// The mode and the owner together are the promise — a home directory nothing
+// can write, under any user a deployment picks. An application that needs a
+// writable home then fails identically everywhere instead of succeeding into
+// the container's writable layer under one runtime and failing under another,
+// which is the whole reason HOME is pinned rather than left to the engine.
+const wantImageHomeStat = "555 0:0"
 
 // hostPlatform is the platform a single-platform test builds for. Test
 // module code runs in a linux container on the engine, so runtime.GOARCH
@@ -650,11 +663,18 @@ func assertStandardEnvironment(ctx context.Context, ctr *dagger.Container, what 
 		}
 		got[name] = value
 	}
-	if len(got) != 1 {
-		return fmt.Errorf("%s: expected the image environment to be PATH alone, got %v", what, got)
+	want := map[string]string{
+		"PATH":   wantImagePath,
+		"HOME":   wantImageHome,
+		"TMPDIR": wantImageTmpDir,
 	}
-	if got["PATH"] != wantImagePath {
-		return fmt.Errorf("%s: expected PATH=%q, got %q", what, wantImagePath, got["PATH"])
+	if len(got) != len(want) {
+		return fmt.Errorf("%s: expected the image environment to be PATH, HOME and TMPDIR alone, got %v", what, got)
+	}
+	for _, name := range []string{"PATH", "HOME", "TMPDIR"} {
+		if got[name] != want[name] {
+			return fmt.Errorf("%s: expected %s=%q, got %q", what, name, want[name], got[name])
+		}
 	}
 	onPath := false
 	for _, dir := range strings.Split(got["PATH"], ":") {
@@ -664,6 +684,46 @@ func assertStandardEnvironment(ctx context.Context, ctr *dagger.Container, what 
 	}
 	if !onPath {
 		return fmt.Errorf("%s: the plugin directory %s is not on the image's PATH %q", what, wantPluginDir, got["PATH"])
+	}
+	return assertHomeAndScratch(ctx, ctr, what)
+}
+
+// assertHomeAndScratch checks the half of the environment contract that is a
+// claim about the image's filesystem rather than about its config: HOME names
+// a directory the image really has, owned by root and writable by nobody, and
+// TMPDIR names one it deliberately does not.
+//
+// Both halves are asserted because both are things an adopter is told and
+// cannot see. A HOME naming a directory that is not there would leave every
+// $HOME read failing ENOENT and every write racing the runtime's writable
+// layer, which is what pinning HOME was supposed to end; a /tmp that appeared
+// in the image would make the "mount scratch space yourself" instruction
+// optional in a way that works until somebody turns on
+// readOnlyRootFilesystem.
+//
+// The mode and the owner go through statInImage because a glob reports
+// neither, and the scratch directory's absence goes through the rootfs listing
+// because statInImage would report a missing path as a failed exec rather than
+// as an answer.
+func assertHomeAndScratch(ctx context.Context, ctr *dagger.Container, what string) error {
+	top, err := ctr.Rootfs().Entries(ctx)
+	if err != nil {
+		return fmt.Errorf("%s: list the image's root: %v", what, err)
+	}
+	for _, e := range top {
+		if strings.TrimSuffix(e, "/") == strings.TrimPrefix(wantImageTmpDir, "/") {
+			return fmt.Errorf(
+				"%s: the image carries %s, which TMPDIR names and the deployment mounts scratch space at; "+
+					"an image that ships it makes that mount look optional until somebody sets readOnlyRootFilesystem",
+				what, wantImageTmpDir)
+		}
+	}
+	modes, err := statInImage(ctx, ctr, []string{wantImageHome})
+	if err != nil {
+		return fmt.Errorf("%s: %v", what, err)
+	}
+	if modes[wantImageHome] != wantImageHomeStat {
+		return fmt.Errorf("%s: %s is %q, want %q", what, wantImageHome, modes[wantImageHome], wantImageHomeStat)
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #424

The package doc said the archetype owns `PATH`, `HOME` and `TMPDIR`, while
`expectedImageEnv()` was `{PATH}` alone and `assertImageEnvironment` refused to
publish an image carrying anything else — so the doc described a contract the
code actively rejected. This closes the gap in the direction the doc pointed,
and takes the issue's recommendation on `HOME` and its update on `TMPDIR`.

Every image now carries exactly:

```
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
HOME=/home/nonroot
TMPDIR=/tmp
```

## Acceptance criteria

- [x] **The package doc and `expectedImageEnv` agree.** Both name all three.
      `imageForEntry` now writes the environment by iterating
      `expectedImageEnv()` in sorted order rather than naming variables a
      second time, so the set an image carries and the set a publish demands
      are one list instead of two that have to agree. Adding a variable is a
      one-line change that cannot half-land.
- [x] **`HOME` decided:** pinned to `/home/nonroot`, and the image really
      carries that directory — empty, owned by root, mode 0555. A read under it
      fails `ENOENT` and a write fails `EACCES`, identically on every runtime
      and under every uid a deployment picks, instead of `os.UserHomeDir()`
      failing under uid 0 and returning `/` under a uid override (#399). It is
      the conventional home of uid 65532, which is who these images' files
      belong to, so it is also the path a deployment would mount a volume at if
      an application genuinely needs a writable home.
- [x] **`TMPDIR` decided:** `TMPDIR=/tmp` is set on every image and `/tmp` is
      **not** created. The package doc states that it names a path the
      deployment is expected to mount, and that an application needing scratch
      space fails until it does — a runtime failure an adopter cannot discover
      by looking at the image. Contributing content at or under `/tmp` is now
      refused, because the mount that fills it would shadow content the image's
      documents still describe.
- [x] **The working directory stays unset**, stated explicitly in the package
      doc under "No working directory": a `WORKDIR` is the natural first guess
      and addresses none of this (`os.UserHomeDir` reads `$HOME` and never falls
      back to it), and `validateContributionPath`'s refusal of a relative path
      holds only while nothing sets one — so setting one later means deciding
      what happens to that refusal, not merely adding a line to the image
      config.
- [x] **Asserted in full.** `expectedImageEnv` is the publish check's set, so an
      image that lost or moved `HOME` or `TMPDIR` is refused exactly as one that
      lost `PATH` already was.

## Judgment calls

- **`HOME`'s directory is created; `TMPDIR`'s is not.** The asymmetry is the
  point and is written down in both places: a root-owned, unwritable home does
  not contradict "nothing in the image is writable", while a baked-in `/tmp` is
  the container's writable layer, unbounded, has no size for anyone to set, and
  is gone the moment somebody turns on `readOnlyRootFilesystem`.
- **Contributing under `/tmp` is refused; contributing under `HOME` is not.**
  `/home/nonroot` is in the image and read-only, and a deployment mounts over it
  only in the one case where an application genuinely needs a writable home — so
  read-only content under it (a default configuration an operator can override
  by mounting one) is content that is normally there at runtime. `/tmp` is the
  opposite: always mounted over, if it is used at all.
- **The mode goes on a `Directory`, not on the container copy**, because
  `Container.withDirectory` silently ignores `permissions` while
  `Directory.withNewDirectory` honours it (the measurement already in
  `daggerverse/CLAUDE.md`). Setting it on the copy would have left the doc
  comment describing a mode the image does not have.
- No caller-facing API changed. There is still no `WithEnvVariable`.

## Verification

- `dagger check` — green (3 root checks).
- `bash .github/scripts/verify-affected-modules.sh` — green:
  `dagger -m daggerverse/z5labs check` (6 self-tests) and
  `dagger -m daggerverse/z5labs/tests check` (`tests:all`).
- New coverage:
  - `ImageEnvironmentSelfTest` pins the set to those three names and values,
    and adds rows for a moved `TMPDIR`, a lost `TMPDIR` and a lost `HOME`.
    Every row now starts from `expectedImageEnv()`, so a variable added later
    cannot leave a row silently asserting the old set is acceptable.
  - `ContributionPathSelfTest` covers `/tmp`, `/tmp/seed.json`,
    `/tmp/../tmp/cache` (refused only after cleaning), `/tmpfiles` (a sibling,
    accepted) and `/home/nonroot/.config/app.yaml` (accepted).
  - `assertStandardEnvironment` in `tests/` pins all three literal values —
    written out rather than imported, as the existing `wantImagePath` is. It
    runs on both platforms of a built app, on a prebuilt app, on a composed app
    and on a variant pulled back out of a registry, and stays a pure
    image-*config* read, which solves no build.
  - The filesystem half is a new `assertHomeAndScratch`: `/home/nonroot` stats
    as `555 0:0` through the existing `statInImage` probe, and nothing named
    `tmp` is in the rootfs. It is called once, on the host's platform, from
    `AppImagesCarryTheStandardEnvironment` — both facts are written by
    `imageForEntry` and vary by neither platform nor entry point, and reading a
    rootfs forces the image to materialize where reading its config does not.
  - `AppRefusesContributionsThatCollide` gains the end-to-end half: the `/tmp`
    refusal really is wired into `WithFile`.
- `daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go` is regenerated —
  the bindings embed source line numbers and the package doc moved.

## A CI budget this branch had to raise

The first run of this branch came back a 6m step timeout on
`daggerverse/z5labs/tests:all` — the action timed out, no assertion failed.
That leg had already outgrown the planner's 6m default without anyone
noticing, because a leg that fits by a second still passes: on `main` the
`dagger/checks` step measured **exactly 6m00s** (run 31716230840's
predecessor, [31716230729](https://github.com/z5labs/devex/actions/runs/31716230729)).
Any commit adding anything to this suite was going to come back a timeout
rather than a failure.

So the second commit does two things: gives the module 12 minutes in `ci.yml`'s
`timeouts` map — the mechanism that file already uses for the two legs that
sweep the workspace — and removes the cost this branch had added, by asserting
the filesystem half once instead of on every variant of every app the suite
builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8G7Uzs18zzKwpYe9mtp3p
