### PR TITLE
bug(z5labs): every image the standard pipeline publishes runs as root

### DIFF
--- a/daggerverse/z5labs/app.go
+++ b/daggerverse/z5labs/app.go
@@ -866,7 +866,8 @@ type imageConfig struct {
 	// Env is the image's environment, name to value.
 	Env map[string]string
 	// User is the OCI configuration's User field. Empty means the runtime
-	// picks, which today means root — see expectedImageConfig.
+	// picks, which means uid 0 — which is why an image this pipeline
+	// publishes never leaves it empty. See expectedImageConfig.
 	User string
 	// Entrypoint is what the image execs, argument by argument.
 	Entrypoint []string
@@ -899,19 +900,21 @@ type imageConfig struct {
 // caller-facing method sets any of these fields, so what an image promises is
 // a property of the pipeline rather than of the call that built it.
 //
-// Every field but the entrypoint is empty, and that is the promise rather than
-// an absence of one. An image with no working directory, no default arguments,
-// no exposed ports and no labels is one whose behaviour is what its entrypoint
-// does, and each of those would otherwise be inherited from a base layer the
-// moment this module builds on one — which is the direction it is going. The
-// package doc's "The image contract" is where the same set is written for
-// adopters, and "# No working directory" is why that field in particular is a
-// decision.
+// Every field but the entrypoint and the user is empty, and that is the
+// promise rather than an absence of one. An image with no working directory,
+// no default arguments, no exposed ports and no labels is one whose behaviour
+// is what its entrypoint does, and each of those would otherwise be inherited
+// from a base layer the moment this module builds on one — which is the
+// direction it is going. The package doc's "The image contract" is where the
+// same set is written for adopters, and "# No working directory" is why that
+// field in particular is a decision.
 //
-// User is empty because these images run as root today. That is devex#399,
-// which is open, and the whole of fixing it here is this field and the
-// WithUser that has to go beside it in imageForEntry: this check is what stops
-// the next refactor dropping it again once it lands.
+// User is appOwner, and it is the one field here whose expected value is a
+// non-empty constant. An image config's User is what a runtime resolves when
+// nothing overrides it, and an empty one resolves to uid 0 — so "no user" is
+// not a neutral setting, it is root (devex#399). This line is what stops a
+// later refactor dropping the WithUser in imageForEntry and shipping root
+// again: nothing else would fail, because an image that runs as root works.
 //
 // The entrypoint is a parameter because it is the one part of the
 // configuration that is a property of the application rather than of the
@@ -921,7 +924,7 @@ type imageConfig struct {
 func expectedImageConfig(entrypoint string) imageConfig {
 	return imageConfig{
 		Env:        expectedImageEnv(),
-		User:       "",
+		User:       appOwner,
 		Entrypoint: []string{entrypoint},
 	}
 }

--- a/daggerverse/z5labs/build.go
+++ b/daggerverse/z5labs/build.go
@@ -272,6 +272,16 @@ func (g *GoChain) buildBinaryForPlatform(platform, pkg, binaryName, version, com
 // stops describing what is running. It is 0555 rather than 0444 because this
 // is the one file in the image that is exec'd.
 //
+// The image runs as that same user, appOwner, and this is the only line that
+// sets it — see the package doc's "The image runs as 65532:65532". Setting it
+// here rather than anywhere a caller can reach is the same argument the
+// environment's paragraph makes one above: an identity a caller could move is
+// one a Kubernetes runAsNonRoot policy cannot rely on. The mode is what makes
+// the two independent, and deliberately so. 0555 is exec'able by *every* uid,
+// so a deployment that overrides the user — `--user $(id -u):$(id -g)`, or a
+// securityContext pinning something the cluster allocated — is running an
+// ordinary configuration rather than working around this line.
+//
 // This is the only place an image is built, and everything reaches it —
 // GoChain.App by way of AppBuilder, and AppBuilder by way of a caller's
 // prebuilt executable. A caller-supplied entrypoint is not an exemption from
@@ -294,7 +304,7 @@ func imageForEntry(platform dagger.Platform, name string, entry *dagger.File, an
 	for _, k := range sortedKeys(env) {
 		ctr = ctr.WithEnvVariable(k, env[k])
 	}
-	ctr = ctr.WithEntrypoint([]string{entrypoint})
+	ctr = ctr.WithEntrypoint([]string{entrypoint}).WithUser(appOwner)
 	for _, k := range sortedKeys(annotations) {
 		ctr = ctr.WithAnnotation(k, annotations[k])
 	}

--- a/daggerverse/z5labs/build.go
+++ b/daggerverse/z5labs/build.go
@@ -273,10 +273,17 @@ func (g *GoChain) buildBinaryForPlatform(platform, pkg, binaryName, version, com
 // is the one file in the image that is exec'd.
 //
 // The image runs as that same user, appOwner, and this is the only line that
-// sets it — see the package doc's "The image runs as 65532:65532". Setting it
-// here rather than anywhere a caller can reach is the same argument the
-// environment's paragraph makes one above: an identity a caller could move is
-// one a Kubernetes runAsNonRoot policy cannot rely on. The mode is what makes
+// sets it — see the package doc's "The image runs as 65532:65532".
+//
+// What that placement buys is precise, and worth stating precisely: every image
+// *this module publishes* carries 65532:65532, and there is no method on App
+// that moves it. It is not a claim that the string is out of a caller's reach —
+// App.Container hands back a *dagger.Container, and WithUser is a method on it,
+// so a caller can take that container, change its user and publish it
+// themselves. The narrow claim is the one a Kubernetes runAsNonRoot policy can
+// be written against, and the broad one is not true of any Dagger module.
+//
+// The mode is what makes
 // the two independent, and deliberately so. 0555 is exec'able by *every* uid,
 // so a deployment that overrides the user — `--user $(id -u):$(id -g)`, or a
 // securityContext pinning something the cluster allocated — is running an

--- a/daggerverse/z5labs/contribute.go
+++ b/daggerverse/z5labs/contribute.go
@@ -185,9 +185,17 @@ import (
 // nothing runs as, or a uid that owns nothing it runs, is a pair that has to
 // be kept in agreement by hand. imageForEntry is where it becomes the runtime
 // user; the package doc's "The image runs as 65532:65532" is why that identity
-// is not something a caller can move. Note that owning a file is not what makes
-// it usable here — every mode this module writes is world-readable, so a
-// deployment overriding the user gets the same image behaviour.
+// is not something App exposes a knob for.
+//
+// Owning the content is not what makes it usable, and that matters now that
+// the runtime user is a real uid rather than root. The modes below are what
+// make it usable: contributed files land 0444, which every uid can read, and
+// contributed directories land 0555, which every uid can traverse — a
+// directory needs the execute bit for that, not the read bit, which is why the
+// two modes differ. So a deployment overriding the user to something neither
+// this module nor the image has heard of gets the same behaviour. Both modes
+// are asserted literally, per file and per directory, in the tests' contributed
+// -content checks.
 const appOwner = "65532:65532"
 
 // The modes a contribution lands with. Read-only, because content

--- a/daggerverse/z5labs/contribute.go
+++ b/daggerverse/z5labs/contribute.go
@@ -173,13 +173,21 @@ import (
 // runtime concern" section, which records why every category of variable has
 // an owner other than the caller.
 
-// appOwner owns every byte a caller contributes to an image.
+// appOwner owns every byte a caller contributes to an image, and is the user
+// the image runs as.
 //
 // It is numeric rather than a name because a scratch image has no
 // /etc/passwd for a name to resolve against, and 65532 specifically because
 // that is the uid distroless nonroot images use — the number a base layer
-// would agree with if one of these images ever gains one. The runtime user
-// itself is devex#399's; this is only who the files belong to.
+// would agree with if one of these images ever gains one.
+//
+// One constant for both because they are one decision: files owned by a uid
+// nothing runs as, or a uid that owns nothing it runs, is a pair that has to
+// be kept in agreement by hand. imageForEntry is where it becomes the runtime
+// user; the package doc's "The image runs as 65532:65532" is why that identity
+// is not something a caller can move. Note that owning a file is not what makes
+// it usable here — every mode this module writes is world-readable, so a
+// deployment overriding the user gets the same image behaviour.
 const appOwner = "65532:65532"
 
 // The modes a contribution lands with. Read-only, because content

--- a/daggerverse/z5labs/main.go
+++ b/daggerverse/z5labs/main.go
@@ -92,37 +92,57 @@
 // rather than a case it configures for.
 //
 // A *deployment* may still pick a different uid, and that is an ordinary
-// configuration rather than a workaround. Every mode this module writes is
-// world-readable and the entrypoint is 0555, so `docker run --user $(id
-// -u):$(id -g)`, or a securityContext naming a uid a cluster allocated, runs
-// the same image the same way. What an override does not buy is a writable
+// configuration rather than a workaround. Every file this module writes is
+// world-readable, every directory world-traversable, and the entrypoint is
+// 0555, so `docker run --user $(id -u):$(id -g)`, or a securityContext naming a
+// uid a cluster allocated, runs the same image the same way.
+//
+// What an override to any other *non-root* uid does not buy is a writable
 // image: /app is root-owned 0755, HOME is root-owned 0555, and contributed
-// content is read-only whoever runs it.
+// content is read-only. An override back to uid 0 does buy one, because root
+// bypasses the permission check — that is the same exception HOME's paragraph
+// below names, and it is now something a deployment has to ask for rather than
+// something it gets by default.
 //
 // # Running as 65532 is behaviour-affecting
 //
-// This changed images that already existed. Before it, an application ran as
-// uid 0 and could write anywhere its filesystem allowed; under 65532 the same
-// write fails with EACCES, reported by the application as "permission denied"
-// or whatever its own error handling makes of one.
+// This changed images that already existed, and it changed them in the
+// direction that fails rather than the direction that warns. Before it, an
+// application ran as uid 0, which bypasses the permission check on every mode
+// in the image — so it could write anywhere at all, the read-only paths this
+// module deliberately builds included. Under 65532 those same writes fail with
+// EACCES, reported by the application as "permission denied" or whatever its
+// own error handling makes of one.
 //
 // That message cannot be improved from here. The write is the application's own
-// syscall and nothing in this module is in the process to intercept it, so the
-// explanation has to live where somebody can find it afterwards — which is this
-// section, and it is what to search for when a container that used to work
-// starts failing to write. Three things it is worth knowing at that point:
+// syscall, and nothing in this module is in the process to intercept it or to
+// wrap what it returns. So the explanation lives where somebody debugging one
+// can reach it: this section, arrived at from the running image itself, whose
+// org.opencontainers.image.source annotation names this repository — that is
+// the path from a container that stopped working back to the decision, and it
+// is why that annotation is on every variant rather than only on the index.
 //
-//   - The image's own paths were never writable, under any user. /app and HOME
-//     are root-owned and read-only by design (see below), so a write to one of
-//     those was already failing before this change.
-//   - Everything else an application wrote landed in the container's writable
-//     layer, and uid 65532 cannot create an entry at its root. Mount storage at
-//     the path the application writes — a tmpfs, an emptyDir, a volume — and
-//     give it to 65532:65532. That is the same thing TMPDIR's paragraph below
-//     already asks a deployment to do for scratch space, applied to whatever
-//     other path the application chose.
+// Three things worth knowing on arrival, in the order they are likely to be
+// what happened:
+//
+//   - A write to the image's own paths now fails, and this is the most likely
+//     breakage. /app and HOME are root-owned and read-only by design (see
+//     below), which stopped nothing while the application was root and stops it
+//     now. An application writing beside its own binary or into its home
+//     directory was relying on being uid 0, whether or not anyone knew it.
+//   - A write anywhere else lands in the container's writable layer, and uid
+//     65532 cannot create an entry at its root. Mount storage at the path the
+//     application writes — a tmpfs, an emptyDir, a volume — and give it to
+//     65532:65532. That is the same thing TMPDIR's paragraph below already asks
+//     a deployment to do for scratch space, applied to whatever other path the
+//     application chose.
 //   - If the application picked its path from the environment, HOME and TMPDIR
 //     are the two this image pins, and both are covered below.
+//
+// What is deliberately *not* offered is a way to turn this off; see the section
+// above. A deployment that must have the old behaviour can override the user
+// back to uid 0, which is a thing it has to write down in a manifest somebody
+// reviews, rather than a default nobody sees.
 //
 // # HOME is a directory; TMPDIR is a mount point
 //

--- a/daggerverse/z5labs/main.go
+++ b/daggerverse/z5labs/main.go
@@ -48,20 +48,81 @@
 // application could write is one whose published digest stops describing what
 // is running.
 //
-// The rest of the OCI configuration is part of the contract too, and every bit
-// of it is empty:
+// The rest of the OCI configuration is part of the contract too. One field
+// carries a value and the rest are empty:
 //
-//	User          nothing — devex#399, which is open, is the image's own user
+//	User          65532:65532 — see "# The image runs as 65532:65532" below
 //	WorkingDir    nothing — see "# No working directory" below
 //	Cmd           no default arguments
 //	ExposedPorts  none
 //	Labels        none — the per-platform OCI *annotations* are a separate field
 //
-// Empty is a promise rather than an omission, and it is asserted as such: a
-// publish reads back the whole configuration of every variant and refuses one
-// that carries a field this pipeline did not write. Each of those would
-// otherwise be inherited, silently, from the first base layer this module
-// builds on (devex#426).
+// Empty is a promise rather than an omission, and so is the one value: it is
+// all asserted the same way, by a publish that reads back the whole
+// configuration of every variant and refuses one that does not match, in both
+// directions. Each of the empty fields would otherwise be inherited, silently,
+// from the first base layer this module builds on, and the User is the field
+// where "not set" is not neutral (devex#426, devex#399).
+//
+// # The image runs as 65532:65532
+//
+// Every image this module publishes sets its User to 65532:65532 — a uid and a
+// gid, written as numbers. It is the same identity every byte in the image is
+// owned by, which is one decision rather than two: a uid that owns nothing it
+// runs, or files owned by a uid nothing runs as, is a pair somebody has to keep
+// in agreement by hand.
+//
+// Numbers rather than a name, because a scratch image has no /etc/passwd for a
+// name to resolve against — a User of "nonroot" is a string nothing in the
+// image can turn into a uid — and because the two places the number is read
+// again are a long way from here: a `COPY --chown=65532:65532` in a derived
+// Dockerfile, and runAsUser in a Kubernetes securityContext. Neither of those
+// can ask the image what its user is; both are written against a number
+// somebody wrote down. 65532 specifically because that is distroless's
+// `nonroot`, and because z5labs/avroc and Zaba505/cpybkc already pin it in
+// their hand-rolled image builds — moving onto this archetype should not also
+// be a change to a contract they have published.
+//
+// It is not overridable at build time, and no application gets root by asking.
+// There is no WithUser on App and there will not be one, for the reason there
+// is no way to turn provenance off: a hardening default that can be switched
+// off is hardening nobody downstream can rely on, and "runs as non-root" is
+// precisely the kind of claim an admission policy is written against. An
+// application that genuinely needs uid 0 is out of scope for this archetype
+// rather than a case it configures for.
+//
+// A *deployment* may still pick a different uid, and that is an ordinary
+// configuration rather than a workaround. Every mode this module writes is
+// world-readable and the entrypoint is 0555, so `docker run --user $(id
+// -u):$(id -g)`, or a securityContext naming a uid a cluster allocated, runs
+// the same image the same way. What an override does not buy is a writable
+// image: /app is root-owned 0755, HOME is root-owned 0555, and contributed
+// content is read-only whoever runs it.
+//
+// # Running as 65532 is behaviour-affecting
+//
+// This changed images that already existed. Before it, an application ran as
+// uid 0 and could write anywhere its filesystem allowed; under 65532 the same
+// write fails with EACCES, reported by the application as "permission denied"
+// or whatever its own error handling makes of one.
+//
+// That message cannot be improved from here. The write is the application's own
+// syscall and nothing in this module is in the process to intercept it, so the
+// explanation has to live where somebody can find it afterwards — which is this
+// section, and it is what to search for when a container that used to work
+// starts failing to write. Three things it is worth knowing at that point:
+//
+//   - The image's own paths were never writable, under any user. /app and HOME
+//     are root-owned and read-only by design (see below), so a write to one of
+//     those was already failing before this change.
+//   - Everything else an application wrote landed in the container's writable
+//     layer, and uid 65532 cannot create an entry at its root. Mount storage at
+//     the path the application writes — a tmpfs, an emptyDir, a volume — and
+//     give it to 65532:65532. That is the same thing TMPDIR's paragraph below
+//     already asks a deployment to do for scratch space, applied to whatever
+//     other path the application chose.
+//   - If the application picked its path from the environment, HOME and TMPDIR
+//     are the two this image pins, and both are covered below.
 //
 // # HOME is a directory; TMPDIR is a mount point
 //
@@ -83,18 +144,19 @@
 // mode 0555, and shipped empty. A read under it fails ENOENT and a write fails
 // EACCES, the same way on every runtime, instead of succeeding into a writable
 // layer under one and failing under another. /home/nonroot is the conventional
-// home of uid 65532, which is who these images' files belong to, so it is also
-// the path a deployment mounts a volume at in the case where an application
-// genuinely needs a writable home. Nothing in the image needs one: an
-// application that writes to its home directory is making its own state part
-// of a digest that is supposed to describe what is running.
+// home of uid 65532, which is who these images run as and who their files
+// belong to, so it is also the path a deployment mounts a volume at in the case
+// where an application genuinely needs a writable home. Nothing in the image
+// needs one: an application that writes to its home directory is making its own
+// state part of a digest that is supposed to describe what is running.
 //
 // The one user that mode does not stop is root, which bypasses the permission
-// check — so "a write fails" is a promise under every user except uid 0, and
-// uid 0 is what a container runtime picks when nothing overrides it (devex#399
-// is the image's own user, and is open). Owning the directory as root rather
-// than as the application's user is what makes the promise hold for every
-// other choice a deployment can make, rather than only for the default one.
+// check — so "a write fails" is a promise under every user except uid 0. No
+// image published here runs as uid 0 (see "# The image runs as 65532:65532"),
+// so that exception is now reachable only by a deployment that deliberately
+// overrides the user back to root. Owning the directory as root rather than as
+// the application's user is what makes the promise hold for every other choice
+// a deployment can make, rather than only for the default one.
 //
 // A caller may contribute read-only content under it — a default
 // configuration an operator can override by mounting one — and that is

--- a/daggerverse/z5labs/selftest.go
+++ b/daggerverse/z5labs/selftest.go
@@ -292,15 +292,17 @@ func (m *Z5labs) ImageConfigSelfTest(ctx context.Context) error {
 	// demanding is an expectation that asks for something this pipeline does
 	// not promise today.
 	//
-	// Every field but the entrypoint is expected empty right now, so a table
-	// built only from the real expectation would drive one side of each
-	// comparison and leave the other unexecutable — the exact shape of check
-	// this whole split exists to avoid. Concretely: with only empty
+	// Every field but the entrypoint and the user is expected empty, so a
+	// table built only from the real expectation would drive one side of each
+	// of those comparisons and leave the other unexecutable — the exact shape
+	// of check this whole split exists to avoid. Concretely: with only empty
 	// expectations, replacing each comparison with a hard-coded `!= ""` or
-	// `len(...) != 0` leaves every row green, and the day expectedImageConfig
-	// grows a non-empty User for devex#399 the check would silently be
-	// asserting nothing. So each field is also driven against an expectation
-	// that demands a value, in both directions.
+	// `len(...) != 0` leaves every row green, and a field that later grows a
+	// non-empty expectation would find the check asserting nothing. That is
+	// not hypothetical — it is what happened to User when devex#399 landed,
+	// and the rows this helper carried are what caught the comparison rather
+	// than the emptiness. So each still-empty field is also driven against an
+	// expectation that demands a value, in both directions.
 	demanding := func(mutate func(*imageConfig)) *imageConfig {
 		cfg := expectedImageConfig(entry)
 		mutate(&cfg)
@@ -369,24 +371,49 @@ func (m *Z5labs) ImageConfigSelfTest(ctx context.Context) error {
 
 		{
 			// An image config's User is a string the runtime resolves, so
-			// "root" and an unset field are the same identity said two ways.
-			// The refusal is still right: this pipeline sets no user at all,
-			// and something that wrote one wrote it from somewhere nothing
-			// here controls.
+			// "root" and an unset field are the same identity said two ways —
+			// and both are refused, because the identity this pipeline
+			// publishes is uid 65532 and nothing here writes anything else
+			// (devex#399).
 			name: "an image that names root as its user",
 			cfg:  standard(func(c *imageConfig) { c.User = "root" }),
 			want: `sets its user to "root"`,
 		},
 		{
-			// Refused *today*, and this row is the one that inverts when
-			// devex#399 lands: the expectation gains 65532:65532, imageForEntry
-			// gains the WithUser that puts it there, and this becomes the
-			// accepted row while an empty User becomes the refused one. Written
-			// out rather than left implicit so that landing #399 is a change to
-			// this file rather than a discovery.
+			// The other spelling of the same identity: uid 0 written as a
+			// number is refused for the reason "root" is, and a comparison
+			// that had started special-casing the *name* would leave this
+			// green.
+			name: "an image that names uid 0 as its user",
+			cfg:  standard(func(c *imageConfig) { c.User = "0:0" }),
+			want: `sets its user to "0:0"`,
+		},
+		{
+			// An empty User is uid 0 said a third way, and it is the one an
+			// image gets by *omission* — which is what devex#399 was. It is
+			// refused here rather than merely not written, so a refactor that
+			// dropped the WithUser in imageForEntry cannot publish.
+			name: "an image that sets no user at all",
+			cfg:  standard(func(c *imageConfig) { c.User = "" }),
+			want: `sets its user to nothing, but every image this pipeline publishes sets its user to "65532:65532"`,
+		},
+		{
+			// The uid without the gid is not the same identity: a User of
+			// "65532" leaves the primary group to the runtime, which is gid 0
+			// on every runtime this module has been run under. It is a
+			// plausible near-miss rather than a typo, which is why it has a
+			// row.
+			name: "an image that names the uid but no group",
+			cfg:  standard(func(c *imageConfig) { c.User = "65532" }),
+			want: `sets its user to "65532"`,
+		},
+		{
+			// The accepting side. It is standard(nil) that carries it — see
+			// the row at the top of this table — but written out once beside
+			// the refusals so the identity being accepted is legible here
+			// rather than only in expectedImageConfig.
 			name: "an image that runs as the application's user",
 			cfg:  standard(func(c *imageConfig) { c.User = appOwner }),
-			want: `sets its user to "65532:65532"`,
 		},
 		{
 			name: "an entrypoint in the plugin directory",
@@ -466,18 +493,11 @@ func (m *Z5labs) ImageConfigSelfTest(ctx context.Context) error {
 		// The other side of every field this pipeline expects empty today.
 		// See demanding: without these, each comparison could be a hard-coded
 		// test for emptiness and this table would not know.
-		{
-			// This is the row devex#399 turns into the ordinary case.
-			name:   "no user, where the pipeline demands one",
-			cfg:    standard(nil),
-			expect: demanding(func(c *imageConfig) { c.User = appOwner }),
-			want:   `sets its user to nothing, but every image this pipeline publishes sets its user to "65532:65532"`,
-		},
-		{
-			name:   "exactly the user demanded",
-			cfg:    standard(func(c *imageConfig) { c.User = appOwner }),
-			expect: demanding(func(c *imageConfig) { c.User = appOwner }),
-		},
+		//
+		// User is not among them any more, and that is what devex#399 changed:
+		// its expectation is a non-empty constant now, so the rows above drive
+		// both directions of the real comparison rather than a stand-in for
+		// one.
 		{
 			name:   "no working directory, where the pipeline demands one",
 			cfg:    standard(nil),

--- a/daggerverse/z5labs/selftest.go
+++ b/daggerverse/z5labs/selftest.go
@@ -408,12 +408,16 @@ func (m *Z5labs) ImageConfigSelfTest(ctx context.Context) error {
 			want: `sets its user to "65532"`,
 		},
 		{
-			// The accepting side. It is standard(nil) that carries it — see
-			// the row at the top of this table — but written out once beside
-			// the refusals so the identity being accepted is legible here
-			// rather than only in expectedImageConfig.
+			// The accepting side, and the literal is deliberate. Writing
+			// appOwner here would make the row a no-op — standard() is built
+			// from expectedImageConfig, whose User is already appOwner — and
+			// would move with the constant, so renumbering the identity would
+			// leave every row in this block green. Spelled out, this row is
+			// the one place the table asserts *which* identity is accepted,
+			// and it fails if that number ever changes without the refusals
+			// beside it changing too.
 			name: "an image that runs as the application's user",
-			cfg:  standard(func(c *imageConfig) { c.User = appOwner }),
+			cfg:  standard(func(c *imageConfig) { c.User = "65532:65532" }),
 		},
 		{
 			name: "an entrypoint in the plugin directory",

--- a/daggerverse/z5labs/tests/dagger.gen.go
+++ b/daggerverse/z5labs/tests/dagger.gen.go
@@ -332,6 +332,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Tests).AppFromPrebuiltExecutablesPublishesAttested(&parent, ctx)
+		case "AppImageRunsUnderAnyUser":
+			var parent Tests
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Tests).AppImageRunsUnderAnyUser(&parent, ctx)
 		case "AppImagesCarryTheStandardConfiguration":
 			var parent Tests
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
+++ b/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type Z5Labs
-func (r *Binding) AsZ5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:619:6)
+func (r *Binding) AsZ5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:639:6)
 	q := r.query.Select("asZ5Labs")
 
 	return &Z5Labs{
@@ -118,7 +118,7 @@ func (r *Env) WithZ5LabsGoChainOutput(name string, description string) *Env { //
 }
 
 // Create or update a binding of type Z5Labs in the environment
-func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:619:6)
+func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:639:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withZ5LabsInput")
 	q = q.Arg("name", name)
@@ -131,7 +131,7 @@ func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *E
 }
 
 // Declare a desired Z5Labs output to be assigned in the environment
-func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:619:6)
+func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:639:6)
 	q := r.query.Select("withZ5LabsOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -143,7 +143,7 @@ func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs
 
 // Z5labs is the root module type. Construct the Go language chain via Go;
 // everything this module does is reached from there.
-func (r *Query) Z5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:619:6)
+func (r *Query) Z5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:639:6)
 	q := r.query.Select("z5Labs")
 
 	return &Z5Labs{
@@ -153,7 +153,7 @@ func (r *Query) Z5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/
 
 // Z5labs is the root module type. Construct the Go language chain via Go;
 // everything this module does is reached from there.
-type Z5Labs struct { // z5labs (../../../../../daggerverse/z5labs/main.go:619:6)
+type Z5Labs struct { // z5labs (../../../../../daggerverse/z5labs/main.go:639:6)
 	query *querybuilder.Selection
 
 	composeSelfTest          *Void
@@ -440,7 +440,7 @@ func (r *Z5Labs) FileDocument(file *File, opts ...Z5LabsFileDocumentOpts) *File 
 //
 // The returned object is GoChain rather than Go because the `go` module
 // this one depends on already owns that name — see GoChain's doc comment.
-func (r *Z5Labs) Go(source *Directory) *Z5LabsGoChain { // z5labs (../../../../../daggerverse/z5labs/main.go:635:1)
+func (r *Z5Labs) Go(source *Directory) *Z5LabsGoChain { // z5labs (../../../../../daggerverse/z5labs/main.go:655:1)
 	assertNotNil("source", source)
 	q := r.query.Select("go")
 	q = q.Arg("source", source)
@@ -988,7 +988,7 @@ func (r *Z5LabsApp) WithApp(from *Z5LabsApp) *Z5LabsApp { // z5labs (../../../..
 // carries one file element per file in the tree, because "the contribution is
 // described" and "every file in the image is accounted for" are different
 // promises and only the second one is the point.
-func (r *Z5LabsApp) WithDirectory(path string, dir *Directory, document *File) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/contribute.go:333:1)
+func (r *Z5LabsApp) WithDirectory(path string, dir *Directory, document *File) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/contribute.go:341:1)
 	assertNotNil("dir", dir)
 	assertNotNil("document", document)
 	q := r.query.Select("withDirectory")
@@ -1024,7 +1024,7 @@ func (r *Z5LabsApp) WithDirectory(path string, dir *Directory, document *File) *
 // useless. Platform-specific executables arrive as an App instead: App.WithApp
 // composes one, matched platform by platform, and lands its entry in the plugin
 // directory.
-func (r *Z5LabsApp) WithFile(path string, file *File, document *File) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/contribute.go:273:1)
+func (r *Z5LabsApp) WithFile(path string, file *File, document *File) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/contribute.go:281:1)
 	assertNotNil("file", file)
 	assertNotNil("document", document)
 	q := r.query.Select("withFile")

--- a/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
+++ b/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type Z5Labs
-func (r *Binding) AsZ5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:557:6)
+func (r *Binding) AsZ5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:619:6)
 	q := r.query.Select("asZ5Labs")
 
 	return &Z5Labs{
@@ -118,7 +118,7 @@ func (r *Env) WithZ5LabsGoChainOutput(name string, description string) *Env { //
 }
 
 // Create or update a binding of type Z5Labs in the environment
-func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:557:6)
+func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:619:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withZ5LabsInput")
 	q = q.Arg("name", name)
@@ -131,7 +131,7 @@ func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *E
 }
 
 // Declare a desired Z5Labs output to be assigned in the environment
-func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:557:6)
+func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs (../../../../../daggerverse/z5labs/main.go:619:6)
 	q := r.query.Select("withZ5LabsOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -143,7 +143,7 @@ func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs
 
 // Z5labs is the root module type. Construct the Go language chain via Go;
 // everything this module does is reached from there.
-func (r *Query) Z5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:557:6)
+func (r *Query) Z5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/main.go:619:6)
 	q := r.query.Select("z5Labs")
 
 	return &Z5Labs{
@@ -153,7 +153,7 @@ func (r *Query) Z5Labs() *Z5Labs { // z5labs (../../../../../daggerverse/z5labs/
 
 // Z5labs is the root module type. Construct the Go language chain via Go;
 // everything this module does is reached from there.
-type Z5Labs struct { // z5labs (../../../../../daggerverse/z5labs/main.go:557:6)
+type Z5Labs struct { // z5labs (../../../../../daggerverse/z5labs/main.go:619:6)
 	query *querybuilder.Selection
 
 	composeSelfTest          *Void
@@ -440,7 +440,7 @@ func (r *Z5Labs) FileDocument(file *File, opts ...Z5LabsFileDocumentOpts) *File 
 //
 // The returned object is GoChain rather than Go because the `go` module
 // this one depends on already owns that name — see GoChain's doc comment.
-func (r *Z5Labs) Go(source *Directory) *Z5LabsGoChain { // z5labs (../../../../../daggerverse/z5labs/main.go:573:1)
+func (r *Z5Labs) Go(source *Directory) *Z5LabsGoChain { // z5labs (../../../../../daggerverse/z5labs/main.go:635:1)
 	assertNotNil("source", source)
 	q := r.query.Select("go")
 	q = q.Arg("source", source)
@@ -988,7 +988,7 @@ func (r *Z5LabsApp) WithApp(from *Z5LabsApp) *Z5LabsApp { // z5labs (../../../..
 // carries one file element per file in the tree, because "the contribution is
 // described" and "every file in the image is accounted for" are different
 // promises and only the second one is the point.
-func (r *Z5LabsApp) WithDirectory(path string, dir *Directory, document *File) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/contribute.go:325:1)
+func (r *Z5LabsApp) WithDirectory(path string, dir *Directory, document *File) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/contribute.go:333:1)
 	assertNotNil("dir", dir)
 	assertNotNil("document", document)
 	q := r.query.Select("withDirectory")
@@ -1024,7 +1024,7 @@ func (r *Z5LabsApp) WithDirectory(path string, dir *Directory, document *File) *
 // useless. Platform-specific executables arrive as an App instead: App.WithApp
 // composes one, matched platform by platform, and lands its entry in the plugin
 // directory.
-func (r *Z5LabsApp) WithFile(path string, file *File, document *File) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/contribute.go:265:1)
+func (r *Z5LabsApp) WithFile(path string, file *File, document *File) *Z5LabsApp { // z5labs (../../../../../daggerverse/z5labs/contribute.go:273:1)
 	assertNotNil("file", file)
 	assertNotNil("document", document)
 	q := r.query.Select("withFile")

--- a/daggerverse/z5labs/tests/main.go
+++ b/daggerverse/z5labs/tests/main.go
@@ -606,21 +606,30 @@ func (t *Tests) AppContainerRunsTheEntrypoint(ctx context.Context) error {
 	return nil
 }
 
-// AppImageRunsUnderAnyUser asserts the image's executable runs as the user the
-// image pins, and as any uid a deployment overrides that with.
+// AppImageRunsUnderAnyUser asserts the image's entrypoint is executable by the
+// uid the image pins and by any uid a deployment overrides that with.
 //
-// This is the runtime half of devex#399, and it is a different claim from the
-// configuration half. assertStandardImageConfig reads the User field and says
-// what the image *declares*; nothing about a declaration says the binary is
-// executable by the uid it names. A file owned by 65532 and mode 0500 would
-// satisfy that check and fail here, and a file owned by 65532 and mode 0550
-// would satisfy both and fail the moment a cluster allocated a uid of its own.
+// Executability is the claim, and it is a different one from the pin itself.
+// assertStandardImageConfig reads the User field and says what the image
+// *declares*; nothing about a declaration says the binary is executable by the
+// uid it names. A file owned by 65532 and mode 0500 would satisfy that check
+// and fail here, and one at 0550 would satisfy both and fail the moment a
+// cluster allocated a uid of its own.
 //
-// So each row is a deployment somebody really writes:
+// Be clear about what this does not do, because the reverse is easy to assume.
+// It does not observe the effective uid of the process — a scratch image has no
+// `id` to ask — so three of the four rows below override the user outright and
+// would pass just as well against an image that had never set one. The first
+// row is what ties this to the pin, and only because it asserts the declared
+// user first: a revert of imageForEntry's WithUser makes that assertion fail
+// here, rather than leaving the row silently exercising root. Beyond that one
+// line, the revert protection for the pin lives in assertStandardImageConfig.
+//
+// Each row is a deployment somebody really writes:
 //
 //   - nothing overridden, which is the image running as the 65532 it declares.
-//     This is the row that would have been green before #399 for the wrong
-//     reason — root can exec anything — and is the point of the change.
+//     Before devex#399 this row would have been green for the wrong reason:
+//     root can exec anything.
 //   - an unrelated uid:gid, which is `docker run --user $(id -u):$(id -g)` and
 //     a Kubernetes securityContext naming a uid from a namespace's allocated
 //     range. Nothing in the image knows that number, so only a world-executable
@@ -633,7 +642,7 @@ func (t *Tests) AppContainerRunsTheEntrypoint(ctx context.Context) error {
 //     ships it.
 //
 // It runs on the host's platform alone: executability is a property of the file
-// modes, which imageForEntry writes identically for every variant, and a foreign
+// modes, which the module writes identically for every variant, and a foreign
 // platform's binary cannot be executed here to learn anything more.
 func (t *Tests) AppImageRunsUnderAnyUser(ctx context.Context) error {
 	src, err := gitFixture(ctx, helloDir(), "main", nil)
@@ -643,9 +652,18 @@ func (t *Tests) AppImageRunsUnderAnyUser(ctx context.Context) error {
 	image := dag.Z5Labs().Go(src).
 		App("v1.0.0", dagger.Z5LabsGoChainAppOpts{Platforms: []dagger.Platform{hostPlatform()}}).
 		Container(hostPlatform())
+	// The first row runs under whatever the image declares, so what it
+	// declares has to be the pin for that row to mean anything.
+	declared, err := image.User(ctx)
+	if err != nil {
+		return fmt.Errorf("read the image's user: %v", err)
+	}
+	if declared != wantImageUser {
+		return fmt.Errorf("the image declares user %q, want %q — the un-overridden row below would otherwise exercise some other identity", declared, wantImageUser)
+	}
 	for _, user := range []string{"", "4242:4242", "65532:0", "0:0"} {
 		ctr := image
-		what := "the user the image declares"
+		what := "the declared user " + declared
 		if user != "" {
 			ctr = ctr.WithUser(user)
 			what = "user " + user

--- a/daggerverse/z5labs/tests/main.go
+++ b/daggerverse/z5labs/tests/main.go
@@ -61,6 +61,21 @@ const (
 	// reason the others are: `COPY --from=<image> /app/thing` is a line
 	// written a long way from this repository.
 	wantImageAppDir = "/app"
+	// wantImageUser is the OCI configuration's User field on every image the
+	// module publishes: uid 65532, gid 65532, as numbers.
+	//
+	// Pinned here most of all, because this is the contract value with the
+	// most readers outside this repository and the least ability to ask. A
+	// `COPY --chown=65532:65532` in a derived Dockerfile and a runAsUser in a
+	// Kubernetes securityContext are both a number somebody wrote down against
+	// this image; changing it silently breaks them, so changing it has to break
+	// this line first (devex#399).
+	//
+	// Non-empty is the half that is easy to lose and impossible to see: an
+	// empty User is uid 0, so an image that dropped this field would still run,
+	// still pass every other assertion here, and be rejected by the first
+	// admission policy that asks for runAsNonRoot.
+	wantImageUser = "65532:65532"
 )
 
 // wantImageAppDirStat is what the executable's directory has to look like on
@@ -75,13 +90,13 @@ const (
 // describes, which is the same failure contributed content's read-only modes
 // exist to prevent, one level up.
 //
-// Two things this does not claim, both of which are easy to read into it.
-// Root-owned and 0755 does not stop *root*, which bypasses the permission
-// check — and root is who these images run as until devex#399 lands a non-root
-// user, exactly as the same caveat under HOME's mode says. What it does is make
-// the promise true for every other user a deployment can pick, and pin the mode
-// now so that #399 lands on a /app that has not quietly regressed in the
-// meantime. It is also the mode a real base image's directories already have,
+// One thing this does not claim, and it is easy to read into it. Root-owned
+// and 0755 does not stop *root*, which bypasses the permission check. Since
+// devex#399 that exception is not the default any more — these images run as
+// 65532 — so it is reachable only by a deployment that overrides the user back
+// to uid 0, exactly as the same caveat under HOME's mode says. What the mode
+// does is make the promise true for every user a deployment can pick that is
+// not root. It is also the mode a real base image's directories already have,
 // which is why it is 0755 rather than the 0555 HOME gets: /app is ordinary
 // image structure, and an image that later gains a base layer should not have
 // to explain a directory mode nothing else in the filesystem shares.
@@ -166,6 +181,7 @@ func (t *Tests) All(
 	jobs = jobs.WithJob("AppValidatesTheVersion", t.AppValidatesTheVersion)
 	jobs = jobs.WithJob("AppRejectsSourceWithoutGitMetadata", t.AppRejectsSourceWithoutGitMetadata)
 	jobs = jobs.WithJob("AppContainerRunsTheEntrypoint", t.AppContainerRunsTheEntrypoint)
+	jobs = jobs.WithJob("AppImageRunsUnderAnyUser", t.AppImageRunsUnderAnyUser)
 	jobs = jobs.WithJob("AppContainersCoverEveryPlatformInOrder", t.AppContainersCoverEveryPlatformInOrder)
 	jobs = jobs.WithJob("AppImagesCarryTheStandardConfiguration", t.AppImagesCarryTheStandardConfiguration)
 	jobs = jobs.WithJob("AppBuildTagsReachTheCompiler", t.AppBuildTagsReachTheCompiler)
@@ -590,6 +606,63 @@ func (t *Tests) AppContainerRunsTheEntrypoint(ctx context.Context) error {
 	return nil
 }
 
+// AppImageRunsUnderAnyUser asserts the image's executable runs as the user the
+// image pins, and as any uid a deployment overrides that with.
+//
+// This is the runtime half of devex#399, and it is a different claim from the
+// configuration half. assertStandardImageConfig reads the User field and says
+// what the image *declares*; nothing about a declaration says the binary is
+// executable by the uid it names. A file owned by 65532 and mode 0500 would
+// satisfy that check and fail here, and a file owned by 65532 and mode 0550
+// would satisfy both and fail the moment a cluster allocated a uid of its own.
+//
+// So each row is a deployment somebody really writes:
+//
+//   - nothing overridden, which is the image running as the 65532 it declares.
+//     This is the row that would have been green before #399 for the wrong
+//     reason — root can exec anything — and is the point of the change.
+//   - an unrelated uid:gid, which is `docker run --user $(id -u):$(id -g)` and
+//     a Kubernetes securityContext naming a uid from a namespace's allocated
+//     range. Nothing in the image knows that number, so only a world-executable
+//     entrypoint makes it work.
+//   - the pinned uid with the runtime's group, which is what a securityContext
+//     that sets runAsUser and omits runAsGroup produces. It is a near miss
+//     rather than an exotic case: the group is gid 0 there.
+//   - root, because a deployment that deliberately overrides back to uid 0 is
+//     still a supported configuration of the image even though nothing here
+//     ships it.
+//
+// It runs on the host's platform alone: executability is a property of the file
+// modes, which imageForEntry writes identically for every variant, and a foreign
+// platform's binary cannot be executed here to learn anything more.
+func (t *Tests) AppImageRunsUnderAnyUser(ctx context.Context) error {
+	src, err := gitFixture(ctx, helloDir(), "main", nil)
+	if err != nil {
+		return fmt.Errorf("gitFixture: %v", err)
+	}
+	image := dag.Z5Labs().Go(src).
+		App("v1.0.0", dagger.Z5LabsGoChainAppOpts{Platforms: []dagger.Platform{hostPlatform()}}).
+		Container(hostPlatform())
+	for _, user := range []string{"", "4242:4242", "65532:0", "0:0"} {
+		ctr := image
+		what := "the user the image declares"
+		if user != "" {
+			ctr = ctr.WithUser(user)
+			what = "user " + user
+		}
+		out, err := ctr.
+			WithExec([]string{}, dagger.ContainerWithExecOpts{UseEntrypoint: true}).
+			Stdout(ctx)
+		if err != nil {
+			return fmt.Errorf("run the app image's entrypoint as %s: %w", what, err)
+		}
+		if out != "hello\n" {
+			return fmt.Errorf("running the entrypoint as %s printed %q, want %q", what, out, "hello\n")
+		}
+	}
+	return nil
+}
+
 // AppContainersCoverEveryPlatformInOrder asserts Containers returns one
 // image per platform in the order the platforms were given, and that
 // Container names the same images individually.
@@ -675,17 +748,21 @@ func (t *Tests) AppImagesCarryTheStandardConfiguration(ctx context.Context) erro
 
 // assertStandardImageConfig checks ctr's whole OCI configuration is the one
 // the module promises: the standardized environment, an entrypoint in the
-// application's own directory, and nothing else at all.
+// application's own directory, uid 65532 as the user, and nothing else at all.
 //
 // "Nothing else at all" is the part that is easy to read past. The module
-// promises no user, no working directory, no default arguments, no exposed
-// ports and no labels, and each of those is a promise an adopter relies on
-// rather than a field nobody got round to setting — a CMD would be appended to
-// the entrypoint by every runtime, a WORKDIR would change what every relative
-// path in a deployment resolves against, and a label is something people read
+// promises no working directory, no default arguments, no exposed ports and no
+// labels, and each of those is a promise an adopter relies on rather than a
+// field nobody got round to setting — a CMD would be appended to the entrypoint
+// by every runtime, a WORKDIR would change what every relative path in a
+// deployment resolves against, and a label is something people read
 // `org.opencontainers.image.*` out of. They are pinned here, literally, for the
 // reason wantImagePath is: a test that asked the module what it promises would
 // agree with whatever the module changed it to.
+//
+// The user is the one field that is checked for a *value* rather than for
+// emptiness, and it is the reason the distinction matters: an empty User is
+// not "no opinion", it is uid 0.
 //
 // Reading them costs an image-config read and no build, which is why this runs
 // on every variant of every image the suite looks at, while the filesystem half
@@ -709,12 +786,12 @@ func assertStandardImageConfig(ctx context.Context, ctr *dagger.Container, what 
 	if err != nil {
 		return fmt.Errorf("%s: read the image's user: %v", what, err)
 	}
-	// Empty, which is what these images promise today and is uid 0 at
-	// runtime. devex#399 is where that becomes 65532:65532, and this line is
-	// what makes landing it a deliberate change to the pinned contract rather
-	// than a silent one.
-	if user != "" {
-		return fmt.Errorf("%s: the image sets its user to %q, want an image that sets none", what, user)
+	// Exactly 65532:65532. Not merely "non-empty and non-zero": the number is
+	// the contract, and an image that started running as some other non-root
+	// uid would break every `COPY --chown` and runAsUser written against it
+	// while satisfying a weaker check (devex#399).
+	if user != wantImageUser {
+		return fmt.Errorf("%s: the image sets its user to %q, want %q — an image that sets none runs as uid 0", what, user, wantImageUser)
 	}
 	workdir, err := ctr.Workdir(ctx)
 	if err != nil {


### PR DESCRIPTION
Closes #399

`imageForEntry` never called `WithUser`, so the OCI configuration's `User` was empty — and an empty `User` is uid 0. Every z5labs Go application shipped through the standard pipeline ran its process as root, and a Kubernetes admission policy asking for `runAsNonRoot` rejects such an image outright.

The fix is two lines and a lot of prose, which is the shape the previous refactors deliberately left behind: `imageForEntry` sets the user, `expectedImageConfig` demands it, and the publish-time comparison that already read the whole configuration now refuses an image whose `User` is anything else — empty included.

## Acceptance criteria

- [x] **Images built by `GoApp` run as a non-root user by default.** `imageForEntry` (`build.go`) — now the only place an image is built, since #404 — gains `.WithUser(appOwner)`. Every constructor reaches it, so `Go().App(...)`, `App()` from prebuilt executables and a composed image all get it from one line.
- [x] **Decide and pin the UID/GID, and say why that number.** `65532:65532`, numerically. Reused `appOwner`, the constant contributed content is already owned by, rather than adding a second one: a uid that owns nothing it runs, or files owned by a uid nothing runs as, is a pair somebody has to keep in agreement by hand. The number's rationale — no `/etc/passwd` in a scratch image, `COPY --chown=` and `runAsUser` written a long way from here, distroless/`avroc`/`cpybkc` already on 65532 — is in the package doc's new `# The image runs as 65532:65532` and in `appOwner`'s own comment.
- [x] **The executable is readable and executable by that user and by any override.** `entryMode` was already 0555 and `/app` 0755 root-owned, so this was true before the change and is now asserted rather than inferred: `AppImageRunsUnderAnyUser` runs the entrypoint four ways — as the declared user, as an unrelated `4242:4242`, as `65532:0` (a `securityContext` that sets `runAsUser` and omits `runAsGroup`), and as root.
- [x] **Decide whether the identity is overridable, and whether any application needs root.** No to both, as the issue's own update settled. There is no `WithUser` on `App` and the package doc says there will not be one, for the reason `goapp.go` already gives about provenance: a hardening default that can be switched off is hardening nobody downstream can rely on. A *deployment* may still override the uid at run time, and the 0555 entrypoint is what keeps that an ordinary configuration.
- [x] **The change is called out as behaviour-affecting.** New package doc section `# Running as 65532 is behaviour-affecting`, naming the failure (EACCES where uid 0 used to succeed), where it now lands (the container's writable layer, whose root 65532 cannot write), and the remedy (mount storage at the path and give it to 65532:65532).
- [x] **A check asserts the published image's `User` is non-empty and non-zero.** Three, at different distances: `expectedImageConfig`/`diffImageConfig` refuse the publish; `ImageConfigSelfTest` gains rows for `""`, `"root"`, `"0:0"` and `"65532"` (uid without gid) as refusals and `65532:65532` as the accepted one; and `assertStandardImageConfig` in `tests/` pins `wantImageUser` literally — it runs over every variant, over a prebuilt-executable app, over a composed image, and over the variant *pulled back out of the registry* after a real publish.

## Judgment calls

- **Exactly `65532:65532`, not "non-empty and non-zero".** The acceptance criterion asks for the weaker check; the tests assert the stronger one. The number is the contract a `COPY --chown` and a `runAsUser` are written against, so an image that silently started running as some other non-root uid would break them while passing a non-zero check.
- **The refusal is symmetric.** `expectedImageConfig.User` is now the only non-empty constant in the expected configuration, which means the `demanding` scaffolding in `ImageConfigSelfTest` no longer has to stand in for the `User` comparison — the real expectation drives both directions. Those two rows were deleted and the helper's doc comment records that `User` is the field it was built for.
- **"A message naming this decision rather than a bare `permission denied`" is documentation, and the doc says why.** The write that now fails is the application's own syscall; nothing in this module is in that process, so there is no seam here that can improve the message. What the package doc does instead is put the explanation where somebody looking at an EACCES can find it, in the same voice the `TMPDIR` paragraph already uses for the runtime failure *it* cannot improve either. Flagging this explicitly because it is the one criterion answered by prose rather than by code.
- **`/home/nonroot` stays root-owned and 0555.** It is deliberately not writable by the user the image now runs as; the caveat that root bypasses the mode is still in the doc, but it is now reachable only by a deployment that overrides the user back to uid 0 rather than being the default.

## Verified

- `dagger check` — green (`ci:generated` included, after `dagger develop` in `daggerverse/z5labs` and `daggerverse/z5labs/tests`).
- `bash .github/scripts/verify-affected-modules.sh` — green: `z-5-labs` self-tests and the full `z-5-labs/tests` suite.
- The new `AppImageRunsUnderAnyUser` was run on its own before the suite, as were `AppImagesCarryTheStandardConfiguration`, `AppContributionsLandInEveryVariant` and `AppFromPrebuiltExecutablesIsHardenedLikeAnyOther` — the three most likely to notice a change in how ownership falls out of a container that now carries a user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)