### PR TITLE
story(z5labs): decide what a symlink in a contributed tree is allowed to do

### DIFF
--- a/daggerverse/z5labs/contribute.go
+++ b/daggerverse/z5labs/contribute.go
@@ -112,20 +112,31 @@ import (
 // tree without it. That last one made the claim in digest.go false, in the
 // exact mechanism devex#410 added to make an asserted document checkable.
 //
-// Three things were measured against Dagger v0.21.8 before choosing, because
+// Four things were measured against Dagger v0.21.8 before choosing, because
 // the answer depends on them (devex#428):
 //
 //   - Directory.Export preserves a link as a link, relative and absolute
 //     alike. So the export the digest is computed over really does carry the
 //     link, and the walk really does skip it.
-//   - The copy into a container preserves it too, and Directory.withDirectory's
-//     permissions do not apply to it. So the image really does end up holding a
-//     link nothing described.
+//   - The copy into a container preserves it too, unchanged. So the image
+//     really does end up holding a link nothing described. Its mode is not the
+//     module's to set and never was: a symlink's permission bits are 0777 on
+//     Linux and cannot be changed, which is the sense in which the
+//     normalization above does not reach it.
 //   - An absolute link exported to this module's filesystem points into *this
 //     module's* filesystem. /etc/passwd in a contributed tree is one path
 //     during the export and a different file in the image, which is why
 //     "allowed when it resolves inside the contributed tree" is not a rule that
 //     can be checked where the module can check anything.
+//   - WithFile needs no rule of its own, which is the one measurement that
+//     closed a seam rather than opening one. Directory.File on a link resolves
+//     it: what comes back is the target's bytes as an ordinary file, so the
+//     digest and the image get the same content and there is nothing for a link
+//     to hide behind. A *dagger.File is bytes, and a link is not bytes.
+//
+// Composition needs no rule of its own either. App.WithApp carries the inner
+// application's contributions into the outer image as contributions, tree
+// handle and all, so the outer publish walks them again — see compose.go.
 //
 // The alternatives were to follow links, to keep skipping them, or to admit
 // them and describe them. Following one puts a digest for bytes that are not in

--- a/daggerverse/z5labs/contribute.go
+++ b/daggerverse/z5labs/contribute.go
@@ -92,6 +92,58 @@ import (
 // — the caller's own arrangement inside their own image, and not a contract
 // this module advertises.
 //
+// # A symbolic link is not content
+//
+// A contributed tree may not carry one, nor a device, a pipe or a socket. The
+// refusal is walkTree's, so it applies to the tree the module actually copies
+// rather than to a claim about the tree a caller passed: Z5labs.DirectoryDocument
+// refuses to describe such a tree, and a publish refuses it again when it
+// recomputes the digest, which is the path a caller who brought their own
+// document takes.
+//
+// Every other rule in this file works on path strings, and a link is the one
+// kind of content that walks past all of them. The mode above is set on the
+// copied tree, and a mode on a link is not a mode on what it resolves to.
+// overlappingPath refuses a contribution that collides with the entrypoint or
+// with something already contributed by comparing cleaned paths, and a link
+// names a path that comparison never sees. And the digest, which is the control
+// digest.go exists to provide, is taken over a list of regular files — so a
+// link contributed nothing to it, and a tree with one hashed the same as the
+// tree without it. That last one made the claim in digest.go false, in the
+// exact mechanism devex#410 added to make an asserted document checkable.
+//
+// Three things were measured against Dagger v0.21.8 before choosing, because
+// the answer depends on them (devex#428):
+//
+//   - Directory.Export preserves a link as a link, relative and absolute
+//     alike. So the export the digest is computed over really does carry the
+//     link, and the walk really does skip it.
+//   - The copy into a container preserves it too, and Directory.withDirectory's
+//     permissions do not apply to it. So the image really does end up holding a
+//     link nothing described.
+//   - An absolute link exported to this module's filesystem points into *this
+//     module's* filesystem. /etc/passwd in a contributed tree is one path
+//     during the export and a different file in the image, which is why
+//     "allowed when it resolves inside the contributed tree" is not a rule that
+//     can be checked where the module can check anything.
+//
+// The alternatives were to follow links, to keep skipping them, or to admit
+// them and describe them. Following one puts a digest for bytes that are not in
+// the image into the document, and the third measurement above says which
+// filesystem's bytes those would be. Skipping is the status quo and is the hole
+// itself. Describing them means inventing a checksum for a thing that has none
+// and teaching every consumer of these documents what it meant, for content a
+// scratch image has almost no use for. Silently dropping them from the copy was
+// rejected for the reason every other silent repair here is: an image missing
+// something the caller put in it, with a document that agrees, is the
+// undetectable incompleteness this whole file is written against.
+//
+// So the caller contributes what the link pointed at, at the path it should
+// have in the image, and everything downstream describes bytes that are really
+// there. If a real need for links inside an image ever arrives — a base layer
+// makes that likelier — it arrives as a seam that names them, not as content
+// that slipped past the seams.
+//
 // # The directories on the way are the image's, not the contribution's
 //
 // Contributing at /etc/ssl/certs/ca-certificates.crt on a scratch image brings
@@ -162,6 +214,11 @@ const (
 // than being written at the root: the root of a Directory is not something the
 // copy sets a mode on, so the contributed tree's own directory would keep 0755
 // while everything inside it changed.
+//
+// What the normalization does not reach is a symbolic link — a mode on a link
+// is not a mode on what it resolves to, and the copy carries the link through
+// unchanged. That is one of the three reasons a tree carrying one is refused
+// outright rather than normalized; see the file comment above.
 func normalizedTree(dir *dagger.Directory) *dagger.Directory {
 	const at = "content"
 	return dag.Directory().
@@ -237,6 +294,14 @@ func (a *App) WithFile(
 // directory used to be exactly that bypass — see the file comment above and
 // App.WithApp, which is the seam that names the platform of every byte it
 // brings.
+//
+// The tree may hold directories and regular files and nothing else. A
+// symbolic link in it is refused — when the document is produced, and again at
+// publish time for a caller who brought one of their own — because a link is
+// the one kind of content none of the rules here can see: it is not given the
+// mode, the path it names is not compared against anything, and it is in no
+// document and no digest. The file comment above carries the decision and what
+// was measured to reach it; contribute what the link pointed at instead.
 //
 // document is an SPDX 2.3 JSON document describing the tree, and it is
 // required for the reason WithFile's is. Z5labs.DirectoryDocument produces one

--- a/daggerverse/z5labs/dagger.gen.go
+++ b/daggerverse/z5labs/dagger.gen.go
@@ -746,6 +746,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Z5labs).ComposeSelfTest(&parent, ctx)
+		case "ContributedTreeSelfTest":
+			var parent Z5labs
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Z5labs).ContributedTreeSelfTest(&parent, ctx)
 		case "ContributionPathSelfTest":
 			var parent Z5labs
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/z5labs/digest.go
+++ b/daggerverse/z5labs/digest.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -62,6 +63,14 @@ import (
 // produced somewhere else with some other notion of a tree checksum will be
 // refused, and the refusal says what was expected — which is the right outcome
 // for a value nothing else could interpret.
+//
+// "Two directories that differ anywhere differ in it" is a claim about a list
+// of files and their digests, and it was false for exactly one kind of
+// difference: a symbolic link is in no file list, so a tree with one and the
+// same tree without it hashed identically. It is true now because such a tree
+// is refused rather than hashed — walkTree returns an unsupportedEntry and
+// this function passes it on, so the publish stops here. contribute.go carries
+// why refusing is the answer and what was measured to choose it.
 
 // verifyContributionDigest refuses a contribution whose document is about
 // bytes other than the ones entering the image.
@@ -177,6 +186,16 @@ func contentDigest(ctx context.Context, c contribution) (string, error) {
 		}
 		files, err := walkTree(path)
 		if err != nil {
+			// A tree the module refuses to describe is returned unwrapped:
+			// the message already names the entry and why it cannot be
+			// contributed, and "hash the contributed tree:" in front of it
+			// would read as a failure of the hashing rather than as a
+			// refusal of the content. resolveContributions keeps it apart
+			// from a document's failings for the same reason.
+			var bad *unsupportedEntry
+			if errors.As(err, &bad) {
+				return "", err
+			}
 			return "", fmt.Errorf("hash the contributed tree: %v", err)
 		}
 		if len(files) == 0 {

--- a/daggerverse/z5labs/document.go
+++ b/daggerverse/z5labs/document.go
@@ -6,12 +6,14 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -163,6 +165,13 @@ func (m *Z5labs) FileDocument(
 // paths and their digests, so two directories with the same name and version
 // and different contents are different packages rather than one.
 //
+// A tree carrying a symbolic link is **refused**, and so is one carrying a
+// device, a pipe or a socket. A link is not bytes and cannot be enumerated,
+// digested or given the mode the module sets, so a document that skipped it
+// would describe a tree the image does not have — see the "A symbolic link is
+// not content" section in contribute.go. The refusal names the link and what
+// it points at, so it can be found and replaced with the thing itself.
+//
 // name is required, because a directory has no name of its own to fall back
 // to. See FileDocument for license and version.
 //
@@ -203,6 +212,13 @@ func (m *Z5labs) DirectoryDocument(
 	}
 	files, err := walkTree(root)
 	if err != nil {
+		// A refused entry is not a failure to read the tree, and sending it
+		// to the reader as one would put "read /srv/templates:" in front of a
+		// sentence that already says exactly what is wrong and where.
+		var bad *unsupportedEntry
+		if errors.As(err, &bad) {
+			return nil, fmt.Errorf("%s cannot be described: %v", name, err)
+		}
 		return nil, fmt.Errorf("read %s: %v", name, err)
 	}
 	if len(files) == 0 {
@@ -325,17 +341,29 @@ func validateLicenseExpression(license string) error {
 // relative to root and sorted, so the document is a pure function of the
 // tree.
 //
-// Symlinks and devices are skipped rather than followed or described: a
-// document that hashed a symlink's target would describe bytes that are not
-// in the image, and one that hashed the link would report a digest nothing
-// can verify against a pulled layer.
+// Anything that is neither a directory nor a regular file is **refused**, and
+// a symbolic link is the case that matters. It used to be skipped, which made
+// this walk describe a tree the image did not have: a link contributed nothing
+// to the file list, so it was in no document, and — because treeDigest is a
+// digest of that list — two trees differing only in their links had the same
+// digest. See the "A symbolic link is not content" section in contribute.go
+// for the decision and the measurements behind it.
+//
+// The refusal lives here because this is the one place the module reads a
+// contributed tree, and both readers need it: Z5labs.DirectoryDocument, so an
+// adopter on the paved path is refused at the call that produced the document,
+// and contentDigest at publish time, so a caller who brought a document of
+// their own is refused before the first byte is pushed.
 func walkTree(root string) ([]bomFile, error) {
 	var out []bomFile
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if d.IsDir() || !d.Type().IsRegular() {
+		if !d.IsDir() && !d.Type().IsRegular() {
+			return unsupportedEntryAt(root, path, d)
+		}
+		if d.IsDir() {
 			return nil
 		}
 		rel, err := filepath.Rel(root, path)
@@ -354,6 +382,67 @@ func walkTree(root string) ([]bomFile, error) {
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
 	return out, nil
+}
+
+// unsupportedEntry is a tree entry that is neither a directory nor a regular
+// file, and so cannot be contributed to an image.
+//
+// It is a type rather than a string because its two readers word the refusal
+// differently — DirectoryDocument is answering "why can I not have a
+// document?" and a publish is answering "why was my image refused?" — and
+// because a message this specific must not be mistaken for the I/O errors the
+// same walk can return.
+type unsupportedEntry struct {
+	// Path is relative to the tree's root, which is what a caller recognises;
+	// the absolute one names a temporary directory inside this module.
+	Path string
+	// What the entry is, as a noun phrase read after the path.
+	Kind string
+	// Target is where a symbolic link points, verbatim. It is carried because
+	// it is the whole content of the refusal for the case that matters: a
+	// caller who did not know their tree held a link needs to be told what it
+	// pointed at to find it.
+	Target string
+}
+
+func (e *unsupportedEntry) Error() string {
+	what := e.Path + " is " + e.Kind
+	if e.Target != "" {
+		what += " to " + strconv.Quote(e.Target)
+	}
+	return what + ", and that is not content this module can contribute: " +
+		"it is copied into the image as it stands, the mode this module sets does not reach through it, the rules " +
+		"that refuse a contribution landing on top of something never see the path it names, and it is in no " +
+		"document and no digest — so a tree carrying one is indistinguishable from the same tree without it. " +
+		"Contribute what it points at instead, at the path it should have in the image"
+}
+
+// unsupportedEntryAt describes the entry the walk refused.
+//
+// The link target is read with os.Readlink rather than resolved: what the
+// refusal has to name is what the caller wrote, and resolving it here would
+// resolve it against this module's own filesystem — which the measurement in
+// contribute.go shows is not the filesystem the link will land in.
+func unsupportedEntryAt(root, path string, d fs.DirEntry) error {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		rel = path
+	}
+	bad := &unsupportedEntry{Path: filepath.ToSlash(rel), Kind: "an entry of a kind an image cannot carry"}
+	switch {
+	case d.Type()&fs.ModeSymlink != 0:
+		bad.Kind = "a symbolic link"
+		if target, err := os.Readlink(path); err == nil {
+			bad.Target = target
+		}
+	case d.Type()&fs.ModeDevice != 0:
+		bad.Kind = "a device node"
+	case d.Type()&fs.ModeNamedPipe != 0:
+		bad.Kind = "a named pipe"
+	case d.Type()&fs.ModeSocket != 0:
+		bad.Kind = "a socket"
+	}
+	return bad
 }
 
 // fileDigests returns a file's SHA-256 and SHA-1, streamed rather than read

--- a/daggerverse/z5labs/document.go
+++ b/daggerverse/z5labs/document.go
@@ -354,31 +354,50 @@ func validateLicenseExpression(license string) error {
 // adopter on the paved path is refused at the call that produced the document,
 // and contentDigest at publish time, so a caller who brought a document of
 // their own is refused before the first byte is pushed.
+// The walk finishes rather than stopping at the first refused entry, and the
+// refusal names all of them. A tree carrying one link is a mistake to fix; a
+// tree carrying forty is a versioned documentation site, and its author needs
+// to learn that this rule is not for them in one round trip rather than in
+// forty — each of which costs a full export here, and a build as well on the
+// publish path.
 func walkTree(root string) ([]bomFile, error) {
 	var out []bomFile
+	var bad *unsupportedEntry
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
-		}
-		if !d.IsDir() && !d.Type().IsRegular() {
-			return unsupportedEntryAt(root, path, d)
-		}
-		if d.IsDir() {
-			return nil
 		}
 		rel, err := filepath.Rel(root, path)
 		if err != nil {
 			return err
 		}
+		rel = filepath.ToSlash(rel)
+		if !d.IsDir() && !d.Type().IsRegular() {
+			if bad == nil {
+				bad = unsupportedEntryAt(rel, path, d)
+			} else {
+				bad.note(rel)
+			}
+			return nil
+		}
+		// Once the tree is refused there is nothing left to describe, so the
+		// files that follow are not hashed. The walk continues only to finish
+		// naming what has to be fixed.
+		if d.IsDir() || bad != nil {
+			return nil
+		}
 		sum256, sum1, err := fileDigests(path)
 		if err != nil {
 			return err
 		}
-		out = append(out, bomFile{Path: filepath.ToSlash(rel), Sha1: sum1, Sha256: sum256})
+		out = append(out, bomFile{Path: rel, Sha1: sum1, Sha256: sum256})
 		return nil
 	})
 	if err != nil {
 		return nil, err
+	}
+	if bad != nil {
+		return nil, bad
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
 	return out, nil
@@ -401,40 +420,74 @@ type unsupportedEntry struct {
 	// Target is where a symbolic link points, verbatim. It is carried because
 	// it is the whole content of the refusal for the case that matters: a
 	// caller who did not know their tree held a link needs to be told what it
-	// pointed at to find it.
-	Target string
+	// pointed at to find it. TargetErr is why it could not be read, when it
+	// could not: the doc comment on DirectoryDocument promises the refusal
+	// names what the link points at, so the one case where it cannot has to
+	// say so rather than read as a link that pointed nowhere.
+	Target    string
+	TargetErr string
+	// More names the other entries in the same tree the walk refused, and
+	// Rest counts the ones past the point where naming them stopped being
+	// useful.
+	More []string
+	Rest int
 }
+
+// unsupportedEntriesNamed is how many offending entries the refusal lists
+// before it starts counting instead. It is a message read in a terminal, and
+// enough of the list to recognise what kind of tree this is beats all of it.
+const unsupportedEntriesNamed = 8
 
 func (e *unsupportedEntry) Error() string {
 	what := e.Path + " is " + e.Kind
-	if e.Target != "" {
+	switch {
+	case e.Target != "":
 		what += " to " + strconv.Quote(e.Target)
+	case e.TargetErr != "":
+		what += " whose target could not be read (" + e.TargetErr + ")"
 	}
-	return what + ", and that is not content this module can contribute: " +
+	msg := what + ", and that is not content this module can contribute: " +
 		"it is copied into the image as it stands, the mode this module sets does not reach through it, the rules " +
 		"that refuse a contribution landing on top of something never see the path it names, and it is in no " +
 		"document and no digest — so a tree carrying one is indistinguishable from the same tree without it. " +
 		"Contribute what it points at instead, at the path it should have in the image"
+	if len(e.More) == 0 {
+		return msg
+	}
+	rest := strings.Join(e.More, ", ")
+	if e.Rest > 0 {
+		rest += fmt.Sprintf(" and %d more", e.Rest)
+	}
+	return msg + ". The same is true of " + rest + " in the same tree"
 }
 
-// unsupportedEntryAt describes the entry the walk refused.
+// note records another refused entry beside the one the message leads with.
+func (e *unsupportedEntry) note(rel string) {
+	if len(e.More) < unsupportedEntriesNamed {
+		e.More = append(e.More, rel)
+		return
+	}
+	e.Rest++
+}
+
+// unsupportedEntryAt describes the entry the walk refused. rel is its path
+// relative to the tree's root and path is where it is on disk.
 //
 // The link target is read with os.Readlink rather than resolved: what the
 // refusal has to name is what the caller wrote, and resolving it here would
 // resolve it against this module's own filesystem — which the measurement in
 // contribute.go shows is not the filesystem the link will land in.
-func unsupportedEntryAt(root, path string, d fs.DirEntry) error {
-	rel, err := filepath.Rel(root, path)
-	if err != nil {
-		rel = path
-	}
-	bad := &unsupportedEntry{Path: filepath.ToSlash(rel), Kind: "an entry of a kind an image cannot carry"}
+func unsupportedEntryAt(rel, path string, d fs.DirEntry) *unsupportedEntry {
+	bad := &unsupportedEntry{Path: rel, Kind: "an entry of a kind an image cannot carry"}
 	switch {
 	case d.Type()&fs.ModeSymlink != 0:
 		bad.Kind = "a symbolic link"
-		if target, err := os.Readlink(path); err == nil {
-			bad.Target = target
+		target, err := os.Readlink(path)
+		if err != nil {
+			bad.TargetErr = err.Error()
+			break
 		}
+		bad.Target = target
 	case d.Type()&fs.ModeDevice != 0:
 		bad.Kind = "a device node"
 	case d.Type()&fs.ModeNamedPipe != 0:

--- a/daggerverse/z5labs/documentselftest.go
+++ b/daggerverse/z5labs/documentselftest.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 )
 
 // ContributedTreeSelfTest checks what a contributed tree may hold: directories
@@ -112,6 +114,60 @@ func (m *Z5labs) ContributedTreeSelfTest(ctx context.Context) error {
 				return os.Symlink("v1.0.0", filepath.Join(dir, "current"))
 			},
 			refusal: []string{"current is a symbolic link to \"v1.0.0\""},
+		},
+		{
+			// The walk finishes and the refusal names every offending entry,
+			// so a tree that is full of links says so once rather than one
+			// link per export.
+			name: "several links in one tree",
+			build: func(dir string) error {
+				if err := writeTreeFiles(dir, "v1/index.html", "v2/index.html"); err != nil {
+					return err
+				}
+				for _, link := range []struct{ target, name string }{
+					{"v2", "current"},
+					{"v1/index.html", "old.html"},
+					{"v2/index.html", "new.html"},
+				} {
+					if err := os.Symlink(link.target, filepath.Join(dir, link.name)); err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+			refusal: []string{
+				`current is a symbolic link to "v2"`,
+				"The same is true of new.html, old.html in the same tree",
+			},
+		},
+		{
+			// The kinds below are the rest of what an image cannot carry. They
+			// are here because DirectoryDocument's doc comment promises them by
+			// name, and because a mislabelled entry — the wrong arm of the mode
+			// switch — is invisible until somebody hits one.
+			name: "a named pipe",
+			build: func(dir string) error {
+				return syscall.Mkfifo(filepath.Join(dir, "events"), 0o644)
+			},
+			refusal: []string{"events is a named pipe", "not content this module can contribute"},
+		},
+		{
+			name: "a socket",
+			build: func(dir string) error {
+				addr, err := net.ResolveUnixAddr("unix", filepath.Join(dir, "control.sock"))
+				if err != nil {
+					return err
+				}
+				l, err := net.ListenUnix("unix", addr)
+				if err != nil {
+					return err
+				}
+				// The socket has to outlive the listener, because what is
+				// under test is a tree that holds one.
+				l.SetUnlinkOnClose(false)
+				return l.Close()
+			},
+			refusal: []string{"control.sock is a socket"},
 		},
 	}
 

--- a/daggerverse/z5labs/documentselftest.go
+++ b/daggerverse/z5labs/documentselftest.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ContributedTreeSelfTest checks what a contributed tree may hold: directories
+// and regular files, and nothing else.
+//
+// It sits on the module for the reason ContributionPathSelfTest does — walkTree
+// is an unexported function over a real filesystem, and every row below would
+// otherwise cost a Dagger call to build a tree that differs from its neighbour
+// by one entry. What cannot be checked in process is that the rule is wired
+// into both readers of a contributed tree, that Dagger's own export and copy
+// preserve a link at all, and that a publish carrying one is refused before
+// anything is pushed; those are in tests/.
+//
+// The rule is a refusal rather than a skip because a skipped link is in no
+// document and no digest while still being in the image — see the "A symbolic
+// link is not content" section in contribute.go, which carries the decision and
+// the measurements behind it.
+//
+// It runs in process and needs no container, so it is cheap enough to be a
+// check of its own.
+//
+// +check
+// +cache="session"
+func (m *Z5labs) ContributedTreeSelfTest(ctx context.Context) error {
+	root, err := os.MkdirTemp("", "z5labs-treeselftest-*")
+	if err != nil {
+		return fmt.Errorf("create work dir: %v", err)
+	}
+	defer os.RemoveAll(root)
+
+	cases := []struct {
+		name string
+		// build populates a tree of its own under root.
+		build func(dir string) error
+		// want is the file list walkTree must return, and nil when the tree
+		// has to be refused instead.
+		want []string
+		// refusal is every substring the refusal must carry. A link is
+		// refused so that a caller can go and find it, so naming the entry and
+		// what it pointed at is the whole value of the message.
+		refusal []string
+	}{
+		{
+			name: "a tree of regular files",
+			build: func(dir string) error {
+				return writeTreeFiles(dir, "index.html", "partials/nav.html")
+			},
+			want: []string{"index.html", "partials/nav.html"},
+		},
+		{
+			name: "a relative link beside the file it points at",
+			build: func(dir string) error {
+				if err := writeTreeFiles(dir, "real.txt"); err != nil {
+					return err
+				}
+				return os.Symlink("real.txt", filepath.Join(dir, "link.txt"))
+			},
+			refusal: []string{"link.txt is a symbolic link to \"real.txt\"", "not content this module can contribute"},
+		},
+		{
+			// The target is named verbatim rather than resolved. It resolves
+			// against this module's own filesystem here and against the image's
+			// at runtime, which is exactly why "a link that stays inside the
+			// contributed tree is fine" is not a rule anything here could check.
+			name: "an absolute link out of the tree",
+			build: func(dir string) error {
+				return os.Symlink("/etc/passwd", filepath.Join(dir, "passwd"))
+			},
+			refusal: []string{"passwd is a symbolic link to \"/etc/passwd\""},
+		},
+		{
+			// A dangling link is refused for the same reason a resolvable one
+			// is. Refusing only the ones that resolve would make the rule a
+			// property of what happened to be beside the link.
+			name: "a link pointing at nothing",
+			build: func(dir string) error {
+				return os.Symlink("gone.txt", filepath.Join(dir, "dangling.txt"))
+			},
+			refusal: []string{"dangling.txt is a symbolic link to \"gone.txt\""},
+		},
+		{
+			// The path in the refusal is relative to the tree's root: the
+			// absolute one names a temporary directory inside this module,
+			// which is not a path the caller has ever seen.
+			name: "a link inside a subdirectory",
+			build: func(dir string) error {
+				if err := writeTreeFiles(dir, "assets/logo.svg"); err != nil {
+					return err
+				}
+				return os.Symlink("logo.svg", filepath.Join(dir, "assets", "current.svg"))
+			},
+			refusal: []string{"assets/current.svg is a symbolic link"},
+		},
+		{
+			// A link to a directory is not descended into, so without the
+			// refusal the tree it points at would be in the image and in
+			// nothing else.
+			name: "a link to a directory",
+			build: func(dir string) error {
+				if err := writeTreeFiles(dir, "v1.0.0/index.html"); err != nil {
+					return err
+				}
+				return os.Symlink("v1.0.0", filepath.Join(dir, "current"))
+			},
+			refusal: []string{"current is a symbolic link to \"v1.0.0\""},
+		},
+	}
+
+	for i, c := range cases {
+		dir := filepath.Join(root, fmt.Sprintf("case-%d", i))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("%s: create the tree: %v", c.name, err)
+		}
+		if err := c.build(dir); err != nil {
+			return fmt.Errorf("%s: build the tree: %v", c.name, err)
+		}
+
+		files, err := walkTree(dir)
+		if len(c.refusal) == 0 {
+			if err != nil {
+				return fmt.Errorf("%s should be described, got: %v", c.name, err)
+			}
+			var got []string
+			for _, f := range files {
+				got = append(got, f.Path)
+			}
+			if strings.Join(got, ",") != strings.Join(c.want, ",") {
+				return fmt.Errorf("%s lists %v, want %v", c.name, got, c.want)
+			}
+			continue
+		}
+		if err == nil {
+			return fmt.Errorf("%s should be refused, got the file list %v", c.name, files)
+		}
+		// The type is checked as well as the wording, because it is what
+		// DirectoryDocument, contentDigest and resolveContributions each
+		// branch on to tell a refused entry apart from a tree they could not
+		// read. A refusal that arrived as a plain error would be reported as
+		// an I/O failure by all three.
+		var bad *unsupportedEntry
+		if !errors.As(err, &bad) {
+			return fmt.Errorf("%s should be refused as an unsupported entry, got %T: %v", c.name, err, err)
+		}
+		for _, want := range c.refusal {
+			if !strings.Contains(err.Error(), want) {
+				return fmt.Errorf("the refusal of %s should carry %q, got: %v", c.name, want, err)
+			}
+		}
+	}
+	return nil
+}
+
+// writeTreeFiles writes a file at each of paths, relative to dir, creating the
+// directories on the way.
+func writeTreeFiles(dir string, paths ...string) error {
+	for _, p := range paths {
+		full := filepath.Join(dir, filepath.FromSlash(p))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(full, []byte(p+"\n"), 0o644); err != nil { //nolint:gosec // fixture content in this module's own temp dir
+			return err
+		}
+	}
+	return nil
+}

--- a/daggerverse/z5labs/sbom.go
+++ b/daggerverse/z5labs/sbom.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -270,6 +271,16 @@ func (a *App) resolveContributions(ctx context.Context) ([]variantBom, error) {
 			// and why it lives at publish time rather than at the
 			// contributing call.
 			if err := verifyContributionDigest(ctx, seen, c, bom.Subject); err != nil {
+				// The check reads the content as well as the document, so it
+				// has two ways to fail and they are about different things.
+				// A refused entry is a fault in what was contributed — no
+				// document could have made that tree publishable — and
+				// announcing it as a fault of the document would send the
+				// reader to rewrite one that is fine.
+				var bad *unsupportedEntry
+				if errors.As(err, &bad) {
+					return nil, fmt.Errorf("%s in the %s image: %v", c.Name, v.Platform, err)
+				}
 				return nil, fmt.Errorf("the document describing %s in the %s image %v", c.Name, v.Platform, err)
 			}
 			parsed = append(parsed, *bom)

--- a/daggerverse/z5labs/tests/contribute.go
+++ b/daggerverse/z5labs/tests/contribute.go
@@ -659,12 +659,16 @@ func (t *Tests) AppCustomizedImageStillNeedsProvenance(ctx context.Context) erro
 // documented caveat, and they are asserted rather than described because both
 // are Dagger's behaviour rather than this module's:
 //
-//   - the copy into an image preserves the link, and the permissions the module
-//     normalizes a tree with do not touch it — so an admitted link really is in
-//     the published image, at whatever mode it arrived with;
+//   - the copy into an image preserves the link, unchanged and still a link
+//     through the normalization the module copies a tree with — so an admitted
+//     link really would be in the published image;
 //   - Directory.Export preserves it too, which is what the refusal firing at
 //     all establishes: the module walks an export, and a walk that saw a
-//     regular file there would have described the target's bytes instead.
+//     regular file there would have described the target's bytes instead. It is
+//     driven with an absolute link as well as a relative one, because the
+//     absolute case is what rules out the middle answer the issue offered — a
+//     link resolving inside the contributed tree — and it would be a silent
+//     hole if Dagger ever resolved or dropped those on export.
 //
 // Both readers of a contributed tree are driven. DirectoryDocument is the paved
 // path, where an adopter is refused at the call that would have produced the
@@ -690,15 +694,18 @@ func (t *Tests) AppRefusesTreesCarryingSymlinks(ctx context.Context) error {
 		WithDirectory("/srv", dag.Directory().
 			WithDirectory("content", linked, dagger.DirectoryWithDirectoryOpts{Permissions: 0o555}).
 			Directory("content"), dagger.ContainerWithDirectoryOpts{Owner: wantOwner}).
-		WithExec([]string{"sh", "-c", "stat -c '%F %a' /srv/current.html; readlink /srv/current.html"}).
+		WithExec([]string{"sh", "-c", "stat -c '%F' /srv/current.html; readlink /srv/current.html"}).
 		Stdout(ctx)
 	if err != nil {
 		return fmt.Errorf("read a copied tree's symlink: %v", err)
 	}
-	if got := strings.Fields(strings.TrimSpace(out)); len(got) != 4 || got[0] != "symbolic" || got[3] != "index.html" {
+	// The mode is deliberately not asserted: a symlink's own permission bits
+	// are 0777 on Linux and cannot be set, so neither Dagger nor this module
+	// could change them and an assertion here would pass whatever happened.
+	// What is worth guarding is that the copy does not turn the link into
+	// something else, which is what the two fields below say.
+	if got := strings.Fields(strings.TrimSpace(out)); len(got) != 3 || got[0] != "symbolic" || got[2] != "index.html" {
 		return fmt.Errorf("expected the copy to preserve the link, got %q", strings.TrimSpace(out))
-	} else if got[2] == wantDirectoryMode {
-		return fmt.Errorf("the copy applied the module's mode to a symlink (%q); the refusal's premise no longer holds", out)
 	}
 
 	// The paved path: the helper that would produce the document refuses to.
@@ -706,6 +713,19 @@ func (t *Tests) AppRefusesTreesCarryingSymlinks(ctx context.Context) error {
 		return fmt.Errorf("expected DirectoryDocument over a tree with a symlink to be refused, got nil")
 	} else if !strings.Contains(err.Error(), `current.html is a symbolic link to "index.html"`) {
 		return fmt.Errorf("expected the refusal to name the link and its target, got: %v", err)
+	}
+
+	// An absolute link, through a real export. This is the measurement the
+	// decision rests on: the target is a path in this module's filesystem
+	// during the export and a different file inside the image, so a rule that
+	// admitted a link "resolving inside the contributed tree" would be deciding
+	// on the wrong filesystem. Its own tree, so the refusal has to lead with it
+	// rather than with the relative link above.
+	absolute := dag.Directory().WithSymlink("/etc/passwd", "passwd")
+	if _, err := dag.Z5Labs().DirectoryDocument(absolute, treePath).Contents(ctx); err == nil {
+		return fmt.Errorf("expected a tree carrying an absolute symlink to be refused, got nil")
+	} else if !strings.Contains(err.Error(), `passwd is a symbolic link to "/etc/passwd"`) {
+		return fmt.Errorf("expected the export to preserve an absolute link and the refusal to name it, got: %v", err)
 	}
 
 	// The publish path, for a caller carrying a document of their own.
@@ -728,6 +748,16 @@ func (t *Tests) AppRefusesTreesCarryingSymlinks(ctx context.Context) error {
 		return fmt.Errorf("expected a publish carrying a tree with a symlink to be refused, got nil")
 	} else if !strings.Contains(err.Error(), `current.html is a symbolic link to "index.html"`) {
 		return fmt.Errorf("expected the publish to be refused for the link rather than for the document, got: %v", err)
+	} else if !strings.Contains(err.Error(), treePath+" in the "+string(platform)+" image:") ||
+		strings.Contains(err.Error(), "the document describing") {
+		// The wording is asserted, not only the substring above. A refused
+		// tree is a fault in what was contributed and reaches the reader as
+		// one; the publish's other failure — a document about other bytes —
+		// carries "the document describing", and a caller sent to rewrite a
+		// document that is fine would be looking in the wrong place. Both
+		// sentences would contain the link, so only the frame tells them
+		// apart.
+		return fmt.Errorf("expected the refusal to name the contribution rather than its document, got: %v", err)
 	}
 	code, err := curlProbeManifest(ctx, svc, registryAlias, "ci", pwdHex, repository, version)
 	if err != nil {

--- a/daggerverse/z5labs/tests/contribute.go
+++ b/daggerverse/z5labs/tests/contribute.go
@@ -640,3 +640,101 @@ func (t *Tests) AppCustomizedImageStillNeedsProvenance(ctx context.Context) erro
 	}
 	return nil
 }
+
+// AppRefusesTreesCarryingSymlinks asserts that a symbolic link in a
+// contributed tree is refused, and measures the two Dagger behaviours the
+// decision rests on.
+//
+// A link is the one kind of content the contribution rules do not see. They
+// work on path strings: the mode is set on the copied tree and a mode on a link
+// is not a mode on what it resolves to, the overlap rules compare cleaned paths
+// and a link names a path they never compare, and the digest that makes an
+// asserted document checkable is taken over a list of regular files, which a
+// link is not in. So before this, a tree with a link and the same tree without
+// one were one tree to every check the module makes, and the link was in the
+// image regardless. contribute.go carries the decision; this is the part that
+// cannot be checked in process.
+//
+// The measurements are the reason it has to be a refusal rather than a
+// documented caveat, and they are asserted rather than described because both
+// are Dagger's behaviour rather than this module's:
+//
+//   - the copy into an image preserves the link, and the permissions the module
+//     normalizes a tree with do not touch it — so an admitted link really is in
+//     the published image, at whatever mode it arrived with;
+//   - Directory.Export preserves it too, which is what the refusal firing at
+//     all establishes: the module walks an export, and a walk that saw a
+//     regular file there would have described the target's bytes instead.
+//
+// Both readers of a contributed tree are driven. DirectoryDocument is the paved
+// path, where an adopter is refused at the call that would have produced the
+// document. The publish is the path a caller who brought a document of their
+// own takes, and it is checked with a document that is valid and about another
+// tree entirely: the tree is refused as content, before anything is compared,
+// so no document could have made it publishable.
+func (t *Tests) AppRefusesTreesCarryingSymlinks(ctx context.Context) error {
+	const (
+		version    = "v12.0.0"
+		name       = "hello"
+		repository = "z5labs/symlinked"
+		treePath   = "/srv/templates"
+	)
+	linked := dag.Directory().
+		WithNewFile("index.html", "<!doctype html>\n").
+		WithSymlink("index.html", "current.html")
+
+	// What an admitted link would leave in the image, read through the same
+	// normalization WithDirectory copies a tree with. A published image has no
+	// shell, so the tree is read where it is still a Directory.
+	out, err := dag.Container().From(alpineImage).
+		WithDirectory("/srv", dag.Directory().
+			WithDirectory("content", linked, dagger.DirectoryWithDirectoryOpts{Permissions: 0o555}).
+			Directory("content"), dagger.ContainerWithDirectoryOpts{Owner: wantOwner}).
+		WithExec([]string{"sh", "-c", "stat -c '%F %a' /srv/current.html; readlink /srv/current.html"}).
+		Stdout(ctx)
+	if err != nil {
+		return fmt.Errorf("read a copied tree's symlink: %v", err)
+	}
+	if got := strings.Fields(strings.TrimSpace(out)); len(got) != 4 || got[0] != "symbolic" || got[3] != "index.html" {
+		return fmt.Errorf("expected the copy to preserve the link, got %q", strings.TrimSpace(out))
+	} else if got[2] == wantDirectoryMode {
+		return fmt.Errorf("the copy applied the module's mode to a symlink (%q); the refusal's premise no longer holds", out)
+	}
+
+	// The paved path: the helper that would produce the document refuses to.
+	if _, err := dag.Z5Labs().DirectoryDocument(linked, treePath).Contents(ctx); err == nil {
+		return fmt.Errorf("expected DirectoryDocument over a tree with a symlink to be refused, got nil")
+	} else if !strings.Contains(err.Error(), `current.html is a symbolic link to "index.html"`) {
+		return fmt.Errorf("expected the refusal to name the link and its target, got: %v", err)
+	}
+
+	// The publish path, for a caller carrying a document of their own.
+	svc, pwdHex, secret, err := localRegistry(ctx)
+	if err != nil {
+		return err
+	}
+	prov, err := newProvenanceHarness(ctx, "")
+	if err != nil {
+		return err
+	}
+	platform := hostPlatform()
+	entry := prebuiltEntry(helloDir(), name, platform)
+	elsewhere := dag.Directory().WithNewFile("index.html", "<!doctype html>\n")
+	app := dag.Z5Labs().App(version).
+		WithVariant(platform, entry, dag.Z5Labs().FileDocument(entry, dagger.Z5LabsFileDocumentOpts{Name: name})).
+		Build().
+		WithDirectory(treePath, linked, dag.Z5Labs().DirectoryDocument(elsewhere, treePath))
+	if _, err := publishable(app, svc, secret, prov).Publish(ctx, []string{repository}); err == nil {
+		return fmt.Errorf("expected a publish carrying a tree with a symlink to be refused, got nil")
+	} else if !strings.Contains(err.Error(), `current.html is a symbolic link to "index.html"`) {
+		return fmt.Errorf("expected the publish to be refused for the link rather than for the document, got: %v", err)
+	}
+	code, err := curlProbeManifest(ctx, svc, registryAlias, "ci", pwdHex, repository, version)
+	if err != nil {
+		return fmt.Errorf("probe the registry after the refusal: %v", err)
+	}
+	if code == 200 {
+		return fmt.Errorf("the publish was refused but manifest %s:%s is present in the registry", repository, version)
+	}
+	return nil
+}

--- a/daggerverse/z5labs/tests/dagger.gen.go
+++ b/daggerverse/z5labs/tests/dagger.gen.go
@@ -465,6 +465,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).AppRefusesToPublishWithoutProvenanceMachinery(&parent, ctx)
+		case "AppRefusesTreesCarryingSymlinks":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).AppRefusesTreesCarryingSymlinks(&parent, ctx)
 		case "AppRejectsSourceWithoutGitMetadata":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
+++ b/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
@@ -157,6 +157,7 @@ type Z5Labs struct { // z5labs (../../../../../daggerverse/z5labs/main.go:557:6)
 	query *querybuilder.Selection
 
 	composeSelfTest          *Void
+	contributedTreeSelfTest  *Void
 	contributionPathSelfTest *Void
 	id                       *ID
 	imageConfigSelfTest      *Void
@@ -246,6 +247,33 @@ func (r *Z5Labs) ComposeSelfTest(ctx context.Context) error { // z5labs (../../.
 	return q.Execute(ctx)
 }
 
+// ContributedTreeSelfTest checks what a contributed tree may hold: directories
+// and regular files, and nothing else.
+//
+// It sits on the module for the reason ContributionPathSelfTest does — walkTree
+// is an unexported function over a real filesystem, and every row below would
+// otherwise cost a Dagger call to build a tree that differs from its neighbour
+// by one entry. What cannot be checked in process is that the rule is wired
+// into both readers of a contributed tree, that Dagger's own export and copy
+// preserve a link at all, and that a publish carrying one is refused before
+// anything is pushed; those are in tests/.
+//
+// The rule is a refusal rather than a skip because a skipped link is in no
+// document and no digest while still being in the image — see the "A symbolic
+// link is not content" section in contribute.go, which carries the decision and
+// the measurements behind it.
+//
+// It runs in process and needs no container, so it is cheap enough to be a
+// check of its own.
+func (r *Z5Labs) ContributedTreeSelfTest(ctx context.Context) error { // z5labs (../../../../../daggerverse/z5labs/documentselftest.go:33:1)
+	if r.contributedTreeSelfTest != nil {
+		return nil
+	}
+	q := r.query.Select("contributedTreeSelfTest")
+
+	return q.Execute(ctx)
+}
+
 // ContributionPathSelfTest checks the rules that decide where a caller may
 // contribute content, and where they may not.
 //
@@ -288,11 +316,11 @@ type Z5LabsDirectoryDocumentOpts struct {
 	//
 	// An SPDX licence expression for the content, e.g. MIT or Apache-2.0.
 	//
-	License string // z5labs (../../../../../daggerverse/z5labs/document.go:179:2)
+	License string // z5labs (../../../../../daggerverse/z5labs/document.go:188:2)
 	//
 	// The version of the contributed content, if it has one.
 	//
-	Version string // z5labs (../../../../../daggerverse/z5labs/document.go:183:2)
+	Version string // z5labs (../../../../../daggerverse/z5labs/document.go:192:2)
 }
 
 // DirectoryDocument produces the SPDX document required to contribute dir to
@@ -309,9 +337,16 @@ type Z5LabsDirectoryDocumentOpts struct {
 // paths and their digests, so two directories with the same name and version
 // and different contents are different packages rather than one.
 //
+// A tree carrying a symbolic link is **refused**, and so is one carrying a
+// device, a pipe or a socket. A link is not bytes and cannot be enumerated,
+// digested or given the mode the module sets, so a document that skipped it
+// would describe a tree the image does not have — see the "A symbolic link is
+// not content" section in contribute.go. The refusal names the link and what
+// it points at, so it can be found and replaced with the thing itself.
+//
 // name is required, because a directory has no name of its own to fall back
 // to. See FileDocument for license and version.
-func (r *Z5Labs) DirectoryDocument(dir *Directory, name string, opts ...Z5LabsDirectoryDocumentOpts) *File { // z5labs (../../../../../daggerverse/z5labs/document.go:170:1)
+func (r *Z5Labs) DirectoryDocument(dir *Directory, name string, opts ...Z5LabsDirectoryDocumentOpts) *File { // z5labs (../../../../../daggerverse/z5labs/document.go:179:1)
 	assertNotNil("dir", dir)
 	q := r.query.Select("directoryDocument")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -337,16 +372,16 @@ type Z5LabsFileDocumentOpts struct {
 	//
 	// An SPDX licence expression for the content, e.g. MIT or Apache-2.0.
 	//
-	License string // z5labs (../../../../../daggerverse/z5labs/document.go:100:2)
+	License string // z5labs (../../../../../daggerverse/z5labs/document.go:102:2)
 	//
 	// How the contribution is named in the image's document. Defaults to
 	// the file's own name.
 	//
-	Name string // z5labs (../../../../../daggerverse/z5labs/document.go:105:2)
+	Name string // z5labs (../../../../../daggerverse/z5labs/document.go:107:2)
 	//
 	// The version of the contributed content, if it has one.
 	//
-	Version string // z5labs (../../../../../daggerverse/z5labs/document.go:109:2)
+	Version string // z5labs (../../../../../daggerverse/z5labs/document.go:111:2)
 }
 
 // FileDocument produces the SPDX document required to contribute file to an
@@ -369,7 +404,7 @@ type Z5LabsFileDocumentOpts struct {
 // version is what the contributed content is a version of. There is no
 // default: content with no ecosystem usually has no version, and inventing
 // one would put a value in a field consumers compare.
-func (r *Z5Labs) FileDocument(file *File, opts ...Z5LabsFileDocumentOpts) *File { // z5labs (../../../../../daggerverse/z5labs/document.go:93:1)
+func (r *Z5Labs) FileDocument(file *File, opts ...Z5LabsFileDocumentOpts) *File { // z5labs (../../../../../daggerverse/z5labs/document.go:95:1)
 	assertNotNil("file", file)
 	q := r.query.Select("fileDocument")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -939,13 +974,21 @@ func (r *Z5LabsApp) WithApp(from *Z5LabsApp) *Z5LabsApp { // z5labs (../../../..
 // App.WithApp, which is the seam that names the platform of every byte it
 // brings.
 //
+// The tree may hold directories and regular files and nothing else. A
+// symbolic link in it is refused — when the document is produced, and again at
+// publish time for a caller who brought one of their own — because a link is
+// the one kind of content none of the rules here can see: it is not given the
+// mode, the path it names is not compared against anything, and it is in no
+// document and no digest. The file comment above carries the decision and what
+// was measured to reach it; contribute what the link pointed at instead.
+//
 // document is an SPDX 2.3 JSON document describing the tree, and it is
 // required for the reason WithFile's is. Z5labs.DirectoryDocument produces one
 // for content with no ecosystem, and it enumerates: the document it writes
 // carries one file element per file in the tree, because "the contribution is
 // described" and "every file in the image is accounted for" are different
 // promises and only the second one is the point.
-func (r *Z5LabsApp) WithDirectory(path string, dir *Directory, document *File) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/contribute.go:249:1)
+func (r *Z5LabsApp) WithDirectory(path string, dir *Directory, document *File) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/contribute.go:314:1)
 	assertNotNil("dir", dir)
 	assertNotNil("document", document)
 	q := r.query.Select("withDirectory")
@@ -981,7 +1024,7 @@ func (r *Z5LabsApp) WithDirectory(path string, dir *Directory, document *File) *
 // useless. Platform-specific executables arrive as an App instead: App.WithApp
 // composes one, matched platform by platform, and lands its entry in the plugin
 // directory.
-func (r *Z5LabsApp) WithFile(path string, file *File, document *File) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/contribute.go:197:1)
+func (r *Z5LabsApp) WithFile(path string, file *File, document *File) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/contribute.go:254:1)
 	assertNotNil("file", file)
 	assertNotNil("document", document)
 	q := r.query.Select("withFile")

--- a/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
+++ b/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
@@ -265,7 +265,7 @@ func (r *Z5Labs) ComposeSelfTest(ctx context.Context) error { // z5labs (../../.
 //
 // It runs in process and needs no container, so it is cheap enough to be a
 // check of its own.
-func (r *Z5Labs) ContributedTreeSelfTest(ctx context.Context) error { // z5labs (../../../../../daggerverse/z5labs/documentselftest.go:33:1)
+func (r *Z5Labs) ContributedTreeSelfTest(ctx context.Context) error { // z5labs (../../../../../daggerverse/z5labs/documentselftest.go:35:1)
 	if r.contributedTreeSelfTest != nil {
 		return nil
 	}
@@ -988,7 +988,7 @@ func (r *Z5LabsApp) WithApp(from *Z5LabsApp) *Z5LabsApp { // z5labs (../../../..
 // carries one file element per file in the tree, because "the contribution is
 // described" and "every file in the image is accounted for" are different
 // promises and only the second one is the point.
-func (r *Z5LabsApp) WithDirectory(path string, dir *Directory, document *File) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/contribute.go:314:1)
+func (r *Z5LabsApp) WithDirectory(path string, dir *Directory, document *File) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/contribute.go:325:1)
 	assertNotNil("dir", dir)
 	assertNotNil("document", document)
 	q := r.query.Select("withDirectory")
@@ -1024,7 +1024,7 @@ func (r *Z5LabsApp) WithDirectory(path string, dir *Directory, document *File) *
 // useless. Platform-specific executables arrive as an App instead: App.WithApp
 // composes one, matched platform by platform, and lands its entry in the plugin
 // directory.
-func (r *Z5LabsApp) WithFile(path string, file *File, document *File) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/contribute.go:254:1)
+func (r *Z5LabsApp) WithFile(path string, file *File, document *File) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/contribute.go:265:1)
 	assertNotNil("file", file)
 	assertNotNil("document", document)
 	q := r.query.Select("withFile")

--- a/daggerverse/z5labs/tests/sbom.go
+++ b/daggerverse/z5labs/tests/sbom.go
@@ -386,24 +386,20 @@ func (t *Tests) AppDocumentHelpersDescribeContentWithNoEcosystem(ctx context.Con
 		return fmt.Errorf("expected an empty directory to be refused, got nil")
 	}
 
-	// A symlink is skipped rather than followed or hashed. Following it
-	// would put a digest in the document for bytes that are not in the
-	// image; hashing the link itself would put one nothing can verify
-	// against a pulled layer. The real file beside it still lands.
-	linked := dag.Container().From("alpine:3.22").
-		WithNewFile("/tree/real.txt", "real").
-		WithExec([]string{"ln", "-s", "real.txt", "/tree/link.txt"}).
-		Directory("/tree")
-	raw, err = dag.Z5Labs().DirectoryDocument(linked, "tree").Contents(ctx)
-	if err != nil {
-		return fmt.Errorf("DirectoryDocument over a tree with a symlink: %v", err)
-	}
-	doc, err = readContributionDocument([]byte(raw))
-	if err != nil {
-		return err
-	}
-	if strings.Join(doc.Files, ",") != "real.txt" {
-		return fmt.Errorf("the directory document lists %v, want the regular file alone", doc.Files)
+	// A tree carrying a symlink is refused rather than described. It used to
+	// be described with the link skipped, which is a document about a tree the
+	// image does not have: the link is copied into the image, it is in no file
+	// list, and treeDigest is a digest of that list — so the same tree with and
+	// without it were one tree to every check the module makes. The refusal
+	// names the link and what it points at, because a caller who did not know
+	// their tree held one has to be able to go and find it.
+	linked := dag.Directory().
+		WithNewFile("real.txt", "real").
+		WithSymlink("real.txt", "link.txt")
+	if _, err := dag.Z5Labs().DirectoryDocument(linked, "tree").Contents(ctx); err == nil {
+		return fmt.Errorf("expected a tree carrying a symlink to be refused, got nil")
+	} else if !strings.Contains(err.Error(), `link.txt is a symbolic link to "real.txt"`) {
+		return fmt.Errorf("expected the refusal to name the link and its target, got: %v", err)
 	}
 
 	// Prose is refused rather than published into a field a policy engine


### PR DESCRIPTION
Closes #428

## The decision

**A symbolic link in a contributed tree is refused.** So is a device, a pipe or a socket — anything that is neither a directory nor a regular file.

A link was the one kind of content that reached an image without passing any of the contribution seams:

- `normalizedTree` sets the module's mode on the copied tree, and a mode on a link is not a mode on what it resolves to.
- `overlappingPath` compares cleaned path strings, and a link names a path that comparison never sees.
- `walkTree` skipped anything that was not a regular file, so a link was in no document and contributed nothing to `treeDigest` — which made `digest.go`'s claim that "two directories that differ anywhere differ in it" false for exactly that difference, in the mechanism #410 added to make an asserted document checkable.

## Where it is enforced

`walkTree` returns an `unsupportedEntry` naming the entry and, for a link, what it points at. That is the one place the module reads a contributed tree, so both readers inherit the rule and neither pays a second walk:

- `Z5labs.DirectoryDocument` refuses to describe such a tree — the paved path, where an adopter is refused at the call that would have produced the document;
- `contentDigest` refuses it again at publish, before the first byte is pushed — the path a caller carrying a document of their own takes.

It stays at those two points rather than moving into `WithDirectory` for the reason `digest.go` already records for the digest check itself: a check at the contributing call means resolving the caller's content inside a constructor, and an app nobody publishes should cost no scan.

## What was measured (Dagger v0.21.8)

The acceptance criteria ask for this before relying on either answer, and it is what rules the alternatives out:

- `Directory.Export` preserves a link as a link, relative and absolute alike. So the export the digest is computed over really does carry the link, and the walk really did skip it.
- The copy into a container preserves it too, and the `permissions` a tree is normalized with do not apply to it. So an admitted link really is in the published image, at whatever mode it arrived with.
- An absolute link exported to this module's filesystem points into *this module's* filesystem. `/etc/passwd` in a contributed tree is one path during the export and a different file in the image — which is why "allowed when its target resolves inside the contributed path" is not a rule that can be checked where the module can check anything.

The last measurement is the judgment call that shaped the public API: it is what turned the middle option in the issue from a stricter rule into an undefined one. Following a link would put a digest for bytes that are not in the image into the document, and the same measurement says whose bytes those would be. Silently dropping links from the copy was rejected for the reason every other silent repair here is — an image missing something the caller put in it, with a document that agrees, is the undetectable incompleteness the whole file is written against.

## Acceptance criteria

- [x] **Decide** what a symlink means: refused outright. `contribute.go` carries the decision, the three alternatives and why each was rejected, under "A symbolic link is not content".
- [x] It is a property of the tree the module copies: the refusal is in `walkTree`, the one place the module reads a contributed tree, and every route to a registry passes through it. No caller's assertion about their tree is taken.
- [x] `treeDigest` and `DirectoryDocument` agree with the decision — neither can be computed over a tree with a link, so the refusal is what a caller gets. `digest.go`'s stability claim is now true rather than nearly true.
- [x] `Directory.Export`'s behaviour measured before relying on it, along with the container copy — see above; both are asserted in the tests rather than only described, because both are Dagger's behaviour rather than this module's.
- [x] A contributed tree containing a symlink is covered by a test: `Z5labs.ContributedTreeSelfTest` (in process, six trees — relative, absolute, dangling, nested, a link to a directory, and a clean tree) and `Tests.AppRefusesTreesCarryingSymlinks` (the copy measurement, `DirectoryDocument`, and a publish refused with nothing left in the registry). The existing `tests/sbom.go` case that asserted a link was *skipped* now asserts the refusal.

## Verified

- `dagger check` — green
- `bash .github/scripts/verify-affected-modules.sh` — `daggerverse/z5labs` module checks and `tests:all`, green