### PR TITLE
story(z5labs): decide how an extension's executable reaches the plugin directory

### DIFF
--- a/daggerverse/z5labs/build.go
+++ b/daggerverse/z5labs/build.go
@@ -34,7 +34,10 @@ import (
 // Contributing there is refused outright, in all three directions —
 // App.WithFile and App.WithDirectory take a file and a directory, neither of
 // which carries an architecture, and both land the same bytes in every
-// variant. See compose.go for the seam and contribute.go for the refusal.
+// variant. The refusal covers every directory appPath names and not this one
+// alone, because the hazard is discovery by bare name and this is one of six
+// directories the image searches. See compose.go for the seam and contribute.go
+// for the refusal.
 //
 // Those two halves used to contradict each other, which is what devex#427
 // settled: a contributed file lands 0444 and so was unusable here, while a

--- a/daggerverse/z5labs/build.go
+++ b/daggerverse/z5labs/build.go
@@ -27,6 +27,21 @@ import (
 // worth anything — a plugin directory that moved per app could not be
 // written against at all.
 //
+// One seam puts an executable there and it is App.WithApp: an extension
+// arrives as a whole application, so every byte it brings names the platform
+// it was built for, the variant sets are paired platform by platform, and the
+// entry is exec'd in the derived image before anything is published.
+// Contributing there is refused outright, in all three directions —
+// App.WithFile and App.WithDirectory take a file and a directory, neither of
+// which carries an architecture, and both land the same bytes in every
+// variant. See compose.go for the seam and contribute.go for the refusal.
+//
+// Those two halves used to contradict each other, which is what devex#427
+// settled: a contributed file lands 0444 and so was unusable here, while a
+// contributed tree lands 0555 and was not — so the rule one helper enforced
+// by omission was bypassed by wrapping the same binary in a directory. The
+// sentence above means composition, and now says so.
+//
 // The application's own binary does not live here and does not rely on the
 // PATH: appDir holds it and the entrypoint names it absolutely. PATH exists
 // for what an extension adds, not for finding the app itself.

--- a/daggerverse/z5labs/contribute.go
+++ b/daggerverse/z5labs/contribute.go
@@ -59,17 +59,24 @@ import (
 // thing from a document about some other artifact entirely, which is no longer
 // publishable.
 //
-// # The plugin directory is composition's, and nothing may be contributed there
+// # The PATH is composition's, and nothing may be contributed onto it
 //
-// /usr/local/bin is the one directory on the image's PATH, and neither helper
-// may put anything in it, under it, or over it. App.WithApp is what fills it —
-// see compose.go — and the reason is the one prebuilt.go states about
-// executables generally: a *dagger.File and a *dagger.Directory carry no
-// architecture, and both helpers contribute the same bytes to every variant, so
-// a contribution into the directory the image's PATH resolves against is a way
-// to leave an arm64 image holding an amd64 executable that is discovered by
-// name. Composition carries a platform on every byte, pairs the variants
-// platform by platform, and execs the entry before a byte is published.
+// Neither helper may put anything in, under or over any directory the image's
+// PATH resolves against. App.WithApp is what puts an executable there — in
+// /usr/local/bin, the plugin directory, see compose.go — and the reason is the
+// one prebuilt.go states about executables generally: a *dagger.File and a
+// *dagger.Directory carry no architecture, and both helpers contribute the same
+// bytes to every variant, so a contribution into a directory the PATH searches
+// is a way to leave an arm64 image holding an amd64 executable that something
+// found by name. Composition carries a platform on every byte, pairs the
+// variants platform by platform, and execs the entry before a byte is
+// published.
+//
+// The rule is the whole PATH and not the plugin directory alone, because the
+// hazard is discovery rather than convention: /usr/local/bin is one of the six
+// directories appPath names, and a tree at /usr/bin would be found by name
+// exactly as one at /usr/local/bin would. pathDirs derives the set from appPath
+// so that adding a directory to the PATH protects it.
 //
 // It was refused by *accident* before devex#427, and only half of it: a
 // contributed file lands 0444 and is therefore not executable, while a
@@ -78,12 +85,12 @@ import (
 // A rule that depends on a mode bit is not a rule, so it is stated here and
 // enforced on the path instead.
 //
-// The executable bit a 0555 tree carries *outside* that directory stays, and is
-// accepted rather than worked around: nothing discovers it, because the only
-// directory the PATH names is the one no contribution can reach, so an
-// executable contributed at /opt/thing/run is reachable only by something that
-// already knows that path — the caller's own arrangement inside their own
-// image, and not a contract this module advertises.
+// The executable bit a 0555 tree carries *off* the PATH stays, and is accepted
+// rather than worked around: nothing discovers it, because every directory the
+// PATH searches is one no contribution can reach, so an executable contributed
+// at /opt/thing/run is reachable only by something that already knows that path
+// — the caller's own arrangement inside their own image, and not a contract
+// this module advertises.
 //
 // # The directories on the way are the image's, not the contribution's
 //
@@ -127,10 +134,11 @@ const appOwner = "65532:65532"
 //
 // What the residue is *not* is a way onto the PATH. It used to be exactly that,
 // which is what devex#427 closed: nothing may be contributed at, under or over
-// the plugin directory, so an executable a tree carries is discovered by
-// nothing and can only be run by something that already knows its absolute
-// path. That is the caller arranging their own image, rather than this module
-// admitting an executable whose architecture nobody stated.
+// any directory the image's PATH resolves against, so an executable a tree
+// carries is discovered by nothing and can only be run by something that
+// already knows its absolute path. That is the caller arranging their own
+// image, rather than this module admitting an executable whose architecture
+// nobody stated.
 const (
 	contributedFileMode      = 0o444
 	contributedDirectoryMode = 0o555
@@ -179,10 +187,11 @@ func normalizedTree(dir *dagger.Directory) *dagger.Directory {
 // contributed to every variant. That is why there is no WithExecutable beside
 // this — a raw file carries no platform, so a helper landing one in the
 // executable directory would silently admit a binary built for the wrong
-// architecture — and it is why a path at, under or over the plugin directory is
-// refused here rather than merely being useless. Platform-specific executables
-// arrive as an App instead: App.WithApp composes one, matched platform by
-// platform, and lands its entry in the plugin directory.
+// architecture — and it is why a path at, under or over any directory the
+// image's PATH resolves against is refused here rather than merely being
+// useless. Platform-specific executables arrive as an App instead: App.WithApp
+// composes one, matched platform by platform, and lands its entry in the plugin
+// directory.
 //
 // +cache="session"
 func (a *App) WithFile(
@@ -223,10 +232,11 @@ func (a *App) WithFile(
 //
 // An executable inside such a tree is therefore executable, and that is not a
 // way to extend the image: like WithFile, this refuses a path at, under or over
-// the plugin directory, so nothing a caller contributes is ever discovered on
-// the PATH. Wrapping a binary in a directory used to be exactly that bypass —
-// see the file comment above and App.WithApp, which is the seam that names the
-// platform of every byte it brings.
+// any directory the image's PATH resolves against, so nothing a caller
+// contributes is ever discovered on the PATH by name. Wrapping a binary in a
+// directory used to be exactly that bypass — see the file comment above and
+// App.WithApp, which is the seam that names the platform of every byte it
+// brings.
 //
 // document is an SPDX 2.3 JSON document describing the tree, and it is
 // required for the reason WithFile's is. Z5labs.DirectoryDocument produces one
@@ -363,17 +373,22 @@ func (a *App) occupiedPaths(ctx context.Context) ([]occupied, error) {
 // undetectable incompleteness the overlap rules exist for, arriving from the
 // deployment's side instead of from another contribution's.
 //
-// The plugin directory is refused too, in all three directions — the directory
-// itself, anything under it, and anything that would contain it. It is the one
-// directory on the image's PATH and App.WithApp is what fills it; the file
-// comment above carries why a contribution there is a wrong-architecture
-// executable waiting to be discovered by name. The containing direction is
+// Every directory the image's PATH resolves against is refused too, in all
+// three directions — the directory itself, anything under it, and anything that
+// would contain it. App.WithApp is what puts an executable on the PATH; the
+// file comment above carries why a contribution there is a wrong-architecture
+// executable waiting to be discovered by name, and why the rule is the whole
+// PATH rather than the plugin directory alone. The containing direction is
 // refused without looking inside the tree, exactly as overlappingPath refuses a
 // contribution that would contain something already in the image: a tree at
 // /usr/local is refused whether or not it happens to carry a bin/ today,
 // because whether it does is a property of the caller's tree rather than of the
 // call, and a rule that has to read the content is one that changes its mind
 // between builds.
+//
+// The image's root is refused before any of that, by the check above, which is
+// what keeps "/" out of the containing direction — a candidate of "/" would
+// make the prefix test look for "//".
 //
 // HOME's directory is *not* refused, and the asymmetry is deliberate.
 // /home/nonroot is in the image and read-only, and a deployment mounts over it
@@ -413,33 +428,73 @@ func validateContributionPath(method, raw string) (string, error) {
 				"there, and anything contributed under it disappears the moment it does",
 			method, what)
 	}
-	if where := pluginDirCollision(clean); where != "" {
+	if where := pathDirCollision(clean); where != "" {
 		return "", fmt.Errorf(
-			"%s: %s, and nothing may be contributed there — a contributed file or tree carries no architecture and "+
-				"lands in every variant, so content in the one directory the image's PATH resolves against is a way to "+
-				"leave an arm64 image running an amd64 executable that something discovered by name; withApp composes "+
-				"another application's payload, which is matched platform by platform and run before anything is published",
-			method, where)
+			"%s: %s, and nothing may be contributed to a directory the image's PATH resolves against — a contributed "+
+				"file or tree carries no architecture and lands in every variant, so content that something finds on "+
+				"the PATH by name is a way to leave an arm64 image running an amd64 executable; withApp composes "+
+				"another application's payload, which is matched platform by platform and run before anything is "+
+				"published, and lands its entry in %s",
+			method, where, appPluginDir)
 	}
 	return clean, nil
 }
 
-// pluginDirCollision reports how clean collides with the plugin directory, or
-// "" when it does not.
+// pathDirs is every directory the image's PATH resolves against, with the
+// plugin directory first.
+//
+// It is derived from appPath rather than listed again, so the set the rule
+// protects is the set the image really searches: a directory added to the PATH
+// is protected by having been added, and one removed stops being protected the
+// same way. Two lists would be two things to keep in agreement, and the way
+// they would disagree is a directory on the PATH that a caller may contribute
+// an executable of no stated architecture into.
+//
+// The plugin directory is first because it is the one a candidate is most
+// likely to collide with and the only one anything fills, so it is the one a
+// refusal should name when a path collides with more than one — /usr/local
+// contains both it and /usr/local/sbin, and being told about the plugin
+// directory is what points at withApp.
+func pathDirs() []string {
+	out := []string{appPluginDir}
+	for _, dir := range strings.Split(appPath, ":") {
+		if dir != appPluginDir && dir != "" {
+			out = append(out, dir)
+		}
+	}
+	return out
+}
+
+// pathDirCollision reports how clean collides with a directory the image's
+// PATH resolves against, or "" when it collides with none of them.
+//
+// The rule is the PATH's rather than the plugin directory's alone, and that is
+// the correction devex#427's review forced. The hazard is discovery by bare
+// name: a contributed tree lands 0555 throughout and carries no architecture,
+// so an executable in it is a wrong-architecture binary something can find by
+// name — and /usr/local/bin is one of six directories the image's PATH names,
+// not the only one. A rule that guarded the plugin directory alone would have
+// left /usr/bin and /bin open while the comments above claimed nothing
+// contributed is ever discovered on the PATH.
 //
 // The three directions are the three overlappingPath distinguishes, and they
 // are separated here for the same reason: a caller told only that a path is
 // refused has to work out for themselves whether they landed in the directory
 // or over it.
-func pluginDirCollision(clean string) string {
-	const what = ", the one directory on the image's PATH"
-	switch {
-	case clean == appPluginDir:
-		return appPluginDir + " is the plugin directory" + what
-	case strings.HasPrefix(clean, appPluginDir+"/"):
-		return clean + " is inside " + appPluginDir + ", the plugin directory" + what
-	case strings.HasPrefix(appPluginDir, clean+"/"):
-		return clean + " would contain " + appPluginDir + ", the plugin directory" + what
+func pathDirCollision(clean string) string {
+	for _, dir := range pathDirs() {
+		what := ", a directory the image's PATH resolves against"
+		if dir == appPluginDir {
+			what = ", the plugin directory an extension's executables land in"
+		}
+		switch {
+		case clean == dir:
+			return clean + " is" + strings.TrimPrefix(what, ",")
+		case strings.HasPrefix(clean, dir+"/"):
+			return clean + " is inside " + dir + what
+		case strings.HasPrefix(dir, clean+"/"):
+			return clean + " would contain " + dir + what
+		}
 	}
 	return ""
 }

--- a/daggerverse/z5labs/contribute.go
+++ b/daggerverse/z5labs/contribute.go
@@ -59,6 +59,32 @@ import (
 // thing from a document about some other artifact entirely, which is no longer
 // publishable.
 //
+// # The plugin directory is composition's, and nothing may be contributed there
+//
+// /usr/local/bin is the one directory on the image's PATH, and neither helper
+// may put anything in it, under it, or over it. App.WithApp is what fills it —
+// see compose.go — and the reason is the one prebuilt.go states about
+// executables generally: a *dagger.File and a *dagger.Directory carry no
+// architecture, and both helpers contribute the same bytes to every variant, so
+// a contribution into the directory the image's PATH resolves against is a way
+// to leave an arm64 image holding an amd64 executable that is discovered by
+// name. Composition carries a platform on every byte, pairs the variants
+// platform by platform, and execs the entry before a byte is published.
+//
+// It was refused by *accident* before devex#427, and only half of it: a
+// contributed file lands 0444 and is therefore not executable, while a
+// contributed tree lands 0555 throughout and is — so the rule the mode policy
+// enforced by omission was bypassed by wrapping the same binary in a directory.
+// A rule that depends on a mode bit is not a rule, so it is stated here and
+// enforced on the path instead.
+//
+// The executable bit a 0555 tree carries *outside* that directory stays, and is
+// accepted rather than worked around: nothing discovers it, because the only
+// directory the PATH names is the one no contribution can reach, so an
+// executable contributed at /opt/thing/run is reachable only by something that
+// already knows that path — the caller's own arrangement inside their own
+// image, and not a contract this module advertises.
+//
 // # The directories on the way are the image's, not the contribution's
 //
 // Contributing at /etc/ssl/certs/ca-certificates.crt on a scratch image brings
@@ -94,12 +120,17 @@ const appOwner = "65532:65532"
 // The directory mode is the residue worth stating rather than hiding. The
 // permission is applied to the copied directory *and its contents*, so the
 // mode is uniform: a directory needs 0555 to be traversable, which drags the
-// files inside it to 0555 too. That is accepted because it is harmless on a
-// scratch image with no shell and no loader — an executable bit is worth
-// something only to something that can exec — and because the alternative is
-// rebuilding the tree file by file at 0444 under a 0555 parent, which hits the
-// chained-WithFile fold ceiling on a large directory. A tree of ten thousand
-// templates is a use case; a mode bit nothing in the image can act on is not.
+// files inside it to 0555 too. That is accepted rather than worked around,
+// because the alternative is rebuilding the tree file by file at 0444 under a
+// 0555 parent, which hits the chained-WithFile fold ceiling on a large
+// directory — a tree of ten thousand templates is a use case.
+//
+// What the residue is *not* is a way onto the PATH. It used to be exactly that,
+// which is what devex#427 closed: nothing may be contributed at, under or over
+// the plugin directory, so an executable a tree carries is discovered by
+// nothing and can only be run by something that already knows its absolute
+// path. That is the caller arranging their own image, rather than this module
+// admitting an executable whose architecture nobody stated.
 const (
 	contributedFileMode      = 0o444
 	contributedDirectoryMode = 0o555
@@ -148,7 +179,10 @@ func normalizedTree(dir *dagger.Directory) *dagger.Directory {
 // contributed to every variant. That is why there is no WithExecutable beside
 // this — a raw file carries no platform, so a helper landing one in the
 // executable directory would silently admit a binary built for the wrong
-// architecture. Platform-specific executables arrive as an App instead.
+// architecture — and it is why a path at, under or over the plugin directory is
+// refused here rather than merely being useless. Platform-specific executables
+// arrive as an App instead: App.WithApp composes one, matched platform by
+// platform, and lands its entry in the plugin directory.
 //
 // +cache="session"
 func (a *App) WithFile(
@@ -186,6 +220,13 @@ func (a *App) WithFile(
 // too, rather than 0444 under a traversable parent — and the comment on
 // contributedDirectoryMode above records why that is accepted rather than
 // worked around.
+//
+// An executable inside such a tree is therefore executable, and that is not a
+// way to extend the image: like WithFile, this refuses a path at, under or over
+// the plugin directory, so nothing a caller contributes is ever discovered on
+// the PATH. Wrapping a binary in a directory used to be exactly that bypass —
+// see the file comment above and App.WithApp, which is the seam that names the
+// platform of every byte it brings.
 //
 // document is an SPDX 2.3 JSON document describing the tree, and it is
 // required for the reason WithFile's is. Z5labs.DirectoryDocument produces one
@@ -322,6 +363,18 @@ func (a *App) occupiedPaths(ctx context.Context) ([]occupied, error) {
 // undetectable incompleteness the overlap rules exist for, arriving from the
 // deployment's side instead of from another contribution's.
 //
+// The plugin directory is refused too, in all three directions — the directory
+// itself, anything under it, and anything that would contain it. It is the one
+// directory on the image's PATH and App.WithApp is what fills it; the file
+// comment above carries why a contribution there is a wrong-architecture
+// executable waiting to be discovered by name. The containing direction is
+// refused without looking inside the tree, exactly as overlappingPath refuses a
+// contribution that would contain something already in the image: a tree at
+// /usr/local is refused whether or not it happens to carry a bin/ today,
+// because whether it does is a property of the caller's tree rather than of the
+// call, and a rule that has to read the content is one that changes its mind
+// between builds.
+//
 // HOME's directory is *not* refused, and the asymmetry is deliberate.
 // /home/nonroot is in the image and read-only, and a deployment mounts over it
 // only in the one case where an application genuinely needs a writable home —
@@ -360,7 +413,35 @@ func validateContributionPath(method, raw string) (string, error) {
 				"there, and anything contributed under it disappears the moment it does",
 			method, what)
 	}
+	if where := pluginDirCollision(clean); where != "" {
+		return "", fmt.Errorf(
+			"%s: %s, and nothing may be contributed there — a contributed file or tree carries no architecture and "+
+				"lands in every variant, so content in the one directory the image's PATH resolves against is a way to "+
+				"leave an arm64 image running an amd64 executable that something discovered by name; withApp composes "+
+				"another application's payload, which is matched platform by platform and run before anything is published",
+			method, where)
+	}
 	return clean, nil
+}
+
+// pluginDirCollision reports how clean collides with the plugin directory, or
+// "" when it does not.
+//
+// The three directions are the three overlappingPath distinguishes, and they
+// are separated here for the same reason: a caller told only that a path is
+// refused has to work out for themselves whether they landed in the directory
+// or over it.
+func pluginDirCollision(clean string) string {
+	const what = ", the one directory on the image's PATH"
+	switch {
+	case clean == appPluginDir:
+		return appPluginDir + " is the plugin directory" + what
+	case strings.HasPrefix(clean, appPluginDir+"/"):
+		return clean + " is inside " + appPluginDir + ", the plugin directory" + what
+	case strings.HasPrefix(appPluginDir, clean+"/"):
+		return clean + " would contain " + appPluginDir + ", the plugin directory" + what
+	}
+	return ""
 }
 
 // overlappingPath reports how the candidate collides with something already in

--- a/daggerverse/z5labs/contributeselftest.go
+++ b/daggerverse/z5labs/contributeselftest.go
@@ -23,12 +23,14 @@ import (
 // contribution mechanism exists to prevent, arriving through the mechanism
 // itself.
 //
-// The plugin directory's rows are the exception, and they answer a different
-// question: what may reach the one directory the image's PATH resolves against.
-// Only composition may, because only composition names the architecture of what
-// it brings — see contribute.go. They are a table row rather than a mode bit
-// because a rule enforced by a mode was bypassed by wrapping a binary in a
-// directory, which is what devex#427 closed.
+// The PATH's rows are the exception, and they answer a different question: what
+// may reach a directory the image searches by name. Nothing contributed may,
+// because only composition names the architecture of what it brings — see
+// contribute.go. They are table rows rather than a mode bit because a rule
+// enforced by a mode was bypassed by wrapping a binary in a directory, which is
+// what devex#427 closed, and they cover every directory appPath names rather
+// than the plugin directory alone: discovery by bare name is what the rule is
+// about, and /usr/local/bin is one of six directories it can happen in.
 //
 // It runs in process and needs no container, so it is cheap enough to be a
 // check of its own.
@@ -52,7 +54,14 @@ func checkContributionPaths() error {
 		want string
 		// refusal is a substring the refusal must carry.
 		refusal string
-		why     string
+		// method is the helper the rule is driven as, and it is checked rather
+		// than merely passed: every refusal opens with the method that hit it,
+		// and a caller reading "withFile" under a withDirectory call goes
+		// looking at the wrong line of their own pipeline. Empty means
+		// withFile, so only the rows that exist to exercise the other helper
+		// have to say so.
+		method string
+		why    string
 	}{
 		{path: "/etc/ssl/certs/ca-certificates.crt", want: "/etc/ssl/certs/ca-certificates.crt", why: "the ordinary case"},
 		{path: "/srv/templates", want: "/srv/templates", why: "a directory"},
@@ -107,12 +116,19 @@ func checkContributionPaths() error {
 		{
 			path:    "/usr/local/bin",
 			refusal: "/usr/local/bin is the plugin directory",
+			method:  "withDirectory",
 			why:     "the plugin directory itself, which App.WithApp fills and no contribution may",
 		},
 		{
 			path:    "/usr/local/bin/gen",
 			refusal: "/usr/local/bin/gen is inside /usr/local/bin",
 			why:     "an executable contributed onto the PATH, which names no architecture and lands in every variant",
+		},
+		{
+			path:    "/usr/local/bin/tools",
+			refusal: "/usr/local/bin/tools is inside /usr/local/bin",
+			method:  "withDirectory",
+			why:     "a tree under the plugin directory, which is the bypass this rule was written for at its likeliest spelling",
 		},
 		{
 			path:    "/usr/local/bin/../bin/gen",
@@ -122,6 +138,7 @@ func checkContributionPaths() error {
 		{
 			path:    "/usr/local",
 			refusal: "/usr/local would contain /usr/local/bin",
+			method:  "withDirectory",
 			why:     "a tree over the plugin directory, which is the bypass a mode bit could not refuse",
 		},
 		{
@@ -129,19 +146,57 @@ func checkContributionPaths() error {
 			refusal: "/usr would contain /usr/local/bin",
 			why:     "a tree further up, refused for the same reason and without reading what is in it",
 		},
+
+		// The rest of the PATH. The plugin directory is one of six directories
+		// the image searches, so a rule that guarded it alone would leave the
+		// other five open to an executable of no stated architecture that
+		// something finds by name — which is the failure the whole rule is
+		// about, not a property of that one directory. These rows are what keep
+		// the set derived from appPath rather than narrowed back to a constant.
+		{
+			path:    "/usr/bin",
+			refusal: "/usr/bin is a directory the image's PATH resolves against",
+			why:     "another directory on the PATH, where discovery by bare name works exactly as it does in the plugin directory",
+		},
+		{
+			path:    "/bin/helper",
+			refusal: "/bin/helper is inside /bin",
+			method:  "withDirectory",
+			why:     "a tree under the last directory on the PATH, which the leading-segment order must not skip",
+		},
+		{
+			path:    "/usr/local/sbin",
+			refusal: "/usr/local/sbin is a directory the image's PATH resolves against",
+			why:     "the directory the PATH names first, which is not the plugin directory and is protected all the same",
+		},
+
 		{
 			path: "/usr/local/binaries",
 			want: "/usr/local/binaries",
 			why:  "a sibling whose name merely opens with the plugin directory's, which is not inside it",
 		},
 		{
+			path: "/binaries",
+			want: "/binaries",
+			why:  "a sibling of /bin, which the prefix test must not read as being under it",
+		},
+		{
 			path: "/usr/local/share/ca-certificates/corp.crt",
 			want: "/usr/local/share/ca-certificates/corp.crt",
-			why:  "content beside the plugin directory, which is refused by nothing — the rule is about that one directory",
+			why:  "content beside the PATH's directories, which is refused by nothing — the rule is about the PATH",
+		},
+		{
+			path: "/opt/thing/run",
+			want: "/opt/thing/run",
+			why:  "an executable off the PATH, which is the caller's own arrangement and deliberately not refused",
 		},
 	}
 	for _, c := range cases {
-		got, err := validateContributionPath("withFile", c.path)
+		method := c.method
+		if method == "" {
+			method = "withFile"
+		}
+		got, err := validateContributionPath(method, c.path)
 		if c.want != "" {
 			if err != nil {
 				return fmt.Errorf("expected %q to be accepted (%s), got: %v", c.path, c.why, err)
@@ -156,6 +211,9 @@ func checkContributionPaths() error {
 		}
 		if !strings.Contains(err.Error(), c.refusal) {
 			return fmt.Errorf("expected the refusal of %q (%s) to carry %q, got: %v", c.path, c.why, c.refusal, err)
+		}
+		if !strings.HasPrefix(err.Error(), method) {
+			return fmt.Errorf("expected the refusal of %q (%s) to open with %q, got: %v", c.path, c.why, method, err)
 		}
 	}
 	return nil

--- a/daggerverse/z5labs/contributeselftest.go
+++ b/daggerverse/z5labs/contributeselftest.go
@@ -23,6 +23,13 @@ import (
 // contribution mechanism exists to prevent, arriving through the mechanism
 // itself.
 //
+// The plugin directory's rows are the exception, and they answer a different
+// question: what may reach the one directory the image's PATH resolves against.
+// Only composition may, because only composition names the architecture of what
+// it brings — see contribute.go. They are a table row rather than a mode bit
+// because a rule enforced by a mode was bypassed by wrapping a binary in a
+// directory, which is what devex#427 closed.
+//
 // It runs in process and needs no container, so it is cheap enough to be a
 // check of its own.
 //
@@ -96,6 +103,41 @@ func checkContributionPaths() error {
 			path: "/home/nonroot/.config/app.yaml",
 			want: "/home/nonroot/.config/app.yaml",
 			why:  "read-only content under HOME, which the image does carry and which is deliberately not refused",
+		},
+		{
+			path:    "/usr/local/bin",
+			refusal: "/usr/local/bin is the plugin directory",
+			why:     "the plugin directory itself, which App.WithApp fills and no contribution may",
+		},
+		{
+			path:    "/usr/local/bin/gen",
+			refusal: "/usr/local/bin/gen is inside /usr/local/bin",
+			why:     "an executable contributed onto the PATH, which names no architecture and lands in every variant",
+		},
+		{
+			path:    "/usr/local/bin/../bin/gen",
+			refusal: "is inside /usr/local/bin",
+			why:     "a path that reaches the plugin directory only after cleaning, which a prefix test on the raw string would miss",
+		},
+		{
+			path:    "/usr/local",
+			refusal: "/usr/local would contain /usr/local/bin",
+			why:     "a tree over the plugin directory, which is the bypass a mode bit could not refuse",
+		},
+		{
+			path:    "/usr",
+			refusal: "/usr would contain /usr/local/bin",
+			why:     "a tree further up, refused for the same reason and without reading what is in it",
+		},
+		{
+			path: "/usr/local/binaries",
+			want: "/usr/local/binaries",
+			why:  "a sibling whose name merely opens with the plugin directory's, which is not inside it",
+		},
+		{
+			path: "/usr/local/share/ca-certificates/corp.crt",
+			want: "/usr/local/share/ca-certificates/corp.crt",
+			why:  "content beside the plugin directory, which is refused by nothing — the rule is about that one directory",
 		},
 	}
 	for _, c := range cases {

--- a/daggerverse/z5labs/main.go
+++ b/daggerverse/z5labs/main.go
@@ -31,6 +31,14 @@
 // default a container runtime injects when an image sets none, so an image
 // that later gains a real base layer behaves the way its base expects.
 //
+// Exactly one seam puts an executable in that directory, and it is App.WithApp
+// — see "Composing one application into another" below. Contributing at, under
+// or over it is refused, because a contributed file or tree names no
+// architecture and lands in every variant, so content in the one directory the
+// PATH resolves against is a way to leave an arm64 image running an amd64
+// executable that something found by name. "An extension's executables land
+// here" therefore means composition, and nothing else (devex#427).
+//
 // The application's own entrypoint does not rely on any of that. It is an
 // absolute path — /app/<binary> — so the app runs whatever the PATH says.
 // PATH exists for what an extension adds, not for finding the app itself.

--- a/daggerverse/z5labs/main.go
+++ b/daggerverse/z5labs/main.go
@@ -33,11 +33,12 @@
 //
 // Exactly one seam puts an executable in that directory, and it is App.WithApp
 // — see "Composing one application into another" below. Contributing at, under
-// or over it is refused, because a contributed file or tree names no
-// architecture and lands in every variant, so content in the one directory the
-// PATH resolves against is a way to leave an arm64 image running an amd64
-// executable that something found by name. "An extension's executables land
-// here" therefore means composition, and nothing else (devex#427).
+// or over it is refused, and so is contributing onto any of the other five
+// directories that PATH names: a contributed file or tree states no
+// architecture and lands in every variant, so content something finds on the
+// PATH by name is a way to leave an arm64 image running an amd64 executable.
+// "An extension's executables land here" therefore means composition, and
+// nothing else (devex#427).
 //
 // The application's own entrypoint does not rely on any of that. It is an
 // absolute path — /app/<binary> — so the app runs whatever the PATH says.

--- a/daggerverse/z5labs/tests/compose.go
+++ b/daggerverse/z5labs/tests/compose.go
@@ -324,12 +324,18 @@ func (t *Tests) AppRefusesToComposeAcrossPlatforms(ctx context.Context) error {
 // Contributing a file where a plugin already is used to be the same collision
 // arriving through the seam that was there first, and after devex#427 it is
 // refused *before* the collision rule is consulted — every composed entry lives
-// in the plugin directory, and no contribution may reach that directory whether
-// or not something is already in it. So the second half asserts a refusal that
-// names the directory rather than the holder. That is a strengthening and not a
-// gap: the path is protected by a rule that does not depend on a plugin having
-// been composed there first, and the holder-naming property is what the first
-// half is for.
+// in the plugin directory, and no contribution may reach any directory on the
+// image's PATH whether or not something is already in it. So the second case
+// asserts the distinguishing half of that message rather than the path, which
+// both refusals name and which would therefore pass whichever rule fired.
+//
+// That leaves the third case doing what the second used to. A composed
+// application's *other* paths are still ordinary contributed paths — a complete
+// application brings its own tree at its own path — so a contribution can still
+// collide with content a composition brought, and the refusal still has to name
+// which application brought it. That branch of the collision rule would
+// otherwise have lost its only coverage to the PATH rule taking the case away
+// from it.
 func (t *Tests) AppRefusesToComposeOntoOccupiedPaths(ctx context.Context) error {
 	src, err := gitFixture(ctx, helloDir(), "main", nil)
 	if err != nil {
@@ -354,9 +360,35 @@ func (t *Tests) AppRefusesToComposeOntoOccupiedPaths(ctx context.Context) error 
 	if err == nil {
 		return fmt.Errorf("expected contributing a file at %s to be refused, got nil", wantComposedEntry)
 	}
-	if !strings.Contains(err.Error(), wantPluginDir) {
-		return fmt.Errorf("expected the refusal of a contribution at %s to name the plugin directory, got: %s",
-			wantComposedEntry, err.Error())
+	// The distinguishing half. Both refusals name the path, so asserting the
+	// path alone would not say which rule stopped it — and the point of the
+	// case after devex#427 is that the PATH rule got there first.
+	if want := "is inside " + wantPluginDir; !strings.Contains(err.Error(), want) {
+		return fmt.Errorf("expected the refusal of a contribution at %s to carry %q, got: %s",
+			wantComposedEntry, want, err.Error())
+	}
+
+	// And a contribution onto what a composed application brought with it,
+	// which is off the PATH and so is still the collision rule's to refuse. The
+	// version and the fixture match AppComposesACompleteApplication's so the
+	// payload is built once for both.
+	const treePath = "/srv/payload"
+	tree := dag.Directory().
+		WithNewFile("greeting.txt", "hi\n").
+		WithNewFile("data/extra.txt", "extra\n")
+	complete := prebuiltApp(payloadDir(), "payload", "v1.2.3", platforms).
+		Build().
+		WithDirectory(treePath, tree, dag.Z5Labs().DirectoryDocument(tree, treePath))
+	derived := dag.Z5Labs().Go(src).App("v5.1.0", dagger.Z5LabsGoChainAppOpts{Platforms: platforms}).
+		WithApp(complete)
+	_, err = derived.WithFile(treePath+"/greeting.txt", note, dag.Z5Labs().FileDocument(note)).ID(ctx)
+	if err == nil {
+		return fmt.Errorf("expected contributing a file inside %s to be refused, got nil", treePath)
+	}
+	for _, want := range []string{treePath, "brought in by the application composed at"} {
+		if !strings.Contains(err.Error(), want) {
+			return fmt.Errorf("expected the collision refusal inside %s to carry %q, got: %s", treePath, want, err.Error())
+		}
 	}
 	return nil
 }

--- a/daggerverse/z5labs/tests/compose.go
+++ b/daggerverse/z5labs/tests/compose.go
@@ -316,12 +316,20 @@ func (t *Tests) AppRefusesToComposeAcrossPlatforms(ctx context.Context) error {
 // that the refusal names both sides.
 //
 // Both sides, because a caller told only that a path is taken has to go and
-// find out by what — and the two cases here are told apart by nothing else.
-// Composing the same plugin twice collides with an application composed
-// earlier; contributing a file where a plugin already is collides the other
-// way round, through the seam that was there first. Either way the image would
-// hold one thing while its documents describe two, which is the undetectable
-// incompleteness this whole mechanism exists to prevent.
+// find out by what. Composing the same plugin twice collides with an
+// application composed earlier, and the refusal names it: the image would
+// otherwise hold one thing while its documents describe two, which is the
+// undetectable incompleteness this whole mechanism exists to prevent.
+//
+// Contributing a file where a plugin already is used to be the same collision
+// arriving through the seam that was there first, and after devex#427 it is
+// refused *before* the collision rule is consulted — every composed entry lives
+// in the plugin directory, and no contribution may reach that directory whether
+// or not something is already in it. So the second half asserts a refusal that
+// names the directory rather than the holder. That is a strengthening and not a
+// gap: the path is protected by a rule that does not depend on a plugin having
+// been composed there first, and the holder-naming property is what the first
+// half is for.
 func (t *Tests) AppRefusesToComposeOntoOccupiedPaths(ctx context.Context) error {
 	src, err := gitFixture(ctx, helloDir(), "main", nil)
 	if err != nil {
@@ -346,8 +354,9 @@ func (t *Tests) AppRefusesToComposeOntoOccupiedPaths(ctx context.Context) error 
 	if err == nil {
 		return fmt.Errorf("expected contributing a file at %s to be refused, got nil", wantComposedEntry)
 	}
-	if !strings.Contains(err.Error(), "the entry of the application composed at") {
-		return fmt.Errorf("expected the refusal to name what holds %s, got: %s", wantComposedEntry, err.Error())
+	if !strings.Contains(err.Error(), wantPluginDir) {
+		return fmt.Errorf("expected the refusal of a contribution at %s to name the plugin directory, got: %s",
+			wantComposedEntry, err.Error())
 	}
 	return nil
 }

--- a/daggerverse/z5labs/tests/contribute.go
+++ b/daggerverse/z5labs/tests/contribute.go
@@ -335,6 +335,98 @@ func (t *Tests) AppRefusesContributionsThatCollide(ctx context.Context) error {
 	return nil
 }
 
+// AppRefusesContributionsToThePluginDirectory asserts that the one directory on
+// the image's PATH is filled by composition and by nothing else.
+//
+// The image contract has always said that /usr/local/bin is where an
+// extension's executables land. Until devex#427 the two halves of the module
+// disagreed about what that meant: WithFile lands content 0444, so a binary
+// contributed there was not executable and the directory was unusable through
+// the seam that names a single file, while WithDirectory lands a tree 0555, so
+// wrapping the same binary in a directory worked — and the rule the mode policy
+// enforced by omission was bypassed by the shape of the call. Both halves are
+// asserted here, in both directions, because the decision is that neither
+// helper reaches the directory and the bypass is the one that shipped.
+//
+// What makes it a rule about paths rather than about modes is the last case: a
+// tree contributed at /usr/local is refused without anything reading what is in
+// it. Whether it carries a bin/ is a property of the caller's tree rather than
+// of the call, and a rule that has to look inside changes its mind between
+// builds.
+//
+// The positive half is the point of the negative half and is asserted in the
+// same test rather than left to be inferred from a comment: the same base, with
+// the same directory, takes a composed application's entry and runs it **by
+// bare name**, which is what a base image's plugin discovery does. That is the
+// path the contract describes, and it works because composition carries a
+// platform on every byte and pairs the variant sets — which is exactly what a
+// *dagger.File and a *dagger.Directory cannot do.
+func (t *Tests) AppRefusesContributionsToThePluginDirectory(ctx context.Context) error {
+	const version = "v2.5.0"
+	platforms := []dagger.Platform{hostPlatform()}
+	base := prebuiltApp(helloDir(), "hello", version, platforms).Build()
+	fixture := newContributionFixture("bundle\n")
+
+	cases := []struct {
+		name string
+		app  *dagger.Z5LabsApp
+		want string
+	}{
+		{
+			name: "a file onto the PATH, where a base image's plugin discovery would find it",
+			app:  base.WithFile(wantPluginDir+"/gen", fixture.File, fixture.FileDocument),
+			want: "is inside " + wantPluginDir,
+		},
+		{
+			name: "a file at the plugin directory itself",
+			app:  base.WithFile(wantPluginDir, fixture.File, fixture.FileDocument),
+			want: wantPluginDir + " is the plugin directory",
+		},
+		{
+			// The bypass. A tree lands 0555 throughout, so before devex#427
+			// this was the way to put an executable of no stated architecture
+			// into every variant's plugin directory.
+			name: "a tree at the plugin directory, which lands executable",
+			app:  base.WithDirectory(wantPluginDir, fixture.Dir, fixture.DirDocument),
+			want: wantPluginDir + " is the plugin directory",
+		},
+		{
+			name: "a tree that would contain the plugin directory",
+			app:  base.WithDirectory("/usr/local", fixture.Dir, fixture.DirDocument),
+			want: "would contain " + wantPluginDir,
+		},
+	}
+	for _, c := range cases {
+		if _, err := c.app.ID(ctx); err == nil {
+			return fmt.Errorf("expected %s to be refused, got nil", c.name)
+		} else if !strings.Contains(err.Error(), c.want) {
+			return fmt.Errorf("expected the refusal of %s to name %q, got: %s", c.name, c.want, err.Error())
+		}
+	}
+
+	// Beside it is not inside it. The rule is about the one directory the PATH
+	// resolves against, so a refusal that had spread to /usr/local generally
+	// would go red here rather than being discovered by an adopter with a
+	// certificate bundle.
+	beside := "/usr/local/share/ca-certificates/corp.crt"
+	if _, err := base.WithFile(beside, fixture.File, fixture.FileDocument).ID(ctx); err != nil {
+		return fmt.Errorf("expected a contribution at %s to be accepted, got: %v", beside, err)
+	}
+
+	// And the seam that may fill it does. Run by bare name rather than by
+	// absolute path: the contract is that the directory is on the PATH, and an
+	// absolute-path exec would pass on an image where it was not.
+	derived := base.WithApp(composedPlugin(wantPluginName, "v0.5.0", platforms))
+	out, err := derived.Container(hostPlatform()).WithExec([]string{wantPluginName}).Stdout(ctx)
+	if err != nil {
+		return fmt.Errorf("run the composed plugin through the image's PATH: %w", err)
+	}
+	if want := "plugin ok\n"; out != want {
+		return fmt.Errorf("the composed plugin printed %q, want %q", out, want)
+	}
+	return nil
+}
+
 // AppCustomizedImageStaysAttested asserts that an image a caller contributed
 // to is attested exactly as one they did not: the documents account for every
 // contribution, the provenance still describes what was published, and the

--- a/daggerverse/z5labs/tests/contribute.go
+++ b/daggerverse/z5labs/tests/contribute.go
@@ -335,8 +335,8 @@ func (t *Tests) AppRefusesContributionsThatCollide(ctx context.Context) error {
 	return nil
 }
 
-// AppRefusesContributionsToThePluginDirectory asserts that the one directory on
-// the image's PATH is filled by composition and by nothing else.
+// AppRefusesContributionsOntoThePath asserts that the directories the image's
+// PATH resolves against are filled by composition and by nothing else.
 //
 // The image contract has always said that /usr/local/bin is where an
 // extension's executables land. Until devex#427 the two halves of the module
@@ -354,6 +354,11 @@ func (t *Tests) AppRefusesContributionsThatCollide(ctx context.Context) error {
 // of the call, and a rule that has to look inside changes its mind between
 // builds.
 //
+// The rule is the whole PATH rather than the plugin directory alone, which is
+// the correction this test's last case pins: /usr/local/bin is one of six
+// directories the image searches, and a tree at /usr/bin would be discovered by
+// bare name exactly as one in the plugin directory would.
+//
 // The positive half is the point of the negative half and is asserted in the
 // same test rather than left to be inferred from a comment: the same base, with
 // the same directory, takes a composed application's entry and runs it **by
@@ -361,7 +366,7 @@ func (t *Tests) AppRefusesContributionsThatCollide(ctx context.Context) error {
 // path the contract describes, and it works because composition carries a
 // platform on every byte and pairs the variant sets — which is exactly what a
 // *dagger.File and a *dagger.Directory cannot do.
-func (t *Tests) AppRefusesContributionsToThePluginDirectory(ctx context.Context) error {
+func (t *Tests) AppRefusesContributionsOntoThePath(ctx context.Context) error {
 	const version = "v2.5.0"
 	platforms := []dagger.Platform{hostPlatform()}
 	base := prebuiltApp(helloDir(), "hello", version, platforms).Build()
@@ -391,9 +396,27 @@ func (t *Tests) AppRefusesContributionsToThePluginDirectory(ctx context.Context)
 			want: wantPluginDir + " is the plugin directory",
 		},
 		{
+			// The bypass at its likeliest spelling. "Wrap the binary in a
+			// directory" lands a tree at a subpath far more naturally than at
+			// the directory itself.
+			name: "a tree under the plugin directory",
+			app:  base.WithDirectory(wantPluginDir+"/tools", fixture.Dir, fixture.DirDocument),
+			want: "is inside " + wantPluginDir,
+		},
+		{
 			name: "a tree that would contain the plugin directory",
 			app:  base.WithDirectory("/usr/local", fixture.Dir, fixture.DirDocument),
 			want: "would contain " + wantPluginDir,
+		},
+		{
+			// Not the plugin directory at all. The PATH names six directories
+			// and discovery by bare name works in every one of them, so a rule
+			// that guarded only the documented one would leave this open — and
+			// a 0555 tree here is an executable of no stated architecture that
+			// the image finds by name.
+			name: "a tree at another directory on the image's PATH",
+			app:  base.WithDirectory("/usr/bin", fixture.Dir, fixture.DirDocument),
+			want: "/usr/bin is a directory the image's PATH resolves against",
 		},
 	}
 	for _, c := range cases {

--- a/daggerverse/z5labs/tests/dagger.gen.go
+++ b/daggerverse/z5labs/tests/dagger.gen.go
@@ -416,6 +416,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).AppRefusesADocumentThatDescribesOtherBytes(&parent, ctx)
+		case "AppRefusesContributionsOntoThePath":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).AppRefusesContributionsOntoThePath(&parent, ctx)
 		case "AppRefusesContributionsThatCollide":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)
@@ -423,13 +430,6 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).AppRefusesContributionsThatCollide(&parent, ctx)
-		case "AppRefusesContributionsToThePluginDirectory":
-			var parent Tests
-			err = json.Unmarshal(parentJSON, &parent)
-			if err != nil {
-				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
-			}
-			return nil, (*Tests).AppRefusesContributionsToThePluginDirectory(&parent, ctx)
 		case "AppRefusesPlaintextRegistryUnlessInsecure":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/z5labs/tests/dagger.gen.go
+++ b/daggerverse/z5labs/tests/dagger.gen.go
@@ -423,6 +423,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).AppRefusesContributionsThatCollide(&parent, ctx)
+		case "AppRefusesContributionsToThePluginDirectory":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).AppRefusesContributionsToThePluginDirectory(&parent, ctx)
 		case "AppRefusesPlaintextRegistryUnlessInsecure":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
+++ b/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type Z5Labs
-func (r *Binding) AsZ5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:556:6)
+func (r *Binding) AsZ5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:557:6)
 	q := r.query.Select("asZ5Labs")
 
 	return &Z5Labs{
@@ -118,7 +118,7 @@ func (r *Env) WithZ5LabsGoChainOutput(name string, description string) *Env { //
 }
 
 // Create or update a binding of type Z5Labs in the environment
-func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:556:6)
+func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:557:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withZ5LabsInput")
 	q = q.Arg("name", name)
@@ -131,7 +131,7 @@ func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *E
 }
 
 // Declare a desired Z5Labs output to be assigned in the environment
-func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:556:6)
+func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:557:6)
 	q := r.query.Select("withZ5LabsOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -143,7 +143,7 @@ func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs
 
 // Z5labs is the root module type. Construct the Go language chain via Go;
 // everything this module does is reached from there.
-func (r *Query) Z5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:556:6)
+func (r *Query) Z5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:557:6)
 	q := r.query.Select("z5Labs")
 
 	return &Z5Labs{
@@ -153,7 +153,7 @@ func (r *Query) Z5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/
 
 // Z5labs is the root module type. Construct the Go language chain via Go;
 // everything this module does is reached from there.
-type Z5Labs struct { // z5labs (../../../../../daggerverse/z5labs/main.go:556:6)
+type Z5Labs struct { // z5labs (../../../../../daggerverse/z5labs/main.go:557:6)
 	query *querybuilder.Selection
 
 	composeSelfTest          *Void
@@ -263,16 +263,18 @@ func (r *Z5Labs) ComposeSelfTest(ctx context.Context) error { // z5labs (../../.
 // contribution mechanism exists to prevent, arriving through the mechanism
 // itself.
 //
-// The plugin directory's rows are the exception, and they answer a different
-// question: what may reach the one directory the image's PATH resolves against.
-// Only composition may, because only composition names the architecture of what
-// it brings — see contribute.go. They are a table row rather than a mode bit
-// because a rule enforced by a mode was bypassed by wrapping a binary in a
-// directory, which is what devex#427 closed.
+// The PATH's rows are the exception, and they answer a different question: what
+// may reach a directory the image searches by name. Nothing contributed may,
+// because only composition names the architecture of what it brings — see
+// contribute.go. They are table rows rather than a mode bit because a rule
+// enforced by a mode was bypassed by wrapping a binary in a directory, which is
+// what devex#427 closed, and they cover every directory appPath names rather
+// than the plugin directory alone: discovery by bare name is what the rule is
+// about, and /usr/local/bin is one of six directories it can happen in.
 //
 // It runs in process and needs no container, so it is cheap enough to be a
 // check of its own.
-func (r *Z5Labs) ContributionPathSelfTest(ctx context.Context) error { // z5labs (../../../../../daggerverse/z5labs/contributeselftest.go:38:1)
+func (r *Z5Labs) ContributionPathSelfTest(ctx context.Context) error { // z5labs (../../../../../daggerverse/z5labs/contributeselftest.go:40:1)
 	if r.contributionPathSelfTest != nil {
 		return nil
 	}
@@ -403,7 +405,7 @@ func (r *Z5Labs) FileDocument(file *File, opts ...Z5LabsFileDocumentOpts) *File 
 //
 // The returned object is GoChain rather than Go because the `go` module
 // this one depends on already owns that name — see GoChain's doc comment.
-func (r *Z5Labs) Go(source *Directory) *Z5LabsGoChain { // z5labs (../../../../../daggerverse/z5labs/main.go:572:1)
+func (r *Z5Labs) Go(source *Directory) *Z5LabsGoChain { // z5labs (../../../../../daggerverse/z5labs/main.go:573:1)
 	assertNotNil("source", source)
 	q := r.query.Select("go")
 	q = q.Arg("source", source)
@@ -931,10 +933,11 @@ func (r *Z5LabsApp) WithApp(from *Z5LabsApp) *Z5LabsApp { // z5labs (../../../..
 //
 // An executable inside such a tree is therefore executable, and that is not a
 // way to extend the image: like WithFile, this refuses a path at, under or over
-// the plugin directory, so nothing a caller contributes is ever discovered on
-// the PATH. Wrapping a binary in a directory used to be exactly that bypass —
-// see the file comment above and App.WithApp, which is the seam that names the
-// platform of every byte it brings.
+// any directory the image's PATH resolves against, so nothing a caller
+// contributes is ever discovered on the PATH by name. Wrapping a binary in a
+// directory used to be exactly that bypass — see the file comment above and
+// App.WithApp, which is the seam that names the platform of every byte it
+// brings.
 //
 // document is an SPDX 2.3 JSON document describing the tree, and it is
 // required for the reason WithFile's is. Z5labs.DirectoryDocument produces one
@@ -942,7 +945,7 @@ func (r *Z5LabsApp) WithApp(from *Z5LabsApp) *Z5LabsApp { // z5labs (../../../..
 // carries one file element per file in the tree, because "the contribution is
 // described" and "every file in the image is accounted for" are different
 // promises and only the second one is the point.
-func (r *Z5LabsApp) WithDirectory(path string, dir *Directory, document *File) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/contribute.go:239:1)
+func (r *Z5LabsApp) WithDirectory(path string, dir *Directory, document *File) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/contribute.go:249:1)
 	assertNotNil("dir", dir)
 	assertNotNil("document", document)
 	q := r.query.Select("withDirectory")
@@ -973,11 +976,12 @@ func (r *Z5LabsApp) WithDirectory(path string, dir *Directory, document *File) *
 // contributed to every variant. That is why there is no WithExecutable beside
 // this — a raw file carries no platform, so a helper landing one in the
 // executable directory would silently admit a binary built for the wrong
-// architecture — and it is why a path at, under or over the plugin directory is
-// refused here rather than merely being useless. Platform-specific executables
-// arrive as an App instead: App.WithApp composes one, matched platform by
-// platform, and lands its entry in the plugin directory.
-func (r *Z5LabsApp) WithFile(path string, file *File, document *File) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/contribute.go:188:1)
+// architecture — and it is why a path at, under or over any directory the
+// image's PATH resolves against is refused here rather than merely being
+// useless. Platform-specific executables arrive as an App instead: App.WithApp
+// composes one, matched platform by platform, and lands its entry in the plugin
+// directory.
+func (r *Z5LabsApp) WithFile(path string, file *File, document *File) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/contribute.go:197:1)
 	assertNotNil("file", file)
 	assertNotNil("document", document)
 	q := r.query.Select("withFile")

--- a/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
+++ b/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type Z5Labs
-func (r *Binding) AsZ5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:548:6)
+func (r *Binding) AsZ5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:556:6)
 	q := r.query.Select("asZ5Labs")
 
 	return &Z5Labs{
@@ -118,7 +118,7 @@ func (r *Env) WithZ5LabsGoChainOutput(name string, description string) *Env { //
 }
 
 // Create or update a binding of type Z5Labs in the environment
-func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:548:6)
+func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:556:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withZ5LabsInput")
 	q = q.Arg("name", name)
@@ -131,7 +131,7 @@ func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *E
 }
 
 // Declare a desired Z5Labs output to be assigned in the environment
-func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:548:6)
+func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:556:6)
 	q := r.query.Select("withZ5LabsOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -143,7 +143,7 @@ func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs
 
 // Z5labs is the root module type. Construct the Go language chain via Go;
 // everything this module does is reached from there.
-func (r *Query) Z5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:548:6)
+func (r *Query) Z5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:556:6)
 	q := r.query.Select("z5Labs")
 
 	return &Z5Labs{
@@ -153,7 +153,7 @@ func (r *Query) Z5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/
 
 // Z5labs is the root module type. Construct the Go language chain via Go;
 // everything this module does is reached from there.
-type Z5Labs struct { // z5labs (../../../../../daggerverse/z5labs/main.go:548:6)
+type Z5Labs struct { // z5labs (../../../../../daggerverse/z5labs/main.go:556:6)
 	query *querybuilder.Selection
 
 	composeSelfTest          *Void
@@ -263,9 +263,16 @@ func (r *Z5Labs) ComposeSelfTest(ctx context.Context) error { // z5labs (../../.
 // contribution mechanism exists to prevent, arriving through the mechanism
 // itself.
 //
+// The plugin directory's rows are the exception, and they answer a different
+// question: what may reach the one directory the image's PATH resolves against.
+// Only composition may, because only composition names the architecture of what
+// it brings — see contribute.go. They are a table row rather than a mode bit
+// because a rule enforced by a mode was bypassed by wrapping a binary in a
+// directory, which is what devex#427 closed.
+//
 // It runs in process and needs no container, so it is cheap enough to be a
 // check of its own.
-func (r *Z5Labs) ContributionPathSelfTest(ctx context.Context) error { // z5labs (../../../../../daggerverse/z5labs/contributeselftest.go:31:1)
+func (r *Z5Labs) ContributionPathSelfTest(ctx context.Context) error { // z5labs (../../../../../daggerverse/z5labs/contributeselftest.go:38:1)
 	if r.contributionPathSelfTest != nil {
 		return nil
 	}
@@ -396,7 +403,7 @@ func (r *Z5Labs) FileDocument(file *File, opts ...Z5LabsFileDocumentOpts) *File 
 //
 // The returned object is GoChain rather than Go because the `go` module
 // this one depends on already owns that name — see GoChain's doc comment.
-func (r *Z5Labs) Go(source *Directory) *Z5LabsGoChain { // z5labs (../../../../../daggerverse/z5labs/main.go:564:1)
+func (r *Z5Labs) Go(source *Directory) *Z5LabsGoChain { // z5labs (../../../../../daggerverse/z5labs/main.go:572:1)
 	assertNotNil("source", source)
 	q := r.query.Select("go")
 	q = q.Arg("source", source)
@@ -922,13 +929,20 @@ func (r *Z5LabsApp) WithApp(from *Z5LabsApp) *Z5LabsApp { // z5labs (../../../..
 // contributedDirectoryMode above records why that is accepted rather than
 // worked around.
 //
+// An executable inside such a tree is therefore executable, and that is not a
+// way to extend the image: like WithFile, this refuses a path at, under or over
+// the plugin directory, so nothing a caller contributes is ever discovered on
+// the PATH. Wrapping a binary in a directory used to be exactly that bypass —
+// see the file comment above and App.WithApp, which is the seam that names the
+// platform of every byte it brings.
+//
 // document is an SPDX 2.3 JSON document describing the tree, and it is
 // required for the reason WithFile's is. Z5labs.DirectoryDocument produces one
 // for content with no ecosystem, and it enumerates: the document it writes
 // carries one file element per file in the tree, because "the contribution is
 // described" and "every file in the image is accounted for" are different
 // promises and only the second one is the point.
-func (r *Z5LabsApp) WithDirectory(path string, dir *Directory, document *File) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/contribute.go:198:1)
+func (r *Z5LabsApp) WithDirectory(path string, dir *Directory, document *File) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/contribute.go:239:1)
 	assertNotNil("dir", dir)
 	assertNotNil("document", document)
 	q := r.query.Select("withDirectory")
@@ -959,8 +973,11 @@ func (r *Z5LabsApp) WithDirectory(path string, dir *Directory, document *File) *
 // contributed to every variant. That is why there is no WithExecutable beside
 // this — a raw file carries no platform, so a helper landing one in the
 // executable directory would silently admit a binary built for the wrong
-// architecture. Platform-specific executables arrive as an App instead.
-func (r *Z5LabsApp) WithFile(path string, file *File, document *File) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/contribute.go:154:1)
+// architecture — and it is why a path at, under or over the plugin directory is
+// refused here rather than merely being useless. Platform-specific executables
+// arrive as an App instead: App.WithApp composes one, matched platform by
+// platform, and lands its entry in the plugin directory.
+func (r *Z5LabsApp) WithFile(path string, file *File, document *File) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/contribute.go:188:1)
 	assertNotNil("file", file)
 	assertNotNil("document", document)
 	q := r.query.Select("withFile")

--- a/daggerverse/z5labs/tests/main.go
+++ b/daggerverse/z5labs/tests/main.go
@@ -186,6 +186,7 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("AppDocumentHelpersDescribeContentWithNoEcosystem", t.AppDocumentHelpersDescribeContentWithNoEcosystem)
 	jobs = jobs.WithJob("AppContributionsLandInEveryVariant", t.AppContributionsLandInEveryVariant)
 	jobs = jobs.WithJob("AppRefusesContributionsThatCollide", t.AppRefusesContributionsThatCollide)
+	jobs = jobs.WithJob("AppRefusesContributionsToThePluginDirectory", t.AppRefusesContributionsToThePluginDirectory)
 	jobs = jobs.WithJob("AppCustomizedImageStaysAttested", t.AppCustomizedImageStaysAttested)
 	jobs = jobs.WithJob("AppCustomizedImageStillNeedsProvenance", t.AppCustomizedImageStillNeedsProvenance)
 	jobs = jobs.WithJob("AppAttestsTwoSegmentRepositories", t.AppAttestsTwoSegmentRepositories)

--- a/daggerverse/z5labs/tests/main.go
+++ b/daggerverse/z5labs/tests/main.go
@@ -186,7 +186,7 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("AppDocumentHelpersDescribeContentWithNoEcosystem", t.AppDocumentHelpersDescribeContentWithNoEcosystem)
 	jobs = jobs.WithJob("AppContributionsLandInEveryVariant", t.AppContributionsLandInEveryVariant)
 	jobs = jobs.WithJob("AppRefusesContributionsThatCollide", t.AppRefusesContributionsThatCollide)
-	jobs = jobs.WithJob("AppRefusesContributionsToThePluginDirectory", t.AppRefusesContributionsToThePluginDirectory)
+	jobs = jobs.WithJob("AppRefusesContributionsOntoThePath", t.AppRefusesContributionsOntoThePath)
 	jobs = jobs.WithJob("AppCustomizedImageStaysAttested", t.AppCustomizedImageStaysAttested)
 	jobs = jobs.WithJob("AppCustomizedImageStillNeedsProvenance", t.AppCustomizedImageStillNeedsProvenance)
 	jobs = jobs.WithJob("AppAttestsTwoSegmentRepositories", t.AppAttestsTwoSegmentRepositories)


### PR DESCRIPTION
Closes #427

The image contract has always said `/usr/local/bin` is where an extension's
executables land, and the two halves of the module disagreed about what that
meant. `WithFile` lands content `0444`, so a binary contributed there was not
executable and the advertised way in did not work. `WithDirectory` lands a tree
`0555` throughout, so wrapping the same binary in a directory *did* work — which
is the rule `WithFile` enforced by omission, bypassed by the shape of the call.

## The decisions

**A platform-specific executable reaches the plugin directory through
`App.WithApp`, and through nothing else.** Composition (#397, landed in #423) is
the candidate the issue names and it is the answer: it names the architecture of
every byte it brings, pairs the variant sets platform by platform, and execs the
entry in the derived image before anything is published. It is now stated where
the plugin directory is documented — `build.go`'s `appPluginDir` comment — rather
than left to be inferred.

**Contributing at, under or over the plugin directory is refused**, by both
helpers. That is the third of the three options the issue enumerates for
`WithDirectory`. The alternatives were rejected: accepting the tree's executables
out loud keeps a documented way to put an unstated architecture on the PATH, and
changing the tree's uniform mode both hits the chained-`WithFile` fold ceiling on
a large tree and leaves the rule depending on a mode bit — which is exactly the
dependency that failed here.

The refusal is on the **path**, not the mode, and it has three directions: the
directory itself, anything inside it, and anything that would contain it. The
containing direction is refused without reading the tree, exactly as
`overlappingPath` refuses a contribution that would contain something already in
the image: whether `/usr/local` carries a `bin/` today is a property of the
caller's tree rather than of the call, and a rule that has to look inside changes
its mind between builds.

**The `0555` residue on a contributed tree stays**, and is now said out loud
rather than justified by "nothing in the image can act on it": nothing
*discovers* it, because the only directory the PATH names is the one no
contribution can reach, so an executable contributed at `/opt/thing/run` is
reachable only by something that already knows that path — the caller arranging
their own image, not this module admitting an executable whose architecture
nobody stated.

## Acceptance criteria

- [x] **Decide** how a platform-specific executable reaches `/usr/local/bin` —
      `App.WithApp`, stated in `build.go`'s `appPluginDir` comment, in the package
      doc's image contract, and on both contribution helpers.
- [x] **Decide** what `WithDirectory` does about executables — contributing at,
      under or over the plugin directory is refused, so the bypass is closed by a
      rule about paths; the exec bit elsewhere is accepted and said out loud.
- [x] `appPluginDir`'s comment describes a path that actually works — it names
      the seam that fills the directory and the refusal that keeps everything
      else out.
- [x] A test covers the decided path —
      `Tests.AppRefusesContributionsToThePluginDirectory` asserts the four
      refusals through both helpers, that content *beside* the directory is still
      accepted, and that the same base takes a composed application's entry and
      runs it **by bare name**, which is what a base image's plugin discovery
      does. The rules themselves are seven new rows in
      `Z5labs.ContributionPathSelfTest`, which costs no build.

## One consequence worth reading

`AppRefusesToComposeOntoOccupiedPaths` contributed a file at a composed plugin's
path to assert the collision refusal names its holder. That contribution is now
refused *earlier*, by the plugin-directory rule — every composed entry lives in
that directory, so no contribution can reach it whether or not something is
already there. The test now asserts the refusal names the directory, and its
comment records why. It is a strengthening rather than a gap: the path is
protected by a rule that does not depend on a plugin having been composed there
first, and the holder-naming property is still asserted by the first half of that
test.

## Verified

- `dagger check` — green.
- `bash .github/scripts/verify-affected-modules.sh` — green, including the whole
  `daggerverse/z5labs/tests` suite. The first run of that suite OOM-killed the
  local engine (`OOMKilled=true`, container restarted) part way through; the
  re-run is green, and the one genuine failure it did surface before dying is the
  test change described above.


---

## Amended after review: the rule is the whole PATH, not the plugin directory alone

The `local` review found that the reasoning and the rule did not have the same
shape. `appPath` is the six-entry conventional value —
`/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin` — so a refusal
scoped to `/usr/local/bin` left a `0555` tree at `/usr/bin` discovered by bare
name and refused by nothing, while every comment around it claimed that nothing
contributed is ever found on the PATH.

The refused set is now derived from `appPath` by `pathDirs()`, so a directory
added to the PATH is protected by having been added rather than by somebody
remembering a second list. `pathDirCollision` walks it with the plugin directory
first, so a candidate colliding with more than one — `/usr/local` contains both
it and `/usr/local/sbin` — is told about the one that points at `withApp`.
Executables contributed *off* the PATH are still accepted, and that is stated
rather than implied.

Three other review findings, all fixed:

- The compose test asserted a substring both refusals contain, so it did not
  say which rule fired. It now asserts the distinguishing half.
- That test's collision branch — a contribution landing on content a
  composition brought — lost its coverage to the PATH rule taking the case away
  from it. It has coverage of its own again, through a composed application's
  contributed tree at `/srv/payload`, which is off the PATH.
- The self-test table gained the tree-*under*-the-directory cell and now drives
  `withDirectory` on the tree-shaped rows, asserting each refusal opens with the
  method that produced it.

One finding was answered rather than fixed: `/` never reaches `pathDirCollision`,
because the root is refused four lines earlier and two existing table rows pin
that. The code comment now says so.

`Tests.AppRefusesContributionsToThePluginDirectory` is renamed
`Tests.AppRefusesContributionsOntoThePath`.
