### PR TITLE
bug(z5labs): a credential survives redaction into the published source annotation when the remote URL does not parse

### DIFF
--- a/daggerverse/z5labs/annotations.go
+++ b/daggerverse/z5labs/annotations.go
@@ -90,22 +90,35 @@ func ociAnnotations(facts gitState, version string) map[string]string {
 //     written for and it is still the right answer — an SSH remote is spelled
 //     `git@host:org/repo`, which is not a URL, has no authority, and carries a
 //     username that is part of the address rather than a secret.
-//   - An authority with no `@`: returned unchanged. It failed to parse for a
-//     reason somewhere else in the string, and there is no credential in it to
-//     omit an annotation over.
-//   - An authority with an `@`: the userinfo is cut out textually, and the
+//   - An authority carrying an `@`: the userinfo is cut out textually, and the
 //     result is then re-parsed. It is published only if it parses and carries
 //     no userinfo; otherwise the empty string is returned and the annotation is
 //     omitted altogether.
+//   - An authority with no `@` in it, but an `@` somewhere later in the string:
+//     omitted. The delimiters that end an authority are `/`, `?` and `#`, and
+//     an unencoded one of those inside a password puts the `@` beyond them —
+//     `https://user:AB/CD@host/org/repo` has the authority `user:AB` by the
+//     grammar and the whole credential by intent. In a string no parser
+//     accepted, those two readings cannot be told apart, so neither is
+//     published.
+//   - Anything else: returned unchanged. There is no `@` after the authority
+//     begins, so there is no userinfo to omit an annotation over.
 //
-// That last clause is the decision devex#425 asked for, and it is the
-// conservative half of the rule rather than the useful one. A textual cut over
-// a string no parser would accept is a claim about a shape nothing validated;
-// re-parsing is what turns it into something checked, and where it cannot be
-// checked, an omitted annotation is the safe outcome. It is the rule
+// The two omitting clauses are the decision devex#425 asked for, and they are
+// the conservative half of the rule rather than the useful one. A textual cut
+// over a string no parser would accept is a claim about a shape nothing
+// validated; re-parsing is what turns it into something checked, and where it
+// cannot be checked, an omitted annotation is the safe outcome. It is the rule
 // ociAnnotations already states for a tree with no origin — a key present and
 // wrong is worse than an absent one — applied to a value that might be a
 // credential rather than to one that is merely blank.
+//
+// The price is paid by a URL that fails to parse for some unrelated reason and
+// happens to carry an `@` in its path: its annotation is dropped even though
+// nothing in it was ever secret. That is the trade taken deliberately. The
+// alternative — cutting at the last `@` anywhere and publishing whatever
+// parses — turns `https://host/or%zg/re@po.git` into `https://po.git`, which is
+// an annotation that is present and wrong.
 //
 // Nothing here reports why a string would not parse. url.Parse's error quotes
 // the whole input, credential included, so a redactor that explained itself
@@ -124,9 +137,12 @@ func redactURLCredentials(raw string) string {
 		return parsed.String()
 	}
 
-	stripped, hadUserinfo := stripAuthorityUserinfo(raw)
-	if !hadUserinfo {
+	stripped, outcome := stripAuthorityUserinfo(raw)
+	switch outcome {
+	case redactionNone:
 		return raw
+	case redactionUnverifiable:
+		return ""
 	}
 	if parsed, err := url.Parse(stripped); err != nil || parsed.User != nil {
 		return ""
@@ -134,44 +150,100 @@ func redactURLCredentials(raw string) string {
 	return stripped
 }
 
-// stripAuthorityUserinfo removes the userinfo from raw's authority
-// component, textually, and reports whether there was one to remove.
+// redaction is what stripAuthorityUserinfo made of a string url.Parse had
+// already refused. There are three answers and not two, because "I found no
+// userinfo" and "I cannot establish that there is none" are different findings
+// and only the first one is safe to publish.
+type redaction int
+
+const (
+	// redactionNone: nothing in the string is userinfo, so it stands as it is.
+	redactionNone redaction = iota
+	// redactionCut: userinfo was removed. The result is a candidate and not yet
+	// an answer — the caller re-parses it before publishing it.
+	redactionCut
+	// redactionUnverifiable: there is an `@` no reading of this string accounts
+	// for, so the caller publishes nothing.
+	redactionUnverifiable
+)
+
+// stripAuthorityUserinfo removes the userinfo from raw's authority component,
+// textually, and reports what it was able to establish.
 //
 // It exists for strings url.Parse has already refused, so it works from the
-// grammar rather than from a parse. Per RFC 3986 the authority is present
-// only when the hierarchical part opens with `//`; it runs to the first `/`,
-// `?` or `#` after that, and within it the userinfo ends at an `@`.
+// grammar rather than from a parse. Per RFC 3986 the authority is present only
+// when the hierarchical part opens with `//`; it runs to the first `/`, `?` or
+// `#` after that, and within it the userinfo ends at an `@`.
 //
-// Two details are load bearing. The `//` has to open the hierarchical part —
-// at the start of the string, or immediately after a scheme — because a
-// doubled slash inside a path is not an authority, and reading one as an
-// authority would rewrite an SSH remote like `git@host:org//repo` into
-// something that is not the address it names. And the split is at the **last**
-// `@` in the authority, which is where url.Parse itself splits: `@` is not
-// legal unescaped in userinfo, so a string carrying two of them is one of the
-// unparseable inputs this path exists for, and splitting at the first would
-// leave the tail of the credential in the value.
-func stripAuthorityUserinfo(raw string) (string, bool) {
-	rest := raw
-	offset := 0
-	if colon := strings.IndexByte(raw, ':'); colon > 0 && isURLScheme(raw[:colon]) {
-		offset = colon + 1
-		rest = raw[offset:]
-	}
-	if !strings.HasPrefix(rest, "//") {
-		return raw, false
+// Three details are load bearing.
+//
+// The `//` has to open the hierarchical part — at the start of the string, or
+// immediately after the colon that ends a scheme — because a doubled slash
+// inside a path is not an authority, and reading one as an authority would
+// rewrite an SSH remote like `git@host:org//repo` into something that is not
+// the address it names.
+//
+// The split is at the **last** `@` in the authority, which is where url.Parse
+// itself splits. A second `@` is not legal unescaped in userinfo, so a string
+// carrying two of them is one of the unparseable inputs this path exists for,
+// and splitting at the first would leave the tail of the credential in the
+// value.
+//
+// And an `@` that falls *outside* the authority is reported as unverifiable
+// rather than as an absence. The delimiter that ended the authority may itself
+// have been part of a password nobody encoded — `/` is in the base64 alphabet
+// that tokens are drawn from, so it is an ordinary thing for a password to
+// contain and the single most likely reason a pasted https remote fails to
+// parse. Treating that as "no userinfo here" is the devex#425 bug in a second
+// costume: the string comes back untouched with the credential in it.
+func stripAuthorityUserinfo(raw string) (string, redaction) {
+	start, ok := authorityStart(raw)
+	if !ok {
+		return raw, redactionNone
 	}
 
-	start := offset + 2
 	end := len(raw)
 	if i := strings.IndexAny(raw[start:], "/?#"); i >= 0 {
 		end = start + i
 	}
-	at := strings.LastIndexByte(raw[start:end], '@')
-	if at < 0 {
-		return raw, false
+	if at := strings.LastIndexByte(raw[start:end], '@'); at >= 0 {
+		return raw[:start] + raw[start+at+1:], redactionCut
 	}
-	return raw[:start] + raw[start+at+1:], true
+	if strings.IndexByte(raw[start:], '@') >= 0 {
+		return "", redactionUnverifiable
+	}
+	return raw, redactionNone
+}
+
+// authorityStart returns the index at which raw's authority component begins,
+// and whether raw has one at all.
+//
+// The authority opens the hierarchical part, so its `//` sits at the start of
+// the string or directly after the colon that ends the scheme. Everything else
+// spelled with a doubled slash is a path, and the case that matters is
+// `git@host:org//repo`: reading that path's `//` as an authority would find an
+// `@` before it and cut the address in half.
+//
+// An empty scheme is admitted — `://user:secret@host/path` is not a legal
+// URI-reference and no tool produces it, but it is a shape carrying a
+// credential, and the point of this path is that it runs on strings nothing
+// accepted.
+func authorityStart(raw string) (int, bool) {
+	slashes := strings.Index(raw, "//")
+	if slashes < 0 {
+		return 0, false
+	}
+	prefix := raw[:slashes]
+	if prefix == "" {
+		return len("//"), true
+	}
+	if !strings.HasSuffix(prefix, ":") {
+		return 0, false
+	}
+	if scheme := prefix[:len(prefix)-1]; scheme != "" && !isURLScheme(scheme) {
+		return 0, false
+	}
+	return slashes + len("//"), true
 }
 
 // isURLScheme reports whether s is a URL scheme: an ASCII letter followed by

--- a/daggerverse/z5labs/annotations.go
+++ b/daggerverse/z5labs/annotations.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"net/url"
+	"strings"
 )
 
 // The standard OCI annotation keys this module populates. They are the
@@ -72,17 +73,125 @@ func ociAnnotations(facts gitState, version string) map[string]string {
 // off. A URL that carried credentials keeps its host and path and loses
 // only the part that was never meant to travel.
 //
-// Anything that does not parse as a URL is returned unchanged: an SSH
-// remote is spelled `git@host:org/repo`, which is not a URL and carries a
-// username that is part of the address rather than a secret.
+// A string that does not parse as a URL is not therefore safe, and treating
+// it as safe is what devex#425 was: the fallback returned the input
+// untouched, and the inputs that reach it include the ones url.Parse refuses
+// *because of the credential inside them*. Any percent not followed by two
+// hex digits, and any control character, in the userinfo is enough — so the
+// correctly encoded credential was redacted and the naive one was published,
+// which inverts the purpose of the function in the one case it cannot parse
+// its way out of.
+//
+// So an unparseable string is read structurally instead. RFC 3986 puts the
+// userinfo in the authority, and the authority is present only where the
+// hierarchical part begins with `//`:
+//
+//   - No authority: returned unchanged. This is the case the old fallback was
+//     written for and it is still the right answer — an SSH remote is spelled
+//     `git@host:org/repo`, which is not a URL, has no authority, and carries a
+//     username that is part of the address rather than a secret.
+//   - An authority with no `@`: returned unchanged. It failed to parse for a
+//     reason somewhere else in the string, and there is no credential in it to
+//     omit an annotation over.
+//   - An authority with an `@`: the userinfo is cut out textually, and the
+//     result is then re-parsed. It is published only if it parses and carries
+//     no userinfo; otherwise the empty string is returned and the annotation is
+//     omitted altogether.
+//
+// That last clause is the decision devex#425 asked for, and it is the
+// conservative half of the rule rather than the useful one. A textual cut over
+// a string no parser would accept is a claim about a shape nothing validated;
+// re-parsing is what turns it into something checked, and where it cannot be
+// checked, an omitted annotation is the safe outcome. It is the rule
+// ociAnnotations already states for a tree with no origin — a key present and
+// wrong is worse than an absent one — applied to a value that might be a
+// credential rather than to one that is merely blank.
+//
+// Nothing here reports why a string would not parse. url.Parse's error quotes
+// the whole input, credential included, so a redactor that explained itself
+// would leak by exactly the path this function closes.
+//
+// SourceRedactionSelfTest is the table this behaviour is stated in.
 func redactURLCredentials(raw string) string {
 	if raw == "" {
 		return ""
 	}
-	parsed, err := url.Parse(raw)
-	if err != nil || parsed.User == nil {
+	if parsed, err := url.Parse(raw); err == nil {
+		if parsed.User == nil {
+			return raw
+		}
+		parsed.User = nil
+		return parsed.String()
+	}
+
+	stripped, hadUserinfo := stripAuthorityUserinfo(raw)
+	if !hadUserinfo {
 		return raw
 	}
-	parsed.User = nil
-	return parsed.String()
+	if parsed, err := url.Parse(stripped); err != nil || parsed.User != nil {
+		return ""
+	}
+	return stripped
+}
+
+// stripAuthorityUserinfo removes the userinfo from raw's authority
+// component, textually, and reports whether there was one to remove.
+//
+// It exists for strings url.Parse has already refused, so it works from the
+// grammar rather than from a parse. Per RFC 3986 the authority is present
+// only when the hierarchical part opens with `//`; it runs to the first `/`,
+// `?` or `#` after that, and within it the userinfo ends at an `@`.
+//
+// Two details are load bearing. The `//` has to open the hierarchical part —
+// at the start of the string, or immediately after a scheme — because a
+// doubled slash inside a path is not an authority, and reading one as an
+// authority would rewrite an SSH remote like `git@host:org//repo` into
+// something that is not the address it names. And the split is at the **last**
+// `@` in the authority, which is where url.Parse itself splits: `@` is not
+// legal unescaped in userinfo, so a string carrying two of them is one of the
+// unparseable inputs this path exists for, and splitting at the first would
+// leave the tail of the credential in the value.
+func stripAuthorityUserinfo(raw string) (string, bool) {
+	rest := raw
+	offset := 0
+	if colon := strings.IndexByte(raw, ':'); colon > 0 && isURLScheme(raw[:colon]) {
+		offset = colon + 1
+		rest = raw[offset:]
+	}
+	if !strings.HasPrefix(rest, "//") {
+		return raw, false
+	}
+
+	start := offset + 2
+	end := len(raw)
+	if i := strings.IndexAny(raw[start:], "/?#"); i >= 0 {
+		end = start + i
+	}
+	at := strings.LastIndexByte(raw[start:end], '@')
+	if at < 0 {
+		return raw, false
+	}
+	return raw[:start] + raw[start+at+1:], true
+}
+
+// isURLScheme reports whether s is a URL scheme: an ASCII letter followed by
+// letters, digits, `+`, `-` and `.`, per RFC 3986.
+//
+// It is what keeps the colon in `git@host:org/repo` from being read as a
+// scheme separator — `git@host` is not a scheme, so that remote has no
+// authority and is left alone.
+func isURLScheme(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case 'a' <= c && c <= 'z', 'A' <= c && c <= 'Z':
+		case i > 0 && ('0' <= c && c <= '9' || c == '+' || c == '-' || c == '.'):
+		default:
+			return false
+		}
+	}
+	return true
 }

--- a/daggerverse/z5labs/annotationsselftest.go
+++ b/daggerverse/z5labs/annotationsselftest.go
@@ -107,13 +107,49 @@ func (m *Z5labs) SourceRedactionSelfTest(ctx context.Context) error {
 			name: "an at sign inside the password",
 			raw:  "https://user:" + secret + "@extra@github.com/org/repo.git",
 			want: "https://github.com/org/repo.git",
-			why:  "the userinfo ends at the last at sign in the authority, not the first: splitting on the first would leave half the credential in the value",
+			why:  "url.Parse escapes the inner at sign and splits at the last one, so this row pins the parsing branch rather than the fallback",
+		},
+		{
+			name: "an at sign inside a password that also defeats the parser",
+			raw:  "https://user:" + secretPercent + "@extra@github.com/org/repo.git",
+			want: "https://github.com/org/repo.git",
+			why:  "the same shape through the fallback, which is where the split at the last at sign is this module's own to get right: splitting at the first would leave the tail of the credential in the value",
+		},
+		{
+			name: "a password carrying an unencoded slash",
+			raw:  "https://user:" + secret + "/CD@github.com/org/repo.git",
+			want: "",
+			why:  "a slash ends the authority, so the at sign falls outside it and the string reads as having no userinfo at all — and a slash is in the base64 alphabet tokens are drawn from, which makes this the likeliest way a pasted remote fails to parse",
+		},
+		{
+			name: "a password carrying an unencoded question mark",
+			raw:  "https://user:" + secret + "?CD@github.com/org/repo.git",
+			want: "",
+			why:  "the query delimiter ends the authority the same way, and the same reading applies",
+		},
+		{
+			name: "a password carrying an unencoded hash",
+			raw:  "https://user:" + secret + "#CD@github.com/org/repo.git",
+			want: "",
+			why:  "the fragment delimiter, the third of them, and the last shape that could put the at sign out of reach",
 		},
 		{
 			name: "userinfo beside an unparseable path",
 			raw:  "https://user:" + secret + "@github.com/or%zg/repo.git",
 			want: "",
 			why:  "the redaction cannot be confirmed by re-parsing, so the annotation is omitted rather than published on trust",
+		},
+		{
+			name: "userinfo behind an empty scheme",
+			raw:  "://user:" + secret + "@github.com/org/repo.git",
+			want: "",
+			why:  "no tool writes this, but it is a credential in an authority, and the fallback runs on strings nothing accepted: the userinfo comes off and the remainder still will not parse, so nothing is published",
+		},
+		{
+			name: "an at sign in the path of a remote that will not parse",
+			raw:  "https://github.com/or%zg/re@po.git",
+			want: "",
+			why:  "the price of the rule above: nothing here is secret, but in a string no parser accepted an at sign after the authority cannot be shown to be part of the path, and an absent annotation beats one that is present and wrong",
 		},
 
 		{

--- a/daggerverse/z5labs/annotationsselftest.go
+++ b/daggerverse/z5labs/annotationsselftest.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// selfTestCredential stands in for the secret half of a remote's userinfo
+// everywhere in this file.
+//
+// It names itself for a reason. The whole point of the rows below is that at
+// least one of them describes a value which, before devex#425, was published
+// verbatim onto a manifest — so a row that failed would print the thing the
+// check exists to keep out of a log. The literal is chosen so that a reader
+// who finds it in CI output learns nothing and reaches for nothing, and the
+// assertions below still never quote it: naming it is the second line of
+// defence, not the first.
+const selfTestCredential = "not-a-real-credential"
+
+// SourceRedactionSelfTest checks redactURLCredentials against the rule rather
+// than against a publish: no remote reaches
+// org.opencontainers.image.source carrying userinfo, and an SSH remote —
+// whose username is part of the address — survives untouched.
+//
+// It is a check of its own because the failure it guards cannot be seen from
+// a publish. A remote whose credential leaks produces an image that builds,
+// pushes and runs exactly like one whose credential was stripped; the
+// difference is a field on a manifest that anyone who can pull the image can
+// read, discovered by whoever reads it rather than by this pipeline. And the
+// inputs that leak are the ones a working tree cannot easily be made to have:
+// driving them through GoChain.gitFacts would mean a container, a repository
+// and a remote URL that git itself would have to accept, per row.
+//
+// It sits on the module rather than in tests/ for the same reason
+// VersionTagsSelfTest does — the function is unexported — and because a table
+// of a dozen remotes costs one in-process call here.
+//
+// The rows are the shapes that distinguish the rule, including the accepting
+// ones. A redactor that returned the empty string for everything would pass a
+// table of leaking inputs alone while deleting the annotation from every
+// image this module publishes.
+//
+// Nothing here quotes an input. url.Parse's own error is the reason the habit
+// is worth keeping: it renders as `parse "<the whole URL>": invalid URL
+// escape "%zz"`, credential included, so a redactor that reported why it
+// could not parse would leak by exactly the path this check closes. The
+// assertions below print a row's name and its expectation, and print what
+// came back only after establishing that it does not carry the credential.
+//
+// +check
+// +cache="session"
+func (m *Z5labs) SourceRedactionSelfTest(ctx context.Context) error {
+	// secret is the credential a row carries, spelled three ways. The plain
+	// one is a URL that parses; the other two are the shapes that made
+	// url.Parse fail and, before this check existed, made the redactor return
+	// its input untouched. A percent that is not followed by two hex digits is
+	// what someone who did not encode a literal `%` in their password
+	// produces, so the correctly encoded credential was redacted and the naive
+	// one was published.
+	const (
+		secret        = selfTestCredential
+		secretPercent = selfTestCredential + "%zz"
+		secretControl = selfTestCredential + "\x7f"
+	)
+
+	cases := []struct {
+		// name identifies the row in a failure. It is what a failure prints in
+		// place of the input, which is never printed.
+		name string
+		raw  string
+		want string
+		why  string
+	}{
+		{
+			name: "the GitHub Actions checkout credential",
+			raw:  "https://x-access-token:" + secret + "@github.com/z5labs/devex.git",
+			want: "https://github.com/z5labs/devex.git",
+			why:  "the case the function was written against: it parses, so the userinfo comes off and the rest is kept",
+		},
+		{
+			name: "a password carrying an unencoded percent",
+			raw:  "https://user:" + secretPercent + "@github.com/z5labs/devex.git",
+			want: "https://github.com/z5labs/devex.git",
+			why:  "url.Parse refuses the escape, and the old fallback published the whole string",
+		},
+		{
+			name: "a password carrying a control character",
+			raw:  "https://user:" + secretControl + "@github.com/org/repo.git",
+			want: "https://github.com/org/repo.git",
+			why:  "the other way userinfo defeats url.Parse, and it published the whole string too",
+		},
+		{
+			name: "an unencoded percent beside a port",
+			raw:  "https://user:" + secretPercent + "@github.com:8443/org/repo.git",
+			want: "https://github.com:8443/org/repo.git",
+			why:  "the port is part of the authority and belongs to the host half of it, so it is kept",
+		},
+		{
+			name: "an unencoded percent with no scheme",
+			raw:  "//user:" + secretPercent + "@github.com/org/repo.git",
+			want: "//github.com/org/repo.git",
+			why:  "a scheme-relative reference has an authority, so it is redacted like any other",
+		},
+		{
+			name: "an at sign inside the password",
+			raw:  "https://user:" + secret + "@extra@github.com/org/repo.git",
+			want: "https://github.com/org/repo.git",
+			why:  "the userinfo ends at the last at sign in the authority, not the first: splitting on the first would leave half the credential in the value",
+		},
+		{
+			name: "userinfo beside an unparseable path",
+			raw:  "https://user:" + secret + "@github.com/or%zg/repo.git",
+			want: "",
+			why:  "the redaction cannot be confirmed by re-parsing, so the annotation is omitted rather than published on trust",
+		},
+
+		{
+			name: "an SSH remote in scp syntax",
+			raw:  "git@github.com:z5labs/devex.git",
+			want: "git@github.com:z5labs/devex.git",
+			why:  "not a URL and not a credential: the username is part of the address, and this is the case the fallback exists for",
+		},
+		{
+			name: "an SSH remote in scp syntax with a doubled slash in its path",
+			raw:  "git@github.com:z5labs//devex.git",
+			want: "git@github.com:z5labs//devex.git",
+			why:  "the doubled slash is in the path, so it must not be read as the start of an authority and turn the address into a redaction",
+		},
+		{
+			name: "an SSH remote spelled as a URL",
+			raw:  "ssh://git@github.com/z5labs/devex.git",
+			want: "ssh://github.com/z5labs/devex.git",
+			why:  "spelled as a URL it has userinfo, and a redactor cannot tell a username that is an address from one that is a login",
+		},
+		{
+			name: "an ordinary public remote",
+			raw:  "https://github.com/z5labs/devex.git",
+			want: "https://github.com/z5labs/devex.git",
+			why:  "nothing to strip, and the annotation is the reason the whole function returns a value at all",
+		},
+		{
+			name: "a public remote whose path will not parse",
+			raw:  "https://github.com/or%zg/repo.git",
+			want: "https://github.com/or%zg/repo.git",
+			why:  "unparseable but with no userinfo anywhere: there is no credential to omit an annotation over",
+		},
+		{
+			name: "no origin at all",
+			raw:  "",
+			want: "",
+			why:  "a tree with no origin, which ociAnnotations turns into an absent key rather than a blank one",
+		},
+	}
+
+	for _, c := range cases {
+		got := redactURLCredentials(c.raw)
+
+		// First, and before anything is quoted: the credential is not in the
+		// result. This is the property the whole check exists for, and it is
+		// asserted separately from the expectation so that it holds even for a
+		// row whose want was written wrongly.
+		if strings.Contains(got, selfTestCredential) {
+			return fmt.Errorf("%s (%s): the credential survived redaction; neither the remote nor the value is quoted here, because printing it is the failure this check exists to prevent", c.name, c.why)
+		}
+		if got != c.want {
+			return fmt.Errorf("%s (%s): want %q, got %q", c.name, c.why, c.want, got)
+		}
+
+		// An invariant that holds whatever the table says, and the one a
+		// future refactor is most likely to break quietly: a value that parses
+		// carries no userinfo. A row could be added with a want that leaks
+		// something other than the sentinel; this catches that, and it catches
+		// a redactor that started returning its input for a shape nobody
+		// tabulated.
+		if parsed, err := url.Parse(got); err == nil && parsed.User != nil {
+			return fmt.Errorf("%s (%s): the redacted value still carries userinfo", c.name, c.why)
+		}
+	}
+	return nil
+}

--- a/daggerverse/z5labs/dagger.gen.go
+++ b/daggerverse/z5labs/dagger.gen.go
@@ -858,6 +858,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Z5labs).ImageSbomSelfTest(&parent, ctx)
+		case "SourceRedactionSelfTest":
+			var parent Z5labs
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Z5labs).SourceRedactionSelfTest(&parent, ctx)
 		case "VariantSetSelfTest":
 			var parent Z5labs
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
+++ b/daggerverse/z5labs/tests/internal/dagger/z-5-labs.gen.go
@@ -162,6 +162,7 @@ type Z5Labs struct { // z5labs (../../../../../daggerverse/z5labs/main.go:639:6)
 	id                       *ID
 	imageConfigSelfTest      *Void
 	imageSbomSelfTest        *Void
+	sourceRedactionSelfTest  *Void
 	variantSetSelfTest       *Void
 	versionTagsSelfTest      *Void
 }
@@ -568,6 +569,44 @@ func (r *Z5Labs) ImageSbomSelfTest(ctx context.Context) error { // z5labs (../..
 		return nil
 	}
 	q := r.query.Select("imageSbomSelfTest")
+
+	return q.Execute(ctx)
+}
+
+// SourceRedactionSelfTest checks redactURLCredentials against the rule rather
+// than against a publish: no remote reaches
+// org.opencontainers.image.source carrying userinfo, and an SSH remote —
+// whose username is part of the address — survives untouched.
+//
+// It is a check of its own because the failure it guards cannot be seen from
+// a publish. A remote whose credential leaks produces an image that builds,
+// pushes and runs exactly like one whose credential was stripped; the
+// difference is a field on a manifest that anyone who can pull the image can
+// read, discovered by whoever reads it rather than by this pipeline. And the
+// inputs that leak are the ones a working tree cannot easily be made to have:
+// driving them through GoChain.gitFacts would mean a container, a repository
+// and a remote URL that git itself would have to accept, per row.
+//
+// It sits on the module rather than in tests/ for the same reason
+// VersionTagsSelfTest does — the function is unexported — and because a table
+// of a dozen remotes costs one in-process call here.
+//
+// The rows are the shapes that distinguish the rule, including the accepting
+// ones. A redactor that returned the empty string for everything would pass a
+// table of leaking inputs alone while deleting the annotation from every
+// image this module publishes.
+//
+// Nothing here quotes an input. url.Parse's own error is the reason the habit
+// is worth keeping: it renders as `parse "<the whole URL>": invalid URL
+// escape "%zz"`, credential included, so a redactor that reported why it
+// could not parse would leak by exactly the path this check closes. The
+// assertions below print a row's name and its expectation, and print what
+// came back only after establishing that it does not carry the credential.
+func (r *Z5Labs) SourceRedactionSelfTest(ctx context.Context) error { // z5labs (../../../../../daggerverse/z5labs/annotationsselftest.go:54:1)
+	if r.sourceRedactionSelfTest != nil {
+		return nil
+	}
+	q := r.query.Select("sourceRedactionSelfTest")
 
 	return q.Execute(ctx)
 }


### PR DESCRIPTION
Closes #425

`redactURLCredentials` returned its input untouched whenever `url.Parse` failed. That
fallback is load bearing — an SSH remote is spelled `git@host:org/repo`, which is not a URL
and whose username is part of the address — but it also caught URLs that fail to parse
*because of the credential inside them*. Any `%` not followed by two hex digits, and any
control character, in the userinfo is enough, so the correctly encoded credential was
redacted and the naive one was published onto `org.opencontainers.image.source`, where
anyone who can pull the image can read it.

## The rule now

An unparseable string is read structurally rather than trusted. Per RFC 3986 the userinfo
lives in the authority, and the authority exists only where the hierarchical part opens
with `//`:

| shape | outcome |
| --- | --- |
| no authority (`git@host:org/repo`) | returned unchanged — not a URL, not a credential |
| an authority carrying an `@` | userinfo cut out textually, then **re-parsed**; published only if it parses with no userinfo, otherwise dropped |
| no `@` in the authority, but one later in the string | dropped — see below |
| anything else | returned unchanged; there is no userinfo to omit an annotation over |

The third row is the review's finding, and it is the same bug in a second costume. `/`, `?`
and `#` end the authority, so an unencoded one *inside a password* puts the `@` beyond it:
`https://user:AB/CD@host/org/repo` has the authority `user:AB` by the grammar and the whole
credential by intent. In a string no parser accepted those two readings cannot be told
apart, so neither is published. `/` is in the base64 alphabet tokens are drawn from, which
makes this the likeliest route into the fallback rather than an exotic one.

Two details in `stripAuthorityUserinfo` are load bearing. The `//` has to open the
hierarchical part — at the start, or right after a colon ending a scheme, empty or valid —
because a doubled slash inside a path is not an authority, and reading one as an authority
would rewrite `git@host:org//repo` into something that is not the address it names. And the
split is at the **last** `@` in the authority, which is where `url.Parse` itself splits;
splitting at the first would leave the tail of a credential in the value.

## The judgment call the issue asked for

> **Decide** what an unparseable string that looks like it carries userinfo becomes — the
> userinfo stripped textually, or the annotation omitted altogether.

**Both, in that order.** The textual strip is the answer when it can be confirmed; the
omission is what happens when it cannot. A textual cut over a string no parser accepted is
a claim about a shape nothing validated, so the result is re-parsed, and only a value that
parses with no userinfo is published. Where the cut cannot be made, or its result cannot be
re-parsed, the empty string comes back and `ociAnnotations` omits the key — the rule it
already states for a tree with no origin, applied to a value that might be a credential
rather than to one that is merely blank.

The price is paid by a URL that fails to parse for some unrelated reason and happens to
carry an `@` in its path: its annotation is dropped though nothing in it was secret. Taken
deliberately, and it has a row of its own. The alternative — cutting at the last `@`
anywhere and publishing whatever parses — turns `https://host/or%zg/re@po.git` into
`https://po.git`, which is an annotation that is present and wrong.

## Acceptance criteria

- [x] **A remote URL whose userinfo prevents `url.Parse` from succeeding does not reach
      `org.opencontainers.image.source` with that userinfo intact.** Both leaking inputs
      from the issue, the three delimiter shapes the review found, and an empty-scheme
      authority are all table rows; every row additionally asserts the credential is not in
      the result at all, independently of what that row's `want` says.
- [x] **An SSH-style remote (`git@host:org/repo`) still survives unchanged.** It has no
      authority, so it takes the unchanged path. A second row carries a doubled slash in
      its path, which is what pins the "the `//` must open the hierarchical part" rule.
- [x] **Decide what an unparseable string that looks like it carries userinfo becomes.**
      Above, and in the function's doc comment.
- [x] **The behaviour is driven by a self-test over the function rather than through a
      publish.** `Z5labs.SourceRedactionSelfTest` (`+check`), twenty rows, in process. It
      runs in the module's own check list, beside `VersionTagsSelfTest` and
      `ImageConfigSelfTest`, because the function is unexported and because the leaking
      inputs would each need a container, a repository and a remote URL git itself would
      accept to reach through `tests/`. The accepting rows are there deliberately: a
      redactor that returned `""` for everything would pass a table of leaking inputs alone
      while deleting the annotation from every image this module publishes.
- [x] **No test, fixture or error message quotes a credential in a form that would end up
      in a CI log.** The stand-in is the literal `not-a-real-credential`. No assertion
      quotes an input; a result is quoted only after establishing the credential is not in
      it. And nothing in `redactURLCredentials` reports *why* a string would not parse —
      `url.Parse`'s error renders as ``parse "<the whole URL>": invalid URL escape "%zz"``,
      credential included, so a redactor that explained itself would leak by exactly the
      path this closes.

## Review

Reviewed by the `local` rung (Copilot was unavailable on this run). It found the
`/?#`-in-password leak above — a genuine miss against criterion 1 — plus a row whose `why`
described a branch it did not reach, and two optional no-authority shapes. The first three
are fixed in 5243879; the fourth (`https:user:pass@host`, which parses) is declined on the
thread, because a rule broad enough to catch it also catches `github.com:org/repo`, the
scp-style remote without a username, which git really does produce.

## Verified

Written test-first: the check went red on "a password carrying an unencoded percent" — with
the credential not quoted in the failure — before `annotations.go` was touched.

- `dagger check` — `ci:generated`, `ci:generated-self-test`, `ci:selection-self-test` OK.
- `bash .github/scripts/verify-affected-modules.sh` — `daggerverse/z5labs`, all eight
  self-tests including the new `source-redaction-self-test`, and `daggerverse/z5labs/tests`
  `tests:all` OK. Re-run after the review fixes.

Bindings regenerated after the last source edit; the generated diff is the new check's
`invoke` case and the consumer binding for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)